### PR TITLE
draw progress bar at start of iteration

### DIFF
--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -290,6 +290,7 @@ def with_progress_bar(iterable, length=None, prefix='Processing', oneline=True,
     should_update = step_calculator(length, granularity)
     i = 0
     try:
+        draw(i)
         for i, x in enumerate(iterable, start=1):
             yield x
             if should_update(i):


### PR DESCRIPTION
## Summary
Draw the progress bar before iteration starts so that it's present for the start instead of only showing up after the first tick.

## Safety Assurance
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Safety story
only used in management commands

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
