### PR TITLE
Fixed missing instances in apps using multiple case search menus

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -133,8 +133,8 @@ def preset_instances(app, instance_name):
         return Instance(**kwargs)
 
 
-@register_factory('item-list', 'schedule', 'indicators', 'commtrack')
 @memoized
+@register_factory('item-list', 'schedule', 'indicators', 'commtrack')
 def generic_fixture_instances(app, instance_name):
     return Instance(id=instance_name, src='jr://fixture/{}'.format(instance_name))
 

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -4,16 +4,17 @@
           relevant="instance('groups')/groups/group and count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 0">
       <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
     </post>
-    <command id="search_command.m0">
+    <command id="search_command.{module_id}">
       <display>
         <text>
-          <locale id="case_search.m0"/>
+          <locale id="case_search.{module_id}"/>
         </text>
       </display>
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
     <instance id="groups" src="jr://fixture/user-groups"/>
+    <instance id="item-list:moons" src="jr://fixture/item-list:moons"/>
     <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
     <instance id="locations" src="jr://fixture/locations"/>
     <instance id="reports" src="jr://fixture/commcare:reports"/>
@@ -28,14 +29,14 @@
         <prompt key="name">
           <display>
             <text>
-              <locale id="search_property.m0.name"/>
+              <locale id="search_property.{module_id}.name"/>
             </text>
           </display>
         </prompt>
         <prompt key="dob">
           <display>
             <text>
-              <locale id="search_property.m0.dob"/>
+              <locale id="search_property.{module_id}.dob"/>
             </text>
           </display>
         </prompt>
@@ -43,8 +44,8 @@
       <datum id="case_id"
              nodeset="instance('results')/results/case[@case_type='case']"
              value="./@case_id"
-             detail-confirm="m0_case_long"
-             detail-select="m0_search_short"/>
+             detail-confirm="{module_id}_case_long"
+             detail-select="{module_id}_search_short"/>
     </session>
     <stack>
       <push>

--- a/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
@@ -33,6 +33,22 @@
         </text>
       </template>
     </field>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.case_short.case_calculated_property_3.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="$calculated_property">
+            <variable name="calculated_property">
+              <xpath function="instance('item-list:moons')/moons_list/moons[favorite='yes']/name"/>
+            </variable>
+          </xpath>
+        </text>
+      </template>
+    </field>
     <action auto_launch="false">
       <display>
         <text>
@@ -111,6 +127,22 @@
           <xpath function="$calculated_property">
             <variable name="calculated_property">
               <xpath function="instance('reports')/report[1]/name"/>
+            </variable>
+          </xpath>
+        </text>
+      </template>
+    </field>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.search_short.case_calculated_property_3.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="$calculated_property">
+            <variable name="calculated_property">
+              <xpath function="instance('item-list:moons')/moons_list/moons[favorite='yes']/name"/>
             </variable>
           </xpath>
         </text>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
@@ -13,6 +13,7 @@
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
+    <instance id="item-list:moons" src="jr://fixture/item-list:moons"/>
     <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
     <instance id="reports" src="jr://fixture/commcare:reports"/>
     <session>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
@@ -13,6 +13,7 @@
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
+    <instance id="item-list:moons" src="jr://fixture/item-list:moons"/>
     <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
     <instance id="locations" src="jr://fixture/locations"/>
     <instance id="reports" src="jr://fixture/commcare:reports"/>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -36,6 +36,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         self.module = self.app.add_module(Module.new_module("Untitled Module", None))
         self.app.new_form(0, "Untitled Form", None)
         self.module.case_type = 'case'
+
         # chosen xpath just used to reference more instances - not considered valid to use in apps
         self.module.case_details.short.columns.append(
             DetailColumn.wrap(dict(
@@ -44,6 +45,15 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 format="calculate",
                 field="whatever",
                 calc_xpath="instance('reports')/report[1]/name",
+            ))
+        )
+        self.module.case_details.short.columns.append(
+            DetailColumn.wrap(dict(
+                header={"en": "moon"},
+                model="case",
+                format="calculate",
+                field="whatever",
+                calc_xpath="instance('item-list:moons')/moons_list/moons[favorite='yes']/name",
             ))
         )
         self.module.case_details.long.columns.append(
@@ -84,7 +94,11 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
             get_url_base_patch.return_value = 'https://www.example.com'
             suite = self.app.create_suite()
-        self.assertXmlPartialEqual(self.get_xml('remote_request'), suite, "./remote-request[1]")
+        self.assertXmlPartialEqual(
+            self.get_xml('remote_request').decode('utf-8').format(module_id="m0"),
+            suite,
+            "./remote-request[1]"
+        )
 
     def test_remote_request_custom_detail(self, *args):
         """Remote requests for modules with custom details point to the custom detail
@@ -105,7 +119,16 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
             get_url_base_patch.return_value = 'https://www.example.com'
             suite = copy_app.create_suite()
-        self.assertXmlPartialEqual(self.get_xml('remote_request'), suite, "./remote-request[1]")
+        self.assertXmlPartialEqual(
+            self.get_xml('remote_request').decode('utf-8').format(module_id="m0"),
+            suite,
+            "./remote-request[1]"
+        )
+        self.assertXmlPartialEqual(
+            self.get_xml('remote_request').decode('utf-8').format(module_id="m1"),
+            suite,
+            "./remote-request[2]"
+        )
 
     def test_case_search_action(self, *args):
         """


### PR DESCRIPTION
## Summary
Memoization was happening incorrectly, which didn't matter as long as `generic_fixture_instances` was only called once, but with multiple remote requests that reference fixtures and therefore multiple calls to `generic_fixture_instances`, the final suite only included the fixture instance in the last remote request.

## Feature Flag
Case claim

## Product Description
Fixes a bug where apps that use case search/claim in multiple menus *and* use case claim options that reference fixtures will throw missing fixture errors.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

This PR adds appropriate tests.

### QA Plan

No QA, automated test coverage is good.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
