### PR TITLE
move APP_USER_PROFILES privilege to advanced and above

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -118,9 +118,9 @@ advanced_v0 = pro_v1 + [
     privileges.BUILD_PROFILES,
     privileges.ADVANCED_DOMAIN_SECURITY,
     privileges.ODATA_FEED,
+    privileges.APP_USER_PROFILES,
 ]
 
 enterprise_v0 = advanced_v0 + [
-    privileges.APP_USER_PROFILES,
     privileges.GEOCODER,
 ]

--- a/corehq/apps/accounting/migrations/0053_app_user_profiles_advanced.py
+++ b/corehq/apps/accounting/migrations/0053_app_user_profiles_advanced.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+from django.core.management import call_command
+from corehq.util.django_migrations import skip_on_fresh_install
+
+from corehq.privileges import APP_USER_PROFILES
+
+
+@skip_on_fresh_install
+def _grandfather_basic_privs(apps, schema_editor):
+    call_command('cchq_prbac_bootstrap')
+    call_command(
+        'cchq_prbac_grandfather_privs',
+        APP_USER_PROFILES,
+        skip_edition='Paused,Community,Standard,Pro',
+        noinput=True,
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('accounting', '0052_geocoder_permissions'),
+    ]
+
+    operations = [
+        migrations.RunPython(_grandfather_basic_privs),
+    ]


### PR DESCRIPTION
## Summary
Product request here https://dimagi-dev.atlassian.net/browse/SAAS-11551
"Make App User Profiles feature available to current and future project spaces on Advanced and Enterprise."

## Product Description
Moves App User Profiles to Advanced plans and above. Grandfathers privilege to all Advanced plans. No QA needed as this is a really straightforward migration

## Safety Assurance
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Safety story
Simple and small migration (we don't have that many advanced roles, etc). tested out locally and does what it does. we've done many migrations like this in the past with no consequence

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
