### PR TITLE
[CEP] Proposal for case create/update API

### DIFF
--- a/corehq/apps/api/tests/test_case_update_api.py
+++ b/corehq/apps/api/tests/test_case_update_api.py
@@ -7,7 +7,7 @@ from casexml.apps.case.mock import CaseBlock
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.users.models import WebUser
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 
 
@@ -20,6 +20,7 @@ class TestUpdateCases(TestCase):
         cls.domain_obj = create_domain(cls.domain)
         cls.web_user = WebUser.create(cls.domain, 'netflix', 'password', None, None)
         cls.case_accessor = CaseAccessors(cls.domain)
+        cls.form_accessor = FormAccessors(cls.domain)
 
     def tearDown(self):
         FormProcessorTestUtils.delete_all_cases(self.domain)
@@ -57,6 +58,11 @@ class TestUpdateCases(TestCase):
             'dob': '1948-11-02',
             'sport': 'chess',
         })
+
+        xform = self.form_accessor.get_form(res['@form_id'])
+        self.assertEqual(xform.metadata.xmlns, 'http://commcarehq.org/case_api')
+        self.assertEqual(xform.metadata.userID, self.web_user.user_id)
+        self.assertEqual(xform.metadata.deviceID, 'user agent string')
 
     def _make_case(self):
         xform, cases = submit_case_blocks([CaseBlock(

--- a/corehq/apps/api/tests/test_case_update_api.py
+++ b/corehq/apps/api/tests/test_case_update_api.py
@@ -1,0 +1,173 @@
+import uuid
+
+from django.test import TestCase
+
+from casexml.apps.case.mock import CaseBlock
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.hqcase.utils import submit_case_blocks
+from corehq.apps.users.models import WebUser
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
+
+
+class TestUpdateCases(TestCase):
+    domain = 'test_update_cases'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = create_domain(cls.domain)
+        cls.web_user = WebUser.create(cls.domain, 'netflix', 'password', None, None)
+        cls.case_accessor = CaseAccessors(cls.domain)
+
+    def tearDown(self):
+        FormProcessorTestUtils.delete_all_cases(self.domain)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+    def post(self, resource_url, body):
+        # TODO
+        pass
+
+    def test_create_case(self):
+        res = self.post('create_case', {
+            # notable exclusions: case_id, date_opened, date_modified
+            '@case_type': 'player',
+            '@case_name': 'Elizabeth Harmon',
+            '@owner_id': 'methuen_home',
+            'properties': {
+                'external_id': '1',
+                'sport': 'chess',
+                'dob': '1948-11-02',
+            },
+        })
+        self.assertEqual(res.keys(), ['@case_id', '@form_id'])
+        case = self.case_accessor.get_case(res['@case_id'])
+        self.assertEqual(case.domain, self.domain)
+        self.assertEqual(case.type, 'player')
+        self.assertEqual(case.name, 'Elizabeth Harmon')
+        self.assertEqual(case.owner_id, 'methuen_home')
+        self.assertEqual(case.opened_by, 'netflix')
+        self.assertEqual(case.external_id, '1')
+        self.assertEqual(case.dynamic_case_properties(), {
+            'dob': '1948-11-02',
+            'sport': 'chess',
+        })
+
+    def _make_case(self):
+        xform, cases = submit_case_blocks([CaseBlock(
+            case_id=str(uuid.uuid4()),
+            case_type='player',
+            case_name='Elizabeth Harmon',
+            owner_id='methuen_home',
+            create=True,
+            update={
+                'external_id': '1',
+                'sport': 'chess',
+                'rank': '1600',
+                'dob': '1948-11-02',
+            }
+        ).as_text()], domain=self.domain)
+        return cases[0]
+
+    def test_update_case(self):
+        case = self._make_case()
+
+        res = self.post(f'update_case/{case.case_id}', {
+            # notable exclusions: case_id, date_opened, date_modified, case_type
+            '@case_name': 'Beth Harmon',
+            '@owner_id': 'us_chess_federation',
+            'properties': {
+                'rank': '2100',
+                'champion': 'true',
+            },
+        })
+        self.assertEqual(res.keys(), ['@case_id', '@form_id'])
+
+        case = self.case_accessor.get_case(case.case_id)
+        self.assertEqual(case.name, 'Beth Harmon')
+        self.assertEqual(case.owner_id, 'us_chess_federation')
+        self.assertEqual(case.dynamic_case_properties(), {
+            'champion': 'true',
+            'dob': '1948-11-02',
+            'rank': '2100',
+            'sport': 'chess',
+        })
+
+    def test_create_child_case(self):
+        parent_case = self._make_case()
+        res = self.post('create_case', {
+            '@case_type': 'match',
+            '@case_name': 'Harmon/Luchenko',
+            '@owner_id': 'harmon',
+            'properties': {
+                'external_id': '23',
+                'winner': 'Harmon',
+            },
+            'indices': {
+                'parent': {
+                    '@case_id': parent_case.case_id,
+                    '@case_type': 'player',
+                    '@relationship': 'child',
+                },
+            },
+        })
+        self.assertEqual(res.keys(), ['@case_id', '@form_id'])
+
+        case = self.case_accessor.get_case(res['@case_id'])
+        self.assertEqual(case.name, 'Harmon/Luchenko')
+        self.assertEqual(case.owner_id, 'harmon')
+        self.assertEqual(case.dynamic_case_properties(), {
+            'external_id': '23',
+            'winner': 'Harmon',
+        })
+        self.assertEqual(case.indices[0].identifier, 'parent')
+        self.assertEqual(case.indices[0].referenced_id, parent_case.case_id)
+        self.assertEqual(case.indices[0].referenced_type, 'player')
+        self.assertEqual(case.indices[0].relationship_id, 'child')
+        self.assertEqual(case.indices[0].case.case_id, parent_case.case_id)
+
+    def test_bulk_action(self):
+        existing_case = self._make_case()
+        res = self.post('bulk_update', [
+            {
+                # update existing case
+                '@case_id': existing_case.case_id,
+                '@case_name': 'Beth Harmon',
+                '@owner_id': 'us_chess_federation',
+                'properties': {
+                    'rank': '2100',
+                    'champion': 'true',
+                },
+            },
+            {
+                # No case_id means this is a new case
+                '@case_type': 'player',
+                '@case_name': 'Jolene',
+                '@owner_id': 'methuen_home',
+                'properties': {
+                    'external_id': '2',
+                    'sport': 'squash',
+                    'dob': '1947-03-09',
+                },
+            },
+        ])
+        #  only returns a single form ID - chunking should happen in the client
+        self.assertEqual(res.keys(), ['@case_ids', '@form_id'])
+
+        updated_case = self.case_accessor.get_case(existing_case.case_id)
+        self.assertEqual(updated_case.name, 'Beth Harmon')
+
+        new_case = self.case_accessor.get_case(res['@case_ids'][1])
+        self.assertEqual(new_case.name, 'Jolene')
+
+    def test_create_parent_and_child_together(self):
+        # TODO? Since this API doesn't let you provide your own case IDs, you
+        # can't reference uncreated cases in indices unless we invent some
+        # syntax specifically for that. Thinking about leaving out of scope for
+        # v1, at least (it wouldn't be a breaking change to add in later).
+        pass


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SC-1021

This is a series of tests demonstrating proposed behavior for an API to create and modify cases.  Currently the supported ways to do that are:

* xform submissions (difficult for partners to structure properly)
* bulk_case_upload_api (requires you to assemble spreadsheets - doable, but would be a weird format for something like an integration)
* zapier API (close to what I want, but it has an [awkward format](https://github.com/dimagi/commcare-hq/blob/b330b1daeb6c24fe203ed94849eb145eaf02c319/corehq/apps/zapier/views.py#L108-L108) and doesn't support bulk actions)

This has the potential to be much more straightforward.

I'm looking for feedback on whether this is the best way to structure the API.  This would be very difficult to change later, so feel free to be nitpicky.  I aimed to use canonical property names when possible, pulled from [this recent effort to consolidate them](https://dimagi-dev.atlassian.net/browse/USH-462).  

The current plan is to make three new views in `hqcase/views.py`, create, update, and bulk_update.  I did consider putting them in a `v0_5.CommCareCaseResource` class by implementing the `obj_create`, `obj_update`, and `post_list` methods and enabling the associated http methods, but I imagine tastypie is more likely to just get in the way.  I'm open to feedback there, though.