### PR TITLE
Only delete up to 1000 formplayer synclogs at a time

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -389,7 +389,7 @@ def delete_synclogs(current_synclog):
         SyncLogSQL.objects.filter(
             user_id=current_synclog.user_id,
             date__lt=current_synclog.date,
-        ).filter(Q(device_id=current_synclog.device_id) | Q(device_id=alt_device_id)).delete()
+        ).filter(Q(device_id=current_synclog.device_id) | Q(device_id=alt_device_id))[:1000].delete()
     elif current_synclog.previous_log_id:
         SyncLogSQL.objects.filter(synclog_id=current_synclog.previous_log_id).delete()
 


### PR DESCRIPTION
## Summary

Followup to #29043 that makes it only delete 1000 at a time to prevent initial stampede and poor performance. I'm not sure if this is a necessary precaution or if deleting 5,000-10,000 rows (and the related indices) in a single query is sufficiently fast.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
