### PR TITLE
process_repeater_stub() task

### DIFF
--- a/corehq/motech/repeaters/const.py
+++ b/corehq/motech/repeaters/const.py
@@ -5,7 +5,10 @@ MAX_RETRY_WAIT = timedelta(days=7)
 MIN_RETRY_WAIT = timedelta(minutes=60)
 CHECK_REPEATERS_INTERVAL = timedelta(minutes=5)
 CHECK_REPEATERS_KEY = 'check-repeaters-key'
-MAX_ATTEMPTS = 6
+# Number of attempts to an online endpoint before cancelling payload
+MAX_ATTEMPTS = 3
+# Number of exponential backoff attempts to an offline endpoint
+MAX_BACKOFF_ATTEMPTS = 6
 # Limit the number of records to forward at a time so that one repeater
 # can't hold up the rest.
 RECORDS_AT_A_TIME = 1000

--- a/corehq/motech/repeaters/const.py
+++ b/corehq/motech/repeaters/const.py
@@ -5,6 +5,10 @@ MAX_RETRY_WAIT = timedelta(days=7)
 MIN_RETRY_WAIT = timedelta(minutes=60)
 CHECK_REPEATERS_INTERVAL = timedelta(minutes=5)
 CHECK_REPEATERS_KEY = 'check-repeaters-key'
+MAX_ATTEMPTS = 6
+# Limit the number of records to forward at a time so that one repeater
+# can't hold up the rest.
+RECORDS_AT_A_TIME = 1000
 
 RECORD_PENDING_STATE = 'PENDING'
 RECORD_SUCCESS_STATE = 'SUCCESS'

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1093,7 +1093,7 @@ class SQLRepeatRecord(models.Model):
         self.repeater_stub.set_next_attempt()
         self._add_failure_attempt(message, MAX_BACKOFF_ATTEMPTS)
 
-    def _add_failure_attempt(self, message, max_attempts)
+    def _add_failure_attempt(self, message, max_attempts):
         if self.num_attempts < max_attempts:
             state = RECORD_FAILURE_STATE
         else:

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1222,8 +1222,7 @@ def send_request(
     else:
         if is_success(response):
             if is_response(response):
-                # Don't bother logging success in
-                # Datadog if the payload wasn't sent.
+                # Log success in Datadog if the payload was sent.
                 log_repeater_success_in_datadog(
                     repeater.domain,
                     response.status_code,

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1189,8 +1189,8 @@ def send_request(
     """
     Calls ``repeater.send_request()`` and handles the result.
 
-    Returns True on success or cancelled, so that the caller knows
-    whether to retry later.
+    Returns True on success or cancelled, which means the caller should
+    not retry. False means a retry should be attempted later.
     """
 
     def is_success(resp):

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1165,7 +1165,7 @@ def attempt_forward_now(repeater_stub: RepeaterStub):
     process_repeater_stub.delay(repeater_stub)
 
 
-def get_payload(repeater: Repeater, repeat_record: SQLRepeatRecord) -> Any:
+def get_payload(repeater: Repeater, repeat_record: SQLRepeatRecord) -> str:
     try:
         return repeater.get_payload(repeat_record)
     except Exception as err:

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -67,18 +67,19 @@ import traceback
 import warnings
 from collections import OrderedDict
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any, overload
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
-from django.utils.functional import cached_property
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from couchdbkit.exceptions import ResourceConflict, ResourceNotFound
 from memoized import memoized
-from requests.exceptions import ConnectionError, Timeout, RequestException
+from requests import Response
+from requests.exceptions import ConnectionError, RequestException, Timeout
 
 from casexml.apps.case.xml import LEGAL_VERSIONS, V2
 from couchforms.const import DEVICE_LOG_XMLNS
@@ -120,6 +121,7 @@ from corehq.motech.utils import b64_aes_decrypt
 from corehq.privileges import DATA_FORWARDING, ZAPIER_INTEGRATION
 from corehq.util.metrics import metrics_counter
 from corehq.util.quickcache import quickcache
+from corehq.util.urlsanitize.urlsanitize import PossibleSSRFAttempt
 
 from .const import (
     MAX_ATTEMPTS,
@@ -149,7 +151,6 @@ from .repeater_generators import (
     ShortFormRepeaterJsonPayloadGenerator,
     UserPayloadGenerator,
 )
-from ...util.urlsanitize.urlsanitize import PossibleSSRFAttempt
 
 
 def log_repeater_timeout_in_datadog(domain):
@@ -1207,7 +1208,13 @@ def send_request(
                                    RECORD_CANCELLED_STATE)  # Don't retry
 
 
-def format_response(response) -> Optional[str]:
+@overload
+def format_response(response: Any) -> None:
+    ...
+@overload
+def format_response(response: Response) -> str:
+    ...
+def format_response(response):
     if not is_response(response):
         return None
     response_text = getattr(response, "text", "")

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1077,11 +1077,7 @@ class SQLRepeatRecord(models.Model):
         that this repeat record does not hold up the rest.
         """
         self.repeater_stub.reset_next_attempt()
-        if self.num_attempts < MAX_ATTEMPTS:
-            state = RECORD_FAILURE_STATE
-        else:
-            state = RECORD_CANCELLED_STATE
-        self._add_failure_attempt(message, state)
+        self._add_failure_attempt(message, MAX_ATTEMPTS)
 
     def add_server_failure_attempt(self, message):
         """
@@ -1095,13 +1091,13 @@ class SQLRepeatRecord(models.Model):
 
         """
         self.repeater_stub.set_next_attempt()
-        if self.num_attempts < MAX_BACKOFF_ATTEMPTS:
+        self._add_failure_attempt(message, MAX_BACKOFF_ATTEMPTS)
+
+    def _add_failure_attempt(self, message, max_attempts)
+        if self.num_attempts < max_attempts:
             state = RECORD_FAILURE_STATE
         else:
             state = RECORD_CANCELLED_STATE
-        self._add_failure_attempt(message, state)
-
-    def _add_failure_attempt(self, message, state):
         self.sqlrepeatrecordattempt_set.create(
             state=state,
             message=message,

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -177,7 +177,7 @@ def process_repeater_stub(repeater_stub: RepeaterStub):
                 # The repeat record is cancelled if there is an error
                 # getting the payload. We can safely move to the next one.
                 continue
-            succeeded_or_cancelled = send_request(repeater_stub.repeater,
-                                                  repeat_record, payload)
-            if not succeeded_or_cancelled:
-                break  # Retry later
+            should_retry = not send_request(repeater_stub.repeater,
+                                            repeat_record, payload)
+            if should_retry:
+                break

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from uuid import uuid4
 
 from django.conf import settings
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
 
 from nose.tools import assert_in
@@ -13,13 +13,22 @@ from corehq.motech.models import ConnectionSettings
 from corehq.motech.utils import b64_aes_encrypt
 
 from ..const import (
+    MAX_ATTEMPTS,
+    MIN_RETRY_WAIT,
     RECORD_CANCELLED_STATE,
     RECORD_FAILURE_STATE,
     RECORD_PENDING_STATE,
     RECORD_SUCCESS_STATE,
 )
-from ..models import FormRepeater, RepeaterStub, get_all_repeater_types
-from ..repeater_generators import FormRepeaterXMLPayloadGenerator
+from ..models import (
+    FormRepeater,
+    RepeaterStub,
+    format_response,
+    get_all_repeater_types,
+    is_response,
+)
+
+DOMAIN = 'test-domain'
 
 
 def test_get_all_repeater_types():
@@ -29,82 +38,81 @@ def test_get_all_repeater_types():
         assert_in(name, types)
 
 
-class RepeaterConnectionSettingsTests(TestCase):
-
-    def setUp(self):
-        self.rep = FormRepeater(
-            domain="greasy-spoon",
-            url="https://spam.example.com/api/",
-            format=FormRepeaterXMLPayloadGenerator.format_name,
-        )
-
-    def tearDown(self):
-        if self.rep.connection_settings_id:
-            ConnectionSettings.objects.filter(
-                pk=self.rep.connection_settings_id
-            ).delete()
-        self.rep.delete()
-
-    def test_create_connection_settings(self):
-        self.assertIsNone(self.rep.connection_settings_id)
-        conn = self.rep.connection_settings
-
-        self.assertIsNotNone(self.rep.connection_settings_id)
-        self.assertEqual(conn.name, self.rep.url)
-
-    def test_notify_addresses(self):
-        self.rep.notify_addresses_str = "admin@example.com"
-        conn = self.rep.connection_settings
-        self.assertEqual(conn.notify_addresses, ["admin@example.com"])
-
-    def test_notify_addresses_none(self):
-        self.rep.notify_addresses_str = None
-        conn = self.rep.connection_settings
-        self.assertEqual(conn.notify_addresses, [])
-
-    def test_password_encrypted(self):
-        self.rep.auth_type = BASIC_AUTH
-        self.rep.username = "terry"
-        self.rep.password = "Don't save me decrypted!"
-        conn = self.rep.connection_settings
-
-        self.assertEqual(self.rep.plaintext_password, conn.plaintext_password)
-        # rep.password was saved decrypted; conn.password is not:
-        self.assertNotEqual(self.rep.password, conn.password)
-
-    def test_password_bug(self):
-        self.rep.auth_type = BASIC_AUTH
-        self.rep.username = "terry"
-        plaintext = "Don't save me decrypted!"
-        ciphertext = b64_aes_encrypt(plaintext)
-        bytestring_repr = f"b'{ciphertext}'"  # bug fixed by commit 3a900068
-        self.rep.password = f'${ALGO_AES}${bytestring_repr}'
-        conn = self.rep.connection_settings
-
-        self.assertEqual(conn.plaintext_password, self.rep.plaintext_password)
-
-
-class TestSQLRepeatRecordOrdering(TestCase):
+class RepeaterFixtureMixin:
 
     def setUp(self):
         self.repeater = FormRepeater(
-            domain='eden',
-            url='https://spam.example.com/api/',
+            domain=DOMAIN,
+            url='https://www.example.com/api/',
         )
         self.repeater.save()
         self.repeater_stub = RepeaterStub.objects.create(
-            domain='eden',
+            domain=DOMAIN,
             repeater_id=self.repeater.get_id,
-        )
-        self.repeater_stub.repeat_records.create(
-            domain=self.repeater_stub.domain,
-            payload_id='eve',
-            registered_at='1970-02-01',
         )
 
     def tearDown(self):
         self.repeater_stub.delete()
         self.repeater.delete()
+
+
+class RepeaterConnectionSettingsTests(RepeaterFixtureMixin, TestCase):
+
+    def tearDown(self):
+        if self.repeater.connection_settings_id:
+            ConnectionSettings.objects.filter(
+                pk=self.repeater.connection_settings_id
+            ).delete()
+        super().tearDown()
+
+    def test_create_connection_settings(self):
+        self.assertIsNone(self.repeater.connection_settings_id)
+        conn = self.repeater.connection_settings
+
+        self.assertIsNotNone(self.repeater.connection_settings_id)
+        self.assertEqual(conn.name, self.repeater.url)
+
+    def test_notify_addresses(self):
+        self.repeater.notify_addresses_str = "admin@example.com"
+        conn = self.repeater.connection_settings
+        self.assertEqual(conn.notify_addresses, ["admin@example.com"])
+
+    def test_notify_addresses_none(self):
+        self.repeater.notify_addresses_str = None
+        conn = self.repeater.connection_settings
+        self.assertEqual(conn.notify_addresses, [])
+
+    def test_password_encrypted(self):
+        self.repeater.auth_type = BASIC_AUTH
+        self.repeater.username = "terry"
+        self.repeater.password = "Don't save me decrypted!"
+        conn = self.repeater.connection_settings
+
+        self.assertEqual(self.repeater.plaintext_password, conn.plaintext_password)
+        # repeater.password was saved decrypted; conn.password is not:
+        self.assertNotEqual(self.repeater.password, conn.password)
+
+    def test_password_bug(self):
+        self.repeater.auth_type = BASIC_AUTH
+        self.repeater.username = "terry"
+        plaintext = "Don't save me decrypted!"
+        ciphertext = b64_aes_encrypt(plaintext)
+        bytestring_repr = f"b'{ciphertext}'"  # bug fixed by commit 3a900068
+        self.repeater.password = f'${ALGO_AES}${bytestring_repr}'
+        conn = self.repeater.connection_settings
+
+        self.assertEqual(conn.plaintext_password, self.repeater.plaintext_password)
+
+
+class TestSQLRepeatRecordOrdering(RepeaterFixtureMixin, TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.repeater_stub.repeat_records.create(
+            domain=DOMAIN,
+            payload_id='eve',
+            registered_at='1970-02-01',
+        )
 
     def test_earlier_record_created_later(self):
         self.repeater_stub.repeat_records.create(
@@ -131,22 +139,7 @@ class TestSQLRepeatRecordOrdering(TestCase):
         self.assertEqual(repeat_records[1].payload_id, 'cain')
 
 
-class RepeaterStubManagerTests(TestCase):
-
-    def setUp(self):
-        self.repeater = FormRepeater(
-            domain="greasy-spoon",
-            url="https://spam.example.com/api/",
-        )
-        self.repeater.save()
-        self.repeater_stub = RepeaterStub.objects.create(
-            domain="greasy-spoon",
-            repeater_id=self.repeater.get_id,
-        )
-
-    def tearDown(self):
-        self.repeater_stub.delete()
-        self.repeater.delete()
+class RepeaterStubManagerTests(RepeaterFixtureMixin, TestCase):
 
     def test_all_ready_no_repeat_records(self):
         repeater_stubs = RepeaterStub.objects.all_ready()
@@ -230,3 +223,137 @@ def set_next_attempt_at(repeater_stub, when):
     finally:
         repeater_stub.next_attempt_at = None
         repeater_stub.save()
+
+
+class ResponseMock:
+    pass
+
+
+class IsResponseTests(SimpleTestCase):
+
+    def test_has_text(self):
+        resp = ResponseMock()
+        resp.text = '<h1>Hello World</h1>'
+        self.assertFalse(is_response(resp))
+
+    def test_has_status_code(self):
+        resp = ResponseMock()
+        resp.status_code = 504
+        self.assertFalse(is_response(resp))
+
+    def test_has_reason(self):
+        resp = ResponseMock()
+        resp.reason = 'Gateway Timeout'
+        self.assertFalse(is_response(resp))
+
+    def test_has_status_code_and_reason(self):
+        resp = ResponseMock()
+        resp.status_code = 504
+        resp.reason = 'Gateway Timeout'
+        self.assertTrue(is_response(resp))
+
+
+class FormatResponseTests(SimpleTestCase):
+
+    def test_non_response(self):
+        resp = ResponseMock()
+        self.assertIsNone(format_response(resp))
+
+    def test_no_text(self):
+        resp = ResponseMock()
+        resp.status_code = 504
+        resp.reason = 'Gateway Timeout'
+        self.assertEqual(format_response(resp), '504: Gateway Timeout')
+
+    def test_with_text(self):
+        resp = ResponseMock()
+        resp.status_code = 200
+        resp.reason = 'OK'
+        resp.text = '<h1>Hello World</h1>'
+        self.assertEqual(format_response(resp), '200: OK\n'
+                                                '<h1>Hello World</h1>')
+
+
+class AddAttemptsTests(RepeaterFixtureMixin, TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.just_now = timezone.now()
+        self.repeater_stub.next_attempt_at = self.just_now
+        self.repeater_stub.save()
+        self.repeat_record = self.repeater_stub.repeat_records.create(
+            domain=DOMAIN,
+            payload_id='eggs',
+            registered_at=timezone.now(),
+        )
+
+    def tearDown(self):
+        self.repeater_stub.delete()
+        self.repeater.delete()
+
+    def test_add_success_attempt_true(self):
+        self.repeat_record.add_success_attempt(response=True)
+        self.assertEqual(self.repeat_record.state, RECORD_SUCCESS_STATE)
+        self.assertIsNone(self.repeater_stub.next_attempt_at)
+        self.assertEqual(self.repeat_record.num_attempts, 1)
+        self.assertEqual(self.repeat_record.attempts[0].state,
+                         RECORD_SUCCESS_STATE)
+        self.assertIsNone(self.repeat_record.attempts[0].message)
+
+    def test_add_success_attempt_200(self):
+        resp = ResponseMock()
+        resp.status_code = 200
+        resp.reason = 'OK'
+        resp.text = '<h1>Hello World</h1>'
+        self.repeat_record.add_success_attempt(response=resp)
+        self.assertEqual(self.repeat_record.state, RECORD_SUCCESS_STATE)
+        self.assertIsNone(self.repeater_stub.next_attempt_at)
+        self.assertEqual(self.repeat_record.num_attempts, 1)
+        self.assertEqual(self.repeat_record.attempts[0].state,
+                         RECORD_SUCCESS_STATE)
+        self.assertEqual(self.repeat_record.attempts[0].message,
+                         format_response(resp))
+
+    def test_add_failure_attempt_fail(self):
+        message = '409: Conflict\n'
+        self.repeat_record.add_failure_attempt(message=message)
+        self.assertEqual(self.repeat_record.state, RECORD_FAILURE_STATE)
+        self.assertGreater(self.repeater_stub.last_attempt_at, self.just_now)
+        self.assertEqual(self.repeater_stub.next_attempt_at,
+                         self.repeater_stub.last_attempt_at + MIN_RETRY_WAIT)
+        self.assertEqual(self.repeat_record.num_attempts, 1)
+        self.assertEqual(self.repeat_record.attempts[0].state,
+                         RECORD_FAILURE_STATE)
+        self.assertEqual(self.repeat_record.attempts[0].message, message)
+        self.assertIsNone(self.repeat_record.attempts[0].traceback)
+
+    def test_add_failure_attempt_cancel(self):
+        message = '409: Conflict\n'
+        for __ in range(MAX_ATTEMPTS + 1):
+            self.repeat_record.add_failure_attempt(message=message)
+        self.assertEqual(self.repeat_record.state, RECORD_CANCELLED_STATE)
+        self.assertGreater(self.repeater_stub.last_attempt_at, self.just_now)
+        self.assertEqual(self.repeater_stub.next_attempt_at,
+                         self.repeater_stub.last_attempt_at + MIN_RETRY_WAIT)
+        self.assertEqual(self.repeat_record.num_attempts, MAX_ATTEMPTS + 1)
+        attempts = list(self.repeat_record.attempts)
+        expected_states = ([RECORD_FAILURE_STATE] * MAX_ATTEMPTS
+                           + [RECORD_CANCELLED_STATE])
+        self.assertEqual([a.state for a in attempts], expected_states)
+        self.assertEqual(attempts[-1].message, message)
+        self.assertIsNone(attempts[-1].traceback)
+
+    def test_add_payload_exception_attempt(self):
+        message = 'ValueError: Schema validation failed'
+        tb_str = 'Traceback ...'
+        self.repeat_record.add_payload_exception_attempt(message=message,
+                                                         tb_str=tb_str)
+        self.assertEqual(self.repeat_record.state, RECORD_CANCELLED_STATE)
+        # Note: Our payload issues do not affect how we deal with their
+        #       server issues:
+        self.assertEqual(self.repeater_stub.next_attempt_at, self.just_now)
+        self.assertEqual(self.repeat_record.num_attempts, 1)
+        self.assertEqual(self.repeat_record.attempts[0].state,
+                         RECORD_CANCELLED_STATE)
+        self.assertEqual(self.repeat_record.attempts[0].message, message)
+        self.assertEqual(self.repeat_record.attempts[0].traceback, tb_str)

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -39,9 +39,10 @@ def test_get_all_repeater_types():
         assert_in(name, types)
 
 
-class RepeaterFixtureMixin:
+class RepeaterTestCase(TestCase):
 
     def setUp(self):
+        super().setUp()
         self.repeater = FormRepeater(
             domain=DOMAIN,
             url='https://www.example.com/api/',
@@ -55,9 +56,10 @@ class RepeaterFixtureMixin:
     def tearDown(self):
         self.repeater_stub.delete()
         self.repeater.delete()
+        super().tearDown()
 
 
-class RepeaterConnectionSettingsTests(RepeaterFixtureMixin, TestCase):
+class RepeaterConnectionSettingsTests(RepeaterTestCase):
 
     def tearDown(self):
         if self.repeater.connection_settings_id:
@@ -105,7 +107,7 @@ class RepeaterConnectionSettingsTests(RepeaterFixtureMixin, TestCase):
         self.assertEqual(conn.plaintext_password, self.repeater.plaintext_password)
 
 
-class TestSQLRepeatRecordOrdering(RepeaterFixtureMixin, TestCase):
+class TestSQLRepeatRecordOrdering(RepeaterTestCase):
 
     def setUp(self):
         super().setUp()
@@ -140,7 +142,7 @@ class TestSQLRepeatRecordOrdering(RepeaterFixtureMixin, TestCase):
         self.assertEqual(repeat_records[1].payload_id, 'cain')
 
 
-class RepeaterStubManagerTests(RepeaterFixtureMixin, TestCase):
+class RepeaterStubManagerTests(RepeaterTestCase):
 
     def test_all_ready_no_repeat_records(self):
         repeater_stubs = RepeaterStub.objects.all_ready()
@@ -275,7 +277,7 @@ class FormatResponseTests(SimpleTestCase):
                                                 '<h1>Hello World</h1>')
 
 
-class AddAttemptsTests(RepeaterFixtureMixin, TestCase):
+class AddAttemptsTests(RepeaterTestCase):
 
     def setUp(self):
         super().setUp()
@@ -287,10 +289,6 @@ class AddAttemptsTests(RepeaterFixtureMixin, TestCase):
             payload_id='eggs',
             registered_at=timezone.now(),
         )
-
-    def tearDown(self):
-        self.repeater_stub.delete()
-        self.repeater.delete()
 
     def test_add_success_attempt_true(self):
         self.repeat_record.add_success_attempt(response=True)

--- a/corehq/motech/repeaters/tests/test_models_slow.py
+++ b/corehq/motech/repeaters/tests/test_models_slow.py
@@ -1,0 +1,164 @@
+import random
+import string
+from collections import namedtuple
+from unittest.mock import patch
+from uuid import uuid4
+
+from django.test import TestCase
+from django.utils import timezone
+
+from requests.exceptions import ConnectionError
+
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
+from corehq.apps.accounting.utils import clear_plan_version_cache
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.receiverwrapper.util import submit_form_locally
+from corehq.motech.models import ConnectionSettings
+from corehq.motech.repeaters.const import (
+    RECORD_FAILURE_STATE,
+    RECORD_SUCCESS_STATE,
+)
+from corehq.motech.repeaters.models import (
+    FormRepeater,
+    RepeaterStub,
+    send_request,
+)
+
+DOMAIN = ''.join([random.choice(string.ascii_lowercase) for __ in range(20)])
+
+
+ResponseMock = namedtuple('ResponseMock', 'status_code reason')
+
+
+class RepeaterFixtureMixin:
+
+    def setUp(self):
+        url = 'https://www.example.com/api/'
+        conn = ConnectionSettings.objects.create(domain=DOMAIN, name=url, url=url)
+        self.repeater = FormRepeater(
+            domain=DOMAIN,
+            connection_settings_id=conn.id,
+            include_app_id_param=False,
+        )
+        self.repeater.save()
+        self.repeater_stub = RepeaterStub.objects.create(
+            domain=DOMAIN,
+            repeater_id=self.repeater.get_id,
+        )
+
+    def tearDown(self):
+        self.repeater_stub.delete()
+        self.repeater.delete()
+
+
+class ServerErrorTests(RepeaterFixtureMixin, TestCase, DomainSubscriptionMixin):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = create_domain(DOMAIN)
+        cls.setup_subscription(DOMAIN, SoftwarePlanEdition.PRO)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.teardown_subscriptions()
+        cls.domain_obj.delete()
+        clear_plan_version_cache()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        self.instance_id = str(uuid4())
+        self.repeat_record = self.repeater_stub.repeat_records.create(
+            domain=DOMAIN,
+            payload_id=self.instance_id,
+            registered_at=timezone.now(),
+        )
+        self.post_xform()
+
+    def post_xform(self):
+        xform = f"""<?xml version='1.0' ?>
+<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
+      xmlns="https://www.commcarehq.org/test/ServerErrorTests/">
+    <foo/>
+    <bar/>
+    <meta>
+        <deviceID>ServerErrorTests</deviceID>
+        <timeStart>2011-10-01T15:25:18.404-04</timeStart>
+        <timeEnd>2011-10-01T15:26:29.551-04</timeEnd>
+        <username>admin</username>
+        <userID>testy.mctestface</userID>
+        <instanceID>{self.instance_id}</instanceID>
+    </meta>
+</data>
+"""
+        submit_form_locally(xform, DOMAIN)
+
+    def reget_repeater_stub(self):
+        return RepeaterStub.objects.get(pk=self.repeater_stub.pk)
+
+    def test_success_on_200(self):
+        resp = ResponseMock(status_code=200, reason='OK')
+        with patch('corehq.motech.repeaters.models.simple_post') as simple_post:
+            simple_post.return_value = resp
+
+            payload = self.repeater.get_payload(self.repeat_record)
+            send_request(self.repeater, self.repeat_record, payload)
+
+            self.assertEqual(self.repeat_record.attempts.last().state,
+                             RECORD_SUCCESS_STATE)
+            repeater_stub = self.reget_repeater_stub()
+            self.assertIsNone(repeater_stub.next_attempt_at)
+
+    def test_no_backoff_on_409(self):
+        resp = ResponseMock(status_code=409, reason='Conflict')
+        with patch('corehq.motech.repeaters.models.simple_post') as simple_post:
+            simple_post.return_value = resp
+
+            payload = self.repeater.get_payload(self.repeat_record)
+            send_request(self.repeater, self.repeat_record, payload)
+
+            self.assertEqual(self.repeat_record.attempts.last().state,
+                             RECORD_FAILURE_STATE)
+            repeater_stub = self.reget_repeater_stub()
+            # Trying tomorrow is just as likely to work as in 5 minutes
+            self.assertIsNone(repeater_stub.next_attempt_at)
+
+    def test_no_backoff_on_500(self):
+        resp = ResponseMock(status_code=500, reason='Internal Server Error')
+        with patch('corehq.motech.repeaters.models.simple_post') as simple_post:
+            simple_post.return_value = resp
+
+            payload = self.repeater.get_payload(self.repeat_record)
+            send_request(self.repeater, self.repeat_record, payload)
+
+            self.assertEqual(self.repeat_record.attempts.last().state,
+                             RECORD_FAILURE_STATE)
+            repeater_stub = self.reget_repeater_stub()
+            self.assertIsNone(repeater_stub.next_attempt_at)
+
+    def test_backoff_on_503(self):
+        resp = ResponseMock(status_code=503, reason='Service Unavailable')
+        with patch('corehq.motech.repeaters.models.simple_post') as simple_post:
+            simple_post.return_value = resp
+
+            payload = self.repeater.get_payload(self.repeat_record)
+            send_request(self.repeater, self.repeat_record, payload)
+
+            self.assertEqual(self.repeat_record.attempts.last().state,
+                             RECORD_FAILURE_STATE)
+            repeater_stub = self.reget_repeater_stub()
+            self.assertIsNotNone(repeater_stub.next_attempt_at)
+
+    def test_backoff_on_connection_error(self):
+        with patch('corehq.motech.repeaters.models.simple_post') as simple_post:
+            simple_post.side_effect = ConnectionError()
+
+            payload = self.repeater.get_payload(self.repeat_record)
+            send_request(self.repeater, self.repeat_record, payload)
+
+            self.assertEqual(self.repeat_record.attempts.last().state,
+                             RECORD_FAILURE_STATE)
+            repeater_stub = self.reget_repeater_stub()
+            self.assertIsNotNone(repeater_stub.next_attempt_at)

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -1183,6 +1183,12 @@ class FormatResponseTests(SimpleTestCase):
 
 class TestGetRetryInterval(SimpleTestCase):
 
+    def test_no_last_checked(self):
+        last_checked = None
+        now = fromisoformat("2020-01-01 00:05:00")
+        interval = _get_retry_interval(last_checked, now)
+        self.assertEqual(interval, MIN_RETRY_WAIT)
+
     def test_min_interval(self):
         last_checked = fromisoformat("2020-01-01 00:00:00")
         now = fromisoformat("2020-01-01 00:05:00")

--- a/corehq/motech/repeaters/tests/test_tasks.py
+++ b/corehq/motech/repeaters/tests/test_tasks.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
@@ -48,13 +49,14 @@ class TestProcessRepeaterStub(TestCase):
             domain=DOMAIN,
             repeater_id=self.repeater.get_id,
         )
-        now = timezone.now()
+        just_now = timezone.now() - timedelta(seconds=10)
         for payload_id in PAYLOAD_IDS:
             self.repeater_stub.repeat_records.create(
                 domain=self.repeater_stub.domain,
                 payload_id=payload_id,
-                registered_at=now,
+                registered_at=just_now,
             )
+            just_now += timedelta(seconds=1)
 
     def tearDown(self):
         self.repeater_stub.delete()

--- a/corehq/motech/repeaters/tests/test_tasks.py
+++ b/corehq/motech/repeaters/tests/test_tasks.py
@@ -1,0 +1,112 @@
+from contextlib import contextmanager
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.receiverwrapper.util import submit_form_locally
+from corehq.form_processor.backends.sql.dbaccessors import FormAccessorSQL
+from corehq.form_processor.utils.xform import (
+    FormSubmissionBuilder,
+    TestFormMetadata,
+)
+from corehq.motech.models import ConnectionSettings
+
+from ..const import (
+    RECORD_CANCELLED_STATE,
+    RECORD_FAILURE_STATE,
+    RECORD_PENDING_STATE,
+)
+from ..models import FormRepeater, RepeaterStub
+from ..tasks import process_repeater_stub
+
+DOMAIN = 'gaidhlig'
+PAYLOAD_IDS = ['aon', 'dha', 'trì', 'ceithir', 'coig', 'sia', 'seachd', 'ochd',
+               'naoi', 'deich']
+
+
+class TestProcessRepeaterStub(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = create_domain(DOMAIN)
+        cls.connection_settings = ConnectionSettings.objects.create(
+            domain=DOMAIN,
+            name='Test API',
+            url="http://localhost/api/"
+        )
+        cls.repeater = FormRepeater(
+            domain=DOMAIN,
+            connection_settings_id=cls.connection_settings.id,
+        )
+        cls.repeater.save()
+
+    def setUp(self):
+        self.repeater_stub = RepeaterStub.objects.create(
+            domain=DOMAIN,
+            repeater_id=self.repeater.get_id,
+        )
+        now = timezone.now()
+        for payload_id in PAYLOAD_IDS:
+            self.repeater_stub.repeat_records.create(
+                domain=self.repeater_stub.domain,
+                payload_id=payload_id,
+                registered_at=now,
+            )
+
+    def tearDown(self):
+        self.repeater_stub.delete()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.repeater.delete()
+        cls.connection_settings.delete()
+        cls.domain.delete()
+        super().tearDownClass()
+
+    def test_get_payload_fails(self):
+        # If the payload of a repeat record is missing, it should be
+        # cancelled, and process_repeater() should continue to the next
+        # payload
+        with patch('corehq.motech.repeaters.models.log_repeater_error_in_datadog'), \
+                patch('corehq.motech.repeaters.tasks.metrics_counter'):
+            process_repeater_stub(self.repeater_stub)
+
+        # All records were tried and cancelled
+        records = list(self.repeater_stub.repeat_records.all())
+        self.assertEqual(len(records), 10)
+        self.assertTrue(all(r.state == RECORD_CANCELLED_STATE for r in records))
+        # All records have a cancelled Attempt
+        self.assertTrue(all(len(r.attempts) == 1 for r in records))
+        self.assertTrue(all(r.attempts[0].state == RECORD_CANCELLED_STATE
+                            for r in records))
+
+    def test_send_request_fails(self):
+        # If send_request() should be retried with the same repeat
+        # record, process_repeater() should exit
+        with patch('corehq.motech.repeaters.models.simple_post') as post_mock, \
+                patch('corehq.motech.repeaters.tasks.metrics_counter'), \
+                form_context(PAYLOAD_IDS):
+            post_mock.return_value = Mock(status_code=400, reason='Bad request')
+            process_repeater_stub(self.repeater_stub)
+
+        # Only the first record was attempted, the rest are still pending
+        states = [r.state for r in self.repeater_stub.repeat_records.all()]
+        self.assertListEqual(states, ([RECORD_FAILURE_STATE]
+                                      + [RECORD_PENDING_STATE] * 9))
+
+
+@contextmanager
+def form_context(form_ids):
+    for form_id in form_ids:
+        builder = FormSubmissionBuilder(
+            form_id=form_id,
+            metadata=TestFormMetadata(domain=DOMAIN),
+        )
+        submit_form_locally(builder.as_xml_string(), DOMAIN)
+    try:
+        yield
+    finally:
+        FormAccessorSQL.hard_delete_forms(DOMAIN, form_ids)


### PR DESCRIPTION
## Summary

This PR is the next in a series to implement [[CEP] Migrate RepeatRecord to SQL](https://github.com/dimagi/commcare-hq/issues/28314).

Previous PR: [SQLRepeatRecord](https://github.com/dimagi/commcare-hq/pull/28952)

no-obligation fyi: @orangejenny @millerdev @snopoke 

I'm opening as a draft PR because there are two things I am looking for feedback on:

#### 1. When to back off

Currently, if 10 forms are submitted and forwarded to an endpoint that is offline, that endpoint is attempted 10 times, then about an hour later it is attempted 10 times again, three hours later 10 times again, each time the interval is multiplied by 3, for up to five days, when eventually all 10 repeat records will be cancelled.

This PR changes that behaviour. Exponential backoff is tracked on a `RepeaterStub` model instead of on each independent repeat record: If 10 forms are submitted, the first form will be forwarded. If the endpoint is offline, only that form will be retried an hour later, then three hours later, etc. If it succeeds within five days, the rest of the 9 forms will be sent. If it continues to fail, it will be cancelled, and HQ will try to send just the second form.

The idea is to dramatically reduce the rate of send attempts that are likely to fail. It also sets up a better foundation for automatically pausing repeaters that appear to be permanently offline.

My biggest concern is to make sure that we **never back off** when the server is fine, and the error is caused by the payload. The [`check_repeaters()`](https://github.com/dimagi/commcare-hq/blob/6977bfb20bb5360b142ea8aedf4f0eeb41024c2c/corehq/motech/repeaters/tasks.py#L69) task runs every five minutes. So the code differentiates between [errors to back off on](https://github.com/dimagi/commcare-hq/blob/13b7ae726f4f58a2b638775e1292b0d493ffc6a2/corehq/motech/repeaters/models.py#L1198), and errors to retry on the next `check_repeaters()` call. My intention is that bad payloads can be cancelled fast (ideally in about half an hour; six attempts, each about five minutes apart), so that bad payloads can't hold up good payloads for five days!

I am open to the idea of not retrying some kinds of errors, but in my experience some third-party servers are under-resourced, and retrying a few minutes later can turn a "500" into a "201". Reducing the number of retries for some kinds of errors might be a happy compromise. I'm also open to taking this conversation somewhere else, and pulling in some USH AEs.


#### 2. How to improve slow tests

I am very interested in alternatives to the test suite in the "Slooow tests to test backoff" commit. It takes 11 seconds to run five tests with `REUSE_DB=True`. The tests follow the approach used by [these Repeater tests](https://github.com/dimagi/commcare-hq/blob/7b01a30873c9a0609a21700880527fcffe4fe4e6/corehq/motech/repeaters/tests/test_repeater.py#L475). The lowest effort would probably be to submit the form in `setUpClass()` and just requeue it in `setUp()`. But I'm curious to know if there is a better, completely different approach the covers the behaviour that these tests are meant to verify.

Do you know faster, better ways to test the same functionality? 


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

The new code is covered by automated tests. (Please point out important gaps in testing in PR feedback.)


### Safety story

Other than through unit tests, none of this code is reachable yet.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
