### PR TITLE
add some more notes about xmlsec to DEV_SETUP

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -69,6 +69,15 @@ Save those backups to somewhere you'll be able to access from the new environmen
   - [Homebrew](https://brew.sh)
   - [libmagic](https://macappstore.org/libmagic) (available via homebrew)
   - [pango](https://www.pango.org/) (available via homebrew)
+  - libxmlsec1 (install with homebrew)
+
+  
+##### xmlsec
+
+`xmlsec` is a `pip` dependency that will require some non-`pip`-installable
+packages. The above notes should have covered these requirements for linux and macOS, 
+but if you are on a different platform or still experiencing issues,
+please see [`xmlsec`'s install notes](https://pypi.org/project/xmlsec/). 
 
 
 #### Set up virtual environment


### PR DESCRIPTION
## Summary
just adding some more notes about the `xmlsec` library requirements in `DEV_SETUP.md`. I had added notes about linux/`apt`, but missed macOS. Also adding a link direct to the `xmlsec` install notes for other platforms or if people encounter issues.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Safety story
just a docs update

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
