### PR TITLE
Fix pre filter for empty dates

### DIFF
--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -32,6 +32,11 @@ from corehq.apps.reports.util import (
     get_null_empty_value_bindparam)
 
 # todo: if someone wants to name an actual choice any of these values, it will break
+from corehq.apps.userreports.datatypes import (
+    DATA_TYPE_DATE,
+    DATA_TYPE_DATETIME
+)
+
 SHOW_ALL_CHOICE = '_all'
 NONE_CHOICE = "\u2400"
 
@@ -258,10 +263,13 @@ class PreFilterValue(FilterValue):
                 get_INFilter_bindparams(self.filter['slug'], ['start_date', 'end_date'])
             )
         elif self._is_empty():
-            return ORFilter([
-                EQFilter(self.filter['field'], self.filter['slug']),
-                ISNULLFilter(self.filter['field']),
-            ])
+            if self.filter.get('datatype') in [DATA_TYPE_DATE, DATA_TYPE_DATETIME]:
+                return ISNULLFilter(self.filter['field'])
+            else:
+                return ORFilter([
+                    EQFilter(self.filter['field'], self.filter['slug']),
+                    ISNULLFilter(self.filter['field']),
+                ])
         elif self._is_exists():
             # this resolves to != '', which also filters out null data in postgres
             return NOTEQFilter(self.filter['field'], self.filter['slug'])
@@ -280,6 +288,8 @@ class PreFilterValue(FilterValue):
                 get_INFilter_element_bindparam(self.filter['slug'], i): str(v)
                 for i, v in enumerate([start_date, end_date])
             }
+        elif self._is_empty() and self.filter.get('datatype') in [DATA_TYPE_DATE, DATA_TYPE_DATETIME]:
+            return {}
         elif self._is_empty() or self._is_exists():
             return {
                 self.filter['slug']: '',

--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -4,6 +4,7 @@ from django.http import HttpRequest, QueryDict
 from django.test import SimpleTestCase, TestCase
 from django.utils.http import urlencode
 
+from corehq.apps.userreports.datatypes import DATA_TYPE_DATETIME, DATA_TYPE_DATE
 from dimagi.utils.dates import DateSpan
 
 from corehq.apps.locations.tests.util import LocationHierarchyTestCase
@@ -413,6 +414,28 @@ class PreFilterTestCase(SimpleTestCase):
                     str(filter_value.to_sql_filter().build_expression()),
                     'empty_field = :empty_field_slug OR empty_field IS NULL'
                 )
+
+    def test_pre_filter_value_empty_date_types(self):
+        pre_values = ['', None]
+        operators = ['', '=']
+        date_types = [DATA_TYPE_DATE, DATA_TYPE_DATETIME]
+        for pre_value in pre_values:
+            for operator in operators:
+                for datatype in date_types:
+                    filter_ = {
+                        'type': 'pre',
+                        'field': 'empty_field',
+                        'slug': 'empty_field_slug',
+                        'datatype': datatype,
+                        'pre_value': pre_value,
+                        'pre_operator': operator
+                    }
+                    filter_value = PreFilterValue(filter_, {'operand': pre_value, 'operator': operator})
+                    self.assertEqual(filter_value.to_sql_values(), {})
+                    self.assertEqual(
+                        str(filter_value.to_sql_filter().build_expression()),
+                        'empty_field IS NULL'
+                    )
 
     def test_pre_filter_value_exists(self):
         pre_values = ['', None]


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://sentry.io/organizations/dimagi/issues/2182609325/events/?environment=india&project=136860

In UCR, Pre report filter seems to be failing when used for date comparisons for null values. Sentry is for date field, but It seems to be happening for both date and datetime types.

```
commcarehq=# select * from temporary_mk;
     created_on      | posting_date 
---------------------+--------------
 2020-01-01 00:00:00 | 2020-01-01
(1 row)

commcarehq=# select * from temporary_mk where posting_date = '';
ERROR:  invalid input syntax for type date: ""
LINE 1: select * from temporary_mk where posting_date = '';
                                                        ^
commcarehq=# select * from temporary_mk where created_on = '';
ERROR:  invalid input syntax for type timestamp: ""
LINE 1: select * from temporary_mk where created_on = '';
```

This PR updates how we create the SQL query to use only "IS NULL" for date and datetime values which should fetch the blank values
```
commcarehq=# \d temporary_mk_2;
                             Table "public.temporary_mk_2"
    Column    |            Type             | Collation | Nullable |      Default      
--------------+-----------------------------+-----------+----------+-------------------
 created_on   | timestamp without time zone |           |          | 
 posting_date | date                        |           | not null | 'now'::text::date

commcarehq=# select * from temporary_mk_2 where created_on = '';
ERROR:  invalid input syntax for type timestamp: ""
LINE 1: select * from temporary_mk_2 where created_on = '';
                                                        ^
commcarehq=# select * from temporary_mk_2;
 created_on | posting_date 
------------+--------------
            | 2020-01-01
(1 row)

commcarehq=# select * from temporary_mk_2 where created_on IS NULL;
 created_on | posting_date 
------------+--------------
            | 2020-01-01
(1 row)
```
Similarly for date
```
commcarehq=# \d temporary_mk_3;
                        Table "public.temporary_mk_3"
    Column    |            Type             | Collation | Nullable | Default 
--------------+-----------------------------+-----------+----------+---------
 created_on   | timestamp without time zone |           |          | 
 posting_date | date                        |           |          | 

commcarehq=# select * from temporary_mk_3 where posting_date is null;
     created_on      | posting_date 
---------------------+--------------
 2020-01-01 00:00:00 | 
 2020-01-01 00:00:00 | 
(2 rows)
```

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
If someone uses pre fitler for date for null values, it should work now.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Test has been added for it.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Should be safe to merge this since it is a bug fix and does not effect any other filter/datatype

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
