### PR TITLE
keep default behaviour for test

### DIFF
--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -760,7 +760,8 @@ class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):
         )['messages']['rows']
         self.assertEqual(rows[0]['flag'], "'password' values must be unique")
 
-    def test_weak_password(self):
+    @patch('corehq.apps.domain.forms.has_custom_clean_password', return_value=False)
+    def test_weak_password(self, _):
         updated_user_spec = deepcopy(self.user_specs[0])
         updated_user_spec["password"] = '123'
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Fixes build failure as seen in https://travis-ci.com/github/dimagi/commcare-hq/jobs/455788684
I believe this failure was not caught in the original PR https://github.com/dimagi/commcare-hq/pull/28786/files because ICDS changes were merged after this was merged, and hence they both were not tested together.
This PR updates the test to keep the default HQ behavior when checking for passwords.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
