### PR TITLE
Bring back case search admin view and add profiling data

### DIFF
--- a/corehq/apps/case_search/static/case_search/js/case_search.js
+++ b/corehq/apps/case_search/static/case_search/js/case_search.js
@@ -39,21 +39,24 @@ hqDefine('case_search/js/case_search', [
         };
 
         self.showResults = ko.computed(function () {
-            return self.count() !== undefined;
+            return !_.isUndefined(self.count()) && !_.isNaN(parseInt(self.count()));
         });
 
-        self.submitButtonIcon = ko.observable("fa fa-search");
+        self.searchButtonIcon = ko.observable("fa fa-search");
+        self.profileButtonIcon = ko.observable("fa fa-clock-o");
 
-        self.submit = function () {
+        self._submit = function (postData) {
+            postData = postData || {};
             self.results([]);
             self.count("-");
             self.took(null);
             self.query(null);
             self.profile(null);
-            self.submitButtonIcon("fa fa-spin fa-refresh");
+            self.searchButtonIcon("fa fa-spin fa-refresh");
+            self.profileButtonIcon("fa fa-spin fa-refresh");
             $.post({
                 url: window.location.href,
-                data: {q: JSON.stringify({
+                data: _.extend(postData, {q: JSON.stringify({
                     type: self.type(),
                     owner_id: self.owner_id(),
                     parameters: self.parameters(),
@@ -61,18 +64,31 @@ hqDefine('case_search/js/case_search', [
                     includeClosed: self.includeClosed(),
                     xpath: self.xpath(),
                 }
-                )},
+                )}),
                 success: function (data) {
                     self.results(data.values);
                     self.count(data.count);
                     self.took(data.took);
                     self.query(data.query);
-                    self.profile(data.profile);
-                    self.submitButtonIcon("fa fa-search");
+                    if (postData.include_profile) {
+                        self.profile(data.profile);
+                    }
+                    self.searchButtonIcon("fa fa-search");
+                    self.profileButtonIcon("fa fa-clock-o");
                 },
                 error: function (response) {
                     alertUser.alert_user(response.responseJSON.message, 'danger');
                 },
+            });
+        };
+
+        self.search = function () {
+            self._submit();
+        };
+
+        self.searchWithProfile = function () {
+            self._submit({
+                include_profile: true,
             });
         };
 

--- a/corehq/apps/case_search/static/case_search/js/case_search.js
+++ b/corehq/apps/case_search/static/case_search/js/case_search.js
@@ -1,0 +1,74 @@
+hqDefine('case_search/js/case_search', [
+    'jquery',
+    'knockout',
+    'hqwebapp/js/alert_user',
+    'hqwebapp/js/initial_page_data',
+], function (
+    $,
+    ko,
+    alertUser,
+    initialPageData
+) {
+    'use strict';
+    var caseSearchModel = function (caseDataUrl) {
+        var self = {};
+        self.type = ko.observable();
+        self.owner_id = ko.observable();
+        self.customQueryAddition = ko.observable();
+        self.includeClosed = ko.observable(false);
+        self.results = ko.observableArray();
+        self.count = ko.observable();
+        self.took = ko.observable();
+        self.query = ko.observable();
+        self.case_data_url = caseDataUrl;
+        self.xpath = ko.observable();
+        self.parameters = ko.observableArray();
+
+        self.addParameter = function () {
+            self.parameters.push({
+                key: "",
+                value: "",
+                clause: "must",
+                fuzzy: false,
+                regex: '',
+            });
+        };
+        self.removeParameter = function () {
+            self.parameters.remove(this);
+        };
+
+        self.submit = function () {
+            self.results([]);
+            self.count("-");
+            self.took(null);
+            self.query(null);
+            $.post({
+                url: window.location.href,
+                data: {q: JSON.stringify({
+                    type: self.type(),
+                    owner_id: self.owner_id(),
+                    parameters: self.parameters(),
+                    customQueryAddition: self.customQueryAddition(),
+                    includeClosed: self.includeClosed(),
+                    xpath: self.xpath(),
+                }
+                )},
+                success: function (data) {
+                    self.results(data.values);
+                    self.count(data.count);
+                    self.took(data.took);
+                    self.query(data.query);
+                },
+                error: function (response) {
+                    alertUser.alert_user(response.responseJSON.message, 'danger');
+                },
+            });
+        };
+
+        return self;
+    };
+
+    $(function () {
+        $("#case-search").koApplyBindings(caseSearchModel(initialPageData.reverse('case_data')));
+    });
+});

--- a/corehq/apps/case_search/static/case_search/js/case_search.js
+++ b/corehq/apps/case_search/static/case_search/js/case_search.js
@@ -20,6 +20,7 @@ hqDefine('case_search/js/case_search', [
         self.count = ko.observable();
         self.took = ko.observable();
         self.query = ko.observable();
+        self.profile = ko.observable();
         self.case_data_url = caseDataUrl;
         self.xpath = ko.observable();
         self.parameters = ko.observableArray();
@@ -37,11 +38,19 @@ hqDefine('case_search/js/case_search', [
             self.parameters.remove(this);
         };
 
+        self.showResults = ko.computed(function () {
+            return self.count() !== undefined;
+        });
+
+        self.submitButtonIcon = ko.observable("fa fa-search");
+
         self.submit = function () {
             self.results([]);
             self.count("-");
             self.took(null);
             self.query(null);
+            self.profile(null);
+            self.submitButtonIcon("fa fa-spin fa-refresh");
             $.post({
                 url: window.location.href,
                 data: {q: JSON.stringify({
@@ -58,6 +67,8 @@ hqDefine('case_search/js/case_search', [
                     self.count(data.count);
                     self.took(data.took);
                     self.query(data.query);
+                    self.profile(data.profile);
+                    self.submitButtonIcon("fa fa-search");
                 },
                 error: function (response) {
                     alertUser.alert_user(response.responseJSON.message, 'danger');

--- a/corehq/apps/case_search/templates/case_search/case_search.html
+++ b/corehq/apps/case_search/templates/case_search/case_search.html
@@ -1,0 +1,170 @@
+{% extends 'hqwebapp/base_section.html' %}
+{% load hq_shared_tags %}
+{% load compress %}
+{% load i18n %}
+
+{% requirejs_main 'case_search/js/case_search' %}
+
+{% block page_content %}
+  {% registerurl 'case_data' request.domain '___' %}
+
+  <div id="case-search">
+    <h3>{% trans "Search Parameters" %}</h3>
+    <div class="row">
+      <div class="col-sm-12">
+        <div class="controls">
+          <form class="form-inline" data-bind="submit: submit" id="case-search-form">
+            {% csrf_token %}
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <strong>{% trans "Case Metadata" %}</strong>
+              </div>
+              <div class="panel-body">
+                <label>
+                  {% trans "Case Type:" %}
+                  <input name="type" type="text" placeholder="Case Type (optional)" data-bind="value: type" class="form-control"/>
+                </label>
+                <label>
+                  {% trans "Owner ID:" %}
+                  <input name="type" type="text" placeholder="Owner ID (optional)" data-bind="value: owner_id" class="form-control"/>
+                </label>
+                <label>
+                  {% trans "Include Closed:" %}
+                  <input name="type" type="checkbox" data-bind="checked: includeClosed"/>
+                </label>
+              </div>
+            </div>
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <strong>{% trans "Case Properties" %}</strong>
+              </div>
+              <div class="panel-body">
+                <table class="table table-striped" >
+                  <thead>
+                  <th>{% trans "Property name" %}</th>
+                  <th>{% trans "Property value" %}</th>
+                  <th>{% trans "Clause" %}</th>
+                  <th>{% trans "Fuzzy" %}</th>
+                  <th>{% trans "Remove Characters" %}</th>
+                  <th></th>
+                  </thead>
+                  <tbody data-bind="foreach: parameters" >
+                  <tr>
+                    <td>
+                      <input name="key" type="text" placeholder="e.g. name" data-bind="value: key" class="form-control"/>
+                    </td>
+                    <td>
+                      <input name="value" type="text"  placeholder="e.g. redbeard" data-bind="value: value" class="form-control"/> </td>
+                    <td>
+                      <select name="clause" data-bind="value: clause" class="form-control">
+                        <option value="must">must</option>
+                        <option value="should">should</option>
+                        <option value="must_not">must_not</option>
+                      </select>
+                    </td>
+                    <td>
+                      <input name="fuzzy" type="checkbox" data-bind="checked: fuzzy">
+                    </td>
+                    <td>
+                      <input name="value" type="text" spellcheck='false' data-bind="value: regex" placeholder="Regular Expression" class="form-control"/>
+                    </td>
+                    <td>
+                                                <span class='btn btn-danger' data-bind="click: $parent.removeParameter">
+                                                    <i class="fa fa-trash"></i> {% trans "Delete" %}
+                                                </span>
+                    </td>
+
+                  </tr>
+
+                  </tbody>
+                </table>
+                <span class="btn btn-primary" id="add-input" data-bind="click: addParameter"><i class="fa fa-plus"></i> Add input</span>
+              </div>
+            </div>
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <strong>XPath Expression</strong>
+              </div>
+              <div class="panel-body">
+                <div class="form-group" style="width:100%">
+                  <textarea style="min-width: 50%" spellcheck="false" class="form-control" name="xpath" type="text" placeholder="e.g: name = 'tyrion' or nickname='the imp'" data-bind="value: xpath"> </textarea>
+                </div>
+              </div>
+            </div>
+            {% if query_additions %}
+              <div class="panel panel-default">
+                <div class="panel-heading">
+                  <strong>{% trans "Custom Query Addition" %}</strong>
+                </div>
+                <div class="panel-body">
+                  <select data-bind="value: customQueryAddition">
+                    <option></option>
+                    {% for query_addition in query_additions %}
+                      <option value="{{ query_addition.id }}">{{ query_addition.name }}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+              </div>
+            {% endif %}
+            <button type="submit" class="btn btn-primary"><i class="fa fa-search"></i> {% trans "Search" %}</button>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-12">
+        <h3>{% trans "Results" %}
+          <small data-bind="visible: count">
+            <span data-bind="text: count"></span> results
+            <span data-bind="visible: took">in <span data-bind="text: took"></span>ms</span>
+          </small>
+        </h3>
+      </div>
+      <div class="col-sm-12" data-bind="visible: query">
+        <a role="button" data-toggle="collapse" data-target="#query">Show Query</a>
+        <pre id="query" class="collapse" data-bind="text: query"></pre>
+      </div>
+      <div class="col-sm-12">
+        <table class="table table-striped">
+          <thead>
+          <tr>
+            <th>{% trans "Name" %}</th>
+            <th>{% trans "Case Type" %}</th>
+            <th>{% trans "Closed" %}</th>
+            <th>{% trans "Properties" %}</th>
+            <th>{% trans "Indices" %}</th>
+            <th>{% trans "Score" %}</th>
+          </tr>
+          </thead>
+          <tbody data-bind="foreach: {data: results, as: 'result' }">
+          <tr>
+            <td>
+              <a data-bind="attr: {href: $parent.case_data_url.replace('___', $data._id)}, text: result['_source']['name']"></a>
+            </td>
+            <td data-bind="text: result['_source']['type']"></td>
+            <td data-bind="text: result['_source']['closed']"></td>
+            <td>
+              <div data-bind="foreach: result['_source']['case_properties']">
+                <small data-bind="text:$data['key']"></small>:
+                <strong data-bind="text:$data['value']"></strong><br />
+              </div>
+            </td>
+            <td>
+              <ul data-bind="foreach: result['_source']['indices']">
+                <li>
+                                        <span class="label label-default"
+                                              data-bind="text: relationship"></span>
+                  <a data-bind="attr: {href: $parents[1].case_data_url.replace('___', $data.referenced_id)},
+                                                      text: identifier"></a>
+                </li>
+              </ul>
+            </td>
+            <td data-bind="text: result['_score']"></td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/corehq/apps/case_search/templates/case_search/case_search.html
+++ b/corehq/apps/case_search/templates/case_search/case_search.html
@@ -8,6 +8,13 @@
 {% block page_content %}
   {% registerurl 'case_data' request.domain '___' %}
 
+  <p class="lead">
+    {% blocktrans %}
+      Use this page to test out <a href='{{ settings_url }}' target='_blank'>case search configuration</a> and profile case search or
+      case list explorer queries.
+    {% endblocktrans %}
+  </p>
+
   <div id="case-search">
     <h3>{% trans "Search Parameters" %}</h3>
     <div class="row">

--- a/corehq/apps/case_search/templates/case_search/case_search.html
+++ b/corehq/apps/case_search/templates/case_search/case_search.html
@@ -20,7 +20,7 @@
     <div class="row">
       <div class="col-sm-12">
         <div class="controls">
-          <form class="form-inline" data-bind="submit: submit" id="case-search-form">
+          <form class="form-inline" id="case-search-form">
             {% csrf_token %}
             <div class="panel panel-default">
               <div class="panel-heading">
@@ -111,8 +111,11 @@
                 </div>
               </div>
             {% endif %}
-            <button type="submit" class="btn btn-primary">
-              <i data-bind="attr: {class: submitButtonIcon}"></i> {% trans "Search" %}
+            <button type="button" class="btn btn-primary" data-bind="click: search">
+              <i data-bind="attr: {class: searchButtonIcon}"></i> {% trans "Search" %}
+            </button>
+            <button type="button" class="btn btn-default" data-bind="click: searchWithProfile">
+              <i data-bind="attr: {class: profileButtonIcon}"></i> {% trans "Profile" %}
             </button>
           </form>
         </div>
@@ -125,7 +128,7 @@
         <ul class="nav nav-tabs">
           <li class="active"><a data-toggle="tab" href="#tabs-results">{% trans "Results" %}</a></li>
           <li><a data-toggle="tab" href="#tabs-query">{% trans "Query" %}</a></li>
-          <li><a data-toggle="tab" href="#tabs-profile">{% trans "Profile" %}</a></li>
+          <li data-bind="visible: profile"><a data-toggle="tab" href="#tabs-profile">{% trans "Profile" %}</a></li>
         </ul>
         <div class="spacer"></div>
       </div>
@@ -176,7 +179,7 @@
           <div class="tab-pane fade" id="tabs-query">
             <pre data-bind="text: query"></pre>
           </div>
-          <div class="tab-pane fade" id="tabs-profile">
+          <div class="tab-pane fade" id="tabs-profile" data-bind="visible: profile">
             <p class="lead" data-bind="visible: count">
               {% blocktrans %}
                 See <a href='https://www.elastic.co/guide/en/elasticsearch/reference/current/search-profile.html' target='_blank'>ElasticSearch docs</a> for help interpreting profile data.

--- a/corehq/apps/case_search/templates/case_search/case_search.html
+++ b/corehq/apps/case_search/templates/case_search/case_search.html
@@ -76,16 +76,14 @@
                       <input name="value" type="text" spellcheck='false' data-bind="value: regex" placeholder="Regular Expression" class="form-control"/>
                     </td>
                     <td>
-                                                <span class='btn btn-danger' data-bind="click: $parent.removeParameter">
-                                                    <i class="fa fa-trash"></i> {% trans "Delete" %}
-                                                </span>
+                      <span class='btn btn-danger' data-bind="click: $parent.removeParameter">
+                        <i class="fa fa-trash"></i> {% trans "Delete" %}
+                      </span>
                     </td>
-
                   </tr>
-
                   </tbody>
                 </table>
-                <span class="btn btn-primary" id="add-input" data-bind="click: addParameter"><i class="fa fa-plus"></i> Add input</span>
+                <span class="btn btn-default" id="add-input" data-bind="click: addParameter"><i class="fa fa-plus"></i> {% trans "Add input" %}</span>
               </div>
             </div>
             <div class="panel panel-default">
@@ -113,65 +111,80 @@
                 </div>
               </div>
             {% endif %}
-            <button type="submit" class="btn btn-primary"><i class="fa fa-search"></i> {% trans "Search" %}</button>
+            <button type="submit" class="btn btn-primary">
+              <i data-bind="attr: {class: submitButtonIcon}"></i> {% trans "Search" %}
+            </button>
           </form>
         </div>
       </div>
     </div>
 
-    <div class="row">
+    <div class="spacer"></div>
+    <div class="row" data-bind="visible: showResults">
       <div class="col-sm-12">
-        <h3>{% trans "Results" %}
-          <small data-bind="visible: count">
-            <span data-bind="text: count"></span> results
-            <span data-bind="visible: took">in <span data-bind="text: took"></span>ms</span>
-          </small>
-        </h3>
-      </div>
-      <div class="col-sm-12" data-bind="visible: query">
-        <a role="button" data-toggle="collapse" data-target="#query">Show Query</a>
-        <pre id="query" class="collapse" data-bind="text: query"></pre>
+        <ul class="nav nav-tabs">
+          <li class="active"><a data-toggle="tab" href="#tabs-results">{% trans "Results" %}</a></li>
+          <li><a data-toggle="tab" href="#tabs-query">{% trans "Query" %}</a></li>
+          <li><a data-toggle="tab" href="#tabs-profile">{% trans "Profile" %}</a></li>
+        </ul>
+        <div class="spacer"></div>
       </div>
       <div class="col-sm-12">
-        <table class="table table-striped">
-          <thead>
-          <tr>
-            <th>{% trans "Name" %}</th>
-            <th>{% trans "Case Type" %}</th>
-            <th>{% trans "Closed" %}</th>
-            <th>{% trans "Properties" %}</th>
-            <th>{% trans "Indices" %}</th>
-            <th>{% trans "Score" %}</th>
-          </tr>
-          </thead>
-          <tbody data-bind="foreach: {data: results, as: 'result' }">
-          <tr>
-            <td>
-              <a data-bind="attr: {href: $parent.case_data_url.replace('___', $data._id)}, text: result['_source']['name']"></a>
-            </td>
-            <td data-bind="text: result['_source']['type']"></td>
-            <td data-bind="text: result['_source']['closed']"></td>
-            <td>
-              <div data-bind="foreach: result['_source']['case_properties']">
-                <small data-bind="text:$data['key']"></small>:
-                <strong data-bind="text:$data['value']"></strong><br />
-              </div>
-            </td>
-            <td>
-              <ul data-bind="foreach: result['_source']['indices']">
-                <li>
-                                        <span class="label label-default"
-                                              data-bind="text: relationship"></span>
-                  <a data-bind="attr: {href: $parents[1].case_data_url.replace('___', $data.referenced_id)},
-                                                      text: identifier"></a>
-                </li>
-              </ul>
-            </td>
-            <td data-bind="text: result['_score']"></td>
-          </tr>
-          </tbody>
-        </table>
+        <div class="tab-content">
+          <div class="tab-pane fade in active" id="tabs-results">
+            <p class="help-block" data-bind="visible: count">
+              <span data-bind="text: count"></span> {% trans "results" %}
+              <span data-bind="visible: took">in <span data-bind="text: took"></span>ms</span>
+            </p>
+            <table class="table table-striped">
+              <thead>
+              <tr>
+                <th>{% trans "Name" %}</th>
+                <th>{% trans "Case Type" %}</th>
+                <th>{% trans "Closed" %}</th>
+                <th>{% trans "Properties" %}</th>
+                <th>{% trans "Indices" %}</th>
+                <th>{% trans "Score" %}</th>
+              </tr>
+              </thead>
+              <tbody data-bind="foreach: {data: results, as: 'result' }">
+                <tr>
+                  <td>
+                    <a data-bind="attr: {href: $parent.case_data_url.replace('___', $data._id)}, text: result['_source']['name']"></a>
+                  </td>
+                  <td data-bind="text: result['_source']['type']"></td>
+                  <td data-bind="text: result['_source']['closed']"></td>
+                  <td>
+                    <div data-bind="foreach: result['_source']['case_properties']">
+                      <small data-bind="text:$data['key']"></small>:
+                      <strong data-bind="text:$data['value']"></strong><br />
+                    </div>
+                  </td>
+                  <td>
+                    <ul data-bind="foreach: result['_source']['indices']">
+                      <li>
+                        <span class="label label-default" data-bind="text: relationship"></span>
+                        <a data-bind="attr: {href: $parents[1].case_data_url.replace('___', $data.referenced_id)}, text: identifier"></a>
+                      </li>
+                    </ul>
+                  </td>
+                  <td data-bind="text: result['_score']"></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="tab-pane fade" id="tabs-query">
+            <pre data-bind="text: query"></pre>
+          </div>
+          <div class="tab-pane fade" id="tabs-profile">
+            <p class="lead" data-bind="visible: count">
+              {% blocktrans %}
+                See <a href='https://www.elastic.co/guide/en/elasticsearch/reference/current/search-profile.html' target='_blank'>ElasticSearch docs</a> for help interpreting profile data.
+              {% endblocktrans %}
+            </p>
+            <pre data-bind="text: profile"></pre>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
 {% endblock %}

--- a/corehq/apps/case_search/urls.py
+++ b/corehq/apps/case_search/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+
+from corehq.apps.case_search.views import CaseSearchView
+
+urlpatterns = [
+    url(r'^search/$', CaseSearchView.as_view(), name=CaseSearchView.urlname),
+]

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -1,0 +1,82 @@
+import json
+import re
+
+from django.http import Http404
+from django.views.generic import TemplateView
+
+from dimagi.utils.web import json_response
+
+from corehq.apps.case_search.models import (
+    CaseSearchQueryAddition,
+    case_search_enabled_for_domain,
+    merge_queries,
+)
+from corehq.apps.domain.decorators import cls_require_superuser_or_contractor
+from corehq.apps.domain.views.base import DomainViewMixin
+from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_MAX_RESULTS
+from corehq.util.view_utils import BadRequest, json_error
+
+
+class CaseSearchView(DomainViewMixin, TemplateView):
+    template_name = 'case_search/case_search.html'
+    urlname = 'case_search'
+
+    @cls_require_superuser_or_contractor
+    def get(self, request, *args, **kwargs):
+        if not case_search_enabled_for_domain(self.domain):
+            raise Http404("Domain does not have case search enabled")
+
+        return self.render_to_response(self.get_context_data())
+
+    def get_context_data(self, **kwargs):
+        context = super(CaseSearchView, self).get_context_data(**kwargs)
+        query_additions = CaseSearchQueryAddition.objects.filter(domain=self.domain)
+        context.update({
+            "query_additions": query_additions,
+        })
+        return context
+
+    @json_error
+    @cls_require_superuser_or_contractor
+    def post(self, request, *args, **kwargs):
+        from corehq.apps.es.case_search import CaseSearchES
+        if not case_search_enabled_for_domain(self.domain):
+            raise BadRequest("Domain does not have case search enabled")
+
+        query = json.loads(request.POST.get('q'))
+        case_type = query.get('type')
+        owner_id = query.get('owner_id')
+        search_params = query.get('parameters', [])
+        query_addition = query.get("customQueryAddition", None)
+        include_closed = query.get("includeClosed", False)
+        xpath = query.get("xpath")
+        search = CaseSearchES()
+        search = search.domain(self.domain).size(10)
+        if not include_closed:
+            search = search.is_closed(False)
+        if case_type:
+            search = search.case_type(case_type)
+        if owner_id:
+            search = search.owner(owner_id)
+        for param in search_params:
+            value = re.sub(param.get('regex', ''), '', param.get('value'))
+            search = search.case_property_query(
+                param.get('key'),
+                value,
+                clause=param.get('clause'),
+                fuzzy=param.get('fuzzy'),
+            )
+        if query_addition:
+            addition = CaseSearchQueryAddition.objects.get(id=query_addition, domain=self.domain)
+            new_query = merge_queries(search.get_query(), addition.query_addition)
+            search = search.set_query(new_query)
+
+        if xpath:
+            search = search.xpath_query(self.domain, xpath)
+        search_results = search.run()
+        return json_response({
+            'values': search_results.raw_hits,
+            'count': search_results.total,
+            'took': search_results.raw['took'],
+            'query': search_results.query.dumps(pretty=True),
+        })

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -75,7 +75,9 @@ class CaseSearchView(BaseDomainView):
         if xpath:
             search = search.xpath_query(self.domain, xpath)
 
-        search = search.enable_profiling()
+        include_profile = request.POST.get("include_profile", False)
+        if include_profile:
+            search = search.enable_profiling()
 
         search_results = search.run()
         return json_response({
@@ -83,5 +85,5 @@ class CaseSearchView(BaseDomainView):
             'count': search_results.total,
             'took': search_results.raw['took'],
             'query': search_results.query.dumps(pretty=True),
-            'profile': json.dumps(search_results.raw['profile'], indent=2),
+            'profile': json.dumps(search_results.raw.get('profile', {}), indent=2),
         })

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -2,19 +2,38 @@ import json
 import re
 
 from django.http import Http404
-from django.views.generic import TemplateView
 
+from django.urls import reverse
+from django.utils.translation import ugettext_lazy
 from dimagi.utils.web import json_response
 
 from corehq.apps.case_search.models import case_search_enabled_for_domain
 from corehq.apps.domain.decorators import cls_require_superuser_or_contractor
-from corehq.apps.domain.views.base import DomainViewMixin
+from corehq.apps.domain.views.base import BaseDomainView
 from corehq.util.view_utils import BadRequest, json_error
 
 
-class CaseSearchView(DomainViewMixin, TemplateView):
+class CaseSearchView(BaseDomainView):
+    section_name = ugettext_lazy("Data")
     template_name = 'case_search/case_search.html'
     urlname = 'case_search'
+    page_title = ugettext_lazy("Case Search")
+
+    @property
+    def section_url(self):
+        return reverse("data_interfaces_default", args=[self.domain])
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname, args=[self.domain])
+
+    @property
+    def page_context(self):
+        context = super().page_context
+        context.update({
+            'settings_url': reverse("case_search_config", args=[self.domain]),
+        })
+        return context
 
     @cls_require_superuser_or_contractor
     def get(self, request, *args, **kwargs):

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -74,10 +74,14 @@ class CaseSearchView(BaseDomainView):
 
         if xpath:
             search = search.xpath_query(self.domain, xpath)
+
+        search = search.enable_profiling()
+
         search_results = search.run()
         return json_response({
             'values': search_results.raw_hits,
             'count': search_results.total,
             'took': search_results.raw['took'],
             'query': search_results.query.dumps(pretty=True),
+            'profile': json.dumps(search_results.raw['profile'], indent=2),
         })

--- a/corehq/apps/domain/templates/domain/admin/case_search.html
+++ b/corehq/apps/domain/templates/domain/admin/case_search.html
@@ -35,6 +35,14 @@
           <label for="enable">{% trans "Enable Case Search" %}</label>
         </p>
 
+        {% if request.user.is_superuser %}
+          <div data-bind="visible: toggleEnabled">
+            {% blocktrans %}
+              Visit <a href='{{ case_search_url }}' target='_blank'>Case Search</a> to test out your configuration.
+            {% endblocktrans %}
+          </div>
+        {% endif %}
+
         <div id="fuzzies_div" data-bind="visible: toggleEnabled">
           <h2>{% trans "Fuzzy Search Properties" %}</h2>
           <p>

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -409,6 +409,7 @@ class CaseSearchConfigView(BaseAdminProjectSettingsView):
         current_values = CaseSearchConfig.objects.get_or_none(pk=self.domain)
         return {
             'case_types': sorted(list(case_types)),
+            'case_search_url': reverse("case_search", args=[self.domain]),
             'values': {
                 'enabled': current_values.enabled if current_values else False,
                 'fuzzy_properties': {

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -316,6 +316,10 @@ class ESQuery(object):
         es.es_query['query']['bool']['must'] = query
         return es
 
+    def enable_profiling(self):
+        self.es_query['profile'] = True
+        return self
+
     def add_query(self, new_query, clause):
         """
         Add a query to the current list of queries

--- a/urls.py
+++ b/urls.py
@@ -68,6 +68,7 @@ domain_specific = [
     url(r'^data_dictionary/', include('corehq.apps.data_dictionary.urls')),
     url(r'^', include(hqwebapp_domain_specific)),
     url(r'^case/', include('corehq.apps.hqcase.urls')),
+    url(r'^case/', include('corehq.apps.case_search.urls')),
     url(r'^case_migrations/', include('corehq.apps.case_migrations.urls')),
     url(r'^cloudcare/', include('corehq.apps.cloudcare.urls')),
     url(r'^fixtures/', include('corehq.apps.fixtures.urls')),


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-566

## Feature Flag
Case search & claim, plus this is limited to superusers

## Product Description
This re-adds the old case search admin page for superusers, and it adds query profiling data to that page.

![Screen Shot 2021-01-11 at 11 19 33 AM](https://user-images.githubusercontent.com/1486591/104210007-5a7ff300-5400-11eb-9cd3-43064d1f4f26.png)


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

No test coverage.

### QA Plan

Not going to QA this because it's internal-only and low-risk: it restores old functionality and makes a minor addition.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
