### PR TITLE
Add any search_filter instances to remote request

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -183,6 +183,9 @@ def get_all_instances_referenced_in_xpaths(app, xpaths):
     instances = set()
     unknown_instance_ids = set()
     for xpath in xpaths:
+        if not xpath:
+            continue
+
         instance_names = re.findall(instance_re, xpath, re.UNICODE)
         for instance_name in instance_names:
             try:

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -78,17 +78,17 @@ class RemoteRequestFactory(object):
         )
 
     def _build_instances(self):
-        query_xpaths = [datum.ref for datum in self._get_remote_request_query_datums()]
-        claim_relevant_xpaths = [self.module.search_config.relevant]
         prompt_select_instances = [
             Instance(id=prop.itemset.instance_id, src=prop.itemset.instance_uri)
             for prop in self.module.search_config.properties
             if prop.itemset.instance_id
         ]
 
+        query_xpaths = [datum.ref for datum in self._get_remote_request_query_datums()]
+        config_xpaths = [self.module.search_config.relevant, self.module.search_config.search_filter]
         instances, unknown_instances = get_all_instances_referenced_in_xpaths(
             self.app,
-            query_xpaths + claim_relevant_xpaths
+            query_xpaths + config_xpaths
         )
         # we use the module's case list/details view to select the datum so also
         # need these instances to be available

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -15,6 +15,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <instance id="groups" src="jr://fixture/user-groups"/>
     <instance id="item-list:moons" src="jr://fixture/item-list:moons"/>
+    <instance id="item-list:trees" src="jr://fixture/item-list:trees"/>
     <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
     <instance id="locations" src="jr://fixture/locations"/>
     <instance id="reports" src="jr://fixture/commcare:reports"/>
@@ -42,7 +43,7 @@
         </prompt>
       </query>
       <datum id="case_id"
-             nodeset="instance('results')/results/case[@case_type='case']"
+             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name]"
              value="./@case_id"
              detail-confirm="{module_id}_case_long"
              detail-select="{module_id}_search_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
@@ -14,6 +14,7 @@
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
     <instance id="groups" src="jr://fixture/user-groups"/>
+    <instance id="item-list:trees" src="jr://fixture/item-list:trees"/>
     <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
     <instance id="locations" src="jr://fixture/locations"/>
     <session>
@@ -40,7 +41,7 @@
         </prompt>
       </query>
       <datum id="case_id"
-             nodeset="instance('results')/results/case[@case_type='case']"
+             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name]"
              value="./@case_id"
              detail-confirm="m0_case_long"
              detail-select="m0_case_short"/>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -72,6 +72,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 CaseSearchProperty(name='dob', label={'en': 'Date of birth'})
             ],
             relevant="{} and {}".format("instance('groups')/groups/group", CLAIM_DEFAULT_RELEVANT_CONDITION),
+            search_filter="name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name",
             default_properties=[
                 DefaultCaseSearchProperty(
                     property='ɨŧsȺŧɍȺᵽ',


### PR DESCRIPTION
## Summary
https://github.com/dimagi/commcare-hq/pull/28906 reminded me that I forgot to do this in https://github.com/dimagi/commcare-hq/pull/28790

## Feature Flag
Case claim

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

In PR.

### QA Plan

No QA, test coverage is good.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
