### PR TITLE
Drop unused payload generator result handlers

### DIFF
--- a/corehq/motech/repeaters/management/commands/update_cancelled_records.py
+++ b/corehq/motech/repeaters/management/commands/update_cancelled_records.py
@@ -144,10 +144,4 @@ class Command(BaseCommand):
             succeeded=True,
         )
         record.add_attempt(success_attempt)
-
-        mock_response = MagicMock()
-        mock_response.status_code = response_status
-        repeater = record.repeater
-        repeater.generator.handle_success(mock_response, repeater.payload_doc(record), record)
-
         record.save()

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -411,13 +411,10 @@ class Repeater(QuickCachedDocumentMixin, Document):
         """
         if isinstance(result, Exception):
             attempt = repeat_record.handle_exception(result)
-            self.generator.handle_exception(result, repeat_record)
         elif _is_response(result) and 200 <= result.status_code < 300 or result is True:
             attempt = repeat_record.handle_success(result)
-            self.generator.handle_success(result, self.payload_doc(repeat_record), repeat_record)
         else:
             attempt = repeat_record.handle_failure(result)
-            self.generator.handle_failure(result, self.payload_doc(repeat_record), repeat_record)
         return attempt
 
     @property

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -65,25 +65,6 @@ class BasePayloadGenerator(object):
             "</data>" % datetime.utcnow()
         )
 
-    def handle_success(self, response, payload_doc, repeat_record):
-        """handle a successful post
-
-        e.g. could be used to store something to the payload_doc once a
-        response is recieved
-
-        """
-        return True
-
-    def handle_failure(self, response, payload_doc, repeat_record):
-        """handle a failed post
-        """
-        return True
-
-    def handle_exception(self, exception, repeat_record):
-        """handle an exception
-        """
-        return True
-
 
 FormatInfo = namedtuple('FormatInfo', 'name label generator_class')
 


### PR DESCRIPTION
## Summary

These methods look like they'd be super useful, but they have not been used in four years. Complex integrations, e.g. ones that follow workflows like OpenMRS or DHIS2, do update cases based on responses, but they do that in the context of sending the payload, not in handling a single response.

YAGNI

(Motivation: Dropping these methods simplifies a possible future (WIP) refactor.)

## Feature Flag
N/A

## Product Description
N/A

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
These methods were not covered by tests

### QA Plan
N/A

### Safety story
None of the fourteen subclasses of this class implement these noop methods. It is safe to remove them.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
