### PR TITLE
Mjr/missing attachments

### DIFF
--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -62,8 +62,6 @@ PROFILE_PROBABILITY = float(os.getenv('COMMCARE_PROFILE_SUBMISSION_PROBABILITY',
 PROFILE_LIMIT = os.getenv('COMMCARE_PROFILE_SUBMISSION_LIMIT')
 PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else 1
 
-logger = logging.getLogger(__name__)
-
 
 @profile_dump('commcare_receiverwapper_process_form.prof', probability=PROFILE_PROBABILITY, limit=PROFILE_LIMIT)
 def _process_form(request, domain, app_id, user_id, authenticated,
@@ -141,7 +139,7 @@ def _process_form(request, domain, app_id, user_id, authenticated,
         try:
             result = submission_post.run()
         except XFormLockError as err:
-            logger.warning('Unable to get lock for form %s', err)
+            logging.warning('Unable to get lock for form %s', err)
             metrics_counter('commcare.xformlocked.count', tags={
                 'domain': domain, 'authenticated': authenticated
             })

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.views.decorators.csrf import csrf_exempt
@@ -60,6 +61,8 @@ from tastypie.http import HttpTooManyRequests
 PROFILE_PROBABILITY = float(os.getenv('COMMCARE_PROFILE_SUBMISSION_PROBABILITY', 0))
 PROFILE_LIMIT = os.getenv('COMMCARE_PROFILE_SUBMISSION_LIMIT')
 PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else 1
+
+logger = logging.getLogger(__file__)
 
 
 @profile_dump('commcare_receiverwapper_process_form.prof', probability=PROFILE_PROBABILITY, limit=PROFILE_LIMIT)
@@ -138,6 +141,7 @@ def _process_form(request, domain, app_id, user_id, authenticated,
         try:
             result = submission_post.run()
         except XFormLockError as err:
+            logger.warning('Unable to get lock for form %s' % err)
             metrics_counter('commcare.xformlocked.count', tags={
                 'domain': domain, 'authenticated': authenticated
             })

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -62,7 +62,7 @@ PROFILE_PROBABILITY = float(os.getenv('COMMCARE_PROFILE_SUBMISSION_PROBABILITY',
 PROFILE_LIMIT = os.getenv('COMMCARE_PROFILE_SUBMISSION_LIMIT')
 PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else 1
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 @profile_dump('commcare_receiverwapper_process_form.prof', probability=PROFILE_PROBABILITY, limit=PROFILE_LIMIT)
@@ -141,7 +141,7 @@ def _process_form(request, domain, app_id, user_id, authenticated,
         try:
             result = submission_post.run()
         except XFormLockError as err:
-            logger.warning('Unable to get lock for form %s' % err)
+            logger.warning('Unable to get lock for form %s', err)
             metrics_counter('commcare.xformlocked.count', tags={
                 'domain': domain, 'authenticated': authenticated
             })

--- a/corehq/ex-submodules/couchforms/models.py
+++ b/corehq/ex-submodules/couchforms/models.py
@@ -368,6 +368,7 @@ class XFormError(XFormInstance):
         instance.__class__ = XFormError
         instance.doc_type = 'XFormError'
         instance.problem = error_message
+        instance.orig_id = None
 
         if with_new_id:
             new_id = uuid.uuid4().hex

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -20,7 +20,9 @@ from ..system_action import system_action
 from ..utils import should_use_sql_backend
 
 
-class CaseUpdateMetadata(namedtuple('CaseUpdateMetadata', ['case', 'is_creation', 'previous_owner_id', 'actions'])):
+
+class CaseUpdateMetadata(namedtuple('CaseUpdateMetadata',
+        ['case', 'is_creation', 'previous_owner_id', 'actions'])):
     def merge(self, other):
         return CaseUpdateMetadata(
             case=self.case,

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -19,8 +19,6 @@ from memoized import memoized
 from ..system_action import system_action
 from ..utils import should_use_sql_backend
 
-logger = logging.getLogger(__name__)
-
 
 class CaseUpdateMetadata(namedtuple('CaseUpdateMetadata',
         ['case', 'is_creation', 'previous_owner_id', 'actions'])):
@@ -110,7 +108,7 @@ class FormProcessorInterface(object):
             if not lock.acquire(blocking=False):
                 raise XFormLockError(xform_id)
         except RedisError:
-            logger.warning('Redis error when locking %s, continuing with no lock', xform_id)
+            logging.warning('Redis error when locking %s, continuing with no lock', xform_id)
             lock = None
         return lock
 

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -19,6 +19,7 @@ from memoized import memoized
 from ..system_action import system_action
 from ..utils import should_use_sql_backend
 
+logger = logging.getLogger(__name__)
 
 
 class CaseUpdateMetadata(namedtuple('CaseUpdateMetadata',
@@ -109,6 +110,7 @@ class FormProcessorInterface(object):
             if not lock.acquire(blocking=False):
                 raise XFormLockError(xform_id)
         except RedisError:
+            logger.warning('Redis error when locking %s, continuing with no lock', xform_id)
             lock = None
         return lock
 

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -98,6 +98,12 @@ class Attachment(IsImageMixin):
                 except IOError:
                     self.content_type = 'application/octet-stream'
 
+    def has_size(self):
+        if not hasattr(self.raw_content, 'size'):
+            return False
+
+        return self.raw_content.size is not None
+
     @property
     @memoized
     def content_length(self):

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -16,7 +16,7 @@ from couchforms import XMLSyntaxError
 from couchforms.exceptions import MissingXMLNSError
 from dimagi.utils.couch import release_lock
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 @contextmanager

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -16,8 +16,6 @@ from couchforms import XMLSyntaxError
 from couchforms.exceptions import MissingXMLNSError
 from dimagi.utils.couch import release_lock
 
-logger = logging.getLogger(__name__)
-
 
 @contextmanager
 def locked_form(xform, interface):
@@ -150,14 +148,14 @@ def _handle_id_conflict(xform, domain):
     interface = FormProcessorInterface(domain)
     if interface.is_duplicate(conflict_id, domain):
         # It looks like a duplicate/edit in the same domain so pursue that workflow.
-        logger.info('Handling duplicate doc id %s for domain %s', conflict_id, domain)
+        logging.info('Handling duplicate doc id %s for domain %s', conflict_id, domain)
         return _handle_duplicate(xform)
     else:
         # the same form was submitted to two domains, or a form was submitted with
         # an ID that belonged to a different doc type. these are likely developers
         # manually testing or broken API users. just resubmit with a generated ID.
         interface.assign_new_id(xform)
-        logger.info('Reassigned doc id from %s to %s', conflict_id, xform.form_id)
+        logging.info('Reassigned doc id from %s to %s', conflict_id, xform.form_id)
         return xform, None
 
 

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -352,7 +352,7 @@ class SubmissionPost(object):
             logger.info(attachment_msg, *attachment_props)
 
     def _log_form_completion(self, form, submission_type):
-        # Orig_id only exists on SQL forms
+        # Orig_id doesn't exist on all couch forms, only XFormError and XFormDeprecated
         if hasattr(form, 'orig_id') and form.orig_id is not None:
             logger.info('Finished %s processing for Form %s with original id %s',
                 submission_type, form.form_id, form.orig_id)

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -336,7 +336,7 @@ class SubmissionPost(object):
             return FormProcessingResult(response, instance, cases, ledgers, submission_type)
 
     def _log_form_details(self, form):
-        attachments = form.attachments if hasattr(form, 'attachments') else []
+        attachments = form.attachments if hasattr(form, 'attachments') else {}
 
         logger.info('Received Form %s with %d attachments',
             form.form_id, len(attachments))

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -47,6 +47,8 @@ from phonelog.utils import process_device_log, SumoLogicLog
 
 from celery.task.control import revoke as revoke_celery_task
 
+logger = logging.getLogger(__name__)
+
 CaseStockProcessingResult = namedtuple(
     'CaseStockProcessingResult',
     'case_result, case_models, stock_result'
@@ -224,6 +226,7 @@ class SubmissionPost(object):
         self._invalidate_caches(submitted_form)
 
         if submitted_form.is_submission_error_log:
+            logger.info('Processing form %s as a submission error', submitted_form.form_id)
             self.formdb.save_new_form(submitted_form)
 
             response = None
@@ -244,10 +247,15 @@ class SubmissionPost(object):
             return FormProcessingResult(response, None, [], [], 'submission_error_log')
 
         if submitted_form.xmlns == SYSTEM_ACTION_XMLNS:
+            logger.info('Processing form %s as a system action', submitted_form.form_id)
             return self.handle_system_action(submitted_form)
 
         if submitted_form.xmlns == DEVICE_LOG_XMLNS:
+            logger.info('Processing form %s as a device log', submitted_form.form_id)
             return self.process_device_log(submitted_form)
+
+        # Begin Normal Form Processing
+        self._log_form_details(submitted_form)
 
         cases = []
         ledgers = []
@@ -322,8 +330,28 @@ class SubmissionPost(object):
                 elif instance.is_error:
                     submission_type = 'error'
 
+            if instance.orig_id:
+                logger.info('Finished %s processing for Form %s with original id %s',
+                    submission_type, instance.form_id, instance.orig_id)
+            else:
+                logger.info('Finished %s processing for Form %s', submission_type, instance.form_id)
+
             response = self._get_open_rosa_response(instance, **openrosa_kwargs)
             return FormProcessingResult(response, instance, cases, ledgers, submission_type)
+
+    def _log_form_details(self, form):
+        logger.info('Received Form %s with %d attachments',
+            form.form_id, len(form.attachments_list))
+
+        for index, attachment in enumerate(form.attachments_list):
+            attachment_msg = 'Form %s, Attachment %s: %s'
+            attachment_props = [form.form_id, index, attachment.name]
+
+            if attachment.is_image:
+                attachment_msg = attachment_msg + ' (%d bytes)'
+                attachment_props.append(attachment.raw_content.size)
+
+            logger.info(attachment_msg, *attachment_props)
 
     def _conditionally_send_device_logs_to_sumologic(self, instance):
         url = getattr(settings, 'SUMOLOGIC_URL', None)

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -345,7 +345,7 @@ class SubmissionPost(object):
             attachment_msg = 'Form %s, Attachment %s: %s'
             attachment_props = [form.form_id, index, name]
 
-            if attachment.has_size():
+            if hasattr(attachment, 'has_size') and attachment.has_size():
                 attachment_msg = attachment_msg + ' (%d bytes)'
                 attachment_props.append(attachment.raw_content.size)
 

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -47,8 +47,6 @@ from phonelog.utils import process_device_log, SumoLogicLog
 
 from celery.task.control import revoke as revoke_celery_task
 
-logger = logging.getLogger(__name__)
-
 CaseStockProcessingResult = namedtuple(
     'CaseStockProcessingResult',
     'case_result, case_models, stock_result'
@@ -226,7 +224,7 @@ class SubmissionPost(object):
         self._invalidate_caches(submitted_form)
 
         if submitted_form.is_submission_error_log:
-            logger.info('Processing form %s as a submission error', submitted_form.form_id)
+            logging.info('Processing form %s as a submission error', submitted_form.form_id)
             self.formdb.save_new_form(submitted_form)
 
             response = None
@@ -247,11 +245,11 @@ class SubmissionPost(object):
             return FormProcessingResult(response, None, [], [], 'submission_error_log')
 
         if submitted_form.xmlns == SYSTEM_ACTION_XMLNS:
-            logger.info('Processing form %s as a system action', submitted_form.form_id)
+            logging.info('Processing form %s as a system action', submitted_form.form_id)
             return self.handle_system_action(submitted_form)
 
         if submitted_form.xmlns == DEVICE_LOG_XMLNS:
-            logger.info('Processing form %s as a device log', submitted_form.form_id)
+            logging.info('Processing form %s as a device log', submitted_form.form_id)
             return self.process_device_log(submitted_form)
 
         # Begin Normal Form Processing
@@ -338,7 +336,7 @@ class SubmissionPost(object):
     def _log_form_details(self, form):
         attachments = form.attachments if hasattr(form, 'attachments') else {}
 
-        logger.info('Received Form %s with %d attachments',
+        logging.info('Received Form %s with %d attachments',
             form.form_id, len(attachments))
 
         for index, (name, attachment) in enumerate(attachments.items()):
@@ -349,15 +347,15 @@ class SubmissionPost(object):
                 attachment_msg = attachment_msg + ' (%d bytes)'
                 attachment_props.append(attachment.raw_content.size)
 
-            logger.info(attachment_msg, *attachment_props)
+            logging.info(attachment_msg, *attachment_props)
 
     def _log_form_completion(self, form, submission_type):
         # Orig_id doesn't exist on all couch forms, only XFormError and XFormDeprecated
         if hasattr(form, 'orig_id') and form.orig_id is not None:
-            logger.info('Finished %s processing for Form %s with original id %s',
+            logging.info('Finished %s processing for Form %s with original id %s',
                 submission_type, form.form_id, form.orig_id)
         else:
-            logger.info('Finished %s processing for Form %s', submission_type, form.form_id)
+            logging.info('Finished %s processing for Form %s', submission_type, form.form_id)
 
     def _conditionally_send_device_logs_to_sumologic(self, instance):
         url = getattr(settings, 'SUMOLOGIC_URL', None)

--- a/corehq/form_processor/tests/test_models.py
+++ b/corehq/form_processor/tests/test_models.py
@@ -1,0 +1,25 @@
+from django.test import SimpleTestCase
+from unittest.mock import MagicMock
+
+from corehq.form_processor.models import Attachment
+
+
+class AttachmentHasSizeTests(SimpleTestCase):
+    def test_handles_no_size_property(self):
+        raw_content = MagicMock(spec_set=[''])
+        attachment = self.create_attachment_with_content(raw_content)
+        self.assertFalse(attachment.has_size())
+
+    def test_handles_None(self):
+        raw_content = MagicMock(size=None, spec_set=['size'])
+        attachment = self.create_attachment_with_content(raw_content)
+        self.assertFalse(attachment.has_size())
+
+    def test_handles_valid_size(self):
+        raw_content = MagicMock(size=1024, spec_set=['size'])
+        attachment = self.create_attachment_with_content(raw_content)
+        self.assertTrue(attachment.has_size())
+
+    @staticmethod
+    def create_attachment_with_content(content):
+        return Attachment(name='test_attachment', raw_content=content, content_type='text')


### PR DESCRIPTION
## Summary
This was created for [SAAS-11693](https://dimagi-dev.atlassian.net/browse/SAAS-11693). A customer has reported missing image attachments on a fairly regular basis. While this was previously due to issues on the mobile side, based on the Sumo Logic logs, it appears HQ should have received the most recent occurrences. Unfortunately, I've been unable to reproduce the issue or find code paths that make it seem likely, so this ticket is meant to provide further context to pin down where this could occur.

This uses the existing (albeit seldom used) logging framework we already have in place to log what form submission receives and the issues it runs into. A typical form submission results in the following output:

```
INFO 2021-01-14 21:39:16,240 submission_post 18579 123145418190848 Received Form 4afacc01-4c61-493a-85ac-35d60abb82b5 with 2 attachments
INFO 2021-01-14 21:39:16,241 submission_post 18579 123145418190848 Form 4afacc01-4c61-493a-85ac-35d60abb82b5, Attachment 0: 1610660349341.jpg (29447 bytes)
INFO 2021-01-14 21:39:16,241 submission_post 18579 123145418190848 Form 4afacc01-4c61-493a-85ac-35d60abb82b5, Attachment 1: form.xml
INFO 2021-01-14 21:39:19,106 submission_post 18579 123145418190848 Finished normal processing for Form 4afacc01-4c61-493a-85ac-35d60abb82b5
INFO 2021-01-14 21:39:25,294 submission_post 18579 123145418190848 Processing form fb7116ff-506d-491b-b0e1-d19ad2e04efd as a device log
```

~~One thing to highlight would be that the few uses of the Django logger we currently have all use the format `logging.<level>()`, whereas I instantiated loggers at the top of the affected files first, which follows Django's examples (and what I believe to be best practice) [here](https://docs.djangoproject.com/en/3.1/topics/logging/#using-logging). Both currently output to the same destination, but module-specific loggers give us more flexibility with what messages get outputting where.~~

There is an issue with our logging configuration that prevents us from following the recommended way to use loggers above. Within the LOGGING configuration of `settings.py`, we have `disable_existing_loggers: True`, which currently disables loggers as I initially tried to implement them. I believe this is caused by django.setup executing multiple times, but changing this behavior might result in a deluge of additional log messages, so this should be done as part of a future ticket.

I am a little concerned about the overhead of adding extra messages to the log file, but I think the above should not make a noticeable impact.

## Product Description

This only adds logging changes, so should be invisible to the user.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

This ticket only adds logging messages, which do not change the 'contract' of our code -- the code never promises to log specific messages, and once this issue is resolved, it may make sense to remove them.

### QA Plan
No QA should be needed

### Safety story
This was tested locally along form submission paths I was evaluating (normal, duplicate, and device log submissions). I also verified that logging worked properly when a lock was unavailable. The other paths are relying on visual inspection.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
