### PR TITLE
Switched allow_mirroring for message log default location

### DIFF
--- a/corehq/apps/reports/filters/fixtures.py
+++ b/corehq/apps/reports/filters/fixtures.py
@@ -36,7 +36,8 @@ class AsyncLocationFilter(BaseReportFilter):
         user = self.request.couch_user
         loc_id = self.request.GET.get('location_id')
         if not loc_id:
-            domain_membership = user.get_domain_membership(self.domain)
+            # Don't use mirroring, because any location found via mirroring won't exist in this domain
+            domain_membership = user.get_domain_membership(self.domain, allow_mirroring=False)
             if domain_membership:
                 loc_id = domain_membership.location_id
         return {


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-507

## Feature Flag
Enterprise permissions

## Product Description
Fixes a 500 in the Message Log that was happening for users who had access to that project only through enterprise permissions.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

I don't think there's test coverage for this.

### QA Plan

Not requesting QA. Small change to UI helper.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
