### PR TITLE
Revert auth.py change from #28989

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -189,9 +189,7 @@ def formplayer_as_user_auth(view):
     @wraps(view)
     def _inner(request, *args, **kwargs):
         with mutable_querydict(request.GET):
-            request_user = request.GET.pop('for', None)
-            if not request_user:
-                request_user = request.GET.pop('as', None)
+            request_user = request.GET.pop('as', None)
 
         if not request_user:
             auth_logger.info(

--- a/corehq/apps/ota/tests/test_formplayer_restore.py
+++ b/corehq/apps/ota/tests/test_formplayer_restore.py
@@ -26,7 +26,6 @@ class FormplayerRestoreTest(TestCase):
         create_domain(cls.domain)
         create_domain(cls.wrong_domain)
         cls.commcare_user = CommCareUser.create(cls.domain, cls.username, '123', None, None)
-        cls.web_user = WebUser.create(cls.domain, uuid.uuid4().hex, '123', None, None)
         cls.uri = reverse('ota_restore', args=[cls.domain])
         cls.uri_wrong_domain = reverse('ota_restore', args=[cls.wrong_domain])
 
@@ -38,9 +37,6 @@ class FormplayerRestoreTest(TestCase):
 
     def test_formplayer_restore(self):
         self._test_formplayer_restore(self.commcare_user)
-
-    def test_formplayer_restore_web_user_as(self):
-        self._test_formplayer_restore(self.commcare_user, self.web_user)
 
     def _test_formplayer_restore(self, as_user, for_user=None):
         data = {'version': 2.0, 'as': as_user.username}


### PR DESCRIPTION
## Summary

The change introduced in #28989 broke SMS forms because the "for" parameter used by formplayer when performing the restore as part of submitting a SMS new-form request was not a valid couch user name, and therefore caused the restore to fail, which caused the new-form request to fail.

SMS form errors:
- An error occurred in the formplayer service.
- Internal Server Error unhandleable response: {"exception": "Unknown user", "status": "error", "url": "...//new-form", "type": "text"}

The URL in internal server error is wrong (and has base URL elided as well), should be .../formplayer/new-form

This change was suggested by @snopoke, who noted that this "will fix the sms stuff and will break the USH prime restore feature which is less important."

See also https://dimagi-dev.atlassian.net/browse/SAAS-11813

<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

There are apparently no tests for SMS forms, so this bug was not caught when the original PR was composed. Writing those tests should be done as part of fixing the USH prime restore feature.

### QA Plan

QA not requested.

### Safety story

Simon has suggested this change and confirmed that it is a safe revert to previous behavior.

### Rollback instructions

- [ ] This PR can be reverted after deploy with no further considerations 

This PR is itself a rollback of a previous change, and should not be reverted without additional work to fix the errors it introduced in SMS forms.
