### PR TITLE
Add member registrations per month

### DIFF
--- a/custom/nutrition_project/commcare_extensions.py
+++ b/custom/nutrition_project/commcare_extensions.py
@@ -1,0 +1,18 @@
+from corehq.apps.userreports.extension_points import (
+    static_ucr_data_source_paths,
+    static_ucr_report_paths,
+)
+
+
+@static_ucr_data_source_paths.extend()
+def ucr_data_sources():
+    return [
+        "custom/nutrition_project/ucr/data_sources/*.json",
+    ]
+
+
+@static_ucr_report_paths.extend()
+def ucr_reports():
+    return [
+        "custom/nutrition_project/ucr/reports/*.json",
+    ]

--- a/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
@@ -1,0 +1,248 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "config": {
+    "table_id": "static-deliveries_v1",
+    "display_name": "Deliveries V1",
+    "referenced_doc_type": "XFormInstance",
+    "base_item_expression": {
+      "type": "property_path",
+      "property_path": [
+        "form",
+        "delivery_details",
+        "child_birth_details",
+        "child_details"
+      ]
+    },
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "xmlns"
+          },
+          "property_value": "http://openrosa.org/formdesigner/F8AE9C85-38E3-4B84-BD16-0198C4907FD9"
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "app_id"
+          },
+          "property_value": "b3c758f7c79e47e3a503115894f18503"
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "type": "expression",
+        "column_id": "username",
+        "display_name": "username",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "username"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "userID",
+        "display_name": "userID",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      },
+      {
+        "display_name": "flw_id",
+        "datatype": "string",
+        "expression": {
+          "type": "named",
+          "name": "user_location_id"
+        },
+        "type": "expression",
+        "column_id": "flw_id"
+      },
+      {
+        "display_name": "supervisor_id",
+        "datatype": "string",
+        "expression": {
+          "location_id": {
+            "type": "named",
+            "name": "user_location_id"
+          },
+          "location_type": "supervisor",
+          "location_property": "_id",
+          "type": "ancestor_location"
+        },
+        "type": "expression",
+        "column_id": "supervisor_id"
+      },
+      {
+        "type": "expression",
+        "column_id": "received_on",
+        "display_name": "received_on",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "received_on"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "completed_time",
+        "display_name": "completed_time",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "timeEnd"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "expression": {
+          "type": "property_name",
+          "property_name": "child_safe_and_alive"
+        },
+        "column_id": "child_safe_and_alive",
+        "datatype": "string",
+        "display_name": "child_safe_and_alive"
+      },
+      {
+        "type": "expression",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "case_open_member_0",
+            "case",
+            "update",
+            "member_gender"
+          ]
+        },
+        "column_id": "gender",
+        "datatype": "string",
+        "display_name": "gender"
+      },
+      {
+        "type": "expression",
+        "column_id": "residential_status",
+        "display_name": "residential_status",
+        "datatype": "string",
+        "expression": {
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "member_residential_status"
+          },
+          "type": "related_doc",
+          "related_doc_type": "CommCareCase",
+          "doc_id_expression": {
+            "type": "root_doc",
+            "expression": {
+              "type": "property_path",
+              "property_path": [
+                "form",
+                "member_case_id_loaded"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "case_open_child_growth_0",
+            "case",
+            "update",
+            "weight"
+          ]
+        },
+        "column_id": "weight",
+        "datatype": "string",
+        "display_name": "weight"
+      },
+      {
+        "type": "expression",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "case_open_child_care_0",
+            "case",
+            "update",
+            "low_birth_weight"
+          ]
+        },
+        "column_id": "low_birth_weight",
+        "datatype": "string",
+        "display_name": "low_birth_weight"
+      }
+    ],
+    "named_expressions": {
+      "user_location_id": {
+        "datatype": "string",
+        "value_expression": {
+          "type": "property_name",
+          "property_name": "location_id"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareUser",
+        "doc_id_expression": {
+          "type": "root_doc",
+          "expression": {
+            "datatype": "string",
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "supervisor_id",
+          "flw_id"
+        ]
+      }
+    ]
+  }
+}

--- a/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
@@ -6,8 +6,8 @@
     "india"
   ],
   "config": {
-    "table_id": "static-deliveries_v1",
-    "display_name": "Deliveries V1",
+    "table_id": "static-record_a_delivery_v1",
+    "display_name": "Record a Delivery V1 (Static)",
     "referenced_doc_type": "XFormInstance",
     "base_item_expression": {
       "type": "property_path",

--- a/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
@@ -180,7 +180,8 @@
               ]
             }
           }
-        }
+        },
+        "comment": "Picked from the mother case since child does not have residential status"
       },
       {
         "type": "expression",

--- a/custom/nutrition_project/ucr/data_sources/member_cases_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/member_cases_v1.json
@@ -1,0 +1,87 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "config": {
+    "table_id": "static-member_cases_v1",
+    "display_name": "Cases - Member V1",
+    "referenced_doc_type": "CommCareCase",
+    "configured_filter": {
+      "operator": "eq",
+      "type": "boolean_expression",
+      "expression": {
+        "type": "property_name",
+        "property_name": "type"
+      },
+      "property_value": "member"
+    },
+    "configured_indicators": [
+      {
+        "type": "expression",
+        "column_id": "flw_id",
+        "display_name": "flw_id",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "owner_id"
+          ]
+        },
+        "is_nullable": true,
+        "is_primary_key": false,
+        "create_index": false
+      },
+      {
+        "type": "expression",
+        "column_id": "supervisor_id",
+        "display_name": "supervisor_id",
+        "datatype": "string",
+        "expression": {
+          "type": "location_parent_id",
+          "location_id_expression": {
+            "type": "property_path",
+            "property_path": [
+              "owner_id"
+            ]
+          }
+        },
+        "is_nullable": true,
+        "is_primary_key": false,
+        "create_index": false
+      },
+      {
+        "type": "expression",
+        "column_id": "opened_on",
+        "display_name": "opened_on",
+        "datatype": "datetime",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "opened_on"
+          ]
+        },
+        "is_nullable": true,
+        "is_primary_key": false,
+        "create_index": false
+      },
+      {
+        "type": "expression",
+        "column_id": "closed",
+        "display_name": "closed",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "closed"
+          ]
+        },
+        "is_nullable": true,
+        "is_primary_key": false,
+        "create_index": false
+      }
+    ]
+  }
+}

--- a/custom/nutrition_project/ucr/data_sources/member_cases_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/member_cases_v1.json
@@ -29,10 +29,7 @@
           "property_path": [
             "owner_id"
           ]
-        },
-        "is_nullable": true,
-        "is_primary_key": false,
-        "create_index": false
+        }
       },
       {
         "type": "expression",
@@ -47,10 +44,7 @@
               "owner_id"
             ]
           }
-        },
-        "is_nullable": true,
-        "is_primary_key": false,
-        "create_index": false
+        }
       },
       {
         "type": "expression",
@@ -62,10 +56,22 @@
           "property_path": [
             "opened_on"
           ]
-        },
-        "is_nullable": true,
-        "is_primary_key": false,
-        "create_index": false
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "month",
+        "display_name": "month",
+        "datatype": "date",
+        "expression": {
+          "type": "month_start_date",
+          "date_expression": {
+            "type": "property_path",
+            "property_path": [
+              "opened_on"
+            ]
+          }
+        }
       },
       {
         "type": "expression",
@@ -77,10 +83,16 @@
           "property_path": [
             "closed"
           ]
-        },
-        "is_nullable": true,
-        "is_primary_key": false,
-        "create_index": false
+        }
+      }
+    ],
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "flw_id",
+          "supervisor_id",
+          "month"
+        ]
       }
     ]
   }

--- a/custom/nutrition_project/ucr/data_sources/member_cases_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/member_cases_v1.json
@@ -60,21 +60,6 @@
       },
       {
         "type": "expression",
-        "column_id": "month",
-        "display_name": "month",
-        "datatype": "date",
-        "expression": {
-          "type": "month_start_date",
-          "date_expression": {
-            "type": "property_path",
-            "property_path": [
-              "opened_on"
-            ]
-          }
-        }
-      },
-      {
-        "type": "expression",
         "column_id": "closed",
         "display_name": "closed",
         "datatype": "string",
@@ -89,9 +74,8 @@
     "sql_column_indexes": [
       {
         "column_ids": [
-          "flw_id",
           "supervisor_id",
-          "month"
+          "flw_id"
         ]
       }
     ]

--- a/custom/nutrition_project/ucr/data_sources/member_cases_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/member_cases_v1.json
@@ -7,7 +7,7 @@
   ],
   "config": {
     "table_id": "static-member_cases_v1",
-    "display_name": "Cases - Member V1",
+    "display_name": "Cases - Member V1 (Static)",
     "referenced_doc_type": "CommCareCase",
     "configured_filter": {
       "operator": "eq",

--- a/custom/nutrition_project/ucr/data_sources/nutrition_delivery_children_3_to_6_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/nutrition_delivery_children_3_to_6_v1.json
@@ -1,0 +1,173 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "config": {
+    "table_id": "static-nutrition_delivery_3_6_v1",
+    "display_name": "Nutrition Delivery (3 to 6 years) V1",
+    "referenced_doc_type": "XFormInstance",
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "xmlns"
+          },
+          "property_value": "http://openrosa.org/formdesigner/87149AFE-1EE9-4C80-AE07-FD12FA808D83"
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "app_id"
+          },
+          "property_value": "b3c758f7c79e47e3a503115894f18503"
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "type": "expression",
+        "column_id": "username",
+        "display_name": "username",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "username"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "userID",
+        "display_name": "userID",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      },
+      {
+        "display_name": "FLW ID",
+        "datatype": "string",
+        "expression": {
+          "type": "named",
+          "name": "user_location_id"
+        },
+        "type": "expression",
+        "column_id": "flw_id"
+      },
+      {
+        "display_name": "Supervisor ID",
+        "datatype": "string",
+        "expression": {
+          "location_id": {
+            "type": "named",
+            "name": "user_location_id"
+          },
+          "location_type": "supervisor",
+          "location_property": "_id",
+          "type": "ancestor_location"
+        },
+        "type": "expression",
+        "column_id": "supervisor_id"
+      },
+      {
+        "type": "expression",
+        "column_id": "received_on",
+        "display_name": "received_on",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "received_on"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "completed_time",
+        "display_name": "completed_time",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "timeEnd"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "nutrition_center_open_today",
+        "display_name": "nutrition_center_open_today",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "nutrition_center_open_today"
+          ]
+        }
+      }
+    ],
+    "named_expressions": {
+      "user_location_id": {
+        "datatype": "string",
+        "value_expression": {
+          "type": "property_name",
+          "property_name": "location_id"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareUser",
+        "doc_id_expression": {
+          "type": "root_doc",
+          "expression": {
+            "datatype": "string",
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "supervisor_id",
+          "flw_id"
+        ]
+      }
+    ]
+  }
+}

--- a/custom/nutrition_project/ucr/data_sources/nutrition_delivery_children_3_to_6_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/nutrition_delivery_children_3_to_6_v1.json
@@ -7,7 +7,7 @@
   ],
   "config": {
     "table_id": "static-nutrition_delivery_3_6_v1",
-    "display_name": "Nutrition Delivery (3 to 6 years) V1",
+    "display_name": "Nutrition Delivery Children (3-6 yrs) V1 (Static)",
     "referenced_doc_type": "XFormInstance",
     "configured_filter": {
       "type": "and",

--- a/custom/nutrition_project/ucr/data_sources/nutrition_delivery_children_3_to_6_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/nutrition_delivery_children_3_to_6_v1.json
@@ -148,16 +148,13 @@
         "type": "related_doc",
         "related_doc_type": "CommCareUser",
         "doc_id_expression": {
-          "type": "root_doc",
-          "expression": {
-            "datatype": "string",
-            "type": "property_path",
-            "property_path": [
-              "form",
-              "meta",
-              "userID"
-            ]
-          }
+          "datatype": "string",
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "userID"
+          ]
         }
       }
     },

--- a/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
@@ -29,24 +29,6 @@
             "property_name": "app_id"
           },
           "property_value": "b3c758f7c79e47e3a503115894f18503"
-        },
-        {
-          "type": "not",
-          "filter": {
-            "type": "boolean_expression",
-            "operator": "in",
-            "expression": {
-              "type": "property_path",
-              "property_path": [
-                "form",
-                "final_edd_calc"
-              ]
-            },
-            "property_value": [
-              "",
-              null
-            ]
-          }
         }
       ]
     },

--- a/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
@@ -1,0 +1,273 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "config": {
+    "table_id": "static-pregnancy_registrations_v1",
+    "display_name": "Pregnancy Registrations V1",
+    "referenced_doc_type": "XFormInstance",
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "xmlns"
+          },
+          "property_value": "http://openrosa.org/formdesigner/C598D396-C69A-4F1B-84FD-92B582DDC57D"
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "app_id"
+          },
+          "property_value": "b3c758f7c79e47e3a503115894f18503"
+        },
+        {
+          "type": "not",
+          "filter": {
+            "type": "boolean_expression",
+            "operator": "in",
+            "expression": {
+              "type": "property_path",
+              "property_path": [
+                "form",
+                "final_edd_calc"
+              ]
+            },
+            "property_value": [
+              "",
+              null
+            ]
+          }
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "type": "expression",
+        "column_id": "username",
+        "display_name": "username",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "username"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "userID",
+        "display_name": "userID",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      },
+      {
+        "display_name": "flw_id",
+        "datatype": "string",
+        "expression": {
+          "type": "named",
+          "name": "user_location_id"
+        },
+        "type": "expression",
+        "column_id": "flw_id"
+      },
+      {
+        "display_name": "supervisor_id",
+        "datatype": "string",
+        "expression": {
+          "location_id_expression": {
+            "type": "named",
+            "name": "user_location_id"
+          },
+          "type": "location_parent_id"
+        },
+        "type": "expression",
+        "column_id": "supervisor_id"
+      },
+      {
+        "type": "expression",
+        "column_id": "received_on",
+        "display_name": "received_on",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "received_on"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "completed_time",
+        "display_name": "completed_time",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "timeEnd"
+            ]
+          }
+        }
+      },
+       {
+        "type": "expression",
+        "column_id": "month",
+        "display_name": "month",
+        "datatype": "date",
+        "expression": {
+          "type": "month_start_date",
+          "date_expression": {
+            "type": "property_path",
+            "property_path": [
+              "opened_on"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "member_case_id",
+        "display_name": "member_case_id",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "member_case_id_loaded"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "currently_pregnant",
+        "display_name": "currently_pregnant",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "currently_pregnant"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "residential_status",
+        "display_name": "residential_status",
+        "datatype": "string",
+        "expression": {
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "member_residential_status"
+          },
+          "type": "related_doc",
+          "related_doc_type": "CommCareCase",
+          "doc_id_expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "member_case_id_loaded"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "closed",
+        "display_name": "closed",
+        "datatype": "string",
+        "expression": {
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "closed"
+          },
+          "type": "related_doc",
+          "related_doc_type": "CommCareCase",
+          "doc_id_expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "member_case_id_loaded"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "form.final_edd_calc",
+        "display_name": "form.final_edd_calc",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "final_edd_calc"
+          ]
+        }
+      }
+    ],
+    "named_expressions": {
+      "user_location_id": {
+        "datatype": "string",
+        "value_expression": {
+          "type": "property_name",
+          "property_name": "location_id"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareUser",
+        "doc_id_expression": {
+          "type": "root_doc",
+          "expression": {
+            "datatype": "string",
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "flw_id",
+          "supervisor_id",
+          "month"
+        ]
+      }
+    ]
+  }
+}

--- a/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
@@ -140,21 +140,6 @@
           }
         }
       },
-       {
-        "type": "expression",
-        "column_id": "month",
-        "display_name": "month",
-        "datatype": "date",
-        "expression": {
-          "type": "month_start_date",
-          "date_expression": {
-            "type": "property_path",
-            "property_path": [
-              "opened_on"
-            ]
-          }
-        }
-      },
       {
         "type": "expression",
         "column_id": "member_case_id",
@@ -263,9 +248,8 @@
     "sql_column_indexes": [
       {
         "column_ids": [
-          "flw_id",
           "supervisor_id",
-          "month"
+          "flw_id"
         ]
       }
     ]

--- a/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
@@ -159,27 +159,6 @@
       },
       {
         "type": "expression",
-        "column_id": "closed",
-        "display_name": "closed",
-        "datatype": "string",
-        "expression": {
-          "value_expression": {
-            "type": "property_name",
-            "property_name": "closed"
-          },
-          "type": "related_doc",
-          "related_doc_type": "CommCareCase",
-          "doc_id_expression": {
-            "type": "property_path",
-            "property_path": [
-              "form",
-              "member_case_id_loaded"
-            ]
-          }
-        }
-      },
-      {
-        "type": "expression",
         "column_id": "form.final_edd_calc",
         "display_name": "form.final_edd_calc",
         "datatype": "string",

--- a/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
@@ -7,7 +7,7 @@
   ],
   "config": {
     "table_id": "static-pregnancy_registrations_v1",
-    "display_name": "Pregnancy Registrations V1",
+    "display_name": "Pregnancy Registrations V1 (Static)",
     "referenced_doc_type": "XFormInstance",
     "configured_filter": {
       "type": "and",

--- a/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
@@ -39,15 +39,12 @@
         "display_name": "username",
         "datatype": "string",
         "expression": {
-          "type": "root_doc",
-          "expression": {
-            "type": "property_path",
-            "property_path": [
-              "form",
-              "meta",
-              "username"
-            ]
-          }
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "username"
+          ]
         }
       },
       {
@@ -56,15 +53,12 @@
         "display_name": "userID",
         "datatype": "string",
         "expression": {
-          "type": "root_doc",
-          "expression": {
-            "type": "property_path",
-            "property_path": [
-              "form",
-              "meta",
-              "userID"
-            ]
-          }
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "userID"
+          ]
         }
       },
       {
@@ -96,13 +90,10 @@
         "display_name": "received_on",
         "datatype": "datetime",
         "expression": {
-          "type": "root_doc",
-          "expression": {
-            "type": "property_path",
-            "property_path": [
-              "received_on"
-            ]
-          }
+          "type": "property_path",
+          "property_path": [
+            "received_on"
+          ]
         }
       },
       {
@@ -111,15 +102,12 @@
         "display_name": "completed_time",
         "datatype": "datetime",
         "expression": {
-          "type": "root_doc",
-          "expression": {
-            "type": "property_path",
-            "property_path": [
-              "form",
-              "meta",
-              "timeEnd"
-            ]
-          }
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "timeEnd"
+          ]
         }
       },
       {
@@ -214,16 +202,13 @@
         "type": "related_doc",
         "related_doc_type": "CommCareUser",
         "doc_id_expression": {
-          "type": "root_doc",
-          "expression": {
-            "datatype": "string",
-            "type": "property_path",
-            "property_path": [
-              "form",
-              "meta",
-              "userID"
-            ]
-          }
+          "datatype": "string",
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "userID"
+          ]
         }
       }
     },

--- a/custom/nutrition_project/ucr/reports/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/reports/deliveries_v1.json
@@ -1,0 +1,264 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "report_id": "static-deliveries_v1",
+  "data_source_table": "static-deliveries_v1",
+  "config": {
+    "title": "Deliveries",
+    "description": "Deliveries per flw per month",
+    "visible": true,
+    "aggregation_columns": [
+      "supervisor_id",
+      "flw_id",
+      "month"
+    ],
+    "filters": [
+      [
+        {
+          "display": "Filter by FLW",
+          "slug": "flw_id",
+          "type": "dynamic_choice_list",
+          "field": "userID",
+          "choice_provider": {
+            "type": "location"
+          },
+          "ancestor_expression": {
+            "field": "supervisor_id",
+            "location_type": "supervisor"
+          },
+          "datatype": "string"
+        },
+        {
+          "display": "Filter by Supervisor",
+          "slug": "supervisor_id",
+          "type": "dynamic_choice_list",
+          "field": "supervisor_id",
+          "choice_provider": {
+            "type": "location"
+          },
+          "datatype": "string"
+        }
+      ]
+    ],
+    "columns": [
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "received_on",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "Supervisor ID",
+        "column_id": "supervisor_id",
+        "type": "field",
+        "field": "supervisor_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "FLW ID",
+        "column_id": "flw_id",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "M_permanent_resident_child_safe_and_alive",
+        "column_id": "M_permanent_resident_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND gender = 'M' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_permanent_resident_not_child_safe_and_alive",
+        "column_id": "M_permanent_resident_not_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'no' AND gender = 'M' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_temp_resident_child_safe_and_alive",
+        "column_id": "M_temp_resident_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND gender = 'M' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_temp_resident_not_child_safe_and_alive",
+        "column_id": "M_temp_resident_not_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'no' AND gender = 'M' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident_child_safe_and_alive",
+        "column_id": "F_permanent_resident_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND gender = 'F' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident_not_child_safe_and_alive",
+        "column_id": "F_permanent_resident_not_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'no' AND gender = 'F' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temp_resident_child_safe_and_alive",
+        "column_id": "F_temp_resident_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND gender = 'F' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temp_resident_not_child_safe_and_alive",
+        "column_id": "F_temp_resident_not_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'no' AND gender = 'F' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_permanent_resident_child_weighed",
+        "column_id": "M_permanent_resident_child_weighed",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND gender = 'M' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_temp_resident_child_weighed",
+        "column_id": "M_temp_resident_child_weighed",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND gender = 'M' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident_child_weighed",
+        "column_id": "F_permanent_resident_child_weighed",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND gender = 'F' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temp_resident_child_weighed",
+        "column_id": "F_temp_resident_child_weighed",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND gender = 'F' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_permanent_resident_child_low_birth_weight",
+        "column_id": "M_permanent_resident_child_low_birth_weight",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND low_birth_weight = 'yes' AND gender = 'M' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_temp_resident_child_low_birth_weight",
+        "column_id": "M_temp_resident_child_low_birth_weight",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND low_birth_weight = 'yes' AND gender = 'M' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident_child_low_birth_weight",
+        "column_id": "F_permanent_resident_child_low_birth_weight",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND low_birth_weight = 'yes' AND gender = 'F' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temp_resident_child_low_birth_weight",
+        "column_id": "F_temp_resident_child_low_birth_weight",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND low_birth_weight = 'yes' AND gender = 'F' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      }
+    ]
+  },
+  "doc_type": "ReportConfiguration"
+}

--- a/custom/nutrition_project/ucr/reports/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/reports/deliveries_v1.json
@@ -17,32 +17,30 @@
       "month"
     ],
     "filters": [
-      [
-        {
-          "display": "Filter by FLW",
-          "slug": "flw_id",
-          "type": "dynamic_choice_list",
-          "field": "userID",
-          "choice_provider": {
-            "type": "location"
-          },
-          "ancestor_expression": {
-            "field": "supervisor_id",
-            "location_type": "supervisor"
-          },
-          "datatype": "string"
+      {
+        "display": "Filter by FLW",
+        "slug": "flw_id",
+        "type": "dynamic_choice_list",
+        "field": "userID",
+        "choice_provider": {
+          "type": "location"
         },
-        {
-          "display": "Filter by Supervisor",
-          "slug": "supervisor_id",
-          "type": "dynamic_choice_list",
+        "ancestor_expression": {
           "field": "supervisor_id",
-          "choice_provider": {
-            "type": "location"
-          },
-          "datatype": "string"
-        }
-      ]
+          "location_type": "supervisor"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "datatype": "string"
+      }
     ],
     "columns": [
       {

--- a/custom/nutrition_project/ucr/reports/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/reports/deliveries_v1.json
@@ -8,7 +8,7 @@
   "report_id": "static-deliveries_v1",
   "data_source_table": "static-deliveries_v1",
   "config": {
-    "title": "Deliveries",
+    "title": "Deliveries V1 (Static)",
     "description": "Deliveries per flw per month",
     "visible": true,
     "aggregation_columns": [

--- a/custom/nutrition_project/ucr/reports/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/reports/deliveries_v1.json
@@ -49,7 +49,7 @@
         "display": "Month",
         "column_id": "month",
         "type": "aggregate_date",
-        "field": "received_on",
+        "field": "completed_time",
         "format": "%Y-%m"
       },
       {

--- a/custom/nutrition_project/ucr/reports/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/reports/deliveries_v1.json
@@ -6,7 +6,7 @@
     "india"
   ],
   "report_id": "static-deliveries_v1",
-  "data_source_table": "static-deliveries_v1",
+  "data_source_table": "static-record_a_delivery_v1",
   "config": {
     "title": "Deliveries V1 (Static)",
     "description": "Deliveries per flw per month",

--- a/custom/nutrition_project/ucr/reports/new_member_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/new_member_registrations_v1.json
@@ -12,8 +12,8 @@
     "description": "New member registrations per flw per month",
     "visible": true,
     "aggregation_columns": [
-      "flw_id",
       "supervisor_id",
+      "flw_id",
       "month"
     ],
     "filters": [
@@ -70,9 +70,9 @@
       {
         "display": "Month",
         "column_id": "month",
-        "type": "field",
-        "field": "month",
-        "aggregation": "simple"
+        "type": "aggregate_date",
+        "field": "opened_on",
+        "format": "%Y-%m"
       },
       {
         "display": "FLW ID",

--- a/custom/nutrition_project/ucr/reports/new_member_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/new_member_registrations_v1.json
@@ -1,0 +1,117 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "report_id": "static-new_member_registrations_v1",
+  "data_source_table": "static-member_cases_v1",
+  "config": {
+    "title": "New member registrations",
+    "description": "New member registrations per flw per month",
+    "visible": true,
+    "aggregation_columns": [
+      "flw_id",
+      "month"
+    ],
+    "filters": [
+      {
+        "display": "Filter by FLW",
+        "slug": "flw_id",
+        "type": "dynamic_choice_list",
+        "field": "flw_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "ancestor_expression": {
+          "field": "supervisor_id",
+          "location_type": "supervisor"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Opened On",
+        "slug": "opened_on",
+        "type": "date",
+        "field": "opened_on",
+        "datatype": "date"
+      },
+      {
+        "display": "Closed",
+        "slug": "closed",
+        "type": "choice_list",
+        "field": "closed",
+        "datatype": "string",
+        "choices": [
+          {
+            "display": "yes",
+            "value": "True"
+          },
+          {
+            "display": "no",
+            "value": "False"
+          }
+        ]
+      }
+    ],
+    "columns": [
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "opened_on",
+        "format": "%Y-%m",
+        "transform": {},
+        "calculate_total": false,
+        "description": null,
+        "visible": true
+      },
+      {
+        "display": {
+          "en": "FLW ID",
+          "hin": "FLW ID"
+        },
+        "column_id": "flw_id",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": {
+          "en": "FLW Name",
+          "hin": "FLW Name"
+        },
+        "column_id": "flw_name",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": {
+          "en": "Population"
+        },
+        "column_id": "open_count",
+        "type": "field",
+        "field": "doc_id",
+        "aggregation": "count",
+        "calculate_total": false
+      }
+    ]
+  },
+  "doc_type": "ReportConfiguration"
+}

--- a/custom/nutrition_project/ucr/reports/new_member_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/new_member_registrations_v1.json
@@ -13,6 +13,7 @@
     "visible": true,
     "aggregation_columns": [
       "flw_id",
+      "supervisor_id",
       "month"
     ],
     "filters": [
@@ -69,29 +70,19 @@
       {
         "display": "Month",
         "column_id": "month",
-        "type": "aggregate_date",
-        "field": "opened_on",
-        "format": "%Y-%m",
-        "transform": {},
-        "calculate_total": false,
-        "description": null,
-        "visible": true
+        "type": "field",
+        "field": "month",
+        "aggregation": "simple"
       },
       {
-        "display": {
-          "en": "FLW ID",
-          "hin": "FLW ID"
-        },
+        "display": "FLW ID",
         "column_id": "flw_id",
         "type": "field",
         "field": "flw_id",
         "aggregation": "simple"
       },
       {
-        "display": {
-          "en": "FLW Name",
-          "hin": "FLW Name"
-        },
+        "display": "FLW Name",
         "column_id": "flw_name",
         "type": "field",
         "field": "flw_id",
@@ -102,14 +93,11 @@
         }
       },
       {
-        "display": {
-          "en": "Population"
-        },
-        "column_id": "open_count",
+        "display": "Population",
+        "column_id": "count",
         "type": "field",
         "field": "doc_id",
-        "aggregation": "count",
-        "calculate_total": false
+        "aggregation": "count"
       }
     ]
   },

--- a/custom/nutrition_project/ucr/reports/new_member_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/new_member_registrations_v1.json
@@ -8,7 +8,7 @@
   "report_id": "static-new_member_registrations_v1",
   "data_source_table": "static-member_cases_v1",
   "config": {
-    "title": "New member registrations",
+    "title": "New member registrations per month (Static)",
     "description": "New member registrations per flw per month",
     "visible": true,
     "aggregation_columns": [

--- a/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
+++ b/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
@@ -1,0 +1,90 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "report_id": "static-number_of_days_open_v1",
+  "data_source_table": "static-nutrition_delivery_3_6_v1",
+  "config": {
+    "title": "Number of days center open",
+    "description": "Number of days center was open per flw per month",
+    "visible": true,
+    "aggregation_columns": [
+      "supervisor_id",
+      "flw_id",
+      "month"
+    ],
+    "filters": [
+      [
+        {
+          "display": "Filter by FLW",
+          "slug": "flw_id",
+          "type": "dynamic_choice_list",
+          "field": "userID",
+          "choice_provider": {
+            "type": "location"
+          },
+          "ancestor_expression": {
+            "field": "supervisor_id",
+            "location_type": "supervisor"
+          },
+          "datatype": "string"
+        },
+        {
+          "display": "Filter by Supervisor",
+          "slug": "supervisor_id",
+          "type": "dynamic_choice_list",
+          "field": "supervisor_id",
+          "choice_provider": {
+            "type": "location"
+          },
+          "datatype": "string"
+        }
+      ]
+    ],
+    "columns": [
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "completed_time",
+        "format": "%Y-%m"
+      },
+      {
+        "display": {
+          "en": "Supervisor ID",
+          "hin": "Supervisor ID"
+        },
+        "column_id": "supervisor_id",
+        "type": "field",
+        "field": "supervisor_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": {
+          "en": "FLW ID",
+          "hin": "FLW ID"
+        },
+        "column_id": "flw_id",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "days_open",
+        "column_id": "days_open",
+        "type": "sum_when",
+        "whens": [
+          [
+            "nutrition_center_open_today = 'yes'",
+            1
+          ]
+        ],
+        "else_": 0
+      }
+    ]
+  },
+  "doc_type": "ReportConfiguration"
+}

--- a/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
+++ b/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
@@ -17,32 +17,30 @@
       "month"
     ],
     "filters": [
-      [
-        {
-          "display": "Filter by FLW",
-          "slug": "flw_id",
-          "type": "dynamic_choice_list",
-          "field": "userID",
-          "choice_provider": {
-            "type": "location"
-          },
-          "ancestor_expression": {
-            "field": "supervisor_id",
-            "location_type": "supervisor"
-          },
-          "datatype": "string"
+      {
+        "display": "Filter by FLW",
+        "slug": "flw_id",
+        "type": "dynamic_choice_list",
+        "field": "userID",
+        "choice_provider": {
+          "type": "location"
         },
-        {
-          "display": "Filter by Supervisor",
-          "slug": "supervisor_id",
-          "type": "dynamic_choice_list",
+        "ancestor_expression": {
           "field": "supervisor_id",
-          "choice_provider": {
-            "type": "location"
-          },
-          "datatype": "string"
-        }
-      ]
+          "location_type": "supervisor"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "datatype": "string"
+      }
     ],
     "columns": [
       {

--- a/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
+++ b/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
@@ -8,7 +8,7 @@
   "report_id": "static-number_of_days_open_v1",
   "data_source_table": "static-nutrition_delivery_3_6_v1",
   "config": {
-    "title": "Number of days center open",
+    "title": "No. of days center open (Static)",
     "description": "Number of days center was open per flw per month",
     "visible": true,
     "aggregation_columns": [

--- a/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
+++ b/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
@@ -53,20 +53,14 @@
         "format": "%Y-%m"
       },
       {
-        "display": {
-          "en": "Supervisor ID",
-          "hin": "Supervisor ID"
-        },
+        "display": "Supervisor ID",
         "column_id": "supervisor_id",
         "type": "field",
         "field": "supervisor_id",
         "aggregation": "simple"
       },
       {
-        "display": {
-          "en": "FLW ID",
-          "hin": "FLW ID"
-        },
+        "display": "FLW ID",
         "column_id": "flw_id",
         "type": "field",
         "field": "flw_id",

--- a/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
@@ -12,8 +12,8 @@
     "description": "Pregnancy Registrations per flw per month",
     "visible": true,
     "aggregation_columns": [
-      "flw_id",
       "supervisor_id",
+      "flw_id",
       "month"
     ],
     "filters": [
@@ -87,9 +87,9 @@
         {
           "display": "Month",
           "column_id": "month",
-          "type": "field",
-          "field": "month",
-          "aggregation": "simple"
+          "type": "aggregate_date",
+          "field": "completed_time",
+          "format": "%Y-%m"
         },
         {
           "display": "Supervisor ID",

--- a/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
@@ -1,0 +1,119 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "report_id": "static-pregnancy_registrations_v1",
+  "data_source_table": "static-pregnancy_registrations_v1",
+  "config": {
+    "title": "Pregnancy Registrations",
+    "description": "Pregnancy Registrations per flw per month",
+    "visible": true,
+    "aggregation_columns": [
+      "flw_id",
+      "supervisor_id",
+      "month"
+    ],
+    "filters": [
+      [
+        {
+          "display": "Filter by FLW",
+          "slug": "flw_id",
+          "type": "dynamic_choice_list",
+          "field": "userID",
+          "choice_provider": {
+            "type": "location"
+          },
+          "ancestor_expression": {
+            "field": "supervisor_id",
+            "location_type": "supervisor"
+          },
+          "datatype": "string"
+        },
+        {
+          "display": "Filter by Supervisor",
+          "slug": "supervisor_id",
+          "type": "dynamic_choice_list",
+          "field": "supervisor_id",
+          "choice_provider": {
+            "type": "location"
+          },
+          "datatype": "string"
+        },
+        {
+          "display": "Residential Status",
+          "slug": "residential_status",
+          "type": "choice_list",
+          "field": "residential_status",
+          "datatype": "string",
+          "choices": [
+            {
+              "display": "Permanent",
+              "value": "permanent_resident"
+            },
+            {
+              "display": "Temporary",
+              "value": "temp_resident"
+            },
+            {
+              "display": "Unavailable",
+              "value": null
+            }
+          ]
+        },
+        {
+          "display": "Currently Pregnant",
+          "slug": "currently_pregnant",
+          "type": "choice_list",
+          "field": "closed",
+          "datatype": "string",
+          "choices": [
+            {
+              "display": "Yes",
+              "value": "True"
+            },
+            {
+              "display": "No",
+              "value": "False"
+            }
+          ]
+        }
+      ]
+    ],
+    "columns": [
+      [
+        {
+          "display": "Month",
+          "column_id": "month",
+          "type": "field",
+          "field": "month",
+          "aggregation": "simple"
+        },
+        {
+          "display": "Supervisor ID",
+          "column_id": "supervisor_id",
+          "type": "field",
+          "field": "supervisor_id",
+          "aggregation": "simple"
+        },
+        {
+          "display": "FLW ID",
+          "column_id": "flw_id",
+          "type": "field",
+          "field": "flw_id",
+          "aggregation": "simple"
+        },
+        {
+          "display": "Count",
+          "column_id": "count",
+          "type": "field",
+          "field": "doc_id",
+          "aggregation": "count"
+        }
+      ]
+    ]
+  },
+  "doc_type": "ReportConfiguration"
+}

--- a/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
@@ -17,102 +17,98 @@
       "month"
     ],
     "filters": [
-      [
-        {
-          "display": "Filter by FLW",
-          "slug": "flw_id",
-          "type": "dynamic_choice_list",
-          "field": "userID",
-          "choice_provider": {
-            "type": "location"
-          },
-          "ancestor_expression": {
-            "field": "supervisor_id",
-            "location_type": "supervisor"
-          },
-          "datatype": "string"
+      {
+        "display": "Filter by FLW",
+        "slug": "flw_id",
+        "type": "dynamic_choice_list",
+        "field": "userID",
+        "choice_provider": {
+          "type": "location"
         },
-        {
-          "display": "Filter by Supervisor",
-          "slug": "supervisor_id",
-          "type": "dynamic_choice_list",
+        "ancestor_expression": {
           "field": "supervisor_id",
-          "choice_provider": {
-            "type": "location"
+          "location_type": "supervisor"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Residential Status",
+        "slug": "residential_status",
+        "type": "choice_list",
+        "field": "residential_status",
+        "datatype": "string",
+        "choices": [
+          {
+            "display": "Permanent",
+            "value": "permanent_resident"
           },
-          "datatype": "string"
-        },
-        {
-          "display": "Residential Status",
-          "slug": "residential_status",
-          "type": "choice_list",
-          "field": "residential_status",
-          "datatype": "string",
-          "choices": [
-            {
-              "display": "Permanent",
-              "value": "permanent_resident"
-            },
-            {
-              "display": "Temporary",
-              "value": "temp_resident"
-            },
-            {
-              "display": "Unavailable",
-              "value": null
-            }
-          ]
-        },
-        {
-          "display": "Currently Pregnant",
-          "slug": "currently_pregnant",
-          "type": "choice_list",
-          "field": "currently_pregnant",
-          "datatype": "string",
-          "choices": [
-            {
-              "display": "Yes",
-              "value": "True"
-            },
-            {
-              "display": "No",
-              "value": "False"
-            }
-          ]
-        }
-      ]
+          {
+            "display": "Temporary",
+            "value": "temp_resident"
+          },
+          {
+            "display": "Unavailable",
+            "value": null
+          }
+        ]
+      },
+      {
+        "display": "Currently Pregnant",
+        "slug": "currently_pregnant",
+        "type": "choice_list",
+        "field": "currently_pregnant",
+        "datatype": "string",
+        "choices": [
+          {
+            "display": "Yes",
+            "value": "True"
+          },
+          {
+            "display": "No",
+            "value": "False"
+          }
+        ]
+      }
     ],
     "columns": [
-      [
-        {
-          "display": "Month",
-          "column_id": "month",
-          "type": "aggregate_date",
-          "field": "completed_time",
-          "format": "%Y-%m"
-        },
-        {
-          "display": "Supervisor ID",
-          "column_id": "supervisor_id",
-          "type": "field",
-          "field": "supervisor_id",
-          "aggregation": "simple"
-        },
-        {
-          "display": "FLW ID",
-          "column_id": "flw_id",
-          "type": "field",
-          "field": "flw_id",
-          "aggregation": "simple"
-        },
-        {
-          "display": "Count",
-          "column_id": "total_count",
-          "type": "field",
-          "field": "doc_id",
-          "aggregation": "count"
-        }
-      ]
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "completed_time",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "Supervisor ID",
+        "column_id": "supervisor_id",
+        "type": "field",
+        "field": "supervisor_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "FLW ID",
+        "column_id": "flw_id",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Count",
+        "column_id": "total_count",
+        "type": "field",
+        "field": "doc_id",
+        "aggregation": "count"
+      }
     ]
   },
   "doc_type": "ReportConfiguration"

--- a/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
@@ -107,7 +107,7 @@
         },
         {
           "display": "Count",
-          "column_id": "count",
+          "column_id": "total_count",
           "type": "field",
           "field": "doc_id",
           "aggregation": "count"

--- a/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
@@ -67,7 +67,7 @@
           "display": "Currently Pregnant",
           "slug": "currently_pregnant",
           "type": "choice_list",
-          "field": "closed",
+          "field": "currently_pregnant",
           "datatype": "string",
           "choices": [
             {

--- a/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
@@ -8,7 +8,7 @@
   "report_id": "static-pregnancy_registrations_v1",
   "data_source_table": "static-pregnancy_registrations_v1",
   "config": {
-    "title": "Pregnancy Registrations",
+    "title": "Pregnancy Registrations V1 (Static)",
     "description": "Pregnancy Registrations per flw per month",
     "visible": true,
     "aggregation_columns": [

--- a/settings.py
+++ b/settings.py
@@ -387,6 +387,7 @@ HQ_APPS = (
     'custom.aaa',
     'custom.inddex',
     'custom.onse',
+    'custom.nutrition_project',
 
     'custom.ccqa',
 
@@ -1075,6 +1076,7 @@ DEFAULT_COMMCARE_EXTENSIONS = [
     "custom.eqa.commcare_extensions",
     "mvp.commcare_extensions",
     "custom.succeed.commcare_extensions",
+    "custom.nutrition_project.commcare_extensions"
 ]
 COMMCARE_EXTENSIONS = []
 
@@ -1960,6 +1962,7 @@ DOMAIN_MODULE_MAP = {
     'testing-ipm-senegal': 'custom.intrahealth',
     'up-nrhm': 'custom.up_nrhm',
     'nhm-af-up': 'custom.up_nrhm',
+    'india-nutrition-project': 'custom.nutrition_project',
 
     'crs-remind': 'custom.apps.crs_reports',
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
We need to add a bunch of reports for [india-nutrition-project](https://india.commcarehq.org/a/india-nutrition-project) built on same lines as ICDS.

More considerations:
1. This is not actively being used by any real project right now but I have been told to consider the maximum scale of 200k - 300k mobile workers when this actually goes live and is rolled out, improvements can be made. So keeping this as a balance of keeping it performant but not overdoing it.
2. Dashboard would come into action in future, but its not clear what architecture it would have or if it would even be within HQ or not (using other 3rd party systems that we tried during ICDS)
3. We want to avoid monthly data sources due to their complexity and stick to normal data sources, mostly form based for reports and then aggregate them by a timestamp (received_on/completion_time)
4. Keeping the directory within HQ instead of making a separate repo. This is a POC-like project and can be considered to be moved out/copied over into its own repo once we have a real project,

This is the first report for total populations. It's a simple case based data source.
[Dynamic Report added for testing](https://india.commcarehq.org/a/india-nutrition-project/configurable_reports/reports/edit/89ee34aa23aa700b7b0ce7951beb6e00/).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This PR just adds a new data source and report for the project. It is not really live so there should be no scale implications of this as well.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Ideally this should not be rolled back because apps would be using it.

- [ ] This PR can be reverted after deploy with no further considerations 
