### PR TITLE
Web apps case search sticky search

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -14,6 +14,11 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 appId = this.model.collection.appId,
                 initialValue = this.options.model.get('value');
 
+            // If input doesn't have a default value, check to see if there's a sticky value from user's last search
+            if (!initialValue) {
+                initialValue = hqImport("cloudcare/js/formplayer/utils/util").getStickyQueryInputs()[this.options.model.get('id')];
+            }
+
             // Initial values are sent from formplayer as strings, but dropdowns expect an integer
             if (initialValue && this.options.model.get('input') === "select1") {
                 initialValue = parseInt(initialValue);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -26,7 +26,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             };
         },
 
-        initialize: function (options) {
+        initialize: function () {
             // If input doesn't have a default value, check to see if there's a sticky value from user's last search
             if (!this.options.model.get('value')) {
                 this.options.model.set('value', hqImport("cloudcare/js/formplayer/utils/util").getStickyQueryInputs()[this.options.model.get('id')]);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -12,23 +12,25 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             var imageUri = this.options.model.get('imageUri'),
                 audioUri = this.options.model.get('audioUri'),
                 appId = this.model.collection.appId,
-                initialValue = this.options.model.get('value');
-
-            // If input doesn't have a default value, check to see if there's a sticky value from user's last search
-            if (!initialValue) {
-                initialValue = hqImport("cloudcare/js/formplayer/utils/util").getStickyQueryInputs()[this.options.model.get('id')];
-            }
+                value = this.options.model.get('value');
 
             // Initial values are sent from formplayer as strings, but dropdowns expect an integer
-            if (initialValue && this.options.model.get('input') === "select1") {
-                initialValue = parseInt(initialValue);
+            if (value && this.options.model.get('input') === "select1") {
+                value = parseInt(value);
             }
 
             return {
                 imageUrl: imageUri ? FormplayerFrontend.getChannel().request('resourceMap', imageUri, appId) : "",
                 audioUrl: audioUri ? FormplayerFrontend.getChannel().request('resourceMap', audioUri, appId) : "",
-                value: initialValue,
+                value: value,
             };
+        },
+
+        initialize: function (options) {
+            // If input doesn't have a default value, check to see if there's a sticky value from user's last search
+            if (!this.options.model.get('value')) {
+                this.options.model.set('value', hqImport("cloudcare/js/formplayer/utils/util").getStickyQueryInputs()[this.options.model.get('id')]);
+            }
         },
 
         ui: {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -60,12 +60,14 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         },
 
         ui: {
+            clearButton: '#query-clear-button',
             submitButton: '#query-submit-button',
             valueDropdown: 'select.query-field',
         },
 
         events: {
             'change @ui.valueDropdown': 'changeDropdown',
+            'click @ui.clearButton': 'clearAction',
             'click @ui.submitButton': 'submitAction',
         },
 
@@ -109,6 +111,14 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                         $field.trigger('change.select2');
                     }
                 }
+            });
+        },
+
+        clearAction: function () {
+            var fields = $(".query-field");
+            fields.each(function () {
+                this.value = '';
+                $(this).trigger('change.select2');
             });
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -70,10 +70,12 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             clearButton: '#query-clear-button',
             submitButton: '#query-submit-button',
             valueDropdown: 'select.query-field',
+            valueInput: 'input.query-field',
         },
 
         events: {
             'change @ui.valueDropdown': 'changeDropdown',
+            'change @ui.valueInput': 'setStickyQueryInputs',
             'click @ui.clearButton': 'clearAction',
             'click @ui.submitButton': 'submitAction',
         },
@@ -118,20 +120,28 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                         $field.trigger('change.select2');
                     }
                 }
+                self.setStickyQueryInputs();
             });
         },
 
         clearAction: function () {
-            var fields = $(".query-field");
+            var self = this,
+                fields = $(".query-field");
             fields.each(function () {
                 this.value = '';
                 $(this).trigger('change.select2');
             });
+            self.setStickyQueryInputs();
         },
 
         submitAction: function (e) {
             e.preventDefault();
             FormplayerFrontend.trigger("menu:query", this.getAnswers());
+        },
+
+        setStickyQueryInputs: function () {
+            var Util = hqImport("cloudcare/js/formplayer/utils/util");
+            Util.setStickyQueryInputs(this.getAnswers());
         },
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -178,6 +178,7 @@ hqDefine("cloudcare/js/formplayer/router", function () {
         var urlObject = Util.currentUrlToObject();
         urlObject.setQueryData(queryDict, true);
         Util.setUrlToObject(urlObject);
+        Util.setStickyQueryInputs(queryDict);
         API.listMenus();
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -26,6 +26,7 @@ hqDefine("cloudcare/js/formplayer/router", function () {
     var API = {
         listApps: function () {
             FormplayerFrontend.regions.getRegion('breadcrumb').empty();
+            Util.setStickyQueryInputs({});
             appsController.listApps();
         },
         singleApp: function (appId) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -179,7 +179,6 @@ hqDefine("cloudcare/js/formplayer/router", function () {
         var urlObject = Util.currentUrlToObject();
         urlObject.setQueryData(queryDict, true);
         Util.setUrlToObject(urlObject);
-        Util.setStickyQueryInputs(queryDict);
         API.listMenus();
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -128,6 +128,20 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
         };
     };
 
+    Util.getStickyQueryInputs = function () {
+        if (!this.stickyQueryInputs) {
+            return {};
+        }
+        return this.stickyQueryInputs[sessionStorage.queryKey] || {};
+    };
+
+    Util.setStickyQueryInputs = function (inputs) {
+        if (!this.stickyQueryInputs) {
+            this.stickyQueryInputs = {};
+        }
+        this.stickyQueryInputs[sessionStorage.queryKey] = inputs;
+    };
+
     Util.CloudcareUrl = function (options) {
         this.appId = options.appId;
         this.copyOf = options.copyOf;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -129,6 +129,9 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
     };
 
     Util.getStickyQueryInputs = function () {
+        if (!hqImport("hqwebapp/js/toggles").toggleEnabled('WEBAPPS_STICKY_SEARCH')) {
+            return {};
+        }
         if (!this.stickyQueryInputs) {
             return {};
         }

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -8,7 +8,10 @@
       <tbody>
       </tbody>
     </table>
-    <button class="btn btn-default" type="submit" id="query-submit-button">
+    <button class="btn btn-default" type="button" id="query-clear-button">
+      <div>{% trans "Clear" %}</div>
+    </button>
+    <button class="btn btn-primary" type="submit" id="query-submit-button">
       <div>{% trans "Submit" %}</div>
     </button>
   </form>

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -766,6 +766,14 @@ CASE_CLAIM_AUTOLAUNCH = StaticToggle(
 )
 
 
+WEBAPPS_STICKY_SEARCH = StaticToggle(
+    'webapps_sticky_search',
+    'COVID: In web apps, save user\'s most recent inputs on case search & claim screen.',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
+
 def _enable_search_index(domain, enabled):
     from corehq.apps.case_search.tasks import reindex_case_search_for_domain
     from corehq.pillows.case_search import domains_needing_search_index


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-71

Simpler version of https://github.com/dimagi/commcare-hq/pull/28824 - this adds sticky search only for the case search/claim screen, not for the case list generic search box. It's controlled by a feature flag, with no user preference option.

Opening for QA. Hold off on review. This builds off of https://github.com/dimagi/commcare-hq/pull/28930, https://github.com/dimagi/commcare-hq/pull/28955/, and https://github.com/dimagi/commcare-hq/pull/28950/, so all of those branches are merged in. I'll rebase as those PRs get merged so that this PR gets easier to review.

Happily, there's no formplayer or commcare-core component to this one.

## Feature Flag
Sticky behavior is behind a new flag: COVID: In web apps, save user's most recent inputs on case search & claim screen.

All projects using case claim will see a new "Clear" button on the search screen:

![Screen Shot 2021-01-17 at 5 10 20 PM](https://user-images.githubusercontent.com/1486591/104857524-12bd0800-58e7-11eb-9866-8350a2f9d01c.png)

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-2328)

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
