### PR TITLE
Create support for referencing the owner_id property

### DIFF
--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -403,10 +403,10 @@ class ParentCasePropertyBuilder(object):
             case_properties.update(self.defaults)
 
         for case_type, case_properties in case_properties_by_case_type.items():
-            for prop in case_properties:
+            for prop in list(case_properties):
                 if prop == 'owner_id':
-                    case_properties_by_case_type[case_type].remove(prop)
-                    case_properties_by_case_type[case_type].add('@owner_id')
+                    case_properties.remove(prop)
+                    case_properties.add('@owner_id')
 
         if self.exclude_invalid_properties:
             from corehq.apps.app_manager.helpers.validators import validate_property

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -189,6 +189,18 @@ def _flatten_case_properties(case_properties_by_case_type):
     return result
 
 
+def _clean_case_type_properties(case_properties_by_case_type):
+    for case_properties in case_properties_by_case_type.values():
+        _replace_properties_with_attributes(case_properties)
+
+
+def _replace_properties_with_attributes(case_properties):
+    for prop in list(case_properties):
+        if prop == 'owner_id':
+            case_properties.remove(prop)
+            case_properties.add('@owner_id')
+
+
 def _propagate_and_normalize_case_properties(case_properties_by_case_type, parent_type_map,
                                              include_parent_properties):
     """
@@ -402,11 +414,7 @@ class ParentCasePropertyBuilder(object):
         for case_properties in case_properties_by_case_type.values():
             case_properties.update(self.defaults)
 
-        for case_type, case_properties in case_properties_by_case_type.items():
-            for prop in list(case_properties):
-                if prop == 'owner_id':
-                    case_properties.remove(prop)
-                    case_properties.add('@owner_id')
+        _clean_case_type_properties(case_properties_by_case_type)
 
         if self.exclude_invalid_properties:
             from corehq.apps.app_manager.helpers.validators import validate_property

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -402,6 +402,12 @@ class ParentCasePropertyBuilder(object):
         for case_properties in case_properties_by_case_type.values():
             case_properties.update(self.defaults)
 
+        for case_type, case_properties in case_properties_by_case_type.items():
+            for prop in case_properties:
+                if prop == 'owner_id':
+                    case_properties_by_case_type[case_type].remove(prop)
+                    case_properties_by_case_type[case_type].add('@owner_id')
+
         if self.exclude_invalid_properties:
             from corehq.apps.app_manager.helpers.validators import validate_property
             for case_type, case_properties in case_properties_by_case_type.items():

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -1,6 +1,5 @@
 import logging
 from collections import defaultdict, deque, namedtuple
-from itertools import chain
 
 from memoized import memoized
 

--- a/corehq/apps/app_manager/app_schemas/casedb_schema.py
+++ b/corehq/apps/app_manager/app_schemas/casedb_schema.py
@@ -1,4 +1,3 @@
-from corehq import toggles
 from corehq.apps.app_manager.app_schemas.case_properties import (
     ParentCasePropertyBuilder,
     get_usercase_properties,

--- a/corehq/apps/app_manager/app_schemas/casedb_schema.py
+++ b/corehq/apps/app_manager/app_schemas/casedb_schema.py
@@ -88,4 +88,7 @@ def generate_property_metadata(prop, descriptions):
         "description": descriptions.get(prop, '')
     }
 
+    if prop == '@owner_id':
+        metadata['name'] = 'owner_id'
+
     return metadata

--- a/corehq/apps/app_manager/app_schemas/casedb_schema.py
+++ b/corehq/apps/app_manager/app_schemas/casedb_schema.py
@@ -42,9 +42,7 @@ def get_casedb_schema(form):
     subsets = [{
         "id": generation_names[i],
         "name": "{} ({})".format(generation_names[i], " or ".join(ctypes)) if i > 0 else base_case_type,
-        "structure": {
-            p: {"description": descriptions_dict.get(t, {}).get(p, '')}
-            for t in ctypes for p in map[t]},
+        "structure": generate_structure(ctypes, map, descriptions_dict),
         "related": {"parent": {
             "hashtag": "#case/" + generation_names[i + 1],
             "subset": generation_names[i + 1],
@@ -68,3 +66,26 @@ def get_casedb_schema(form):
         "structure": {},
         "subsets": subsets,
     }
+
+
+def generate_structure(case_types, case_to_property_mapping, descriptions):
+    structure = {}
+
+    for case_type in case_types:
+        case_properties = case_to_property_mapping[case_type]
+        case_descriptions = descriptions.get(case_type, {})
+        properties_with_metadata = {
+            prop: generate_property_metadata(prop, case_descriptions)
+            for prop in case_properties
+        }
+        structure.update(properties_with_metadata)
+
+    return structure
+
+
+def generate_property_metadata(prop, descriptions):
+    metadata = {
+        "description": descriptions.get(prop, '')
+    }
+
+    return metadata

--- a/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
@@ -44,6 +44,17 @@ class GetCasePropertiesTest(SimpleTestCase, TestXmlMixin):
             })
             self.assertCaseProperties(factory.app, 'house', ['foo', 'bar'])
 
+    def test_owner_id_maps_to_attribute(self):
+        factory = AppFactory()
+        # Create form1 which uses case type 'house'
+        module1, form1 = factory.new_module(Module, 'open_case', 'house')
+        # Form1 updates house.owner_id
+        factory.form_requires_case(form1, case_type='house', update={
+            'owner_id': 'new_owner'
+        })
+        # Verify that the actual case property is '@owner_id', not 'owner_id'
+        self.assertCaseProperties(factory.app, 'house', ['@owner_id'])
+
     def test_case_sharing(self):
         factory1 = AppFactory()
         factory2 = AppFactory()

--- a/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
@@ -10,6 +10,7 @@ from corehq.apps.app_manager.app_schemas.case_properties import (
     _CaseTypeEquivalence,
     _CaseTypeRef,
     get_case_properties,
+    _replace_properties_with_attributes
 )
 from corehq.apps.app_manager.models import (
     AdvancedModule,
@@ -192,3 +193,15 @@ class DocTests(SimpleTestCase):
     def test_doctests(self):
         results = doctest.testmod(corehq.apps.app_manager.app_schemas.case_properties)
         self.assertEqual(results.failed, 0)
+
+
+class ReplacePropertyWithAttributesTests(SimpleTestCase):
+    def test_replaces_owner_id_with_attribute(self):
+        case_properties = {'owner_id'}
+        _replace_properties_with_attributes(case_properties)
+        self.assertSetEqual(case_properties, {'@owner_id'})
+
+    def test_replacement_preserves_other_names(self):
+        case_properties = {'@one', 'owner_id', '@two'}
+        _replace_properties_with_attributes(case_properties)
+        self.assertSetEqual(case_properties, {'@one', '@owner_id', '@two'})

--- a/corehq/apps/app_manager/app_schemas/tests/test_schema.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_schema.py
@@ -1,5 +1,4 @@
 import re
-from datetime import datetime
 
 from django.test import SimpleTestCase
 
@@ -12,7 +11,6 @@ from corehq.apps.app_manager.app_schemas.session_schema import (
 )
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.app_manager.tests.app_factory import AppFactory
-from corehq.util.test_utils import flag_enabled
 
 
 @patch('corehq.apps.app_manager.app_schemas.casedb_schema.get_case_property_description_dict',

--- a/corehq/apps/app_manager/app_schemas/tests/test_schema.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_schema.py
@@ -299,6 +299,13 @@ class SchemaTest(SimpleTestCase):
                 },
             })
 
+    def test_casedb_schema_maps_owner_id_to_attribute_with_name(self):
+        form = self.add_form("owner_case_type", {"owner_id": "new_owner"})
+        schema = get_casedb_schema(form)
+        structure = schema['subsets'][0]['structure']
+        self.assertIn('@owner_id', structure)
+        self.assertEqual(structure['@owner_id']['name'], 'owner_id')
+
     # -- helpers --
 
     def assert_has_kv_pairs(self, test_dict, expected_dict):

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -121,11 +121,11 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
             "property_value": self.case_type,
         }
         self.assertEqual(expected_filter, builder.filter)
-        expected_property_names = [
+        expected_property_names = {
             "closed", "closed_on", "first_name", "last_name", "modified_on", "name", "opened_on",
-            "owner_id", "user_id", "computed/owner_name", "computed/user_name",
-        ]
-        self.assertEqual(expected_property_names, list(builder.data_source_properties.keys()))
+            "@owner_id", "user_id", "computed/owner_name", "computed/user_name",
+        }
+        self.assertSetEqual(expected_property_names, set(builder.data_source_properties.keys()))
         owner_name_prop = builder.data_source_properties['computed/owner_name']
         self.assertEqual('computed/owner_name', owner_name_prop.get_id())
         self.assertEqual('Case Owner', owner_name_prop.get_text())


### PR DESCRIPTION
## Summary
This is the 2nd of two requests aimed at: https://dimagi-dev.atlassian.net/browse/SAAS-10135.  The first PR, https://github.com/dimagi/Vellum/pull/983, sets up Vellum support to read 'aliased' properties (properties that have one name, but want to be displayed as another). This is necessary for owner_id, because the real xpath is '@owner_id', but Vellum hashtags cannot support the '@'.

The changes in this PR are specific to owner_id. I chose not to make them generic, because I wasn't aware of any other property currently needing this treatment. Should we have multiple properties handled this way, I think it would make sense to abstract out the fix.

## Product Description
Assuming the Vellum fix is also applied, app builders should be able to create an 'owner_id' variable that:
- will be useable as an 'easy reference'
- when de-referencing in an app, will resolve to the form's owner, rather than an empty value.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
- The changes to case_properties.py is tested in test_case_properties.py:GetCasePropertiesTest.test_owner_id_maps_to_attribute
- Remapping owner_id in casedb_schema is tested in test_schema.py:SchemaTest.test_casedb_schema_maps_owner_id_to_attribute_with_name
- The refactoring in casedb_schema should be covered by the existing tests in test_schema.py

### QA Plan
I'm not sure whether this should run through QA or not.

### Safety story
This PR depends on the Vellum PR to allow Vellum to behave correctly. Without the Vellum PR, Vellum will attempt to build a hashtag with '@owner_id', which is not supported.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
