### PR TITLE
Add toggles to block domains and email domains from outgoing emails

### DIFF
--- a/corehq/ex-submodules/dimagi/utils/django/email.py
+++ b/corehq/ex-submodules/dimagi/utils/django/email.py
@@ -62,7 +62,7 @@ def get_valid_recipients(recipients, domain=None):
     if domain and BLOCKED_DOMAIN_EMAIL_SENDERS.enabled(domain):
         # don't sent email if domain is blocked
         metrics_gauge('commcare.bounced_email', len(recipients), tags={
-            'domain': domain,
+            'email_domain': domain,
         }, multiprocess_mode=MPM_LIVESUM)
         return []
 

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -143,7 +143,9 @@ class EmailContent(Content):
             return
 
         metrics_counter('commcare.messaging.email.sent', tags={'domain': logged_event.domain})
-        send_mail_async.delay(subject, message, settings.DEFAULT_FROM_EMAIL, [email_address], logged_subevent.id)
+        send_mail_async.delay(subject, message, settings.DEFAULT_FROM_EMAIL,
+                              [email_address], logged_subevent.id,
+                              domain=logged_event.domain)
 
         email = Email(
             domain=logged_event.domain,

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1957,3 +1957,19 @@ DEFAULT_EXPORT_SETTINGS = StaticToggle(
     Allows an enterprise admin to set default export settings for all domains under the enterprise account.
     """
 )
+
+BLOCKED_EMAIL_DOMAIN_RECIPIENTS = StaticToggle(
+    'blocked_email_domain_recipients',
+    'Block any outgoing email addresses that have an email domain which '
+    'match a domain in this list.',
+    TAG_INTERNAL,
+    namespaces=[NAMESPACE_EMAIL_DOMAIN],
+)
+
+BLOCKED_DOMAIN_EMAIL_SENDERS = StaticToggle(
+    'blocked_domain_email_senders',
+    'Domains in this list are blocked from sending emails through our '
+    'messaging feature',
+    TAG_INTERNAL,
+    namespaces=[NAMESPACE_DOMAIN],
+)

--- a/corehq/util/models.py
+++ b/corehq/util/models.py
@@ -122,10 +122,6 @@ class BouncedEmail(models.Model):
             )
         )
 
-        BouncedEmail.objects.filter(email__in=set()).values_list(
-            'email', flat=True
-        )
-
         transient_emails = set(
             TransientBounceEmail.get_active_query().filter(
                 email__in=list_of_emails,


### PR DESCRIPTION
## Summary
Yesterday we had an incident (still somewhat ongoing) where one project space uploaded a lot of obviously (and purposely for their test purposes) fake emails which triggered thousands of LIVE conditional alerts. This triggered thousands of emails which expectedly bounced on SES right after sending. As a result, our global bounce rate skyrocketed to nearly 25%, and we had no way to pull the plug on either the domain firing the conditional alert triggered emails or prevent a known and repeatedly fake email (in this case xxxx@email3.com with different values for xxxx) from being sent out.

This PR introduces a few ways of preventing this from happening in the future, or at least allowing us to respond before things get out of hand:
1) An email-domain namespaced toggle which ensures that any email ending in that email-domain is never sent.
2) A domain namespaced toggle which specifies the list of domains (project spaces) not allowed send out conditional alert email messages. This will not affect other system-related emails for that domain (scheduled reports, invites, etc)...ONLY conditional alerts.
3) A rudimentary email format checker that makes sure that the portion after the `@` includes a top-level domain (e.g. `@gmail.com` instead of `@gmail`) and that it also contains an `@` sign. I didn't want to go deeper into formatting validation at this level, as I firmly believe email format validation should happen as close to the original input as possible so that immediate feedback can be given to the user that the address is invalid. Kat suggested a service from Twilio called SendGrid which we should definitely consider as a more robust fix for this.

## Feature Flag
Two feature flags: `BLOCKED_EMAIL_DOMAIN_RECIPIENTS` and `BLOCKED_DOMAIN_EMAIL_SENDERS`

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
I added tests for every change made. 100% confident in its robustness.

### QA Plan
No QA needed. Everything fully covered by automated testing.

### Safety story
Everything fully covered by automated testing.

### Rollback instructions
Easy to rollback if needed
- [x] This PR can be reverted after deploy with no further considerations 
