### PR TITLE
Case claim option to configure session variable

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2101,6 +2101,7 @@ class CaseSearch(DocumentSchema):
     """
     Properties and search command label
     """
+    session_var = StringProperty(default="case_id")
     command_label = DictProperty(default={'en': 'Search All Cases'})
     properties = SchemaListProperty(CaseSearchProperty)
     auto_launch = BooleanProperty(default=False)

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -9,7 +9,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             });
         };
 
-    var searchViewModel = function (searchProperties, autoLaunch, includeClosed, defaultProperties, lang, searchCommandLabel,
+    var searchViewModel = function (searchProperties, sessionVar, autoLaunch, includeClosed, defaultProperties, lang, searchCommandLabel,
         searchButtonDisplayCondition, searchFilter, searchRelevant, blacklistedOwnerIdsExpression, saveButton, searchFilterObservable) {
         var self = {},
             DEFAULT_CLAIM_RELEVANT = "count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 0";
@@ -109,6 +109,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             return self;
         };
 
+        self.sessionVar = ko.observable(sessionVar);
         self.searchCommandLabel = ko.observable(searchCommandLabel[lang] || "");
         self.searchButtonDisplayCondition = ko.observable(searchButtonDisplayCondition);
         self.autoLaunch = ko.observable(autoLaunch);
@@ -249,6 +250,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         self.serialize = function () {
             return {
                 properties: self._getProperties(),
+                session_var: self.sessionVar(),
                 auto_launch: self.autoLaunch(),
                 relevant: self.relevant(),
                 search_button_display_condition: self.searchButtonDisplayCondition(),
@@ -260,6 +262,9 @@ hqDefine("app_manager/js/details/case_claim", function () {
             };
         };
 
+        self.sessionVar.subscribe(function () {
+            saveButton.fire('change');
+        });
         self.autoLaunch.subscribe(function () {
             saveButton.fire('change');
         });

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
@@ -1124,6 +1124,7 @@ hqDefine('app_manager/js/details/screen_config', function () {
                     // Set up case search
                     self.search = hqImport("app_manager/js/details/case_claim").searchViewModel(
                         spec.searchProperties || [],
+                        spec.searchSessionVar,
                         spec.autoLaunch,
                         spec.includeClosed,
                         spec.defaultProperties,

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -42,6 +42,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
                     multimedia: initial_page_data('multimedia_object_map'),
                     searchProperties: options.search_properties || [],
                     searchRelevant: options.search_relevant || "",
+                    searchSessionVar: options.search_session_var,
                     autoLaunch: options.auto_launch,
                     includeClosed: options.include_closed,
                     defaultProperties: options.default_properties || [],

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -63,7 +63,7 @@ class RemoteRequestFactory(object):
             "data": [
                 QueryData(
                     key='case_id',
-                    ref=QuerySessionXPath('case_id').instance(),
+                    ref=QuerySessionXPath(self.module.search_config.session_var).instance(),
                 ),
             ],
         }
@@ -86,7 +86,7 @@ class RemoteRequestFactory(object):
             if prop.itemset.instance_id
         ]
 
-        query_xpaths = [QuerySessionXPath('case_id').instance()]
+        query_xpaths = [QuerySessionXPath(self.module.search_config.session_var).instance()]
         query_xpaths.extend([datum.ref for datum in self._get_remote_request_query_datums()])
         query_xpaths.extend([self.module.search_config.relevant, self.module.search_config.search_filter])
         instances, unknown_instances = get_all_instances_referenced_in_xpaths(self.app, query_xpaths)
@@ -126,7 +126,7 @@ class RemoteRequestFactory(object):
             nodeset = f"{nodeset}[{interpolate_xpath(self.module.search_config.search_filter)}]"
 
         return [SessionDatum(
-            id='case_id',
+            id=self.module.search_config.session_var,
             nodeset=nodeset,
             value='./@case_id',
             detail_select=details_helper.get_detail_id_safe(self.module, short_detail_id),
@@ -181,7 +181,7 @@ class RemoteRequestFactory(object):
     def _build_stack(self):
         stack = Stack()
         frame = PushFrame()
-        frame.add_rewind(QuerySessionXPath('case_id').instance())
+        frame.add_rewind(QuerySessionXPath(self.module.search_config.session_var).instance())
         stack.add_frame(frame)
         return stack
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -307,6 +307,17 @@
               </label>
             </div>
           </div>
+          <div class="form-group">
+            <label for="search-session-var" class="control-label {% css_label_class %}">
+              {% trans "Session variable" %}
+              <span class="hq-help-template" data-title="{% trans "Session Variable" %}"
+                    data-content="{% trans_html_attr "Name of session variable that claimed case id should populate." %}">
+              </span>
+            </label>
+            <div class="{% css_field_class %}">
+              <input class="form-control" type="text" data-bind="value: sessionVar" id="search-session-var"/>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -170,6 +170,27 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             suite.xpath(ref_path)[0]
         )
 
+    def test_case_search_session_var(self, *args):
+        self.module.search_config.session_var = "other_case_id"
+        suite = self.app.create_suite()
+        self.assertXmlPartialEqual('''
+            <partial>
+              <data key="case_id" ref="instance('commcaresession')/session/data/other_case_id"/>
+            </partial>
+        ''', suite, './remote-request[1]/post/data')
+        self.assertXmlPartialEqual('''
+            <partial>
+              <stack>
+                <push>
+                  <rewind value="instance('commcaresession')/session/data/other_case_id"/>
+                </push>
+              </stack>
+            </partial>
+        ''', suite, './remote-request[1]/stack')
+        suite = parse_normalize(suite, to_string=False)
+        self.assertEqual("other_case_id", suite.xpath("./remote-request[1]/session/datum/@id")[0])
+        self.assertEqual("./@case_id", suite.xpath("./remote-request[1]/session/datum/@value")[0])
+
     def test_case_search_action_relevant_condition(self, *args):
         condition = "'foo' = 'bar'"
         self.module.search_config.search_button_display_condition = condition

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -205,11 +205,13 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
                 module.search_config.search_button_display_condition if module_offers_search(module) else "",
             'search_relevant':
                 module.search_config.relevant if module_offers_search(module) else "",
-            'search_command_label':
-                # use default if module_offers_search is false because module.search_config doesn't exist yet
-                module.search_config.command_label if hasattr(module, 'search_config') else "",
             'blacklisted_owner_ids_expression': (
                 module.search_config.blacklisted_owner_ids_expression if module_offers_search(module) else ""),
+
+            # populate these even if module_offers_search is false because search_config might just not exist yet
+            'search_command_label':
+                module.search_config.command_label if hasattr(module, 'search_config') else "",
+            'search_session_var': module.search_config.session_var if hasattr(module, 'search_config') else "",
         },
     }
     if toggles.CASE_DETAIL_PRINT.enabled(app.domain):
@@ -1065,6 +1067,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
             command_label = module.search_config.command_label
             command_label[lang] = search_properties.get('search_command_label', '')
             module.search_config = CaseSearch(
+                session_var=search_properties.get('session_var', ""),
                 command_label=command_label,
                 properties=[
                     CaseSearchProperty.wrap(p)


### PR DESCRIPTION
## Summary
The new USH deduplication workflow relies on a double case claim workflow based on [changes to select parent first](https://github.com/dimagi/commcare-hq/pull/28935). This means there are two different session variables that need to be populated, but case claim currently hard codes `case_id` into the remote request:

```
<remote-request>
  <post url="http://localhost:8000/a/bosco/phone/claim-case/">
    <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
  </post>
  <command id="search_command.m2">...</command>
  <instance id="commcaresession" src="jr://instance/session"/>
  <session>
    <query url="http://localhost:8000/a/bosco/phone/search/" storage-instance="results" template="case">
      <data key="case_type" ref="'song'"/>
      <data key="include_closed" ref="'False'"/>
      <prompt key="name">...</prompt>
    </query>
    <datum id="case_id" nodeset="instance('results')/results/case[@case_type='song']" value="./@case_id" detail-select="m2_search_short" detail-confirm="m2_case_long"/>
  </session>
  <stack>
    <push>
      <rewind value="instance('commcaresession')/session/data/case_id"/>
    </push>
  </stack>
</remote-request>
```

This PR adds a session variable attribute to case claim options, which defaults to `case_id` and is replaces `case_id` in all of the above usages except for the `<data>` key (because that's the POST variable [sent to the claim request](https://github.com/dimagi/commcare-hq/blob/8d226b8b6adf726a2159a44916ce7b0ff03edec7/corehq/apps/ota/views.py#L133)) and the `./@case_id` (because that's id of the selected case, used to populate the datum).

## Feature Flag
Case search & claim

## Product Description
Adds "session variable" option to case claim options, which will default to "case_id" and being ignored by all non-USH projects.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

This PR includes test coverage.

### QA Plan

Not planning formal QA, although USH is testing the deduplication workflow on staging. I've tested locally and the PR includes test coverage.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
