### PR TITLE
Add a link to view the data source

### DIFF
--- a/corehq/apps/userreports/templates/userreports/edit_report_config.html
+++ b/corehq/apps/userreports/templates/userreports/edit_report_config.html
@@ -13,6 +13,9 @@
           <a href="{% url 'configurable' domain report.get_id %}" class="btn btn-default">{% trans 'View Report' %}</a>
         </div>
         <div class="btn-group">
+          <a href="{% url 'edit_configurable_data_source' domain report.config_id %}" class="btn btn-default">{% trans 'View Data Source' %}</a>
+        </div>
+        <div class="btn-group">
           <a href="{% url 'configurable_report_json' domain report.get_id %}"
              class="btn btn-default track-usage-link"
              data-category="UCR"


### PR DESCRIPTION
## Summary

I'm always mildly annoyed at matching the string from the `config_id` field to the data sources on the sidebar, especially when there are duplicates, so I added a link:

![image](https://user-images.githubusercontent.com/2367539/101937859-69307b80-3bb0-11eb-93bf-f442608747e4.png)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
It's just a link, so worst case scenario, it leads nowhere.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
