### PR TITLE
Serve reports from cache only if file is served as response

### DIFF
--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -649,7 +649,6 @@ class GenericReportView(object):
         return json_response(self.json_dict)
 
     @property
-    @request_cache()
     def export_response(self):
         """
         Intention: Not to be overridden in general.
@@ -660,9 +659,13 @@ class GenericReportView(object):
             export_all_rows_task.delay(self.__class__, self.__getstate__())
             return HttpResponse()
         else:
-            temp = io.BytesIO()
-            export_from_tables(self.export_table, temp, self.export_format)
-            return export_response(temp, self.export_format, self.export_name)
+            self._export_response_direct()
+
+    @request_cache()
+    def _export_response_direct(self):
+        temp = io.BytesIO()
+        export_from_tables(self.export_table, temp, self.export_format)
+        return export_response(temp, self.export_format, self.export_name)
 
     @property
     @request_cache()

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -659,6 +659,8 @@ class GenericReportView(object):
             export_all_rows_task.delay(self.__class__, self.__getstate__())
             return HttpResponse()
         else:
+            # We only want to cache the responses which serve files directly
+            # The response which return 200 and emails the reports should not be cached
             self._export_response_direct()
 
     @request_cache()


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-11400

In the reports in which "Export as excel functionality" emails the report to users the users were getting report only one time if they request multiple times in an hour. This was happening because the responses of the reports were cached and in these reports, the response was 200 Ok which tells users that the report will be mailed to them. The PR addresses that issue.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The changes have been tested locally and it affects 2 or three reports and does not alter behaviour in any way.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
