### PR TITLE
rate limit ajax requests from multi-option filters

### DIFF
--- a/corehq/apps/reports/static/reports/js/filters/select2s.js
+++ b/corehq/apps/reports/static/reports/js/filters/select2s.js
@@ -100,6 +100,7 @@ hqDefine("reports/js/filters/select2s", [
             ajax: {
                 url: data.endpoint,
                 dataType: 'json',
+                delay: 250,
                 data: function (params) {
                     return {
                         q: params.term,

--- a/corehq/apps/reports/static/reports/js/filters/select2s.js
+++ b/corehq/apps/reports/static/reports/js/filters/select2s.js
@@ -100,7 +100,7 @@ hqDefine("reports/js/filters/select2s", [
             ajax: {
                 url: data.endpoint,
                 dataType: 'json',
-                delay: 250,
+                delay: 500,
                 data: function (params) {
                     return {
                         q: params.term,


### PR DESCRIPTION
## Summary
While debugging this: https://dimagi-dev.atlassian.net/browse/SAAS-11795 I noticed that the EMWF filter issues ajax requests for every change in the filter input. This PR adds rate limiting to those requests as described by https://select2.org/data-sources/ajax#rate-limiting-requests.

This same mechanism is already in use in other select2 inputs elsewhere in the codebase.

## Safety Assurance
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Safety story
Exactly the same thing is already in use in other places in HQ.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
