### PR TITLE
only dump TransifexOrganization once

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -135,7 +135,7 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('case_importer.CaseUploadRecord', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('translations.SMSTranslations', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('translations.TransifexBlacklist', SimpleFilter('domain')),
-    FilteredModelIteratorBuilder('translations.TransifexOrganization', SimpleFilter('transifexproject__domain')),
+    UniqueFilteredModelIteratorBuilder('translations.TransifexOrganization', SimpleFilter('transifexproject__domain')),
     FilteredModelIteratorBuilder('translations.TransifexProject', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('zapier.ZapierSubscription', SimpleFilter('domain')),
 ]]

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -627,7 +627,10 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
         TransifexProject.objects.create(
             organization=org, slug='testp', name='demop', domain=self.domain_name
         )
-        self._dump_and_load(Counter({TransifexOrganization: 1, TransifexProject: 1}))
+        TransifexProject.objects.create(
+            organization=org, slug='testp1', name='demop1', domain=self.domain_name
+        )
+        self._dump_and_load(Counter({TransifexOrganization: 1, TransifexProject: 2}))
 
     def test_filtered_dump_load(self):
         from corehq.apps.locations.tests.test_location_types import make_loc_type


### PR DESCRIPTION
## Summary
Because of how the filtering is done with a join on `TransifexProject` the `TransifexOrganization` get's dumped once for each `TransifexProject`.

## Safety Assurance
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
Unit tests update

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
