### PR TITLE
create metrics for failed logins

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -530,7 +530,7 @@ def check_lockout(fn):
             return fn(request, *args, **kwargs)
 
         user = CouchUser.get_by_username(username)
-        if user and user.is_locked_out() and user.supports_lockout():
+        if user and user.is_locked_out():
             return json_response({"error": _("maximum password attempts exceeded")}, status_code=401)
         else:
             return fn(request, *args, **kwargs)

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -308,8 +308,8 @@ class HQAuthenticationTokenForm(AuthenticationTokenForm):
             else:
                 raise
 
-        # Handle the edge-case where the user locks himself out on this screen,
-        # then enters a correct token afterwards
+        # Handle the edge-case where the user enters a correct token
+        # after being locked out
         couch_user = CouchUser.get_by_username(self.user.username)
         if couch_user and couch_user.is_locked_out():
             metrics_counter('commcare.auth.lockouts')
@@ -332,10 +332,10 @@ class HQBackupTokenForm(BackupTokenForm):
             else:
                 raise
 
-        # Handle the edge-case where the user locks himself out on this screen,
-        # then enters a correct token afterwards
+        # Handle the edge-case where the user enters a correct token
+        # after being locked out
         couch_user = CouchUser.get_by_username(self.user.username)
         if couch_user and couch_user.is_locked_out():
-            metrics_counter('commcare.auth.token_lockout')
+            metrics_counter('commcare.auth.lockouts')
             raise ValidationError(LOCKOUT_MESSAGE)
         return cleaned_data

--- a/corehq/apps/hqwebapp/signals.py
+++ b/corehq/apps/hqwebapp/signals.py
@@ -5,6 +5,7 @@ from django.contrib.auth.signals import user_logged_in, user_login_failed
 from django.dispatch import receiver
 
 from corehq.apps.users.models import CouchUser
+from corehq.util.metrics import metrics_counter
 
 
 def clear_login_attempts(user):
@@ -26,9 +27,27 @@ def clear_failed_logins_and_unlock_account(sender, request, user, **kwargs):
 
 
 @receiver(user_login_failed)
-def add_failed_attempt(sender, credentials, **kwargs):
+def add_failed_attempt(sender, credentials, token_failure=False, **kwargs):
     user = CouchUser.get_by_username(credentials['username'])
-    if user and not user.is_locked_out() and user.supports_lockout():
+    if not user:
+        metrics_counter('commcare.auth.invalid_user')
+        return
+
+    if token_failure:
+        metrics_counter('commcare.auth.invalid_token')
+
+    locked_out = user.is_locked_out()
+
+    if locked_out:
+        lockout_result = 'locked_out'
+    else:
+        lockout_result = 'should_be_locked_out' if not user.should_be_locked_out() else 'allowed_to_retry'
+
+    metrics_counter('commcare.auth.failed_attempts', tags={
+        'result': lockout_result
+    })
+
+    if not locked_out:
         if user.attempt_date == date.today():
             user.login_attempts += 1
         else:

--- a/corehq/apps/hqwebapp/signals.py
+++ b/corehq/apps/hqwebapp/signals.py
@@ -41,7 +41,7 @@ def add_failed_attempt(sender, credentials, token_failure=False, **kwargs):
     if locked_out:
         lockout_result = 'locked_out'
     else:
-        lockout_result = 'should_be_locked_out' if not user.should_be_locked_out() else 'allowed_to_retry'
+        lockout_result = 'should_be_locked_out' if user.should_be_locked_out() else 'allowed_to_retry'
 
     metrics_counter('commcare.auth.failed_attempts', tags={
         'result': lockout_result

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1112,6 +1112,9 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         return self.username.endswith('@dimagi.com')
 
     def is_locked_out(self):
+        return self.supports_lockout() and self.should_be_locked_out()
+
+    def should_be_locked_out(self):
         return self.login_attempts >= MAX_LOGIN_ATTEMPTS
 
     @property

--- a/corehq/apps/users/tests/test_confirm_account.py
+++ b/corehq/apps/users/tests/test_confirm_account.py
@@ -29,6 +29,8 @@ class TestAccountConfirmation(TestCase):
         )
         # confirm user can't login
         self.assertEqual(False, self.client.login(username=self.username, password=self.password))
+        # Refresh the user after a failed login, as it will be out of date
+        self.user = CommCareUser.get_by_username(self.username)
 
     @classmethod
     def tearDownClass(cls):
@@ -44,6 +46,8 @@ class TestAccountConfirmation(TestCase):
 
         # confirm user can't login
         self.assertEqual(False, self.client.login(username=self.username, password=self.password))
+        # User is now outdated from the failed login, re-fetch
+        self.user = CommCareUser.get_by_username(self.username)
 
         new_password = 'm0r3s3cr3t!'
         self.user.confirm_account(password=new_password)


### PR DESCRIPTION
## Summary

Part of our security work. [JIRA ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11661).
The intention is to surface a metric any time a user fails to log in.

## Product Description

This should be invisible to users. Currently, web users are the only users locked out by default -- commcare users need an additional toggle to be locked out. Given the sensitivity of information that we now deal with, this looks like an oversight. To surface the number of commcare users who would be affected by this, CouchUser.is_locked_out() was modified so that all failed attempts are recorded (if not acted upon), even for those with the toggle off.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

Introduced tests to cover the refactoring for what 'is_locked_out' should mean. During pairing with @dannyroberts, we initially decided additional testing was not needed, but given the additional logic of what metric gets fired when, I could be convinced otherwise.

### QA Plan

General steps are to verify that logging in and failing to log in are handled as normal. This should include normal logins, two-factor logins, and two-factor logins from a backup token. Because an inability to log in means an inability to use our system, I'm hoping smoke tests can be run to make sure this doesn't disrupt normal operations.

### Safety story

I've done testing on staging and have verified the metrics appear in [this dashboard](https://app.datadoghq.com/dashboard/ph4-knh-mga?from_ts=1611279873404&live=true&to_ts=1611283473404&tpl_var_environment=staging)

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
