### PR TITLE
Only run on environments with an "onse-iss" domain

### DIFF
--- a/custom/onse/tasks.py
+++ b/custom/onse/tasks.py
@@ -15,6 +15,7 @@ from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
 from dimagi.utils.chunked import chunked
 
+from corehq.apps.domain.dbaccessors import domain_exists
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCaseSQL
@@ -82,6 +83,8 @@ def update_facility_cases_from_dhis2_data_elements(
         otherwise they are emailed.
 
     """
+    if not domain_exists(DOMAIN):
+        return
     dhis2_server = get_dhis2_server(print_notifications)
     try:
         clays = get_clays()


### PR DESCRIPTION
## Summary

The `update_facility_cases_from_dhis2_data_elements()` task is custom code for the "onse-iss" domain, and should only run on Staging, Prod, and their own environment if/when they migrate to a self-hosted server.

This change is prompted by [this soft-assert](https://github.com/dimagi/commcare-hq/blob/e246d66654501cf38ffb225a161c613ff2be9374/custom/onse/tasks.py#L117).

(This task checks for both the right domain name, and the existence of a `ConnectionSettings` instance [with the right name](https://github.com/dimagi/commcare-hq/blob/e246d66654501cf38ffb225a161c613ff2be9374/custom/onse/tasks.py#L109) in that domain before it executes.)


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below


### Safety story

* 2-line change excl. import
* Tiny blast radius: Custom code
* Very low usage: Runs once every three months


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
