### PR TITLE
Fixed case claim relevancy UI

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -213,7 +213,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 }
             );
         };
-        self._getRelevant = function () {
+        self._relevant = ko.computed(function () {
             if (self.default_relevant()) {
                 if (!self.relevant() || self.relevant().trim() === "") {
                     return DEFAULT_CLAIM_RELEVANT;
@@ -222,13 +222,13 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 }
             }
             return self.relevant().trim();
-        };
+        });
 
         self.serialize = function () {
             return {
                 properties: self._getProperties(),
                 auto_launch: self.autoLaunch(),
-                relevant: self._getRelevant(),
+                relevant: self._relevant(),
                 search_button_display_condition: self.searchButtonDisplayCondition(),
                 search_command_label: self.searchCommandLabel(),
                 search_filter: self.searchFilter(),
@@ -244,7 +244,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         self.includeClosed.subscribe(function () {
             saveButton.fire('change');
         });
-        self.default_relevant.subscribe(function () {
+        self._relevant.subscribe(function () {
             saveButton.fire('change');
         });
         self.searchProperties.subscribe(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -112,7 +112,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         self.searchCommandLabel = ko.observable(searchCommandLabel[lang] || "");
         self.searchButtonDisplayCondition = ko.observable(searchButtonDisplayCondition);
         self.autoLaunch = ko.observable(autoLaunch);
-        self.relevant = ko.observable('');
+        self.extraRelevant = ko.observable('');
         self.defaultRelevant = ko.observable(true);
         self.includeClosed = ko.observable(includeClosed);
         self.searchProperties = ko.observableArray();
@@ -213,22 +213,22 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 }
             );
         };
-        self._relevant = ko.computed(function () {
+        self.relevant = ko.computed(function () {
             if (self.defaultRelevant()) {
-                if (!self.relevant() || self.relevant().trim() === "") {
+                if (!self.extraRelevant() || self.extraRelevant().trim() === "") {
                     return DEFAULT_CLAIM_RELEVANT;
                 } else {
-                    return "(" + DEFAULT_CLAIM_RELEVANT + ") and (" + self.relevant().trim() + ")";
+                    return "(" + DEFAULT_CLAIM_RELEVANT + ") and (" + self.extraRelevant().trim() + ")";
                 }
             }
-            return self.relevant().trim();
+            return self.extraRelevant().trim();
         });
 
         self.serialize = function () {
             return {
                 properties: self._getProperties(),
                 auto_launch: self.autoLaunch(),
-                relevant: self._relevant(),
+                relevant: self.relevant(),
                 search_button_display_condition: self.searchButtonDisplayCondition(),
                 search_command_label: self.searchCommandLabel(),
                 search_filter: self.searchFilter(),
@@ -244,7 +244,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         self.includeClosed.subscribe(function () {
             saveButton.fire('change');
         });
-        self._relevant.subscribe(function () {
+        self.relevant.subscribe(function () {
             saveButton.fire('change');
         });
         self.searchProperties.subscribe(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -113,7 +113,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         self.searchButtonDisplayCondition = ko.observable(searchButtonDisplayCondition);
         self.autoLaunch = ko.observable(autoLaunch);
         self.relevant = ko.observable('');
-        self.default_relevant = ko.observable(true);
+        self.defaultRelevant = ko.observable(true);
         self.includeClosed = ko.observable(includeClosed);
         self.searchProperties = ko.observableArray();
         self.defaultProperties = ko.observableArray();
@@ -214,7 +214,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             );
         };
         self._relevant = ko.computed(function () {
-            if (self.default_relevant()) {
+            if (self.defaultRelevant()) {
                 if (!self.relevant() || self.relevant().trim() === "") {
                     return DEFAULT_CLAIM_RELEVANT;
                 } else {

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
@@ -1131,6 +1131,7 @@ hqDefine('app_manager/js/details/screen_config', function () {
                         spec.searchCommandLabel,
                         spec.searchButtonDisplayCondition,
                         spec.searchFilter,
+                        spec.searchRelevant,
                         spec.blacklistedOwnerIdsExpression,
                         self.shortScreen.saveButton,
                         self.filter.filterText

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -41,6 +41,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
                     contextVariables: state,
                     multimedia: initial_page_data('multimedia_object_map'),
                     searchProperties: options.search_properties || [],
+                    searchRelevant: options.search_relevant || "",
                     autoLaunch: options.auto_launch,
                     includeClosed: options.include_closed,
                     defaultProperties: options.default_properties || [],

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -260,7 +260,7 @@
               </span>
             </label>
             <div class="{% css_field_class %}">
-              <textarea data-bind="value: relevant"
+              <textarea data-bind="value: extraRelevant"
                         class="form-control vertical-resize"
                         id="claim-relevant-condition"
                         spellcheck="false"

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -273,7 +273,7 @@
             </label>
             <div class="checkbox {% css_field_class %}">
               <label>
-                <input type="checkbox" id="search-default-relevant" data-bind="checked: default_relevant">
+                <input type="checkbox" id="search-default-relevant" data-bind="checked: defaultRelevant">
               </label>
             </div>
           </div>

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -203,6 +203,8 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
             'search_filter': module.search_config.search_filter if module_offers_search(module) else "",
             'search_button_display_condition':
                 module.search_config.search_button_display_condition if module_offers_search(module) else "",
+            'search_relevant':
+                module.search_config.relevant if module_offers_search(module) else "",
             'search_command_label':
                 # use default if module_offers_search is false because module.search_config doesn't exist yet
                 module.search_config.command_label if hasattr(module, 'search_config') else "",


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/QA-2122

The `CaseSearch.relevant` attribute, an xpath expression that determines whether or not a case may be claimed, is controlled by these two UI inputs:

![Screen Shot 2020-12-21 at 5 26 10 PM](https://user-images.githubusercontent.com/1486591/102828129-ea0e2500-43b1-11eb-8732-b3d48ca365fd.png)

The final value of `relevant` ANDs together the claim condition (if provided) and a default condition that checks if the case already appears in the user's casedb (if the checkbox is checked). This works fine to save the value, but once it's saved, there's no logic to pass the value of `relevant` back to the UI and parse out the two pieces so the user can edit them. This PR adds that logic.


## Feature Flag
Case search & claim

## Product Description
Fixes bug where values for "Don't claim cases already owned by the user" and "Claim condition" were saved but weren't shown correctly on the UI, so user couldn't edit them.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

This fixes a qabug, QA team will verify it.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
