### PR TITLE
Revert "create metrics for failed logins"

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -534,7 +534,7 @@ def check_lockout(fn):
             return fn(request, *args, **kwargs)
 
         user = CouchUser.get_by_username(username)
-        if user and user.is_locked_out():
+        if user and user.is_locked_out() and user.supports_lockout():
             return json_response({"error": _("maximum password attempts exceeded")}, status_code=401)
         else:
             return fn(request, *args, **kwargs)

--- a/corehq/apps/hqwebapp/signals.py
+++ b/corehq/apps/hqwebapp/signals.py
@@ -5,7 +5,6 @@ from django.contrib.auth.signals import user_logged_in, user_login_failed
 from django.dispatch import receiver
 
 from corehq.apps.users.models import CouchUser
-from corehq.util.metrics import metrics_counter
 
 
 def clear_login_attempts(user):
@@ -27,27 +26,9 @@ def clear_failed_logins_and_unlock_account(sender, request, user, **kwargs):
 
 
 @receiver(user_login_failed)
-def add_failed_attempt(sender, credentials, token_failure=False, **kwargs):
+def add_failed_attempt(sender, credentials, **kwargs):
     user = CouchUser.get_by_username(credentials['username'])
-    if not user:
-        metrics_counter('commcare.auth.invalid_user')
-        return
-
-    if token_failure:
-        metrics_counter('commcare.auth.invalid_token')
-
-    locked_out = user.is_locked_out()
-
-    if locked_out:
-        lockout_result = 'locked_out'
-    else:
-        lockout_result = 'should_be_locked_out' if user.should_be_locked_out() else 'allowed_to_retry'
-
-    metrics_counter('commcare.auth.failed_attempts', tags={
-        'result': lockout_result
-    })
-
-    if not locked_out:
+    if user and not user.is_locked_out() and user.supports_lockout():
         if user.attempt_date == date.today():
             user.login_attempts += 1
         else:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1112,9 +1112,6 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         return self.username.endswith('@dimagi.com')
 
     def is_locked_out(self):
-        return self.supports_lockout() and self.should_be_locked_out()
-
-    def should_be_locked_out(self):
         return self.login_attempts >= MAX_LOGIN_ATTEMPTS
 
     @property

--- a/corehq/apps/users/tests/test_confirm_account.py
+++ b/corehq/apps/users/tests/test_confirm_account.py
@@ -29,8 +29,6 @@ class TestAccountConfirmation(TestCase):
         )
         # confirm user can't login
         self.assertEqual(False, self.client.login(username=self.username, password=self.password))
-        # Refresh the user after a failed login, as it will be out of date
-        self.user = CommCareUser.get_by_username(self.username)
 
     @classmethod
     def tearDownClass(cls):
@@ -46,8 +44,6 @@ class TestAccountConfirmation(TestCase):
 
         # confirm user can't login
         self.assertEqual(False, self.client.login(username=self.username, password=self.password))
-        # User is now outdated from the failed login, re-fetch
-        self.user = CommCareUser.get_by_username(self.username)
 
         new_password = 'm0r3s3cr3t!'
         self.user.confirm_account(password=new_password)

--- a/corehq/apps/users/tests/test_user_model.py
+++ b/corehq/apps/users/tests/test_user_model.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 
 from django.test import SimpleTestCase, TestCase
-from unittest.mock import patch
 
 from corehq.apps.custom_data_fields.models import (
     CustomDataFieldsDefinition,
@@ -21,8 +20,6 @@ from corehq.form_processor.utils import (
     get_simple_wrapped_form,
 )
 from corehq.util.test_utils import softer_assert
-
-from corehq.apps.users.models import MAX_LOGIN_ATTEMPTS
 
 
 class UserModelTest(TestCase):
@@ -50,15 +47,6 @@ class UserModelTest(TestCase):
         FormProcessorTestUtils.delete_all_xforms(self.domain)
         self.domain_obj.delete()
         super(UserModelTest, self).tearDown()
-
-    def create_commcare_user(self, username):
-        return CommCareUser.create(
-            domain=self.domain,
-            username=username,
-            password='***',
-            created_by=None,
-            created_via=None,
-        )
 
     @run_with_all_backends
     def test_get_form_ids(self):
@@ -177,26 +165,6 @@ class UserModelTest(TestCase):
 
         definition.delete()
         web_user.delete(deleted_by=None)
-
-    @patch('corehq.apps.users.models.toggles.MOBILE_LOGIN_LOCKOUT.enabled')
-    def test_commcare_user_is_locked_only_with_toggle(self, mock_lockout_enabled_for_domain):
-        # Web Users should always be locked out when they go beyond
-        # the the max login attempts,
-        # but Commcare Users need an additional domain toggle
-        commcare_user = self.create_commcare_user('test_user')
-        commcare_user.login_attempts = MAX_LOGIN_ATTEMPTS
-        mock_lockout_enabled_for_domain.return_value = False
-
-        self.assertFalse(commcare_user.is_locked_out())
-
-    @patch('corehq.apps.users.models.toggles.MOBILE_LOGIN_LOCKOUT.enabled')
-    def test_commcare_user_should_be_locked_out(self, mock_lockout_enabled_for_domain):
-        # Make sure the we know the user should be locked, if not for the toggle
-        commcare_user = self.create_commcare_user('test_user')
-        commcare_user.login_attempts = MAX_LOGIN_ATTEMPTS
-        mock_lockout_enabled_for_domain.return_value = False
-
-        self.assertTrue(commcare_user.should_be_locked_out())
 
 
 class UserDeviceTest(SimpleTestCase):


### PR DESCRIPTION
Reverts dimagi/commcare-hq#28939

Causing ResouceConflict errors during form submission: https://sentry.io/organizations/dimagi/issues/2186196976/?project=136860&query=is%3Aunresolved