### PR TITLE
Update owner_id case command

### DIFF
--- a/custom/covid/management/commands/update_owner_ids.py
+++ b/custom/covid/management/commands/update_owner_ids.py
@@ -28,11 +28,16 @@ class Command(CaseUpdateCommand):
         case_ids = self.find_case_ids_by_type(domain, case_type)
         accessor = CaseAccessors(domain)
 
+        locations_objects = {}
         case_blocks = []
         skip_count = 0
         for case in accessor.iter_cases(case_ids):
             owner_id = case.get_case_property('owner_id')
-            location_obj = SQLLocation.objects.get(location_id=owner_id)
+            if owner_id in locations_objects:
+                location_obj = locations_objects[owner_id]
+            else:
+                location_obj = SQLLocation.objects.get(location_id=owner_id)
+                locations_objects[owner_id] = location_obj
             if location_obj:
                 children = location_obj.get_children()
                 has_correct_child_location_type = False

--- a/custom/covid/management/commands/update_owner_ids.py
+++ b/custom/covid/management/commands/update_owner_ids.py
@@ -1,0 +1,55 @@
+from xml.etree import cElementTree as ElementTree
+
+from casexml.apps.case.mock import CaseBlock
+from dimagi.utils.chunked import chunked
+
+from corehq.apps.hqcase.utils import submit_case_blocks
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.apps.locations.models import SQLLocation
+from custom.covid.management.commands.update_cases import CaseUpdateCommand
+
+BATCH_SIZE = 100
+DEVICE_ID = __name__ + ".update_owner_ids"
+CHILD_LOCATION_TYPE = 'investigators'
+
+
+class Command(CaseUpdateCommand):
+    help = f"Changes the owner_id of a case to the location_id of the child location with type " \
+           f"{CHILD_LOCATION_TYPE} of the current location"
+
+    def case_block(self, case, child_location):
+        return ElementTree.tostring(CaseBlock.deprecated_init(
+            create=False,
+            case_id=case.case_id,
+            owner_id=child_location.location_id,
+        ).as_xml()).decode('utf-8')
+
+    def update_cases(self, domain, case_type, user_id):
+        case_ids = self.find_case_ids_by_type(domain, case_type)
+        accessor = CaseAccessors(domain)
+
+        case_blocks = []
+        skip_count = 0
+        for case in accessor.iter_cases(case_ids):
+            owner_id = case.get_case_property('owner_id')
+            location_obj = SQLLocation.objects.get(location_id=owner_id)
+            if location_obj:
+                children = location_obj.get_children()
+                has_correct_child_location_type = False
+                for child_location in children:
+                    if child_location.location_type.name == CHILD_LOCATION_TYPE:
+                        case_blocks.append(self.case_block(case, child_location))
+                        has_correct_child_location_type = True
+                        break
+                if not has_correct_child_location_type:
+                    skip_count += 1
+            else:
+                skip_count += 1
+        print(f"{len(case_blocks)} to update in {domain}, {skip_count} cases have skipped due to unknown owner_id"
+              f" or has no child location of type {CHILD_LOCATION_TYPE}.")
+
+        total = 0
+        for chunk in chunked(case_blocks, BATCH_SIZE):
+            submit_case_blocks(chunk, domain, device_id=DEVICE_ID, user_id=user_id)
+            total += len(chunk)
+            print("Updated {} cases on domain {}".format(total, domain))


### PR DESCRIPTION
## Summary
For these two tickets [here](https://dimagi-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=162&modal=detail&selectedIssue=USH-590&assignee=5f314baf6db35e0039014d73) and [here](https://dimagi-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=162&modal=detail&selectedIssue=USH-591&assignee=5f314baf6db35e0039014d73). the only difference is `case_type` which is handled by the parameters.

## Product Description
From the spec, the script needs to:
- Look up current owner_id of the investigation case
- Find the location of type "investigators" that is a child of that location
- Change the owner_id to this location_id

It does not check the `location_type` of the location found in the owner_id, but if you read the spec and that feels like a requirement let me know. 

## Safety Assurance

- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
Test added in test_management_commands.py

### QA Plan
I am not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
