### PR TITLE
add 'natural_key' to blob meta

### DIFF
--- a/corehq/blobs/models.py
+++ b/corehq/blobs/models.py
@@ -120,6 +120,11 @@ class BlobMeta(PartitionedModel, Model):
         with self.open() as fileobj:
             return get_content_md5(fileobj)
 
+    def natural_key(self):
+        # necessary for dumping models from a sharded DB so that we exclude the
+        # SQL 'id' field which won't be unique across all the DB's
+        return self.key
+
 
 class DeletedBlobMeta(PartitionedModel, Model):
     """Metadata about a non-temporary object deleted from the blob db


### PR DESCRIPTION
## Summary
This is needed when dumping blob meta to prevent primary key
collisions when re-loading the data. This is safe since
BlobMeta is not referenced by anywhere by it's primary key.

See https://docs.djangoproject.com/en/3.1/topics/serialization/#serialization-of-natural-keys for more info on natural keys.

## Safety Assurance
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
Covered by existing tests in the `blobs` app and the `dump_reload` app.

### Safety story
Addition of a single method to the class which is not used outside of model serialization (which only happens when running the `dump_domain_data` management command).

### Rollback instructions
- [X] This PR can be reverted after deploy with no further considerations 
