### PR TITLE
Added case_type as a required argument to update_case_index_relationship

### DIFF
--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -12,7 +12,6 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
 
 BATCH_SIZE = 100
-CASE_TYPE = "lab_result"
 DEVICE_ID = __name__ + ".update_case_index_relationship"
 
 
@@ -35,10 +34,10 @@ def case_block(case):
     ).as_xml()).decode('utf-8')
 
 
-def update_cases(domain, username):
+def update_cases(domain, case_type, username):
     accessor = CaseAccessors(domain)
-    case_ids = accessor.get_case_ids_in_domain(CASE_TYPE)
-    print(f"Found {len(case_ids)} {CASE_TYPE} cases in {domain}")
+    case_ids = accessor.get_case_ids_in_domain(case_type)
+    print(f"Found {len(case_ids)} {case_type} cases in {domain}")
 
     user_id = username_to_user_id(username)
 
@@ -59,18 +58,19 @@ def update_cases(domain, username):
 
 
 class Command(BaseCommand):
-    help = (f"Updates all {CASE_TYPE} case indices to use an extension relationship instead of parent.")
+    help = ("Updates all case indices of a specfied case type to use an extension relationship instead of parent.")
 
     def add_arguments(self, parser):
         parser.add_argument('domain')
+        parser.add_argument('case_type')
         parser.add_argument('username')
         parser.add_argument('--and-linked', action='store_true', default=False)
 
-    def handle(self, domain, username, **options):
+    def handle(self, domain, case_type, username, **options):
         domains = {domain}
         if options["and_linked"]:
             domains = domains | {link.linked_domain for link in get_linked_domains(domain)}
 
         for domain in domains:
             print(f"Processing {domain}")
-            update_cases(domain, username)
+            update_cases(domain, case_type, username)

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -7,6 +7,7 @@ from dimagi.utils.chunked import chunked
 
 from corehq.apps.linked_domain.dbaccessors import get_linked_domains
 from corehq.apps.hqcase.utils import submit_case_blocks
+from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.apps.users.util import username_to_user_id
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
@@ -40,6 +41,8 @@ def update_cases(domain, case_type, username):
     print(f"Found {len(case_ids)} {case_type} cases in {domain}")
 
     user_id = username_to_user_id(username)
+    if not user_id:
+        user_id = SYSTEM_USER_ID
 
     case_blocks = []
     skip_count = 0


### PR DESCRIPTION
## Summary
Requested by this [ticket](https://dimagi-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=162&modal=detail&selectedIssue=USH-586&assignee=5f314baf6db35e0039014d73). Changes the constant CASE_TYPE into a parameter so this can be run on different case types than 'lab_results'

The second commit addresses a comment from this [PR](https://github.com/dimagi/commcare-hq/pull/28886) that I missed before. 


## Safety Assurance

- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I am certain that this PR will not introduce a regression for the reasons below


### QA Plan
I am not requesting QA.

### Safety story
I will run this script on a test domain before running it on all the requested domains.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
