### PR TITLE
Switched a few text inputs for textareas

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -18,7 +18,12 @@
       </td>
       {% if js_options.default_value_expression_enabled %}
         <td class="col-sm-3">
-          <input class="form-control" type="text" data-bind="value: property.defaultValue"/>
+          <textarea
+            class="form-control vertical-resize"
+            rows="1"
+            data-bind="value: property.defaultValue"
+            spellcheck="false"
+          ></textarea>
         </td>
       {% endif %}
       {% if js_options.search_prompt_appearance_enabled %}
@@ -172,12 +177,12 @@
               <input class="form-control" type="text" data-bind="value: property"/>
             </td>
             <td class="col-sm-6">
-              <input
-                class="form-control"
-                type="text"
+              <textarea
+                class="form-control vertical-resize"
+                rows="1"
                 data-bind="value: defaultValue"
                 spellcheck="false"
-              />
+              ></textarea>
             </td>
             <td class="col-sm-2">
               <i style="cursor: pointer;" class="fa fa-remove"


### PR DESCRIPTION
## Summary
Anywhere you can enter an xpath expression, someone is going to need a multi-line monstrosity. Switch these two expression inputs to textareas:

![Screen Shot 2021-01-26 at 10 33 11 AM](https://user-images.githubusercontent.com/1486591/105866865-6f44b500-5fc2-11eb-8a8d-c55e19a9eeeb.png)

## Feature Flag
Case search & claim

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

Not requesting QA. Minor template change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
