### PR TITLE
support getting count without querying

### DIFF
--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -12,6 +12,9 @@ class DomainFilter(metaclass=ABCMeta):
         of the others."""
         raise NotImplementedError()
 
+    def count(self, domain_name):
+        return None
+
 
 class SimpleFilter(DomainFilter):
     def __init__(self, filter_kwarg):
@@ -40,6 +43,9 @@ class UsernameFilter(DomainFilter):
     def __init__(self, usernames=None):
         self.usernames = usernames
 
+    def count(self, domain_name):
+        return len(self.usernames) if self.usernames is not None else None
+
     def get_filters(self, domain_name):
         """
         :return: A generator of filters each filtering for at most 500 users.
@@ -60,6 +66,9 @@ class IDFilter(DomainFilter):
     def __init__(self, field, ids):
         self.field = field
         self.ids = ids
+
+    def count(self, domain_name):
+        return len(self.get_ids(domain_name))
 
     def get_ids(self, domain_name):
         return self.ids
@@ -97,7 +106,10 @@ class UnfilteredModelIteratorBuilder(object):
         return objects.using(self.db_alias).order_by(self.model_class._meta.pk.name)
 
     def querysets(self):
-        return self._base_queryset()
+        yield self._base_queryset()
+
+    def count(self):
+        return sum(q.count() for q in self.querysets())
 
     def iterators(self):
         for queryset in self.querysets():
@@ -115,11 +127,17 @@ class FilteredModelIteratorBuilder(UnfilteredModelIteratorBuilder):
     def build(self, domain, model_class, db_alias):
         return self.__class__(self.model_label, self.filter).prepare(domain, model_class, db_alias)
 
+    def count(self):
+        count = self.filter.count(self.domain)
+        if count is not None:
+            return count
+        return super(FilteredModelIteratorBuilder, self).count()
+
     def querysets(self):
         queryset = self._base_queryset()
         filters = self.filter.get_filters(self.domain)
-        for filter in filters:
-            yield queryset.filter(filter)
+        for filter_ in filters:
+            yield queryset.filter(filter_)
 
 
 class UniqueFilteredModelIteratorBuilder(FilteredModelIteratorBuilder):


### PR DESCRIPTION
## Summary
When exporting large datasets having the progress output is very helpful. For the ICDS data export I added progress output for the SQL exporter https://github.com/dimagi/commcare-icds/pull/157/files#diff-2299e47508434b48a9b377144efb0fe3e4f283b35ce6539b3b641a968b5b2251R150

This change moves the counting to the builders and filters so that the SQL count query can be skipped if the filter already knows the total count (e.g. when filtering by ID or username).

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
