### PR TITLE
pop last selection on error

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -4,6 +4,7 @@
 
 hqDefine("cloudcare/js/formplayer/menus/api", function () {
     var FormplayerFrontend = hqImport("cloudcare/js/formplayer/app");
+    var Util = hqImport("cloudcare/js/formplayer/utils/util");
 
     var API = {
         queryFormplayer: function (params, route) {
@@ -83,6 +84,11 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
                                 gettext('Unable to connect to form playing service. ' +
                                         'Please report an issue if you continue to see this message.')
                             );
+                        }
+                        var urlObject = Util.currentUrlToObject();
+                        if (urlObject.steps) {
+                            urlObject.steps.pop();
+                            Util.setUrlToObject(urlObject);
                         }
                         defer.reject();
                     },


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-272
When menu navigation errors, and the page does not actually change, the previous selection is preserved in the set of steps. This causes them to be included in subsequent requests, which can lead to unexpected behavior (the first failed request is for menu 1, the second is menu 2, but when it succeeds you select menu 1 and then the second element of that menu), and overflowed selection errors.

This PR removes the last selection when menu navigation returns an error, if a selection array exists (not when an app is selected from the home screen).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
I tested this locally.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
