### PR TITLE
Set default filter for "Remote API Logs" page

### DIFF
--- a/corehq/motech/templates/motech/logs.html
+++ b/corehq/motech/templates/motech/logs.html
@@ -8,7 +8,7 @@
     <div class="form-group">
       <form method="GET">
         <span class="col-sm-2">
-          <label for="filter_from_date">From date</label>
+          <label for="filter_from_date">From date*</label>
           <input class="form-control"
                  type="text"
                  name="filter_from_date"

--- a/corehq/motech/templates/motech/logs.html
+++ b/corehq/motech/templates/motech/logs.html
@@ -97,11 +97,11 @@
     <div class="col-sm-10">
       <span>
           {% if page_obj.has_previous %}
-            [<a href="?page={{ page_obj.previous_page_number }}">Previous</a>]
+            [<a href="?{% url_replace 'page' page_obj.previous_page_number %}">Previous</a>]
           {% endif %}
         <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
         {% if page_obj.has_next %}
-          [<a href="?page={{ page_obj.next_page_number }}">Next</a>]
+          [<a href="?{% url_replace 'page' page_obj.next_page_number %}">Next</a>]
         {% endif %}
       </span>
     </div>

--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime, timedelta
 
 from django.http import Http404, JsonResponse
 from django.urls import reverse
@@ -40,15 +41,16 @@ class MotechLogListView(BaseProjectSettingsView, ListView):
     paginate_by = 100
 
     def get_queryset(self):
-        filter_from_date = self.request.GET.get("filter_from_date")
+        filter_from_date = self.request.GET.get("filter_from_date",
+                                                _a_week_ago())
         filter_to_date = self.request.GET.get("filter_to_date")
         filter_payload = self.request.GET.get("filter_payload")
         filter_url = self.request.GET.get("filter_url")
         filter_status = self.request.GET.get("filter_status")
 
-        queryset = RequestLog.objects.filter(domain=self.domain)
-        if filter_from_date:
-            queryset = queryset.filter(timestamp__gte=filter_from_date)
+        queryset = (RequestLog.objects
+                    .filter(domain=self.domain)
+                    .filter(timestamp__gte=filter_from_date))
         if filter_to_date:
             queryset = queryset.filter(timestamp__lte=filter_to_date)
         if filter_payload:
@@ -79,7 +81,8 @@ class MotechLogListView(BaseProjectSettingsView, ListView):
     def get_context_data(self, **kwargs):
         context = super(MotechLogListView, self).get_context_data(**kwargs)
         context.update({
-            "filter_from_date": self.request.GET.get("filter_from_date", ""),
+            "filter_from_date": self.request.GET.get("filter_from_date",
+                                                     _a_week_ago()),
             "filter_to_date": self.request.GET.get("filter_to_date", ""),
             "filter_payload": self.request.GET.get("filter_payload", ""),
             "filter_url": self.request.GET.get("filter_url", ""),
@@ -283,3 +286,8 @@ def test_connection_settings(request, domain):
                 "success": False,
                 "response": "Try saving the connection first"
             })
+
+
+def _a_week_ago() -> str:
+    last_week = datetime.today() - timedelta(days=7)
+    return last_week.strftime('%Y-%m-%d')


### PR DESCRIPTION
## Summary

Jira: [SC-1198](https://dimagi-dev.atlassian.net/browse/SC-1198)


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below


### Safety story

Fixes a broken page by setting a default value for an existing filter.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
