### PR TITLE
Drop unused functions from Case Search

### DIFF
--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -264,25 +264,3 @@ def build_filter_from_xpath(domain, xpath):
             bad_part = lex_token_error.groups()[1]
             raise CaseFilterError(error_message.format(bad_part, ", ".join(ALL_OPERATORS)), bad_part)
         raise CaseFilterError(_("Malformed search query"), None)
-
-
-def get_properties_from_ast(node):
-    """Returns a list of case properties referenced in the XPath expression
-
-    Skips malformed parts of the XPath expression
-    """
-    columns = set()
-
-    def visit(node):
-        if not hasattr(node, 'op'):
-            return
-
-        if node.op in ([EQ, NEQ] + list(COMPARISON_MAPPING.keys())):
-            columns.add(serialize(node.left))
-
-        if node.op in list(OPERATOR_MAPPING.keys()):
-            visit(node.left)
-            visit(node.right)
-
-    visit(node)
-    return list(columns)

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -286,7 +286,3 @@ def get_properties_from_ast(node):
 
     visit(node)
     return list(columns)
-
-
-def get_properties_from_xpath(xpath):
-    return get_properties_from_ast(parse_xpath(xpath))


### PR DESCRIPTION
## Summary

While exploring Case Search for use with the FHIR API, I noticed two unused functions.

If these functions are useful, like maybe from the console to check XPaths, then we should keep them. But if not, let's drop them.


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below


### Safety story

Searching the codebase with `git grep` showed that `get_properties_from_xpath()` is never called, and `get_properties_from_ast()` is only called by its unit test.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
