### PR TITLE
put sum when behind ff like sum when template

### DIFF
--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -1466,8 +1466,7 @@ Here's an example using ``age_in_months_buckets``:
 SumWhenColumn and SumWhenTemplateColumn
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Note: ``SumWhenColumn`` usage is limited to static reports, and ``SumWhenTemplateColumn``
-usage is behind a feature flag.
+Note: ``SumWhenColumn`` and ``SumWhenTemplateColumn`` usage is behind a feature flag.
 
 Sum When columns allow you to aggregate data based on arbitrary conditions.
 

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -377,19 +377,15 @@ class SumWhenColumn(_CaseExpressionColumn):
     @classmethod
     def restricted_to_static(cls, domain):
         # The conditional expressions used here don't have sufficient safety checks,
-        # so this column type is only available for static reports.  To release this,
+        # so this column type is behind feature flag. To release this,
         # we should require that conditions be expressed using a PreFilterValue type
         # syntax, as attempted in commit 02833e28b7aaf5e0a71741244841ad9910ffb1e5
-        return True
+        return not UCR_SUM_WHEN_TEMPLATES.enabled(domain)
 
 
 class SumWhenTemplateColumn(SumWhenColumn):
     type = TypeProperty("sum_when_template")
     whens = ListProperty(DictProperty)      # List of SumWhenTemplateSpec dicts
-
-    @classmethod
-    def restricted_to_static(cls, domain):
-        return not UCR_SUM_WHEN_TEMPLATES.enabled(domain)
 
     def get_whens(self):
         from corehq.apps.userreports.reports.factory import SumWhenTemplateFactory

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -690,6 +690,8 @@ UCR_SUM_WHEN_TEMPLATES = StaticToggle(
     [NAMESPACE_DOMAIN],
     description=(
         "Enables use of SumWhenTemplateColumn with custom expressions in dynamic UCRS."
+        "Feature still being fine tuned so should be used cautiously. "
+        "Do not enable if you don't fully understand the use and impact of it."
     ),
     help_link='https://commcare-hq.readthedocs.io/ucr.html#sumwhencolumn-and-sumwhentemplatecolumn',
 )


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Make `Sum When` available on HQ behind a feature flag for development purposes instead of just static reports. 
Using the same feature flag that gives access to `Sum when template`

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`UCR_SUM_WHEN_TEMPLATES`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Users can now use [sum when](https://commcare-hq.readthedocs.io/ucr.html?highlight=ucr#sumwhencolumn-and-sumwhentemplatecolumn) columns on HQ Configurable reports UI, just like sum when template columns.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
No domain has this feature flag enabled on prod. It was only used by icds domains on India. So there should be no behavior change for any project outside the ones enabled.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
