### PR TITLE
Re-bucket restore case load metric

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -364,4 +364,4 @@ def compile_response(timing_context, restore_state, response, batches, update_pr
         update_progress(done)
 
 
-RESTORE_CASE_LOAD_BUCKETS = [10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000]
+RESTORE_CASE_LOAD_BUCKETS = [10, 30, 100, 300, 1000, 3000, 10000, 30000, 100000, 300000, 1000000]

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -311,7 +311,7 @@ def batch_cases(accessor, case_ids):
         'commcare.restore.case_load',
         len(case_ids),
         'cases',
-        [10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000],
+        RESTORE_CASE_LOAD_BUCKETS,
         tags={'domain': accessor.domain}
     )
     ids = iter(case_ids)
@@ -362,3 +362,6 @@ def compile_response(timing_context, restore_state, response, batches, update_pr
 
         done += len(cases)
         update_progress(done)
+
+
+RESTORE_CASE_LOAD_BUCKETS = [10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000]

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -364,4 +364,4 @@ def compile_response(timing_context, restore_state, response, batches, update_pr
         update_progress(done)
 
 
-RESTORE_CASE_LOAD_BUCKETS = [10, 30, 100, 300, 1000, 3000, 10000, 30000, 100000, 300000, 1000000]
+RESTORE_CASE_LOAD_BUCKETS = [100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000, 200000, 500000, 1000000]


### PR DESCRIPTION
## Summary
I've found graphs such as https://app.datadoghq.com/dashboard/b5y-ujq-yaf?from_ts=1585585782688&fullscreen_section=overview&fullscreen_widget=7014445048885642&live=true&to_ts=1609255782688&tpl_var_baseline_domain=%2A&tpl_var_domain=%2A&fullscreen_start_ts=1585587347443&fullscreen_end_ts=1609257347443&fullscreen_paused=false to be limited in their usefulness because the range of buckets is both too granular and too short: we have too much information about whether it was 20 or 50 cases (which we don't care so much about) and not enough information about whether it was 11k, 90k or 250k cases.

This PR ~(1) switches from the 1, 2, 5, 10 exponential pattern to a 1, 3, 10 exponential pattern and (2)~ extends the range so that the largest bucket is "over_1000000"—high enough that we're quite sure we never hit it, which means if we _do_ hit it that's extremely useful information.

This PR has the annoyance that any change in metrics does, namely that we will have to adjust our graphs to match the new boundaries, and even then there will forever be a quantum change in the way the data looks. I think that's mitigated by the fact that ~the 10, 100, 1000, etc~ *most of the* boundaries remain the same which provides some continuity in the graphs.

@calellowitz I'm curious to hear your thoughts

See also https://github.com/dimagi/commcare-hq/pull/28937 which is somewhat related but not interdependent.

## Feature Flag
None

## Product Description
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

QA is not needed

### Safety story
This is a very minor change that will either not affect anyone or fail so catastrophically (i.e. syntax error) that it would be caught by tests.

### Rollback instructions

This can be safely rolled back; the only consideration is that it would switch back the way the graphs in datadog look, a very minor thing.
