### PR TITLE
Mjr/multiple aggregations test date fix

### DIFF
--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -363,8 +363,10 @@ class AgeInMonthsBucketsColumn(IntegerBucketsColumn):
     type = TypeProperty('age_in_months_buckets')
 
     def _base_expression(self, bounds):
-        return "extract(year from age({}))*12 + extract(month from age({})) BETWEEN {} and {}".format(
-            self.field, self.field, bounds[0], bounds[1])
+        current_date = date.today().isoformat()
+        return "extract(year from age(date('{}'), {}))*12 + \
+            extract(month from age(date('{}'), {})) BETWEEN {} and {}".format(
+            current_date, self.field, current_date, self.field, bounds[0], bounds[1])
 
 
 class SumWhenColumn(_CaseExpressionColumn):

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -1,6 +1,5 @@
 from django.http import HttpRequest
 from django.test import TestCase
-from datetime import datetime, timedelta
 
 from corehq.apps.userreports.exceptions import BadSpecError, UserReportsError
 from corehq.apps.userreports.models import (

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -1,3 +1,4 @@
+from freezegun import freeze_time
 from django.http import HttpRequest
 from django.test import TestCase
 
@@ -604,56 +605,38 @@ class TestReportAggregationSQL(ConfigurableReportAggregationTestMixin, TestCase)
         )
 
 
+@freeze_time("2020-12-30")
 class TestReportMultipleAggregationsSQL(ConfigurableReportAggregationTestMixin, TestCase):
-    # Note that these constants are subtracted from today's date, so the month parts of the names
-    # are approximations: the first one will usually fall one year and two months ago, but will
-    # sometimes fall one year and three months ago. The only place this matters in tests is
-    # test_aggregate_date, which groups by month, so it matters which rows are in the same month.
-    ONE_YEAR_TWO_MONTHS = 365 + 28 * 2 + 5
-    ONE_YEAR_THREE_MONTHS = 365 + 28 * 3 + 7
-    ONE_YEAR_THREE_MONTHS_OTHER = 365 + 28 * 3 + 8
-    MORE_THAN_TWO_YEARS = 365 * 2 + 75
-
-    @classmethod
-    def _relative_date(cls, days_offset):
-        return (datetime.utcnow() - timedelta(days=days_offset)).strftime("%Y-%m-%d")
-
-    @classmethod
-    def _relative_month(cls, days_offset):
-        return (datetime.utcnow() - timedelta(days=days_offset)).strftime("%Y-%m")
-
     @classmethod
     def _create_data(cls):
-        # This data uses relative dates because if the dates were hard-coded, eventually the
-        # age_in_months_buckets tests would break.
         for row in [
             {
                 "state": "MA",
                 "city": "Boston",
                 "number": 4,
                 "age_at_registration": 1,
-                "date": cls._relative_date(cls.ONE_YEAR_TWO_MONTHS),
+                "date": "2019-10-30"
             },
             {
                 "state": "MA",
                 "city": "Boston",
                 "number": 3,
                 "age_at_registration": 5,
-                "date": cls._relative_date(cls.ONE_YEAR_THREE_MONTHS),
+                "date": "2019-09-30"
             },
             {
                 "state": "MA",
                 "city": "Cambridge",
                 "number": 2,
                 "age_at_registration": 8,
-                "date": cls._relative_date(cls.ONE_YEAR_THREE_MONTHS_OTHER),
+                "date": "2019-09-29"
             },
             {
                 "state": "TN",
                 "city": "Nashville",
                 "number": 1,
                 "age_at_registration": 14,
-                "date": cls._relative_date(cls.MORE_THAN_TWO_YEARS),
+                "date": "2018-10-15"
             },
         ]:
             cls._new_case(row).save()
@@ -912,31 +895,14 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportAggregationTestMixin, 
             ],
         )
         view = self._create_view(report_config)
-        if (
-            self._relative_month(self.ONE_YEAR_THREE_MONTHS)
-            == self._relative_month(self.ONE_YEAR_THREE_MONTHS_OTHER)
-        ):
-            # Typical use case, the two of the MA rows that are a day apart fall in the same month
-            self.assertEqual(
-                view.export_table,
-                [['foo',
-                  [['report_column_display_state', 'month', 'report_column_display_number'],
-                   ['MA', self._relative_month(self.ONE_YEAR_TWO_MONTHS), 4],
-                   ['MA', self._relative_month(self.ONE_YEAR_THREE_MONTHS), 5],
-                   ['TN', self._relative_month(self.MORE_THAN_TWO_YEARS), 1]]]]
-            )
-        else:
-            # One day each month, those two rows will be in different months.
-            # This no longer tests that the aggregation is summing, it just makes sure this test doesn't fail.
-            self.assertEqual(
-                view.export_table,
-                [['foo',
-                  [['report_column_display_state', 'month', 'report_column_display_number'],
-                   ['MA', self._relative_month(self.ONE_YEAR_TWO_MONTHS), 4],
-                   ['MA', self._relative_month(self.ONE_YEAR_THREE_MONTHS), 3],
-                   ['MA', self._relative_month(self.ONE_YEAR_THREE_MONTHS_OTHER), 2],
-                   ['TN', self._relative_month(self.MORE_THAN_TWO_YEARS), 1]]]]
-            )
+        self.assertEqual(
+            view.export_table,
+            [['foo',
+                [['report_column_display_state', 'month', 'report_column_display_number'],
+                ['MA', '2019-10', 4],
+                ['MA', '2019-09', 5],
+                ['TN', '2018-10', 1]]]]
+        )
 
     def test_integer_buckets(self):
         report_config = self._create_report(


### PR DESCRIPTION
## Summary
The tests in corehq/apps/userreports/tests/test_report_aggregation.py were unstable -- because they relied on the current date and did calculations based on month groupings, data returned was at the mercy of the relative date. An [attempt](https://github.com/dimagi/commcare-hq/pull/26520) was made in the past to remove this issue, by using freezegun to fix the date, but because half the solution relied on python, and half relied on postgres, this made the code difficult to reason about. This PR removes the postgres side, by using the [two-argument version of age](https://www.postgresqltutorial.com/postgresql-age/) rather than the single-argument one. The two-argument version lets us pass in the current date, rather than rely on postgres to generate it for us.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

Relying on the existing tests to catch any issues introduced by this change.

### QA Plan

As this is supposedly only used by ICDS, the risk is low enough to not require QA.

### Safety story
As mentioned above, because it has a limited usage, this PR isn't particularly dangerous.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
