### PR TITLE
fix dump when using load balanced databases

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -215,9 +215,15 @@ def get_all_model_iterators_builders_for_domain(model_class, domain, builders, l
         using = [limit_to_db]
 
     for db_alias in using:
-        if not model_class._meta.proxy and router.allow_migrate_model(db_alias, model_class):
-            for builder in builders:
-                yield model_class, builder.build(domain, model_class, db_alias)
+        if model_class._meta.proxy:
+            continue
+
+        master_db = settings.DATABASES[db_alias].get('STANDBY', {}).get('MASTER')
+        if not router.allow_migrate_model(master_db or db_alias, model_class):
+            continue
+
+        for builder in builders:
+            yield model_class, builder.build(domain, model_class, db_alias)
 
 
 def get_excluded_apps_and_models(excludes):


### PR DESCRIPTION
## Summary
`router.allow_migrate_model` always returns False for a standby DB so check the master DB instead.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
Covered by existing tests

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
