### PR TITLE
fix digest auth on APIs using LoginAndDomainAuthentication

### DIFF
--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -121,9 +121,8 @@ class LoginAndDomainAuthentication(HQAuthenticationMixin, Authentication):
 
     def is_authenticated(self, request, **kwargs):
         return self._auth_test(request, wrappers=[
-            self._get_auth_decorator(request),
-            wrap_4xx_errors_for_apis,
             require_api_permission('access_api', login_decorator=self._get_auth_decorator(request)),
+            wrap_4xx_errors_for_apis,
         ], **kwargs)
 
     def _auth_test(self, request, wrappers, **kwargs):


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Digest authentication [has been broken on tasty APIs using `LoginAndDomainAuthorization`](https://github.com/dimagi/commcare-hq/pull/29002#issuecomment-762676703) since, I believe, this commit: https://github.com/dimagi/commcare-hq/commit/a715df7ce94440648246c87d42814650af6efccd

The duplicate call to `self._get_auth_decorator(request)` causes the digest nonce to be used twice, which then causes an `IntegrityError` that causes `django_digest` to fail ([here](https://github.com/dimagi/django-digest/blob/master/django_digest/backend/storage.py#L107-L114))

This fix mirrors how `RequirePermissionAuthentication` works, which has been working reliably - probably why we didn't notice this. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Not worth announcing since no one noticed.

## Safety Assurance

- [ ] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

No test coverage because simulating digest authentication is a pain.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

This is a bug that I noticed and fixed while attempting to validate the safety of [another PR](https://github.com/dimagi/commcare-hq/pull/29002). It feels quite safe.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
