### PR TITLE
Fix header caching when roles are updated.

### DIFF
--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -350,7 +350,7 @@ def clear_app_cache(request, domain):
         startkey=[domain],
         limit=1,
     ).all()
-    ApplicationsTab.clear_dropdown_cache(domain, request.couch_user.get_id)
+    ApplicationsTab.clear_dropdown_cache(domain, request.couch_user)
 
 
 def get_apps_base_context(request, domain, app):

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -422,7 +422,7 @@ class AddSavedReportConfigView(View):
                 delattr(self.config, "days")
 
         self.config.save()
-        ProjectReportsTab.clear_dropdown_cache(self.domain, request.couch_user.get_id)
+        ProjectReportsTab.clear_dropdown_cache(self.domain, request.couch_user)
         touch_saved_reports_views(request.couch_user, self.domain)
 
         return json_response(self.config)
@@ -497,7 +497,7 @@ def delete_config(request, domain, config_id):
         raise Http404()
 
     config.delete()
-    ProjectReportsTab.clear_dropdown_cache(domain, request.couch_user.get_id)
+    ProjectReportsTab.clear_dropdown_cache(domain, request.couch_user)
 
     touch_saved_reports_views(request.couch_user, domain)
     return HttpResponse()
@@ -724,7 +724,7 @@ class ScheduledReportsView(BaseProjectReportSectionView):
                 )
 
             self.report_notification.save()
-            ProjectReportsTab.clear_dropdown_cache(self.domain, self.request.couch_user.get_id)
+            ProjectReportsTab.clear_dropdown_cache(self.domain, self.request.couch_user)
             if self.is_new:
                 DomainAuditRecordEntry.update_calculations(self.domain, 'cp_n_saved_scheduled_reports')
                 messages.success(request, _("Scheduled report added."))

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -659,7 +659,7 @@ class ConfigureReport(ReportBuilderView):
                     })
                     return self.get(request, domain, *args, **kwargs)
                 else:
-                    ProjectReportsTab.clear_dropdown_cache(domain, request.couch_user.get_id)
+                    ProjectReportsTab.clear_dropdown_cache(domain, request.couch_user)
             self._delete_temp_data_source(report_data)
             send_hubspot_form(HUBSPOT_SAVED_UCR_FORM_ID, request)
             return json_response({
@@ -799,7 +799,7 @@ def delete_report(request, domain, report_id):
             _("This report was used in one or more applications. "
               "It has been removed from there too.")
         )
-    ProjectReportsTab.clear_dropdown_cache(domain, request.couch_user.get_id)
+    ProjectReportsTab.clear_dropdown_cache(domain, request.couch_user)
     redirect = request.GET.get("redirect", None)
     if not redirect:
         redirect = reverse('configurable_reports_home', args=[domain])

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -717,7 +717,7 @@ class _AuthorizableMixin(IsMemberOfMixin):
         return False
 
     @memoized
-    def get_role(self, domain=None, checking_global_admin=True):
+    def get_role(self, domain=None, checking_global_admin=True, allow_mirroring=False):
         """
         Get the role object for this user
         """
@@ -730,8 +730,8 @@ class _AuthorizableMixin(IsMemberOfMixin):
 
         if checking_global_admin and self.is_global_admin():
             return AdminUserRole(domain=domain)
-        if self.is_member_of(domain):
-            return self.get_domain_membership(domain).role
+        if self.is_member_of(domain, allow_mirroring):
+            return self.get_domain_membership(domain, allow_mirroring).role
         else:
             raise DomainMembershipError()
 

--- a/corehq/tabs/templates/tabs/menu_main.html
+++ b/corehq/tabs/templates/tabs/menu_main.html
@@ -5,9 +5,6 @@
   {% for tab in tabs %}
     {% cache 500 header_tab tab.class_name tab.domain tab.is_active_tab tab.couch_user.get_id role_rev LANGUAGE_CODE %}
       {% with tab.filtered_dropdown_items as items %}
-        <script>
-          console.log('["{{ tab.class_name}}","{{tab.domain}}","{{tab.is_active_tab}}","{{tab.couch_user.get_id}}","{{LANGUAGE_CODE}}, {{role_rev}}"]')
-        </script>
         <li class="mainmenu-tab {% if items %}dropdown{% endif %}{% if tab.is_active_tab %} active{% endif %}"
             id="{{ tab.class_name }}"
           {% if ANALYTICS_IDS.GOOGLE_ANALYTICS_API_ID and tab.ga_tracker %}

--- a/corehq/tabs/templates/tabs/menu_main.html
+++ b/corehq/tabs/templates/tabs/menu_main.html
@@ -3,8 +3,11 @@
 {% get_current_language as LANGUAGE_CODE %}
 <ul class="nav navbar-nav mainmenu-tabs collapse" id="hq-main-tabs" role="menu">
   {% for tab in tabs %}
-    {% cache 500 header_tab tab.class_name tab.domain tab.is_active_tab tab.couch_user.get_id LANGUAGE_CODE %}
+    {% cache 500 header_tab tab.class_name tab.domain tab.is_active_tab tab.couch_user.get_id role_rev LANGUAGE_CODE %}
       {% with tab.filtered_dropdown_items as items %}
+        <script>
+          console.log('["{{ tab.class_name}}","{{tab.domain}}","{{tab.is_active_tab}}","{{tab.couch_user.get_id}}","{{LANGUAGE_CODE}}, {{role_rev}}"]')
+        </script>
         <li class="mainmenu-tab {% if items %}dropdown{% endif %}{% if tab.is_active_tab %} active{% endif %}"
             id="{{ tab.class_name }}"
           {% if ANALYTICS_IDS.GOOGLE_ANALYTICS_API_ID and tab.ga_tracker %}

--- a/corehq/tabs/templatetags/menu_tags.py
+++ b/corehq/tabs/templatetags/menu_tags.py
@@ -1,3 +1,4 @@
+from corehq.apps.users.models import DomainMembershipError
 from django import template
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
@@ -89,13 +90,17 @@ class MainMenuNode(template.Node):
 
         # set the context variable in the highest scope so it can be used in
         # other blocks
-        user_role = couch_user.get_role(domain)
+        try:
+            user_role = couch_user.get_role(domain)
+            role_rev = user_role._rev if user_role else None
+        except DomainMembershipError:
+            role_rev = None
 
         context.dicts[0]['active_tab'] = active_tab
         flat = context.flatten()
         flat.update({
             'tabs': visible_tabs,
-            'role_rev': user_role._rev if user_role else None
+            'role_rev': role_rev
         })
         return mark_safe(render_to_string('tabs/menu_main.html', flat))
 

--- a/corehq/tabs/templatetags/menu_tags.py
+++ b/corehq/tabs/templatetags/menu_tags.py
@@ -89,10 +89,13 @@ class MainMenuNode(template.Node):
 
         # set the context variable in the highest scope so it can be used in
         # other blocks
+        user_role = couch_user.get_role(domain)
+
         context.dicts[0]['active_tab'] = active_tab
         flat = context.flatten()
         flat.update({
             'tabs': visible_tabs,
+            'role_rev': user_role._rev if user_role else None
         })
         return mark_safe(render_to_string('tabs/menu_main.html', flat))
 

--- a/corehq/tabs/templatetags/menu_tags.py
+++ b/corehq/tabs/templatetags/menu_tags.py
@@ -91,7 +91,7 @@ class MainMenuNode(template.Node):
         # set the context variable in the highest scope so it can be used in
         # other blocks
         try:
-            user_role = couch_user.get_role(domain)
+            user_role = couch_user.get_role(domain, allow_mirroring=True)
             role_rev = user_role._rev if user_role else None
         except DomainMembershipError:
             role_rev = None

--- a/corehq/tabs/templatetags/menu_tags.py
+++ b/corehq/tabs/templatetags/menu_tags.py
@@ -90,9 +90,11 @@ class MainMenuNode(template.Node):
 
         # set the context variable in the highest scope so it can be used in
         # other blocks
+        role_rev = None
         try:
-            user_role = couch_user.get_role(domain, allow_mirroring=True)
-            role_rev = user_role._rev if user_role else None
+            if couch_user:
+                user_role = couch_user.get_role(domain, allow_mirroring=True)
+                role_rev = user_role._rev if user_role else None
         except DomainMembershipError:
             role_rev = None
 

--- a/corehq/tabs/uitab.py
+++ b/corehq/tabs/uitab.py
@@ -230,13 +230,17 @@ class UITab(object):
         return urls
 
     @classmethod
-    def clear_dropdown_cache(cls, domain, user_id):
+    def clear_dropdown_cache(cls, domain, user):
+        user_id = user.get_id
+        user_role = user.get_role(domain)
+        role_rev = user_role._rev if user_role else None
         for is_active in True, False:
             key = make_template_fragment_key('header_tab', [
                 cls.class_name(),
                 domain,
                 is_active,
                 user_id,
+                role_rev,
                 get_language(),
             ])
             cache.delete(key)
@@ -245,7 +249,8 @@ class UITab(object):
     def clear_dropdown_cache_for_all_domain_users(cls, domain):
         from corehq.apps.users.models import CouchUser
         for user_id in CouchUser.ids_by_domain(domain):
-            cls.clear_dropdown_cache(domain, user_id)
+            user = CouchUser.get_by_user_id(user_id)
+            cls.clear_dropdown_cache(domain, user)
 
     @property
     def css_id(self):

--- a/corehq/tabs/uitab.py
+++ b/corehq/tabs/uitab.py
@@ -234,7 +234,7 @@ class UITab(object):
     def clear_dropdown_cache(cls, domain, user):
         user_id = user.get_id
         try:
-            user_role = user.get_role(domain)
+            user_role = user.get_role(domain, allow_mirroring=True)
             role_rev = user_role._rev if user_role else None
         except DomainMembershipError:
             role_rev = None

--- a/corehq/tabs/uitab.py
+++ b/corehq/tabs/uitab.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from corehq.apps.users.models import DomainMembershipError
 
 from django.conf import settings
 from django.core.cache import cache
@@ -232,8 +233,11 @@ class UITab(object):
     @classmethod
     def clear_dropdown_cache(cls, domain, user):
         user_id = user.get_id
-        user_role = user.get_role(domain)
-        role_rev = user_role._rev if user_role else None
+        try:
+            user_role = user.get_role(domain)
+            role_rev = user_role._rev if user_role else None
+        except DomainMembershipError:
+            role_rev = None
         for is_active in True, False:
             key = make_template_fragment_key('header_tab', [
                 cls.class_name(),


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Presently if we update a role then for the next 500 seconds stale options are displayed on the header tab. The PR
- Added role revision id to the list of vary_on on template cache.
- Updates the cache busting logic and include `role._rev` in it.
- Updates the usage of function `clear_dropdown_cahe` to pass `couch_user` instead of `user_id`. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The changes only update the way we cache header tab and the way we bust it. I have tested it locally and put it on staging too.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
