### PR TITLE
avoid failing if no display

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -741,7 +741,7 @@ class ReportConfiguration(QuickCachedDocumentMixin, Document):
         """
         langs = set()
         for item in self.columns + self.filters:
-            if isinstance(item['display'], dict):
+            if isinstance(item.get('display'), dict):
                 langs |= set(item['display'].keys())
         return langs
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SUPPORT-6689

https://sentry.io/organizations/dimagi/issues/2067909498/events/958262eb87364859ad764ba949a89d1a/events/?project=136860


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Should be a safe change that should not cause any other issue. Instead of failing HQ would just ignore, if user has not mentioned any display field for the column or filters.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
