### PR TITLE
[javascript security vulnerability] ensure that at least yargs-parser ^18.1.3 is installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
         "lodash": "^4.17.19",
         "mem": "^4.0.0",
         "minimatch": "^3.0.2",
+        "yargs-parser": "^18.1.3",
         "underscore.string": "^3.3.5"
     },
     "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6451,28 +6451,13 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yargs-parser@^15.0.1:
-  version "15.0.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
-  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^18.1.2, yargs-parser@^18.1.3:
+yargs-parser@^15.0.1, yargs-parser@^18.1.2, yargs-parser@^18.1.3, yargs-parser@^7.0.0:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
-
-yargs-parser@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
-  integrity sha1-jQrELxbqVd69MyyvTEA4s+P139k=
-  dependencies:
-    camelcase "^4.1.0"
 
 yargs@^14.2.3:
   version "14.2.3"


### PR DESCRIPTION
## Summary
Based on a thorough dig through `yarn.lock` it seems that `yargs-parser` is our favorite dev packages' favorite sub-sub dependency. Tracing these sub-sub dependencies up to the top-level dependencies, I discovered that the `npm` and `modernizr` would be the only packages to experience an issue as a result of this. Since `yarn install` works, I assume `npm` isn't bothered, and both `npm` and `modernizr` being unaffected will be easily confirmed with a passing build

As long as the build passes, this is a safe requirements change to merge as it doesn't trickle up to any user-facing code.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
Since these are dev dependencies run on build of HQ, our automated test coverage will catch issues (if any) with this change.

### QA Plan
No QA needed

### Safety story
`yargs-parser` is a sub-sub dependency of only dev dependencies. As long as the build passes, we are ok.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
