### PR TITLE
Added username as a required argument to update_case_index_relationship

### DIFF
--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -7,7 +7,7 @@ from dimagi.utils.chunked import chunked
 
 from corehq.apps.linked_domain.dbaccessors import get_linked_domains
 from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.apps.users.util import SYSTEM_USER_ID
+from corehq.apps.users.util import username_to_user_id
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
 
@@ -35,10 +35,12 @@ def case_block(case):
     ).as_xml()).decode('utf-8')
 
 
-def update_cases(domain):
+def update_cases(domain, username):
     accessor = CaseAccessors(domain)
     case_ids = accessor.get_case_ids_in_domain(CASE_TYPE)
     print(f"Found {len(case_ids)} {CASE_TYPE} cases in {domain}")
+
+    user_id = username_to_user_id(username)
 
     case_blocks = []
     skip_count = 0
@@ -51,7 +53,7 @@ def update_cases(domain):
 
     total = 0
     for chunk in chunked(case_blocks, BATCH_SIZE):
-        submit_case_blocks(chunk, domain, device_id=DEVICE_ID, user_id=SYSTEM_USER_ID)
+        submit_case_blocks(chunk, domain, device_id=DEVICE_ID, user_id=user_id)
         total += len(chunk)
         print("Updated {} cases on domain {}".format(total, domain))
 
@@ -61,13 +63,14 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('domain')
+        parser.add_argument('username')
         parser.add_argument('--and-linked', action='store_true', default=False)
 
-    def handle(self, domain, **options):
+    def handle(self, domain, username, **options):
         domains = {domain}
         if options["and_linked"]:
             domains = domains | {link.linked_domain for link in get_linked_domains(domain)}
 
         for domain in domains:
             print(f"Processing {domain}")
-            update_cases(domain)
+            update_cases(domain, username)


### PR DESCRIPTION
## Summary
Adds a username parameter so the case updates can be made by a particular user of choice instead of only the system user.
This issue was brought up in [this ticket](https://dimagi-dev.atlassian.net/browse/SUPPORT-6132).

## Safety Assurance

- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I am certain that this PR will not introduce a regression for the reasons below


### QA Plan
I am not requesting QA. 

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
