### PR TITLE
prevent closed in case import

### DIFF
--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -29,7 +29,7 @@ from soil.progress import update_task_state
 
 # Don't allow users to change the case type by accident using a custom field. But do allow users to change
 # owner_id, external_id, etc. (See also custom_data_fields.models.RESERVED_WORDS)
-RESERVED_FIELDS = ('type',)
+RESERVED_FIELDS = ('type', 'closed')
 EXTERNAL_ID = 'external_id'
 
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
We currently let you set a case property called `closed` with case imports, which allows you to put cases in a bad state. This adds it to the list of reserved words.

The proper way to close in case with an import is to use the column `close` and set it to `yes`. It is not possible to use an import to open a closed case.
 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Case imports will no longer allow you to have a column called `closed`. An error will be shown to the user telling them that this column is forbidden if they attempt to.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This adds a keyword to a static list and does not change any other functionality.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
