### PR TITLE
prefix progress output if not 'oneline'

### DIFF
--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -264,6 +264,8 @@ def with_progress_bar(iterable, length=None, prefix='Processing', oneline=True,
     granularity = min(50, length or 50)
     start = datetime.now()
 
+    info_prefix = '' if oneline else f'{prefix} '
+
     def draw(position, done=False):
         overall_position = offset + position
         overall_percent = overall_position / length if length > 0 else 1
@@ -286,7 +288,7 @@ def with_progress_bar(iterable, length=None, prefix='Processing', oneline=True,
         stream.flush()
 
     if oneline != "concise":
-        print("Started at {:%Y-%m-%d %H:%M:%S}".format(start), file=stream)
+        print("{}Started at {:%Y-%m-%d %H:%M:%S}".format(info_prefix, start), file=stream)
     should_update = step_calculator(length, granularity)
     i = 0
     try:
@@ -299,8 +301,8 @@ def with_progress_bar(iterable, length=None, prefix='Processing', oneline=True,
         draw(i, done=True)
     if oneline != "concise":
         end = datetime.now()
-        print("Finished at {:%Y-%m-%d %H:%M:%S}".format(end), file=stream)
-        print("Elapsed time: {}".format(display_seconds((end - start).total_seconds())), file=stream)
+        print("{}Finished at {:%Y-%m-%d %H:%M:%S}".format(info_prefix, end), file=stream)
+        print("{}Elapsed time: {}".format(info_prefix, display_seconds((end - start).total_seconds())), file=stream)
 
 
 def step_calculator(length, granularity):


### PR DESCRIPTION
## Summary
Include prefix for info lines when using `oneline=False` to give context to the info messages. This is mostly useful if there are multiple progress bars outputting concurrently.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
