### PR TITLE
Web apps sticky search

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -299,6 +299,7 @@ hqDefine("cloudcare/js/formplayer/app", function () {
             phoneMode: options.phoneMode,
             oneQuestionPerScreen: options.oneQuestionPerScreen,
             language: options.language,
+            stickySearches: options.stickySearches,
         });
 
         FormplayerFrontend.getChannel().request('gridPolyfillPath', options.gridPolyfillPath);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
@@ -52,6 +52,9 @@ hqDefine("cloudcare/js/formplayer/apps/controller", function () {
             settings.push(
                 new Backbone.Model({ slug: slugs.CLEAR_USER_DATA })
             );
+            settings.push(
+                new Backbone.Model({ slug: slugs.STICKY_SEARCHES })
+            );
             collection = new Backbone.Collection(settings);
             settingsView = hqImport("cloudcare/js/formplayer/layout/views/settings").SettingsView({
                 collection: collection,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
@@ -1,6 +1,6 @@
 hqDefine("cloudcare/js/formplayer/constants", function () {
     return {
-        ALLOWED_SAVED_OPTIONS: ['oneQuestionPerScreen', 'language'],
+        ALLOWED_SAVED_OPTIONS: ['oneQuestionPerScreen', 'language', 'stickySearches'],
 
         // These should match corehq/apps/cloudcare/const.py
         WEB_APPS_ENVIRONMENT: 'web-apps',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
@@ -9,6 +9,7 @@ hqDefine("cloudcare/js/formplayer/layout/views/settings", function () {
         SET_DISPLAY: 'display',
         CLEAR_USER_DATA: 'clear-user-data',
         BREAK_LOCKS: 'break-locks',
+        STICKY_SEARCHES: 'sticky-searches',
     };
 
     /**
@@ -112,6 +113,34 @@ hqDefine("cloudcare/js/formplayer/layout/views/settings", function () {
         },
     });
 
+    /**
+     * Sets whether or not searches should be sticky, for both case lists and case claim.
+     * Available in both app preview and web apps.
+     */
+    var StickySearchesView = Marionette.View.extend({
+        template: _.template($("#sticky-searches-setting-template").html() || ""),
+        tagName: 'tr',
+        initialize: function () {
+            this.currentUser = FormplayerFrontend.getChannel().request('currentUser');
+        },
+        ui: {
+            stickySearches: '.js-sticky-searches',
+        },
+        events: {
+            'switchChange.bootstrapSwitch @ui.stickySearches': 'onChangeStickySearches',
+        },
+        onRender: function () {
+            this.ui.stickySearches.bootstrapSwitch(
+                'state',
+                this.currentUser.displayOptions.stickySearches
+            );
+        },
+        onChangeStickySearches: function (e, switchValue) {
+            this.currentUser.displayOptions.stickySearches = switchValue;
+            Util.saveDisplayOptions(this.currentUser.displayOptions);
+        },
+    });
+
     var SettingsView = Marionette.CollectionView.extend({
         childViewContainer: 'tbody',
         childView: function (item) {
@@ -123,6 +152,8 @@ hqDefine("cloudcare/js/formplayer/layout/views/settings", function () {
                 return ClearUserDataView;
             } else if (item.get('slug') === slugs.BREAK_LOCKS) {
                 return BreakLocksView;
+            } else if (item.get('slug') === slugs.STICKY_SEARCHES) {
+                return StickySearchesView;
             }
         },
         ui: {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
@@ -12,6 +12,7 @@ hqDefine("cloudcare/js/formplayer/main", function () {
             gridPolyfillPath: initialPageData('grid_polyfill_path'),
             debuggerEnabled: initialPageData('debugger_enabled'),
             singleAppMode: initialPageData('single_app_mode'),
+            stickySearches: toggles.toggleEnabled('WEBAPPS_STICKY_SEARCH'),
             environment: initialPageData('environment'),
             useLiveQuery: toggles.toggleEnabled('FORMPLAYER_USE_LIVEQUERY'),
             changeFormLanguage: toggles.toggleEnabled('CHANGE_FORM_LANGUAGE'),

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -278,6 +278,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         ui: {
             actionButton: '.caselist-action-button button',
             searchButton: '#case-list-search-button',
+            clearButton: '#case-list-clear-button',
             paginators: '.page-link',
             columnHeader: '.header-clickable',
         },
@@ -285,6 +286,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         events: {
             'click @ui.actionButton': 'caseListAction',
             'click @ui.searchButton': 'caseListSearch',
+            'click @ui.clearButton': 'caseListClear',
             'click @ui.paginators': 'paginateAction',
             'click @ui.columnHeader': 'columnSortAction',
             'keypress': 'keyAction',
@@ -293,6 +295,12 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         caseListAction: function (e) {
             var index = $(e.currentTarget).data().index;
             FormplayerFrontend.trigger("menu:select", "action " + index);
+        },
+
+        caseListClear: function (e) {
+            e.preventDefault();
+            $('#searchText').val('');
+            $('#searchText').focus();
         },
 
         caseListSearch: function (e) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -36,11 +36,20 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         },
 
         ui: {
+            clearButton: '#query-clear-button',
             submitButton: '#query-submit-button',
         },
 
         events: {
+            'click @ui.clearButton': 'clearAction',
             'click @ui.submitButton': 'submitAction',
+        },
+
+        clearAction: function (e) {
+            var fields = $(".query-field");
+            fields.each(function (index) {
+                this.value = '';
+            });
         },
 
         submitAction: function (e) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -9,12 +9,14 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         template: _.template($("#query-view-item-template").html() || ""),
 
         templateContext: function () {
-            var imageUri = this.options.model.get('imageUri');
-            var audioUri = this.options.model.get('audioUri');
-            var appId = this.model.collection.appId;
+            var imageUri = this.options.model.get('imageUri'),
+                audioUri = this.options.model.get('audioUri'),
+                appId = this.model.collection.appId,
+                queryDict = hqImport("cloudcare/js/formplayer/utils/util").getSavedQuery();
             return {
                 imageUrl: imageUri ? FormplayerFrontend.getChannel().request('resourceMap', imageUri, appId) : "",
                 audioUrl: audioUri ? FormplayerFrontend.getChannel().request('resourceMap', audioUri, appId) : "",
+                initialValue: queryDict[this.options.model.get('id')] || '',
             };
         },
     });
@@ -50,6 +52,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             fields.each(function (index) {
                 this.value = '';
             });
+            hqImport("cloudcare/js/formplayer/utils/util").saveQuery({});
         },
 
         submitAction: function (e) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -47,9 +47,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             'click @ui.submitButton': 'submitAction',
         },
 
-        clearAction: function (e) {
+        clearAction: function () {
             var fields = $(".query-field");
-            fields.each(function (index) {
+            fields.each(function () {
                 this.value = '';
             });
             hqImport("cloudcare/js/formplayer/utils/util").saveQuery({});

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -51,6 +51,8 @@ hqDefine("cloudcare/js/formplayer/router", function () {
                 // We can't do any menu navigation without an appId
                 FormplayerFrontend.trigger("apps:list");
             } else {
+                urlObject.setSearch(Util.getSavedSearch());
+                Util.setUrlToObject(urlObject);
                 menusController.selectMenu(urlObject);
             }
         },
@@ -170,6 +172,7 @@ hqDefine("cloudcare/js/formplayer/router", function () {
     FormplayerFrontend.on("menu:search", function (search) {
         var urlObject = Util.currentUrlToObject();
         urlObject.setSearch(search);
+        Util.saveSearch(search);
         Util.setUrlToObject(urlObject);
         API.listMenus();
     });
@@ -177,6 +180,7 @@ hqDefine("cloudcare/js/formplayer/router", function () {
     FormplayerFrontend.on("menu:query", function (queryDict) {
         var urlObject = Util.currentUrlToObject();
         urlObject.setQuery(queryDict);
+        Util.saveQuery(queryDict);
         Util.setUrlToObject(urlObject);
         API.listMenus();
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -51,7 +51,7 @@ hqDefine("cloudcare/js/formplayer/router", function () {
                 // We can't do any menu navigation without an appId
                 FormplayerFrontend.trigger("apps:list");
             } else {
-                urlObject.setSearch(Util.getSavedSearch());
+                urlObject.setSearch(Util.getSavedSearch() || urlObject.search);
                 Util.setUrlToObject(urlObject);
                 menusController.selectMenu(urlObject);
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/integration_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/integration_spec.js
@@ -48,6 +48,7 @@ describe('FormplayerFrontend Integration', function () {
             newOptions.phoneMode = true;
             newOptions.oneQuestionPerScreen = true;
             newOptions.language = 'sindarin';
+            newOptions.stickySearches = true;
 
             FormplayerFrontend.start(newOptions);
 
@@ -64,6 +65,7 @@ describe('FormplayerFrontend Integration', function () {
                 landingPageAppMode: undefined,
                 oneQuestionPerScreen: true,
                 language: 'sindarin',
+                stickySearches: true,
             });
         });
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
@@ -89,6 +89,7 @@ hqDefine("cloudcare/js/formplayer/users/views", function () {
             next: '.js-user-next',
             prev: '.js-user-previous',
             search: '.js-user-search',
+            clear: '.js-user-clear',
             query: '.js-user-query',
             page: '.js-page',
         },
@@ -97,6 +98,7 @@ hqDefine("cloudcare/js/formplayer/users/views", function () {
             'click @ui.prev': 'onClickPrev',
             'click @ui.page': 'onClickPage',
             'submit @ui.search': 'onSubmitUserSearch',
+            'click @ui.clear': 'onClearUserSearch',
         },
         templateContext: function () {
             return {
@@ -157,6 +159,11 @@ hqDefine("cloudcare/js/formplayer/users/views", function () {
                 'query': this.ui.query.val(),
                 'page': 1,  // Reset page to one when doing a query
             });
+        },
+        onClearUserSearch: function (e) {
+            e.preventDefault();
+            this.ui.query.val('');
+            this.ui.query.focus();
         },
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -151,7 +151,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             this.steps.push(step);
             //clear out pagination and search when we take a step
             this.page = null;
-            this.search = null;
+            this.clearSearch();
         };
 
         this.setPage = function (page) {
@@ -169,6 +169,13 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             this.sortIndex = null;
         };
 
+        this.clearSearch = function () {
+            var user = hqImport("cloudcare/js/formplayer/app").getChannel().request('currentUser');
+            if (!user.displayOptions.stickySearches) {
+                this.search = null;
+            }
+        }
+
         this.setQuery = function (queryDict) {
             this.queryDict = queryDict;
         };
@@ -178,14 +185,14 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             this.steps = null;
             this.page = null;
             this.sortIndex = null;
-            this.search = null;
+            this.clearSearch();
             this.queryDict = null;
         };
 
         this.onSubmit = function () {
             this.page = null;
             this.sortIndex = null;
-            this.search = null;
+            this.clearSearch();
             this.queryDict = null;
         };
 
@@ -199,7 +206,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
                 this.steps = this.steps.splice(0, index);
             }
             this.page = null;
-            this.search = null;
+            this.clearSearch();
             this.queryDict = null;
             this.sortIndex = null;
         };

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -151,7 +151,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             this.steps.push(step);
             //clear out pagination and search when we take a step
             this.page = null;
-            //this.search = null;
+            this.search = null;
         };
 
         this.setPage = function (page) {
@@ -161,7 +161,6 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
         this.setSort = function (sortIndex) {
             this.sortIndex = sortIndex;
         };
-
 
         this.setSearch = function (search) {
             this.search = search;
@@ -179,14 +178,14 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             this.steps = null;
             this.page = null;
             this.sortIndex = null;
-            //this.search = null;
+            this.search = null;
             this.queryDict = null;
         };
 
         this.onSubmit = function () {
             this.page = null;
             this.sortIndex = null;
-            //this.search = null;
+            this.search = null;
             this.queryDict = null;
         };
 
@@ -200,7 +199,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
                 this.steps = this.steps.splice(0, index);
             }
             this.page = null;
-            //this.search = null;
+            this.search = null;
             this.queryDict = null;
             this.sortIndex = null;
         };
@@ -241,11 +240,26 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
     };
 
     // Saved query handling
-    var savedQueries = {},
+    var savedSearches = {},     // text search for case lists
+        savedQueries = {},      // case claim
         bell = "\u0007";
     function stepsKey() {
         var urlObject = Util.currentUrlToObject();
+        if (!urlObject.steps) {
+            return "";
+        }
         return urlObject.steps.join(bell);
+    };
+
+    Util.saveSearch = function (query) {
+        savedSearches[stepsKey()] = query;
+    };
+
+    Util.getSavedSearch = function () {
+        var user = hqImport("cloudcare/js/formplayer/app").getChannel().request('currentUser');
+        if (user.displayOptions.stickySearches) {
+            return savedSearches[stepsKey()] || "";
+        }
     };
 
     Util.saveQuery = function (query) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -253,7 +253,11 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
     };
 
     Util.getSavedQuery = function () {
-        return savedQueries[stepsKey()] || {};
+        var user = hqImport("cloudcare/js/formplayer/app").getChannel().request('currentUser');
+        if (user.displayOptions.stickySearches) {
+            return savedQueries[stepsKey()] || {};
+        }
+        return {};
     };
 
     // String polyfills

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -151,7 +151,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             this.steps.push(step);
             //clear out pagination and search when we take a step
             this.page = null;
-            this.search = null;
+            //this.search = null;
         };
 
         this.setPage = function (page) {
@@ -179,14 +179,14 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             this.steps = null;
             this.page = null;
             this.sortIndex = null;
-            this.search = null;
+            //this.search = null;
             this.queryDict = null;
         };
 
         this.onSubmit = function () {
             this.page = null;
             this.sortIndex = null;
-            this.search = null;
+            //this.search = null;
             this.queryDict = null;
         };
 
@@ -200,7 +200,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
                 this.steps = this.steps.splice(0, index);
             }
             this.page = null;
-            this.search = null;
+            //this.search = null;
             this.queryDict = null;
             this.sortIndex = null;
         };
@@ -240,6 +240,23 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
         return new Util.CloudcareUrl(options);
     };
 
+    // Saved query handling
+    var savedQueries = {},
+        bell = "\u0007";
+    function stepsKey() {
+        var urlObject = Util.currentUrlToObject();
+        return urlObject.steps.join(bell);
+    };
+
+    Util.saveQuery = function (query) {
+        savedQueries[stepsKey()] = query;
+    };
+
+    Util.getSavedQuery = function () {
+        return savedQueries[stepsKey()] || {};
+    };
+
+    // String polyfills
     if (!String.prototype.startsWith) {
         String.prototype.startsWith = function (searchString, position) {
             position = position || 0;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -249,7 +249,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             return "";
         }
         return urlObject.steps.join(bell);
-    };
+    }
 
     Util.saveSearch = function (query) {
         savedSearches[stepsKey()] = query;

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -13,6 +13,9 @@
           <button class="btn btn-default" type="button" id="case-list-search-button">
             <i class="fa fa-search" aria-hidden="true"></i>
           </button>
+          <button class="btn btn-default" type="button" id="case-list-clear-button">
+            <i class="fa fa-times" aria-hidden="true"></i>
+          </button>
         </div>
       </div>
     </div>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -22,6 +22,6 @@
     <div><%- text ? text : "" %></div>
   </td>
   <td class="col-sm-2">
-    <input type="text" class="query-field form-control">
+    <input type="text" class="query-field form-control" value="<%- initialValue %>" />
   </td>
 </script>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -8,7 +8,10 @@
       <tbody>
       </tbody>
     </table>
-    <button class="btn btn-default" type="submit" id="query-submit-button">
+    <button class="btn btn-default" type="button" id="query-clear-button">
+      <div>{% trans "Clear" %}</div>
+    </button>
+    <button class="btn btn-primary" type="submit" id="query-submit-button">
       <div>{% trans "Submit" %}</div>
     </button>
   </form>

--- a/corehq/apps/cloudcare/templates/formplayer/settings_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/settings_view.html
@@ -21,6 +21,10 @@
   <th>{% trans "Use one question per screen" %}</th>
   <td><input class="js-one-question-per-screen" type="checkbox" data-size="mini" /></td>
 </script>
+<script type="text/template" id="sticky-searches-setting-template">
+  <th>{% trans "Save search results" %}</th>
+  <td><input class="js-sticky-searches" type="checkbox" data-size="mini" /></td>
+</script>
 <script type="text/template" id="lang-setting-template">
   <th>{% trans "Set the application language" %}</th>
   <td>

--- a/corehq/apps/cloudcare/templates/formplayer/users.html
+++ b/corehq/apps/cloudcare/templates/formplayer/users.html
@@ -17,6 +17,9 @@
           <button class="btn btn-default" type="submit">
             <i class="fa fa-search" aria-hidden="true"></i>
           </button>
+          <button class="btn btn-default js-user-clear" type="button">
+            <i class="fa fa-times" aria-hidden="true"></i>
+          </button>
         </div>
       </div>
     </form>

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -738,6 +738,14 @@ ROLE_WEBAPPS_PERMISSIONS = StaticToggle(
 )
 
 
+WEBAPPS_STICKY_SEARCH = StaticToggle(
+    'webapps_sticky_search',
+    'In Web Apps, save user\'s most recent search parameters.',
+    TAG_PRODUCT,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
+
 SYNC_SEARCH_CASE_CLAIM = StaticToggle(
     'search_claim',
     'Enable synchronous mobile searching and case claiming',


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-71

## Product Description
Adds setting to web apps & app preview that will cause case list searches & case claim searches to be saved. Searches are saved per menu, so if you search "foo" in one case list and then go to another, the second case list won't have a search, but when you go back to the first case list, you'll again see "foo."

Since searches can contain sensitive data, they're not stored anywhere "real", only in running code. This means the stickiness only lasts until the user refreshes the page or leaves web apps.

![Screen Shot 2020-11-27 at 9 03 18 PM](https://user-images.githubusercontent.com/1486591/100491802-997a1380-30f4-11eb-8fa2-a89c329eabe4.png)

Also adds a "Clear" button to case claim:
![Screen Shot 2020-11-27 at 9 03 08 PM](https://user-images.githubusercontent.com/1486591/100491794-9121d880-30f4-11eb-94d5-4820df48adb8.png)

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

Just the one test that's updated in this PR.

### QA Plan

Will request QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
