### PR TITLE
Web Apps accessibility fixes for collapsible groups

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -3,6 +3,7 @@ hqDefine("cloudcare/js/form_entry/fullform-ui", function () {
     var Const = hqImport("cloudcare/js/form_entry/const"),
         Utils = hqImport("cloudcare/js/form_entry/utils");
     var md = window.markdownit();
+    var groupNum = 0;
 
     //Overriden by downstream contexts, check before changing
     window.mdAnchorRender = md.renderer.rules.link_open || function (tokens, idx, options, env, self) {
@@ -369,6 +370,7 @@ hqDefine("cloudcare/js/form_entry/fullform-ui", function () {
         Container.call(self, json);
 
         self.parent = parent;
+        self.groupId = groupNum++;
         self.rel_ix = ko.observable(relativeIndex(self.ix()));
         self.isRepetition = parent instanceof Repeat;
         if (_.has(json, 'domain_meta') && _.has(json, 'style')) {
@@ -381,6 +383,17 @@ hqDefine("cloudcare/js/form_entry/fullform-ui", function () {
         self.toggleChildren = function () {
             if (self.collapsible) {
                 self.showChildren(!self.showChildren());
+            }
+        };
+
+        self.captionId = function () {
+            return "group_".concat(self.groupId).concat("_caption");
+        };
+
+        self.keyPressAction = function (data, event) {
+            // Toggle children on Enter or Space.
+            if (event.keyCode === 13 || event.keyCode === 32) {
+                this.toggleChildren(data, event);
             }
         };
 

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -10,7 +10,21 @@
           'panel panel-default': collapsible,
           'required-group': !showChildren() && childrenRequired(),
         }">
-    <fieldset class="gr-header" data-bind="css: {'panel-heading': collapsible, clickable: collapsible}, click: toggleChildren">
+    <fieldset class="gr-header" data-bind="
+        css: {
+          'panel-heading': collapsible,
+           clickable: collapsible
+        },
+        attr: collapsible ? {
+                role: 'button',
+                'aria-expanded': showChildren() ? 'true' : 'false',
+                'aria-labelledby': captionId()
+              } : {
+                'aria-labelledby': captionId()
+              },
+        click: toggleChildren,
+        event: {keypress: keyPressAction}"
+              tabindex="0">
       <div data-bind="ifnot: collapsible">
         <legend>
           <span class="caption webapp-markdown-output"
@@ -29,7 +43,7 @@
               css: {'fa-angle-double-right': !showChildren(), 'fa-angle-double-down': showChildren()},
           "></i>
         </div>
-        <span class="caption" data-bind="html: caption()"></span><!-- Markdown interferes with header styling -->
+        <span class="caption" data-bind="html: caption(), attr: {id: captionId()}"></span><!-- Markdown interferes with header styling -->
         <i class="fa fa-warning text-danger pull-right" data-bind="visible: hasError() && !showChildren()"></i>
         <button class="btn btn-xs btn-danger del pull-right" href="#" data-bind="
                     visible: isRepetition,


### PR DESCRIPTION
## Summary
This PR is a subset of a larger PR (#28972) for improved Web Apps accessibility. We expect one customer to roll out collapsible groups in their forms and possibly break their screen reader users before #28972 can be QA tested. So this PR is intended as an emergency fix just for collapsible groups accessibility that we could test with screen reader users on staging before deploying.

## Related issues
https://dimagi-dev.atlassian.net/browse/USH-499

## Product Description
Collapsible groups (i.e. groups with the advanced attribute "group-collapse") are added to the tab order so they become focusable. They have ARIA labels and they activate on either a Space or Enter key press. This is largely based on the [ARIA accordion pattern](https://www.w3.org/TR/wai-aria-practices/#accordion).

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I am certain that this PR will not introduce a regression for the reasons below

### QA Plan
If this PR is needed (i.e. if the customer's forms are broken for screen readers) we expect to test this with a screen reader end user from staging and not have a QA review. If the forms are not broken, we'll delete this PR and proceed with the larger one (#28972) which will be QA tested.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
