### PR TITLE
Vectorlink reports

### DIFF
--- a/custom/abt/reports/late_pmt.py
+++ b/custom/abt/reports/late_pmt.py
@@ -93,7 +93,7 @@ class LatePMTUsers(SqlData):
 class LatePmtReport(GenericTabularReport, CustomProjectReport, DatespanMixin):
     report_title = "Late PMT"
     slug = 'late_pmt'
-    name = "Late PMT"
+    name = "Late PMT 2019"
 
     languages = (
         'en',

--- a/custom/abt/reports/late_pmt_2020.py
+++ b/custom/abt/reports/late_pmt_2020.py
@@ -27,7 +27,7 @@ INDICATORS_FORM_XMLNS = 'http://openrosa.org/formdesigner/00CEB41B-2967-4370-9EA
 class LatePmt2020Report(GenericTabularReport, CustomProjectReport, DatespanMixin):
     report_title = "Late PMT"
     slug = 'late_pmt_2020'
-    name = "Late PMT 2020"
+    name = "Late PMT"
 
     languages = (
         'en',

--- a/custom/abt/reports/supervisory_report_v2020.json
+++ b/custom/abt/reports/supervisory_report_v2020.json
@@ -66,10 +66,6 @@
             {
                 "field": "level_4",
                 "order": "ASC"
-            },
-            {
-                "field": "username",
-                "order": "ASC"
             }
         ],
         "filters": [
@@ -245,27 +241,6 @@
                     "sw": "Date and Time Submitted",
                     "kin": "Date and Time Submitted",
                     "por": "Data e Hora de Submiss\u00e3o"
-                },
-                "aggregation": "simple"
-            },
-            {
-                "description": null,
-                "field": "username",
-                "format": "default",
-                "transform": {
-
-                },
-                "column_id": "username",
-                "alias": null,
-                "calculate_total": false,
-                "type": "field",
-                "display": {
-                    "fra": "Nom d'utilisateur",
-                    "frm": "Nom d'utilisateur",
-                    "en": "Username",
-                    "sw": "Username",
-                    "kin": "Username",
-                    "por": "Utilizador"
                 },
                 "aggregation": "simple"
             },

--- a/custom/abt/reports/supervisory_report_v2020.json
+++ b/custom/abt/reports/supervisory_report_v2020.json
@@ -37,7 +37,7 @@
         "doc_type": "ReportConfiguration",
         "domain": "airs",
         "description": "",
-        "title": "Supervisory Report 2020",
+        "title": "Supervisory Report",
         "sort_expression": [
             {
                 "field": "form_name",


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
A few cosmetic changes to some custom reports:

https://dimagi-dev.atlassian.net/browse/SC-1199
https://dimagi-dev.atlassian.net/browse/SC-1201
https://dimagi-dev.atlassian.net/browse/SC-1202

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Assuming the reports all compile to valid JSON (which I believe has [test coverage](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/tests/test_static_reports.py#L55-L57)) the changes all feel very low risk, since it is just changing text and removing things.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
