### PR TITLE
make sure docker has xmlsec1 required by python3-saml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,9 @@ RUN apt-get update \
   && apt-get update \
   && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
     --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* /src/*.deb
+  && rm -rf /var/lib/apt/lists/* /src/*.deb \
+# install xmlsec required by python3-saml
+  && apt-get install -y libxml2-dev libxmlsec1-dev
 
 COPY requirements/test-requirements.txt package.json /vendor/
 


### PR DESCRIPTION
## Summary
The build for this PR is failing because docker needs the xmlsec1 library installed.
https://github.com/dimagi/commcare-hq/pull/28938

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
Updates the dockerfile

### Safety story
This only updated the docker file

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
