### PR TITLE
Add pregnancy registrations

### DIFF
--- a/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
@@ -29,24 +29,6 @@
             "property_name": "app_id"
           },
           "property_value": "b3c758f7c79e47e3a503115894f18503"
-        },
-        {
-          "type": "not",
-          "filter": {
-            "type": "boolean_expression",
-            "operator": "in",
-            "expression": {
-              "type": "property_path",
-              "property_path": [
-                "form",
-                "final_edd_calc"
-              ]
-            },
-            "property_value": [
-              "",
-              null
-            ]
-          }
         }
       ]
     },

--- a/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
@@ -1,0 +1,273 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "config": {
+    "table_id": "static-pregnancy_registrations_v1",
+    "display_name": "Pregnancy Registrations V1",
+    "referenced_doc_type": "XFormInstance",
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "xmlns"
+          },
+          "property_value": "http://openrosa.org/formdesigner/C598D396-C69A-4F1B-84FD-92B582DDC57D"
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "app_id"
+          },
+          "property_value": "b3c758f7c79e47e3a503115894f18503"
+        },
+        {
+          "type": "not",
+          "filter": {
+            "type": "boolean_expression",
+            "operator": "in",
+            "expression": {
+              "type": "property_path",
+              "property_path": [
+                "form",
+                "final_edd_calc"
+              ]
+            },
+            "property_value": [
+              "",
+              null
+            ]
+          }
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "type": "expression",
+        "column_id": "username",
+        "display_name": "username",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "username"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "userID",
+        "display_name": "userID",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      },
+      {
+        "display_name": "flw_id",
+        "datatype": "string",
+        "expression": {
+          "type": "named",
+          "name": "user_location_id"
+        },
+        "type": "expression",
+        "column_id": "flw_id"
+      },
+      {
+        "display_name": "supervisor_id",
+        "datatype": "string",
+        "expression": {
+          "location_id_expression": {
+            "type": "named",
+            "name": "user_location_id"
+          },
+          "type": "location_parent_id"
+        },
+        "type": "expression",
+        "column_id": "supervisor_id"
+      },
+      {
+        "type": "expression",
+        "column_id": "received_on",
+        "display_name": "received_on",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "received_on"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "completed_time",
+        "display_name": "completed_time",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "timeEnd"
+            ]
+          }
+        }
+      },
+       {
+        "type": "expression",
+        "column_id": "month",
+        "display_name": "month",
+        "datatype": "date",
+        "expression": {
+          "type": "month_start_date",
+          "date_expression": {
+            "type": "property_path",
+            "property_path": [
+              "opened_on"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "member_case_id",
+        "display_name": "member_case_id",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "member_case_id_loaded"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "currently_pregnant",
+        "display_name": "currently_pregnant",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "currently_pregnant"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "residential_status",
+        "display_name": "residential_status",
+        "datatype": "string",
+        "expression": {
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "member_residential_status"
+          },
+          "type": "related_doc",
+          "related_doc_type": "CommCareCase",
+          "doc_id_expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "member_case_id_loaded"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "closed",
+        "display_name": "closed",
+        "datatype": "string",
+        "expression": {
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "closed"
+          },
+          "type": "related_doc",
+          "related_doc_type": "CommCareCase",
+          "doc_id_expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "member_case_id_loaded"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "form.final_edd_calc",
+        "display_name": "form.final_edd_calc",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "final_edd_calc"
+          ]
+        }
+      }
+    ],
+    "named_expressions": {
+      "user_location_id": {
+        "datatype": "string",
+        "value_expression": {
+          "type": "property_name",
+          "property_name": "location_id"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareUser",
+        "doc_id_expression": {
+          "type": "root_doc",
+          "expression": {
+            "datatype": "string",
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "flw_id",
+          "supervisor_id",
+          "month"
+        ]
+      }
+    ]
+  }
+}

--- a/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
@@ -140,21 +140,6 @@
           }
         }
       },
-       {
-        "type": "expression",
-        "column_id": "month",
-        "display_name": "month",
-        "datatype": "date",
-        "expression": {
-          "type": "month_start_date",
-          "date_expression": {
-            "type": "property_path",
-            "property_path": [
-              "opened_on"
-            ]
-          }
-        }
-      },
       {
         "type": "expression",
         "column_id": "member_case_id",
@@ -263,9 +248,8 @@
     "sql_column_indexes": [
       {
         "column_ids": [
-          "flw_id",
           "supervisor_id",
-          "month"
+          "flw_id"
         ]
       }
     ]

--- a/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
@@ -159,27 +159,6 @@
       },
       {
         "type": "expression",
-        "column_id": "closed",
-        "display_name": "closed",
-        "datatype": "string",
-        "expression": {
-          "value_expression": {
-            "type": "property_name",
-            "property_name": "closed"
-          },
-          "type": "related_doc",
-          "related_doc_type": "CommCareCase",
-          "doc_id_expression": {
-            "type": "property_path",
-            "property_path": [
-              "form",
-              "member_case_id_loaded"
-            ]
-          }
-        }
-      },
-      {
-        "type": "expression",
         "column_id": "form.final_edd_calc",
         "display_name": "form.final_edd_calc",
         "datatype": "string",

--- a/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
@@ -7,7 +7,7 @@
   ],
   "config": {
     "table_id": "static-pregnancy_registrations_v1",
-    "display_name": "Pregnancy Registrations V1",
+    "display_name": "Pregnancy Registrations V1 (Static)",
     "referenced_doc_type": "XFormInstance",
     "configured_filter": {
       "type": "and",

--- a/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
@@ -39,15 +39,12 @@
         "display_name": "username",
         "datatype": "string",
         "expression": {
-          "type": "root_doc",
-          "expression": {
-            "type": "property_path",
-            "property_path": [
-              "form",
-              "meta",
-              "username"
-            ]
-          }
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "username"
+          ]
         }
       },
       {
@@ -56,15 +53,12 @@
         "display_name": "userID",
         "datatype": "string",
         "expression": {
-          "type": "root_doc",
-          "expression": {
-            "type": "property_path",
-            "property_path": [
-              "form",
-              "meta",
-              "userID"
-            ]
-          }
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "userID"
+          ]
         }
       },
       {
@@ -96,13 +90,10 @@
         "display_name": "received_on",
         "datatype": "datetime",
         "expression": {
-          "type": "root_doc",
-          "expression": {
-            "type": "property_path",
-            "property_path": [
-              "received_on"
-            ]
-          }
+          "type": "property_path",
+          "property_path": [
+            "received_on"
+          ]
         }
       },
       {
@@ -111,15 +102,12 @@
         "display_name": "completed_time",
         "datatype": "datetime",
         "expression": {
-          "type": "root_doc",
-          "expression": {
-            "type": "property_path",
-            "property_path": [
-              "form",
-              "meta",
-              "timeEnd"
-            ]
-          }
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "timeEnd"
+          ]
         }
       },
       {
@@ -214,16 +202,13 @@
         "type": "related_doc",
         "related_doc_type": "CommCareUser",
         "doc_id_expression": {
-          "type": "root_doc",
-          "expression": {
-            "datatype": "string",
-            "type": "property_path",
-            "property_path": [
-              "form",
-              "meta",
-              "userID"
-            ]
-          }
+          "datatype": "string",
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "userID"
+          ]
         }
       }
     },

--- a/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
@@ -12,8 +12,8 @@
     "description": "Pregnancy Registrations per flw per month",
     "visible": true,
     "aggregation_columns": [
-      "flw_id",
       "supervisor_id",
+      "flw_id",
       "month"
     ],
     "filters": [
@@ -87,9 +87,9 @@
         {
           "display": "Month",
           "column_id": "month",
-          "type": "field",
-          "field": "month",
-          "aggregation": "simple"
+          "type": "aggregate_date",
+          "field": "completed_time",
+          "format": "%Y-%m"
         },
         {
           "display": "Supervisor ID",

--- a/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
@@ -1,0 +1,119 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "report_id": "static-pregnancy_registrations_v1",
+  "data_source_table": "static-pregnancy_registrations_v1",
+  "config": {
+    "title": "Pregnancy Registrations",
+    "description": "Pregnancy Registrations per flw per month",
+    "visible": true,
+    "aggregation_columns": [
+      "flw_id",
+      "supervisor_id",
+      "month"
+    ],
+    "filters": [
+      [
+        {
+          "display": "Filter by FLW",
+          "slug": "flw_id",
+          "type": "dynamic_choice_list",
+          "field": "userID",
+          "choice_provider": {
+            "type": "location"
+          },
+          "ancestor_expression": {
+            "field": "supervisor_id",
+            "location_type": "supervisor"
+          },
+          "datatype": "string"
+        },
+        {
+          "display": "Filter by Supervisor",
+          "slug": "supervisor_id",
+          "type": "dynamic_choice_list",
+          "field": "supervisor_id",
+          "choice_provider": {
+            "type": "location"
+          },
+          "datatype": "string"
+        },
+        {
+          "display": "Residential Status",
+          "slug": "residential_status",
+          "type": "choice_list",
+          "field": "residential_status",
+          "datatype": "string",
+          "choices": [
+            {
+              "display": "Permanent",
+              "value": "permanent_resident"
+            },
+            {
+              "display": "Temporary",
+              "value": "temp_resident"
+            },
+            {
+              "display": "Unavailable",
+              "value": null
+            }
+          ]
+        },
+        {
+          "display": "Currently Pregnant",
+          "slug": "currently_pregnant",
+          "type": "choice_list",
+          "field": "closed",
+          "datatype": "string",
+          "choices": [
+            {
+              "display": "Yes",
+              "value": "True"
+            },
+            {
+              "display": "No",
+              "value": "False"
+            }
+          ]
+        }
+      ]
+    ],
+    "columns": [
+      [
+        {
+          "display": "Month",
+          "column_id": "month",
+          "type": "field",
+          "field": "month",
+          "aggregation": "simple"
+        },
+        {
+          "display": "Supervisor ID",
+          "column_id": "supervisor_id",
+          "type": "field",
+          "field": "supervisor_id",
+          "aggregation": "simple"
+        },
+        {
+          "display": "FLW ID",
+          "column_id": "flw_id",
+          "type": "field",
+          "field": "flw_id",
+          "aggregation": "simple"
+        },
+        {
+          "display": "Count",
+          "column_id": "count",
+          "type": "field",
+          "field": "doc_id",
+          "aggregation": "count"
+        }
+      ]
+    ]
+  },
+  "doc_type": "ReportConfiguration"
+}

--- a/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
@@ -17,102 +17,98 @@
       "month"
     ],
     "filters": [
-      [
-        {
-          "display": "Filter by FLW",
-          "slug": "flw_id",
-          "type": "dynamic_choice_list",
-          "field": "userID",
-          "choice_provider": {
-            "type": "location"
-          },
-          "ancestor_expression": {
-            "field": "supervisor_id",
-            "location_type": "supervisor"
-          },
-          "datatype": "string"
+      {
+        "display": "Filter by FLW",
+        "slug": "flw_id",
+        "type": "dynamic_choice_list",
+        "field": "userID",
+        "choice_provider": {
+          "type": "location"
         },
-        {
-          "display": "Filter by Supervisor",
-          "slug": "supervisor_id",
-          "type": "dynamic_choice_list",
+        "ancestor_expression": {
           "field": "supervisor_id",
-          "choice_provider": {
-            "type": "location"
+          "location_type": "supervisor"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Residential Status",
+        "slug": "residential_status",
+        "type": "choice_list",
+        "field": "residential_status",
+        "datatype": "string",
+        "choices": [
+          {
+            "display": "Permanent",
+            "value": "permanent_resident"
           },
-          "datatype": "string"
-        },
-        {
-          "display": "Residential Status",
-          "slug": "residential_status",
-          "type": "choice_list",
-          "field": "residential_status",
-          "datatype": "string",
-          "choices": [
-            {
-              "display": "Permanent",
-              "value": "permanent_resident"
-            },
-            {
-              "display": "Temporary",
-              "value": "temp_resident"
-            },
-            {
-              "display": "Unavailable",
-              "value": null
-            }
-          ]
-        },
-        {
-          "display": "Currently Pregnant",
-          "slug": "currently_pregnant",
-          "type": "choice_list",
-          "field": "currently_pregnant",
-          "datatype": "string",
-          "choices": [
-            {
-              "display": "Yes",
-              "value": "True"
-            },
-            {
-              "display": "No",
-              "value": "False"
-            }
-          ]
-        }
-      ]
+          {
+            "display": "Temporary",
+            "value": "temp_resident"
+          },
+          {
+            "display": "Unavailable",
+            "value": null
+          }
+        ]
+      },
+      {
+        "display": "Currently Pregnant",
+        "slug": "currently_pregnant",
+        "type": "choice_list",
+        "field": "currently_pregnant",
+        "datatype": "string",
+        "choices": [
+          {
+            "display": "Yes",
+            "value": "True"
+          },
+          {
+            "display": "No",
+            "value": "False"
+          }
+        ]
+      }
     ],
     "columns": [
-      [
-        {
-          "display": "Month",
-          "column_id": "month",
-          "type": "aggregate_date",
-          "field": "completed_time",
-          "format": "%Y-%m"
-        },
-        {
-          "display": "Supervisor ID",
-          "column_id": "supervisor_id",
-          "type": "field",
-          "field": "supervisor_id",
-          "aggregation": "simple"
-        },
-        {
-          "display": "FLW ID",
-          "column_id": "flw_id",
-          "type": "field",
-          "field": "flw_id",
-          "aggregation": "simple"
-        },
-        {
-          "display": "Count",
-          "column_id": "total_count",
-          "type": "field",
-          "field": "doc_id",
-          "aggregation": "count"
-        }
-      ]
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "completed_time",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "Supervisor ID",
+        "column_id": "supervisor_id",
+        "type": "field",
+        "field": "supervisor_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "FLW ID",
+        "column_id": "flw_id",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Count",
+        "column_id": "total_count",
+        "type": "field",
+        "field": "doc_id",
+        "aggregation": "count"
+      }
     ]
   },
   "doc_type": "ReportConfiguration"

--- a/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
@@ -107,7 +107,7 @@
         },
         {
           "display": "Count",
-          "column_id": "count",
+          "column_id": "total_count",
           "type": "field",
           "field": "doc_id",
           "aggregation": "count"

--- a/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
@@ -67,7 +67,7 @@
           "display": "Currently Pregnant",
           "slug": "currently_pregnant",
           "type": "choice_list",
-          "field": "closed",
+          "field": "currently_pregnant",
           "datatype": "string",
           "choices": [
             {

--- a/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
@@ -8,7 +8,7 @@
   "report_id": "static-pregnancy_registrations_v1",
   "data_source_table": "static-pregnancy_registrations_v1",
   "config": {
-    "title": "Pregnancy Registrations",
+    "title": "Pregnancy Registrations V1 (Static)",
     "description": "Pregnancy Registrations per flw per month",
     "visible": true,
     "aggregation_columns": [


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Building on from https://github.com/dimagi/commcare-hq/pull/29056, adding report for pregnancy registered.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This PR just adds a new data source and report for the project. It is not really live so there should be no scale implications of this as well.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Ideally this should not be rolled back because apps would be using it.

- [ ] This PR can be reverted after deploy with no further considerations 
