### PR TITLE
Clean up some Repeat Record Report code

### DIFF
--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -216,16 +216,16 @@ def delete_old_rule_submission_logs():
 
 
 @task(serializer='pickle')
-def task_operate_on_payloads(payload_ids, domain, action=''):
+def task_operate_on_payloads(record_ids, domain, action=''):
     task = task_operate_on_payloads
 
-    if not payload_ids:
+    if not record_ids:
         return {'messages': {'errors': [_('No Payloads are supplied')]}}
 
     if not action:
         return {'messages': {'errors': [_('No action specified')]}}
 
-    response = operate_on_payloads(payload_ids, domain, action, task)
+    response = operate_on_payloads(record_ids, domain, action, task)
 
     return response
 

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.core.cache import cache
-from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 
 from celery.schedules import crontab
@@ -12,18 +11,6 @@ from celery.utils.log import get_task_logger
 from dimagi.utils.couch import CriticalSection
 from dimagi.utils.logging import notify_error
 
-from corehq.apps.data_interfaces.models import (
-    AUTO_UPDATE_XMLNS,
-    AutomaticUpdateRule,
-    CaseRuleActionResult,
-    CaseRuleSubmission,
-    DomainCaseRuleRun,
-)
-from corehq.apps.data_interfaces.utils import (
-    add_cases_to_case_group,
-    archive_or_restore_forms,
-    operate_on_payloads,
-)
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
 from corehq.form_processor.interfaces.dbaccessors import (
@@ -38,10 +25,20 @@ from corehq.motech.repeaters.dbaccessors import (
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 from corehq.toggles import DISABLE_CASE_UPDATE_RULE_SCHEDULED_TASK
 from corehq.util.decorators import serial_task
-from corehq.util.log import send_HTML_email
 
-from .dispatcher import EditDataInterfaceDispatcher
-from .interfaces import BulkFormManagementInterface, FormManagementMode
+from .interfaces import FormManagementMode
+from .models import (
+    AUTO_UPDATE_XMLNS,
+    AutomaticUpdateRule,
+    CaseRuleActionResult,
+    CaseRuleSubmission,
+    DomainCaseRuleRun,
+)
+from .utils import (
+    add_cases_to_case_group,
+    archive_or_restore_forms,
+    operate_on_payloads,
+)
 
 logger = get_task_logger('data_interfaces')
 ONE_HOUR = 60 * 60

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -231,15 +231,15 @@ def task_operate_on_payloads(payload_ids, domain, action=''):
 
 
 @task(serializer='pickle')
-def task_generate_ids_and_operate_on_payloads(data, domain, action=''):
+def task_generate_ids_and_operate_on_payloads(query_string_dict, domain, action=''):
     task = task_generate_ids_and_operate_on_payloads
 
-    if not data:
+    if not query_string_dict:
         return {'messages': {'errors': [_('No data is supplied')]}}
 
     if not action:
         return {'messages': {'errors': [_('No action specified')]}}
 
-    response = generate_ids_and_operate_on_payloads(data, domain, action, task)
+    response = generate_ids_and_operate_on_payloads(query_string_dict, domain, action, task)
 
     return response

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -223,10 +223,12 @@ def task_operate_on_payloads(record_ids, domain, action=''):
 
 
 @task(serializer='pickle')
-def task_generate_ids_and_operate_on_payloads(query_string_dict, domain, action=''):
-    payload_id = query_string_dict.get('payload_id') or None
-    repeater_id = query_string_dict.get('repeater') or None
-
+def task_generate_ids_and_operate_on_payloads(
+    payload_id: Optional[str],
+    repeater_id: Optional[str],
+    domain: str,
+    action: str = '',
+) -> dict:
     repeat_record_ids = _get_repeat_record_ids(payload_id, repeater_id, domain)
     return operate_on_payloads(repeat_record_ids, domain, action,
                                task=task_generate_ids_and_operate_on_payloads)

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -220,27 +220,12 @@ def delete_old_rule_submission_logs():
 
 @task(serializer='pickle')
 def task_operate_on_payloads(record_ids, domain, action=''):
-    task = task_operate_on_payloads
-
-    if not record_ids:
-        return {'messages': {'errors': [_('No Payloads are supplied')]}}
-
-    if not action:
-        return {'messages': {'errors': [_('No action specified')]}}
-
-    response = operate_on_payloads(record_ids, domain, action, task)
-
-    return response
+    return operate_on_payloads(record_ids, domain, action,
+                               task=task_operate_on_payloads)
 
 
 @task(serializer='pickle')
 def task_generate_ids_and_operate_on_payloads(query_string_dict, domain, action=''):
-    if not query_string_dict:
-        return {'messages': {'errors': [_('No data is supplied')]}}
-
-    if not action:
-        return {'messages': {'errors': [_('No action specified')]}}
-
     repeat_record_ids = _get_repeat_record_ids(query_string_dict, domain)
     return operate_on_payloads(repeat_record_ids, domain, action,
                                task=task_generate_ids_and_operate_on_payloads)

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -32,8 +32,8 @@ from corehq.form_processor.interfaces.dbaccessors import (
 )
 from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.motech.repeaters.dbaccessors import (
-    _get_startkey_endkey_all_records,
     get_repeat_records_by_payload_id,
+    iter_repeat_records_by_repeater,
 )
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 from corehq.toggles import DISABLE_CASE_UPDATE_RULE_SCHEDULED_TASK
@@ -238,14 +238,7 @@ def _get_repeat_record_ids(query_string_dict, domain):
     if query_string_dict.get('payload_id', None):
         results = get_repeat_records_by_payload_id(domain, query_string_dict['payload_id'])
     else:
-        from corehq.motech.repeaters.models import RepeatRecord
-        kwargs = {
-            'include_docs': True,
-            'reduce': False,
-            'descending': True,
-        }
-        kwargs.update(_get_startkey_endkey_all_records(domain, query_string_dict['repeater']))
-        results = RepeatRecord.get_db().view('repeaters/repeat_records', **kwargs).all()
+        results = iter_repeat_records_by_repeater(domain, query_string_dict['repeater'])
     ids = [x['id'] for x in results]
 
     return ids

--- a/corehq/apps/data_interfaces/tests/test_tasks.py
+++ b/corehq/apps/data_interfaces/tests/test_tasks.py
@@ -1,13 +1,15 @@
-from unittest.mock import patch, Mock
 from unittest.case import TestCase
+from unittest.mock import patch
 
-from corehq.apps.data_interfaces.tasks import task_operate_on_payloads, task_generate_ids_and_operate_on_payloads
+from corehq.apps.data_interfaces.tasks import (
+    task_generate_ids_and_operate_on_payloads,
+    task_operate_on_payloads,
+)
 
 
 class TestTasks(TestCase):
 
-    @patch('corehq.apps.data_interfaces.tasks.operate_on_payloads')
-    def test_task_operate_on_payloads_no_action(self, mock_operate_on_payloads):
+    def test_task_operate_on_payloads_no_action(self):
         response = task_operate_on_payloads(
             record_ids=['payload_id'],
             domain='test_domain',
@@ -15,34 +17,24 @@ class TestTasks(TestCase):
         )
         self.assertEqual(response,
                          {'messages': {'errors': ['No action specified']}})
-        self.assertEqual(mock_operate_on_payloads.call_count, 0)
 
-    @patch('corehq.apps.data_interfaces.tasks.operate_on_payloads')
-    def test_task_operate_on_payloads_no_payload_ids(self, mock_operate_on_payloads):
+    def test_task_operate_on_payloads_no_payload_ids(self):
         response = task_operate_on_payloads(
             record_ids=[],
             domain='test_domain',
             action='test_action'
         )
         self.assertEqual(response,
-                         {'messages': {'errors': ['No Payloads are supplied']}})
-        self.assertEqual(mock_operate_on_payloads.call_count, 0)
+                         {'messages': {'errors': ['No payloads specified']}})
 
-    @patch('corehq.apps.data_interfaces.tasks.operate_on_payloads')
-    @patch('corehq.apps.data_interfaces.tasks.task_operate_on_payloads')
-    def test_task_operate_on_payloads_valid(self, mock_task, mock_operate_on_payloads):
-        task_operate_on_payloads(
-            record_ids=['payload_id'],
-            domain='test_domain',
-            action='test_action',
-        )
-
-        self.assertEqual(mock_operate_on_payloads.call_count, 1)
-        mock_operate_on_payloads.assert_called_with(['payload_id'], 'test_domain', 'test_action', mock_task)
-
-    def test_task_generate_ids_and_operate_on_payloads_no_action(self):
+    @patch('corehq.apps.data_interfaces.tasks._get_repeat_record_ids')
+    def test_task_generate_ids_and_operate_on_payloads_no_action(
+        self,
+        get_repeat_record_ids_mock,
+    ):
+        get_repeat_record_ids_mock.return_value = ['c0ffee', 'deadbeef']
         response = task_generate_ids_and_operate_on_payloads(
-            query_string_dict=['payload_id'],
+            query_string_dict={'payload_id': 'c0ffee'},
             domain='test_domain',
             action=''
         )
@@ -51,9 +43,9 @@ class TestTasks(TestCase):
 
     def test_task_generate_ids_and_operate_on_payloads_no_data(self):
         response = task_generate_ids_and_operate_on_payloads(
-            query_string_dict=[],
+            query_string_dict={},
             domain='test_domain',
             action=''
         )
         self.assertEqual(response,
-                         {'messages': {'errors': ['No data is supplied']}})
+                         {'messages': {'errors': ['No payloads specified']}})

--- a/corehq/apps/data_interfaces/tests/test_tasks.py
+++ b/corehq/apps/data_interfaces/tests/test_tasks.py
@@ -48,7 +48,7 @@ class TestTasks(TestCase):
     def test_task_generate_ids_and_operate_on_payloads_no_action(self, mock_generate_ids):
         with patch('corehq.apps.data_interfaces.tasks._') as _:
             response = task_generate_ids_and_operate_on_payloads(
-                data=['payload_id'],
+                query_string_dict=['payload_id'],
                 domain='test_domain',
                 action=''
             )
@@ -61,7 +61,7 @@ class TestTasks(TestCase):
     def test_task_generate_ids_and_operate_on_payloads_no_data(self, mock_generate_ids):
         with patch('corehq.apps.data_interfaces.tasks._') as _:
             response = task_generate_ids_and_operate_on_payloads(
-                data=[],
+                query_string_dict=[],
                 domain='test_domain',
                 action=''
             )
@@ -73,12 +73,11 @@ class TestTasks(TestCase):
     @patch('corehq.apps.data_interfaces.tasks.generate_ids_and_operate_on_payloads')
     @patch('corehq.apps.data_interfaces.tasks.task_generate_ids_and_operate_on_payloads')
     def test_task_generate_ids_and_operate_on_payloads_valid(self, mock_task, mock_generate_ids):
-        payload = {
-            'data': ['payload_id'],
-            'domain': 'test_domain',
-            'action': 'test_action',
-        }
-        response = task_generate_ids_and_operate_on_payloads(**payload)
+        task_generate_ids_and_operate_on_payloads(
+            query_string_dict=['payload_id'],
+            domain='test_domain',
+            action='test_action',
+        )
 
         self.assertEqual(mock_generate_ids.call_count, 1)
         mock_generate_ids.assert_called_with(['payload_id'], 'test_domain', 'test_action', mock_task)

--- a/corehq/apps/data_interfaces/tests/test_tasks.py
+++ b/corehq/apps/data_interfaces/tests/test_tasks.py
@@ -9,37 +9,33 @@ class TestTasks(TestCase):
     @patch('corehq.apps.data_interfaces.tasks.operate_on_payloads')
     def test_task_operate_on_payloads_no_action(self, mock_operate_on_payloads):
         response = task_operate_on_payloads(
-            payload_ids=['payload_id'],
+            record_ids=['payload_id'],
             domain='test_domain',
             action=''
         )
-        expected_response = {'messages': {'errors': ['No action specified']}}
-
-        self.assertEqual(response, expected_response)
+        self.assertEqual(response,
+                         {'messages': {'errors': ['No action specified']}})
         self.assertEqual(mock_operate_on_payloads.call_count, 0)
 
     @patch('corehq.apps.data_interfaces.tasks.operate_on_payloads')
     def test_task_operate_on_payloads_no_payload_ids(self, mock_operate_on_payloads):
-        with patch('corehq.apps.data_interfaces.tasks._') as _:
-            response = task_operate_on_payloads(
-                payload_ids=[],
-                domain='test_domain',
-                action='test_action'
-            )
-            expected_response = {'messages': {'errors': [_('No Payloads are supplied')]}}
-
-        self.assertEqual(response, expected_response)
+        response = task_operate_on_payloads(
+            record_ids=[],
+            domain='test_domain',
+            action='test_action'
+        )
+        self.assertEqual(response,
+                         {'messages': {'errors': ['No Payloads are supplied']}})
         self.assertEqual(mock_operate_on_payloads.call_count, 0)
 
     @patch('corehq.apps.data_interfaces.tasks.operate_on_payloads')
     @patch('corehq.apps.data_interfaces.tasks.task_operate_on_payloads')
     def test_task_operate_on_payloads_valid(self, mock_task, mock_operate_on_payloads):
-        payload = {
-            'payload_ids': ['payload_id'],
-            'domain': 'test_domain',
-            'action': 'test_action',
-        }
-        response = task_operate_on_payloads(**payload)
+        task_operate_on_payloads(
+            record_ids=['payload_id'],
+            domain='test_domain',
+            action='test_action',
+        )
 
         self.assertEqual(mock_operate_on_payloads.call_count, 1)
         mock_operate_on_payloads.assert_called_with(['payload_id'], 'test_domain', 'test_action', mock_task)

--- a/corehq/apps/data_interfaces/tests/test_tasks.py
+++ b/corehq/apps/data_interfaces/tests/test_tasks.py
@@ -34,7 +34,8 @@ class TestTasks(TestCase):
     ):
         get_repeat_record_ids_mock.return_value = ['c0ffee', 'deadbeef']
         response = task_generate_ids_and_operate_on_payloads(
-            query_string_dict={'payload_id': 'c0ffee'},
+            payload_id='c0ffee',
+            repeater_id=None,
             domain='test_domain',
             action=''
         )
@@ -43,7 +44,8 @@ class TestTasks(TestCase):
 
     def test_task_generate_ids_and_operate_on_payloads_no_data(self):
         response = task_generate_ids_and_operate_on_payloads(
-            query_string_dict={},
+            payload_id=None,
+            repeater_id=None,
             domain='test_domain',
             action=''
         )

--- a/corehq/apps/data_interfaces/tests/test_tasks.py
+++ b/corehq/apps/data_interfaces/tests/test_tasks.py
@@ -40,40 +40,20 @@ class TestTasks(TestCase):
         self.assertEqual(mock_operate_on_payloads.call_count, 1)
         mock_operate_on_payloads.assert_called_with(['payload_id'], 'test_domain', 'test_action', mock_task)
 
-    @patch('corehq.apps.data_interfaces.tasks.generate_ids_and_operate_on_payloads')
-    def test_task_generate_ids_and_operate_on_payloads_no_action(self, mock_generate_ids):
-        with patch('corehq.apps.data_interfaces.tasks._') as _:
-            response = task_generate_ids_and_operate_on_payloads(
-                query_string_dict=['payload_id'],
-                domain='test_domain',
-                action=''
-            )
-            expected_response = {'messages': {'errors': [_('No action specified')]}}
-
-        self.assertEqual(response, expected_response)
-        self.assertEqual(mock_generate_ids.call_count, 0)
-
-    @patch('corehq.apps.data_interfaces.tasks.generate_ids_and_operate_on_payloads')
-    def test_task_generate_ids_and_operate_on_payloads_no_data(self, mock_generate_ids):
-        with patch('corehq.apps.data_interfaces.tasks._') as _:
-            response = task_generate_ids_and_operate_on_payloads(
-                query_string_dict=[],
-                domain='test_domain',
-                action=''
-            )
-            expected_response = {'messages': {'errors': [_('No data is supplied')]}}
-
-        self.assertEqual(response, expected_response)
-        self.assertEqual(mock_generate_ids.call_count, 0)
-
-    @patch('corehq.apps.data_interfaces.tasks.generate_ids_and_operate_on_payloads')
-    @patch('corehq.apps.data_interfaces.tasks.task_generate_ids_and_operate_on_payloads')
-    def test_task_generate_ids_and_operate_on_payloads_valid(self, mock_task, mock_generate_ids):
-        task_generate_ids_and_operate_on_payloads(
+    def test_task_generate_ids_and_operate_on_payloads_no_action(self):
+        response = task_generate_ids_and_operate_on_payloads(
             query_string_dict=['payload_id'],
             domain='test_domain',
-            action='test_action',
+            action=''
         )
+        self.assertEqual(response,
+                         {'messages': {'errors': ['No action specified']}})
 
-        self.assertEqual(mock_generate_ids.call_count, 1)
-        mock_generate_ids.assert_called_with(['payload_id'], 'test_domain', 'test_action', mock_task)
+    def test_task_generate_ids_and_operate_on_payloads_no_data(self):
+        response = task_generate_ids_and_operate_on_payloads(
+            query_string_dict=[],
+            domain='test_domain',
+            action=''
+        )
+        self.assertEqual(response,
+                         {'messages': {'errors': ['No data is supplied']}})

--- a/corehq/apps/data_interfaces/tests/test_utils.py
+++ b/corehq/apps/data_interfaces/tests/test_utils.py
@@ -91,9 +91,9 @@ class TestTasks(TestCase):
 
         mock__get_ids.assert_called_once()
         mock__get_ids.assert_called_with(mock_payload, 'test_domain')
-        self.mock_payload_ids = mock__get_ids(mock_payload, 'test_domain')
+        mock_record_ids = mock__get_ids(mock_payload, 'test_domain')
         mock_operate_on_payloads.assert_called_once()
-        mock_operate_on_payloads.assert_called_with(self.mock_payload_ids, 'test_domain', 'test_action',
+        mock_operate_on_payloads.assert_called_with(mock_record_ids, 'test_domain', 'test_action',
                                                     task=task_generate_ids_and_operate_on_payloads)
 
     @patch('corehq.apps.data_interfaces.utils.DownloadBase')
@@ -249,8 +249,6 @@ class TestTasks(TestCase):
     @patch('corehq.apps.data_interfaces.utils.DownloadBase')
     @patch('corehq.apps.data_interfaces.utils._validate_record')
     def test_operate_on_payloads_no_task_from_excel_true_requeue(self, mock__validate_record, mock_DownloadBase):
-        mock_payload_one, self.mock_payload_two = Mock(id='id_1'), Mock(id='id_2')
-        self.mock_payload_ids = [mock_payload_one.id, self.mock_payload_two.id]
         mock__validate_record.side_effect = [self.mock_payload_one, None]
 
         with patch('corehq.apps.data_interfaces.utils._') as _:

--- a/corehq/apps/data_interfaces/tests/test_utils.py
+++ b/corehq/apps/data_interfaces/tests/test_utils.py
@@ -1,16 +1,20 @@
 from unittest.case import TestCase
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 from couchdbkit import ResourceNotFound
 
-from corehq.apps.data_interfaces.utils import _get_ids, _validate_record, generate_ids_and_operate_on_payloads, \
-    operate_on_payloads
+from corehq.apps.data_interfaces.utils import (
+    _get_repeat_record_ids,
+    _validate_record,
+    generate_ids_and_operate_on_payloads,
+    operate_on_payloads,
+)
 
 
 class TestUtils(TestCase):
 
     def test__get_ids_no_data(self):
-        response = _get_ids('', 'test_domain')
+        response = _get_repeat_record_ids('', 'test_domain')
 
         self.assertEqual(response, [])
 
@@ -21,7 +25,7 @@ class TestUtils(TestCase):
         data = {
             'payload_id': Mock()
         }
-        response = _get_ids(data, 'test_domain')
+        _get_repeat_record_ids(data, 'test_domain')
 
         self.assertEqual(mock_get_repeat_records_by_payload_id.call_count, 1)
         mock_get_repeat_records_by_payload_id.assert_called_with('test_domain', data['payload_id'])
@@ -39,7 +43,7 @@ class TestUtils(TestCase):
             {'id': 'id_1'},
             {'id': 'id_2'}
         ]
-        response = _get_ids(data, 'test_domain')
+        response = _get_repeat_record_ids(data, 'test_domain')
 
         mock_get_repeat_records_by_payload_id.assert_not_called()
         mock__get_startkey_endkey_all_records.assert_called_with('test_domain', data['repeater'])
@@ -81,7 +85,7 @@ class TestTasks(TestCase):
         self.mock_payload_one, self.mock_payload_two = Mock(id='id_1'), Mock(id='id_2')
         self.mock_payload_ids = [self.mock_payload_one.id, self.mock_payload_two.id]
 
-    @patch('corehq.apps.data_interfaces.utils._get_ids')
+    @patch('corehq.apps.data_interfaces.utils._get_repeat_record_ids')
     @patch('corehq.apps.data_interfaces.utils.operate_on_payloads')
     def test_generate_ids_and_operate_on_payloads_success(self, mock_operate_on_payloads, mock__get_ids):
         mock_payload = Mock()

--- a/corehq/apps/data_interfaces/tests/test_utils.py
+++ b/corehq/apps/data_interfaces/tests/test_utils.py
@@ -82,8 +82,10 @@ class TestTasks(TestCase):
     @patch('corehq.apps.data_interfaces.tasks._get_repeat_record_ids')
     @patch('corehq.apps.data_interfaces.tasks.operate_on_payloads')
     def test_generate_ids_and_operate_on_payloads_success(self, mock_operate_on_payloads, mock__get_ids):
-        query_string_dict = {'payload_id': 'c0ffee', 'repeater': 'deadbeef'}
-        task_generate_ids_and_operate_on_payloads(query_string_dict, 'test_domain', 'test_action')
+        payload_id = 'c0ffee'
+        repeater_id = 'deadbeef'
+        task_generate_ids_and_operate_on_payloads(
+            payload_id, repeater_id, 'test_domain', 'test_action')
 
         mock__get_ids.assert_called_once()
         mock__get_ids.assert_called_with('c0ffee', 'deadbeef', 'test_domain')

--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -2,7 +2,6 @@ from django.utils.translation import ugettext as _
 
 from couchdbkit import ResourceNotFound
 
-from corehq.motech.repeaters.dbaccessors import get_repeat_records_by_payload_id, _get_startkey_endkey_all_records
 from soil import DownloadBase
 
 from corehq.apps.casegroups.models import CommCareCaseGroup
@@ -161,35 +160,6 @@ def operate_on_payloads(repeat_record_ids, domain, action, task=None, from_excel
         _("Successfully {action} {count} form(s)".format(action=action, count=success_count))
 
     return {"messages": response}
-
-
-def generate_ids_and_operate_on_payloads(query_string_dict, domain, action, task=None, from_excel=False):
-
-    repeat_record_ids = _get_repeat_record_ids(query_string_dict, domain)
-
-    response = operate_on_payloads(repeat_record_ids, domain, action, task, from_excel)
-
-    return {"messages": response}
-
-
-def _get_repeat_record_ids(query_string_dict, domain):
-    if not query_string_dict:
-        return []
-
-    if query_string_dict.get('payload_id', None):
-        results = get_repeat_records_by_payload_id(domain, query_string_dict['payload_id'])
-    else:
-        from corehq.motech.repeaters.models import RepeatRecord
-        kwargs = {
-            'include_docs': True,
-            'reduce': False,
-            'descending': True,
-        }
-        kwargs.update(_get_startkey_endkey_all_records(domain, query_string_dict['repeater']))
-        results = RepeatRecord.get_db().view('repeaters/repeat_records', **kwargs).all()
-    ids = [x['id'] for x in results]
-
-    return ids
 
 
 def _validate_record(r, domain):

--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -162,21 +162,21 @@ def operate_on_payloads(payload_ids, domain, action, task=None, from_excel=False
     return {"messages": response}
 
 
-def generate_ids_and_operate_on_payloads(data, domain, action, task=None, from_excel=False):
+def generate_ids_and_operate_on_payloads(query_string_dict, domain, action, task=None, from_excel=False):
 
-    payload_ids = _get_ids(data, domain)
+    payload_ids = _get_ids(query_string_dict, domain)
 
     response = operate_on_payloads(payload_ids, domain, action, task, from_excel)
 
     return {"messages": response}
 
 
-def _get_ids(data, domain):
-    if not data:
+def _get_ids(query_string_dict, domain):
+    if not query_string_dict:
         return []
 
-    if data.get('payload_id', None):
-        results = get_repeat_records_by_payload_id(domain, data['payload_id'])
+    if query_string_dict.get('payload_id', None):
+        results = get_repeat_records_by_payload_id(domain, query_string_dict['payload_id'])
     else:
         from corehq.motech.repeaters.models import RepeatRecord
         kwargs = {
@@ -184,7 +184,7 @@ def _get_ids(data, domain):
             'reduce': False,
             'descending': True,
         }
-        kwargs.update(_get_startkey_endkey_all_records(domain, data['repeater']))
+        kwargs.update(_get_startkey_endkey_all_records(domain, query_string_dict['repeater']))
         results = RepeatRecord.get_db().view('repeaters/repeat_records', **kwargs).all()
     ids = [x['id'] for x in results]
 

--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -117,6 +117,11 @@ def property_references_parent(case_property):
 
 
 def operate_on_payloads(repeat_record_ids, domain, action, task=None, from_excel=False):
+    if not repeat_record_ids:
+        return {'messages': {'errors': [_('No payloads specified')]}}
+    if not action:
+        return {'messages': {'errors': [_('No action specified')]}}
+
     response = {
         'errors': [],
         'success': [],

--- a/corehq/motech/repeaters/dbaccessors.py
+++ b/corehq/motech/repeaters/dbaccessors.py
@@ -112,6 +112,22 @@ def iter_repeat_records_by_domain(domain, repeater_id=None, state=None, since=No
         yield RepeatRecord.wrap(doc['doc'])
 
 
+def iter_repeat_records_by_repeater(domain, repeater_id, chunk_size=1000):
+    from corehq.motech.repeaters.models import RepeatRecord
+    kwargs = {
+        'include_docs': True,
+        'reduce': False,
+        'descending': True,
+    }
+    kwargs.update(_get_startkey_endkey_all_records(domain, repeater_id))
+    for doc in paginate_view(
+            RepeatRecord.get_db(),
+            'repeaters/repeat_records',
+            chunk_size,
+            **kwargs):
+        yield RepeatRecord.wrap(doc['doc'])
+
+
 def get_repeat_records_by_payload_id(domain, payload_id):
     from .models import RepeatRecord
     results = RepeatRecord.get_db().view(

--- a/corehq/motech/repeaters/templates/repeaters/repeat_record_report.html
+++ b/corehq/motech/repeaters/templates/repeaters/repeat_record_report.html
@@ -46,10 +46,10 @@
       {% endif %}
   </div>
   <div id="warning" class="alert alert-warning hide">
-    {% blocktrans %}You need to select at least one payload!{% endblocktrans %}
+    {% blocktrans %}Please select at least one payload{% endblocktrans %}
   </div>
   <div id="not-allowed" class="alert alert-warning hide">
-    {% blocktrans %}This action is not allowed for some of selected payloads!{% endblocktrans %}
+    {% blocktrans %}This action is not allowed for some of the selected payloads{% endblocktrans %}
   </div>
   <div class="modal fade" id="are-you-sure">
     <div class="modal-dialog">

--- a/corehq/motech/repeaters/templates/repeaters/repeat_record_report.html
+++ b/corehq/motech/repeaters/templates/repeaters/repeat_record_report.html
@@ -34,8 +34,8 @@
                 {% blocktrans %}Select all {{ total }} payloads{% endblocktrans %}
             </label>
             <label class="checkbox" >
-              <input type="checkbox" id="cancel-all" data-id="{{ form_query_string_cancellable|urlencode }}">
-                {% blocktrans %}Select {{ total_cancel }} cancellable payloads{% endblocktrans %}
+              <input type="checkbox" id="cancel-all" data-id="{{ form_query_string_pending|urlencode }}">
+                {% blocktrans %}Select {{ total_pending }} pending payloads{% endblocktrans %}
             </label>
             <label class="checkbox" >
               <input type="checkbox" id="requeue-all" data-id="{{ form_query_string_requeue|urlencode }}">

--- a/corehq/motech/repeaters/templates/repeaters/repeat_record_report.html
+++ b/corehq/motech/repeaters/templates/repeaters/repeat_record_report.html
@@ -38,8 +38,8 @@
                 {% blocktrans %}Select {{ total_pending }} pending payloads{% endblocktrans %}
             </label>
             <label class="checkbox" >
-              <input type="checkbox" id="requeue-all" data-id="{{ form_query_string_requeue|urlencode }}">
-                {% blocktrans %}Select {{ total_requeue }} requeue payloads{% endblocktrans %}
+              <input type="checkbox" id="requeue-all" data-id="{{ form_query_string_cancelled|urlencode }}">
+                {% blocktrans %}Select {{ total_cancelled }} cancelled payloads{% endblocktrans %}
             </label>
           </div>
         </div>

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -1,3 +1,5 @@
+from urllib.parse import parse_qsl
+
 from django.http import Http404, HttpResponse, JsonResponse
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -394,21 +396,8 @@ def _change_record_state(base_string, string_to_add):
 
 
 def _url_parameters_to_dict(url_params):
-    dict_to_return = {}
-    if not url_params:
-        return dict_to_return
-
-    while url_params != '':
-        pos_one = url_params.find('=')
-        pos_two = url_params.find('&')
-        if pos_two == -1:
-            pos_two = len(url_params)
-        key = url_params[:pos_one]
-        value = url_params[pos_one+1:pos_two]
-        dict_to_return[key] = value
-        url_params = url_params[pos_two+1:] if pos_two != len(url_params) else ''
-
-    return dict_to_return
+    name_value_pairs = parse_qsl(url_params, keep_blank_values=True)
+    return dict(name_value_pairs)
 
 
 def _schedule_task_with_flag(request, domain, action):

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -390,12 +390,12 @@ def _url_parameters_to_dict(url_params):
 
 def _schedule_task_with_flag(request, domain, action):
     query = _get_query(request)
-    data = None
+    query_string_dict = None
     if query:
         form_query_string = six.moves.urllib.parse.unquote(query)
-        data = _url_parameters_to_dict(form_query_string)
+        query_string_dict = _url_parameters_to_dict(form_query_string)
     task_ref = expose_cached_download(payload=None, expiry=1 * 60 * 60, file_extension=None)
-    task = task_generate_ids_and_operate_on_payloads.delay(data, domain, action)
+    task = task_generate_ids_and_operate_on_payloads.delay(query_string_dict, domain, action)
     task_ref.set_task(task)
 
 

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -357,12 +357,10 @@ def _change_record_state(query_string, state):
     if not state:
         return query_string
 
-    query_string_list = []
-    for name, value in parse_qsl(query_string, keep_blank_values=True):
-        if name == 'record_state':
-            value = state
-        query_string_list.append((name, value))
-    return urlencode(query_string_list)
+    query = dict(parse_qsl(query_string, keep_blank_values=True))
+    if 'record_state' in query:
+        query['record_state'] = state
+    return urlencode(query)
 
 
 def _schedule_task_with_flag(request, domain, action):

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -255,19 +255,19 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
         context = super(DomainForwardingRepeatRecords, self).report_context
 
         total = get_repeat_record_count(self.domain, self.repeater_id)
-        total_cancel = get_pending_repeat_record_count(self.domain, self.repeater_id)
+        total_pending = get_pending_repeat_record_count(self.domain, self.repeater_id)
         total_requeue = get_cancelled_repeat_record_count(self.domain, self.repeater_id)
 
         form_query_string = self.request.GET.urlencode()
         form_query_string_requeue = _change_record_state(form_query_string, 'CANCELLED')
-        form_query_string_cancellable = _change_record_state(form_query_string, 'PENDING')
+        form_query_string_pending = _change_record_state(form_query_string, 'PENDING')
 
         context.update(
             total=total,
-            total_cancel=total_cancel,
+            total_pending=total_pending,
             total_requeue=total_requeue,
             form_query_string=form_query_string,
-            form_query_string_cancellable=form_query_string_cancellable,
+            form_query_string_pending=form_query_string_pending,
             form_query_string_requeue=form_query_string_requeue,
         )
         return context

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -346,7 +346,7 @@ def requeue_repeat_record(request, domain):
     return HttpResponse('OK')
 
 
-def _get_records(request):
+def _get_record_ids_from_request(request):
     record_ids = request.POST.get('record_id') or ''
     return record_ids.strip().split()
 
@@ -423,7 +423,7 @@ def _schedule_task_with_flag(request, domain, action):
 
 
 def _schedule_task_without_flag(request, domain, action):
-    records = _get_records(request)
+    record_ids = _get_record_ids_from_request(request)
     task_ref = expose_cached_download(payload=None, expiry=1 * 60 * 60, file_extension=None)
-    task = task_operate_on_payloads.delay(records, domain, action)
+    task = task_operate_on_payloads.delay(record_ids, domain, action)
     task_ref.set_task(task)

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -365,7 +365,10 @@ def _change_record_state(query_string, state):
 
 def _schedule_task_with_flag(request, domain, action):
     task_ref = expose_cached_download(payload=None, expiry=1 * 60 * 60, file_extension=None)
-    task = task_generate_ids_and_operate_on_payloads.delay(request.POST, domain, action)
+    payload_id = request.POST.get('payload_id') or None
+    repeater_id = request.POST.get('repeater') or None
+    task = task_generate_ids_and_operate_on_payloads.delay(
+        payload_id, repeater_id, domain, action)
     task_ref.set_task(task)
 
 

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -1,4 +1,4 @@
-from urllib.parse import parse_qsl
+from urllib.parse import parse_qsl, urlencode
 
 from django.http import Http404, HttpResponse, JsonResponse
 from django.template.loader import render_to_string
@@ -369,30 +369,18 @@ def _get_flag(request):
     return flag if flag else ''
 
 
-def _change_record_state(base_string, string_to_add):
-    if not base_string:
+def _change_record_state(query_string, state):
+    if not query_string:
         return ''
-    elif not string_to_add:
-        return base_string
+    if not state:
+        return query_string
 
-    string_to_look_for = 'record_state='
-    pos_start = 0
-    pos_end = 0
-    for r in range(len(base_string)):
-        if base_string[r:r+13] == string_to_look_for:
-            pos_start = r + 13
-            break
-
-    string_to_look_for = '&payload_id='
-    the_rest_of_string = base_string[pos_start:]
-    for r in range(len(the_rest_of_string)):
-        if the_rest_of_string[r:r+12] == string_to_look_for:
-            pos_end = r
-            break
-
-    string_to_return = base_string[:pos_start] + string_to_add + the_rest_of_string[pos_end:]
-
-    return string_to_return
+    query_string_list = []
+    for name, value in parse_qsl(query_string, keep_blank_values=True):
+        if name == 'record_state':
+            value = state
+        query_string_list.append((name, value))
+    return urlencode(query_string_list)
 
 
 def _url_parameters_to_dict(url_params):

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -256,19 +256,19 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
 
         total = get_repeat_record_count(self.domain, self.repeater_id)
         total_pending = get_pending_repeat_record_count(self.domain, self.repeater_id)
-        total_requeue = get_cancelled_repeat_record_count(self.domain, self.repeater_id)
+        total_cancelled = get_cancelled_repeat_record_count(self.domain, self.repeater_id)
 
         form_query_string = self.request.GET.urlencode()
-        form_query_string_requeue = _change_record_state(form_query_string, 'CANCELLED')
+        form_query_string_cancelled = _change_record_state(form_query_string, 'CANCELLED')
         form_query_string_pending = _change_record_state(form_query_string, 'PENDING')
 
         context.update(
             total=total,
             total_pending=total_pending,
-            total_requeue=total_requeue,
+            total_cancelled=total_cancelled,
             form_query_string=form_query_string,
             form_query_string_pending=form_query_string_pending,
-            form_query_string_requeue=form_query_string_requeue,
+            form_query_string_cancelled=form_query_string_cancelled,
         )
         return context
 

--- a/corehq/motech/repeaters/views/tests/test_repeat_records.py
+++ b/corehq/motech/repeaters/views/tests/test_repeat_records.py
@@ -5,17 +5,6 @@ from corehq.motech.repeaters.views import repeat_records
 from unittest.mock import Mock
 from unittest.case import TestCase
 
-query_strings = [
-    None,
-    '',
-    'repeater=&record_state=&payload_id=payload_3',
-    'repeater=repeater_3&record_state=STATUS_2&payload_id=payload_2',
-    'repeater=&record_state=&payload_id=',
-    'repeater=repeater_1&record_state=STATUS_2&payload_id=payload_1',
-    'repeater=&record_state=STATUS&payload_id=payload_2',
-    'repeater=repeater_2&record_state=STATUS&payload_id=',
-]
-
 
 class TestUtilities(TestCase):
 
@@ -50,6 +39,16 @@ class TestUtilities(TestCase):
             assert_equal(result, expected_result)
 
     def test__change_record_state(self):
+        query_strings = [
+            None,
+            '',
+            'repeater=&record_state=&payload_id=payload_3',
+            'repeater=repeater_3&record_state=STATUS_2&payload_id=payload_2',
+            'repeater=&record_state=&payload_id=',
+            'repeater=repeater_1&record_state=STATUS_2&payload_id=payload_1',
+            'repeater=&record_state=STATUS&payload_id=payload_2',
+            'repeater=repeater_2&record_state=STATUS&payload_id=',
+        ]
         strings_to_add = [
             'NO_STATUS',
             'NO_STATUS',
@@ -74,5 +73,7 @@ class TestUtilities(TestCase):
         for qs, str_to_add, expected_result in zip(query_strings,
                                                    strings_to_add,
                                                    desired_strings):
-            result = repeat_records._change_record_state(qs, str_to_add)
+            query_dict = QueryDict(qs)
+            result = repeat_records._change_record_state(
+                query_dict, str_to_add).urlencode()
             self.assertEqual(result, expected_result)

--- a/corehq/motech/repeaters/views/tests/test_repeat_records.py
+++ b/corehq/motech/repeaters/views/tests/test_repeat_records.py
@@ -1,3 +1,5 @@
+from nose.tools import assert_equal
+
 from corehq.motech.repeaters.views import repeat_records
 from unittest.mock import Mock, patch
 from unittest.case import TestCase
@@ -49,12 +51,12 @@ class TestUtilities(TestCase):
 
     def test__get_flag(self):
         mock_request = Mock()
-        mock_request.POST.get.side_effect = [None, 'flag']
-        expected_flags = ['', 'flag']
-
-        for expected_result in expected_flags:
-            records_ids = repeat_records._get_flag(mock_request)
-            self.assertEqual(records_ids, expected_result)
+        flag_values = [None, '', 'flag']
+        expected_results = ['', '', 'flag']
+        for value, expected_result in zip(flag_values, expected_results):
+            mock_request.POST.get.return_value = value
+            result = repeat_records._get_flag(mock_request)
+            assert_equal(result, expected_result)
 
     def test__change_record_state(self):
         strings_to_add = [

--- a/corehq/motech/repeaters/views/tests/test_repeat_records.py
+++ b/corehq/motech/repeaters/views/tests/test_repeat_records.py
@@ -27,7 +27,7 @@ class TestUtilities(TestCase):
         ]
 
         for r in range(5):
-            records_ids = repeat_records._get_records(mock_request)
+            records_ids = repeat_records._get_record_ids_from_request(mock_request)
             self.assertEqual(records_ids, expected_records_ids[r])
 
     def test__get_query(self):
@@ -142,7 +142,7 @@ class TestUtilities(TestCase):
     @patch('corehq.motech.repeaters.views.repeat_records.expose_cached_download')
     @patch('corehq.motech.repeaters.views.repeat_records._url_parameters_to_dict')
     @patch('corehq.motech.repeaters.views.repeat_records.six.moves.urllib.parse.unquote')
-    @patch('corehq.motech.repeaters.views.repeat_records._get_records')
+    @patch('corehq.motech.repeaters.views.repeat_records._get_record_ids_from_request')
     def test__schedule_task_without_flag(self, mock__get_records, mock_unquote,
                                          mock__url_parameters_to_dict, mock_expose_cache_download,
                                          mock_task_operate_on_payloads):


### PR DESCRIPTION
## Summary

Clean up some of the Repeat Record Report code

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

This refactor touches the tests that cover its changes.

### Safety story

This refactor does not change any functionality.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
