### PR TITLE
dockerfile: only install libxmlsec1-dev as docker build is complaining it can't find libxml2-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* /src/*.deb \
 # install xmlsec required by python3-saml
-  && apt-get install -y libxml2-dev libxmlsec1-dev
+  && apt-get install -y libxmlsec1-dev
 
 COPY requirements/test-requirements.txt package.json /vendor/
 


### PR DESCRIPTION
## Summary
small update to docker build

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below
