### PR TITLE
Fixed case claim UI checkbox again

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -118,14 +118,24 @@ hqDefine("app_manager/js/details/case_claim", function () {
         self.searchFilter = ko.observable(searchFilter);
         self.blacklistedOwnerIdsExpression = ko.observable(blacklistedOwnerIdsExpression);
 
+        // Parse searchRelevant into DEFAULT_CLAIM_RELEVANT, which controls a checkbox,
+        // and the remainder of the expression, if any, which appears in a textbox.
         // Note that this fragile parsing logic needs to match the self.relevant calculation below
         // and cannot be changed without migrating existing CaseSearch documents
         var defaultRelevant = false,
-            extraRelevant = searchRelevant,
-            prefix = "(" + DEFAULT_CLAIM_RELEVANT + ") and (";
-        if (searchRelevant && searchRelevant.startsWith(prefix)) {
-            defaultRelevant = true;
-            extraRelevant = searchRelevant.substr(prefix.length, searchRelevant.length - prefix.length - 1);
+            prefix = "(" + DEFAULT_CLAIM_RELEVANT + ") and (",
+            extraRelevant;
+        if (searchRelevant) {
+            searchRelevant = searchRelevant.trim();
+            if (searchRelevant === DEFAULT_CLAIM_RELEVANT) {
+                defaultRelevant = true;
+                extraRelevant = "";
+            } else if (searchRelevant.startsWith(prefix)) {
+                defaultRelevant = true;
+                extraRelevant = searchRelevant.substr(prefix.length, searchRelevant.length - prefix.length - 1);
+            } else {
+                extraRelevant = searchRelevant;
+            }
         }
         self.extraRelevant = ko.observable(extraRelevant);
         self.defaultRelevant = ko.observable(defaultRelevant);

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -124,7 +124,8 @@ hqDefine("app_manager/js/details/case_claim", function () {
         // and cannot be changed without migrating existing CaseSearch documents
         var defaultRelevant = false,
             prefix = "(" + DEFAULT_CLAIM_RELEVANT + ") and (",
-            extraRelevant;
+            extraRelevant = "";
+        searchRelevant = searchRelevant || "";
         if (searchRelevant) {
             searchRelevant = searchRelevant.trim();
             if (searchRelevant === DEFAULT_CLAIM_RELEVANT) {


### PR DESCRIPTION
## Summary

https://dimagi-dev.atlassian.net/browse/QA-2231

Followup for https://github.com/dimagi/commcare-hq/pull/28926/

I wish the `CaseSearch` model matched the UI, with a flag for default relevant and a string for any additional condition...but not badly enough to migrate the existing documents right now.

## Feature Flag
Case search & claim

## Product Description
Fixes recently-introduced UI bug in case claim settings, where checking "Don't claim cases already owned by the user" would cause an unexpected expression to appear in "Claim Condition".

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

QA team will verify.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
