### PR TITLE
Fix calendar appearing on clicking help text

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -321,6 +321,7 @@ hqDefine("cloudcare/js/form_entry/fullform-ui", function () {
 
         self.afterRender = function () {
             $(document).on("click", ".help-text-trigger", function (event) {
+                event.preventDefault();
                 var container = $(event.currentTarget).closest(".caption");
                 container.find(".modal").modal('show');
             });

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -139,10 +139,7 @@
                 <p align="left" data-bind="text: help"></p>
               </div>
               <div class="modal-footer">
-                <!-- This needs to be a <span> instead of a <button> because (inexplicably) making it
-                a button causes it to get clicked automatically when the modal opens, thus closing
-                the modal immediately after it opens. We have yet to figure out why this is so. -->
-                <span class="btn btn-default help-modal-close" data-dismiss="modal">{% trans "Close" %}</span>
+                <button class="btn btn-default help-modal-close" data-dismiss="modal">{% trans "Close" %}</button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Fixes an issue coming in webapps where when we click on help text the calendar used to appear as well.
https://dimagi-dev.atlassian.net/browse/SAAS-11570
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

It is a small JS change and has been tested on local and staging envs and no issues were observed in the testing.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Changes have been tested on local and on staging, [Link to staging](https://staging.commcarehq.org/a/ap-test-project/cloudcare/apps/v2/#%7B%22appId%22%3A%227b71a2a377124be8bc8389a4656f0ca5%22%2C%22copyOf%22%3A%2270920c6ee9136f4fc99dd5ca57f5cfe9%22%2C%22steps%22%3A%5B0%2C0%5D%2C%22page%22%3Anull%2C%22search%22%3Anull%7D)
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
