### PR TITLE
Upgrade pip-tools

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -141,7 +141,7 @@ pexpect==4.8.0            # via ipython
 phonenumberslite==8.12.10  # via -r requirements.in
 pickleshare==0.7.5        # via ipython
 pillow==7.2.0             # via -r requirements.in, cairosvg, django-simple-captcha, reportlab
-pip-tools==5.3.1          # via -r test-requirements.in
+pip-tools==5.5.0          # via -r test-requirements.in
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0              # via -r requirements.in
 prometheus-client==0.7.1  # via -r requirements.in

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -4,246 +4,713 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-alabaster==0.7.12         # via sphinx
-alembic==1.4.3            # via -r requirements.in
-amqp==2.6.1               # via kombu
-architect==0.5.6          # via -r requirements.in
-argparse==1.4.0           # via unittest2
-attrs==18.2.0             # via -r requirements.in
-babel==2.8.0              # via django-phonenumber-field, sphinx
-backcall==0.2.0           # via ipython
-beautifulsoup4==4.9.3     # via -r test-requirements.in
-billiard==3.5.0.4         # via -r requirements.in, celery
-boto3==1.15.12            # via -r requirements.in
-botocore==1.18.12         # via boto3, s3transfer
-cairocffi==1.1.0          # via cairosvg, weasyprint
-cairosvg==2.5.1           # via weasyprint
-https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl  # via -r requirements.in, django-celery-results
-certifi==2020.6.20        # via elasticsearch7, requests, sentry-sdk
-cffi==1.14.3              # via cairocffi, cryptography, csiphash, weasyprint
-chardet==3.0.4            # via ghdiff, requests
-click==7.1.2              # via git-build-branch, pip-tools
-cloudant==2.14.0          # via jsonobject-couchdbkit
-colorama==0.4.3           # via sniffer
-commcaretranslationchecker==0.9.7  # via -r requirements.in
-commonmark==0.9.1         # via recommonmark
-concurrent-log-handler==0.9.12  # via -r requirements.in
-contextlib2==0.6.0.post1  # via git-build-branch, schema
-coverage==4.5.1           # via -r test-requirements.in
-cryptography==3.3.1       # via pyopenssl
-csiphash==0.0.5           # via -r requirements.in
-cssselect2==0.3.0         # via cairosvg, weasyprint
-datadog==0.39.0           # via -r requirements.in
-ddtrace==0.44.0           # via -r requirements.in
-decorator==4.0.11         # via -r requirements.in, datadog, ipython, jsonpath-rw, traitlets
-defusedxml==0.5.0         # via -r requirements.in, cairosvg, python3-saml
-deprecated==1.2.10        # via pygithub
-diff-match-patch==20120106  # via -r requirements.in
-dimagi-memoized==1.1.3    # via -r requirements.in
-django-angular==2.2.4     # via -r requirements.in
-django-appconf==1.0.4     # via django-compressor, django-statici18n
-django-braces==1.14.0     # via -r requirements.in
-django-bulk-update==2.2.0  # via -r requirements.in
-django-celery-results==1.0.4  # via -r requirements.in
-django-compressor==2.1    # via -r requirements.in
-django-countries==4.6     # via -r requirements.in
-django-crispy-forms==1.10.0  # via -r requirements.in
-django-cte==1.1.4         # via -r requirements.in
-django-debug-toolbar==3.1  # via -r dev-requirements.in
-django-extensions==3.1.0  # via -r dev-requirements.in
-django-formtools==2.1     # via -r requirements.in, django-two-factor-auth
-django-logentry-admin==1.0.6  # via -r requirements.in
-https://github.com/dimagi/django-nose/raw/fast-first-1.4.6.1/releases/django_nose-1.4.6.1-py2.py3-none-any.whl  # via -r test-requirements.in
-django-oauth-toolkit==1.3.2  # via -r requirements.in
-django-otp==0.9.4         # via -r requirements.in, django-two-factor-auth
-django-partial-index==0.6.0  # via -r requirements.in
-django-phonenumber-field==2.3.1  # via -r requirements.in, django-two-factor-auth
-django-prbac==1.0.1       # via -r requirements.in
-django-ranged-response==0.2.0  # via django-simple-captcha
-django-redis-sessions==0.6.1  # via -r requirements.in
-django-redis==4.12.1      # via -r requirements.in
-django-simple-captcha==0.5.13  # via -r requirements.in
-django-statici18n==1.9.0  # via -r requirements.in
-django-tastypie==0.14.3   # via -r requirements.in
-django-transfer==0.4      # via -r requirements.in
-django-two-factor-auth==1.12.1  # via -r requirements.in
-django-user-agents==0.4.0  # via -r requirements.in
-django-websocket-redis==0.6.0  # via -r requirements.in
-django==2.2.16            # via -r requirements.in, django-angular, django-appconf, django-braces, django-bulk-update, django-debug-toolbar, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
-djangorestframework==3.12.2  # via -r requirements.in
-dnspython==1.15.0         # via -r requirements.in, email-validator
-docutils==0.15.2          # via -r dev-requirements.in, recommonmark, sphinx
-dropbox==9.3.0            # via -r requirements.in
-elasticsearch2==2.5.1     # via -r requirements.in
-elasticsearch7==7.9.1     # via -r requirements.in
-elasticsearch==1.9.0      # via -r requirements.in
-email_validator==1.1.2    # via -r requirements.in
-et-xmlfile==1.0.1         # via openpyxl
-ethiopian-date-converter==0.1.5  # via -r requirements.in
-eulxml==1.1.3             # via -r requirements.in
-fakecouch==0.0.15         # via -r test-requirements.in
-faker==5.0.2              # via -r requirements.in
-fancycompleter==0.9.1     # via pdbpp
-fixture==1.5.11           # via -r dev-requirements.in
-flake8==3.8.4             # via -r dev-requirements.in
-flaky==3.7.0              # via -r test-requirements.in
-freezegun==0.3.15         # via -r test-requirements.in
-gevent==1.4.0             # via -r requirements.in, django-websocket-redis, gipc, git-build-branch
-ghdiff==0.4               # via -r requirements.in
-gipc==1.1.0               # via -r requirements.in
-git-build-branch==0.1.9   # via -r dev-requirements.in
-gnureadline==6.3.8        # via -r dev-requirements.in
-graphviz==0.14.2          # via -r dev-requirements.in
-greenlet==0.4.17          # via -r requirements.in, django-websocket-redis, gevent
-gunicorn==20.0.4          # via -r requirements.in
-hiredis==1.1.0            # via -r requirements.in
-html5lib==1.1             # via weasyprint
-httpagentparser==1.9.0    # via -r requirements.in
-idna==2.10                # via email-validator, requests
-imagesize==1.2.0          # via sphinx
-importlib-metadata==2.0.0  # via flake8
-intervaltree==3.1.0       # via ddtrace
-ipdb==0.11                # via -r dev-requirements.in
-ipython-genutils==0.2.0   # via traitlets
-ipython==7.16.1           # via -r dev-requirements.in, ipdb
-iso8601==0.1.13           # via -r requirements.in
-isodate==0.6.0            # via python3-saml
-jdcal==1.4.1              # via openpyxl
-jedi==0.17.2              # via ipython
-jenkinsapi==0.2.28        # via -r dev-requirements.in
-jinja2==2.11.2            # via -r requirements.in, sphinx
-jmespath==0.10.0          # via boto3, botocore
-json-delta==2.0           # via -r requirements.in
-jsonfield==2.1.1          # via -r requirements.in, django-prbac
-jsonobject-couchdbkit==1.0.1  # via -r requirements.in
-jsonobject==0.9.9         # via -r requirements.in, git-build-branch, jsonobject-couchdbkit
-jsonpath-rw==1.4.0        # via -r requirements.in
-kafka-python==1.4.7       # via -r requirements.in
-kombu==4.2.2.post1        # via -r requirements.in, celery
-laboratory==0.2.0         # via -r requirements.in
-linecache2==1.0.0         # via traceback2
-lxml==4.3.5               # via -r requirements.in, eulxml, xmlsec
-mako==1.1.3               # via alembic
-markdown==2.2.1           # via -r requirements.in, pycco
-markupsafe==1.1.1         # via jinja2, mako
-mccabe==0.6.1             # via flake8
-mock==2.0.0               # via -r requirements.in
-modernize==0.7            # via -r dev-requirements.in
-nose-exclude==0.5.0       # via -r test-requirements.in
-nose==1.3.7               # via -r test-requirements.in, django-nose, nose-exclude, sniffer
-oauthlib==3.1.0           # via django-oauth-toolkit, requests-oauthlib
-openpyxl==2.6.4           # via -r requirements.in, commcaretranslationchecker
-packaging==20.4           # via sphinx
-parso==0.7.1              # via jedi
-pbr==5.5.0                # via mock
-pdbpp==0.10.2             # via -r dev-requirements.in
-pexpect==4.8.0            # via ipython
-phonenumberslite==8.12.10  # via -r requirements.in
-pickleshare==0.7.5        # via ipython
-pillow==7.2.0             # via -r requirements.in, cairosvg, django-simple-captcha, reportlab
-pip-tools==5.5.0          # via -r test-requirements.in
-ply==3.11                 # via eulxml, jsonpath-rw
-polib==1.1.0              # via -r requirements.in
-prometheus-client==0.7.1  # via -r requirements.in
-prompt-toolkit==3.0.7     # via ipython
-protobuf==3.13.0          # via ddtrace
-psutil==5.7.3             # via -r dev-requirements.in
-psycogreen==1.0.2         # via -r requirements.in
-psycopg2==2.8.6           # via -r requirements.in, sqlalchemy-postgres-copy
-ptyprocess==0.6.0         # via pexpect
-py-kissmetrics==1.1.0     # via -r requirements.in
-pycco==0.5.1              # via -r requirements.in
-pycodestyle==2.6.0        # via flake8
-pycparser==2.20           # via cffi
-pycryptodome==3.9.9       # via -r requirements.in
-pyflakes==2.2.0           # via flake8
-pygithub==1.54            # via -r requirements.in
-pygments==2.7.1           # via -r requirements.in, ipython, pdbpp, pycco, sphinx
-pygooglechart==0.4.0      # via -r requirements.in
-pyjwt==1.7.1              # via pygithub, twilio
-pyopenssl==20.0.1         # via -r requirements.in
-pyparsing==2.4.7          # via packaging
-pyphen==0.9.5             # via weasyprint
-pyrepl==0.9.0             # via fancycompleter
-pysocks==1.7.1            # via twilio
-pystache==0.5.4           # via pycco
-python-dateutil==2.8.1    # via -r requirements.in, alembic, botocore, django-tastypie, faker, freezegun
-python-editor==1.0.4      # via alembic
-python-imap==1.0.0        # via -r requirements.in
-python-levenshtein==0.12.0  # via -r requirements.in
-python-magic==0.4.18      # via -r requirements.in
-python-mimeparse==1.6.0   # via django-tastypie
-python-termstyle==0.1.10  # via sniffer
-python3-saml==1.9.0       # via -r requirements.in
-pytz==2020.1              # via -r requirements.in, babel, celery, django, jenkinsapi, twilio
-pyyaml==5.3.1             # via -r requirements.in, git-build-branch
-pyzxcvbn==0.8.0           # via -r requirements.in
-qrcode==4.0.4             # via -r requirements.in, django-two-factor-auth
-quickcache==0.5.4         # via -r requirements.in
-rcssmin==1.0.6            # via django-compressor
-recommonmark==0.6.0       # via -r dev-requirements.in
-redis==3.5.3              # via -r requirements.in, django-redis, django-redis-sessions, django-websocket-redis
-reportlab==3.5.53         # via -r requirements.in
-requests-mock==1.8.0      # via -r test-requirements.in
-requests-oauthlib==1.3.0  # via -r requirements.in
-requests==2.24.0          # via -r requirements.in, cloudant, datadog, django-oauth-toolkit, dropbox, jenkinsapi, pygithub, requests-mock, requests-oauthlib, sphinx, stripe, tinys3, twilio
-rjsmin==1.0.12            # via django-compressor
-s3transfer==0.3.3         # via boto3
-schema==0.7.2             # via -r requirements.in
-sentry-sdk==0.19.4        # via -r requirements.in
-sh==1.14.1                # via -r requirements.in, git-build-branch
-simpleeval==0.9.10        # via -r requirements.in
-simplejson==3.17.2        # via -r requirements.in, django-prbac
-six==1.15.0               # via -r requirements.in, cryptography, django-braces, django-simple-captcha, django-statici18n, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, fixture, freezegun, ghdiff, html5lib, isodate, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, packaging, pip-tools, protobuf, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, tenacity, traitlets, transifex-client, twilio, unittest2
-smartypants==2.0.1        # via pycco
-sniffer==0.4.1            # via -r dev-requirements.in
-snowballstemmer==2.0.0    # via sphinx
-socketpool==0.5.3         # via -r requirements.in
-sortedcontainers==2.3.0   # via intervaltree
-soupsieve==2.0.1          # via beautifulsoup4
-sphinx-rtd-theme==0.4.3   # via -r dev-requirements.in
-sphinx==2.2.2             # via -r dev-requirements.in, recommonmark, sphinx-rtd-theme
-sphinxcontrib-applehelp==1.0.2  # via sphinx
-sphinxcontrib-devhelp==1.0.2  # via sphinx
-sphinxcontrib-django==0.5.1  # via -r dev-requirements.in
-sphinxcontrib-htmlhelp==1.0.3  # via sphinx
-sphinxcontrib-jsmath==1.0.1  # via sphinx
-sphinxcontrib-qthelp==1.0.3  # via sphinx
-sphinxcontrib-serializinghtml==1.1.4  # via sphinx
-sqlagg==0.17.2            # via -r requirements.in
-sqlalchemy-postgres-copy==0.5.0  # via -r test-requirements.in
-sqlalchemy==1.3.19        # via -r requirements.in, alembic, sqlagg, sqlalchemy-postgres-copy
-sqlparse==0.3.1           # via django, django-debug-toolbar
-stripe==2.54.0            # via -r requirements.in
-suds-jurko==0.6           # via -r requirements.in
-tenacity==6.2.0           # via ddtrace
-testil==1.1               # via -r test-requirements.in
-text-unidecode==1.3       # via -r requirements.in, faker
-tinycss2==1.0.2           # via cairosvg, cssselect2, weasyprint
-tinys3==0.1.12            # via -r requirements.in
-traceback2==1.4.0         # via unittest2
-traitlets==4.3.3          # via ipython
-transifex-client==0.12.4  # via -r dev-requirements.in
-tropo-webapi-python==0.1.3  # via -r requirements.in
-turn-python==0.0.1        # via -r requirements.in
-twilio==6.5.1             # via -r requirements.in
-ua-parser==0.10.0         # via user-agents
-unittest2==1.1.0          # via -r test-requirements.in
-urllib3==1.25.10          # via botocore, elasticsearch, elasticsearch2, elasticsearch7, py-kissmetrics, requests, sentry-sdk, transifex-client
-user-agents==2.2.0        # via django-user-agents
-vine==1.3.0               # via amqp
-wcwidth==0.2.5            # via prompt-toolkit
-weasyprint==51            # via -r requirements.in
-webencodings==0.5.1       # via cssselect2, html5lib, tinycss2
-werkzeug==1.0.1           # via -r requirements.in
-wheel==0.29.0             # via -r dev-requirements.in
-wmctrl==0.3               # via pdbpp
-wrapt==1.12.1             # via deprecated
-xlrd==1.0.0               # via -r requirements.in
-xlwt==1.3.0               # via -r requirements.in
-xmlsec==1.3.9             # via python3-saml
-zipp==3.2.0               # via importlib-metadata
+alabaster==0.7.12
+    # via sphinx
+alembic==1.4.3
+    # via -r requirements.in
+amqp==2.6.1
+    # via kombu
+architect==0.5.6
+    # via -r requirements.in
+argparse==1.4.0
+    # via unittest2
+attrs==18.2.0
+    # via -r requirements.in
+babel==2.8.0
+    # via
+    #   django-phonenumber-field
+    #   sphinx
+backcall==0.2.0
+    # via ipython
+beautifulsoup4==4.9.3
+    # via -r test-requirements.in
+billiard==3.5.0.4
+    # via
+    #   -r requirements.in
+    #   celery
+boto3==1.15.12
+    # via -r requirements.in
+botocore==1.18.12
+    # via
+    #   boto3
+    #   s3transfer
+cairocffi==1.1.0
+    # via
+    #   cairosvg
+    #   weasyprint
+cairosvg==2.5.1
+    # via weasyprint
+https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
+    # via
+    #   -r requirements.in
+    #   django-celery-results
+certifi==2020.6.20
+    # via
+    #   elasticsearch7
+    #   requests
+    #   sentry-sdk
+cffi==1.14.3
+    # via
+    #   cairocffi
+    #   cryptography
+    #   csiphash
+    #   weasyprint
+chardet==3.0.4
+    # via
+    #   ghdiff
+    #   requests
+click==7.1.2
+    # via
+    #   git-build-branch
+    #   pip-tools
+cloudant==2.14.0
+    # via jsonobject-couchdbkit
+colorama==0.4.3
+    # via sniffer
+commcaretranslationchecker==0.9.7
+    # via -r requirements.in
+commonmark==0.9.1
+    # via recommonmark
+concurrent-log-handler==0.9.12
+    # via -r requirements.in
+contextlib2==0.6.0.post1
+    # via
+    #   git-build-branch
+    #   schema
+coverage==4.5.1
+    # via -r test-requirements.in
+cryptography==3.3.1
+    # via pyopenssl
+csiphash==0.0.5
+    # via -r requirements.in
+cssselect2==0.3.0
+    # via
+    #   cairosvg
+    #   weasyprint
+datadog==0.39.0
+    # via -r requirements.in
+ddtrace==0.44.0
+    # via -r requirements.in
+decorator==4.0.11
+    # via
+    #   -r requirements.in
+    #   datadog
+    #   ipython
+    #   jsonpath-rw
+    #   traitlets
+defusedxml==0.5.0
+    # via
+    #   -r requirements.in
+    #   cairosvg
+    #   python3-saml
+deprecated==1.2.10
+    # via pygithub
+diff-match-patch==20120106
+    # via -r requirements.in
+dimagi-memoized==1.1.3
+    # via -r requirements.in
+django-angular==2.2.4
+    # via -r requirements.in
+django-appconf==1.0.4
+    # via
+    #   django-compressor
+    #   django-statici18n
+django-braces==1.14.0
+    # via -r requirements.in
+django-bulk-update==2.2.0
+    # via -r requirements.in
+django-celery-results==1.0.4
+    # via -r requirements.in
+django-compressor==2.1
+    # via -r requirements.in
+django-countries==4.6
+    # via -r requirements.in
+django-crispy-forms==1.10.0
+    # via -r requirements.in
+django-cte==1.1.4
+    # via -r requirements.in
+django-debug-toolbar==3.1
+    # via -r dev-requirements.in
+django-extensions==3.1.0
+    # via -r dev-requirements.in
+django-formtools==2.1
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+django-logentry-admin==1.0.6
+    # via -r requirements.in
+https://github.com/dimagi/django-nose/raw/fast-first-1.4.6.1/releases/django_nose-1.4.6.1-py2.py3-none-any.whl
+    # via -r test-requirements.in
+django-oauth-toolkit==1.3.2
+    # via -r requirements.in
+django-otp==0.9.4
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+django-partial-index==0.6.0
+    # via -r requirements.in
+django-phonenumber-field==2.3.1
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+django-prbac==1.0.1
+    # via -r requirements.in
+django-ranged-response==0.2.0
+    # via django-simple-captcha
+django-redis-sessions==0.6.1
+    # via -r requirements.in
+django-redis==4.12.1
+    # via -r requirements.in
+django-simple-captcha==0.5.13
+    # via -r requirements.in
+django-statici18n==1.9.0
+    # via -r requirements.in
+django-tastypie==0.14.3
+    # via -r requirements.in
+django-transfer==0.4
+    # via -r requirements.in
+django-two-factor-auth==1.12.1
+    # via -r requirements.in
+django-user-agents==0.4.0
+    # via -r requirements.in
+django-websocket-redis==0.6.0
+    # via -r requirements.in
+django==2.2.16
+    # via
+    #   -r requirements.in
+    #   django-angular
+    #   django-appconf
+    #   django-braces
+    #   django-bulk-update
+    #   django-debug-toolbar
+    #   django-formtools
+    #   django-logentry-admin
+    #   django-oauth-toolkit
+    #   django-otp
+    #   django-phonenumber-field
+    #   django-prbac
+    #   django-ranged-response
+    #   django-redis
+    #   django-simple-captcha
+    #   django-statici18n
+    #   django-two-factor-auth
+    #   django-user-agents
+    #   djangorestframework
+    #   jsonfield
+djangorestframework==3.12.2
+    # via -r requirements.in
+dnspython==1.15.0
+    # via
+    #   -r requirements.in
+    #   email-validator
+docutils==0.15.2
+    # via
+    #   -r dev-requirements.in
+    #   recommonmark
+    #   sphinx
+dropbox==9.3.0
+    # via -r requirements.in
+elasticsearch2==2.5.1
+    # via -r requirements.in
+elasticsearch7==7.9.1
+    # via -r requirements.in
+elasticsearch==1.9.0
+    # via -r requirements.in
+email_validator==1.1.2
+    # via -r requirements.in
+et-xmlfile==1.0.1
+    # via openpyxl
+ethiopian-date-converter==0.1.5
+    # via -r requirements.in
+eulxml==1.1.3
+    # via -r requirements.in
+fakecouch==0.0.15
+    # via -r test-requirements.in
+faker==5.0.2
+    # via -r requirements.in
+fancycompleter==0.9.1
+    # via pdbpp
+fixture==1.5.11
+    # via -r dev-requirements.in
+flake8==3.8.4
+    # via -r dev-requirements.in
+flaky==3.7.0
+    # via -r test-requirements.in
+freezegun==0.3.15
+    # via -r test-requirements.in
+gevent==1.4.0
+    # via
+    #   -r requirements.in
+    #   django-websocket-redis
+    #   gipc
+    #   git-build-branch
+ghdiff==0.4
+    # via -r requirements.in
+gipc==1.1.0
+    # via -r requirements.in
+git-build-branch==0.1.9
+    # via -r dev-requirements.in
+gnureadline==6.3.8
+    # via -r dev-requirements.in
+graphviz==0.14.2
+    # via -r dev-requirements.in
+greenlet==0.4.17
+    # via
+    #   -r requirements.in
+    #   django-websocket-redis
+    #   gevent
+gunicorn==20.0.4
+    # via -r requirements.in
+hiredis==1.1.0
+    # via -r requirements.in
+html5lib==1.1
+    # via weasyprint
+httpagentparser==1.9.0
+    # via -r requirements.in
+idna==2.10
+    # via
+    #   email-validator
+    #   requests
+imagesize==1.2.0
+    # via sphinx
+importlib-metadata==2.0.0
+    # via flake8
+intervaltree==3.1.0
+    # via ddtrace
+ipdb==0.11
+    # via -r dev-requirements.in
+ipython-genutils==0.2.0
+    # via traitlets
+ipython==7.16.1
+    # via
+    #   -r dev-requirements.in
+    #   ipdb
+iso8601==0.1.13
+    # via -r requirements.in
+isodate==0.6.0
+    # via python3-saml
+jdcal==1.4.1
+    # via openpyxl
+jedi==0.17.2
+    # via ipython
+jenkinsapi==0.2.28
+    # via -r dev-requirements.in
+jinja2==2.11.2
+    # via
+    #   -r requirements.in
+    #   sphinx
+jmespath==0.10.0
+    # via
+    #   boto3
+    #   botocore
+json-delta==2.0
+    # via -r requirements.in
+jsonfield==2.1.1
+    # via
+    #   -r requirements.in
+    #   django-prbac
+jsonobject-couchdbkit==1.0.1
+    # via -r requirements.in
+jsonobject==0.9.9
+    # via
+    #   -r requirements.in
+    #   git-build-branch
+    #   jsonobject-couchdbkit
+jsonpath-rw==1.4.0
+    # via -r requirements.in
+kafka-python==1.4.7
+    # via -r requirements.in
+kombu==4.2.2.post1
+    # via
+    #   -r requirements.in
+    #   celery
+laboratory==0.2.0
+    # via -r requirements.in
+linecache2==1.0.0
+    # via traceback2
+lxml==4.3.5
+    # via
+    #   -r requirements.in
+    #   eulxml
+    #   xmlsec
+mako==1.1.3
+    # via alembic
+markdown==2.2.1
+    # via
+    #   -r requirements.in
+    #   pycco
+markupsafe==1.1.1
+    # via
+    #   jinja2
+    #   mako
+mccabe==0.6.1
+    # via flake8
+mock==2.0.0
+    # via -r requirements.in
+modernize==0.7
+    # via -r dev-requirements.in
+nose-exclude==0.5.0
+    # via -r test-requirements.in
+nose==1.3.7
+    # via
+    #   -r test-requirements.in
+    #   django-nose
+    #   nose-exclude
+    #   sniffer
+oauthlib==3.1.0
+    # via
+    #   django-oauth-toolkit
+    #   requests-oauthlib
+openpyxl==2.6.4
+    # via
+    #   -r requirements.in
+    #   commcaretranslationchecker
+packaging==20.4
+    # via sphinx
+parso==0.7.1
+    # via jedi
+pbr==5.5.0
+    # via mock
+pdbpp==0.10.2
+    # via -r dev-requirements.in
+pexpect==4.8.0
+    # via ipython
+phonenumberslite==8.12.10
+    # via -r requirements.in
+pickleshare==0.7.5
+    # via ipython
+pillow==7.2.0
+    # via
+    #   -r requirements.in
+    #   cairosvg
+    #   django-simple-captcha
+    #   reportlab
+pip-tools==5.5.0
+    # via -r test-requirements.in
+ply==3.11
+    # via
+    #   eulxml
+    #   jsonpath-rw
+polib==1.1.0
+    # via -r requirements.in
+prometheus-client==0.7.1
+    # via -r requirements.in
+prompt-toolkit==3.0.7
+    # via ipython
+protobuf==3.13.0
+    # via ddtrace
+psutil==5.7.3
+    # via -r dev-requirements.in
+psycogreen==1.0.2
+    # via -r requirements.in
+psycopg2==2.8.6
+    # via
+    #   -r requirements.in
+    #   sqlalchemy-postgres-copy
+ptyprocess==0.6.0
+    # via pexpect
+py-kissmetrics==1.1.0
+    # via -r requirements.in
+pycco==0.5.1
+    # via -r requirements.in
+pycodestyle==2.6.0
+    # via flake8
+pycparser==2.20
+    # via cffi
+pycryptodome==3.9.9
+    # via -r requirements.in
+pyflakes==2.2.0
+    # via flake8
+pygithub==1.54
+    # via -r requirements.in
+pygments==2.7.1
+    # via
+    #   -r requirements.in
+    #   ipython
+    #   pdbpp
+    #   pycco
+    #   sphinx
+pygooglechart==0.4.0
+    # via -r requirements.in
+pyjwt==1.7.1
+    # via
+    #   pygithub
+    #   twilio
+pyopenssl==20.0.1
+    # via -r requirements.in
+pyparsing==2.4.7
+    # via packaging
+pyphen==0.9.5
+    # via weasyprint
+pyrepl==0.9.0
+    # via fancycompleter
+pysocks==1.7.1
+    # via twilio
+pystache==0.5.4
+    # via pycco
+python-dateutil==2.8.1
+    # via
+    #   -r requirements.in
+    #   alembic
+    #   botocore
+    #   django-tastypie
+    #   faker
+    #   freezegun
+python-editor==1.0.4
+    # via alembic
+python-imap==1.0.0
+    # via -r requirements.in
+python-levenshtein==0.12.0
+    # via -r requirements.in
+python-magic==0.4.18
+    # via -r requirements.in
+python-mimeparse==1.6.0
+    # via django-tastypie
+python-termstyle==0.1.10
+    # via sniffer
+python3-saml==1.9.0
+    # via -r requirements.in
+pytz==2020.1
+    # via
+    #   -r requirements.in
+    #   babel
+    #   celery
+    #   django
+    #   jenkinsapi
+    #   twilio
+pyyaml==5.3.1
+    # via
+    #   -r requirements.in
+    #   git-build-branch
+pyzxcvbn==0.8.0
+    # via -r requirements.in
+qrcode==4.0.4
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+quickcache==0.5.4
+    # via -r requirements.in
+rcssmin==1.0.6
+    # via django-compressor
+recommonmark==0.6.0
+    # via -r dev-requirements.in
+redis==3.5.3
+    # via
+    #   -r requirements.in
+    #   django-redis
+    #   django-redis-sessions
+    #   django-websocket-redis
+reportlab==3.5.53
+    # via -r requirements.in
+requests-mock==1.8.0
+    # via -r test-requirements.in
+requests-oauthlib==1.3.0
+    # via -r requirements.in
+requests==2.24.0
+    # via
+    #   -r requirements.in
+    #   cloudant
+    #   datadog
+    #   django-oauth-toolkit
+    #   dropbox
+    #   jenkinsapi
+    #   pygithub
+    #   requests-mock
+    #   requests-oauthlib
+    #   sphinx
+    #   stripe
+    #   tinys3
+    #   twilio
+rjsmin==1.0.12
+    # via django-compressor
+s3transfer==0.3.3
+    # via boto3
+schema==0.7.2
+    # via -r requirements.in
+sentry-sdk==0.19.4
+    # via -r requirements.in
+sh==1.14.1
+    # via
+    #   -r requirements.in
+    #   git-build-branch
+simpleeval==0.9.10
+    # via -r requirements.in
+simplejson==3.17.2
+    # via
+    #   -r requirements.in
+    #   django-prbac
+six==1.15.0
+    # via
+    #   -r requirements.in
+    #   cryptography
+    #   django-braces
+    #   django-simple-captcha
+    #   django-statici18n
+    #   django-transfer
+    #   django-websocket-redis
+    #   dropbox
+    #   ethiopian-date-converter
+    #   eulxml
+    #   fixture
+    #   freezegun
+    #   ghdiff
+    #   html5lib
+    #   isodate
+    #   jsonfield
+    #   jsonobject
+    #   jsonobject-couchdbkit
+    #   jsonpath-rw
+    #   mock
+    #   packaging
+    #   protobuf
+    #   pyopenssl
+    #   python-dateutil
+    #   pyzxcvbn
+    #   qrcode
+    #   quickcache
+    #   requests-mock
+    #   sqlalchemy-postgres-copy
+    #   tenacity
+    #   traitlets
+    #   transifex-client
+    #   twilio
+    #   unittest2
+smartypants==2.0.1
+    # via pycco
+sniffer==0.4.1
+    # via -r dev-requirements.in
+snowballstemmer==2.0.0
+    # via sphinx
+socketpool==0.5.3
+    # via -r requirements.in
+sortedcontainers==2.3.0
+    # via intervaltree
+soupsieve==2.0.1
+    # via beautifulsoup4
+sphinx-rtd-theme==0.4.3
+    # via -r dev-requirements.in
+sphinx==2.2.2
+    # via
+    #   -r dev-requirements.in
+    #   recommonmark
+    #   sphinx-rtd-theme
+sphinxcontrib-applehelp==1.0.2
+    # via sphinx
+sphinxcontrib-devhelp==1.0.2
+    # via sphinx
+sphinxcontrib-django==0.5.1
+    # via -r dev-requirements.in
+sphinxcontrib-htmlhelp==1.0.3
+    # via sphinx
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-qthelp==1.0.3
+    # via sphinx
+sphinxcontrib-serializinghtml==1.1.4
+    # via sphinx
+sqlagg==0.17.2
+    # via -r requirements.in
+sqlalchemy-postgres-copy==0.5.0
+    # via -r test-requirements.in
+sqlalchemy==1.3.19
+    # via
+    #   -r requirements.in
+    #   alembic
+    #   sqlagg
+    #   sqlalchemy-postgres-copy
+sqlparse==0.3.1
+    # via
+    #   django
+    #   django-debug-toolbar
+stripe==2.54.0
+    # via -r requirements.in
+suds-jurko==0.6
+    # via -r requirements.in
+tenacity==6.2.0
+    # via ddtrace
+testil==1.1
+    # via -r test-requirements.in
+text-unidecode==1.3
+    # via
+    #   -r requirements.in
+    #   faker
+tinycss2==1.0.2
+    # via
+    #   cairosvg
+    #   cssselect2
+    #   weasyprint
+tinys3==0.1.12
+    # via -r requirements.in
+traceback2==1.4.0
+    # via unittest2
+traitlets==4.3.3
+    # via ipython
+transifex-client==0.12.4
+    # via -r dev-requirements.in
+tropo-webapi-python==0.1.3
+    # via -r requirements.in
+turn-python==0.0.1
+    # via -r requirements.in
+twilio==6.5.1
+    # via -r requirements.in
+ua-parser==0.10.0
+    # via user-agents
+unittest2==1.1.0
+    # via -r test-requirements.in
+urllib3==1.25.10
+    # via
+    #   botocore
+    #   elasticsearch
+    #   elasticsearch2
+    #   elasticsearch7
+    #   py-kissmetrics
+    #   requests
+    #   sentry-sdk
+    #   transifex-client
+user-agents==2.2.0
+    # via django-user-agents
+vine==1.3.0
+    # via amqp
+wcwidth==0.2.5
+    # via prompt-toolkit
+weasyprint==51
+    # via -r requirements.in
+webencodings==0.5.1
+    # via
+    #   cssselect2
+    #   html5lib
+    #   tinycss2
+werkzeug==1.0.1
+    # via -r requirements.in
+wheel==0.29.0
+    # via -r dev-requirements.in
+wmctrl==0.3
+    # via pdbpp
+wrapt==1.12.1
+    # via deprecated
+xlrd==1.0.0
+    # via -r requirements.in
+xlwt==1.3.0
+    # via -r requirements.in
+xmlsec==1.3.9
+    # via python3-saml
+zipp==3.2.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.2.3               # via pip-tools
-setuptools==50.3.0        # via cairocffi, cssselect2, django-websocket-redis, gunicorn, ipdb, ipython, protobuf, python-levenshtein, python-termstyle, sphinx, tinycss2, weasyprint
+pip==20.2.3
+    # via pip-tools
+setuptools==50.3.0
+    # via
+    #   cairocffi
+    #   cssselect2
+    #   django-websocket-redis
+    #   gunicorn
+    #   ipdb
+    #   ipython
+    #   protobuf
+    #   python-levenshtein
+    #   python-termstyle
+    #   sphinx
+    #   tinycss2
+    #   weasyprint

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -4,192 +4,570 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-alembic==1.4.3            # via -r requirements.in
-amqp==2.6.1               # via kombu
-architect==0.5.6          # via -r requirements.in
-attrs==18.2.0             # via -r requirements.in
-babel==2.8.0              # via django-phonenumber-field, flower
-backcall==0.2.0           # via ipython
-billiard==3.5.0.4         # via -r requirements.in, celery
-boto3==1.15.12            # via -r requirements.in
-botocore==1.18.12         # via boto3, s3transfer
-cairocffi==1.1.0          # via cairosvg, weasyprint
-cairosvg==2.5.1           # via weasyprint
-https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl  # via -r requirements.in, django-celery-results, flower
-certifi==2020.6.20        # via -r prod-requirements.in, elasticsearch7, requests, sentry-sdk
-cffi==1.14.3              # via cairocffi, cryptography, csiphash, weasyprint
-chardet==3.0.4            # via ghdiff, requests
-cloudant==2.14.0          # via jsonobject-couchdbkit
-commcaretranslationchecker==0.9.7  # via -r requirements.in
-concurrent-log-handler==0.9.12  # via -r requirements.in
-contextlib2==0.6.0.post1  # via schema
-cryptography==3.2         # via -r prod-requirements.in, pyopenssl
-csiphash==0.0.5           # via -r requirements.in
-cssselect2==0.3.0         # via cairosvg, weasyprint
-datadog==0.39.0           # via -r requirements.in
-ddtrace==0.44.0           # via -r requirements.in
-decorator==4.0.11         # via -r requirements.in, datadog, ipython, jsonpath-rw, traitlets
-defusedxml==0.5.0         # via -r requirements.in, cairosvg, python3-saml
-deprecated==1.2.10        # via pygithub
-diff-match-patch==20120106  # via -r requirements.in
-dimagi-memoized==1.1.3    # via -r requirements.in
-django-angular==2.2.4     # via -r requirements.in
-django-appconf==1.0.4     # via django-compressor, django-statici18n
-django-braces==1.14.0     # via -r requirements.in
-django-bulk-update==2.2.0  # via -r requirements.in
-django-celery-results==1.0.4  # via -r requirements.in
-django-compressor==2.1    # via -r requirements.in
-django-countries==4.6     # via -r requirements.in
-django-crispy-forms==1.10.0  # via -r requirements.in
-django-cte==1.1.4         # via -r requirements.in
-django-formtools==2.1     # via -r requirements.in, django-two-factor-auth
-django-logentry-admin==1.0.6  # via -r requirements.in
-django-oauth-toolkit==1.3.2  # via -r requirements.in
-django-otp==0.9.4         # via -r requirements.in, django-two-factor-auth
-django-partial-index==0.6.0  # via -r requirements.in
-django-phonenumber-field==2.3.1  # via -r requirements.in, django-two-factor-auth
-django-prbac==1.0.1       # via -r requirements.in
-django-ranged-response==0.2.0  # via django-simple-captcha
-django-redis-sessions==0.6.1  # via -r requirements.in
-django-redis==4.12.1      # via -r requirements.in
-django-simple-captcha==0.5.13  # via -r requirements.in
-django-statici18n==1.9.0  # via -r requirements.in
-django-tastypie==0.14.3   # via -r requirements.in
-django-transfer==0.4      # via -r requirements.in
-django-two-factor-auth==1.12.1  # via -r requirements.in
-django-user-agents==0.4.0  # via -r requirements.in
-django-websocket-redis==0.6.0  # via -r requirements.in
-django==2.2.16            # via -r requirements.in, django-angular, django-appconf, django-braces, django-bulk-update, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
-djangorestframework==3.12.2  # via -r requirements.in
-dnspython==1.15.0         # via -r requirements.in, email-validator
-dropbox==9.3.0            # via -r requirements.in
-elasticsearch2==2.5.1     # via -r requirements.in
-elasticsearch7==7.9.1     # via -r requirements.in
-elasticsearch==1.9.0      # via -r requirements.in
-email_validator==1.1.2    # via -r requirements.in
-et-xmlfile==1.0.1         # via openpyxl
-ethiopian-date-converter==0.1.5  # via -r requirements.in
-eulxml==1.1.3             # via -r requirements.in
-faker==5.0.2              # via -r requirements.in
-flower==0.9.2             # via -r prod-requirements.in
-gevent==1.4.0             # via -r requirements.in, django-websocket-redis, gipc
-ghdiff==0.4               # via -r requirements.in
-gipc==1.1.0               # via -r requirements.in
-greenlet==0.4.17          # via -r requirements.in, django-websocket-redis, gevent
-gunicorn==20.0.4          # via -r requirements.in
-hiredis==1.1.0            # via -r requirements.in
-html5lib==1.1             # via weasyprint
-httpagentparser==1.9.0    # via -r requirements.in
-idna==2.10                # via -r prod-requirements.in, email-validator, requests
-intervaltree==3.1.0       # via ddtrace
-ipython-genutils==0.2.0   # via traitlets
-ipython==7.16.1           # via -r prod-requirements.in
-iso8601==0.1.13           # via -r requirements.in
-isodate==0.6.0            # via python3-saml
-jdcal==1.4.1              # via openpyxl
-jedi==0.17.2              # via ipython
-jinja2==2.11.2            # via -r requirements.in
-jmespath==0.10.0          # via boto3, botocore
-json-delta==2.0           # via -r requirements.in
-jsonfield==2.1.1          # via -r requirements.in, django-prbac
-jsonobject-couchdbkit==1.0.1  # via -r requirements.in
-jsonobject==0.9.9         # via -r requirements.in, jsonobject-couchdbkit
-jsonpath-rw==1.4.0        # via -r requirements.in
-kafka-python==1.4.7       # via -r requirements.in
-kombu==4.2.2.post1        # via -r requirements.in, celery
-laboratory==0.2.0         # via -r requirements.in
-lxml==4.3.5               # via -r requirements.in, eulxml, xmlsec
-mako==1.1.3               # via alembic
-markdown==2.2.1           # via -r requirements.in, pycco
-markupsafe==1.1.1         # via jinja2, mako
-mock==2.0.0               # via -r requirements.in
-ndg-httpsclient==0.5.1    # via -r prod-requirements.in
-oauthlib==3.1.0           # via django-oauth-toolkit, requests-oauthlib
-openpyxl==2.6.4           # via -r requirements.in, commcaretranslationchecker
-parso==0.7.1              # via jedi
-pbr==5.5.0                # via mock
-pexpect==4.8.0            # via ipython
-phonenumberslite==8.12.10  # via -r requirements.in
-pickleshare==0.7.5        # via ipython
-pillow==7.2.0             # via -r requirements.in, cairosvg, django-simple-captcha, reportlab
-ply==3.11                 # via eulxml, jsonpath-rw
-polib==1.1.0              # via -r requirements.in
-prometheus-client==0.7.1  # via -r requirements.in
-prompt-toolkit==3.0.7     # via ipython
-protobuf==3.13.0          # via ddtrace
-psycogreen==1.0.2         # via -r requirements.in
-psycopg2==2.8.6           # via -r requirements.in
-ptyprocess==0.6.0         # via pexpect
-py-kissmetrics==1.1.0     # via -r requirements.in
-pyasn1==0.4.8             # via -r prod-requirements.in, ndg-httpsclient
-pycco==0.5.1              # via -r requirements.in
-pycparser==2.20           # via cffi
-pycryptodome==3.9.9       # via -r requirements.in
-pygithub==1.54            # via -r requirements.in
-pygments==2.7.1           # via -r requirements.in, ipython, pycco
-pygooglechart==0.4.0      # via -r requirements.in
-pyjwt==1.7.1              # via pygithub, twilio
-pyopenssl==20.0.1         # via -r prod-requirements.in, -r requirements.in, ndg-httpsclient
-pyphen==0.9.5             # via weasyprint
-pysocks==1.7.1            # via twilio
-pystache==0.5.4           # via pycco
-python-dateutil==2.8.1    # via -r requirements.in, alembic, botocore, django-tastypie, faker
-python-editor==1.0.4      # via alembic
-python-imap==1.0.0        # via -r requirements.in
-python-levenshtein==0.12.0  # via -r requirements.in
-python-magic==0.4.18      # via -r requirements.in
-python-mimeparse==1.6.0   # via django-tastypie
-python3-saml==1.9.0       # via -r requirements.in
-pytz==2020.1              # via -r requirements.in, babel, celery, django, flower, twilio
-pyyaml==5.3.1             # via -r requirements.in
-pyzxcvbn==0.8.0           # via -r requirements.in
-qrcode==4.0.4             # via -r requirements.in, django-two-factor-auth
-quickcache==0.5.4         # via -r requirements.in
-rcssmin==1.0.6            # via django-compressor
-redis==3.5.3              # via -r requirements.in, django-redis, django-redis-sessions, django-websocket-redis
-reportlab==3.5.53         # via -r requirements.in
-requests-oauthlib==1.3.0  # via -r requirements.in
-requests==2.24.0          # via -r requirements.in, cloudant, datadog, django-oauth-toolkit, dropbox, pygithub, requests-oauthlib, stripe, tinys3, twilio
-rjsmin==1.0.12            # via django-compressor
-s3transfer==0.3.3         # via boto3
-schema==0.7.2             # via -r requirements.in
-sentry-sdk==0.19.4        # via -r requirements.in
-setproctitle==1.1.10      # via -r prod-requirements.in
-sh==1.14.1                # via -r requirements.in
-simpleeval==0.9.10        # via -r requirements.in
-simplejson==3.17.2        # via -r requirements.in, django-prbac
-six==1.15.0               # via -r requirements.in, cryptography, django-braces, django-simple-captcha, django-statici18n, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, ghdiff, html5lib, isodate, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, protobuf, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, tenacity, traitlets, twilio
-smartypants==2.0.1        # via pycco
-socketpool==0.5.3         # via -r requirements.in
-sortedcontainers==2.3.0   # via intervaltree
-sqlagg==0.17.2            # via -r requirements.in
-sqlalchemy==1.3.19        # via -r requirements.in, alembic, sqlagg
-sqlparse==0.3.1           # via django
-stripe==2.54.0            # via -r requirements.in
-suds-jurko==0.6           # via -r requirements.in
-tenacity==6.2.0           # via ddtrace
-text-unidecode==1.3       # via -r requirements.in, faker
-tinycss2==1.0.2           # via cairosvg, cssselect2, weasyprint
-tinys3==0.1.12            # via -r requirements.in
-tornado==4.5.3            # via -r prod-requirements.in, flower
-traitlets==4.3.3          # via ipython
-tropo-webapi-python==0.1.3  # via -r requirements.in
-turn-python==0.0.1        # via -r requirements.in
-twilio==6.5.1             # via -r requirements.in
-ua-parser==0.10.0         # via user-agents
-urllib3==1.25.10          # via botocore, elasticsearch, elasticsearch2, elasticsearch7, py-kissmetrics, requests, sentry-sdk
-user-agents==2.2.0        # via django-user-agents
-uwsgi==2.0.19.1           # via -r prod-requirements.in
-vine==1.3.0               # via amqp
-wcwidth==0.2.5            # via prompt-toolkit
-weasyprint==51            # via -r requirements.in
-webencodings==0.5.1       # via cssselect2, html5lib, tinycss2
-werkzeug==1.0.1           # via -r requirements.in
-wrapt==1.12.1             # via deprecated
-xlrd==1.0.0               # via -r requirements.in
-xlwt==1.3.0               # via -r requirements.in
-xmlsec==1.3.9             # via python3-saml
+alembic==1.4.3
+    # via -r requirements.in
+amqp==2.6.1
+    # via kombu
+architect==0.5.6
+    # via -r requirements.in
+attrs==18.2.0
+    # via -r requirements.in
+babel==2.8.0
+    # via
+    #   django-phonenumber-field
+    #   flower
+backcall==0.2.0
+    # via ipython
+billiard==3.5.0.4
+    # via
+    #   -r requirements.in
+    #   celery
+boto3==1.15.12
+    # via -r requirements.in
+botocore==1.18.12
+    # via
+    #   boto3
+    #   s3transfer
+cairocffi==1.1.0
+    # via
+    #   cairosvg
+    #   weasyprint
+cairosvg==2.5.1
+    # via weasyprint
+https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
+    # via
+    #   -r requirements.in
+    #   django-celery-results
+    #   flower
+certifi==2020.6.20
+    # via
+    #   -r prod-requirements.in
+    #   elasticsearch7
+    #   requests
+    #   sentry-sdk
+cffi==1.14.3
+    # via
+    #   cairocffi
+    #   cryptography
+    #   csiphash
+    #   weasyprint
+chardet==3.0.4
+    # via
+    #   ghdiff
+    #   requests
+cloudant==2.14.0
+    # via jsonobject-couchdbkit
+commcaretranslationchecker==0.9.7
+    # via -r requirements.in
+concurrent-log-handler==0.9.12
+    # via -r requirements.in
+contextlib2==0.6.0.post1
+    # via schema
+cryptography==3.2
+    # via
+    #   -r prod-requirements.in
+    #   pyopenssl
+csiphash==0.0.5
+    # via -r requirements.in
+cssselect2==0.3.0
+    # via
+    #   cairosvg
+    #   weasyprint
+datadog==0.39.0
+    # via -r requirements.in
+ddtrace==0.44.0
+    # via -r requirements.in
+decorator==4.0.11
+    # via
+    #   -r requirements.in
+    #   datadog
+    #   ipython
+    #   jsonpath-rw
+    #   traitlets
+defusedxml==0.5.0
+    # via
+    #   -r requirements.in
+    #   cairosvg
+    #   python3-saml
+deprecated==1.2.10
+    # via pygithub
+diff-match-patch==20120106
+    # via -r requirements.in
+dimagi-memoized==1.1.3
+    # via -r requirements.in
+django-angular==2.2.4
+    # via -r requirements.in
+django-appconf==1.0.4
+    # via
+    #   django-compressor
+    #   django-statici18n
+django-braces==1.14.0
+    # via -r requirements.in
+django-bulk-update==2.2.0
+    # via -r requirements.in
+django-celery-results==1.0.4
+    # via -r requirements.in
+django-compressor==2.1
+    # via -r requirements.in
+django-countries==4.6
+    # via -r requirements.in
+django-crispy-forms==1.10.0
+    # via -r requirements.in
+django-cte==1.1.4
+    # via -r requirements.in
+django-formtools==2.1
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+django-logentry-admin==1.0.6
+    # via -r requirements.in
+django-oauth-toolkit==1.3.2
+    # via -r requirements.in
+django-otp==0.9.4
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+django-partial-index==0.6.0
+    # via -r requirements.in
+django-phonenumber-field==2.3.1
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+django-prbac==1.0.1
+    # via -r requirements.in
+django-ranged-response==0.2.0
+    # via django-simple-captcha
+django-redis-sessions==0.6.1
+    # via -r requirements.in
+django-redis==4.12.1
+    # via -r requirements.in
+django-simple-captcha==0.5.13
+    # via -r requirements.in
+django-statici18n==1.9.0
+    # via -r requirements.in
+django-tastypie==0.14.3
+    # via -r requirements.in
+django-transfer==0.4
+    # via -r requirements.in
+django-two-factor-auth==1.12.1
+    # via -r requirements.in
+django-user-agents==0.4.0
+    # via -r requirements.in
+django-websocket-redis==0.6.0
+    # via -r requirements.in
+django==2.2.16
+    # via
+    #   -r requirements.in
+    #   django-angular
+    #   django-appconf
+    #   django-braces
+    #   django-bulk-update
+    #   django-formtools
+    #   django-logentry-admin
+    #   django-oauth-toolkit
+    #   django-otp
+    #   django-phonenumber-field
+    #   django-prbac
+    #   django-ranged-response
+    #   django-redis
+    #   django-simple-captcha
+    #   django-statici18n
+    #   django-two-factor-auth
+    #   django-user-agents
+    #   djangorestframework
+    #   jsonfield
+djangorestframework==3.12.2
+    # via -r requirements.in
+dnspython==1.15.0
+    # via
+    #   -r requirements.in
+    #   email-validator
+dropbox==9.3.0
+    # via -r requirements.in
+elasticsearch2==2.5.1
+    # via -r requirements.in
+elasticsearch7==7.9.1
+    # via -r requirements.in
+elasticsearch==1.9.0
+    # via -r requirements.in
+email_validator==1.1.2
+    # via -r requirements.in
+et-xmlfile==1.0.1
+    # via openpyxl
+ethiopian-date-converter==0.1.5
+    # via -r requirements.in
+eulxml==1.1.3
+    # via -r requirements.in
+faker==5.0.2
+    # via -r requirements.in
+flower==0.9.2
+    # via -r prod-requirements.in
+gevent==1.4.0
+    # via
+    #   -r requirements.in
+    #   django-websocket-redis
+    #   gipc
+ghdiff==0.4
+    # via -r requirements.in
+gipc==1.1.0
+    # via -r requirements.in
+greenlet==0.4.17
+    # via
+    #   -r requirements.in
+    #   django-websocket-redis
+    #   gevent
+gunicorn==20.0.4
+    # via -r requirements.in
+hiredis==1.1.0
+    # via -r requirements.in
+html5lib==1.1
+    # via weasyprint
+httpagentparser==1.9.0
+    # via -r requirements.in
+idna==2.10
+    # via
+    #   -r prod-requirements.in
+    #   email-validator
+    #   requests
+intervaltree==3.1.0
+    # via ddtrace
+ipython-genutils==0.2.0
+    # via traitlets
+ipython==7.16.1
+    # via -r prod-requirements.in
+iso8601==0.1.13
+    # via -r requirements.in
+isodate==0.6.0
+    # via python3-saml
+jdcal==1.4.1
+    # via openpyxl
+jedi==0.17.2
+    # via ipython
+jinja2==2.11.2
+    # via -r requirements.in
+jmespath==0.10.0
+    # via
+    #   boto3
+    #   botocore
+json-delta==2.0
+    # via -r requirements.in
+jsonfield==2.1.1
+    # via
+    #   -r requirements.in
+    #   django-prbac
+jsonobject-couchdbkit==1.0.1
+    # via -r requirements.in
+jsonobject==0.9.9
+    # via
+    #   -r requirements.in
+    #   jsonobject-couchdbkit
+jsonpath-rw==1.4.0
+    # via -r requirements.in
+kafka-python==1.4.7
+    # via -r requirements.in
+kombu==4.2.2.post1
+    # via
+    #   -r requirements.in
+    #   celery
+laboratory==0.2.0
+    # via -r requirements.in
+lxml==4.3.5
+    # via
+    #   -r requirements.in
+    #   eulxml
+    #   xmlsec
+mako==1.1.3
+    # via alembic
+markdown==2.2.1
+    # via
+    #   -r requirements.in
+    #   pycco
+markupsafe==1.1.1
+    # via
+    #   jinja2
+    #   mako
+mock==2.0.0
+    # via -r requirements.in
+ndg-httpsclient==0.5.1
+    # via -r prod-requirements.in
+oauthlib==3.1.0
+    # via
+    #   django-oauth-toolkit
+    #   requests-oauthlib
+openpyxl==2.6.4
+    # via
+    #   -r requirements.in
+    #   commcaretranslationchecker
+parso==0.7.1
+    # via jedi
+pbr==5.5.0
+    # via mock
+pexpect==4.8.0
+    # via ipython
+phonenumberslite==8.12.10
+    # via -r requirements.in
+pickleshare==0.7.5
+    # via ipython
+pillow==7.2.0
+    # via
+    #   -r requirements.in
+    #   cairosvg
+    #   django-simple-captcha
+    #   reportlab
+ply==3.11
+    # via
+    #   eulxml
+    #   jsonpath-rw
+polib==1.1.0
+    # via -r requirements.in
+prometheus-client==0.7.1
+    # via -r requirements.in
+prompt-toolkit==3.0.7
+    # via ipython
+protobuf==3.13.0
+    # via ddtrace
+psycogreen==1.0.2
+    # via -r requirements.in
+psycopg2==2.8.6
+    # via -r requirements.in
+ptyprocess==0.6.0
+    # via pexpect
+py-kissmetrics==1.1.0
+    # via -r requirements.in
+pyasn1==0.4.8
+    # via
+    #   -r prod-requirements.in
+    #   ndg-httpsclient
+pycco==0.5.1
+    # via -r requirements.in
+pycparser==2.20
+    # via cffi
+pycryptodome==3.9.9
+    # via -r requirements.in
+pygithub==1.54
+    # via -r requirements.in
+pygments==2.7.1
+    # via
+    #   -r requirements.in
+    #   ipython
+    #   pycco
+pygooglechart==0.4.0
+    # via -r requirements.in
+pyjwt==1.7.1
+    # via
+    #   pygithub
+    #   twilio
+pyopenssl==20.0.1
+    # via
+    #   -r prod-requirements.in
+    #   -r requirements.in
+    #   ndg-httpsclient
+pyphen==0.9.5
+    # via weasyprint
+pysocks==1.7.1
+    # via twilio
+pystache==0.5.4
+    # via pycco
+python-dateutil==2.8.1
+    # via
+    #   -r requirements.in
+    #   alembic
+    #   botocore
+    #   django-tastypie
+    #   faker
+python-editor==1.0.4
+    # via alembic
+python-imap==1.0.0
+    # via -r requirements.in
+python-levenshtein==0.12.0
+    # via -r requirements.in
+python-magic==0.4.18
+    # via -r requirements.in
+python-mimeparse==1.6.0
+    # via django-tastypie
+python3-saml==1.9.0
+    # via -r requirements.in
+pytz==2020.1
+    # via
+    #   -r requirements.in
+    #   babel
+    #   celery
+    #   django
+    #   flower
+    #   twilio
+pyyaml==5.3.1
+    # via -r requirements.in
+pyzxcvbn==0.8.0
+    # via -r requirements.in
+qrcode==4.0.4
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+quickcache==0.5.4
+    # via -r requirements.in
+rcssmin==1.0.6
+    # via django-compressor
+redis==3.5.3
+    # via
+    #   -r requirements.in
+    #   django-redis
+    #   django-redis-sessions
+    #   django-websocket-redis
+reportlab==3.5.53
+    # via -r requirements.in
+requests-oauthlib==1.3.0
+    # via -r requirements.in
+requests==2.24.0
+    # via
+    #   -r requirements.in
+    #   cloudant
+    #   datadog
+    #   django-oauth-toolkit
+    #   dropbox
+    #   pygithub
+    #   requests-oauthlib
+    #   stripe
+    #   tinys3
+    #   twilio
+rjsmin==1.0.12
+    # via django-compressor
+s3transfer==0.3.3
+    # via boto3
+schema==0.7.2
+    # via -r requirements.in
+sentry-sdk==0.19.4
+    # via -r requirements.in
+setproctitle==1.1.10
+    # via -r prod-requirements.in
+sh==1.14.1
+    # via -r requirements.in
+simpleeval==0.9.10
+    # via -r requirements.in
+simplejson==3.17.2
+    # via
+    #   -r requirements.in
+    #   django-prbac
+six==1.15.0
+    # via
+    #   -r requirements.in
+    #   cryptography
+    #   django-braces
+    #   django-simple-captcha
+    #   django-statici18n
+    #   django-transfer
+    #   django-websocket-redis
+    #   dropbox
+    #   ethiopian-date-converter
+    #   eulxml
+    #   ghdiff
+    #   html5lib
+    #   isodate
+    #   jsonfield
+    #   jsonobject
+    #   jsonobject-couchdbkit
+    #   jsonpath-rw
+    #   mock
+    #   protobuf
+    #   pyopenssl
+    #   python-dateutil
+    #   pyzxcvbn
+    #   qrcode
+    #   quickcache
+    #   tenacity
+    #   traitlets
+    #   twilio
+smartypants==2.0.1
+    # via pycco
+socketpool==0.5.3
+    # via -r requirements.in
+sortedcontainers==2.3.0
+    # via intervaltree
+sqlagg==0.17.2
+    # via -r requirements.in
+sqlalchemy==1.3.19
+    # via
+    #   -r requirements.in
+    #   alembic
+    #   sqlagg
+sqlparse==0.3.1
+    # via django
+stripe==2.54.0
+    # via -r requirements.in
+suds-jurko==0.6
+    # via -r requirements.in
+tenacity==6.2.0
+    # via ddtrace
+text-unidecode==1.3
+    # via
+    #   -r requirements.in
+    #   faker
+tinycss2==1.0.2
+    # via
+    #   cairosvg
+    #   cssselect2
+    #   weasyprint
+tinys3==0.1.12
+    # via -r requirements.in
+tornado==4.5.3
+    # via
+    #   -r prod-requirements.in
+    #   flower
+traitlets==4.3.3
+    # via ipython
+tropo-webapi-python==0.1.3
+    # via -r requirements.in
+turn-python==0.0.1
+    # via -r requirements.in
+twilio==6.5.1
+    # via -r requirements.in
+ua-parser==0.10.0
+    # via user-agents
+urllib3==1.25.10
+    # via
+    #   botocore
+    #   elasticsearch
+    #   elasticsearch2
+    #   elasticsearch7
+    #   py-kissmetrics
+    #   requests
+    #   sentry-sdk
+user-agents==2.2.0
+    # via django-user-agents
+uwsgi==2.0.19.1
+    # via -r prod-requirements.in
+vine==1.3.0
+    # via amqp
+wcwidth==0.2.5
+    # via prompt-toolkit
+weasyprint==51
+    # via -r requirements.in
+webencodings==0.5.1
+    # via
+    #   cssselect2
+    #   html5lib
+    #   tinycss2
+werkzeug==1.0.1
+    # via -r requirements.in
+wrapt==1.12.1
+    # via deprecated
+xlrd==1.0.0
+    # via -r requirements.in
+xlwt==1.3.0
+    # via -r requirements.in
+xmlsec==1.3.9
+    # via python3-saml
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.2.3               # via -r prod-requirements.in
-setuptools==50.3.0        # via cairocffi, cssselect2, django-websocket-redis, gunicorn, ipython, protobuf, python-levenshtein, tinycss2, weasyprint
+pip==20.2.3
+    # via -r prod-requirements.in
+setuptools==50.3.0
+    # via
+    #   cairocffi
+    #   cssselect2
+    #   django-websocket-redis
+    #   gunicorn
+    #   ipython
+    #   protobuf
+    #   python-levenshtein
+    #   tinycss2
+    #   weasyprint

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,174 +4,514 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-alembic==1.4.3            # via -r requirements.in
-amqp==2.6.1               # via kombu
-architect==0.5.6          # via -r requirements.in
-attrs==18.2.0             # via -r requirements.in
-babel==2.8.0              # via django-phonenumber-field
-billiard==3.5.0.4         # via -r requirements.in, celery
-boto3==1.15.12            # via -r requirements.in
-botocore==1.18.12         # via boto3, s3transfer
-cairocffi==1.1.0          # via cairosvg, weasyprint
-cairosvg==2.5.1           # via weasyprint
-https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl  # via -r requirements.in, django-celery-results
-certifi==2020.6.20        # via elasticsearch7, requests, sentry-sdk
-cffi==1.14.3              # via cairocffi, cryptography, csiphash, weasyprint
-chardet==3.0.4            # via ghdiff, requests
-cloudant==2.14.0          # via jsonobject-couchdbkit
-commcaretranslationchecker==0.9.7  # via -r requirements.in
-concurrent-log-handler==0.9.12  # via -r requirements.in
-contextlib2==0.6.0.post1  # via schema
-cryptography==3.3.1       # via pyopenssl
-csiphash==0.0.5           # via -r requirements.in
-cssselect2==0.3.0         # via cairosvg, weasyprint
-datadog==0.39.0           # via -r requirements.in
-ddtrace==0.44.0           # via -r requirements.in
-decorator==4.0.11         # via -r requirements.in, datadog, jsonpath-rw
-defusedxml==0.5.0         # via -r requirements.in, cairosvg, python3-saml
-deprecated==1.2.10        # via pygithub
-diff-match-patch==20120106  # via -r requirements.in
-dimagi-memoized==1.1.3    # via -r requirements.in
-django-angular==2.2.4     # via -r requirements.in
-django-appconf==1.0.4     # via django-compressor, django-statici18n
-django-braces==1.14.0     # via -r requirements.in
-django-bulk-update==2.2.0  # via -r requirements.in
-django-celery-results==1.0.4  # via -r requirements.in
-django-compressor==2.1    # via -r requirements.in
-django-countries==4.6     # via -r requirements.in
-django-crispy-forms==1.10.0  # via -r requirements.in
-django-cte==1.1.4         # via -r requirements.in
-django-formtools==2.1     # via -r requirements.in, django-two-factor-auth
-django-logentry-admin==1.0.6  # via -r requirements.in
-django-oauth-toolkit==1.3.2  # via -r requirements.in
-django-otp==0.9.4         # via -r requirements.in, django-two-factor-auth
-django-partial-index==0.6.0  # via -r requirements.in
-django-phonenumber-field==2.3.1  # via -r requirements.in, django-two-factor-auth
-django-prbac==1.0.1       # via -r requirements.in
-django-ranged-response==0.2.0  # via django-simple-captcha
-django-redis-sessions==0.6.1  # via -r requirements.in
-django-redis==4.12.1      # via -r requirements.in
-django-simple-captcha==0.5.13  # via -r requirements.in
-django-statici18n==1.9.0  # via -r requirements.in
-django-tastypie==0.14.3   # via -r requirements.in
-django-transfer==0.4      # via -r requirements.in
-django-two-factor-auth==1.12.1  # via -r requirements.in
-django-user-agents==0.4.0  # via -r requirements.in
-django-websocket-redis==0.6.0  # via -r requirements.in
-django==2.2.16            # via -r requirements.in, django-angular, django-appconf, django-braces, django-bulk-update, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
-djangorestframework==3.12.2  # via -r requirements.in
-dnspython==1.15.0         # via -r requirements.in, email-validator
-dropbox==9.3.0            # via -r requirements.in
-elasticsearch2==2.5.1     # via -r requirements.in
-elasticsearch7==7.9.1     # via -r requirements.in
-elasticsearch==1.9.0      # via -r requirements.in
-email_validator==1.1.2    # via -r requirements.in
-et-xmlfile==1.0.1         # via openpyxl
-ethiopian-date-converter==0.1.5  # via -r requirements.in
-eulxml==1.1.3             # via -r requirements.in
-faker==5.0.2              # via -r requirements.in
-gevent==1.4.0             # via -r requirements.in, django-websocket-redis, gipc
-ghdiff==0.4               # via -r requirements.in
-gipc==1.1.0               # via -r requirements.in
-greenlet==0.4.17          # via -r requirements.in, django-websocket-redis, gevent
-gunicorn==20.0.4          # via -r requirements.in
-hiredis==1.1.0            # via -r requirements.in
-html5lib==1.1             # via weasyprint
-httpagentparser==1.9.0    # via -r requirements.in
-idna==2.10                # via email-validator, requests
-intervaltree==3.1.0       # via ddtrace
-iso8601==0.1.13           # via -r requirements.in
-isodate==0.6.0            # via python3-saml
-jdcal==1.4.1              # via openpyxl
-jinja2==2.11.2            # via -r requirements.in
-jmespath==0.10.0          # via boto3, botocore
-json-delta==2.0           # via -r requirements.in
-jsonfield==2.1.1          # via -r requirements.in, django-prbac
-jsonobject-couchdbkit==1.0.1  # via -r requirements.in
-jsonobject==0.9.9         # via -r requirements.in, jsonobject-couchdbkit
-jsonpath-rw==1.4.0        # via -r requirements.in
-kafka-python==1.4.7       # via -r requirements.in
-kombu==4.2.2.post1        # via -r requirements.in, celery
-laboratory==0.2.0         # via -r requirements.in
-lxml==4.3.5               # via -r requirements.in, eulxml, xmlsec
-mako==1.1.3               # via alembic
-markdown==2.2.1           # via -r requirements.in, pycco
-markupsafe==1.1.1         # via jinja2, mako
-mock==2.0.0               # via -r requirements.in
-oauthlib==3.1.0           # via django-oauth-toolkit, requests-oauthlib
-openpyxl==2.6.4           # via -r requirements.in, commcaretranslationchecker
-pbr==5.5.0                # via mock
-phonenumberslite==8.12.10  # via -r requirements.in
-pillow==7.2.0             # via -r requirements.in, cairosvg, django-simple-captcha, reportlab
-ply==3.11                 # via eulxml, jsonpath-rw
-polib==1.1.0              # via -r requirements.in
-prometheus-client==0.7.1  # via -r requirements.in
-protobuf==3.13.0          # via ddtrace
-psycogreen==1.0.2         # via -r requirements.in
-psycopg2==2.8.6           # via -r requirements.in
-py-kissmetrics==1.1.0     # via -r requirements.in
-pycco==0.5.1              # via -r requirements.in
-pycparser==2.20           # via cffi
-pycryptodome==3.9.9       # via -r requirements.in
-pygithub==1.54            # via -r requirements.in
-pygments==2.7.1           # via -r requirements.in, pycco
-pygooglechart==0.4.0      # via -r requirements.in
-pyjwt==1.7.1              # via pygithub, twilio
-pyopenssl==20.0.1         # via -r requirements.in
-pyphen==0.9.5             # via weasyprint
-pysocks==1.7.1            # via twilio
-pystache==0.5.4           # via pycco
-python-dateutil==2.8.1    # via -r requirements.in, alembic, botocore, django-tastypie, faker
-python-editor==1.0.4      # via alembic
-python-imap==1.0.0        # via -r requirements.in
-python-levenshtein==0.12.0  # via -r requirements.in
-python-magic==0.4.18      # via -r requirements.in
-python-mimeparse==1.6.0   # via django-tastypie
-python3-saml==1.9.0       # via -r requirements.in
-pytz==2020.1              # via -r requirements.in, babel, celery, django, twilio
-pyyaml==5.3.1             # via -r requirements.in
-pyzxcvbn==0.8.0           # via -r requirements.in
-qrcode==4.0.4             # via -r requirements.in, django-two-factor-auth
-quickcache==0.5.4         # via -r requirements.in
-rcssmin==1.0.6            # via django-compressor
-redis==3.5.3              # via -r requirements.in, django-redis, django-redis-sessions, django-websocket-redis
-reportlab==3.5.53         # via -r requirements.in
-requests-oauthlib==1.3.0  # via -r requirements.in
-requests==2.24.0          # via -r requirements.in, cloudant, datadog, django-oauth-toolkit, dropbox, pygithub, requests-oauthlib, stripe, tinys3, twilio
-rjsmin==1.0.12            # via django-compressor
-s3transfer==0.3.3         # via boto3
-schema==0.7.2             # via -r requirements.in
-sentry-sdk==0.19.4        # via -r requirements.in
-sh==1.14.1                # via -r requirements.in
-simpleeval==0.9.10        # via -r requirements.in
-simplejson==3.17.2        # via -r requirements.in, django-prbac
-six==1.15.0               # via -r requirements.in, cryptography, django-braces, django-simple-captcha, django-statici18n, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, ghdiff, html5lib, isodate, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, protobuf, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, tenacity, twilio
-smartypants==2.0.1        # via pycco
-socketpool==0.5.3         # via -r requirements.in
-sortedcontainers==2.3.0   # via intervaltree
-sqlagg==0.17.2            # via -r requirements.in
-sqlalchemy==1.3.19        # via -r requirements.in, alembic, sqlagg
-sqlparse==0.3.1           # via django
-stripe==2.54.0            # via -r requirements.in
-suds-jurko==0.6           # via -r requirements.in
-tenacity==6.2.0           # via ddtrace
-text-unidecode==1.3       # via -r requirements.in, faker
-tinycss2==1.0.2           # via cairosvg, cssselect2, weasyprint
-tinys3==0.1.12            # via -r requirements.in
-tropo-webapi-python==0.1.3  # via -r requirements.in
-turn-python==0.0.1        # via -r requirements.in
-twilio==6.5.1             # via -r requirements.in
-ua-parser==0.10.0         # via user-agents
-urllib3==1.25.10          # via botocore, elasticsearch, elasticsearch2, elasticsearch7, py-kissmetrics, requests, sentry-sdk
-user-agents==2.2.0        # via django-user-agents
-vine==1.3.0               # via amqp
-weasyprint==51            # via -r requirements.in
-webencodings==0.5.1       # via cssselect2, html5lib, tinycss2
-werkzeug==1.0.1           # via -r requirements.in
-wrapt==1.12.1             # via deprecated
-xlrd==1.0.0               # via -r requirements.in
-xlwt==1.3.0               # via -r requirements.in
-xmlsec==1.3.9             # via python3-saml
+alembic==1.4.3
+    # via -r requirements.in
+amqp==2.6.1
+    # via kombu
+architect==0.5.6
+    # via -r requirements.in
+attrs==18.2.0
+    # via -r requirements.in
+babel==2.8.0
+    # via django-phonenumber-field
+billiard==3.5.0.4
+    # via
+    #   -r requirements.in
+    #   celery
+boto3==1.15.12
+    # via -r requirements.in
+botocore==1.18.12
+    # via
+    #   boto3
+    #   s3transfer
+cairocffi==1.1.0
+    # via
+    #   cairosvg
+    #   weasyprint
+cairosvg==2.5.1
+    # via weasyprint
+https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
+    # via
+    #   -r requirements.in
+    #   django-celery-results
+certifi==2020.6.20
+    # via
+    #   elasticsearch7
+    #   requests
+    #   sentry-sdk
+cffi==1.14.3
+    # via
+    #   cairocffi
+    #   cryptography
+    #   csiphash
+    #   weasyprint
+chardet==3.0.4
+    # via
+    #   ghdiff
+    #   requests
+cloudant==2.14.0
+    # via jsonobject-couchdbkit
+commcaretranslationchecker==0.9.7
+    # via -r requirements.in
+concurrent-log-handler==0.9.12
+    # via -r requirements.in
+contextlib2==0.6.0.post1
+    # via schema
+cryptography==3.3.1
+    # via pyopenssl
+csiphash==0.0.5
+    # via -r requirements.in
+cssselect2==0.3.0
+    # via
+    #   cairosvg
+    #   weasyprint
+datadog==0.39.0
+    # via -r requirements.in
+ddtrace==0.44.0
+    # via -r requirements.in
+decorator==4.0.11
+    # via
+    #   -r requirements.in
+    #   datadog
+    #   jsonpath-rw
+defusedxml==0.5.0
+    # via
+    #   -r requirements.in
+    #   cairosvg
+    #   python3-saml
+deprecated==1.2.10
+    # via pygithub
+diff-match-patch==20120106
+    # via -r requirements.in
+dimagi-memoized==1.1.3
+    # via -r requirements.in
+django-angular==2.2.4
+    # via -r requirements.in
+django-appconf==1.0.4
+    # via
+    #   django-compressor
+    #   django-statici18n
+django-braces==1.14.0
+    # via -r requirements.in
+django-bulk-update==2.2.0
+    # via -r requirements.in
+django-celery-results==1.0.4
+    # via -r requirements.in
+django-compressor==2.1
+    # via -r requirements.in
+django-countries==4.6
+    # via -r requirements.in
+django-crispy-forms==1.10.0
+    # via -r requirements.in
+django-cte==1.1.4
+    # via -r requirements.in
+django-formtools==2.1
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+django-logentry-admin==1.0.6
+    # via -r requirements.in
+django-oauth-toolkit==1.3.2
+    # via -r requirements.in
+django-otp==0.9.4
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+django-partial-index==0.6.0
+    # via -r requirements.in
+django-phonenumber-field==2.3.1
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+django-prbac==1.0.1
+    # via -r requirements.in
+django-ranged-response==0.2.0
+    # via django-simple-captcha
+django-redis-sessions==0.6.1
+    # via -r requirements.in
+django-redis==4.12.1
+    # via -r requirements.in
+django-simple-captcha==0.5.13
+    # via -r requirements.in
+django-statici18n==1.9.0
+    # via -r requirements.in
+django-tastypie==0.14.3
+    # via -r requirements.in
+django-transfer==0.4
+    # via -r requirements.in
+django-two-factor-auth==1.12.1
+    # via -r requirements.in
+django-user-agents==0.4.0
+    # via -r requirements.in
+django-websocket-redis==0.6.0
+    # via -r requirements.in
+django==2.2.16
+    # via
+    #   -r requirements.in
+    #   django-angular
+    #   django-appconf
+    #   django-braces
+    #   django-bulk-update
+    #   django-formtools
+    #   django-logentry-admin
+    #   django-oauth-toolkit
+    #   django-otp
+    #   django-phonenumber-field
+    #   django-prbac
+    #   django-ranged-response
+    #   django-redis
+    #   django-simple-captcha
+    #   django-statici18n
+    #   django-two-factor-auth
+    #   django-user-agents
+    #   djangorestframework
+    #   jsonfield
+djangorestframework==3.12.2
+    # via -r requirements.in
+dnspython==1.15.0
+    # via
+    #   -r requirements.in
+    #   email-validator
+dropbox==9.3.0
+    # via -r requirements.in
+elasticsearch2==2.5.1
+    # via -r requirements.in
+elasticsearch7==7.9.1
+    # via -r requirements.in
+elasticsearch==1.9.0
+    # via -r requirements.in
+email_validator==1.1.2
+    # via -r requirements.in
+et-xmlfile==1.0.1
+    # via openpyxl
+ethiopian-date-converter==0.1.5
+    # via -r requirements.in
+eulxml==1.1.3
+    # via -r requirements.in
+faker==5.0.2
+    # via -r requirements.in
+gevent==1.4.0
+    # via
+    #   -r requirements.in
+    #   django-websocket-redis
+    #   gipc
+ghdiff==0.4
+    # via -r requirements.in
+gipc==1.1.0
+    # via -r requirements.in
+greenlet==0.4.17
+    # via
+    #   -r requirements.in
+    #   django-websocket-redis
+    #   gevent
+gunicorn==20.0.4
+    # via -r requirements.in
+hiredis==1.1.0
+    # via -r requirements.in
+html5lib==1.1
+    # via weasyprint
+httpagentparser==1.9.0
+    # via -r requirements.in
+idna==2.10
+    # via
+    #   email-validator
+    #   requests
+intervaltree==3.1.0
+    # via ddtrace
+iso8601==0.1.13
+    # via -r requirements.in
+isodate==0.6.0
+    # via python3-saml
+jdcal==1.4.1
+    # via openpyxl
+jinja2==2.11.2
+    # via -r requirements.in
+jmespath==0.10.0
+    # via
+    #   boto3
+    #   botocore
+json-delta==2.0
+    # via -r requirements.in
+jsonfield==2.1.1
+    # via
+    #   -r requirements.in
+    #   django-prbac
+jsonobject-couchdbkit==1.0.1
+    # via -r requirements.in
+jsonobject==0.9.9
+    # via
+    #   -r requirements.in
+    #   jsonobject-couchdbkit
+jsonpath-rw==1.4.0
+    # via -r requirements.in
+kafka-python==1.4.7
+    # via -r requirements.in
+kombu==4.2.2.post1
+    # via
+    #   -r requirements.in
+    #   celery
+laboratory==0.2.0
+    # via -r requirements.in
+lxml==4.3.5
+    # via
+    #   -r requirements.in
+    #   eulxml
+    #   xmlsec
+mako==1.1.3
+    # via alembic
+markdown==2.2.1
+    # via
+    #   -r requirements.in
+    #   pycco
+markupsafe==1.1.1
+    # via
+    #   jinja2
+    #   mako
+mock==2.0.0
+    # via -r requirements.in
+oauthlib==3.1.0
+    # via
+    #   django-oauth-toolkit
+    #   requests-oauthlib
+openpyxl==2.6.4
+    # via
+    #   -r requirements.in
+    #   commcaretranslationchecker
+pbr==5.5.0
+    # via mock
+phonenumberslite==8.12.10
+    # via -r requirements.in
+pillow==7.2.0
+    # via
+    #   -r requirements.in
+    #   cairosvg
+    #   django-simple-captcha
+    #   reportlab
+ply==3.11
+    # via
+    #   eulxml
+    #   jsonpath-rw
+polib==1.1.0
+    # via -r requirements.in
+prometheus-client==0.7.1
+    # via -r requirements.in
+protobuf==3.13.0
+    # via ddtrace
+psycogreen==1.0.2
+    # via -r requirements.in
+psycopg2==2.8.6
+    # via -r requirements.in
+py-kissmetrics==1.1.0
+    # via -r requirements.in
+pycco==0.5.1
+    # via -r requirements.in
+pycparser==2.20
+    # via cffi
+pycryptodome==3.9.9
+    # via -r requirements.in
+pygithub==1.54
+    # via -r requirements.in
+pygments==2.7.1
+    # via
+    #   -r requirements.in
+    #   pycco
+pygooglechart==0.4.0
+    # via -r requirements.in
+pyjwt==1.7.1
+    # via
+    #   pygithub
+    #   twilio
+pyopenssl==20.0.1
+    # via -r requirements.in
+pyphen==0.9.5
+    # via weasyprint
+pysocks==1.7.1
+    # via twilio
+pystache==0.5.4
+    # via pycco
+python-dateutil==2.8.1
+    # via
+    #   -r requirements.in
+    #   alembic
+    #   botocore
+    #   django-tastypie
+    #   faker
+python-editor==1.0.4
+    # via alembic
+python-imap==1.0.0
+    # via -r requirements.in
+python-levenshtein==0.12.0
+    # via -r requirements.in
+python-magic==0.4.18
+    # via -r requirements.in
+python-mimeparse==1.6.0
+    # via django-tastypie
+python3-saml==1.9.0
+    # via -r requirements.in
+pytz==2020.1
+    # via
+    #   -r requirements.in
+    #   babel
+    #   celery
+    #   django
+    #   twilio
+pyyaml==5.3.1
+    # via -r requirements.in
+pyzxcvbn==0.8.0
+    # via -r requirements.in
+qrcode==4.0.4
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+quickcache==0.5.4
+    # via -r requirements.in
+rcssmin==1.0.6
+    # via django-compressor
+redis==3.5.3
+    # via
+    #   -r requirements.in
+    #   django-redis
+    #   django-redis-sessions
+    #   django-websocket-redis
+reportlab==3.5.53
+    # via -r requirements.in
+requests-oauthlib==1.3.0
+    # via -r requirements.in
+requests==2.24.0
+    # via
+    #   -r requirements.in
+    #   cloudant
+    #   datadog
+    #   django-oauth-toolkit
+    #   dropbox
+    #   pygithub
+    #   requests-oauthlib
+    #   stripe
+    #   tinys3
+    #   twilio
+rjsmin==1.0.12
+    # via django-compressor
+s3transfer==0.3.3
+    # via boto3
+schema==0.7.2
+    # via -r requirements.in
+sentry-sdk==0.19.4
+    # via -r requirements.in
+sh==1.14.1
+    # via -r requirements.in
+simpleeval==0.9.10
+    # via -r requirements.in
+simplejson==3.17.2
+    # via
+    #   -r requirements.in
+    #   django-prbac
+six==1.15.0
+    # via
+    #   -r requirements.in
+    #   cryptography
+    #   django-braces
+    #   django-simple-captcha
+    #   django-statici18n
+    #   django-transfer
+    #   django-websocket-redis
+    #   dropbox
+    #   ethiopian-date-converter
+    #   eulxml
+    #   ghdiff
+    #   html5lib
+    #   isodate
+    #   jsonfield
+    #   jsonobject
+    #   jsonobject-couchdbkit
+    #   jsonpath-rw
+    #   mock
+    #   protobuf
+    #   pyopenssl
+    #   python-dateutil
+    #   pyzxcvbn
+    #   qrcode
+    #   quickcache
+    #   tenacity
+    #   twilio
+smartypants==2.0.1
+    # via pycco
+socketpool==0.5.3
+    # via -r requirements.in
+sortedcontainers==2.3.0
+    # via intervaltree
+sqlagg==0.17.2
+    # via -r requirements.in
+sqlalchemy==1.3.19
+    # via
+    #   -r requirements.in
+    #   alembic
+    #   sqlagg
+sqlparse==0.3.1
+    # via django
+stripe==2.54.0
+    # via -r requirements.in
+suds-jurko==0.6
+    # via -r requirements.in
+tenacity==6.2.0
+    # via ddtrace
+text-unidecode==1.3
+    # via
+    #   -r requirements.in
+    #   faker
+tinycss2==1.0.2
+    # via
+    #   cairosvg
+    #   cssselect2
+    #   weasyprint
+tinys3==0.1.12
+    # via -r requirements.in
+tropo-webapi-python==0.1.3
+    # via -r requirements.in
+turn-python==0.0.1
+    # via -r requirements.in
+twilio==6.5.1
+    # via -r requirements.in
+ua-parser==0.10.0
+    # via user-agents
+urllib3==1.25.10
+    # via
+    #   botocore
+    #   elasticsearch
+    #   elasticsearch2
+    #   elasticsearch7
+    #   py-kissmetrics
+    #   requests
+    #   sentry-sdk
+user-agents==2.2.0
+    # via django-user-agents
+vine==1.3.0
+    # via amqp
+weasyprint==51
+    # via -r requirements.in
+webencodings==0.5.1
+    # via
+    #   cssselect2
+    #   html5lib
+    #   tinycss2
+werkzeug==1.0.1
+    # via -r requirements.in
+wrapt==1.12.1
+    # via deprecated
+xlrd==1.0.0
+    # via -r requirements.in
+xlwt==1.3.0
+    # via -r requirements.in
+xmlsec==1.3.9
+    # via python3-saml
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==50.3.0        # via cairocffi, cssselect2, django-websocket-redis, gunicorn, protobuf, python-levenshtein, tinycss2, weasyprint
+setuptools==50.3.0
+    # via
+    #   cairocffi
+    #   cssselect2
+    #   django-websocket-redis
+    #   gunicorn
+    #   protobuf
+    #   python-levenshtein
+    #   tinycss2
+    #   weasyprint

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -114,7 +114,7 @@ openpyxl==2.6.4           # via -r requirements.in, commcaretranslationchecker
 pbr==5.5.0                # via mock
 phonenumberslite==8.12.10  # via -r requirements.in
 pillow==7.2.0             # via -r requirements.in, cairosvg, django-simple-captcha, reportlab
-pip-tools==5.3.1          # via -r test-requirements.in
+pip-tools==5.5.0          # via -r test-requirements.in
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0              # via -r requirements.in
 prometheus-client==0.7.1  # via -r requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -4,193 +4,564 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-alembic==1.4.3            # via -r requirements.in
-amqp==2.6.1               # via kombu
-architect==0.5.6          # via -r requirements.in
-argparse==1.4.0           # via unittest2
-attrs==18.2.0             # via -r requirements.in
-babel==2.8.0              # via django-phonenumber-field
-beautifulsoup4==4.9.3     # via -r test-requirements.in
-billiard==3.5.0.4         # via -r requirements.in, celery
-boto3==1.15.12            # via -r requirements.in
-botocore==1.18.12         # via boto3, s3transfer
-cairocffi==1.1.0          # via cairosvg, weasyprint
-cairosvg==2.5.1           # via weasyprint
-https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl  # via -r requirements.in, django-celery-results
-certifi==2020.6.20        # via elasticsearch7, requests, sentry-sdk
-cffi==1.14.3              # via cairocffi, cryptography, csiphash, weasyprint
-chardet==3.0.4            # via ghdiff, requests
-click==7.1.2              # via pip-tools
-cloudant==2.14.0          # via jsonobject-couchdbkit
-commcaretranslationchecker==0.9.7  # via -r requirements.in
-concurrent-log-handler==0.9.12  # via -r requirements.in
-contextlib2==0.6.0.post1  # via schema
-coverage==4.5.1           # via -r test-requirements.in
-cryptography==3.3.1       # via pyopenssl
-csiphash==0.0.5           # via -r requirements.in
-cssselect2==0.3.0         # via cairosvg, weasyprint
-datadog==0.39.0           # via -r requirements.in
-ddtrace==0.44.0           # via -r requirements.in
-decorator==4.0.11         # via -r requirements.in, datadog, jsonpath-rw
-defusedxml==0.5.0         # via -r requirements.in, cairosvg, python3-saml
-deprecated==1.2.10        # via pygithub
-diff-match-patch==20120106  # via -r requirements.in
-dimagi-memoized==1.1.3    # via -r requirements.in
-django-angular==2.2.4     # via -r requirements.in
-django-appconf==1.0.4     # via django-compressor, django-statici18n
-django-braces==1.14.0     # via -r requirements.in
-django-bulk-update==2.2.0  # via -r requirements.in
-django-celery-results==1.0.4  # via -r requirements.in
-django-compressor==2.1    # via -r requirements.in
-django-countries==4.6     # via -r requirements.in
-django-crispy-forms==1.10.0  # via -r requirements.in
-django-cte==1.1.4         # via -r requirements.in
-django-formtools==2.1     # via -r requirements.in, django-two-factor-auth
-django-logentry-admin==1.0.6  # via -r requirements.in
-https://github.com/dimagi/django-nose/raw/fast-first-1.4.6.1/releases/django_nose-1.4.6.1-py2.py3-none-any.whl  # via -r test-requirements.in
-django-oauth-toolkit==1.3.2  # via -r requirements.in
-django-otp==0.9.4         # via -r requirements.in, django-two-factor-auth
-django-partial-index==0.6.0  # via -r requirements.in
-django-phonenumber-field==2.3.1  # via -r requirements.in, django-two-factor-auth
-django-prbac==1.0.1       # via -r requirements.in
-django-ranged-response==0.2.0  # via django-simple-captcha
-django-redis-sessions==0.6.1  # via -r requirements.in
-django-redis==4.12.1      # via -r requirements.in
-django-simple-captcha==0.5.13  # via -r requirements.in
-django-statici18n==1.9.0  # via -r requirements.in
-django-tastypie==0.14.3   # via -r requirements.in
-django-transfer==0.4      # via -r requirements.in
-django-two-factor-auth==1.12.1  # via -r requirements.in
-django-user-agents==0.4.0  # via -r requirements.in
-django-websocket-redis==0.6.0  # via -r requirements.in
-django==2.2.16            # via -r requirements.in, django-angular, django-appconf, django-braces, django-bulk-update, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
-djangorestframework==3.12.2  # via -r requirements.in
-dnspython==1.15.0         # via -r requirements.in, email-validator
-dropbox==9.3.0            # via -r requirements.in
-elasticsearch2==2.5.1     # via -r requirements.in
-elasticsearch7==7.9.1     # via -r requirements.in
-elasticsearch==1.9.0      # via -r requirements.in
-email_validator==1.1.2    # via -r requirements.in
-et-xmlfile==1.0.1         # via openpyxl
-ethiopian-date-converter==0.1.5  # via -r requirements.in
-eulxml==1.1.3             # via -r requirements.in
-fakecouch==0.0.15         # via -r test-requirements.in
-faker==5.0.2              # via -r requirements.in
-flaky==3.7.0              # via -r test-requirements.in
-freezegun==0.3.15         # via -r test-requirements.in
-gevent==1.4.0             # via -r requirements.in, django-websocket-redis, gipc
-ghdiff==0.4               # via -r requirements.in
-gipc==1.1.0               # via -r requirements.in
-greenlet==0.4.17          # via -r requirements.in, django-websocket-redis, gevent
-gunicorn==20.0.4          # via -r requirements.in
-hiredis==1.1.0            # via -r requirements.in
-html5lib==1.1             # via weasyprint
-httpagentparser==1.9.0    # via -r requirements.in
-idna==2.10                # via email-validator, requests
-intervaltree==3.1.0       # via ddtrace
-iso8601==0.1.13           # via -r requirements.in
-isodate==0.6.0            # via python3-saml
-jdcal==1.4.1              # via openpyxl
-jinja2==2.11.2            # via -r requirements.in
-jmespath==0.10.0          # via boto3, botocore
-json-delta==2.0           # via -r requirements.in
-jsonfield==2.1.1          # via -r requirements.in, django-prbac
-jsonobject-couchdbkit==1.0.1  # via -r requirements.in
-jsonobject==0.9.9         # via -r requirements.in, jsonobject-couchdbkit
-jsonpath-rw==1.4.0        # via -r requirements.in
-kafka-python==1.4.7       # via -r requirements.in
-kombu==4.2.2.post1        # via -r requirements.in, celery
-laboratory==0.2.0         # via -r requirements.in
-linecache2==1.0.0         # via traceback2
-lxml==4.3.5               # via -r requirements.in, eulxml, xmlsec
-mako==1.1.3               # via alembic
-markdown==2.2.1           # via -r requirements.in, pycco
-markupsafe==1.1.1         # via jinja2, mako
-mock==2.0.0               # via -r requirements.in
-nose-exclude==0.5.0       # via -r test-requirements.in
-nose==1.3.7               # via -r test-requirements.in, django-nose, nose-exclude
-oauthlib==3.1.0           # via django-oauth-toolkit, requests-oauthlib
-openpyxl==2.6.4           # via -r requirements.in, commcaretranslationchecker
-pbr==5.5.0                # via mock
-phonenumberslite==8.12.10  # via -r requirements.in
-pillow==7.2.0             # via -r requirements.in, cairosvg, django-simple-captcha, reportlab
-pip-tools==5.5.0          # via -r test-requirements.in
-ply==3.11                 # via eulxml, jsonpath-rw
-polib==1.1.0              # via -r requirements.in
-prometheus-client==0.7.1  # via -r requirements.in
-protobuf==3.13.0          # via ddtrace
-psycogreen==1.0.2         # via -r requirements.in
-psycopg2==2.8.6           # via -r requirements.in, sqlalchemy-postgres-copy
-py-kissmetrics==1.1.0     # via -r requirements.in
-pycco==0.5.1              # via -r requirements.in
-pycparser==2.20           # via cffi
-pycryptodome==3.9.9       # via -r requirements.in
-pygithub==1.54            # via -r requirements.in
-pygments==2.7.1           # via -r requirements.in, pycco
-pygooglechart==0.4.0      # via -r requirements.in
-pyjwt==1.7.1              # via pygithub, twilio
-pyopenssl==20.0.1         # via -r requirements.in
-pyphen==0.9.5             # via weasyprint
-pysocks==1.7.1            # via twilio
-pystache==0.5.4           # via pycco
-python-dateutil==2.8.1    # via -r requirements.in, alembic, botocore, django-tastypie, faker, freezegun
-python-editor==1.0.4      # via alembic
-python-imap==1.0.0        # via -r requirements.in
-python-levenshtein==0.12.0  # via -r requirements.in
-python-magic==0.4.18      # via -r requirements.in
-python-mimeparse==1.6.0   # via django-tastypie
-python3-saml==1.9.0       # via -r requirements.in
-pytz==2020.1              # via -r requirements.in, babel, celery, django, twilio
-pyyaml==5.3.1             # via -r requirements.in
-pyzxcvbn==0.8.0           # via -r requirements.in
-qrcode==4.0.4             # via -r requirements.in, django-two-factor-auth
-quickcache==0.5.4         # via -r requirements.in
-rcssmin==1.0.6            # via django-compressor
-redis==3.5.3              # via -r requirements.in, django-redis, django-redis-sessions, django-websocket-redis
-reportlab==3.5.53         # via -r requirements.in
-requests-mock==1.8.0      # via -r test-requirements.in
-requests-oauthlib==1.3.0  # via -r requirements.in
-requests==2.24.0          # via -r requirements.in, cloudant, datadog, django-oauth-toolkit, dropbox, pygithub, requests-mock, requests-oauthlib, stripe, tinys3, twilio
-rjsmin==1.0.12            # via django-compressor
-s3transfer==0.3.3         # via boto3
-schema==0.7.2             # via -r requirements.in
-sentry-sdk==0.19.4        # via -r requirements.in
-sh==1.14.1                # via -r requirements.in
-simpleeval==0.9.10        # via -r requirements.in
-simplejson==3.17.2        # via -r requirements.in, django-prbac
-six==1.15.0               # via -r requirements.in, cryptography, django-braces, django-simple-captcha, django-statici18n, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, freezegun, ghdiff, html5lib, isodate, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pip-tools, protobuf, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, tenacity, twilio, unittest2
-smartypants==2.0.1        # via pycco
-socketpool==0.5.3         # via -r requirements.in
-sortedcontainers==2.3.0   # via intervaltree
-soupsieve==2.0.1          # via beautifulsoup4
-sqlagg==0.17.2            # via -r requirements.in
-sqlalchemy-postgres-copy==0.5.0  # via -r test-requirements.in
-sqlalchemy==1.3.19        # via -r requirements.in, alembic, sqlagg, sqlalchemy-postgres-copy
-sqlparse==0.3.1           # via django
-stripe==2.54.0            # via -r requirements.in
-suds-jurko==0.6           # via -r requirements.in
-tenacity==6.2.0           # via ddtrace
-testil==1.1               # via -r test-requirements.in
-text-unidecode==1.3       # via -r requirements.in, faker
-tinycss2==1.0.2           # via cairosvg, cssselect2, weasyprint
-tinys3==0.1.12            # via -r requirements.in
-traceback2==1.4.0         # via unittest2
-tropo-webapi-python==0.1.3  # via -r requirements.in
-turn-python==0.0.1        # via -r requirements.in
-twilio==6.5.1             # via -r requirements.in
-ua-parser==0.10.0         # via user-agents
-unittest2==1.1.0          # via -r test-requirements.in
-urllib3==1.25.10          # via botocore, elasticsearch, elasticsearch2, elasticsearch7, py-kissmetrics, requests, sentry-sdk
-user-agents==2.2.0        # via django-user-agents
-vine==1.3.0               # via amqp
-weasyprint==51            # via -r requirements.in
-webencodings==0.5.1       # via cssselect2, html5lib, tinycss2
-werkzeug==1.0.1           # via -r requirements.in
-wrapt==1.12.1             # via deprecated
-xlrd==1.0.0               # via -r requirements.in
-xlwt==1.3.0               # via -r requirements.in
-xmlsec==1.3.9             # via python3-saml
+alembic==1.4.3
+    # via -r requirements.in
+amqp==2.6.1
+    # via kombu
+architect==0.5.6
+    # via -r requirements.in
+argparse==1.4.0
+    # via unittest2
+attrs==18.2.0
+    # via -r requirements.in
+babel==2.8.0
+    # via django-phonenumber-field
+beautifulsoup4==4.9.3
+    # via -r test-requirements.in
+billiard==3.5.0.4
+    # via
+    #   -r requirements.in
+    #   celery
+boto3==1.15.12
+    # via -r requirements.in
+botocore==1.18.12
+    # via
+    #   boto3
+    #   s3transfer
+cairocffi==1.1.0
+    # via
+    #   cairosvg
+    #   weasyprint
+cairosvg==2.5.1
+    # via weasyprint
+https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
+    # via
+    #   -r requirements.in
+    #   django-celery-results
+certifi==2020.6.20
+    # via
+    #   elasticsearch7
+    #   requests
+    #   sentry-sdk
+cffi==1.14.3
+    # via
+    #   cairocffi
+    #   cryptography
+    #   csiphash
+    #   weasyprint
+chardet==3.0.4
+    # via
+    #   ghdiff
+    #   requests
+click==7.1.2
+    # via pip-tools
+cloudant==2.14.0
+    # via jsonobject-couchdbkit
+commcaretranslationchecker==0.9.7
+    # via -r requirements.in
+concurrent-log-handler==0.9.12
+    # via -r requirements.in
+contextlib2==0.6.0.post1
+    # via schema
+coverage==4.5.1
+    # via -r test-requirements.in
+cryptography==3.3.1
+    # via pyopenssl
+csiphash==0.0.5
+    # via -r requirements.in
+cssselect2==0.3.0
+    # via
+    #   cairosvg
+    #   weasyprint
+datadog==0.39.0
+    # via -r requirements.in
+ddtrace==0.44.0
+    # via -r requirements.in
+decorator==4.0.11
+    # via
+    #   -r requirements.in
+    #   datadog
+    #   jsonpath-rw
+defusedxml==0.5.0
+    # via
+    #   -r requirements.in
+    #   cairosvg
+    #   python3-saml
+deprecated==1.2.10
+    # via pygithub
+diff-match-patch==20120106
+    # via -r requirements.in
+dimagi-memoized==1.1.3
+    # via -r requirements.in
+django-angular==2.2.4
+    # via -r requirements.in
+django-appconf==1.0.4
+    # via
+    #   django-compressor
+    #   django-statici18n
+django-braces==1.14.0
+    # via -r requirements.in
+django-bulk-update==2.2.0
+    # via -r requirements.in
+django-celery-results==1.0.4
+    # via -r requirements.in
+django-compressor==2.1
+    # via -r requirements.in
+django-countries==4.6
+    # via -r requirements.in
+django-crispy-forms==1.10.0
+    # via -r requirements.in
+django-cte==1.1.4
+    # via -r requirements.in
+django-formtools==2.1
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+django-logentry-admin==1.0.6
+    # via -r requirements.in
+https://github.com/dimagi/django-nose/raw/fast-first-1.4.6.1/releases/django_nose-1.4.6.1-py2.py3-none-any.whl
+    # via -r test-requirements.in
+django-oauth-toolkit==1.3.2
+    # via -r requirements.in
+django-otp==0.9.4
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+django-partial-index==0.6.0
+    # via -r requirements.in
+django-phonenumber-field==2.3.1
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+django-prbac==1.0.1
+    # via -r requirements.in
+django-ranged-response==0.2.0
+    # via django-simple-captcha
+django-redis-sessions==0.6.1
+    # via -r requirements.in
+django-redis==4.12.1
+    # via -r requirements.in
+django-simple-captcha==0.5.13
+    # via -r requirements.in
+django-statici18n==1.9.0
+    # via -r requirements.in
+django-tastypie==0.14.3
+    # via -r requirements.in
+django-transfer==0.4
+    # via -r requirements.in
+django-two-factor-auth==1.12.1
+    # via -r requirements.in
+django-user-agents==0.4.0
+    # via -r requirements.in
+django-websocket-redis==0.6.0
+    # via -r requirements.in
+django==2.2.16
+    # via
+    #   -r requirements.in
+    #   django-angular
+    #   django-appconf
+    #   django-braces
+    #   django-bulk-update
+    #   django-formtools
+    #   django-logentry-admin
+    #   django-oauth-toolkit
+    #   django-otp
+    #   django-phonenumber-field
+    #   django-prbac
+    #   django-ranged-response
+    #   django-redis
+    #   django-simple-captcha
+    #   django-statici18n
+    #   django-two-factor-auth
+    #   django-user-agents
+    #   djangorestframework
+    #   jsonfield
+djangorestframework==3.12.2
+    # via -r requirements.in
+dnspython==1.15.0
+    # via
+    #   -r requirements.in
+    #   email-validator
+dropbox==9.3.0
+    # via -r requirements.in
+elasticsearch2==2.5.1
+    # via -r requirements.in
+elasticsearch7==7.9.1
+    # via -r requirements.in
+elasticsearch==1.9.0
+    # via -r requirements.in
+email_validator==1.1.2
+    # via -r requirements.in
+et-xmlfile==1.0.1
+    # via openpyxl
+ethiopian-date-converter==0.1.5
+    # via -r requirements.in
+eulxml==1.1.3
+    # via -r requirements.in
+fakecouch==0.0.15
+    # via -r test-requirements.in
+faker==5.0.2
+    # via -r requirements.in
+flaky==3.7.0
+    # via -r test-requirements.in
+freezegun==0.3.15
+    # via -r test-requirements.in
+gevent==1.4.0
+    # via
+    #   -r requirements.in
+    #   django-websocket-redis
+    #   gipc
+ghdiff==0.4
+    # via -r requirements.in
+gipc==1.1.0
+    # via -r requirements.in
+greenlet==0.4.17
+    # via
+    #   -r requirements.in
+    #   django-websocket-redis
+    #   gevent
+gunicorn==20.0.4
+    # via -r requirements.in
+hiredis==1.1.0
+    # via -r requirements.in
+html5lib==1.1
+    # via weasyprint
+httpagentparser==1.9.0
+    # via -r requirements.in
+idna==2.10
+    # via
+    #   email-validator
+    #   requests
+intervaltree==3.1.0
+    # via ddtrace
+iso8601==0.1.13
+    # via -r requirements.in
+isodate==0.6.0
+    # via python3-saml
+jdcal==1.4.1
+    # via openpyxl
+jinja2==2.11.2
+    # via -r requirements.in
+jmespath==0.10.0
+    # via
+    #   boto3
+    #   botocore
+json-delta==2.0
+    # via -r requirements.in
+jsonfield==2.1.1
+    # via
+    #   -r requirements.in
+    #   django-prbac
+jsonobject-couchdbkit==1.0.1
+    # via -r requirements.in
+jsonobject==0.9.9
+    # via
+    #   -r requirements.in
+    #   jsonobject-couchdbkit
+jsonpath-rw==1.4.0
+    # via -r requirements.in
+kafka-python==1.4.7
+    # via -r requirements.in
+kombu==4.2.2.post1
+    # via
+    #   -r requirements.in
+    #   celery
+laboratory==0.2.0
+    # via -r requirements.in
+linecache2==1.0.0
+    # via traceback2
+lxml==4.3.5
+    # via
+    #   -r requirements.in
+    #   eulxml
+    #   xmlsec
+mako==1.1.3
+    # via alembic
+markdown==2.2.1
+    # via
+    #   -r requirements.in
+    #   pycco
+markupsafe==1.1.1
+    # via
+    #   jinja2
+    #   mako
+mock==2.0.0
+    # via -r requirements.in
+nose-exclude==0.5.0
+    # via -r test-requirements.in
+nose==1.3.7
+    # via
+    #   -r test-requirements.in
+    #   django-nose
+    #   nose-exclude
+oauthlib==3.1.0
+    # via
+    #   django-oauth-toolkit
+    #   requests-oauthlib
+openpyxl==2.6.4
+    # via
+    #   -r requirements.in
+    #   commcaretranslationchecker
+pbr==5.5.0
+    # via mock
+phonenumberslite==8.12.10
+    # via -r requirements.in
+pillow==7.2.0
+    # via
+    #   -r requirements.in
+    #   cairosvg
+    #   django-simple-captcha
+    #   reportlab
+pip-tools==5.5.0
+    # via -r test-requirements.in
+ply==3.11
+    # via
+    #   eulxml
+    #   jsonpath-rw
+polib==1.1.0
+    # via -r requirements.in
+prometheus-client==0.7.1
+    # via -r requirements.in
+protobuf==3.13.0
+    # via ddtrace
+psycogreen==1.0.2
+    # via -r requirements.in
+psycopg2==2.8.6
+    # via
+    #   -r requirements.in
+    #   sqlalchemy-postgres-copy
+py-kissmetrics==1.1.0
+    # via -r requirements.in
+pycco==0.5.1
+    # via -r requirements.in
+pycparser==2.20
+    # via cffi
+pycryptodome==3.9.9
+    # via -r requirements.in
+pygithub==1.54
+    # via -r requirements.in
+pygments==2.7.1
+    # via
+    #   -r requirements.in
+    #   pycco
+pygooglechart==0.4.0
+    # via -r requirements.in
+pyjwt==1.7.1
+    # via
+    #   pygithub
+    #   twilio
+pyopenssl==20.0.1
+    # via -r requirements.in
+pyphen==0.9.5
+    # via weasyprint
+pysocks==1.7.1
+    # via twilio
+pystache==0.5.4
+    # via pycco
+python-dateutil==2.8.1
+    # via
+    #   -r requirements.in
+    #   alembic
+    #   botocore
+    #   django-tastypie
+    #   faker
+    #   freezegun
+python-editor==1.0.4
+    # via alembic
+python-imap==1.0.0
+    # via -r requirements.in
+python-levenshtein==0.12.0
+    # via -r requirements.in
+python-magic==0.4.18
+    # via -r requirements.in
+python-mimeparse==1.6.0
+    # via django-tastypie
+python3-saml==1.9.0
+    # via -r requirements.in
+pytz==2020.1
+    # via
+    #   -r requirements.in
+    #   babel
+    #   celery
+    #   django
+    #   twilio
+pyyaml==5.3.1
+    # via -r requirements.in
+pyzxcvbn==0.8.0
+    # via -r requirements.in
+qrcode==4.0.4
+    # via
+    #   -r requirements.in
+    #   django-two-factor-auth
+quickcache==0.5.4
+    # via -r requirements.in
+rcssmin==1.0.6
+    # via django-compressor
+redis==3.5.3
+    # via
+    #   -r requirements.in
+    #   django-redis
+    #   django-redis-sessions
+    #   django-websocket-redis
+reportlab==3.5.53
+    # via -r requirements.in
+requests-mock==1.8.0
+    # via -r test-requirements.in
+requests-oauthlib==1.3.0
+    # via -r requirements.in
+requests==2.24.0
+    # via
+    #   -r requirements.in
+    #   cloudant
+    #   datadog
+    #   django-oauth-toolkit
+    #   dropbox
+    #   pygithub
+    #   requests-mock
+    #   requests-oauthlib
+    #   stripe
+    #   tinys3
+    #   twilio
+rjsmin==1.0.12
+    # via django-compressor
+s3transfer==0.3.3
+    # via boto3
+schema==0.7.2
+    # via -r requirements.in
+sentry-sdk==0.19.4
+    # via -r requirements.in
+sh==1.14.1
+    # via -r requirements.in
+simpleeval==0.9.10
+    # via -r requirements.in
+simplejson==3.17.2
+    # via
+    #   -r requirements.in
+    #   django-prbac
+six==1.15.0
+    # via
+    #   -r requirements.in
+    #   cryptography
+    #   django-braces
+    #   django-simple-captcha
+    #   django-statici18n
+    #   django-transfer
+    #   django-websocket-redis
+    #   dropbox
+    #   ethiopian-date-converter
+    #   eulxml
+    #   freezegun
+    #   ghdiff
+    #   html5lib
+    #   isodate
+    #   jsonfield
+    #   jsonobject
+    #   jsonobject-couchdbkit
+    #   jsonpath-rw
+    #   mock
+    #   protobuf
+    #   pyopenssl
+    #   python-dateutil
+    #   pyzxcvbn
+    #   qrcode
+    #   quickcache
+    #   requests-mock
+    #   sqlalchemy-postgres-copy
+    #   tenacity
+    #   twilio
+    #   unittest2
+smartypants==2.0.1
+    # via pycco
+socketpool==0.5.3
+    # via -r requirements.in
+sortedcontainers==2.3.0
+    # via intervaltree
+soupsieve==2.0.1
+    # via beautifulsoup4
+sqlagg==0.17.2
+    # via -r requirements.in
+sqlalchemy-postgres-copy==0.5.0
+    # via -r test-requirements.in
+sqlalchemy==1.3.19
+    # via
+    #   -r requirements.in
+    #   alembic
+    #   sqlagg
+    #   sqlalchemy-postgres-copy
+sqlparse==0.3.1
+    # via django
+stripe==2.54.0
+    # via -r requirements.in
+suds-jurko==0.6
+    # via -r requirements.in
+tenacity==6.2.0
+    # via ddtrace
+testil==1.1
+    # via -r test-requirements.in
+text-unidecode==1.3
+    # via
+    #   -r requirements.in
+    #   faker
+tinycss2==1.0.2
+    # via
+    #   cairosvg
+    #   cssselect2
+    #   weasyprint
+tinys3==0.1.12
+    # via -r requirements.in
+traceback2==1.4.0
+    # via unittest2
+tropo-webapi-python==0.1.3
+    # via -r requirements.in
+turn-python==0.0.1
+    # via -r requirements.in
+twilio==6.5.1
+    # via -r requirements.in
+ua-parser==0.10.0
+    # via user-agents
+unittest2==1.1.0
+    # via -r test-requirements.in
+urllib3==1.25.10
+    # via
+    #   botocore
+    #   elasticsearch
+    #   elasticsearch2
+    #   elasticsearch7
+    #   py-kissmetrics
+    #   requests
+    #   sentry-sdk
+user-agents==2.2.0
+    # via django-user-agents
+vine==1.3.0
+    # via amqp
+weasyprint==51
+    # via -r requirements.in
+webencodings==0.5.1
+    # via
+    #   cssselect2
+    #   html5lib
+    #   tinycss2
+werkzeug==1.0.1
+    # via -r requirements.in
+wrapt==1.12.1
+    # via deprecated
+xlrd==1.0.0
+    # via -r requirements.in
+xlwt==1.3.0
+    # via -r requirements.in
+xmlsec==1.3.9
+    # via python3-saml
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.2.3               # via pip-tools
-setuptools==50.3.0        # via cairocffi, cssselect2, django-websocket-redis, gunicorn, protobuf, python-levenshtein, tinycss2, weasyprint
+pip==20.2.3
+    # via pip-tools
+setuptools==50.3.0
+    # via
+    #   cairocffi
+    #   cssselect2
+    #   django-websocket-redis
+    #   gunicorn
+    #   protobuf
+    #   python-levenshtein
+    #   tinycss2
+    #   weasyprint


### PR DESCRIPTION
## Summary

This changes the format of requirements.txt files, which is necessary because [dependabot has also upgraded](https://github.com/dependabot/dependabot-core/pull/2943). Dependabot PRs will generate large/hard to read diffs until we are on the same version.

Tests will fail on new dependabot PRs until this is merged.

The only dependency upgraded in this PR is pip-tools (https://github.com/dimagi/commcare-hq/commit/d292be893d2d5b1c08f6854c5d88da76429c0b12). The second commit is formatting change only.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below
- [x] This PR can be reverted after deploy with no further considerations 
