### PR TITLE
Add translation to "Case Claim"

### DIFF
--- a/corehq/apps/api/data/default/app_strings.txt
+++ b/corehq/apps/api/data/default/app_strings.txt
@@ -26,6 +26,7 @@ case.date.opened=Date Opened
 case.id=ID
 case.name=Name
 case.status=Currently Open
+case.search.title=Case Claim
 case_lists.m2=Sub Case One Cases
 case_lists.m3=Cases
 cchq.case=Case

--- a/corehq/apps/api/data/en/app_strings.txt
+++ b/corehq/apps/api/data/en/app_strings.txt
@@ -25,6 +25,7 @@ button.No=NO
 case.date.opened=Date Opened
 case.id=ID
 case.name=Name
+case.search.title=Case Claim
 case.status=Currently Open
 case_lists.m2=Sub Case One Cases
 case_lists.m3=Cases


### PR DESCRIPTION
## Summary
No formal ticket but here's the doc: https://docs.google.com/document/d/1hhOcFFJiLeiXb1wY9Tg8W160tFz2J8qCRB9_AgqhtgI/edit
(includes a pic of the screen where the "Case Claim" title is)

Goes along with this [PR](https://github.com/dimagi/commcare-core/compare/smh/case-claim-translation?expand=1)

## Feature Flag
Case claim

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I am certain that this PR will not introduce a regression for the reasons below

### QA Plan
No QA but I was able to test locally.

### Safety story
 Along with other changes, I was able to changes "Case Claim" and change it back successfully. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
