### PR TITLE
fixed flaky test in test_metadata

### DIFF
--- a/corehq/blobs/tests/test_metadata.py
+++ b/corehq/blobs/tests/test_metadata.py
@@ -208,8 +208,8 @@ class TestMetaDB(TestCase):
         metadb.reparent("old", new_parent)
         self.assertEqual(metadb.get_for_parent("old"), [])
         self.assertEqual(
-            [m.id for m in metadb.get_for_parent(new_parent)],
-            [m.id for m in metas],
+            {m.id for m in metadb.get_for_parent(new_parent)},
+            {m.id for m in metas},
         )
         self.assertEqual(len(metadb.get_for_parent("no-change")), 1)
 


### PR DESCRIPTION
## Summary

No ticket, this was encountered while doing work for another ticket.
corehq.blobs.tests.test_metadata.py:TestMetaDB.test_reparent was failing with the below error:
```
FAIL: corehq.blobs.tests.test_metadata:TestMetaDB.test_reparent
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/commcare-hq-ro/corehq/blobs/tests/test_metadata.py", line 212, in test_reparent
    [m.id for m in metas],
AssertionError: Lists differ: [902, 903, 901] != [901, 902, 903]
```

The test compares the output of a postgres filter query with a list -- the issue is that postgres queries are unordered by default (unless they include an 'order_by' clause). It appeared that the keys were unique and that ordering was not important, so changing to set comparison fixes the problem.


## Product Description
Testing only, so no visible changes.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

The change occurs within a test.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
