### PR TITLE
ignore couch doc types in sql exporter

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -244,7 +244,13 @@ def get_excluded_apps_and_models(excludes):
             try:
                 app_config = apps.get_app_config(exclude)
             except LookupError:
-                raise DomainDumpError('Unknown app in excludes: %s' % exclude)
+                from corehq.util.couch import get_document_class_by_doc_type
+                from corehq.util.exceptions import DocumentClassNotFound
+                # ignore this if it's a couch doc type
+                try:
+                    get_document_class_by_doc_type(exclude)
+                except DocumentClassNotFound:
+                    raise DomainDumpError('Unknown app in excludes: %s' % exclude)
             excluded_apps.add(app_config)
     return excluded_apps, excluded_models
 


### PR DESCRIPTION
## Summary
This allows using SQL types and Couch types at the same time.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
