### PR TITLE
Allow configuring "Search All Cases" text in case claim

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -9,7 +9,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             });
         };
 
-    var searchViewModel = function (searchProperties, autoLaunch, includeClosed, defaultProperties, lang,
+    var searchViewModel = function (searchProperties, autoLaunch, includeClosed, defaultProperties, lang, searchCommandLabel,
         searchButtonDisplayCondition, searchFilter, blacklistedOwnerIdsExpression, saveButton, searchFilterObservable) {
         var self = {},
             DEFAULT_CLAIM_RELEVANT = "count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 0";
@@ -109,6 +109,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             return self;
         };
 
+        self.searchCommandLabel = ko.observable(searchCommandLabel[lang] || "");
         self.searchButtonDisplayCondition = ko.observable(searchButtonDisplayCondition);
         self.autoLaunch = ko.observable(autoLaunch);
         self.relevant = ko.observable('');
@@ -229,6 +230,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 auto_launch: self.autoLaunch(),
                 relevant: self._getRelevant(),
                 search_button_display_condition: self.searchButtonDisplayCondition(),
+                search_command_label: self.searchCommandLabel(),
                 search_filter: self.searchFilter(),
                 include_closed: self.includeClosed(),
                 default_properties: self._getDefaultProperties(),
@@ -249,6 +251,9 @@ hqDefine("app_manager/js/details/case_claim", function () {
             saveButton.fire('change');
         });
         self.defaultProperties.subscribe(function () {
+            saveButton.fire('change');
+        });
+        self.searchCommandLabel.subscribe(function () {
             saveButton.fire('change');
         });
         self.searchButtonDisplayCondition.subscribe(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
@@ -1128,6 +1128,7 @@ hqDefine('app_manager/js/details/screen_config', function () {
                         spec.includeClosed,
                         spec.defaultProperties,
                         spec.lang,
+                        spec.searchCommandLabel,
                         spec.searchButtonDisplayCondition,
                         spec.searchFilter,
                         spec.blacklistedOwnerIdsExpression,

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -45,6 +45,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
                     includeClosed: options.include_closed,
                     defaultProperties: options.default_properties || [],
                     searchButtonDisplayCondition: options.search_button_display_condition,
+                    searchCommandLabel: options.search_command_label,
                     searchFilter: options.search_filter,
                     blacklistedOwnerIdsExpression: options.blacklisted_owner_ids_expression,
                 });

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -1,5 +1,6 @@
 {% load hq_shared_tags %}
 {% load i18n %}
+{% load xforms_extras %}
 
 <legend>
   {% trans "Case Search and Claim" %}
@@ -192,13 +193,20 @@
       </div>
       <div class="panel-body">
         <div class="form-horizontal">
+          <div class="form-group">
+            <label for="search_command_label" class="{% css_label_class %} control-label">
+              {% trans "Label for Case Search" %}
+            </label>
+            <div class="{% css_field_class %}">
+              {% input_trans module.search_config.command_label langs input_name='search_command_label' input_id='search_command_label' data_bind="value: searchCommandLabel" %}
+            </div>
+          </div>
           {% if show_auto_launch %}
             <div class="form-group">
               <label class="control-label {% css_label_class %}" for="search-auto-launch">
                 {% trans "Web Apps Autolaunch" %}
               <span class="hq-help-template" data-title="{% trans "Web Apps Autolaunch" %}"
-                    data-content="{% trans_html_attr "In Web Apps, automatically launch case claim whenever user
-visits this case list." %}">
+                    data-content="{% trans_html_attr "In Web Apps, automatically launch case claim whenever user visits this case list." %}">
               </span>
               </label>
               <div class="checkbox {% css_field_class %}">

--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -70,14 +70,17 @@ def html_name(name):
 
 
 @register.simple_tag
-def input_trans(name, langs=None, input_name='name'):
+def input_trans(name, langs=None, input_name='name', input_id=None, data_bind=None):
     template = '''
         <input type="text"
-               name="{}"
+               name="{}" {} {}
                class="form-control"
                value="%(value)s"
                placeholder="%(placeholder)s" />
-    '''.format(input_name)
+    '''.format(
+        input_name,
+        f"id='{input_id}'" if input_id else "",
+        f"data-bind='{data_bind}'" if data_bind else "")
     return _input_trans(template, name, langs=langs)
 
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -203,6 +203,9 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
             'search_filter': module.search_config.search_filter if module_offers_search(module) else "",
             'search_button_display_condition':
                 module.search_config.search_button_display_condition if module_offers_search(module) else "",
+            'search_command_label':
+                # use default if module_offers_search is false because module.search_config doesn't exist yet
+                module.search_config.command_label if hasattr(module, 'search_config') else "",
             'blacklisted_owner_ids_expression': (
                 module.search_config.blacklisted_owner_ids_expression if module_offers_search(module) else ""),
         },
@@ -1057,7 +1060,10 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
                 search_properties.get('properties') is not None
                 or search_properties.get('default_properties') is not None
         ):
+            command_label = module.search_config.command_label
+            command_label[lang] = search_properties.get('search_command_label', '')
             module.search_config = CaseSearch(
+                command_label=command_label,
                 properties=[
                     CaseSearchProperty.wrap(p)
                     for p in _update_search_properties(

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/util.js
@@ -119,6 +119,15 @@ hqDefine("cloudcare/js/formplayer/menus/util", function () {
         if (menuResponse.type === "commands") {
             return hqImport("cloudcare/js/formplayer/menus/views").MenuListView(menuData);
         } else if (menuResponse.type === "query") {
+            if (hqImport('hqwebapp/js/toggles').toggleEnabled('APP_ANALYTICS')) {
+                var props = {
+                    domain: FormplayerFrontend.getChannel().request('currentUser').domain,
+                };
+                if (menuResponse.breadcrumbs && menuResponse.breadcrumbs.length) {
+                    props.name = menuResponse.breadcrumbs[menuResponse.breadcrumbs.length - 1];
+                }
+                hqImport('analytix/js/kissmetrix').track.event('Case Search', props);
+            }
             return hqImport("cloudcare/js/formplayer/menus/views/query")(menuData);
         } else if (menuResponse.type === "entities") {
             if (hqImport('hqwebapp/js/toggles').toggleEnabled('APP_ANALYTICS')) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -53,12 +53,6 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     payload[model[index].get('id')] = this.value;
                 }
             });
-            if (hqImport('hqwebapp/js/toggles').toggleEnabled('APP_ANALYTICS')) {
-                hqImport('analytix/js/kissmetrix').track.event('Case Search', {
-                    domain: FormplayerFrontend.getChannel().request('currentUser').domain,
-                    name: model[0].collection.title,
-                });
-            }
             FormplayerFrontend.trigger("menu:query", payload);
         },
     });


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-534

Adds label to case claim options UI.

## Feature Flag
Case search & claim

## Product Description
Configured in app manager's cast list config tab:
![Screen Shot 2020-12-17 at 9 34 52 PM](https://user-images.githubusercontent.com/1486591/102567604-d4e27f00-40af-11eb-8fde-f8d986441385.png)

Text is used in search button on case list, then in breadcrumbs, and also in title of search results:
![Screen Shot 2020-12-17 at 9 31 42 PM](https://user-images.githubusercontent.com/1486591/102567622-e0ce4100-40af-11eb-9129-7f3a56ec1599.png)

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

Some test coverage, updated in this PR.

### QA Plan

Planning to request QA post-deploy, [ticket here](https://dimagi-dev.atlassian.net/browse/QA-2194). USH wants this deployed soon, and since it's a new piece of UI odds of it breaking existing code are low.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
