### PR TITLE
Removed unused dbaccessor

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -447,20 +447,6 @@ def get_all_apps(domain):
     return chain(get_apps_in_domain(domain), _saved_apps())
 
 
-def get_all_app_ids(domain):
-    """
-    Returns a list of all the app_ids ever built and current Applications.
-    """
-    from .models import Application
-    results = Application.get_db().view(
-        'app_manager/saved_app',
-        startkey=[domain],
-        endkey=[domain, {}],
-        include_docs=False,
-    ).all()
-    return [result['id'] for result in results]
-
-
 def get_all_built_app_ids_and_versions(domain, app_id=None):
     """
     Returns a list of all the app_ids ever built and their version.

--- a/corehq/apps/app_manager/tests/test_dbaccessors.py
+++ b/corehq/apps/app_manager/tests/test_dbaccessors.py
@@ -4,7 +4,6 @@ from couchdbkit.exceptions import NoResultFound
 
 from corehq.apps.app_manager.dbaccessors import (
     domain_has_apps,
-    get_all_app_ids,
     get_all_built_app_ids_and_versions,
     get_app,
     get_app_cached,
@@ -176,10 +175,6 @@ class DBAccessorsTest(TestCase, DocTestMixin):
             self.domain, app_ids_in_domain
         )
         self.assertEqual(len(app_ids), 1)  # Should get the one that has_submissions
-
-    def test_get_all_app_ids_for_domain(self):
-        app_ids = get_all_app_ids(self.domain)
-        self.assertEqual(len(app_ids), 3)
 
     def test_get_latest_built_app_ids_and_versions(self):
         build_ids_and_versions = get_latest_app_ids_and_versions(self.domain)


### PR DESCRIPTION
## Summary
Dropping dead code

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
