### PR TITLE
Reapply ConnectionSettings migration

### DIFF
--- a/corehq/motech/repeaters/migrations/0003_migrate_connectionsettings.py
+++ b/corehq/motech/repeaters/migrations/0003_migrate_connectionsettings.py
@@ -1,6 +1,18 @@
 from django.db import migrations
 
+from couchdbkit import ResourceNotFound
+
 from corehq.motech.repeaters.models import Repeater
+
+DELETED_REPEATER_CLASSES = (
+    'ChemistBETSVoucherRepeater',
+    'LabBETSVoucherRepeater',
+    'BETS180TreatmentRepeater',
+    'BETSDrugRefillRepeater',
+    'BETSSuccessfulTreatmentRepeater',
+    'BETSDiagnosisAndNotificationRepeater',
+    'BETSAYUSHReferralRepeater',
+)
 
 
 def _migrate_to_connectionsettings(apps, schema_editor):
@@ -13,7 +25,28 @@ def iter_repeaters():
     for result in Repeater.get_db().view('repeaters/repeaters',
                                          reduce=False,
                                          include_docs=True).all():
-        yield Repeater.wrap(result['doc'])
+        try:
+            repeater = Repeater.wrap(result['doc'])
+        except ResourceNotFound:
+            if result['doc']['doc_type'] in DELETED_REPEATER_CLASSES:
+                # repeater is an instance of a class that has been deleted
+                # from the codebase. It is safe to delete because it does
+                # not have repeat records waiting to be sent, and no future
+                # repeat records will be created for it.
+                delete_zombie_repeater_instance(result['doc'])
+                continue
+            else:
+                raise
+        else:
+            yield repeater
+
+
+def delete_zombie_repeater_instance(document: dict):
+    assert document['doc_type'] in DELETED_REPEATER_CLASSES
+    db = Repeater.get_db()
+    # Do not delete old repeat records. There could be thousands, and they
+    # are benign because they will not be resent.
+    db.delete_doc(document['_id'])
 
 
 class Migration(migrations.Migration):

--- a/corehq/motech/repeaters/migrations/0003_migrate_connectionsettings.py
+++ b/corehq/motech/repeaters/migrations/0003_migrate_connectionsettings.py
@@ -12,6 +12,22 @@ DELETED_REPEATER_CLASSES = (
     'BETSSuccessfulTreatmentRepeater',
     'BETSDiagnosisAndNotificationRepeater',
     'BETSAYUSHReferralRepeater',
+    'BETSUserRepeater',
+    'BETSLocationRepeater',
+    'BETSBeneficiaryRepeater',
+
+    'NikshayRegisterPatientRepeater',
+    'NikshayHIVTestRepeater',
+    'NikshayTreatmentOutcomeRepeater',
+    'NikshayFollowupRepeater',
+    'NikshayRegisterPrivatePatientRepeater',
+    'NikshayHealthEstablishmentRepeater',
+
+    'NinetyNineDotsRegisterPatientRepeater',
+    'NinetyNineDotsUpdatePatientRepeater',
+    'NinetyNineDotsAdherenceRepeater',
+    'NinetyNineDotsTreatmentOutcomeRepeater',
+    'NinetyNineDotsUnenrollPatientRepeater',
 )
 
 

--- a/corehq/motech/repeaters/migrations/0003_migrate_connectionsettings.py
+++ b/corehq/motech/repeaters/migrations/0003_migrate_connectionsettings.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+from corehq.motech.repeaters.models import Repeater
+
+
+def _migrate_to_connectionsettings(apps, schema_editor):
+    for repeater in iter_repeaters():
+        if not repeater.connection_settings_id:
+            repeater.create_connection_settings()
+
+
+def iter_repeaters():
+    for result in Repeater.get_db().view('repeaters/repeaters',
+                                         reduce=False,
+                                         include_docs=True).all():
+        yield Repeater.wrap(result['doc'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('repeaters', '0002_sqlrepeatrecord'),
+        ('motech', '0007_auto_20200909_2138'),
+    ]
+
+    operations = [
+        migrations.RunPython(_migrate_to_connectionsettings,
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
+    ]

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -416,10 +416,25 @@ class Repeater(QuickCachedDocumentMixin, Document):
 
     @property
     def plaintext_password(self):
+
+        def clean_repr(bytes_repr):
+            """
+            Drops the bytestring representation from ``bytes_repr``
+
+            >>> clean_repr("b'spam'")
+            'spam'
+            """
+            if bytes_repr.startswith("b'") and bytes_repr.endswith("'"):
+                return bytes_repr[2:-1]
+            return bytes_repr
+
         if self.password is None:
             return ''
         if self.password.startswith('${algo}$'.format(algo=ALGO_AES)):
             ciphertext = self.password.split('$', 2)[2]
+            # Work around Py2to3 string-handling bug in encryption code
+            # (fixed on 2018-03-12 by commit 3a900068)
+            ciphertext = clean_repr(ciphertext)
             return b64_aes_decrypt(ciphertext)
         return self.password
 
@@ -491,7 +506,7 @@ class Repeater(QuickCachedDocumentMixin, Document):
             auth_type=self.auth_type,
             username=self.username,
             skip_cert_verify=self.skip_cert_verify,
-            notify_addresses_str=self.notify_addresses_str,
+            notify_addresses_str=self.notify_addresses_str or '',
         )
         # Allow ConnectionSettings to encrypt old Repeater passwords:
         conn.plaintext_password = self.plaintext_password

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -8,8 +8,9 @@ from django.utils import timezone
 
 from nose.tools import assert_in
 
-from corehq.motech.const import BASIC_AUTH
+from corehq.motech.const import ALGO_AES, BASIC_AUTH
 from corehq.motech.models import ConnectionSettings
+from corehq.motech.utils import b64_aes_encrypt
 
 from ..const import (
     RECORD_CANCELLED_STATE,
@@ -34,10 +35,6 @@ class RepeaterConnectionSettingsTests(TestCase):
         self.rep = FormRepeater(
             domain="greasy-spoon",
             url="https://spam.example.com/api/",
-            auth_type=BASIC_AUTH,
-            username="terry",
-            password="Don't save me decrypted!",
-            notify_addresses_str="admin@example.com",
             format=FormRepeaterXMLPayloadGenerator.format_name,
         )
 
@@ -54,9 +51,37 @@ class RepeaterConnectionSettingsTests(TestCase):
 
         self.assertIsNotNone(self.rep.connection_settings_id)
         self.assertEqual(conn.name, self.rep.url)
+
+    def test_notify_addresses(self):
+        self.rep.notify_addresses_str = "admin@example.com"
+        conn = self.rep.connection_settings
+        self.assertEqual(conn.notify_addresses, ["admin@example.com"])
+
+    def test_notify_addresses_none(self):
+        self.rep.notify_addresses_str = None
+        conn = self.rep.connection_settings
+        self.assertEqual(conn.notify_addresses, [])
+
+    def test_password_encrypted(self):
+        self.rep.auth_type = BASIC_AUTH
+        self.rep.username = "terry"
+        self.rep.password = "Don't save me decrypted!"
+        conn = self.rep.connection_settings
+
         self.assertEqual(self.rep.plaintext_password, conn.plaintext_password)
         # rep.password was saved decrypted; conn.password is not:
         self.assertNotEqual(self.rep.password, conn.password)
+
+    def test_password_bug(self):
+        self.rep.auth_type = BASIC_AUTH
+        self.rep.username = "terry"
+        plaintext = "Don't save me decrypted!"
+        ciphertext = b64_aes_encrypt(plaintext)
+        bytestring_repr = f"b'{ciphertext}'"  # bug fixed by commit 3a900068
+        self.rep.password = f'${ALGO_AES}${bytestring_repr}'
+        conn = self.rep.connection_settings
+
+        self.assertEqual(conn.plaintext_password, self.rep.plaintext_password)
 
 
 class TestSQLRepeatRecordOrdering(TestCase):


### PR DESCRIPTION
## Summary

Reverts a reverted migration to create `ConnectionSettings` instances for `Repeaters`, and resolves the reason it was reverted.

* [Original PR](https://github.com/dimagi/commcare-hq/pull/28958)
* [Revert PR](https://github.com/dimagi/commcare-hq/pull/28966)

The problem was caused by instances stored in Couch for classes that have been deleted from the codebase.

This PR checks for those instances, and deletes them.


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below


### Safety story

The deleted classes were used by eNikshay for the BETS project. Instances should not exist in environments other than India and perhaps Staging. I am unaware of any other Repeater subclasses that have been deleted from the codebase.

The instances are safe to delete because they do not have repeat records waiting to be sent, and no new repeat records can be created for them. The repeat records of these repeaters are intentionally not deleted because there could be thousands of them (I have not checked) and deleting them could take a long time. This should be done outside of a migration.

(Migrating repeat records from Couch to SQL is in the works, and deleting all old Couch repeat records may happen as part of that initiative.)


### Rollback instructions

This migration does not need to be reversed. As before, the PR can just be reverted.

- [x] This PR can be reverted after deploy with no further considerations 
