### PR TITLE
query synclogs to get list of users for formplayer sync prime

### DIFF
--- a/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
+++ b/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
@@ -88,9 +88,12 @@ class Command(BaseCommand):
         results = []
         with futures.ThreadPoolExecutor(max_workers=pool_size) as executor:
             for user in users:
-                executor.submit(process_row, user, validate, dry_run)
+                results.append(executor.submit(process_row, user, validate, dry_run))
 
             futures.wait(results)
+
+        if not results:
+            print("\nNo users processed")
 
 
 def process_row(row, validate, dry_run):

--- a/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
+++ b/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
@@ -91,7 +91,7 @@ class Command(BaseCommand):
 
         results = []
         with futures.ThreadPoolExecutor(max_workers=pool_size) as executor:
-            sys.stderr.write(f"Spawning tasks\n")
+            sys.stderr.write("Spawning tasks\n")
             for user in users:
                 results.append(executor.submit(process_row, user, validate, dry_run))
 
@@ -100,6 +100,7 @@ class Command(BaseCommand):
 
         if not results:
             sys.stderr.write("\nNo users processed")
+
 
 def process_row(row, validate, dry_run):
     def _log_message(msg, is_error=True):
@@ -134,6 +135,7 @@ def process_row(row, validate, dry_run):
     except Exception as e:
         _log_message(f"{e}")
 
+
 def _get_users_from_csv(path):
     with open(path, 'r') as file:
         reader = csv.reader(file)
@@ -141,6 +143,7 @@ def _get_users_from_csv(path):
         for row in reader:
             if row != ["domain", "username", "as_user"]:  # skip header
                 yield row
+
 
 def _get_user_db_query(domains, date_cutoff, min_cases, limit):
     query = SyncLogSQL.objects.values(
@@ -157,6 +160,7 @@ def _get_user_db_query(domains, date_cutoff, min_cases, limit):
         query = query[:limit]
 
     return query
+
 
 def _get_users_from_db(domains, last_synced_days, min_cases, limit):
     query = _get_user_db_query(domains, last_synced_days, min_cases, limit)

--- a/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
+++ b/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
@@ -179,7 +179,7 @@ def _get_users_from_db(domains, last_synced_days, min_cases, limit):
         request_user = CouchUser.get_by_user_id(row["request_user_id"]).username
 
         as_username = None
-        if row["user_id"] == row["request_user_id"]:
+        if row["user_id"] != row["request_user_id"]:
             as_user = CouchUser.get_by_user_id(row["user_id"])
             as_username = raw_username(as_user.username) if as_user else None
 

--- a/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
+++ b/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
@@ -144,8 +144,14 @@ def _get_users_from_csv(path):
         reader = csv.reader(file)
 
         for row in reader:
-            if row != ["domain", "username", "as_user"]:  # skip header
-                yield row
+            if not row or row == ["domain", "username", "as_user"]:  # skip header
+                continue
+
+            if len(row) != 3:
+                _log_message(row, "Expected exactly 3 values in each row", True)
+                continue
+
+            yield row
 
 
 def _get_user_db_query(domains, date_cutoff, min_cases, limit):

--- a/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
+++ b/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
@@ -148,13 +148,15 @@ def _get_users_from_csv(path):
 def _get_user_db_query(domains, date_cutoff, min_cases, limit):
     query = SyncLogSQL.objects.values(
         "domain", "user_id", "request_user_id"
-    ).filter(date__gt=date_cutoff, is_formplayer=True).order_by("date")
+    ).filter(date__gt=date_cutoff, is_formplayer=True)
 
     if domains:
         query = query.filter(domain__in=domains)
 
     if min_cases:
         query = query.filter(case_count__gte=min_cases)
+
+    query = query.distinct()
 
     if limit:
         query = query[:limit]

--- a/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
+++ b/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
@@ -1,55 +1,165 @@
 import csv
+import inspect
 import sys
+from argparse import RawTextHelpFormatter
 from concurrent import futures
+from datetime import datetime
 
+from dateutil.relativedelta import relativedelta
 from django.core.management.base import BaseCommand
 
+from casexml.apps.phone.models import SyncLogSQL
+from corehq.apps.formplayer_api.exceptions import FormplayerResponseException
 from corehq.apps.formplayer_api.sync_db import sync_db
 from corehq.apps.users.models import CouchUser
-from corehq.apps.users.util import format_username
+from corehq.apps.users.util import format_username, raw_username
+from corehq.util.argparse_types import validate_integer
 
 
 class Command(BaseCommand):
-    help = "Call the Formplayer API for each user in passed in CSV to force a sync."
+    help = inspect.cleandoc(
+        """Call the Formplayer sync API for users from CSV or matching criteria.
+        Usage:
+        
+        ### With users in a CSV file ###
+        
+        CSV Columns: "domain, username, as_user"
+        
+        %(prog)s --from-csv path/to/users.csv
+        
+        ### Query DB for users ###
+        
+        %(prog)s --domains a b c --last-synced-days 2 --min-cases 500 --limit 1000
+        
+        Use "--dry-run" and "--dry-run-count" to gauge impact of command.
+        """
+    )
+
+    def create_parser(self, *args, **kwargs):
+        # required to get nice output from `--help`
+        parser = super(Command, self).create_parser(*args, **kwargs)
+        parser.formatter_class = RawTextHelpFormatter
+        return parser
 
     def add_arguments(self, parser):
-        parser.add_argument('path', help='Path to CSV file. Columns "domain, username, as_user"')
-        parser.add_argument('-t', '--threads', type=int, default=10, help='Number of threads to use.')
+        parser.add_argument('--from-csv',
+                            help='Path to CSV file. Columns "domain, username, as_user". When this is supplied '
+                                 'only users in this file will be synced.')
 
-    def handle(self, path, **options):
+        parser.add_argument('--domains', nargs='*', help='Match users in these domains.')
+        parser.add_argument('--last-synced-days', action=validate_integer(gt=0, lt=31), default=1,
+                            help='Match users who have synced within the given window. '
+                                 'Defaults to 1 day ago. Max = 30.')
+        parser.add_argument('--min-cases', action=validate_integer(gt=0),
+                            help='Match users with this many cases or more.')
+
+        parser.add_argument('--limit', action=validate_integer(gt=0), help='Limit the number of users matched.')
+        parser.add_argument('-t', '--threads', action=validate_integer(gt=0), default=10,
+                            help='Number of threads to use.')
+        parser.add_argument('--dry-run', action='store_true', help='Only print the list of users.')
+        parser.add_argument('--dry-run-count', action='store_true', help='Only print the count of matched users.')
+
+    def handle(self, from_csv=None, domains=None, last_synced_days=None, min_cases=None, limit=None, **options):
         pool_size = options['threads']
-        with open(path, 'r') as file:
-            reader = csv.reader(file)
+        dry_run = options['dry_run']
+        dry_run_count = options['dry_run_count']
 
-            results = []
-            with futures.ThreadPoolExecutor(max_workers=pool_size) as executor:
-                row = next(reader)
-                if row[0] != "domain":  # skip header
-                    executor.submit(process_row, row)
+        validate = True
+        if from_csv:
+            users = _get_users_from_csv(from_csv)
+            if dry_run_count:
+                print(f"\n{len(list(users))} users in CSV file '{from_csv}'")
+                return
+        else:
+            domains = [domain.strip() for domain in domains if domain.strip()] if domains else None
+            date_cutoff = datetime.utcnow().date() - relativedelta(days=last_synced_days)
+            if dry_run_count:
+                query = _get_user_db_query(domains, date_cutoff, min_cases, limit)
+                print(f"\nMatched {query.count()} users for filters:")
+                print(f"\tDomains: {domains or '---'}")
+                print(f"\tSynced after: {date_cutoff}")
+                print(f"\tMin cases: {min_cases or '---'}")
+                print(f"\tLimit: {limit or '---'}")
+                return
 
-                for row in reader:
-                    executor.submit(process_row, row)
+            users = _get_users_from_db(domains, date_cutoff, min_cases, limit)
+            validate = False
 
-                futures.wait(results)
+        results = []
+        with futures.ThreadPoolExecutor(max_workers=pool_size) as executor:
+            for user in users:
+                executor.submit(process_row, user, validate, dry_run)
+
+            futures.wait(results)
 
 
-def process_row(row):
+def process_row(row, validate, dry_run):
+    def _log_message(msg):
+        row_csv = ','.join(row)
+        sys.stderr.write(f'{row_csv},"{msg}"\n')
+
     domain, username, as_user = row
-    user = CouchUser.get_by_username(username)
-    if not user:
-        sys.stderr.write(f"Row failure: unknown username: {','.join(row)}\n")
+    if validate:
+        user = CouchUser.get_by_username(username)
+        if not user:
+            _log_message("ERROR: unknown username")
+            return
+
+        if as_user:
+            as_username = format_username(as_user, domain) if '@' not in as_user else as_user
+            restore_as_user = CouchUser.get_by_username(as_username)
+            if not restore_as_user:
+                _log_message("ERROR: unknown as_user")
+
+            if domain != restore_as_user.domain:
+                _log_message("ERROR: domain mismatch with as_user")
+
+    if dry_run:
+        _log_message("dry run success")
         return
 
-    if as_user:
-        as_username = format_username(as_user, domain) if '@' not in as_user else as_user
-        restore_as_user = CouchUser.get_by_username(as_username)
-        if not restore_as_user:
-            sys.stderr.write(f"Row failure: unknown as_user: {','.join(row)}\n")
-
-        if domain != restore_as_user.domain:
-            sys.stderr.write(f"Row failure: domain mismatch with as_user: {','.join(row)}\n")
-
     try:
-        sync_db(domain, user.username, as_user or None)
+        sync_db(domain, username, as_user or None)
+    except FormplayerResponseException as e:
+        _log_message(f"ERROR: {e.response_json['exception']}")
     except Exception as e:
-        sys.stderr.write(f"Row failure: {e}: {','.join(row)}\n")
+        _log_message(f"ERROR: {e}")
+
+
+def _get_users_from_csv(path):
+    with open(path, 'r') as file:
+        reader = csv.reader(file)
+
+        for row in reader:
+            if row != ["domain", "username", "as_user"]:  # skip header
+                yield row
+
+
+def _get_user_db_query(domains, date_cutoff, min_cases, limit):
+    query = SyncLogSQL.objects.values(
+        "domain", "user_id", "request_user_id"
+    ).filter(date__gt=date_cutoff, is_formplayer=True).order_by("date")
+
+    if domains:
+        query = query.filter(domain__in=domains)
+
+    if min_cases:
+        query = query.filter(case_count__gte=min_cases)
+
+    if limit:
+        query = query[:limit]
+
+    return query
+
+
+def _get_users_from_db(domains, last_synced_days, min_cases, limit):
+    query = _get_user_db_query(domains, last_synced_days, min_cases, limit)
+    for row in query.iterator():
+        request_user = CouchUser.get_by_user_id(row["request_user_id"]).username
+
+        as_username = None
+        if row["user_id"] == row["request_user_id"]:
+            as_user = CouchUser.get_by_user_id(row["user_id"])
+            as_username = raw_username(as_user.username) if as_user else None
+
+        yield row["domain"], request_user, as_username

--- a/corehq/util/argparse_types.py
+++ b/corehq/util/argparse_types.py
@@ -20,3 +20,27 @@ def date_type(value):
             "Invalid date specified: '%s'. "
             "Expected date in the format: YYYY-MM-DD" % value
         )
+
+
+def validate_integer(gt=None, lt=None):
+    """Return argparser action to validate integer inputs:
+
+    parser.add_argument('--count', action=validate_integer(gt=0, lt=11), help="Integer between 1 and 10")
+    """
+
+    class ValidateIntegerRange(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            try:
+                values = int(values)
+            except ValueError:
+                raise argparse.ArgumentError(self, f"Invalid integer: {values}")
+
+            if gt is not None and gt >= values:
+                raise argparse.ArgumentError(self, f"Must be greater than {gt}")
+
+            if lt is not None and lt <= values:
+                raise argparse.ArgumentError(self, f"Must be less than than {lt}")
+
+            setattr(namespace, self.dest, values)
+
+    return ValidateIntegerRange


### PR DESCRIPTION
## Summary
Building on https://github.com/dimagi/commcare-hq/pull/29006 this updates the `prime_formplayer_restores` management command to allow querying the DB to get the list of users.

Supported filters:
* domain
* synced withing X days
* minimum case load

Also supports dry run to allow validating users / checking matched user count prior to run.

## Safety Assurance
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x I am certain that this PR will not introduce a regression for the reasons below

### QA Plan
QA will be done by using `dry-run` to check user list.

### Safety story
Changes restricted to management command.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
