### PR TITLE
dockerfile: docker build still throwing errors with libxmlsec1-dev, removing requirement for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,7 @@ RUN apt-get update \
   && apt-get update \
   && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
     --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* /src/*.deb \
-# install xmlsec required by python3-saml
-  && apt-get install -y libxmlsec1-dev
+  && rm -rf /var/lib/apt/lists/* /src/*.deb
 
 COPY requirements/test-requirements.txt package.json /vendor/
 


### PR DESCRIPTION
## Summary
 i'm going to remove the line trying to install `libxmlsec1-dev` and move `python3-saml` into `prod-requirements` for the sso stuff. the tests shouldn't require python3-saml for right now (I hope)...based on the imports it shouldn't be that way, but we'll see :/