### PR TITLE
remove unused DomainRateLimiter

### DIFF
--- a/corehq/ex-submodules/dimagi/utils/rate_limit.py
+++ b/corehq/ex-submodules/dimagi/utils/rate_limit.py
@@ -1,7 +1,7 @@
-from datetime import datetime, timedelta
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 
 
+# todo: should this be replaced project_limits.RateLimiter?
 def rate_limit(key, actions_allowed=60, how_often=60):
     """
     A simple util to be used for rate limiting, using redis as a backend.
@@ -40,68 +40,3 @@ def rate_limit(key, actions_allowed=60, how_often=60):
         client.expire(key, how_often)
 
     return value <= actions_allowed
-
-
-class DomainRateLimiter(object):
-    """
-    A util for rate limiting by domain.
-    For example, to allow a domain to only send 100 SMS every 60 seconds:
-
-    limiter = DomainRateLimiter('send-sms-for-', 100, 60)
-    ...
-    if limiter.can_perform_action('my-domain'):
-        <perform action>
-    else:
-        <delay action>
-    """
-    def __init__(self, key, actions_allowed, how_often):
-        """
-        key - the beginning of the redis key that will be used to rate limit on;
-        the actual key that is used will be key + domain
-
-        actions_allowed - see rate_limit()
-
-        how_often - see rate_limit()
-        """
-        self.key = key
-        self.actions_allowed = actions_allowed
-        self.how_often = how_often
-
-        """
-        Dictionary of {domain: datetime}
-        When a domain exceeds its allowed actions, an entry is put here to
-        note the timestamp when the domain should be allowed to perform
-        actions again. This is meant to save calls to redis when we know
-        a domain is in a "cool down" phase.
-
-        NOTE: Multiple processes might all have their own instance of a
-        DomainRateLimiter with the same key, and that's ok, it just means
-        each process will make 1 extra call to redis and then stop after that.
-        This also doesn't have to be thread safe since dirty reads won't
-        affect the overall function of the rate limiter.
-        """
-        self.cooldown = {}
-
-    def can_perform_action(self, domain):
-        """
-        Returns True if the action can be performed, False if the action should
-        be delayed because the number of allowed actions has been exceeded.
-        """
-        if domain in self.cooldown and datetime.utcnow() < self.cooldown[domain]:
-            return False
-
-        key = self.key + domain
-        if rate_limit(key, actions_allowed=self.actions_allowed, how_often=self.how_often):
-            return True
-        else:
-            # Add an entry to self.cooldown so that next time we don't have to
-            # make a call to redis
-            client = get_redis_client().client.get_client()
-            time_remaining = client.ttl(key)
-            if time_remaining < 0:
-                # If we just happened to time it so that the key just expired or
-                # a key was just created but doesn't have a timeout yet, then use a
-                # value of 0 here and the cool down will be ignored.
-                time_remaining = 0
-            self.cooldown[domain] = datetime.utcnow() + timedelta(seconds=time_remaining)
-            return False

--- a/corehq/ex-submodules/dimagi/utils/tests/test_rate_limit.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/test_rate_limit.py
@@ -1,4 +1,4 @@
-from dimagi.utils.rate_limit import rate_limit, DomainRateLimiter
+from dimagi.utils.rate_limit import rate_limit
 from django.test import SimpleTestCase
 # import the datetime module and not datetime.datetime:
 # "datetime" has to be the datetime module since the tests/__init__.py file
@@ -20,23 +20,4 @@ class RateLimitTestCase(SimpleTestCase):
             iteration_count += 1
 
         self.assertEqual(rate_limit_count, 20)
-        self.assertGreater(iteration_count, 20)
-
-    def test_domain_rate_limit(self):
-        rate_limiter = DomainRateLimiter('rate-limit-domain-', 10, 3)
-        domains = ('d1', 'd2')
-        domain_counts = {domain: 0 for domain in domains}
-
-        start = datetime.datetime.utcnow()
-        iteration_count = 0
-
-        while (datetime.datetime.utcnow() - start) < datetime.timedelta(seconds=5):
-            # Only allow 10 actions every 3 seconds in an 5 second period of time
-            for domain in domains:
-                if rate_limiter.can_perform_action(domain):
-                    domain_counts[domain] += 1
-            iteration_count += 1
-
-        for domain in domains:
-            self.assertEqual(domain_counts[domain], 20)
         self.assertGreater(iteration_count, 20)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Removes unused code. Tried to use this to implement rate limiting on https://github.com/dimagi/commcare-hq/pull/29042 before realizing it wasn't actually used anywhere else in HQ.

Hopefully this prevents future confusion.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
