### PR TITLE
install libxmlsec1-dev and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
      openjdk-7-jdk \
      wget \
+     xmlsec1-devel \
   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
   && apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
      openjdk-7-jdk \
      wget \
-     xmlsec1-devel \
+     libxml2-dev \
+     libxmlsec1-dev \
+     libxmlsec1-openssl \
   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
   && apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
   && apt-get update \
   && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
     --no-install-recommends \
+  # this line deletes all package sources, so don't apt-get install anything after this:
   && rm -rf /var/lib/apt/lists/* /src/*.deb
 
 COPY requirements/test-requirements.txt package.json /vendor/


### PR DESCRIPTION
## Summary
this adds the `libxmlsec1-dev` package to the list of `apt-get` packages in the `Dockerfile`. Also includes a helpful comment to not try and `apt-get install` packages after we've deleted all the sources!

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Safety story
Modifies the docker image. if the image build fails, it will default to an older image until it's fixed, so no impact on travis tests etc.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
