### PR TITLE
Make links in Web Apps more accessible

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
@@ -17,8 +17,8 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
             FormplayerFrontend.trigger("app:select", this.model.get('_id'));
         },
 
-        rowKeyAction: function(e) {
-            if (e.keyCode == 13) {
+        rowKeyAction: function (e) {
+            if (e.keyCode === 13) {
                 // Select application on Enter keydown event.
                 this.rowClick(e);
             }
@@ -61,22 +61,22 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
             FormplayerFrontend.trigger("settings:list");
         },
         incompleteSessionsKeyAction: function (e) {
-            if (e.keyCode == 13) {
+            if (e.keyCode === 13) {
                 this.incompleteSessionsClick(e);
             }
         },
         syncKeyAction: function (e) {
-            if (e.keyCode == 13) {
+            if (e.keyCode === 13) {
                 this.syncClick(e);
             }
         },
         restoreAsKeyAction: function (e) {
-            if (e.keyCode == 13) {
+            if (e.keyCode === 13) {
                 this.onClickRestoreAs(e);
             }
         },
         settingsKeyAction: function (e) {
-            if (e.keyCode == 13) {
+            if (e.keyCode === 13) {
                 this.onClickSettings(e);
             }
         },
@@ -144,7 +144,7 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
             FormplayerFrontend.trigger("app:select", this.appId);
         },
         keyAction: function (e) {
-            if (e.keyCode == 13) {
+            if (e.keyCode === 13) {
                 this.startApp(e);
             }
         },
@@ -183,10 +183,10 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
             FormplayerFrontend.trigger("app:select", this.appId);
         },
         keyAction: function (e) {
-            if (e.keyCode == 13) {
+            if (e.keyCode === 13) {
                 this.startApp();
             }
-        }
+        },
     });
 
     return {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
@@ -9,11 +9,19 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
         className: "grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request",
         events: {
             "click": "rowClick",
+            "keydown": "rowKeyAction",
         },
 
         rowClick: function (e) {
             e.preventDefault();
             FormplayerFrontend.trigger("app:select", this.model.get('_id'));
+        },
+
+        rowKeyAction: function(e) {
+            if (e.keyCode == 13) {
+                // Select application on Enter keydown event.
+                this.rowClick(e);
+            }
         },
 
         templateContext: function () {
@@ -31,6 +39,10 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
             'click .js-sync-item': 'syncClick',
             'click .js-restore-as-item': 'onClickRestoreAs',
             'click .js-settings': 'onClickSettings',
+            'keydown .js-incomplete-sessions-item': 'incompleteSessionsKeyAction',
+            'keydown .js-sync-item': 'syncKeyAction',
+            'keydown .js-restore-as-item': 'restoreAsKeyAction',
+            'keydown .js-settings': 'settingsKeyAction',
         },
         incompleteSessionsClick: function (e) {
             e.preventDefault();
@@ -48,6 +60,26 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
             e.preventDefault();
             FormplayerFrontend.trigger("settings:list");
         },
+        incompleteSessionsKeyAction: function (e) {
+            if (e.keyCode == 13) {
+                this.incompleteSessionsClick(e);
+            }
+        },
+        syncKeyAction: function (e) {
+            if (e.keyCode == 13) {
+                this.syncClick(e);
+            }
+        },
+        restoreAsKeyAction: function (e) {
+            if (e.keyCode == 13) {
+                this.onClickRestoreAs(e);
+            }
+        },
+        settingsKeyAction: function (e) {
+            if (e.keyCode == 13) {
+                this.onClickSettings(e);
+            }
+        },
     };
 
     var GridView = Marionette.CollectionView.extend({
@@ -60,6 +92,10 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
         syncClick: _.extend(BaseAppView.syncClick),
         onClickRestoreAs: _.extend(BaseAppView.onClickRestoreAs),
         onClickSettings: _.extend(BaseAppView.onClickSettings),
+        incompleteSessionsKeyAction: _.extend(BaseAppView.incompleteSessionsKeyAction),
+        syncKeyAction: _.extend(BaseAppView.syncKeyAction),
+        restoreAsKeyAction: _.extend(BaseAppView.restoreAsKeyAction),
+        settingsKeyAction: _.extend(BaseAppView.settingsKeyAction),
     });
 
     /**
@@ -75,11 +111,16 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
 
         events: _.extend({
             'click .js-start-app': 'startApp',
+            'keydown .js-start-app': 'keyAction',
         }, BaseAppView.events),
         incompleteSessionsClick: _.extend(BaseAppView.incompleteSessionsClick),
         syncClick: _.extend(BaseAppView.syncClick),
         onClickRestoreAs: _.extend(BaseAppView.onClickRestoreAs),
         onClickSettings: _.extend(BaseAppView.onClickSettings),
+        incompleteSessionsKeyAction: _.extend(BaseAppView.incompleteSessionsKeyAction),
+        syncKeyAction: _.extend(BaseAppView.syncKeyAction),
+        restoreAsKeyAction: _.extend(BaseAppView.restoreAsKeyAction),
+        settingsKeyAction: _.extend(BaseAppView.settingsKeyAction),
 
         initialize: function (options) {
             this.appId = options.appId;
@@ -102,6 +143,11 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
             hqImport('analytix/js/google').track.event("App Preview", "User clicked Start App");
             FormplayerFrontend.trigger("app:select", this.appId);
         },
+        keyAction: function (e) {
+            if (e.keyCode == 13) {
+                this.startApp(e);
+            }
+        },
     });
 
     var LandingPageAppView = Marionette.View.extend({
@@ -110,11 +156,16 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
 
         events: _.extend({
             'click .js-start-app': 'startApp',
+            'keydown .js-start-app': 'keyAction',
         }, BaseAppView.events),
         incompleteSessionsClick: _.extend(BaseAppView.incompleteSessionsClick),
         syncClick: _.extend(BaseAppView.syncClick),
         onClickRestoreAs: _.extend(BaseAppView.onClickRestoreAs),
         onClickSettings: _.extend(BaseAppView.onClickSettings),
+        incompleteSessionsKeyAction: _.extend(BaseAppView.incompleteSessionsKeyAction),
+        syncKeyAction: _.extend(BaseAppView.syncKeyAction),
+        restoreAsKeyAction: _.extend(BaseAppView.restoreAsKeyAction),
+        settingsKeyAction: _.extend(BaseAppView.settingsKeyAction),
 
         initialize: function (options) {
             this.appId = options.appId;
@@ -131,6 +182,11 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
         startApp: function () {
             FormplayerFrontend.trigger("app:select", this.appId);
         },
+        keyAction: function (e) {
+            if (e.keyCode == 13) {
+                this.startApp();
+            }
+        }
     });
 
     return {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -319,6 +319,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             'click @ui.paginators': 'paginateAction',
             'click @ui.columnHeader': 'columnSortAction',
             'keypress': 'keyAction',
+            'keypress @ui.paginators': 'paginateKeyAction',
         },
 
         caseListAction: function (e) {
@@ -341,6 +342,13 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         paginateAction: function (e) {
             var pageSelection = $(e.currentTarget).data("id");
             FormplayerFrontend.trigger("menu:paginate", pageSelection);
+        },
+
+        paginateKeyAction: function (e) {
+            if (event.which === 13 || event.keyCode === 13) {
+                e.stopImmediatePropagation();
+                this.paginateAction(e);
+            }
         },
 
         columnSortAction: function (e) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -231,21 +231,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         className: "formplayer-request",
 
         attributes: function () {
-            // For the ARIA label, we use the first datum that is not
-            // an image or a graph.
-            var label = "";
-            var data = this.options.model.get('data');
-            var styles = this.options.styles;
-            for (let i = 0; i < data.length && i < styles.length; i++) {
-                if (styles[i].displayFormat != 'Image' &&
-                    styles[i].displayFormat != 'Graph') {
-                    label = data[i];
-                }
-            }
-
+            var label_id = "case-view-item-".concat(this.options.model.attributes.id);
             return {"role": "link",
                     "tabindex": "0",
-                    "aria-label": label};
+                    "aria-labelledby": label_id};
         },
 
         rowClick: function (e) {
@@ -267,6 +256,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 resolveUri: function (uri) {
                     return FormplayerFrontend.getChannel().request('resourceMap', uri, appId);
                 },
+                labelId: "case-view-item-".concat(this.options.model.attributes.id),
             };
         },
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -15,7 +15,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         className: "formplayer-request",
         attributes: function () {
             var displayText = this.options.model.attributes.displayText;
-            return {"tabindex": "0",
+            return {"role": "link",
+                    "tabindex": "0",
                     "aria-label": displayText.concat(" (Aria Label)")};
         },
         events: {
@@ -241,7 +242,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                     label = data[i];
                 }
             }
-            return {"tabindex": "0",
+            return {"role": "link",
+                    "tabindex": "0",
                     "aria-label": label};
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -319,7 +319,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             'click @ui.paginators': 'paginateAction',
             'click @ui.columnHeader': 'columnSortAction',
             'keypress': 'keyAction',
-            'keypress @ui.paginators': 'paginateKeyAction',
         },
 
         caseListAction: function (e) {
@@ -342,13 +341,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         paginateAction: function (e) {
             var pageSelection = $(e.currentTarget).data("id");
             FormplayerFrontend.trigger("menu:paginate", pageSelection);
-        },
-
-        paginateKeyAction: function (e) {
-            if (event.which === 13 || event.keyCode === 13) {
-                e.stopImmediatePropagation();
-                this.paginateAction(e);
-            }
         },
 
         columnSortAction: function (e) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -461,14 +461,26 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         tagName: "li",
         template: _.template($("#breadcrumb-item-template").html() || ""),
         className: "breadcrumb-text",
+        attributes: function() {
+            return {
+                "role": "link",
+                "tabindex": "0",
+            };
+        },
         events: {
             "click": "crumbClick",
+            "keydown": "crumbKeyAction",
         },
 
         crumbClick: function (e) {
             e.preventDefault();
             var crumbId = this.options.model.get('id');
             FormplayerFrontend.trigger("breadcrumbSelect", crumbId);
+        },
+        crumbKeyAction: function(e) {
+            if (e.keyCode === 13) {
+                this.crumbClick(e);
+            }
         },
     });
 
@@ -479,9 +491,15 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         childViewContainer: "ol",
         events: {
             'click .js-home': 'onClickHome',
+            'keydown .js-home': 'onKeyActionHome',
         },
         onClickHome: function () {
             FormplayerFrontend.trigger('navigateHome');
+        },
+        onKeyActionHome: function (e) {
+            if (e.keyCode === 13) {
+                this.onClickHome();
+            }
         },
 
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -15,9 +15,11 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         className: "formplayer-request",
         attributes: function () {
             var displayText = this.options.model.attributes.displayText;
-            return {"role": "link",
-                    "tabindex": "0",
-                    "aria-label": displayText};
+            return {
+                "role": "link",
+                "tabindex": "0",
+                "aria-label": displayText
+            };
         },
         events: {
             "click": "rowClick",
@@ -74,8 +76,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             $pauseBtn.addClass('hide');
             $pauseBtn.parent().find('.js-module-audio').get(0).pause();
         },
-        rowKeyAction: function(e) {
-            if (e.keyCode == 13) {
+        rowKeyAction: function (e) {
+            if (e.keyCode === 13) {
                 this.rowClick(e);
             }
         },
@@ -231,10 +233,12 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         className: "formplayer-request",
 
         attributes: function () {
-            var label_id = "case-view-item-".concat(this.options.model.attributes.id);
-            return {"role": "link",
-                    "tabindex": "0",
-                    "aria-labelledby": label_id};
+            var labelId = "case-view-item-".concat(this.options.model.attributes.id);
+            return {
+                "role": "link",
+                "tabindex": "0",
+                "aria-labelledby": labelId
+            };
         },
 
         rowClick: function (e) {
@@ -242,8 +246,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             FormplayerFrontend.trigger("menu:show:detail", this.model.get('id'), 0, false);
         },
 
-        rowKeyAction: function(e) {
-            if (e.keyCode == 13) {
+        rowKeyAction: function (e) {
+            if (e.keyCode === 13) {
                 this.rowClick(e);
             }
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -17,7 +17,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             var displayText = this.options.model.attributes.displayText;
             return {"role": "link",
                     "tabindex": "0",
-                    "aria-label": displayText.concat(" (Aria Label)")};
+                    "aria-label": displayText};
         },
         events: {
             "click": "rowClick",
@@ -242,6 +242,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                     label = data[i];
                 }
             }
+
             return {"role": "link",
                     "tabindex": "0",
                     "aria-label": label};

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -461,7 +461,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         tagName: "li",
         template: _.template($("#breadcrumb-item-template").html() || ""),
         className: "breadcrumb-text",
-        attributes: function() {
+        attributes: function () {
             return {
                 "role": "link",
                 "tabindex": "0",
@@ -477,7 +477,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             var crumbId = this.options.model.get('id');
             FormplayerFrontend.trigger("breadcrumbSelect", crumbId);
         },
-        crumbKeyAction: function(e) {
+        crumbKeyAction: function (e) {
             if (e.keyCode === 13) {
                 this.crumbClick(e);
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -18,7 +18,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             return {
                 "role": "link",
                 "tabindex": "0",
-                "aria-label": displayText
+                "aria-label": displayText,
             };
         },
         events: {
@@ -237,7 +237,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             return {
                 "role": "link",
                 "tabindex": "0",
-                "aria-labelledby": labelId
+                "aria-labelledby": labelId,
             };
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -13,10 +13,16 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             }
         },
         className: "formplayer-request",
+        attributes: function () {
+            var displayText = this.options.model.attributes.displayText;
+            return {"tabindex": "0",
+                    "aria-label": displayText.concat(" (Aria Label)")};
+        },
         events: {
             "click": "rowClick",
             "click .js-module-audio-play": "audioPlay",
             "click .js-module-audio-pause": "audioPause",
+            "keydown": "rowKeyAction",
         },
 
         initialize: function (options) {
@@ -66,6 +72,11 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             $pauseBtn.parent().find('.js-module-audio-play').removeClass('hide');
             $pauseBtn.addClass('hide');
             $pauseBtn.parent().find('.js-module-audio').get(0).pause();
+        },
+        rowKeyAction: function(e) {
+            if (e.keyCode == 13) {
+                this.rowClick(e);
+            }
         },
         templateContext: function () {
             var imageUri = this.options.model.get('imageUri');
@@ -213,13 +224,36 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
         events: {
             "click": "rowClick",
+            "keydown": "rowKeyAction",
         },
 
         className: "formplayer-request",
 
+        attributes: function () {
+            // For the ARIA label, we use the first datum that is not
+            // an image or a graph.
+            var label = "";
+            var data = this.options.model.get('data');
+            var styles = this.options.styles;
+            for (let i = 0; i < data.length && i < styles.length; i++) {
+                if (styles[i].displayFormat != 'Image' &&
+                    styles[i].displayFormat != 'Graph') {
+                    label = data[i];
+                }
+            }
+            return {"tabindex": "0",
+                    "aria-label": label};
+        },
+
         rowClick: function (e) {
             e.preventDefault();
             FormplayerFrontend.trigger("menu:show:detail", this.model.get('id'), 0, false);
+        },
+
+        rowKeyAction: function(e) {
+            if (e.keyCode == 13) {
+                this.rowClick(e);
+            }
         },
 
         templateContext: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -15,9 +15,11 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
 
         attributes: function () {
             var sessionLabelId = "SessionLabel-".concat(this.model.get('sessionId'));
-            return {"role": "link",
-                    "tabindex": "0",
-                    "aria-labelledby": sessionLabelId};
+            return {
+                "role": "link",
+                "tabindex": "0",
+                "aria-labelledby": sessionLabelId
+            };
         },
 
         template: _.template($("#session-view-item-template").html() || ""),
@@ -28,8 +30,8 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
             FormplayerFrontend.trigger("getSession", model.get('sessionId'));
         },
 
-        rowKeyAction: function(e) {
-            if (e.keyCode == 13) {
+        rowKeyAction: function (e) {
+            if (e.keyCode === 13) {
                 this.rowClick(e);
             }
         },
@@ -54,10 +56,10 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
                 },
             });
         },
-        deleteKeyAction: function(e) {
+        deleteKeyAction: function (e) {
             // The ARIA button role would activate on either Space or Enter,
             // but we require Enter for now to avoid accidental deletions.
-            if (e.keyCode == 13) {
+            if (e.keyCode === 13) {
                 this.onDeleteSession(e);
             }
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -18,7 +18,7 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
             return {
                 "role": "link",
                 "tabindex": "0",
-                "aria-labelledby": sessionLabelId
+                "aria-labelledby": sessionLabelId,
             };
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -8,7 +8,16 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
         className: "formplayer-request",
         events: {
             "click": "rowClick",
+            "keydown": "rowKeyAction",
             "click .module-delete-control": "onDeleteSession",
+            "keydown .module-delete-control": "deleteKeyAction",
+        },
+
+        attributes: function () {
+            var sessionLabelId = "SessionLabel-".concat(this.model.get('sessionId'));
+            return {"role": "link",
+                    "tabindex": "0",
+                    "aria-labelledBy": sessionLabelId};
         },
 
         template: _.template($("#session-view-item-template").html() || ""),
@@ -19,9 +28,16 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
             FormplayerFrontend.trigger("getSession", model.get('sessionId'));
         },
 
+        rowKeyAction: function(e) {
+            if (e.keyCode == 13) {
+                this.rowClick(e);
+            }
+        },
+
         templateContext: function () {
             return {
                 humanDateOpened: moment(this.model.get('dateOpened')).fromNow(),
+                labelId: "SessionLabel-".concat(this.model.get('sessionId')),
             };
         },
         onDeleteSession: function (e) {
@@ -37,6 +53,13 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
                     FormplayerFrontend.getChannel().request("deleteSession", self.model);
                 },
             });
+        },
+        deleteKeyAction: function(e) {
+            // The ARIA button role would activate on either Space or Enter,
+            // but we require Enter for now to avoid accidental deletions.
+            if (e.keyCode == 13) {
+                this.onDeleteSession(e);
+            }
         },
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -17,7 +17,7 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
             var sessionLabelId = "SessionLabel-".concat(this.model.get('sessionId'));
             return {"role": "link",
                     "tabindex": "0",
-                    "aria-labelledBy": sessionLabelId};
+                    "aria-labelledby": sessionLabelId};
         },
 
         template: _.template($("#session-view-item-template").html() || ""),

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
@@ -47,7 +47,7 @@ hqDefine("cloudcare/js/formplayer/users/views", function () {
             return {
                 "role": "link",
                 "tabindex": "0",
-                "aria-label": this.model.get('username')
+                "aria-label": this.model.get('username'),
             };
         },
         onClickUser: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
@@ -44,9 +44,11 @@ hqDefine("cloudcare/js/formplayer/users/views", function () {
             'keydown': 'onKeyActionUser',
         },
         attributes: function () {
-            return {"role": "link",
-                    "tabindex": "0",
-                    "aria-label": this.model.get('username')};
+            return {
+                "role": "link",
+                "tabindex": "0",
+                "aria-label": this.model.get('username')
+            };
         },
         onClickUser: function () {
             Util.confirmationModal({
@@ -66,8 +68,8 @@ hqDefine("cloudcare/js/formplayer/users/views", function () {
                 }.bind(this),
             });
         },
-        onKeyActionUser: function(e) {
-            if (e.keyCode == 13) {
+        onKeyActionUser: function (e) {
+            if (e.keyCode === 13) {
                 this.onClickUser();
             }
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
@@ -41,6 +41,12 @@ hqDefine("cloudcare/js/formplayer/users/views", function () {
         tagName: 'tr',
         events: {
             'click': 'onClickUser',
+            'keydown': 'onKeyActionUser',
+        },
+        attributes: function () {
+            return {"role": "link",
+                    "tabindex": "0",
+                    "aria-label": this.model.get('username')};
         },
         onClickUser: function () {
             Util.confirmationModal({
@@ -59,6 +65,11 @@ hqDefine("cloudcare/js/formplayer/users/views", function () {
                     );
                 }.bind(this),
             });
+        },
+        onKeyActionUser: function(e) {
+            if (e.keyCode == 13) {
+                this.onClickUser();
+            }
         },
     });
 

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -68,7 +68,7 @@
         <ul class="pagination">
           <% if (currentPage > 0) { %>
           <li class="page-item" id="prev-page">
-            <a class="page-link" aria-label="Previous" data-id="<%= currentPage - 1 %>">
+            <a class="page-link" aria-label="Previous" tabindex="0" data-id="<%= currentPage - 1 %>">
               <span aria-hidden="true"><i class="fa fa-angle-double-left"></i></span>
               <span class="sr-only">{% trans "Previous" %}</span>
             </a>
@@ -82,11 +82,11 @@
           </li>
           <% } %>
           <% for (i = 0; i < pageCount; i++) { %>
-          <li class="page-item<% if (i === currentPage) { %> active<% } %>"><a class="page-link" data-id="<%= i %>"><%= i + 1 %></a></li>
+          <li class="page-item<% if (i === currentPage) { %> active<% } %>"><a class="page-link" tabindex="0" data-id="<%= i %>"><%= i + 1 %></a></li>
           <% } %>
           <% if (currentPage < pageCount - 1) { %>
           <li class="page-item" id="next-page">
-            <a class="page-link" aria-label="Next" data-id="<%= currentPage + 1 %>">
+            <a class="page-link" aria-label="Next" tabindex="0" data-id="<%= currentPage + 1 %>">
               <span aria-hidden="true"><i class="fa fa-angle-double-right"></i></span>
               <span class="sr-only">{% trans "Next" %}</span>
             </a>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -114,7 +114,7 @@
   <% } else if (styles[index].displayFormat === 'Graph') { %>
   <td class="module-caselist-column"><iframe srcdoc="<%= datum %>" height="300" width="300"></iframe></td>
   <% } else { %>
-  <td class="module-caselist-column"><%= datum %></td>
+  <td class="module-caselist-column" id="<%= labelId %>"><%= datum %></td>
   <% } %>
   <% } %>
   <% }); %>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -68,7 +68,7 @@
         <ul class="pagination">
           <% if (currentPage > 0) { %>
           <li class="page-item" id="prev-page">
-            <a class="page-link" aria-label="Previous" tabindex="0" data-id="<%= currentPage - 1 %>">
+            <a class="page-link" aria-label="Previous" data-id="<%= currentPage - 1 %>">
               <span aria-hidden="true"><i class="fa fa-angle-double-left"></i></span>
               <span class="sr-only">{% trans "Previous" %}</span>
             </a>
@@ -82,11 +82,11 @@
           </li>
           <% } %>
           <% for (i = 0; i < pageCount; i++) { %>
-          <li class="page-item<% if (i === currentPage) { %> active<% } %>"><a class="page-link" tabindex="0" data-id="<%= i %>"><%= i + 1 %></a></li>
+          <li class="page-item<% if (i === currentPage) { %> active<% } %>"><a class="page-link" data-id="<%= i %>"><%= i + 1 %></a></li>
           <% } %>
           <% if (currentPage < pageCount - 1) { %>
           <li class="page-item" id="next-page">
-            <a class="page-link" aria-label="Next" tabindex="0" data-id="<%= currentPage + 1 %>">
+            <a class="page-link" aria-label="Next" data-id="<%= currentPage + 1 %>">
               <span aria-hidden="true"><i class="fa fa-angle-double-right"></i></span>
               <span class="sr-only">{% trans "Next" %}</span>
             </a>

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -11,39 +11,39 @@
 
     </div>
     <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-      <div class="js-incomplete-sessions-item appicon appicon-incomplete" role="link" tabindex="0" aria-label="Incomplete forms (Aria label)">
+      <div class="js-incomplete-sessions-item appicon appicon-incomplete" role="link" tabindex="0" aria-labelledby="grid-template-incomplete-forms-heading">
         <i class="ff ff-incomplete-bg appicon-icon appicon-icon-bg" aria-hidden="true"></i>
         <i class="ff ff-incomplete-fg appicon-icon appicon-icon-fg" aria-hidden="true"></i>
         <div class="appicon-title">
-          <h3>{% trans "Incomplete Forms" %}</h3>
+          <h3 id="grid-template-incomplete-forms-heading">{% trans "Incomplete Forms" %}</h3>
         </div>
       </div>
     </div>
 
     <div class=" grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-      <div class="js-sync-item appicon appicon-sync" role="link" tabindex="0" aria-label="Sync (Aria label)">
+      <div class="js-sync-item appicon appicon-sync" role="link" tabindex="0" aria-labelledby="grid-template-sync-heading">
         <i class="ff ff-sync appicon-icon" aria-hidden="true"></i>
         <div class="appicon-title">
-          <h3>{% trans "Sync" %}</h3>
+          <h3 id="grid-template-sync-heading">{% trans "Sync" %}</h3>
         </div>
       </div>
     </div>
 
     {% if request|can_use_restore_as %}
       <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-        <div class="js-restore-as-item appicon appicon-restore-as" role="link" tabindex="0" aria-label="Login as (Aria label)">
+        <div class="js-restore-as-item appicon appicon-restore-as" role="link" tabindex="0" aria-labelledby="grid-template-login-as-heading">
           <i class="fa fa-user appicon-icon" aria-hidden="true"></i>
           <div class="appicon-title">
-            <h3>{% trans "Login as" %}</h3>
+            <h3 id="grid-template-login-as-heading">{% trans "Login as" %}</h3>
           </div>
         </div>
       </div>
     {% endif %}
     <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-      <div class="js-settings appicon appicon-settings" role="link" tabindex="0" aria-label="Settings (Aria label)">
+      <div class="js-settings appicon appicon-settings" role="link" tabindex="0" aria-labelledby="grid-template-settings-heading">
         <i class="fa fa-gear appicon-icon" aria-hidden="true"></i>
         <div class="appicon-title">
-          <h3>{% trans "Settings" %}</h3>
+          <h3 id="grid-template-settings-heading">{% trans "Settings" %}</h3>
         </div>
       </div>
     </div>
@@ -57,48 +57,48 @@
   <div class="container container-appicons">
     <div class="row">
       <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-        <div class="js-start-app appicon appicon-start" role="link" tabindex="0" aria-label="Start (Aria label)">
+        <div class="js-start-app appicon appicon-start" role="link" tabindex="0" aria-labelledby="single-app-start-heading">
           <i class="ff ff-start-bg appicon-icon appicon-icon-bg" aria-hidden="true"></i>
           <i class="ff ff-start-fg appicon-icon appicon-icon-fg" aria-hidden="true"></i>
           <div class="appicon-title">
-            <h3>{% trans "Start" %}</h3>
+            <h3 id="single-app-start-heading">{% trans "Start" %}</h3>
           </div>
         </div>
       </div>
       <% if (showIncompleteForms()) { %>
       <div class=" grid-item col-xs-6 col-sm-4 formplayer-request">
-        <div class="js-incomplete-sessions-item appicon appicon-incomplete" role="link" tabindex="0" aria-label="Incomplete forms (Aria label)">
+        <div class="js-incomplete-sessions-item appicon appicon-incomplete" role="link" tabindex="0" aria-labelledby="single-app-incomplete-forms-heading">
           <i class="ff ff-incomplete-bg appicon-icon appicon-icon-bg" aria-hidden="true"></i>
           <i class="ff ff-incomplete-fg appicon-icon appicon-icon-fg" aria-hidden="true"></i>
           <div class="appicon-title">
-            <h3>{% trans "Incomplete Forms" %}</h3>
+            <h3 id="single-app-incomplete-forms-heading">{% trans "Incomplete Forms" %}</h3>
           </div>
         </div>
       </div>
       <% } %>
       <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-        <div class="js-sync-item appicon appicon-sync" role="link" tabindex="0" aria-label="Sync (Aria label)">
+        <div class="js-sync-item appicon appicon-sync" role="link" tabindex="0" aria-labelledby="single-app-sync-heading">
           <i class="ff ff-sync appicon-icon" aria-hidden="true"></i>
           <div class="appicon-title">
-            <h3>{% trans "Sync" %}</h3>
+            <h3 id="single-app-sync-heading">{% trans "Sync" %}</h3>
           </div>
         </div>
       </div>
       {% if request|can_use_restore_as %}
         <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-          <div class="js-restore-as-item appicon appicon-restore-as" role="link" tabindex="0" aria-label="Login as (Aria label)">
+          <div class="js-restore-as-item appicon appicon-restore-as" role="link" tabindex="0" aria-labelledby="single-app-login-as-heading">
             <i class="fa fa-user appicon-icon" aria-hidden="true"></i>
             <div class="appicon-title">
-              <h3>{% trans "Login as" %}</h3>
+              <h3 id="single-app-login-as-heading">{% trans "Login as" %}</h3>
             </div>
           </div>
         </div>
       {% endif %}
       <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-        <div class="js-settings appicon appicon-settings" role="link" tabindex="0" aria-label="Settings (Aria label)">
+        <div class="js-settings appicon appicon-settings" role="link" tabindex="0" aria-labelledby="single-app-settings-heading">
           <i class="fa fa-gear appicon-icon" aria-hidden="true"></i>
           <div class="appicon-title">
-            <h3>{% trans "Settings" %}</h3>
+            <h3 id="single-app-settings-heading">{% trans "Settings" %}</h3>
           </div>
         </div>
       </div>
@@ -111,7 +111,7 @@
   <div class="container">
     <div class="spacer"></div>
     <div class="col-xs-6 col-sm-4 col-xs-offset-3 col-sm-offset-4">
-      <div class="appicon appicon-default js-start-app" role="link" tabindex="0" aria-label="<%= appName %> (Aria label)">
+      <div class="appicon appicon-default js-start-app" role="link" tabindex="0" aria-label="<%= appName %>">
         <% if (!imageUrl) { %>
           <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
         <% } else { %>
@@ -127,7 +127,7 @@
 </script>
 
 <script id="row-template" type="text/template">
-  <div class="appicon appicon-default" role="link" tabindex="0" aria-label="<%- name %> (Aria label)">
+  <div class="appicon appicon-default" role="link" tabindex="0" aria-label="<%- name %>">
     <% if (!imageUrl) { %>
       <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
     <% } else { %>

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -11,7 +11,7 @@
 
     </div>
     <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-      <div class="js-incomplete-sessions-item appicon appicon-incomplete" tabindex="0" aria-label="Incomplete forms (Aria label)">
+      <div class="js-incomplete-sessions-item appicon appicon-incomplete" role="link" tabindex="0" aria-label="Incomplete forms (Aria label)">
         <i class="ff ff-incomplete-bg appicon-icon appicon-icon-bg" aria-hidden="true"></i>
         <i class="ff ff-incomplete-fg appicon-icon appicon-icon-fg" aria-hidden="true"></i>
         <div class="appicon-title">
@@ -21,7 +21,7 @@
     </div>
 
     <div class=" grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-      <div class="js-sync-item appicon appicon-sync" tabindex="0" aria-label="Sync (Aria label)">
+      <div class="js-sync-item appicon appicon-sync" role="link" tabindex="0" aria-label="Sync (Aria label)">
         <i class="ff ff-sync appicon-icon" aria-hidden="true"></i>
         <div class="appicon-title">
           <h3>{% trans "Sync" %}</h3>
@@ -31,7 +31,7 @@
 
     {% if request|can_use_restore_as %}
       <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-        <div class="js-restore-as-item appicon appicon-restore-as" tabindex="0" aria-label="Login as (Aria label)">
+        <div class="js-restore-as-item appicon appicon-restore-as" role="link" tabindex="0" aria-label="Login as (Aria label)">
           <i class="fa fa-user appicon-icon" aria-hidden="true"></i>
           <div class="appicon-title">
             <h3>{% trans "Login as" %}</h3>
@@ -40,7 +40,7 @@
       </div>
     {% endif %}
     <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-      <div class="js-settings appicon appicon-settings" tabindex="0" aria-label="Settings (Aria label)">
+      <div class="js-settings appicon appicon-settings" role="link" tabindex="0" aria-label="Settings (Aria label)">
         <i class="fa fa-gear appicon-icon" aria-hidden="true"></i>
         <div class="appicon-title">
           <h3>{% trans "Settings" %}</h3>
@@ -57,7 +57,7 @@
   <div class="container container-appicons">
     <div class="row">
       <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-        <div class="js-start-app appicon appicon-start" tabindex="0" aria-label="Start (Aria label)">
+        <div class="js-start-app appicon appicon-start" role="link" tabindex="0" aria-label="Start (Aria label)">
           <i class="ff ff-start-bg appicon-icon appicon-icon-bg" aria-hidden="true"></i>
           <i class="ff ff-start-fg appicon-icon appicon-icon-fg" aria-hidden="true"></i>
           <div class="appicon-title">
@@ -67,7 +67,7 @@
       </div>
       <% if (showIncompleteForms()) { %>
       <div class=" grid-item col-xs-6 col-sm-4 formplayer-request">
-        <div class="js-incomplete-sessions-item appicon appicon-incomplete" tabindex="0" aria-label="Incomplete forms (Aria label)">
+        <div class="js-incomplete-sessions-item appicon appicon-incomplete" role="link" tabindex="0" aria-label="Incomplete forms (Aria label)">
           <i class="ff ff-incomplete-bg appicon-icon appicon-icon-bg" aria-hidden="true"></i>
           <i class="ff ff-incomplete-fg appicon-icon appicon-icon-fg" aria-hidden="true"></i>
           <div class="appicon-title">
@@ -77,7 +77,7 @@
       </div>
       <% } %>
       <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-        <div class="js-sync-item appicon appicon-sync" tabindex="0" aria-label="Sync (Aria label)">
+        <div class="js-sync-item appicon appicon-sync" role="link" tabindex="0" aria-label="Sync (Aria label)">
           <i class="ff ff-sync appicon-icon" aria-hidden="true"></i>
           <div class="appicon-title">
             <h3>{% trans "Sync" %}</h3>
@@ -86,7 +86,7 @@
       </div>
       {% if request|can_use_restore_as %}
         <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-          <div class="js-restore-as-item appicon appicon-restore-as" tabindex="0" aria-label="Login as (Aria label)">
+          <div class="js-restore-as-item appicon appicon-restore-as" role="link" tabindex="0" aria-label="Login as (Aria label)">
             <i class="fa fa-user appicon-icon" aria-hidden="true"></i>
             <div class="appicon-title">
               <h3>{% trans "Login as" %}</h3>
@@ -95,7 +95,7 @@
         </div>
       {% endif %}
       <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-        <div class="js-settings appicon appicon-settings" tabindex="0" aria-label="Settings (Aria label)">
+        <div class="js-settings appicon appicon-settings" role="link" tabindex="0" aria-label="Settings (Aria label)">
           <i class="fa fa-gear appicon-icon" aria-hidden="true"></i>
           <div class="appicon-title">
             <h3>{% trans "Settings" %}</h3>
@@ -111,7 +111,7 @@
   <div class="container">
     <div class="spacer"></div>
     <div class="col-xs-6 col-sm-4 col-xs-offset-3 col-sm-offset-4">
-      <div class="appicon appicon-default js-start-app" tabindex="0" aria-label="<%= appName %> (Aria label)">
+      <div class="appicon appicon-default js-start-app" role="link" tabindex="0" aria-label="<%= appName %> (Aria label)">
         <% if (!imageUrl) { %>
           <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
         <% } else { %>
@@ -127,7 +127,7 @@
 </script>
 
 <script id="row-template" type="text/template">
-  <div class="appicon appicon-default" tabindex="0" aria-label="<%- name %> (Aria label)">
+  <div class="appicon appicon-default" role="link" tabindex="0" aria-label="<%- name %> (Aria label)">
     <% if (!imageUrl) { %>
       <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
     <% } else { %>

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -11,7 +11,7 @@
 
     </div>
     <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-      <div class="js-incomplete-sessions-item appicon appicon-incomplete">
+      <div class="js-incomplete-sessions-item appicon appicon-incomplete" tabindex="0" aria-label="Incomplete forms (Aria label)">
         <i class="ff ff-incomplete-bg appicon-icon appicon-icon-bg" aria-hidden="true"></i>
         <i class="ff ff-incomplete-fg appicon-icon appicon-icon-fg" aria-hidden="true"></i>
         <div class="appicon-title">
@@ -21,7 +21,7 @@
     </div>
 
     <div class=" grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-      <div class="js-sync-item appicon appicon-sync">
+      <div class="js-sync-item appicon appicon-sync" tabindex="0" aria-label="Sync (Aria label)">
         <i class="ff ff-sync appicon-icon" aria-hidden="true"></i>
         <div class="appicon-title">
           <h3>{% trans "Sync" %}</h3>
@@ -31,7 +31,7 @@
 
     {% if request|can_use_restore_as %}
       <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-        <div class="js-restore-as-item appicon appicon-restore-as">
+        <div class="js-restore-as-item appicon appicon-restore-as" tabindex="0" aria-label="Login as (Aria label)">
           <i class="fa fa-user appicon-icon" aria-hidden="true"></i>
           <div class="appicon-title">
             <h3>{% trans "Login as" %}</h3>
@@ -40,7 +40,7 @@
       </div>
     {% endif %}
     <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-      <div class="js-settings appicon appicon-settings">
+      <div class="js-settings appicon appicon-settings" tabindex="0" aria-label="Settings (Aria label)">
         <i class="fa fa-gear appicon-icon" aria-hidden="true"></i>
         <div class="appicon-title">
           <h3>{% trans "Settings" %}</h3>
@@ -57,7 +57,7 @@
   <div class="container container-appicons">
     <div class="row">
       <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-        <div class="js-start-app appicon appicon-start">
+        <div class="js-start-app appicon appicon-start" tabindex="0" aria-label="Start (Aria label)">
           <i class="ff ff-start-bg appicon-icon appicon-icon-bg" aria-hidden="true"></i>
           <i class="ff ff-start-fg appicon-icon appicon-icon-fg" aria-hidden="true"></i>
           <div class="appicon-title">
@@ -67,7 +67,7 @@
       </div>
       <% if (showIncompleteForms()) { %>
       <div class=" grid-item col-xs-6 col-sm-4 formplayer-request">
-        <div class="js-incomplete-sessions-item appicon appicon-incomplete">
+        <div class="js-incomplete-sessions-item appicon appicon-incomplete" tabindex="0" aria-label="Incomplete forms (Aria label)">
           <i class="ff ff-incomplete-bg appicon-icon appicon-icon-bg" aria-hidden="true"></i>
           <i class="ff ff-incomplete-fg appicon-icon appicon-icon-fg" aria-hidden="true"></i>
           <div class="appicon-title">
@@ -77,7 +77,7 @@
       </div>
       <% } %>
       <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-        <div class="js-sync-item appicon appicon-sync">
+        <div class="js-sync-item appicon appicon-sync" tabindex="0" aria-label="Sync (Aria label)">
           <i class="ff ff-sync appicon-icon" aria-hidden="true"></i>
           <div class="appicon-title">
             <h3>{% trans "Sync" %}</h3>
@@ -86,7 +86,7 @@
       </div>
       {% if request|can_use_restore_as %}
         <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-          <div class="js-restore-as-item appicon appicon-restore-as">
+          <div class="js-restore-as-item appicon appicon-restore-as" tabindex="0" aria-label="Login as (Aria label)">
             <i class="fa fa-user appicon-icon" aria-hidden="true"></i>
             <div class="appicon-title">
               <h3>{% trans "Login as" %}</h3>
@@ -95,7 +95,7 @@
         </div>
       {% endif %}
       <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
-        <div class="js-settings appicon appicon-settings">
+        <div class="js-settings appicon appicon-settings" tabindex="0" aria-label="Settings (Aria label)">
           <i class="fa fa-gear appicon-icon" aria-hidden="true"></i>
           <div class="appicon-title">
             <h3>{% trans "Settings" %}</h3>
@@ -111,7 +111,7 @@
   <div class="container">
     <div class="spacer"></div>
     <div class="col-xs-6 col-sm-4 col-xs-offset-3 col-sm-offset-4">
-      <div class="appicon appicon-default js-start-app">
+      <div class="appicon appicon-default js-start-app" tabindex="0" aria-label="<%= appName %> (Aria label)">
         <% if (!imageUrl) { %>
           <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
         <% } else { %>
@@ -127,7 +127,7 @@
 </script>
 
 <script id="row-template" type="text/template">
-  <div class="appicon appicon-default">
+  <div class="appicon appicon-default" tabindex="0" aria-label="<%- name %> (Aria label)">
     <% if (!imageUrl) { %>
       <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
     <% } else { %>

--- a/corehq/apps/cloudcare/templates/formplayer/menu_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/menu_list.html
@@ -121,7 +121,7 @@
 
 <script type="text/template" id="breadcrumb-list-template">
   <ol class="breadcrumb">
-    <li class="js-home breadcrumb-text"><i class="fa fa-home"></i></li>
+    <li class="js-home breadcrumb-text" role="link" tabindex="0" aria-label="Home"><i class="fa fa-home"></i></li>
     <div class="pull-right dropdown dropdown-menu-right" id="form-menu">
     </div>
   </ol>

--- a/corehq/apps/cloudcare/templates/formplayer/session_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/session_list.html
@@ -47,7 +47,7 @@
       <% if (caseName) { %>(<%- caseName %>)<% } %>
       opened <%- humanDateOpened %>
     </h3>
-    <div class="module-delete-control" role="button" tabindex="0" aria-label="Delete form">
+    <div class="module-delete-control" role="button" tabindex="0" aria-label="{% trans_html_attr 'Delete form' %}">
       <i class="fa fa-trash module-icon module-delete-icon"></i>
     </div>
   </td>

--- a/corehq/apps/cloudcare/templates/formplayer/session_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/session_list.html
@@ -42,12 +42,12 @@
     </div>
   </td>
   <td class="module-column module-column-name module-column-name-session">
-    <h3>
+    <h3 id="<%- labelId %>">
       <b><%- title %></b>
       <% if (caseName) { %>(<%- caseName %>)<% } %>
       opened <%- humanDateOpened %>
     </h3>
-    <div class="module-delete-control">
+    <div class="module-delete-control" role="button" tabindex="0" aria-label="Delete form">
       <i class="fa fa-trash module-icon module-delete-icon"></i>
     </div>
   </td>


### PR DESCRIPTION
## Summary

https://dimagi-dev.atlassian.net/browse/USH-394

Make links in Web Apps more accessible.

This is the first change to improve Web Apps accessibility based on feedback from screen reader users. The overall plan for this work is described in [this document](https://docs.google.com/document/d/1fHNaVlaFl1xrbtPbMqj0YpByss1e0_hzCRlAUbVLboM/edit?usp=sharing), which includes links to the feedback from a vendor and links to accessibility standards and resources.

This first change makes navigation links in Web Apps implement the [WAI-ARIA](https://www.w3.org/TR/wai-aria/) role of "link", which typically involves 4 parts:

1. find the appropriate HTML element and add the role="link" attribute which informs screen readers to treat it as a link.
2. put the element into the tab order with the tabindex="0" attribute, so it can receive keyboard focus.
3. add a keyboard event handler to the Marionette view for the element which treats Enter key presses like mouse clicks.
4. add a label with either aria-labelledby or aria-label to tell a screen reader what text to read for the element.

Using aria-labelledby, which refers to another element by id, is preferable to aria-label, so I tried to use aria-labelledby in most cases. Using aria-labelledby with translated terms should read them after translation, which definitely seems better.

## Product Description

For users without a screen reader, this change enables keyboard navigation of Web Apps, using the Tab and Enter keys. Navigating by keyboard is one way to test that it works. No other changes should be evident without a screen reader.

### QA Plan

The QA plan will be check navigation of these pages by mouse to ensure there are no regressions and to test navigation by keyboard to see if the changes actually work.

[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-2188)

### Safety story

WAI-ARIA attributes are designed to have no effect outside of accessibility tools, so they shouldn't cause any regressions.

The other changes are putting elements into the focus ring and handling key clicks on them, which should not affect existing users who navigate by mouse clicks.

### Rollback instructions

- [X] This PR can be reverted after deploy with no further considerations 
