### PR TITLE
Support couch_sql_diff ... patch --select=with-[diffs|changes]

### DIFF
--- a/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
+++ b/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
@@ -78,10 +78,11 @@ class Command(BaseCommand):
             help='''
                 Diff specific items. The value of this option may be
                 'pending' to clear out in-process diffs OR 'with-diffs'
-                or 'with-changes' to re-diff items that previously had
-                diffs or changes respectively OR a comma-delimited list
-                of case ids OR a path to a file containing a case id on
-                each line. The path must begin with / or ./
+                or 'with-changes' to patch or re-diff items that
+                previously had diffs or changes respectively OR a
+                comma-delimited list of case ids OR a path to a file
+                containing a case id on each line. The path must begin
+                with / or ./
 
                 With the "show" or "filter" actions, this option should
                 be a doc type, optionally followed by a colon and one or
@@ -150,6 +151,8 @@ class Command(BaseCommand):
             raise CommandError(f'{action} --csv not allowed')
         if self.dry_run and action != FILTER:
             raise CommandError(f'{action} --dry-run not allowed')
+        if self.select == "pending" and action == PATCH:
+            raise CommandError(f'{action} --select=pending not allowed')
 
         if self.reset:
             if action != CASES:


### PR DESCRIPTION
Improve command line options for `couch_sql_diff` command, allowing a subset of cases (with diffs or changes) to be patched.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below
- [x] This PR can be reverted after deploy with no further considerations 
