### PR TITLE
Updated auto close rule help page text to reflect new setting

### DIFF
--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
@@ -15,7 +15,7 @@
       <p>
         {% blocktrans %}
           Create rules for closing cases from CommCareHQ.
-          All rules run every day at midnight GMT.
+          All rules run every day at {{ time }} GMT.
           For more information, see the <a href="{{ help_site_url }}">Help Site</a>.
         {% endblocktrans %}
       </p>

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -46,6 +46,7 @@ from corehq.apps.data_interfaces.tasks import (
     bulk_form_management_async,
     bulk_upload_cases_to_group,
 )
+from corehq.apps.domain.models import Domain
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqcase.utils import get_case_by_identifier
@@ -629,7 +630,11 @@ class AutomaticUpdateRuleListView(DataInterfaceSection, CRUDPaginatedViewMixin):
     @property
     def page_context(self):
         context = self.pagination_context
-        context['help_site_url'] = 'https://confluence.dimagi.com/display/commcarepublic/Automatically+Close+Cases'
+        domain_obj = Domain.get_by_name(self.domain)
+        context.update({
+            'help_site_url': 'https://confluence.dimagi.com/display/commcarepublic/Automatically+Close+Cases',
+            'time': f"{domain_obj.auto_case_update_hour}:00" if domain_obj.auto_case_update_hour else _('midnight'),
+        })
         return context
 
     @property


### PR DESCRIPTION
## Summary
Followup for https://github.com/dimagi/commcare-hq/pull/28928/

Updates this help text, which previously always said "midnight":

![Screen Shot 2021-02-02 at 4 29 19 PM](https://user-images.githubusercontent.com/1486591/106665152-f7532d80-6573-11eb-9184-ea841dfcfcb4.png)

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

Minor, tested locally, no QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
