### PR TITLE
Count messaging email sends and bounces by domain

### DIFF
--- a/corehq/apps/sms/event_handlers.py
+++ b/corehq/apps/sms/event_handlers.py
@@ -1,4 +1,5 @@
 from corehq.apps.sms.models import MessagingSubEvent, MessagingEvent
+from corehq.util.metrics import metrics_counter
 
 
 def handle_email_messaging_subevent(message, subevent_id):
@@ -22,6 +23,9 @@ def handle_email_messaging_subevent(message, subevent_id):
         if recipient_addresses:
             additional_error_text = f"{additional_error_text} - {', '.join(recipient_addresses)}"
 
+        metrics_counter('commcare.messaging.email.bounced', len(bounced_recipients), tags={
+            'domain': subevent.parent.domain,
+        })
         subevent.error(MessagingEvent.ERROR_EMAIL_BOUNCED,
                        additional_error_text=additional_error_text)
     elif event_type == 'Send':

--- a/corehq/ex-submodules/dimagi/utils/django/email.py
+++ b/corehq/ex-submodules/dimagi/utils/django/email.py
@@ -28,7 +28,7 @@ LARGE_FILE_SIZE_ERROR_CODES = [LARGE_FILE_SIZE_ERROR_CODE, LARGE_FILE_SIZE_ERROR
 def mark_local_bounced_email(bounced_addresses, message_id):
     from corehq.apps.sms.models import MessagingEvent, MessagingSubEvent
     from corehq.apps.users.models import Invitation, InvitationStatus
-    if Invitation.EMAIL_ID_PREFIX in message_id:
+    if isinstance(message_id, str) and Invitation.EMAIL_ID_PREFIX in message_id:
         try:
             invite = Invitation.objects.get(uuid=message_id.split(Invitation.EMAIL_ID_PREFIX)[1])
         except Invitation.DoesNotExist:

--- a/corehq/ex-submodules/dimagi/utils/django/email.py
+++ b/corehq/ex-submodules/dimagi/utils/django/email.py
@@ -6,7 +6,7 @@ from django.core.mail.message import EmailMultiAlternatives
 from dimagi.utils.logging import notify_exception
 from django.utils.translation import ugettext as _
 
-from corehq.util.metrics import metrics_gauge
+from corehq.util.metrics import metrics_gauge, metrics_counter
 from corehq.util.metrics.const import MPM_LIVESUM
 
 NO_HTML_EMAIL_MESSAGE = """
@@ -42,6 +42,7 @@ def mark_local_bounced_email(bounced_addresses, message_id):
         except MessagingSubEvent.DoesNotExist:
             pass
         else:
+            metrics_counter('commcare.messaging.email.bounced', tags={'domain': subevent.parent.domain})
             subevent.error(
                 MessagingEvent.ERROR_EMAIL_BOUNCED,
                 additional_error_text=", ".join(bounced_addresses)

--- a/corehq/ex-submodules/dimagi/utils/django/email.py
+++ b/corehq/ex-submodules/dimagi/utils/django/email.py
@@ -42,7 +42,9 @@ def mark_local_bounced_email(bounced_addresses, message_id):
         except MessagingSubEvent.DoesNotExist:
             pass
         else:
-            metrics_counter('commcare.messaging.email.bounced', tags={'domain': subevent.parent.domain})
+            metrics_counter('commcare.messaging.email.bounced', len(bounced_addresses), tags={
+                'domain': subevent.parent.domain,
+            })
             subevent.error(
                 MessagingEvent.ERROR_EMAIL_BOUNCED,
                 additional_error_text=", ".join(bounced_addresses)

--- a/corehq/ex-submodules/dimagi/utils/django/email.py
+++ b/corehq/ex-submodules/dimagi/utils/django/email.py
@@ -42,7 +42,7 @@ def mark_local_bounced_email(bounced_addresses, message_id):
         except MessagingSubEvent.DoesNotExist:
             pass
         else:
-            metrics_counter('commcare.messaging.email.bounced', len(bounced_addresses), tags={
+            metrics_counter('commcare.messaging.email.preemptively_bounced', len(bounced_addresses), tags={
                 'domain': subevent.parent.domain,
             })
             subevent.error(

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -18,6 +18,8 @@ from corehq.apps.sms.models import MessagingEvent, PhoneNumber, PhoneBlacklist, 
 from corehq.apps.sms.util import touchforms_error_is_config_error, get_formplayer_exception
 from corehq.apps.smsforms.models import SQLXFormsSession
 from memoized import memoized
+
+from corehq.util.metrics import metrics_counter
 from dimagi.utils.modules import to_function
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField
@@ -140,6 +142,7 @@ class EmailContent(Content):
             logged_subevent.error(MessagingEvent.ERROR_TRIAL_EMAIL_LIMIT_REACHED)
             return
 
+        metrics_counter('commcare.messaging.email.sent', tags={'domain': logged_event.domain})
         send_mail_async.delay(subject, message, settings.DEFAULT_FROM_EMAIL, [email_address], logged_subevent.id)
 
         email = Email(


### PR DESCRIPTION
## Summary

This is 100% an eyeballed PR. But I think this should allow us to start counting how many messaging emails each domain sends and how many of them bounce. (Since bounces are asynchronous, I'm emitting them as two separate metrics, not a single metric with a status tag.)

## Feature Flag
None

## Product Description
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

~I believe tests would catch a total failure here like an import error. I've opened https://github.com/dimagi/commcare-hq/pull/28921 to validate that.~ This code is verifiably not tested.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
metric_counter is pretty good at not throwing errors because of some internal thing. The only questions are whether everything referenced always exists at the time it's called etc. Looking at the code it clearly does, and if the tests pass here but fail on the dummy PR I made to validate it then it's a pretty good sign that that code won't crash.

Deployed to staging as well so we can try one round trip and make sure it works. Noticed and fixed another existing issue, and tested the functionality. Created dashboards based on it and the metrics are reporting as expected: https://app.datadoghq.com/dashboard/nm2-qek-dg6/email-bounces?from_ts=1608517585000&live=true&to_ts=1608603985000&tpl_var_environment=staging.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
