### PR TITLE
Add tests for untested feature

### DIFF
--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -291,6 +291,31 @@ class TestCaseSearchLookups(TestCase):
             ['c1']
         )
 
+    def test_fuzzy_case_property_query(self):
+        self._assert_query_runs_correctly(
+            self.domain,
+            [
+                {'_id': 'c1', 'foo': 'redbeard'},
+                {'_id': 'c2', 'foo': 'blackbeard'},
+            ],
+            CaseSearchES().domain(self.domain).case_property_query("foo", "backbeard", fuzzy=True),
+            None,
+            ['c2']
+        )
+
+    def test_regex_case_property_query(self):
+        self._assert_query_runs_correctly(
+            self.domain,
+            [
+                {'_id': 'c1', 'foo': 'redbeard'},
+                {'_id': 'c2', 'foo': 'blackbeard'},
+                {'_id': 'c3', 'foo': 'redblack'},
+            ],
+            CaseSearchES().domain(self.domain).regexp_case_property_query("foo", ".*beard.*"),
+            None,
+            ['c1', 'c2']
+        )
+
     def test_multiple_case_search_queries(self):
         query = (CaseSearchES().domain(self.domain)
                  .case_property_query("foo", "redbeard")


### PR DESCRIPTION
## Summary
Add tests for untested feature

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

NA

### Safety story


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 

@orangejenny 