### PR TITLE
Remove is_active filter while fetching users form es

### DIFF
--- a/corehq/apps/users/dbaccessors/all_commcare_users.py
+++ b/corehq/apps/users/dbaccessors/all_commcare_users.py
@@ -56,7 +56,7 @@ def get_commcare_users_by_filters(domain, user_filters, count_only=False):
                 user_filters.get('location_id', None), count_only]):
         return get_all_commcare_users_by_domain(domain)
 
-    query = _get_es_query(domain, user_filters)
+    query = _get_es_query(domain, user_filters).remove_default_filter('active')
 
     if count_only:
         return query.count()

--- a/corehq/apps/users/dbaccessors/all_commcare_users.py
+++ b/corehq/apps/users/dbaccessors/all_commcare_users.py
@@ -18,7 +18,7 @@ def get_all_commcare_users_by_domain(domain):
 
 
 def get_mobile_usernames_by_filters(domain, user_filters):
-    query = _get_es_query(domain, user_filters).remove_default_filter('active')
+    query = _get_es_query(domain, user_filters)
     return query.values_list('base_username', flat=True)
 
 
@@ -27,7 +27,7 @@ def _get_es_query(domain, user_filters):
     search_string = user_filters.get('search_string', None)
     location_id = user_filters.get('location_id', None)
 
-    query = UserES().domain(domain).mobile_users()
+    query = UserES().domain(domain).mobile_users().remove_default_filter('active')
 
     if role_id:
         query = query.role_id(role_id)
@@ -56,7 +56,7 @@ def get_commcare_users_by_filters(domain, user_filters, count_only=False):
                 user_filters.get('location_id', None), count_only]):
         return get_all_commcare_users_by_domain(domain)
 
-    query = _get_es_query(domain, user_filters).remove_default_filter('active')
+    query = _get_es_query(domain, user_filters)
 
     if count_only:
         return query.count()

--- a/corehq/apps/users/dbaccessors/all_commcare_users.py
+++ b/corehq/apps/users/dbaccessors/all_commcare_users.py
@@ -18,7 +18,7 @@ def get_all_commcare_users_by_domain(domain):
 
 
 def get_mobile_usernames_by_filters(domain, user_filters):
-    query = _get_es_query(domain, user_filters)
+    query = _get_es_query(domain, user_filters).remove_default_filter('active')
     return query.values_list('base_username', flat=True)
 
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-11643
While downloading the mobile workers, the count that we were showing was for only active users but the downloaded users also contained inactive users also. Which resulted in the premature generation of a report download link when inactive users are more. And when the user used to click on the link it would result in 404.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested it locally, works fine. And is a small change that affects one place.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
