### PR TITLE
Remove coverage

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -111,8 +111,8 @@ function _run_tests() {
 
     if [ "$TEST" == "python-sharded-and-javascript" ]; then
         ./manage.py create_kafka_topics
-        echo "coverage run manage.py test $@ $TESTS"
-        /vendor/bin/coverage run manage.py test "$@" $TESTS
+        echo "./manage.py test $@ $TESTS"
+        ./manage.py test "$@" $TESTS
 
         ./manage.py migrate --noinput
         ./manage.py runserver 0.0.0.0:8000 &> commcare-hq.log &
@@ -121,8 +121,8 @@ function _run_tests() {
          grunt test "$@"
     elif [ "$TEST" != "javascript" ]; then
         ./manage.py create_kafka_topics
-        echo "coverage run manage.py test $@ $TESTS"
-        /vendor/bin/coverage run manage.py test "$@" $TESTS
+        echo "./manage.py test $@ $TESTS"
+        ./manage.py test "$@" $TESTS
     else
         ./manage.py migrate --noinput
         ./manage.py runserver 0.0.0.0:8000 &> commcare-hq.log &

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -77,8 +77,6 @@ contextlib2==0.6.0.post1
     # via
     #   git-build-branch
     #   schema
-coverage==4.5.1
-    # via -r test-requirements.in
 cryptography==3.3.1
     # via pyopenssl
 csiphash==0.0.5

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -1,7 +1,6 @@
 -r requirements.in
 
 beautifulsoup4>=4.4.1
-coverage==4.5.1
 django-nose @ https://github.com/dimagi/django-nose/raw/fast-first-1.4.6.1/releases/django_nose-1.4.6.1-py2.py3-none-any.whl
 fakecouch==0.0.15
 nose==1.3.7

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -63,8 +63,6 @@ concurrent-log-handler==0.9.12
     # via -r requirements.in
 contextlib2==0.6.0.post1
     # via schema
-coverage==4.5.1
-    # via -r test-requirements.in
 cryptography==3.3.1
     # via pyopenssl
 csiphash==0.0.5


### PR DESCRIPTION
I think we are not using it, and tests are failing when [dependabot tries to upgrade it](https://github.com/dimagi/commcare-hq/pull/29044). Looks like we stopped using coverage/coveralls as of https://github.com/dimagi/commcare-hq/pull/14657, and we stopped installing it directly in .travis.yml in https://github.com/dimagi/commcare-hq/commit/d07141c700aa079ce7fc28466ba516d326b1dc33. See also https://github.com/dimagi/commcare-hq/pull/9764

[.coveragerc](https://github.com/dimagi/commcare-hq/blob/43202d838fe08210954f4ca49e0674dee70b5ad4/.coveragerc) has not been removed since it seems like it could be useful for running coverage in a local dev environment.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below
- [x] This PR can be reverted after deploy with no further considerations 
