### PR TITLE
Increase CASE_SEARCH_MAX_RESULTS

### DIFF
--- a/corehq/apps/case_search/const.py
+++ b/corehq/apps/case_search/const.py
@@ -9,6 +9,9 @@ INDICES_PATH = 'indices'
 REFERENCED_ID = 'referenced_id'
 IDENTIFIER = 'identifier'
 
+# Maximum number of results to pull from ElasticSearch
+CASE_SEARCH_MAX_RESULTS = 500
+
 # Added to each case response when case searches are performed
 RELEVANCE_SCORE = "commcare_search_score"
 
@@ -21,7 +24,7 @@ SYSTEM_PROPERTIES = [
     INDEXED_ON,
 ]
 
-# Properties that are inconsitent between case models stored in HQ and casedb
+# Properties that are inconsistent between case models stored in HQ and casedb
 # expressions. We store these as case properties in the case search index so
 # they are easily searchable, then remove them when pulling the case source
 # from ES

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -9,7 +9,7 @@ from corehq.apps.case_search.models import (
     FuzzyProperties,
 )
 from corehq.apps.es.case_search import CaseSearchES
-from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_MAX_RESULTS
+from corehq.apps.case_search.const import CASE_SEARCH_MAX_RESULTS
 
 
 class CaseSearchCriteria(object):

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -13,6 +13,7 @@ from casexml.apps.case.util import post_case_blocks
 from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
 from pillowtop.es_utils import initialize_index_and_mapping
 
+from corehq.apps.case_search.const import CASE_SEARCH_MAX_RESULTS
 from corehq.apps.case_search.models import (
     CLAIM_CASE_TYPE,
     CASE_SEARCH_XPATH_QUERY_KEY,
@@ -30,7 +31,6 @@ from corehq.pillows.case_search import CaseSearchReindexerFactory, domains_needi
 from corehq.pillows.mappings.case_search_mapping import (
     CASE_SEARCH_INDEX,
     CASE_SEARCH_INDEX_INFO,
-    CASE_SEARCH_MAX_RESULTS,
 )
 from corehq.util.elastic import ensure_index_deleted
 

--- a/corehq/pillows/mappings/case_search_mapping.py
+++ b/corehq/pillows/mappings/case_search_mapping.py
@@ -6,7 +6,7 @@ from pillowtop.es_utils import ElasticsearchIndexInfo, CASE_SEARCH_HQ_INDEX_NAME
 
 CASE_SEARCH_INDEX = prefix_for_tests("case_search_2018-05-29")
 CASE_SEARCH_ALIAS = prefix_for_tests("case_search")
-CASE_SEARCH_MAX_RESULTS = 100
+CASE_SEARCH_MAX_RESULTS = 500
 CASE_SEARCH_MAPPING = mapping_from_json('case_search_mapping.json')
 
 

--- a/corehq/pillows/mappings/case_search_mapping.py
+++ b/corehq/pillows/mappings/case_search_mapping.py
@@ -6,7 +6,6 @@ from pillowtop.es_utils import ElasticsearchIndexInfo, CASE_SEARCH_HQ_INDEX_NAME
 
 CASE_SEARCH_INDEX = prefix_for_tests("case_search_2018-05-29")
 CASE_SEARCH_ALIAS = prefix_for_tests("case_search")
-CASE_SEARCH_MAX_RESULTS = 500
 CASE_SEARCH_MAPPING = mapping_from_json('case_search_mapping.json')
 
 


### PR DESCRIPTION
## Summary
See https://dimagi-dev.atlassian.net/browse/USH-511

## Feature Flag
Case claim

## Product Description
This increases the maximum number of results that a case claim search can return.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

Case claim has tests.

### QA Plan

None. This is a low-risk change to a single constant.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
