### PR TITLE
Added support for EOF nav to search-first case lists

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -240,6 +240,16 @@ hqDefine("cloudcare/js/formplayer/app", function () {
                 Util.setUrlToObject(urlObject);
 
                 if (resp.nextScreen !== null && resp.nextScreen !== undefined) {
+                    if (resp.nextScreen.autolaunch) {
+                        FormplayerFrontend.trigger("clearForm");
+                        urlObject.setSteps(resp.nextScreen.selections.concat([resp.nextScreen.autolaunch]));
+                        Util.setUrlToObject(urlObject);
+                        hqImport("cloudcare/js/formplayer/menus/controller").selectMenu({
+                            appId: urlObject.appId,
+                            steps: urlObject.steps,
+                        });
+                        return;
+                    }
                     FormplayerFrontend.trigger("renderResponse", resp.nextScreen);
                 } else if (urlObject.appId !== null && urlObject.appId !== undefined) {
                     FormplayerFrontend.trigger("apps:currentApp");


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/QA-2124

As with search-first case lists, this works by recognizing that the current response is a menu that uses autolaunch, and then immediately issuing a request for the autolaunch action.

Uses basically the same logic as [breadcrumbSelect](https://github.com/dimagi/commcare-hq/blob/5a5bd765a168e5446d454ac22900114050937f07/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js#L212-L222)

## Feature Flag
Case search & claim

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

No automated tests for this.

### QA Plan

QA team will verify this fix.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
