### PR TITLE
prune synclogs for formplayer users

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -382,6 +382,12 @@ def delete_synclogs(current_synclog):
             app_id=current_synclog.app_id,
             date__lt=current_synclog.date
         ).delete()
+    elif current_synclog.user_id and current_synclog.is_formplayer:
+        SyncLogSQL.objects.filter(
+            user_id=current_synclog.user_id,
+            device_id=current_synclog.device_id,
+            date__lt=current_synclog.date,
+        ).delete()
     elif current_synclog.previous_log_id:
         SyncLogSQL.objects.filter(synclog_id=current_synclog.previous_log_id).delete()
 
@@ -412,9 +418,7 @@ def synclog_to_sql_object(synclog_json_object):
             had_state_error=synclog_json_object.had_state_error,
             error_date=synclog_json_object.error_date,
             error_hash=synclog_json_object.error_hash,
-            is_formplayer=(
-                synclog_json_object.device_id and synclog_json_object.device_id.startswith("WebAppsLogin")
-            ),
+            is_formplayer=synclog_json_object.is_formplayer,
             case_count=synclog_json_object.case_count(),
             request_user_id=synclog_json_object.request_user_id,
         )
@@ -616,6 +620,10 @@ class SimplifiedSyncLog(AbstractSyncLog):
         if self._purged_cases is None:
             self._purged_cases = set()
         return self._purged_cases
+
+    @property
+    def is_formplayer(self):
+        return self.device_id and self.device_id.startswith("WebAppsLogin")
 
     def case_count(self):
         return len(self.case_ids_on_phone)


### PR DESCRIPTION
## Summary
Additionaly synclog pruning for formplayer syncs.

Matching is done on `device_id` to ensure we differentiate between syncs directly from the user vs syncs 'as' the user.

Note that this won't make a big impact on disk size without vacuuming or a tool like pg_repack.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
Updated to include test case.

### Safety story
Extension of existing functionality. 

### Rollback instructions
- [X] This PR can be reverted after deploy with no further considerations 
