### PR TITLE
Fix modal classes

### DIFF
--- a/docs/ui_helpers.rst
+++ b/docs/ui_helpers.rst
@@ -261,19 +261,28 @@ You should add the following to your `base-puppy-template` knockout template:
                 Update Puppy
             </button>
 
-            <div class="modal hide fade"
+            <div class="modal fade"
                  data-bind="
                     attr: {
                         id: 'update-puppy-' + id
                     }
                  ">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h3>
-                        Update puppy <strong data-bind="text: name"></strong>:
-                    </h3>
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button"
+                                    class="close"
+                                    data-dismiss="modal"
+                                    aria-hidden="true">&times;</button>
+                            <h3>
+                                Update puppy <strong data-bind="text: name"></strong>:
+                            </h3>
+                        </div>
+                        <div class="modal-body">
+                            <div data-bind="html: updateForm"></div>
+                        </div>
+                    </div>
                 </div>
-                <div data-bind="html: updateForm"></div>
             </div>
         </td>
     </script>


### PR DESCRIPTION
## Summary

Updates CRUD Paginated View docs.

Brings classes for the Update modal in line with the Delete modal.

(Technical documentation only.)

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
