### PR TITLE
Updated case search dropdown requests to accept new value from formpl…

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -100,7 +100,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     var choices = response.models[i].get('itemsetChoices');
                     if (choices) {
                         var $field = $($fields.get(i)),
-                            value = parseInt($field.val());
+                            value = parseInt(response.models[i].get('value'));
                         $field.select2('close');    // force close dropdown, the set below can interfere with this when clearing selection
                         self.collection.models[i].set({
                             itemsetChoices: choices,


### PR DESCRIPTION
…ayer

## Summary
Somewhat related to discussions around https://github.com/dimagi/formplayer/pull/831, but can be released independently of that PR.

Basically, web apps should be totally depending on formplayer for the dropdown index values, instead of saving the old value.

## Feature Flag
Case search & claim

## Product Description
Probably not worth announcing, fixes subtle bugs when you have case claim dropdowns that are dependent on each other.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests.

### QA Plan

Tested locally. Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
