### PR TITLE
Replaced app.modules with app.get_modules()

### DIFF
--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -470,13 +470,13 @@ def handle_shadow_child_modules(app, shadow_parent):
         changes = True
 
     source_module_children = [
-        m for m in app.modules
+        m for m in app.get_modules()
         if m.root_module_id == shadow_parent.source_module_id
         and m.module_type != 'shadow'
     ]
 
     shadow_parent_children = [
-        m for m in app.modules
+        m for m in app.get_modules()
         if m.root_module_id == shadow_parent.unique_id
     ]
 


### PR DESCRIPTION
## Summary
[Support ticket](https://dimagi-dev.atlassian.net/browse/USH-638)
These errors seem related to an issue addressed in this [PR](https://github.com/dimagi/commcare-hq/pull/24375) where `app.modules` does not necessarily ensure `self.parent_` is populated for those modules, but `app.get_modules()` does.


## Safety Assurance

- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
Tests are in place for `handle_shadow_child_modules`

### QA Plan
I am not requesting QA

### Safety story
I was not able to replicate the issues mentioned in the ticket locally or in the shell to ensure that this fixes the ticket. However, I ensured that the same values were returned whether using `app.modules` or `app.get_modules()` and that locally everything worked as expected. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
