### PR TITLE
Handle missing form with no XML blob

### DIFF
--- a/corehq/apps/couch_sql_migration/tests/test_statedb.py
+++ b/corehq/apps/couch_sql_migration/tests/test_statedb.py
@@ -287,6 +287,13 @@ def test_counters():
         })
 
 
+def test_add_duplicate_missing_docs():
+    with init_db() as db:
+        db.add_missing_docs("abc", ["doc1"])
+        db.add_missing_docs("abc", ["doc1"])
+        eq(list(db.iter_missing_doc_ids("abc")), ["doc1"])
+
+
 @with_setup(teardown=delete_db)
 def test_pickle():
     with init_db(memory=False) as db:


### PR DESCRIPTION
Fix for ongoing Couch to SQL forms and cases migration

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below
- [x] This PR can be reverted after deploy with no further considerations 
