### PR TITLE
Couch to SQL forms & cases: minor fixup

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -884,7 +884,10 @@ def _migrate_form_attachments(sql_form, couch_form):
         if len(metas) == 1:
             couch_meta = couch_form.blobs.get("form.xml")
             if couch_meta is None:
-                assert not metas[0].blob_exists(), metas
+                if metas[0].blob_exists():
+                    # not sure how this is possible, but at least one
+                    # form existed that hit this branch.
+                    return metas[0]
             elif metas[0].key != couch_meta.key:
                 assert not blobdb.exists(couch_meta.key), couch_meta
                 if metas[0].blob_exists():

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -57,6 +57,7 @@ COMMIT = "COMMIT"
 RESET = "reset"  # was --blow-away
 REWIND = "rewind"
 STATS = "stats"
+INFO = "info"
 DIFF = "diff"
 
 CACHED = "cached"
@@ -82,6 +83,7 @@ class Command(BaseCommand):
             RESET,
             REWIND,
             STATS,
+            INFO,
             DIFF,
         ])
         parser.add_argument('--no-input', action='store_true', default=False)
@@ -297,6 +299,11 @@ class Command(BaseCommand):
 
     def do_stats(self, domain):
         self.print_stats(domain, short=not self.verbose)
+
+    def do_info(self, domain):
+        status = get_couch_sql_migration_status(domain)
+        print(f"Couch to SQL migration status for {domain}: {status}")
+        self.print_couch_stats(domain)
 
     def do_diff(self, domain):
         from .couch_sql_diff import format_doc_diffs

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db.models import Q
 
+from couchforms.analytics import get_last_form_submission_received
 from couchforms.models import XFormInstance, doc_types
 from dimagi.utils.chunked import chunked
 
@@ -383,6 +384,8 @@ class Command(BaseCommand):
         for entity in MissingIds.DOC_TYPES:
             count = get_couch_doc_count(domain, entity, couchdb)
             print(f"Total {entity}s: {count}")
+        received_on = get_last_form_submission_received(domain)
+        print(f"Last form submission: {received_on}")
 
 
 def _confirm(message):


### PR DESCRIPTION
- Handle unexpected form XML blob exists scenario
- Add most recent form submission date to _not started_ stats
- Add 'info' action to get couch domain information for in-progress migration

:tropical_fish: Review by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below
- [x] This PR can be reverted after deploy with no further considerations 
