### PR TITLE
Updated web apps search algorithms to not mutate combobox options

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -630,7 +630,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
             return true;
         }
         query = query.toLowerCase();
-        option.text = option.text.toLowerCase();
+        var haystack = option.text.toLowerCase();
 
         var match;
         if (matchType === Const.COMBOBOX_MULTIWORD) {
@@ -639,7 +639,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
             // Assumption is both query and choice will not be very long. Runtime is O(nm)
             // where n is number of words in the query, and m is number of words in the choice
             var wordsInQuery = query.split(' ');
-            var wordsInChoice = option.text.split(' ');
+            var wordsInChoice = haystack.split(' ');
 
             match = _.all(wordsInQuery, function (word) {
                 return _.include(wordsInChoice, word);
@@ -647,8 +647,8 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         } else if (matchType === Const.COMBOBOX_FUZZY) {
             // Fuzzy filter, matches if query is "close" to answer
             match = (
-                (window.Levenshtein.get(option.text, query) <= 2 && query.length > 3) ||
-                option.text === query
+                (window.Levenshtein.get(haystack, query) <= 2 && query.length > 3) ||
+                haystack === query
             );
         }
 
@@ -658,7 +658,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         }
 
         // Standard filter, matches only start of word
-        return option.text.startsWith(query);
+        return haystack.startsWith(query);
     };
 
     ComboboxEntry.prototype = Object.create(DropdownEntry.prototype);


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/issue/SUPPORT-7309

Followup for https://github.com/dimagi/commcare-hq/pull/29045

## Product Description
Probably not worth announcing. Fixes a minor, recently-introduced bug where the casing of options in web apps dropdowns would get lowercased.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

The search algorithms have test coverage. The dropdown UI does not.

### QA Plan

Minor, tested locally, not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
