### PR TITLE
revert greenlet back to 0.4.15 from 0.4.17 due to segfault

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -7,6 +7,7 @@
 alabaster==0.7.12         # via sphinx
 alembic==1.4.3            # via -r requirements.in
 amqp==2.6.1               # via kombu
+appnope==0.1.2            # via ipython
 architect==0.5.6          # via -r requirements.in
 argparse==1.4.0           # via unittest2
 attrs==18.2.0             # via -r requirements.in
@@ -93,7 +94,7 @@ gipc==1.1.0               # via -r requirements.in
 git-build-branch==0.1.9   # via -r dev-requirements.in
 gnureadline==6.3.8        # via -r dev-requirements.in
 graphviz==0.14.2          # via -r dev-requirements.in
-greenlet==0.4.17          # via -r requirements.in, django-websocket-redis, gevent
+greenlet==0.4.15          # via -r requirements.in, django-websocket-redis, gevent
 gunicorn==20.0.4          # via -r requirements.in
 hiredis==1.1.0            # via -r requirements.in
 html5lib==1.1             # via weasyprint

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -6,6 +6,7 @@
 #
 alembic==1.4.3            # via -r requirements.in
 amqp==2.6.1               # via kombu
+appnope==0.1.2            # via ipython
 architect==0.5.6          # via -r requirements.in
 attrs==18.2.0             # via -r requirements.in
 babel==2.8.0              # via django-phonenumber-field, flower
@@ -75,7 +76,7 @@ flower==0.9.2             # via -r prod-requirements.in
 gevent==1.4.0             # via -r requirements.in, django-websocket-redis, gipc
 ghdiff==0.4               # via -r requirements.in
 gipc==1.1.0               # via -r requirements.in
-greenlet==0.4.17          # via -r requirements.in, django-websocket-redis, gevent
+greenlet==0.4.15          # via -r requirements.in, django-websocket-redis, gevent
 gunicorn==20.0.4          # via -r requirements.in
 hiredis==1.1.0            # via -r requirements.in
 html5lib==1.1             # via weasyprint

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -53,7 +53,7 @@ Faker==0.8.15
 gevent==1.4.0
 ghdiff==0.4
 gipc~=1.1.0  # for gevent+multiprocessing, used by Couch to SQL migration
-greenlet==0.4.17
+greenlet==0.4.15
 gunicorn
 hiredis==1.1.0
 httpagentparser~=1.7

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -72,7 +72,7 @@ faker==0.8.15             # via -r requirements.in
 gevent==1.4.0             # via -r requirements.in, django-websocket-redis, gipc
 ghdiff==0.4               # via -r requirements.in
 gipc==1.1.0               # via -r requirements.in
-greenlet==0.4.17          # via -r requirements.in, django-websocket-redis, gevent
+greenlet==0.4.15          # via -r requirements.in, django-websocket-redis, gevent
 gunicorn==20.0.4          # via -r requirements.in
 hiredis==1.1.0            # via -r requirements.in
 html5lib==1.1             # via weasyprint

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -80,7 +80,7 @@ freezegun==0.3.15         # via -r test-requirements.in
 gevent==1.4.0             # via -r requirements.in, django-websocket-redis, gipc
 ghdiff==0.4               # via -r requirements.in
 gipc==1.1.0               # via -r requirements.in
-greenlet==0.4.17          # via -r requirements.in, django-websocket-redis, gevent
+greenlet==0.4.15          # via -r requirements.in, django-websocket-redis, gevent
 gunicorn==20.0.4          # via -r requirements.in
 hiredis==1.1.0            # via -r requirements.in
 html5lib==1.1             # via weasyprint


### PR DESCRIPTION
## Summary
manually reverting https://github.com/dimagi/commcare-hq/pull/28763
causing the following error when running `sync_couch_views`
```
/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: greenlet.greenlet size changed, may indicate binary incompatibility. Expected 144 from C header, got 152 from PyObject
  return f(*args, **kwds)
/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: greenlet.greenlet size changed, may indicate binary incompatibility. Expected 144 from C header, got 152 from PyObject
  return f(*args, **kwds)
/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: greenlet.greenlet size changed, may indicate binary incompatibility. Expected 144 from C header, got 152 from PyObject
  return f(*args, **kwds)
/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: greenlet.greenlet size changed, may indicate binary incompatibility. Expected 144 from C header, got 152 from PyObject
  return f(*args, **kwds)
/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: greenlet.greenlet size changed, may indicate binary incompatibility. Expected 144 from C header, got 152 from PyObject
  return f(*args, **kwds)
/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: greenlet.greenlet size changed, may indicate binary incompatibility. Expected 144 from C header, got 152 from PyObject
  return f(*args, **kwds)
/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: greenlet.greenlet size changed, may indicate binary incompatibility. Expected 144 from C header, got 152 from PyObject
  return f(*args, **kwds)
/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: greenlet.greenlet size changed, may indicate binary incompatibility. Expected 144 from C header, got 152 from PyObject
  return f(*args, **kwds)
/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: greenlet.greenlet size changed, may indicate binary incompatibility. Expected 144 from C header, got 152 from PyObject
  return f(*args, **kwds)
/Users/biyeun/.virtualenvs/hq/lib/python3.7/site-packages/kombu/utils/functional.py:8: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
  from collections import Iterable, Mapping, OrderedDict
/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/_bootstrap.py:219: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  return f(*args, **kwds)
/Users/biyeun/.virtualenvs/hq/lib/python3.7/site-packages/celery/utils/text.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
  from collections import Callable
/Users/biyeun/.virtualenvs/hq/lib/python3.7/site-packages/celery/utils/imports.py:5: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp as _imp
/Users/biyeun/.virtualenvs/hq/lib/python3.7/site-packages/celery/utils/collections.py:7: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
  from collections import Callable, Mapping, MutableMapping, MutableSet
/Users/biyeun/.virtualenvs/hq/lib/python3.7/site-packages/celery/utils/collections.py:9: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
  from collections import Sequence, deque
/Users/biyeun/.virtualenvs/hq/lib/python3.7/site-packages/celery/canvas.py:13: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
  from collections import MutableSequence, deque
/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/_bootstrap_external.py:525: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/biyeun/Code/hq/src/main_couch_sql_datamigration.log' mode='a' encoding='UTF-8'>
  code = marshal.loads(data)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: greenlet.greenlet size changed, may indicate binary incompatibility. Expected 144 from C header, got 152 from PyObject
  return f(*args, **kwds)
Segmentation fault: 11
```

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Safety story
this is a rollback to a known working version and should be done ASAP
