### PR TITLE
Add days center open report

### DIFF
--- a/custom/nutrition_project/ucr/data_sources/nutrition_delivery_children_3_to_6_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/nutrition_delivery_children_3_to_6_v1.json
@@ -1,0 +1,173 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "config": {
+    "table_id": "static-nutrition_delivery_3_6_v1",
+    "display_name": "Nutrition Delivery (3 to 6 years) V1",
+    "referenced_doc_type": "XFormInstance",
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "xmlns"
+          },
+          "property_value": "http://openrosa.org/formdesigner/87149AFE-1EE9-4C80-AE07-FD12FA808D83"
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "app_id"
+          },
+          "property_value": "b3c758f7c79e47e3a503115894f18503"
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "type": "expression",
+        "column_id": "username",
+        "display_name": "username",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "username"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "userID",
+        "display_name": "userID",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      },
+      {
+        "display_name": "FLW ID",
+        "datatype": "string",
+        "expression": {
+          "type": "named",
+          "name": "user_location_id"
+        },
+        "type": "expression",
+        "column_id": "flw_id"
+      },
+      {
+        "display_name": "Supervisor ID",
+        "datatype": "string",
+        "expression": {
+          "location_id": {
+            "type": "named",
+            "name": "user_location_id"
+          },
+          "location_type": "supervisor",
+          "location_property": "_id",
+          "type": "ancestor_location"
+        },
+        "type": "expression",
+        "column_id": "supervisor_id"
+      },
+      {
+        "type": "expression",
+        "column_id": "received_on",
+        "display_name": "received_on",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "received_on"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "completed_time",
+        "display_name": "completed_time",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "timeEnd"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "nutrition_center_open_today",
+        "display_name": "nutrition_center_open_today",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "nutrition_center_open_today"
+          ]
+        }
+      }
+    ],
+    "named_expressions": {
+      "user_location_id": {
+        "datatype": "string",
+        "value_expression": {
+          "type": "property_name",
+          "property_name": "location_id"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareUser",
+        "doc_id_expression": {
+          "type": "root_doc",
+          "expression": {
+            "datatype": "string",
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "supervisor_id",
+          "flw_id"
+        ]
+      }
+    ]
+  }
+}

--- a/custom/nutrition_project/ucr/data_sources/nutrition_delivery_children_3_to_6_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/nutrition_delivery_children_3_to_6_v1.json
@@ -7,7 +7,7 @@
   ],
   "config": {
     "table_id": "static-nutrition_delivery_3_6_v1",
-    "display_name": "Nutrition Delivery (3 to 6 years) V1",
+    "display_name": "Nutrition Delivery Children (3-6 yrs) V1 (Static)",
     "referenced_doc_type": "XFormInstance",
     "configured_filter": {
       "type": "and",

--- a/custom/nutrition_project/ucr/data_sources/nutrition_delivery_children_3_to_6_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/nutrition_delivery_children_3_to_6_v1.json
@@ -148,16 +148,13 @@
         "type": "related_doc",
         "related_doc_type": "CommCareUser",
         "doc_id_expression": {
-          "type": "root_doc",
-          "expression": {
-            "datatype": "string",
-            "type": "property_path",
-            "property_path": [
-              "form",
-              "meta",
-              "userID"
-            ]
-          }
+          "datatype": "string",
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "userID"
+          ]
         }
       }
     },

--- a/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
+++ b/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
@@ -1,0 +1,90 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "report_id": "static-number_of_days_open_v1",
+  "data_source_table": "static-nutrition_delivery_3_6_v1",
+  "config": {
+    "title": "Number of days center open",
+    "description": "Number of days center was open per flw per month",
+    "visible": true,
+    "aggregation_columns": [
+      "supervisor_id",
+      "flw_id",
+      "month"
+    ],
+    "filters": [
+      [
+        {
+          "display": "Filter by FLW",
+          "slug": "flw_id",
+          "type": "dynamic_choice_list",
+          "field": "userID",
+          "choice_provider": {
+            "type": "location"
+          },
+          "ancestor_expression": {
+            "field": "supervisor_id",
+            "location_type": "supervisor"
+          },
+          "datatype": "string"
+        },
+        {
+          "display": "Filter by Supervisor",
+          "slug": "supervisor_id",
+          "type": "dynamic_choice_list",
+          "field": "supervisor_id",
+          "choice_provider": {
+            "type": "location"
+          },
+          "datatype": "string"
+        }
+      ]
+    ],
+    "columns": [
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "completed_time",
+        "format": "%Y-%m"
+      },
+      {
+        "display": {
+          "en": "Supervisor ID",
+          "hin": "Supervisor ID"
+        },
+        "column_id": "supervisor_id",
+        "type": "field",
+        "field": "supervisor_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": {
+          "en": "FLW ID",
+          "hin": "FLW ID"
+        },
+        "column_id": "flw_id",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "days_open",
+        "column_id": "days_open",
+        "type": "sum_when",
+        "whens": [
+          [
+            "nutrition_center_open_today = 'yes'",
+            1
+          ]
+        ],
+        "else_": 0
+      }
+    ]
+  },
+  "doc_type": "ReportConfiguration"
+}

--- a/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
+++ b/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
@@ -17,32 +17,30 @@
       "month"
     ],
     "filters": [
-      [
-        {
-          "display": "Filter by FLW",
-          "slug": "flw_id",
-          "type": "dynamic_choice_list",
-          "field": "userID",
-          "choice_provider": {
-            "type": "location"
-          },
-          "ancestor_expression": {
-            "field": "supervisor_id",
-            "location_type": "supervisor"
-          },
-          "datatype": "string"
+      {
+        "display": "Filter by FLW",
+        "slug": "flw_id",
+        "type": "dynamic_choice_list",
+        "field": "userID",
+        "choice_provider": {
+          "type": "location"
         },
-        {
-          "display": "Filter by Supervisor",
-          "slug": "supervisor_id",
-          "type": "dynamic_choice_list",
+        "ancestor_expression": {
           "field": "supervisor_id",
-          "choice_provider": {
-            "type": "location"
-          },
-          "datatype": "string"
-        }
-      ]
+          "location_type": "supervisor"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "datatype": "string"
+      }
     ],
     "columns": [
       {

--- a/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
+++ b/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
@@ -8,7 +8,7 @@
   "report_id": "static-number_of_days_open_v1",
   "data_source_table": "static-nutrition_delivery_3_6_v1",
   "config": {
-    "title": "Number of days center open",
+    "title": "No. of days center open (Static)",
     "description": "Number of days center was open per flw per month",
     "visible": true,
     "aggregation_columns": [

--- a/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
+++ b/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
@@ -53,20 +53,14 @@
         "format": "%Y-%m"
       },
       {
-        "display": {
-          "en": "Supervisor ID",
-          "hin": "Supervisor ID"
-        },
+        "display": "Supervisor ID",
         "column_id": "supervisor_id",
         "type": "field",
         "field": "supervisor_id",
         "aggregation": "simple"
       },
       {
-        "display": {
-          "en": "FLW ID",
-          "hin": "FLW ID"
-        },
+        "display": "FLW ID",
         "column_id": "flw_id",
         "type": "field",
         "field": "flw_id",


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Building on https://github.com/dimagi/commcare-hq/pull/29056, to add report for number of days center was open.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This PR just adds a new data source and report for the project. It is not really live so there should be no scale implications of this as well.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Ideally this should not be rolled back because apps would be using it.

- [ ] This PR can be reverted after deploy with no further considerations 
