### PR TITLE
Fixed bug in case detail nodeset sorting

### DIFF
--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -104,7 +104,7 @@ class FormattedDetailColumn(object):
         self.parent_tab_nodeset = parent_tab_nodeset
 
     def has_sort_node_for_nodeset_column(self):
-        return False
+        return self.parent_tab_nodeset and self.detail.sort_nodeset_columns_for_detail()
 
     @property
     def locale_id(self):
@@ -469,9 +469,6 @@ class LateFlag(HideShortHeaderColumn):
 
 @register_format_type('invisible')
 class Invisible(HideShortColumn):
-
-    def has_sort_node_for_nodeset_column(self):
-        return self.parent_tab_nodeset and self.detail.sort_nodeset_columns_for_detail()
 
     @property
     def header(self):


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-596

Nodeset sorting works like this:
![Screen Shot 2021-01-12 at 3 45 11 PM](https://user-images.githubusercontent.com/1486591/104370675-3c43f100-54ed-11eb-9caf-fbb5bf3827bf.png)

...so `has_sort_node_for_nodeset_column` was written to only return true for invisible (search only) columns. But [sort_columns](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/util.py#L519-L523) is keyed by field, so when the same field is in the case detail config twice, the sort element can end up getting assigned to the other column.

This PR updates `has_sort_node_for_nodeset_column` to return true for any column type.

## Feature Flag
Associate a nodeset with a case detail tab

## Product Description
Fixes nodeset sorting in cases where the same field is used both as a search only property and as a visible property.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

Nodesets are tested in `test_suite.py`

### QA Plan

Not QAing. Minor change with low risk.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
