### PR TITLE
Redo "Purge alternate device_id (due to recent formplayer change)" with random toggle

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -11,6 +11,7 @@ from django.db import models
 
 import architect
 import six
+from django.db.models import Q
 from memoized import memoized
 
 from casexml.apps.case import const
@@ -383,13 +384,31 @@ def delete_synclogs(current_synclog):
             date__lt=current_synclog.date
         ).delete()
     elif current_synclog.user_id and current_synclog.is_formplayer:
+        # see comment in get_alt_device_id about the purpose of this short-lived code
+        alt_device_id = get_alt_device_id(current_synclog.device_id)
         SyncLogSQL.objects.filter(
             user_id=current_synclog.user_id,
-            device_id=current_synclog.device_id,
             date__lt=current_synclog.date,
-        ).delete()
+        ).filter(Q(device_id=current_synclog.device_id) | Q(device_id=alt_device_id)).delete()
     elif current_synclog.previous_log_id:
         SyncLogSQL.objects.filter(synclog_id=current_synclog.previous_log_id).delete()
+
+
+def get_alt_device_id(device_id):
+    # this function and its usage can be deleted on or after March 31
+    # https://github.com/dimagi/formplayer/pull/808 changed the device_id format
+    # and this logic helps us purge both old and new format device_ids
+    try:
+        parts = device_id.split('*')
+        if len(parts) == 4:
+            return '*'.join([parts[0], parts[1].replace('.', '_'), parts[2], parts[3]])
+        else:
+            return device_id
+    # this is a short lived piece of code and an optimization
+    # and it's more important to us that it never causes an error
+    # than it is that it works
+    except Exception:
+        return device_id
 
 
 def synclog_to_sql_object(synclog_json_object):

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -42,7 +42,7 @@ from dimagi.utils.couch import LooselyEqualDocumentSchema
 from dimagi.utils.logging import notify_exception
 
 from corehq.apps.domain.models import Domain
-from corehq.toggles import ENABLE_LOADTEST_USERS, LEGACY_SYNC_SUPPORT
+from corehq.toggles import ENABLE_LOADTEST_USERS, LEGACY_SYNC_SUPPORT, NAMESPACE_OTHER
 from corehq.util.global_request import get_request_domain
 from corehq.util.soft_assert import soft_assert
 
@@ -390,7 +390,7 @@ def delete_synclogs(current_synclog):
             date__lt=current_synclog.date,
         )
         device_id_filter = Q(device_id=current_synclog.device_id)
-        if toggles.CLEAN_OLD_FORMPLAYER_SYNCS.enabled(current_synclog.user_id):
+        if toggles.CLEAN_OLD_FORMPLAYER_SYNCS.enabled(current_synclog.user_id, NAMESPACE_OTHER):
             # see comment in get_alt_device_id about the purpose of this short-lived code
             alt_device_id = get_alt_device_id(current_synclog.device_id)
             device_id_filter = device_id_filter | Q(device_id=alt_device_id)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_purge.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_purge.py
@@ -1,9 +1,11 @@
 import uuid
 
 from django.test import TestCase
+from testil import eq
 
 from casexml.apps.case.xml import V1
 from casexml.apps.phone.exceptions import MissingSyncLog
+from casexml.apps.phone.models import get_alt_device_id
 from casexml.apps.phone.tests.utils import create_restore_user
 from casexml.apps.phone.utils import MockDevice
 
@@ -101,3 +103,8 @@ class TestSyncPurge(TestCase):
         fourth_sync = device.sync()
         response = fourth_sync.config.get_response()
         self.assertEqual(response.status_code, 200)
+
+
+def test_get_alt_device_id():
+    eq(get_alt_device_id('WebAppsLogin*mr.snuggles@example.com*as*example.mr.snuggles'),
+                         'WebAppsLogin*mr_snuggles@example_com*as*example.mr.snuggles')

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1992,3 +1992,11 @@ BLOCKED_DOMAIN_EMAIL_SENDERS = StaticToggle(
     TAG_INTERNAL,
     namespaces=[NAMESPACE_DOMAIN],
 )
+
+CLEAN_OLD_FORMPLAYER_SYNCS = DynamicallyPredictablyRandomToggle(
+    'clean_old_formplayer_syncs',
+    'Delete old formplayer syncs during submission processing',
+    TAG_INTERNAL,
+    namespaces=[NAMESPACE_OTHER],
+    default_randomness=0.001
+)


### PR DESCRIPTION
Redo of https://github.com/dimagi/commcare-hq/pull/29043 that adds a random toggle to allow a more controlled rollout

https://dimagi-dev.atlassian.net/browse/SAAS-11766

Below content copied from #29043
## Summary

This change is to make up for the change in device_id format from formplayer in
https://github.com/dimagi/formplayer/pull/808
and can be reverted on or after March 31 once synclogs have slid out of the 9 week window

This should (hopefully) make Simon's recent PR #29024 much more effective in purging historical syncs, something that will free up a lot of disk space (which we'll have to run pg_repack to realize).

## Feature Flag
`CLEAN_OLD_FORMPLAYER_SYNCS`

## Product Description
No visible changes. Deletes a lot of unused "synclogs" and will cause each user to go through one slower restore over the course of a slow incremental rollout that we can control. We've estimated how slow, and for .01% of users it will be more than 1m but less than 2m. For 99% of users it will be under 20s. For 90% of users it will at 5s. (We got this from pulling data on extraneous rows per user, and an empirical calculation of how long the delete query takes to run for various numbers of rows to delete.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

There's a test `test_prune_formplayer_synclogs` that covers this code and indeed caught a simple usage error that broke the build and has since been fixed.

### QA Plan

No formal QA because the issue isn't whether it works in vacuum, it's how it handles production traffic. For that we have a the "predictably random toggle" that will apply the change to 1 in 1000 to begin with and we can notch it up slowly from there, and notch it down if we go too fast.

### Safety story

This will be deployed on staging and india before production, and a basic formplayer sync will be tested with the toggle set to 0 (0%) and then again with the toggle set to 1 (100%), just to make sure it doesn't break in some obvious way.

### Rollback instructions

To "roll back" the feature, you can set the `CLEAN_OLD_FORMPLAYER_SYNCS` toggle's factor to 0. If that doesn't work for any reason then yes this PR can be reverted.

- [x] This PR can be reverted after deploy with no further considerations 