### PR TITLE
Add link to refresh data dictionary

### DIFF
--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -97,6 +97,13 @@
           {% trans "Add Case Property Group" %}
         </button>
       </form>
+      <p class="text-muted" style="margin-top: .5rem;">
+        {% url 'generate_data_dictionary' domain as refresh_url %}
+        {% blocktrans %}
+        Missing properties or case types? <a href="{{ refresh_url }}" target="_blank">Click to sync</a>
+        (opens in a new tab, may be slow...)
+        {% endblocktrans %}
+      </p>
     </div>
   </div>
 {% endblock %}

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -97,7 +97,7 @@
           {% trans "Add Case Property Group" %}
         </button>
       </form>
-      <p class="text-muted" style="margin-top: .5rem;">
+      <p class="help-block">
         {% url 'generate_data_dictionary' domain as refresh_url %}
         {% blocktrans %}
         Missing properties or case types? <a href="{{ refresh_url }}" target="_blank">Click to sync</a>

--- a/corehq/apps/data_dictionary/urls.py
+++ b/corehq/apps/data_dictionary/urls.py
@@ -12,7 +12,7 @@ from corehq.apps.data_dictionary.views import (
 from corehq.apps.hqwebapp.decorators import waf_allow
 
 urlpatterns = [
-    url(r"^generate/$", generate_data_dictionary),
+    url(r"^generate/$", generate_data_dictionary, name='generate_data_dictionary'),
     url(r"^json/$", data_dictionary_json, name='data_dictionary_json'),
     url(r"^json/?(?P<case_type_name>\w+)/?$", data_dictionary_json, name='case_type_dictionary_json'),
     url(r"^update_case_property/$", update_case_property, name='update_case_property'),


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Struggled to figure this out today - turns out it's a magic link in confluence docs. Maybe easier if it were more discoverable?

![image](https://user-images.githubusercontent.com/66555/105987638-392d3100-60a7-11eb-9ee0-e770b830759d.png)

This PR just adds the grey text at the bottom of the screenshot.

I understand this could be a computationally expensive operation so may have intentionally been obfuscated. My thinking was that it might be ok since it's feature-flagged?

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

Data Dictionary

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
