### PR TITLE
Add JS Dependencies to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   open-pull-requests-limit: 5
   labels:
   - product/invisible
-- package-ecosystem: yarn
+- package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,12 @@ updates:
   open-pull-requests-limit: 5
   labels:
   - product/invisible
+- package-ecosystem: yarn
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 5
+  labels:
+  - product/invisible
+  - dependencies/javascript

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -67,6 +67,9 @@ labels:
 - name: 'dependencies'
   color: navy
   description: 'Pull requests that update a dependency file'
+- name: 'dependencies/javascript'
+  color: grey
+  description: 'Change in javascript dependency.'
 - name: 'awaiting QA'
   color: light_orange
   description: 'QA in progress. Do not merge'


### PR DESCRIPTION
## Summary
- adds js dependencies to dependabot
- adds new dependencies/javascript label so that we can differentiate between js and python PRs 

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Safety story
dependabot config only

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
