### PR TITLE
Fixed error resulting from blank case claim condition

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -58,16 +58,18 @@ class RemoteRequestFactory(object):
         )
 
     def _build_remote_request_post(self):
-        return RemoteRequestPost(
-            url=absolute_reverse('claim_case', args=[self.domain]),
-            relevant=self.module.search_config.relevant,
-            data=[
+        kwargs = {
+            "url": absolute_reverse('claim_case', args=[self.domain]),
+            "data": [
                 QueryData(
                     key='case_id',
                     ref=QuerySessionXPath('case_id').instance(),
                 ),
-            ]
-        )
+            ],
+        }
+        if self.module.search_config.relevant:
+            kwargs["relevant"] = self.module.search_config.relevant
+        return RemoteRequestPost(**kwargs)
 
     def _build_command(self):
         return Command(


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/QA-2222

Passing either a blank string or `None` results in `relevant=""` in the suite, which doesn't work: https://sentry.io/organizations/dimagi/issues/2128886157/

I think this has been around for a while and was exposed by https://github.com/dimagi/commcare-hq/pull/28926/

## Feature Flag
Case search and claim

## Product Description
Fixes web apps / mobile error when "Case condition" is blank and "Don't claim cases already owned by the user" is unchecked.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

None

### QA Plan

Minor, tested locally, not going to QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
