### PR TITLE
Purge alternate device_id (due to recent formplayer change)

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -11,6 +11,7 @@ from django.db import models
 
 import architect
 import six
+from django.db.models import Q
 from memoized import memoized
 
 from casexml.apps.case import const
@@ -383,13 +384,31 @@ def delete_synclogs(current_synclog):
             date__lt=current_synclog.date
         ).delete()
     elif current_synclog.user_id and current_synclog.is_formplayer:
+        # see comment in get_alt_device_id about the purpose of this short-lived code
+        alt_device_id = get_alt_device_id(current_synclog.device_id)
         SyncLogSQL.objects.filter(
             user_id=current_synclog.user_id,
-            device_id=current_synclog.device_id,
             date__lt=current_synclog.date,
-        ).delete()
+        ).filter(Q(device_id=current_synclog.device_id) | Q(device_id=alt_device_id)).delete()
     elif current_synclog.previous_log_id:
         SyncLogSQL.objects.filter(synclog_id=current_synclog.previous_log_id).delete()
+
+
+def get_alt_device_id(device_id):
+    # this function and its usage can be deleted on or after March 31
+    # https://github.com/dimagi/formplayer/pull/808 changed the device_id format
+    # and this logic helps us purge both old and new format device_ids
+    try:
+        parts = device_id.split('*')
+        if len(parts) == 4:
+            return '*'.join([parts[0], parts[1].replace('.', '_'), parts[2], parts[3]])
+        else:
+            return device_id
+    # this is a short lived piece of code and an optimization
+    # and it's more important to us that it never causes an error
+    # than it is that it works
+    except Exception:
+        return device_id
 
 
 def synclog_to_sql_object(synclog_json_object):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_purge.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_purge.py
@@ -1,9 +1,11 @@
 import uuid
 
 from django.test import TestCase
+from testil import eq
 
 from casexml.apps.case.xml import V1
 from casexml.apps.phone.exceptions import MissingSyncLog
+from casexml.apps.phone.models import get_alt_device_id
 from casexml.apps.phone.tests.utils import create_restore_user
 from casexml.apps.phone.utils import MockDevice
 
@@ -101,3 +103,8 @@ class TestSyncPurge(TestCase):
         fourth_sync = device.sync()
         response = fourth_sync.config.get_response()
         self.assertEqual(response.status_code, 200)
+
+
+def test_get_alt_device_id():
+    eq(get_alt_device_id('WebAppsLogin*mr.snuggles@example.com*as*example.mr.snuggles'),
+                         'WebAppsLogin*mr_snuggles@example_com*as*example.mr.snuggles')


### PR DESCRIPTION
## Summary

This change is to make up for the change in device_id format from formplayer in
https://github.com/dimagi/formplayer/pull/808
and can be reverted on or after March 31 once synclogs have slid out of the 9 week window

This should (hopefully) make Simon's recent PR #29024 much more effective in purging historical syncs, something that will free up a lot of disk space (which we'll have to run pg_repack to realize).

## Feature Flag
None

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
