### PR TITLE
Disable Submit button and autosubmit the form when the backend says so

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -222,6 +222,7 @@ hqDefine("cloudcare/js/form_entry/fullform-ui", function () {
         self.currentIndex = ko.observable("0");
         self.atLastIndex = ko.observable(false);
         self.atFirstIndex = ko.observable(true);
+        self.shouldAutoSubmit = json.shouldAutoSubmit;
 
         var _updateIndexCallback = function (ix, isAtFirstIndex, isAtLastIndex) {
             self.currentIndex(ix.toString());
@@ -298,7 +299,7 @@ hqDefine("cloudcare/js/form_entry/fullform-ui", function () {
         });
 
         self.showSubmitButton = ko.computed(function () {
-            return !self.showInFormNavigation();
+            return !self.showInFormNavigation() && !self.shouldAutoSubmit;
         });
 
         self.submitForm = function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -511,6 +511,9 @@ hqDefine("cloudcare/js/form_entry/webformsession", function () {
             var self = this;
             self.session_id = self.session_id || resp.session_id;
             self.form = Utils.initialRender(resp, self.resourceMap, $form);
+            if (resp.shouldAutoSubmit) {
+                self.submitForm(self.form);
+            }
         };
 
         // Initialize


### PR DESCRIPTION
@calellowitz @orangejenny 

## Summary

Implements front-side change of https://dimagi-dev.atlassian.net/browse/USH-480 
Corresponding formplayer URL - https://github.com/dimagi/formplayer/pull/786/files

When formplayer detects that a form should be automatically submitted, the front-end disables the Submit button and then submits the form automatically.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

QA plan to be developed

### Safety story

This should only kick in in advanced forms with special itext keys.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
