### PR TITLE
make combobox search case insensitive

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -629,6 +629,8 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         if (!query || !option.text) {
             return true;
         }
+        query = query.toLowerCase();
+        option.text = option.text.toLowerCase();
 
         var match;
         if (matchType === Const.COMBOBOX_MULTIWORD) {
@@ -645,8 +647,8 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         } else if (matchType === Const.COMBOBOX_FUZZY) {
             // Fuzzy filter, matches if query is "close" to answer
             match = (
-                (window.Levenshtein.get(option.text.toLowerCase(), query.toLowerCase()) <= 2 && query.length > 3) ||
-                option.text.toLowerCase() === query.toLowerCase()
+                (window.Levenshtein.get(option.text, query) <= 2 && query.length > 3) ||
+                option.text === query
             );
         }
 
@@ -656,7 +658,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         }
 
         // Standard filter, matches only start of word
-        return option.text.toLowerCase().startsWith(query.toLowerCase());
+        return option.text.startsWith(query);
     };
 
     ComboboxEntry.prototype = Object.create(DropdownEntry.prototype);


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Two of the three methods already were case insensitive. Consistency is good.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
