### PR TITLE
Track fresh restore case loads

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -267,7 +267,10 @@ def do_livequery(timing_context, restore_state, response, async_task=None):
                 len(sync_ids),
                 'cases',
                 RESTORE_CASE_LOAD_BUCKETS,
-                tags={'domain': accessor.domain}
+                tags={
+                    'domain': accessor.domain,
+                    'restore_type': 'incremental' if restore_state.last_sync_log else 'fresh'
+                }
             )
             compile_response(
                 timing_context,

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -311,7 +311,7 @@ def batch_cases(accessor, case_ids):
         'commcare.restore.case_load',
         len(case_ids),
         'cases',
-        [10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000],
+        RESTORE_CASE_LOAD_BUCKETS,
         tags={'domain': accessor.domain}
     )
     ids = iter(case_ids)
@@ -362,3 +362,6 @@ def compile_response(timing_context, restore_state, response, batches, update_pr
 
         done += len(cases)
         update_progress(done)
+
+
+RESTORE_CASE_LOAD_BUCKETS = [10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000]

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -262,6 +262,13 @@ def do_livequery(timing_context, restore_state, response, async_task=None):
 
         with timing_context("compile_response(%s cases)" % len(sync_ids)):
             iaccessor = PrefetchIndexCaseAccessor(accessor, indices)
+            metrics_histogram(
+                'commcare.restore.case_load',
+                len(sync_ids),
+                'cases',
+                RESTORE_CASE_LOAD_BUCKETS,
+                tags={'domain': accessor.domain}
+            )
             compile_response(
                 timing_context,
                 restore_state,
@@ -307,13 +314,6 @@ def batch_cases(accessor, case_ids):
         return list(islice(iterable, n))
 
     track_load = case_load_counter("livequery_restore", accessor.domain)
-    metrics_histogram(
-        'commcare.restore.case_load',
-        len(case_ids),
-        'cases',
-        RESTORE_CASE_LOAD_BUCKETS,
-        tags={'domain': accessor.domain}
-    )
     ids = iter(case_ids)
     while True:
         next_ids = take(1000, ids)


### PR DESCRIPTION
## Summary
This adds a tag to `commcare.restores.case_loads` that splits out fresh restores from incremental syncs. This lets us do things like the following:
- graph fresh sync sizes, to surface (1) high volumes of cold starts and (2) the distribution of actual case load sizes on a particular domain. (#2 isn't perfect since it reports only on fresh sync which may skew the perceived distribution, but it'll still be pretty accurate for surfacing the overall range of case pool sizes.)
- graph incremental restores alone, to surface huge additions or churn in fixed case pools

See also https://github.com/dimagi/commcare-hq/pull/28936 which is somewhat related but not interdependent.

## Feature Flag
None

## Product Description
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

No new coverage, but this part of the codebase is quite well tested.

### QA Plan

None necessary

### Safety story
The change here is quite plain and if it fails would fail big and result in a test failure; or at most screw up metrics collection.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
