### PR TITLE
add reporting DB mapping to citus regardless of whether or not ICDS code is present

### DIFF
--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -244,6 +244,7 @@ REPORTING_DATABASES = {
     'default': 'default',
     'ucr': 'default',
     'aaa-data': 'default',
+    'icds-ucr-citus': 'icds-ucr'
 }
 
 if os.path.exists("extensions/icds/custom/icds"):
@@ -255,7 +256,6 @@ if os.path.exists("extensions/icds/custom/icds"):
     )
     COMMCARE_EXTENSIONS = ["custom.icds.commcare_extensions"]
 
-    REPORTING_DATABASES['icds-ucr-citus'] = 'icds-ucr'
     LOCAL_CUSTOM_DB_ROUTING = {
         "icds_reports": "icds-ucr-citus"
     }


### PR DESCRIPTION
## Summary
This test (https://github.com/dimagi/commcare-hq/blob/ea21ce9bf54bef5807d27d56565e856826e7c1a9/corehq/apps/userreports/tests/test_data_source_citus.py#L17) depends on the mapping being present.

## Safety Assurance
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Rollback instructions
- [X] This PR can be reverted after deploy with no further considerations 
