### PR TITLE
Add deliveries report

### DIFF
--- a/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
@@ -1,0 +1,248 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "config": {
+    "table_id": "static-deliveries_v1",
+    "display_name": "Deliveries V1",
+    "referenced_doc_type": "XFormInstance",
+    "base_item_expression": {
+      "type": "property_path",
+      "property_path": [
+        "form",
+        "delivery_details",
+        "child_birth_details",
+        "child_details"
+      ]
+    },
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "xmlns"
+          },
+          "property_value": "http://openrosa.org/formdesigner/F8AE9C85-38E3-4B84-BD16-0198C4907FD9"
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "app_id"
+          },
+          "property_value": "b3c758f7c79e47e3a503115894f18503"
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "type": "expression",
+        "column_id": "username",
+        "display_name": "username",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "username"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "userID",
+        "display_name": "userID",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      },
+      {
+        "display_name": "flw_id",
+        "datatype": "string",
+        "expression": {
+          "type": "named",
+          "name": "user_location_id"
+        },
+        "type": "expression",
+        "column_id": "flw_id"
+      },
+      {
+        "display_name": "supervisor_id",
+        "datatype": "string",
+        "expression": {
+          "location_id": {
+            "type": "named",
+            "name": "user_location_id"
+          },
+          "location_type": "supervisor",
+          "location_property": "_id",
+          "type": "ancestor_location"
+        },
+        "type": "expression",
+        "column_id": "supervisor_id"
+      },
+      {
+        "type": "expression",
+        "column_id": "received_on",
+        "display_name": "received_on",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "received_on"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "completed_time",
+        "display_name": "completed_time",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "timeEnd"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "expression": {
+          "type": "property_name",
+          "property_name": "child_safe_and_alive"
+        },
+        "column_id": "child_safe_and_alive",
+        "datatype": "string",
+        "display_name": "child_safe_and_alive"
+      },
+      {
+        "type": "expression",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "case_open_member_0",
+            "case",
+            "update",
+            "member_gender"
+          ]
+        },
+        "column_id": "gender",
+        "datatype": "string",
+        "display_name": "gender"
+      },
+      {
+        "type": "expression",
+        "column_id": "residential_status",
+        "display_name": "residential_status",
+        "datatype": "string",
+        "expression": {
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "member_residential_status"
+          },
+          "type": "related_doc",
+          "related_doc_type": "CommCareCase",
+          "doc_id_expression": {
+            "type": "root_doc",
+            "expression": {
+              "type": "property_path",
+              "property_path": [
+                "form",
+                "member_case_id_loaded"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "case_open_child_growth_0",
+            "case",
+            "update",
+            "weight"
+          ]
+        },
+        "column_id": "weight",
+        "datatype": "string",
+        "display_name": "weight"
+      },
+      {
+        "type": "expression",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "case_open_child_care_0",
+            "case",
+            "update",
+            "low_birth_weight"
+          ]
+        },
+        "column_id": "low_birth_weight",
+        "datatype": "string",
+        "display_name": "low_birth_weight"
+      }
+    ],
+    "named_expressions": {
+      "user_location_id": {
+        "datatype": "string",
+        "value_expression": {
+          "type": "property_name",
+          "property_name": "location_id"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareUser",
+        "doc_id_expression": {
+          "type": "root_doc",
+          "expression": {
+            "datatype": "string",
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "supervisor_id",
+          "flw_id"
+        ]
+      }
+    ]
+  }
+}

--- a/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
@@ -6,8 +6,8 @@
     "india"
   ],
   "config": {
-    "table_id": "static-deliveries_v1",
-    "display_name": "Deliveries V1",
+    "table_id": "static-record_a_delivery_v1",
+    "display_name": "Record a Delivery V1 (Static)",
     "referenced_doc_type": "XFormInstance",
     "base_item_expression": {
       "type": "property_path",

--- a/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
@@ -180,7 +180,8 @@
               ]
             }
           }
-        }
+        },
+        "comment": "Picked from the mother case since child does not have residential status"
       },
       {
         "type": "expression",

--- a/custom/nutrition_project/ucr/reports/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/reports/deliveries_v1.json
@@ -1,0 +1,264 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "report_id": "static-deliveries_v1",
+  "data_source_table": "static-deliveries_v1",
+  "config": {
+    "title": "Deliveries",
+    "description": "Deliveries per flw per month",
+    "visible": true,
+    "aggregation_columns": [
+      "supervisor_id",
+      "flw_id",
+      "month"
+    ],
+    "filters": [
+      [
+        {
+          "display": "Filter by FLW",
+          "slug": "flw_id",
+          "type": "dynamic_choice_list",
+          "field": "userID",
+          "choice_provider": {
+            "type": "location"
+          },
+          "ancestor_expression": {
+            "field": "supervisor_id",
+            "location_type": "supervisor"
+          },
+          "datatype": "string"
+        },
+        {
+          "display": "Filter by Supervisor",
+          "slug": "supervisor_id",
+          "type": "dynamic_choice_list",
+          "field": "supervisor_id",
+          "choice_provider": {
+            "type": "location"
+          },
+          "datatype": "string"
+        }
+      ]
+    ],
+    "columns": [
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "received_on",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "Supervisor ID",
+        "column_id": "supervisor_id",
+        "type": "field",
+        "field": "supervisor_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "FLW ID",
+        "column_id": "flw_id",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "M_permanent_resident_child_safe_and_alive",
+        "column_id": "M_permanent_resident_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND gender = 'M' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_permanent_resident_not_child_safe_and_alive",
+        "column_id": "M_permanent_resident_not_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'no' AND gender = 'M' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_temp_resident_child_safe_and_alive",
+        "column_id": "M_temp_resident_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND gender = 'M' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_temp_resident_not_child_safe_and_alive",
+        "column_id": "M_temp_resident_not_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'no' AND gender = 'M' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident_child_safe_and_alive",
+        "column_id": "F_permanent_resident_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND gender = 'F' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident_not_child_safe_and_alive",
+        "column_id": "F_permanent_resident_not_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'no' AND gender = 'F' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temp_resident_child_safe_and_alive",
+        "column_id": "F_temp_resident_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND gender = 'F' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temp_resident_not_child_safe_and_alive",
+        "column_id": "F_temp_resident_not_child_safe_and_alive",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'no' AND gender = 'F' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_permanent_resident_child_weighed",
+        "column_id": "M_permanent_resident_child_weighed",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND gender = 'M' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_temp_resident_child_weighed",
+        "column_id": "M_temp_resident_child_weighed",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND gender = 'M' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident_child_weighed",
+        "column_id": "F_permanent_resident_child_weighed",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND gender = 'F' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temp_resident_child_weighed",
+        "column_id": "F_temp_resident_child_weighed",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND gender = 'F' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_permanent_resident_child_low_birth_weight",
+        "column_id": "M_permanent_resident_child_low_birth_weight",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND low_birth_weight = 'yes' AND gender = 'M' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_temp_resident_child_low_birth_weight",
+        "column_id": "M_temp_resident_child_low_birth_weight",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND low_birth_weight = 'yes' AND gender = 'M' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident_child_low_birth_weight",
+        "column_id": "F_permanent_resident_child_low_birth_weight",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND low_birth_weight = 'yes' AND gender = 'F' AND residential_status = 'permanent_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temp_resident_child_low_birth_weight",
+        "column_id": "F_temp_resident_child_low_birth_weight",
+        "type": "sum_when",
+        "whens": [
+          [
+            "child_safe_and_alive = 'yes' AND weight is NOT NULL AND low_birth_weight = 'yes' AND gender = 'F' AND residential_status = 'temp_resident'",
+            1
+          ]
+        ],
+        "else_": 0
+      }
+    ]
+  },
+  "doc_type": "ReportConfiguration"
+}

--- a/custom/nutrition_project/ucr/reports/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/reports/deliveries_v1.json
@@ -17,32 +17,30 @@
       "month"
     ],
     "filters": [
-      [
-        {
-          "display": "Filter by FLW",
-          "slug": "flw_id",
-          "type": "dynamic_choice_list",
-          "field": "userID",
-          "choice_provider": {
-            "type": "location"
-          },
-          "ancestor_expression": {
-            "field": "supervisor_id",
-            "location_type": "supervisor"
-          },
-          "datatype": "string"
+      {
+        "display": "Filter by FLW",
+        "slug": "flw_id",
+        "type": "dynamic_choice_list",
+        "field": "userID",
+        "choice_provider": {
+          "type": "location"
         },
-        {
-          "display": "Filter by Supervisor",
-          "slug": "supervisor_id",
-          "type": "dynamic_choice_list",
+        "ancestor_expression": {
           "field": "supervisor_id",
-          "choice_provider": {
-            "type": "location"
-          },
-          "datatype": "string"
-        }
-      ]
+          "location_type": "supervisor"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "datatype": "string"
+      }
     ],
     "columns": [
       {

--- a/custom/nutrition_project/ucr/reports/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/reports/deliveries_v1.json
@@ -8,7 +8,7 @@
   "report_id": "static-deliveries_v1",
   "data_source_table": "static-deliveries_v1",
   "config": {
-    "title": "Deliveries",
+    "title": "Deliveries V1 (Static)",
     "description": "Deliveries per flw per month",
     "visible": true,
     "aggregation_columns": [

--- a/custom/nutrition_project/ucr/reports/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/reports/deliveries_v1.json
@@ -49,7 +49,7 @@
         "display": "Month",
         "column_id": "month",
         "type": "aggregate_date",
-        "field": "received_on",
+        "field": "completed_time",
         "format": "%Y-%m"
       },
       {

--- a/custom/nutrition_project/ucr/reports/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/reports/deliveries_v1.json
@@ -6,7 +6,7 @@
     "india"
   ],
   "report_id": "static-deliveries_v1",
-  "data_source_table": "static-deliveries_v1",
+  "data_source_table": "static-record_a_delivery_v1",
   "config": {
     "title": "Deliveries V1 (Static)",
     "description": "Deliveries per flw per month",


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Building on from https://github.com/dimagi/commcare-hq/pull/29056, adding a report for deliveries

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This PR just adds a new data source and report for the project. It is not really live so there should be no scale implications of this as well.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Ideally this should not be rolled back because apps would be using it.

- [ ] This PR can be reverted after deploy with no further considerations 
