### PR TITLE
Create CaseUpdateCommand

### DIFF
--- a/custom/covid/management/commands/add_hq_user_id_to_case.py
+++ b/custom/covid/management/commands/add_hq_user_id_to_case.py
@@ -5,67 +5,44 @@ from django.core.management.base import BaseCommand
 from casexml.apps.case.mock import CaseBlock
 from dimagi.utils.chunked import chunked
 
-from corehq.apps.linked_domain.dbaccessors import get_linked_domains
 from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.apps.users.util import SYSTEM_USER_ID, normalize_username
+from corehq.apps.users.util import normalize_username
 from corehq.apps.users.util import username_to_user_id
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-
+from custom.covid.management.commands.update_cases import CaseUpdateCommand
 
 BATCH_SIZE = 100
 DEVICE_ID = __name__ + ".add_hq_user_id_to_case"
 CASE_TYPE = 'checkin'
 
 
-def case_block(case, user_id):
-    return ElementTree.tostring(CaseBlock.deprecated_init(
-        create=False,
-        case_id=case.case_id,
-        update={'hq_user_id': user_id},
-    ).as_xml()).decode('utf-8')
-
-
-def update_cases(domain, username):
-    accessor = CaseAccessors(domain)
-    case_ids = accessor.get_case_ids_in_domain(CASE_TYPE)
-    print(f"Found {len(case_ids)} {CASE_TYPE} cases in {domain}")
-
-    user_id = username_to_user_id(username)
-    if not user_id:
-        user_id = SYSTEM_USER_ID
-
-    case_blocks = []
-    skip_count = 0
-    for case in accessor.iter_cases(case_ids):
-        username_of_associated_mobile_workers = case.get_case_property('username')
-        user_id_of_mobile_worker = username_to_user_id(normalize_username(username_of_associated_mobile_workers,
-                                                                          domain))
-        if user_id_of_mobile_worker:
-            case_blocks.append(case_block(case, user_id_of_mobile_worker))
-        else:
-            skip_count += 1
-    print(f"{len(case_blocks)} to update in {domain}, {skip_count} cases have skipped due to unknown username.")
-
-    total = 0
-    for chunk in chunked(case_blocks, BATCH_SIZE):
-        submit_case_blocks(chunk, domain, device_id=DEVICE_ID, user_id=user_id)
-        total += len(chunk)
-        print("Updated {} cases on domain {}".format(total, domain))
-
-
-class Command(BaseCommand):
+class Command(CaseUpdateCommand):
     help = "Updates checkin cases to hold the userid of the mobile worker that the checkin case is associated with"
 
-    def add_arguments(self, parser):
-        parser.add_argument('domain')
-        parser.add_argument('username')
-        parser.add_argument('--and-linked', action='store_true', default=False)
+    def case_block(self, case, user_id):
+        return ElementTree.tostring(CaseBlock.deprecated_init(
+            create=False,
+            case_id=case.case_id,
+            update={'hq_user_id': user_id},
+        ).as_xml()).decode('utf-8')
 
-    def handle(self, domain, username, **options):
-        domains = {domain}
-        if options["and_linked"]:
-            domains = domains | {link.linked_domain for link in get_linked_domains(domain)}
+    def update_cases(self, domain, user_id):
+        case_ids = self.find_case_ids_by_type(domain, CASE_TYPE)
+        accessor = CaseAccessors(domain)
+        case_blocks = []
+        skip_count = 0
+        for case in accessor.iter_cases(case_ids):
+            username_of_associated_mobile_workers = case.get_case_property('username')
+            user_id_of_mobile_worker = username_to_user_id(normalize_username(username_of_associated_mobile_workers,
+                                                                              domain))
+            if user_id_of_mobile_worker:
+                case_blocks.append(self.case_block(case, user_id_of_mobile_worker))
+            else:
+                skip_count += 1
+        print(f"{len(case_blocks)} to update in {domain}, {skip_count} cases have skipped due to unknown username.")
 
-        for domain in domains:
-            print(f"Processing {domain}")
-            update_cases(domain, username)
+        total = 0
+        for chunk in chunked(case_blocks, BATCH_SIZE):
+            submit_case_blocks(chunk, domain, device_id=DEVICE_ID, user_id=user_id)
+            total += len(chunk)
+            print("Updated {} cases on domain {}".format(total, domain))

--- a/custom/covid/management/commands/add_hq_user_id_to_case.py
+++ b/custom/covid/management/commands/add_hq_user_id_to_case.py
@@ -1,7 +1,5 @@
 from xml.etree import cElementTree as ElementTree
 
-from django.core.management.base import BaseCommand
-
 from casexml.apps.case.mock import CaseBlock
 from dimagi.utils.chunked import chunked
 
@@ -13,7 +11,6 @@ from custom.covid.management.commands.update_cases import CaseUpdateCommand
 
 BATCH_SIZE = 100
 DEVICE_ID = __name__ + ".add_hq_user_id_to_case"
-CASE_TYPE = 'checkin'
 
 
 class Command(CaseUpdateCommand):
@@ -26,8 +23,8 @@ class Command(CaseUpdateCommand):
             update={'hq_user_id': user_id},
         ).as_xml()).decode('utf-8')
 
-    def update_cases(self, domain, user_id):
-        case_ids = self.find_case_ids_by_type(domain, CASE_TYPE)
+    def update_cases(self, domain, case_type, user_id):
+        case_ids = self.find_case_ids_by_type(domain, case_type)
         accessor = CaseAccessors(domain)
         case_blocks = []
         skip_count = 0

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -1,14 +1,11 @@
 from xml.etree import cElementTree as ElementTree
 
-from django.core.management.base import BaseCommand
+from custom.covid.management.commands.update_cases import CaseUpdateCommand
 
 from casexml.apps.case.mock import CaseBlock
 from dimagi.utils.chunked import chunked
 
-from corehq.apps.linked_domain.dbaccessors import get_linked_domains
 from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.apps.users.util import SYSTEM_USER_ID
-from corehq.apps.users.util import username_to_user_id
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
 
@@ -25,55 +22,34 @@ def needs_update(case):
     return index.referenced_type == "patient" and index.relationship == "child"
 
 
-def case_block(case):
-    index = case.indices[0]
-    return ElementTree.tostring(CaseBlock.deprecated_init(
-        create=False,
-        case_id=case.case_id,
-        owner_id='-',
-        index={index.identifier: (index.referenced_type, index.referenced_id, "extension")},
-    ).as_xml()).decode('utf-8')
-
-
-def update_cases(domain, case_type, username):
-    accessor = CaseAccessors(domain)
-    case_ids = accessor.get_case_ids_in_domain(case_type)
-    print(f"Found {len(case_ids)} {case_type} cases in {domain}")
-
-    user_id = username_to_user_id(username)
-    if not user_id:
-        user_id = SYSTEM_USER_ID
-
-    case_blocks = []
-    skip_count = 0
-    for case in accessor.iter_cases(case_ids):
-        if should_skip(case):
-            skip_count += 1
-        elif needs_update(case):
-            case_blocks.append(case_block(case))
-    print(f"{len(case_blocks)} to update in {domain}, {skip_count} cases have skipped due to multiple indices.")
-
-    total = 0
-    for chunk in chunked(case_blocks, BATCH_SIZE):
-        submit_case_blocks(chunk, domain, device_id=DEVICE_ID, user_id=user_id)
-        total += len(chunk)
-        print("Updated {} cases on domain {}".format(total, domain))
-
-
-class Command(BaseCommand):
+class Command(CaseUpdateCommand):
     help = ("Updates all case indices of a specfied case type to use an extension relationship instead of parent.")
 
-    def add_arguments(self, parser):
-        parser.add_argument('domain')
-        parser.add_argument('case_type')
-        parser.add_argument('username')
-        parser.add_argument('--and-linked', action='store_true', default=False)
+    def case_block(self, case):
+        index = case.indices[0]
+        return ElementTree.tostring(CaseBlock.deprecated_init(
+            create=False,
+            case_id=case.case_id,
+            owner_id='-',
+            index={index.identifier: (index.referenced_type, index.referenced_id, "extension")},
+        ).as_xml()).decode('utf-8')
 
-    def handle(self, domain, case_type, username, **options):
-        domains = {domain}
-        if options["and_linked"]:
-            domains = domains | {link.linked_domain for link in get_linked_domains(domain)}
+    def update_cases(self, domain, case_type, user_id):
+        accessor = CaseAccessors(domain)
+        case_ids = accessor.get_case_ids_in_domain(case_type)
+        print(f"Found {len(case_ids)} {case_type} cases in {domain}")
 
-        for domain in domains:
-            print(f"Processing {domain}")
-            update_cases(domain, case_type, username)
+        case_blocks = []
+        skip_count = 0
+        for case in accessor.iter_cases(case_ids):
+            if should_skip(case):
+                skip_count += 1
+            elif needs_update(case):
+                case_blocks.append(self.case_block(case))
+        print(f"{len(case_blocks)} to update in {domain}, {skip_count} cases have skipped due to multiple indices.")
+
+        total = 0
+        for chunk in chunked(case_blocks, BATCH_SIZE):
+            submit_case_blocks(chunk, domain, device_id=DEVICE_ID, user_id=user_id)
+            total += len(chunk)
+            print("Updated {} cases on domain {}".format(total, domain))

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -15,7 +15,7 @@ class CaseUpdateCommand(BaseCommand):
     def case_block(self):
         raise NotImplementedError()
 
-    def update_cases(self, domain, user_id):
+    def update_cases(self, domain, case_type, user_id):
         raise NotImplementedError()
 
     def find_case_ids_by_type(self, domain, case_type):
@@ -26,10 +26,11 @@ class CaseUpdateCommand(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('domain')
+        parser.add_argument('case_type')
         parser.add_argument('username')
         parser.add_argument('--and-linked', action='store_true', default=False)
 
-    def handle(self, domain, username, **options):
+    def handle(self, domain, case_type, username, **options):
         domains = {domain}
         if options["and_linked"]:
             domains = domains | {link.linked_domain for link in get_linked_domains(domain)}
@@ -40,4 +41,4 @@ class CaseUpdateCommand(BaseCommand):
 
         for domain in domains:
             print(f"Processing {domain}")
-            self.update_cases(domain, user_id)
+            self.update_cases(domain, case_type, user_id)

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -27,16 +27,19 @@ class CaseUpdateCommand(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('domain')
         parser.add_argument('case_type')
-        parser.add_argument('username')
+        parser.add_argument('--username', type=str, default=None)
         parser.add_argument('--and-linked', action='store_true', default=False)
 
-    def handle(self, domain, case_type, username, **options):
+    def handle(self, domain, case_type, **options):
         domains = {domain}
         if options["and_linked"]:
             domains = domains | {link.linked_domain for link in get_linked_domains(domain)}
 
-        user_id = username_to_user_id(username)
-        if not user_id:
+        if options["username"]:
+            user_id = username_to_user_id(options["username"])
+            if not user_id:
+                raise Exception("The username you entered is invalid")
+        else:
             user_id = SYSTEM_USER_ID
 
         for domain in domains:

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -1,0 +1,43 @@
+from django.core.management.base import BaseCommand
+
+from corehq.apps.linked_domain.dbaccessors import get_linked_domains
+from corehq.apps.users.util import SYSTEM_USER_ID
+from corehq.apps.users.util import username_to_user_id
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+
+
+class CaseUpdateCommand(BaseCommand):
+    """
+        Base class for updating cases of a specific case_type.
+        Override all methods that raise NotImplementedError.
+    """
+
+    def case_block(self):
+        raise NotImplementedError()
+
+    def update_cases(self, domain, user_id):
+        raise NotImplementedError()
+
+    def find_case_ids_by_type(self, domain, case_type):
+        accessor = CaseAccessors(domain)
+        case_ids = accessor.get_case_ids_in_domain(case_type)
+        print(f"Found {len(case_ids)} {case_type} cases in {domain}")
+        return case_ids
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+        parser.add_argument('username')
+        parser.add_argument('--and-linked', action='store_true', default=False)
+
+    def handle(self, domain, username, **options):
+        domains = {domain}
+        if options["and_linked"]:
+            domains = domains | {link.linked_domain for link in get_linked_domains(domain)}
+
+        user_id = username_to_user_id(username)
+        if not user_id:
+            user_id = SYSTEM_USER_ID
+
+        for domain in domains:
+            print(f"Processing {domain}")
+            self.update_cases(domain, user_id)

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -43,6 +43,10 @@ class CaseCommandsTest(TestCase):
         delete_all_users()
         super().tearDown()
 
+    def test_invalid_username(self):
+        with self.assertRaises(Exception):
+            call_command('add_hq_user_id_to_case', self.domain, 'checkin', '--username=afakeuserthatdoesnotexist')
+
     def submit_case_block(self, create, case_id, **kwargs):
         return post_case_blocks(
             [
@@ -69,7 +73,7 @@ class CaseCommandsTest(TestCase):
         self.assertEqual('', checkin_case.get_case_property('hq_user_id'))
         self.assertEqual(checkin_case.username, 'mobile_worker_1')
 
-        call_command('add_hq_user_id_to_case', self.domain, 'checkin', None)
+        call_command('add_hq_user_id_to_case', self.domain, 'checkin')
 
         checkin_case = self.case_accessor.get_case(checkin_case_id)
         lab_result_case = self.case_accessor.get_case(lab_result_case_id)
@@ -92,7 +96,7 @@ class CaseCommandsTest(TestCase):
         self.assertEqual(lab_result_case.indices[0].referenced_type, 'patient')
         self.assertEqual(lab_result_case.indices[0].relationship, 'child')
 
-        call_command('update_case_index_relationship', self.domain, 'lab_result', None)
+        call_command('update_case_index_relationship', self.domain, 'lab_result')
 
         lab_result_case = self.case_accessor.get_case(lab_result_case_id)
         self.assertEqual(lab_result_case.indices[0].relationship, 'extension')


### PR DESCRIPTION
## Summary
Changed suggesting in this [PR](https://github.com/dimagi/commcare-hq/pull/28992#discussion_r558309121). This new `CaseUpdateCommand` class will be used in upcoming script tasks.


## Safety Assurance

- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
Updated tests for commands in test_management_commands.py

### QA Plan
I am not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
