### PR TITLE
Fixed lookup table pull for remote linked apps

### DIFF
--- a/corehq/apps/linked_domain/remote_accessors.py
+++ b/corehq/apps/linked_domain/remote_accessors.py
@@ -28,8 +28,9 @@ def get_custom_data_models(domain_link, limit_types=None):
     return _do_request_to_remote_hq_json(url, domain_link.remote_details, domain_link.linked_domain, params)
 
 
-def get_fixture(domain_link):
-    return _do_simple_request('linked_domain:fixtures', domain_link)
+def get_fixture(domain_link, tag):
+    url = reverse('linked_domain:fixture', args=[domain_link.master_domain, tag])
+    return _do_request_to_remote_hq_json(url, domain_link.remote_details, domain_link.linked_domain)
 
 
 def get_user_roles(domain_link):


### PR DESCRIPTION
## Summary
https://sentry.io/organizations/dimagi/issues/2021629685/events/f5f4b0b189d9439da39f8744dc30be1d/

## Feature Flag
Linked project spaces

## Product Description
This fixes lookup table updates for remote linked project spaces

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

Not a ton for remote linked apps.

### QA Plan

Not QAing. This code has never worked and is only used by USH teams for their performance testing projects.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
