### PR TITLE
🐞 Fix pagination of ConnectionSettings

### DIFF
--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -153,7 +153,8 @@ class ConnectionSettingsListView(BaseProjectSettingsView, CRUDPaginatedViewMixin
 
     @property
     def paginated_list(self):
-        for connection_settings in self.base_query.all():
+        start, end = self.skip, self.skip + self.limit
+        for connection_settings in self.base_query.all()[start:end]:
             yield {
                 "itemData": self._get_item_data(connection_settings),
                 "template": "connection-settings-template",


### PR DESCRIPTION
## Summary

Small. Does what it says on the label.


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below


### Safety story

* Two-line change to set a range on a queryset.
* [Identical code used elsewhere](https://github.com/dimagi/commcare-hq/blob/500f9a5c8f2d748589f22845183b330ec2b13a34/corehq/motech/dhis2/views.py#L59-L60).
* Tested locally.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
