### PR TITLE
read blob meta from zip file

### DIFF
--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -142,5 +142,5 @@ def _get_dump_meta(extracted_dir):
         return json.loads(f.read())
 
 
-def get_tmp_extract_dir(dump_file_path):
-    return '_tmp_load_{}'.format(dump_file_path)
+def get_tmp_extract_dir(dump_file_path, specifier=""):
+    return f'_tmp_load_{specifier}_{dump_file_path}'

--- a/corehq/blobs/management/commands/export_selected_blobs.py
+++ b/corehq/blobs/management/commands/export_selected_blobs.py
@@ -93,8 +93,6 @@ class Command(BaseCommand):
             for result in futures.as_completed(results):
                 filenames.append(result.result())
 
-            executor.shutdown()
-
         if options.get("json_output"):
             return json.dumps({"paths": filenames})
 

--- a/corehq/blobs/management/commands/export_selected_blobs.py
+++ b/corehq/blobs/management/commands/export_selected_blobs.py
@@ -4,15 +4,12 @@ import inspect
 import json
 import logging
 import os
-import pathlib
 import re
-import shutil
 import zipfile
 from collections import namedtuple
 from concurrent import futures
 from pathlib import Path
 
-import atexit
 from django.core.management import BaseCommand, CommandError
 
 from corehq.apps.dump_reload.management.commands.load_domain_data import get_tmp_extract_dir

--- a/corehq/blobs/management/commands/export_selected_blobs.py
+++ b/corehq/blobs/management/commands/export_selected_blobs.py
@@ -48,7 +48,8 @@ class Command(BaseCommand):
     @change_log_level('botocore', logging.WARNING)
     def handle(self, path, **options):
         already_exported = get_lines_from_file(options['already_exported'])
-        print("Found {} existing blobs, these will be skipped".format(len(already_exported)))
+        if already_exported:
+            print("Found {} existing blobs, these will be skipped".format(len(already_exported)))
 
         filter_pattern = options.get('meta-file-filter')
         filter_rx = None
@@ -83,8 +84,6 @@ class Command(BaseCommand):
                 prefix = f"Exporting from {path.name}"
                 for obj in with_progress_bar(_key_iterator(path), length=expected_count, prefix=prefix):
                     migrator.process_object(obj)
-                    if migrator.total_blobs % 1000 == 0:
-                        print("Processed {} objects".format(migrator.total_blobs))
 
         print("Exported {} objects to {}".format(migrator.total_blobs, export_filename))
         if options.get("json_output"):

--- a/corehq/blobs/management/commands/export_selected_blobs.py
+++ b/corehq/blobs/management/commands/export_selected_blobs.py
@@ -108,8 +108,6 @@ def _export_blobs(output_path, path, meta):
         for obj in with_progress_bar(_key_iterator(path), length=expected_count, prefix=prefix, oneline=False):
             migrator.process_object(obj)
 
-    print("Exported {} objects to {}".format(migrator.total_blobs, export_filename))
-
     return export_filename
 
 

--- a/corehq/blobs/management/commands/export_selected_blobs.py
+++ b/corehq/blobs/management/commands/export_selected_blobs.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
     @change_log_level('botocore', logging.WARNING)
     def handle(self, path, **options):
         use_extracted = options.get('use_extracted')
-        output_path = options.get('output_path', '')
+        output_path = options.get('output_path') or ''
 
         already_exported = get_lines_from_file(options['already_exported'])
         if already_exported:

--- a/corehq/blobs/management/commands/export_selected_blobs.py
+++ b/corehq/blobs/management/commands/export_selected_blobs.py
@@ -103,7 +103,7 @@ def _export_blobs(path, meta):
     with migrator:
         expected_count = meta[path.stem]["blobs.BlobMeta"]
         prefix = f"Exporting from {path.name}"
-        for obj in with_progress_bar(_key_iterator(path), length=expected_count, prefix=prefix, oneline='concise'):
+        for obj in with_progress_bar(_key_iterator(path), length=expected_count, prefix=prefix, oneline=False):
             migrator.process_object(obj)
 
     print("Exported {} objects to {}".format(migrator.total_blobs, export_filename))

--- a/corehq/blobs/management/commands/export_selected_blobs.py
+++ b/corehq/blobs/management/commands/export_selected_blobs.py
@@ -27,9 +27,8 @@ class Command(BaseCommand):
     help = inspect.cleandoc("""
     Usage ./manage.py export_selected_blobs [options] path_to_export_zip
 
-    'path_to_blob_meta' may be a gzip file or a plain text file containing a single JSON
-    representation of the BlobMeta class per line. Use `dump_domain_data` to generate
-    the file.
+    'path_to_export_zip' must be a ZIP file generated using `dump_domain_data` and must
+    include a `meta.json` file with the object counts.
 
     To top-up an older blob dump, first extract a list of names from the archive:
         $ tar --list -f blob_export.tar.gz > blob_export.list

--- a/corehq/blobs/management/commands/export_selected_blobs.py
+++ b/corehq/blobs/management/commands/export_selected_blobs.py
@@ -69,14 +69,18 @@ class Command(BaseCommand):
         export_meta_files = []
         if not target_path.exists():
             with zipfile.ZipFile(path, 'r') as archive:
-                meta = json.loads(archive.read("meta.json"))
+                archive.extract('meta.json', target_dir)
                 for dump_file in archive.namelist():
-                    if _filter(dump_file):
-                        export_meta_files.append(target_path.joinpath(dump_file))
+                    if 'blob_meta' in dump_file:
                         archive.extract(dump_file, target_dir)
         elif not self.use_extracted:
             raise CommandError(
                 "Extracted dump already exists at {}. Delete it or use --use-extracted".format(target_dir))
+
+        meta = json.loads(target_path.joinpath('meta.json').read_text())
+        for file in target_path.iterdir():
+            if _filter(file.name):
+                export_meta_files.append(file)
 
         results = []
         filenames = []

--- a/corehq/blobs/management/commands/export_selected_blobs.py
+++ b/corehq/blobs/management/commands/export_selected_blobs.py
@@ -99,7 +99,7 @@ def _export_blobs(path, meta):
     with migrator:
         expected_count = meta[path.stem]["blobs.BlobMeta"]
         prefix = f"Exporting from {path.name}"
-        for obj in with_progress_bar(_key_iterator(path), length=expected_count, prefix=prefix):
+        for obj in with_progress_bar(_key_iterator(path), length=expected_count, prefix=prefix, oneline='concise'):
             migrator.process_object(obj)
 
     print("Exported {} objects to {}".format(migrator.total_blobs, export_filename))


### PR DESCRIPTION
## Summary
This changes the input to the `export_selected_blobs` command so that it handles extracting the blob meta gzip files out of the ZIP file created by `dump_domain_data` or `dump_data_by_location`. This is useful since `dump_data_by_location` creates one gzip file per DB / datatype combination which in the case of ICDS results in 40 files.

It also uses threads to run the export for each blob meta GZ file in parallel and adds progress output.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
