### PR TITLE
tar is more strict about paths on Linux than MacOS

### DIFF
--- a/scripts/vellum-to-hq
+++ b/scripts/vellum-to-hq
@@ -228,7 +228,7 @@ def require_clean_working_tree(git, context="", abort=sys.exit):
 
 def get_version(vellum_tar):
     try:
-        return sh.tar("xOf", vellum_tar, "version.txt").strip()
+        return sh.tar("xOf", vellum_tar, "./version.txt").strip()
     except sh.ErrorReturnCode:
         return ""
 

--- a/scripts/vellum-to-hq
+++ b/scripts/vellum-to-hq
@@ -15,7 +15,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
-import re
 import subprocess
 import sys
 from argparse import ArgumentParser, RawDescriptionHelpFormatter


### PR DESCRIPTION
Tiny tweaks to vellum-to-hq script.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below
- [x] This PR can be reverted after deploy with no further considerations 
