### PR TITLE
Allow session auth for user-domains API, and clean up decorators

### DIFF
--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -10,14 +10,7 @@ from corehq.apps.api.odata.views import odata_permissions_check
 from corehq.apps.domain.auth import BASIC, determine_authtype_from_header
 from corehq.apps.domain.decorators import (
     api_key_auth,
-    basic_auth,
     basic_auth_or_try_api_key_auth,
-    digest_auth,
-    login_or_api_key,
-    login_or_basic,
-    login_or_digest,
-    login_or_oauth2,
-    oauth2_auth,
     get_auth_decorator_map,
 )
 from corehq.apps.users.decorators import (
@@ -95,20 +88,7 @@ class LoginAndDomainAuthentication(HQAuthenticationMixin, Authentication):
             set this to True to allow session based access to this resource
         """
         super(LoginAndDomainAuthentication, self).__init__(*args, **kwargs)
-        if allow_session_auth:
-            self.decorator_map = {
-                'digest': login_or_digest,
-                'basic': login_or_basic,
-                'api_key': login_or_api_key,
-                'oauth2': login_or_oauth2,
-            }
-        else:
-            self.decorator_map = {
-                'digest': digest_auth,
-                'basic': basic_auth,
-                'api_key': api_key_auth,
-                'oauth2': oauth2_auth,
-            }
+        self.decorator_map = get_auth_decorator_map(require_domain=True, allow_sessions=allow_session_auth)
 
     def is_authenticated(self, request, **kwargs):
         return self._auth_test(request, wrappers=[

--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -61,8 +61,9 @@ class LoginAuthentication(HQAuthenticationMixin, Authentication):
     """
     Just checks you are able to login. Does not check against any permissions/domains, etc.
     """
-    def __init__(self):
-        self.decorator_map = get_auth_decorator_map(require_domain=False, allow_sessions=False)
+    def __init__(self, allow_session_auth=False):
+        super().__init__()
+        self.decorator_map = get_auth_decorator_map(require_domain=False, allow_sessions=allow_session_auth)
 
     def is_authenticated(self, request, **kwargs):
         return self._auth_test(request, wrappers=[

--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -10,18 +10,15 @@ from corehq.apps.api.odata.views import odata_permissions_check
 from corehq.apps.domain.auth import BASIC, determine_authtype_from_header
 from corehq.apps.domain.decorators import (
     api_key_auth,
-    api_key_auth_no_domain,
     basic_auth,
-    basic_auth_no_domain,
     basic_auth_or_try_api_key_auth,
     digest_auth,
-    digest_auth_no_domain,
     login_or_api_key,
     login_or_basic,
     login_or_digest,
     login_or_oauth2,
     oauth2_auth,
-    oauth2_auth_no_domain,
+    get_auth_decorator_map,
 )
 from corehq.apps.users.decorators import (
     require_api_permission,
@@ -65,13 +62,7 @@ class LoginAuthentication(HQAuthenticationMixin, Authentication):
     Just checks you are able to login. Does not check against any permissions/domains, etc.
     """
     def __init__(self):
-        super().__init__()
-        self.decorator_map = {
-            'digest': digest_auth_no_domain,
-            'basic': basic_auth_no_domain,
-            'api_key': api_key_auth_no_domain,
-            'oauth2': oauth2_auth_no_domain,
-        }
+        self.decorator_map = get_auth_decorator_map(require_domain=False, allow_sessions=False)
 
     def is_authenticated(self, request, **kwargs):
         return self._auth_test(request, wrappers=[

--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -22,7 +22,6 @@ from corehq.apps.domain.decorators import (
 )
 from corehq.apps.users.decorators import (
     require_api_permission,
-    require_permission,
     require_permission_raw,
 )
 from corehq.toggles import API_THROTTLE_WHITELIST, IS_CONTRACTOR

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -825,7 +825,7 @@ class UserDomainsResource(CorsResourceMixin, Resource):
 
     class Meta(object):
         resource_name = 'user_domains'
-        authentication = LoginAuthentication()
+        authentication = LoginAuthentication(allow_session_auth=True)
         object_class = UserDomain
         include_resource_uri = False
 

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -404,11 +404,6 @@ basic_auth = login_or_basic_ex(allow_sessions=False)
 api_key_auth = login_or_api_key_ex(allow_sessions=False)
 oauth2_auth = login_or_oauth2_ex(allow_sessions=False)
 
-digest_auth_no_domain = login_or_digest_ex(allow_sessions=False, require_domain=False)
-basic_auth_no_domain = login_or_basic_ex(allow_sessions=False, require_domain=False)
-api_key_auth_no_domain = login_or_api_key_ex(allow_sessions=False, require_domain=False)
-oauth2_auth_no_domain = login_or_oauth2_ex(allow_sessions=False, require_domain=False)
-
 basic_auth_or_try_api_key_auth = login_or_basic_or_api_key_ex(allow_sessions=False)
 
 

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -396,13 +396,8 @@ api_auth = _get_multi_auth_decorator(default=DIGEST)
 login_or_digest = login_or_digest_ex()
 login_or_basic = login_or_basic_ex()
 login_or_api_key = login_or_api_key_ex()
-login_or_oauth2 = login_or_oauth2_ex()
 
-# Use these decorators on views to exclusively allow any one authorization method and not session based auth
-digest_auth = login_or_digest_ex(allow_sessions=False)
-basic_auth = login_or_basic_ex(allow_sessions=False)
 api_key_auth = login_or_api_key_ex(allow_sessions=False)
-oauth2_auth = login_or_oauth2_ex(allow_sessions=False)
 
 basic_auth_or_try_api_key_auth = login_or_basic_or_api_key_ex(allow_sessions=False)
 

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -412,6 +412,16 @@ oauth2_auth_no_domain = login_or_oauth2_ex(allow_sessions=False, require_domain=
 basic_auth_or_try_api_key_auth = login_or_basic_or_api_key_ex(allow_sessions=False)
 
 
+def get_auth_decorator_map(require_domain=True, allow_sessions=True):
+    # get a mapped set of decorators for different auth types with the specified parameters
+    return {
+        'digest': login_or_digest_ex(require_domain=require_domain, allow_sessions=allow_sessions),
+        'basic': login_or_basic_ex(require_domain=require_domain, allow_sessions=allow_sessions),
+        'api_key': login_or_api_key_ex(require_domain=require_domain, allow_sessions=allow_sessions),
+        'oauth2': login_or_oauth2_ex(require_domain=require_domain, allow_sessions=allow_sessions),
+    }
+
+
 def two_factor_check(view_func, api_key):
     def _outer(fn):
         @wraps(fn)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Ran into this while working on https://github.com/dimagi/commcare-hq/pull/29001 and decided to fix it in the meantime. Then in the process realized I could clean up some copy/paste redundancy in our API auth code.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Enables the [User Domains API](https://confluence.dimagi.com/display/commcarepublic/User+Domain+List) to load in a browser if you're already logged in.

## Safety Assurance

I'm not sure I agree this is high risk though am not sure I understand how those terms should be used in today's HQ climate.

- [ ] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

There is good test coverage for the functions and classes that changed in [test_auth.py](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/api/tests/test_auth.py)

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

It is a relatively mechanical refactor, plus a tiny change in functionality and the code is well-tested.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
