### PR TITLE
Save mobile worker user_ids to all checkin cases

### DIFF
--- a/custom/covid/management/commands/add_hq_user_id_to_case.py
+++ b/custom/covid/management/commands/add_hq_user_id_to_case.py
@@ -1,0 +1,71 @@
+from xml.etree import cElementTree as ElementTree
+
+from django.core.management.base import BaseCommand
+
+from casexml.apps.case.mock import CaseBlock
+from dimagi.utils.chunked import chunked
+
+from corehq.apps.linked_domain.dbaccessors import get_linked_domains
+from corehq.apps.hqcase.utils import submit_case_blocks
+from corehq.apps.users.util import SYSTEM_USER_ID, normalize_username
+from corehq.apps.users.util import username_to_user_id
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+
+
+BATCH_SIZE = 100
+DEVICE_ID = __name__ + ".add_hq_user_id_to_case"
+CASE_TYPE = 'checkin'
+
+
+def case_block(case, user_id):
+    return ElementTree.tostring(CaseBlock.deprecated_init(
+        create=False,
+        case_id=case.case_id,
+        update={'hq_user_id': user_id},
+    ).as_xml()).decode('utf-8')
+
+
+def update_cases(domain, username):
+    accessor = CaseAccessors(domain)
+    case_ids = accessor.get_case_ids_in_domain(CASE_TYPE)
+    print(f"Found {len(case_ids)} {CASE_TYPE} cases in {domain}")
+
+    user_id = username_to_user_id(username)
+    if not user_id:
+        user_id = SYSTEM_USER_ID
+
+    case_blocks = []
+    skip_count = 0
+    for case in accessor.iter_cases(case_ids):
+        username_of_associated_mobile_workers = case.get_case_property('username')
+        user_id_of_mobile_worker = username_to_user_id(normalize_username(username_of_associated_mobile_workers,
+                                                                          domain))
+        if user_id_of_mobile_worker:
+            case_blocks.append(case_block(case, user_id_of_mobile_worker))
+        else:
+            skip_count += 1
+    print(f"{len(case_blocks)} to update in {domain}, {skip_count} cases have skipped due to unknown username.")
+
+    total = 0
+    for chunk in chunked(case_blocks, BATCH_SIZE):
+        submit_case_blocks(chunk, domain, device_id=DEVICE_ID, user_id=user_id)
+        total += len(chunk)
+        print("Updated {} cases on domain {}".format(total, domain))
+
+
+class Command(BaseCommand):
+    help = "Updates checkin cases to hold the userid of the mobile worker that the checkin case is associated with"
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+        parser.add_argument('username')
+        parser.add_argument('--and-linked', action='store_true', default=False)
+
+    def handle(self, domain, username, **options):
+        domains = {domain}
+        if options["and_linked"]:
+            domains = domains | {link.linked_domain for link in get_linked_domains(domain)}
+
+        for domain in domains:
+            print(f"Processing {domain}")
+            update_cases(domain, username)

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -1,0 +1,65 @@
+from django.core.management import call_command
+from django.test import TestCase
+
+from casexml.apps.case.mock import CaseFactory
+
+from corehq.apps.app_manager.util import enable_usercase
+from corehq.apps.callcenter.sync_user_case import sync_user_cases
+from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
+from corehq.apps.users.models import CommCareUser
+from corehq.apps.users.util import normalize_username
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
+
+
+class CaseCommandsTest(TestCase):
+    domain = 'cases-domain'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        delete_all_users()
+
+        cls.domain_obj = create_domain(cls.domain)
+        enable_usercase(cls.domain)
+
+        cls.factory = CaseFactory(domain=cls.domain)
+        cls.case_accessor = CaseAccessors(cls.domain)
+
+        username = normalize_username("mobile_worker_1", cls.domain)
+        cls.mobile_worker = CommCareUser.create(cls.domain, username, "123", None, None)
+        cls.user_id = cls.mobile_worker.user_id
+        sync_user_cases(cls.mobile_worker)
+        cls.mobile_worker.save()
+
+        cls.checkin_case1 = cls.factory.create_case(
+            case_type="checkin",
+            owner_id=cls.mobile_worker.get_id,
+            update={"username": cls.mobile_worker.raw_username,
+                    "hq_user_id": None}
+        )
+        cls.lab_result_case1 = cls.factory.create_case(
+            case_type="lab_result",
+            owner_id=cls.mobile_worker.get_id,
+            update={"username": cls.mobile_worker.raw_username,
+                    "hq_user_id": None},
+        )
+
+    def tearDown(self):
+        FormProcessorTestUtils.delete_all_cases(self.domain)
+        delete_all_users()
+        super().tearDown()
+
+    def test_add_hq_user_id_to_case(self):
+        checkin_case_first = self.case_accessor.get_case(self.checkin_case1.case_id)
+        self.assertEqual('', checkin_case_first.get_case_property('hq_user_id'))
+        self.assertEqual(checkin_case_first.username, 'mobile_worker_1')
+
+        call_command('add_hq_user_id_to_case', self.domain, None)
+
+        checkin_case_first = self.case_accessor.get_case(self.checkin_case1.case_id)
+        lab_result_case_first = self.case_accessor.get_case(self.lab_result_case1.case_id)
+
+        self.assertEqual(checkin_case_first.get_case_property('hq_user_id'), self.user_id)
+        self.assertEqual(lab_result_case_first.hq_user_id, '')


### PR DESCRIPTION
## Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/USH-587) and from the spec here are the requirements for the script: 

- Lookup the username of the mobile worker associated with the case (saved in case property: username)
- Find the id of the mobile worker associated with that username
- Save the id to the property hq_user_id on the checkin case

## Product Description
Parameters are domain, username, and --is-linked. Batch size is set as a constant ([same as here](https://github.com/dimagi/commcare-hq/blob/master/custom/covid/management/commands/update_case_index_relationship.py)). I'm curious if batch size should also be a parameter based on the spec (can also follow up with someone on product). 

## Safety Assurance

- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
Tests were added to ensure that the `hq_user_id` was being updated in that domain for `case_type` 'checkin'. I plan on adding to these tests for the next scripts to be written as well.

### QA Plan
I am not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
