### PR TITLE
Couch to SQL forms & cases: ignore bad ledgers

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -276,6 +276,7 @@ class CouchSqlDomainMigrator:
             try:
                 sql_form = get_sql_form(couch_form.form_id)
             except XFormNotFound:
+                sql_form = None
                 proc = "" if form_is_processed else " unprocessed"
                 log.error("Error migrating%s form %s",
                     proc, couch_form.form_id, exc_info=exc_info)
@@ -287,7 +288,7 @@ class CouchSqlDomainMigrator:
             try:
                 sql_form = get_sql_form(couch_form.form_id)
             except XFormNotFound:
-                pass
+                sql_form = None
             if self.stop_on_error:
                 raise err from None
         finally:

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -295,9 +295,12 @@ class CouchSqlDomainMigrator:
                 self._save_diffs(couch_form, sql_form)
 
     def _save_diffs(self, couch_form, sql_form):
-        couch_json = couch_form.to_json()
-        sql_json = {} if sql_form is None else sql_form_to_json(sql_form)
-        self.statedb.save_form_diffs(couch_json, sql_json)
+        if sql_form is not None:
+            couch_json = couch_form.to_json()
+            sql_json = sql_form_to_json(sql_form)
+            self.statedb.save_form_diffs(couch_json, sql_json)
+        else:
+            self.statedb.add_missing_docs("XFormInstance", [couch_form.form_id])
 
     def _get_case_stock_result(self, sql_form, couch_form):
         case_stock_result = None

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -7,35 +7,10 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db.models import Q
 
-from corehq.apps.domain.models import Domain
 from couchforms.models import XFormInstance, doc_types
 from dimagi.utils.chunked import chunked
 
-from corehq.apps.couch_sql_migration.couchsqlmigration import (
-    CASE_DOC_TYPES,
-    CleanBreak,
-    do_couch_to_sql_migration,
-    setup_logging,
-)
-from corehq.apps.couch_sql_migration.missingdocs import (
-    find_missing_docs,
-    recheck_missing_docs,
-)
-from corehq.apps.couch_sql_migration.progress import (
-    MigrationStatus,
-    couch_sql_migration_in_progress,
-    get_couch_sql_migration_status,
-    set_couch_sql_migration_complete,
-    set_couch_sql_migration_not_started,
-    set_couch_sql_migration_started,
-)
-from corehq.apps.couch_sql_migration.rewind import rewind_iteration_state
-from corehq.apps.couch_sql_migration.statedb import (
-    Counts,
-    delete_state_db,
-    init_state_db,
-    open_state_db,
-)
+from corehq.apps.domain.models import Domain
 from corehq.form_processor.backends.sql.dbaccessors import (
     CaseAccessorSQL,
     FormAccessorSQL,
@@ -48,6 +23,29 @@ from corehq.sql_db.util import (
 )
 from corehq.util.log import with_progress_bar
 from corehq.util.markup import shell_green, shell_red
+
+from ...couchsqlmigration import (
+    CASE_DOC_TYPES,
+    CleanBreak,
+    do_couch_to_sql_migration,
+    setup_logging,
+)
+from ...missingdocs import find_missing_docs, recheck_missing_docs
+from ...progress import (
+    MigrationStatus,
+    couch_sql_migration_in_progress,
+    get_couch_sql_migration_status,
+    set_couch_sql_migration_complete,
+    set_couch_sql_migration_not_started,
+    set_couch_sql_migration_started,
+)
+from ...rewind import rewind_iteration_state
+from ...statedb import (
+    Counts,
+    delete_state_db,
+    init_state_db,
+    open_state_db,
+)
 
 log = logging.getLogger('main_couch_sql_datamigration')
 

--- a/corehq/apps/couch_sql_migration/patches.py
+++ b/corehq/apps/couch_sql_migration/patches.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 
 from memoized import memoized
 
-import casexml.apps.case.xform as module
+import casexml.apps.case.xform as case_xform
 from casexml.apps.case.exceptions import IllegalCaseId
 from casexml.apps.case.xform import has_case_id
 from couchforms.models import XFormInstance
@@ -72,11 +72,8 @@ def patch_case_date_modified_fixer():
                     case_block["@date_modified"] = f"20{old[6:8]}-{old[:5]} {old[9:]}"
         return has_case
 
-    module.has_case_id = has_case_id_and_valid_date_modified
-    try:
+    with patch(case_xform, "has_case_id", has_case_id_and_valid_date_modified):
         yield
-    finally:
-        module.has_case_id = has_case_id
 
 
 @contextmanager
@@ -89,12 +86,8 @@ def patch_DateTimeProperty_wrap():
         return real_wrap(self, value)
 
     weird_utc_date = re.compile(r"^(\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d)\+00:00Z$")
-    real_wrap = DateTimeProperty._wrap
-    DateTimeProperty._wrap = wrap
-    try:
+    with patch(DateTimeProperty, "_wrap", wrap) as real_wrap:
         yield
-    finally:
-        DateTimeProperty._wrap = real_wrap
 
 
 @contextmanager
@@ -113,15 +106,13 @@ def patch_XFormInstance_get_xml():
     if hasattr(XFormInstance, "_unsafe_get_xml"):
         # noop when already patched
         yield
-        return
-
-    XFormInstance._unsafe_get_xml = XFormInstance.get_xml
-    XFormInstance.get_xml = get_xml
-    try:
-        yield
-    finally:
-        XFormInstance.get_xml = XFormInstance._unsafe_get_xml
-        del XFormInstance._unsafe_get_xml
+    else:
+        with patch(XFormInstance, "get_xml", get_xml) as unsafe_get_xml:
+            XFormInstance._unsafe_get_xml = unsafe_get_xml
+            try:
+                yield
+            finally:
+                del XFormInstance._unsafe_get_xml
 
 
 @contextmanager
@@ -130,12 +121,8 @@ def patch_kafka():
         doc_id = change_meta.document_id
         log.debug("kafka not publishing doc_id=%s to %s", doc_id, topic)
 
-    send_change = ChangeProducer.send_change
-    ChangeProducer.send_change = drop_change
-    try:
+    with patch(ChangeProducer, "send_change", drop_change):
         yield
-    finally:
-        ChangeProducer.send_change = send_change
 
 
 @contextmanager
@@ -146,10 +133,16 @@ def patch_illegal_ledger_case_id():
         except IllegalCaseId:
             pass  # ignore transfer with missing src and dest case_id
 
-    mod = ledger_form
-    real_get_helpers = mod._get_transaction_helpers_from_transfer_instruction
-    mod._get_transaction_helpers_from_transfer_instruction = get_helpers
-    try:
+    method = "_get_transaction_helpers_from_transfer_instruction"
+    with patch(ledger_form, method, get_helpers) as real_get_helpers:
         yield
+
+
+@contextmanager
+def patch(obj, attr, new_value):
+    old_value = getattr(obj, attr)
+    setattr(obj, attr, new_value)
+    try:
+        yield old_value
     finally:
-        mod._get_transaction_helpers_from_transfer_instruction = real_get_helpers
+        setattr(obj, attr, old_value)

--- a/corehq/apps/couch_sql_migration/patches.py
+++ b/corehq/apps/couch_sql_migration/patches.py
@@ -28,6 +28,7 @@ def migration_patches():
             patch_DateTimeProperty_wrap(), \
             patch_case_date_modified_fixer(), \
             patch_illegal_ledger_case_id(), \
+            patch_ledger_balance_without_product(), \
             patch_kafka():
         yield
 
@@ -134,6 +135,18 @@ def patch_illegal_ledger_case_id():
             pass  # ignore transfer with missing src and dest case_id
 
     method = "_get_transaction_helpers_from_transfer_instruction"
+    with patch(ledger_form, method, get_helpers) as real_get_helpers:
+        yield
+
+
+@contextmanager
+def patch_ledger_balance_without_product():
+    def get_helpers(ledger_instruction):
+        if not ledger_instruction.entry_id:
+            return
+        yield from real_get_helpers(ledger_instruction)
+
+    method = "_get_transaction_helpers_from_balance_instruction"
     with patch(ledger_form, method, get_helpers) as real_get_helpers:
         yield
 

--- a/corehq/apps/couch_sql_migration/statedb.py
+++ b/corehq/apps/couch_sql_migration/statedb.py
@@ -46,7 +46,7 @@ def open_state_db(domain, state_dir, *, readonly=True):
     """Open state db in read-only mode"""
     db_filepath = _get_state_db_filepath(domain, state_dir)
     if not os.path.exists(db_filepath):
-        raise Error(f"not found: {db_filepath}")
+        raise NotFoundError(db_filepath)
     return StateDB.open(domain, db_filepath, readonly=readonly)
 
 
@@ -635,7 +635,7 @@ class StateDB(DiffDB):
             session.execute("VACUUM")
 
 
-class Error(Exception):
+class NotFoundError(Exception):
     pass
 
 

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -475,6 +475,18 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.do_migration()
         self.assertEqual(self._get_form_ids('XFormError'), {'im-a-bad-form'})
 
+    def test_form_migration_integrity_error_resulting_in_missing_form(self):
+        self.submit_form(SIMPLE_FORM_XML)
+        with mock.patch.object(mod, "save_migrated_models", side_effect=mod.IntegrityError):
+            self.do_migration(diffs=IGNORE)
+        self.compare_diffs(missing={"XFormInstance": 1})
+
+    def test_form_migration_exception_resulting_in_missing_form(self):
+        self.submit_form(SIMPLE_FORM_XML)
+        with mock.patch.object(mod, "save_migrated_models", side_effect=Exception):
+            self.do_migration(diffs=IGNORE)
+        self.compare_diffs(missing={"XFormInstance": 1})
+
     def test_duplicate_form_migration(self):
         with open('corehq/ex-submodules/couchforms/tests/data/posts/duplicate.xml', encoding='utf-8') as f:
             duplicate_form_xml = f.read()

--- a/corehq/apps/couch_sql_migration/tests/test_statedb.py
+++ b/corehq/apps/couch_sql_migration/tests/test_statedb.py
@@ -66,7 +66,7 @@ def test_db_unique_id():
 @with_setup(teardown=delete_db)
 def test_open_state_db():
     assert not os.path.exists(_get_state_db_filepath("test", state_dir))
-    with assert_raises(mod.Error):
+    with assert_raises(mod.NotFoundError):
         open_state_db("test", state_dir)
     with init_db(memory=False) as db:
         uid = db.unique_id


### PR DESCRIPTION
Few things in here:
- Show nicer output when running stats on domain that has not yet been migrated.
- Record missing forms as missing rather than as a diff.
- Show missing forms when showing diffs.
- Do not try to process ledgers that would otherwise cause processing errors.

:blowfish: Review by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below
- [x] This PR can be reverted after deploy with no further considerations 
