### PR TITLE
Add Enterprise SSO feature flag

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1960,6 +1960,13 @@ DEFAULT_EXPORT_SETTINGS = StaticToggle(
     """
 )
 
+ENTERPRISE_SSO = StaticToggle(
+    'enterprise_sso',
+    'Enable Enterprise SSO options for the users specified in this list.',
+    TAG_PRODUCT,
+    namespaces=[NAMESPACE_USER],
+)
+
 BLOCKED_EMAIL_DOMAIN_RECIPIENTS = StaticToggle(
     'blocked_email_domain_recipients',
     'Block any outgoing email addresses that have an email domain which '


### PR DESCRIPTION
## Summary
This adds an enterprise sso feature flag that can be enabled for specific users.

## Feature Flag
Introduces a new feature flag `ENTERPRISE_SSO`

## Product Description
This is just a feature flag

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### QA Plan
No QA needed.

### Safety story
Just a feature flag. Nothing else.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
