### PR TITLE
Update store_billable max_retries and default_retry_delay to account for Twilio delays

### DIFF
--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -465,6 +465,9 @@ def store_billable(self, msg):
                 multipart_count=int(math.ceil(len(msg.text) / msg_length)),
             )
         except RetryBillableTaskException as e:
+            # WARNING: Please do not remove messages from this queue
+            # unless you have a backup plan for how to process them
+            # before the end of the month billing cycle. If not, LEAVE AS IS.
             self.retry(exc=e)
 
 

--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -49,7 +49,6 @@ from corehq.apps.sms.models import (
 from corehq.apps.sms.util import is_contact_active
 from corehq.apps.smsbillables.exceptions import (
     RetryBillableTaskException,
-    DeliveredBillableException,
 )
 from corehq.apps.smsbillables.models import SmsBillable
 from corehq.apps.users.models import CouchUser
@@ -441,9 +440,14 @@ def send_to_sms_queue(queued_sms):
     process_sms.apply_async([queued_sms.pk])
 
 
-@no_result_task(serializer='pickle', queue='background_queue', default_retry_delay=10 * 60,
-                max_retries=10, bind=True)
+@no_result_task(serializer='pickle', queue='background_queue', default_retry_delay=60 * 60,
+                max_retries=23, bind=True)
 def store_billable(self, msg):
+    """
+    Creates billable in db that contains price of the message
+    default_retry_delay/max_retries are set based on twilio support numbers:
+    Most messages will have a price within 2 hours of delivery, all within 24 hours max
+    """
     if not isinstance(msg, SMS):
         raise Exception("Expected msg to be an SMS")
 
@@ -462,11 +466,6 @@ def store_billable(self, msg):
             )
         except RetryBillableTaskException as e:
             self.retry(exc=e)
-        except DeliveredBillableException:
-            # don't retry, but do raise error for logging purposes and make sure
-            # the original message's ID is associated with the error
-            # (the backend ID is stored with it already)
-            raise DeliveredBillableException(f"msg_couch_id={msg.couch_id}")
 
 
 @no_result_task(serializer='pickle', queue='background_queue', acks_late=True)

--- a/corehq/apps/smsbillables/exceptions.py
+++ b/corehq/apps/smsbillables/exceptions.py
@@ -8,7 +8,3 @@ class SMSRateCalculatorError(Exception):
 
 class RetryBillableTaskException(Exception):
     pass
-
-
-class DeliveredBillableException(Exception):
-    pass

--- a/corehq/apps/smsbillables/models.py
+++ b/corehq/apps/smsbillables/models.py
@@ -18,7 +18,6 @@ from corehq.apps.sms.util import clean_phone_number
 from corehq.apps.smsbillables.exceptions import (
     AmbiguousPrefixException,
     RetryBillableTaskException,
-    DeliveredBillableException,
 )
 from corehq.apps.smsbillables.utils import (
     log_smsbillables_error,
@@ -408,9 +407,7 @@ class SmsBillable(models.Model):
     @classmethod
     def get_charge_details_through_api(cls, backend_instance, backend_message_id):
         status, price, multipart_count = backend_instance.get_provider_charges(backend_message_id)
-        if status is not None and status.lower() == 'delivered' and price is None:
-            raise DeliveredBillableException(f"backend_message_id={backend_message_id}")
-        elif status is None or status.lower() in [
+        if status is None or status.lower() in [
             'accepted',
             'queued',
             'sending',


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Investigate DeliveredBillableException](https://dimagi-dev.atlassian.net/browse/SAAS-11525)

For context, @biyeun noticed `SmsBillable` objects without a price. She added the `DeliveredBillableException` to better track when a message was delivered, but did not have a price associated with it. This ticket was created to investigate the root cause of those exceptions.

After getting in touch with Twilio support, their recommended expectation is that most messages will have an associated price within 2 hours of delivery, and allow 24 hours to be safe. This could explain why we previously had saved `SmsBillable` objects with no price since our retry_delay/max_retries combination would give up after ~100 minutes. This ensures we allow enough time to properly store a price with an `SmsBillable`.

The `store_billable` task does not take up a large portion of tasks on the `background_queue` so I am not concerned about introducing too much extra load on celery machines by increasing `max_retries`.

My one concern is how this could affect invoices. I don't know how we currently address the potential delay of an up to date billable, but obviously this increases the potential delayed time of an updated billable. This is where we fetch SmsBillables for an invoice which does not appear to take any delay into consideration:
https://github.com/dimagi/commcare-hq/blob/1086ab4377c85bb446c68e4e167db08365ba810e/corehq/apps/accounting/invoicing.py#L873-L885
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
This only changes Celery behavior.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The change does not fundamentally change behavior, so we will continue to store billables as we did before, but with a longer delay before retrying. If there are any users who are monitoring SmsBillables like a hawk, they might notice it is taking longer. 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
