### PR TITLE
allow running migrations test in isolation

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -54,7 +54,7 @@ function run_tests() {
     now=`date +%s`
     su cchq -c "../run_tests $TEST $(printf " %q" "$@")"
     [ "$TEST" == "python-sharded-and-javascript" ] && scripts/test-make-requirements.sh
-    [ "$TEST" == "python-sharded-and-javascript" ] && scripts/test-django-migrations.sh
+    [ "$TEST" == "python-sharded-and-javascript" -o "$TEST_MIGRATIONS" ] && scripts/test-django-migrations.sh
     delta=$((`date +%s` - $now))
 
     send_timing_metric_to_datadog "tests" $delta


### PR DESCRIPTION
## Summary
Used by ICDS repo build: https://github.com/dimagi/commcare-icds/pull/161

## Safety Assurance
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
