### PR TITLE
use default travis python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-python: 2.7
 sudo: required
 group: edge
 branches:


### PR DESCRIPTION
## Summary
Remove python version pinning from Travis config. The default version at present is 3.6. Note that doesn't have the version used to run tests since that is done inside the Docker container.


## Safety Assurance
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I am certain that this PR will not introduce a regression for the reasons below

### Rollback instructions
- [X] This PR can be reverted after deploy with no further considerations 
