### PR TITLE
Added post datum instance in remote request suite generation

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -86,12 +86,10 @@ class RemoteRequestFactory(object):
             if prop.itemset.instance_id
         ]
 
-        query_xpaths = [datum.ref for datum in self._get_remote_request_query_datums()]
-        config_xpaths = [self.module.search_config.relevant, self.module.search_config.search_filter]
-        instances, unknown_instances = get_all_instances_referenced_in_xpaths(
-            self.app,
-            query_xpaths + config_xpaths
-        )
+        query_xpaths = [QuerySessionXPath('case_id').instance()]
+        query_xpaths.extend([datum.ref for datum in self._get_remote_request_query_datums()])
+        query_xpaths.extend([self.module.search_config.relevant, self.module.search_config.search_filter])
+        instances, unknown_instances = get_all_instances_referenced_in_xpaths(self.app, query_xpaths)
         # we use the module's case list/details view to select the datum so also
         # need these instances to be available
         instances |= get_instances_for_module(self.app, self.module)


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/QA-2230

Similar to https://github.com/dimagi/commcare-hq/pull/28914/, this just adds another xpath to the set that's checked when app manager decides which instances to add to the `<remote-request>`. This guarantees that `commcaresession` gets added as an instance, since that's where the case id fetched by case search gets stored.

`commcaresession` would already get added if the module used the "Don't claim cases already owned by the user" option, or if any other xpaths in the module's detail config referenced the session, so this is likely a rare bug.

## Feature Flag
Case search & claim

## Product Description
Fixes a bug in case claim apps, where in apps configured a particular way, claiming a case already owned by the user would throw an error.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

Good test coverage in `test_suite_remote_request.py`

### QA Plan

QA team will verify this.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
