### PR TITLE
fix exist pre filter check for dates

### DIFF
--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -457,6 +457,27 @@ class PreFilterTestCase(SimpleTestCase):
                 'exists_field != :exists_field_slug'
             )
 
+    def test_pre_filter_value_exists_date_types(self):
+        pre_values = ['', None]
+        operator = '!='
+        date_types = [DATA_TYPE_DATE, DATA_TYPE_DATETIME]
+        for pre_value in pre_values:
+            for datatype in date_types:
+                filter_ = {
+                    'type': 'pre',
+                    'field': 'exists_field',
+                    'slug': 'exists_field_slug',
+                    'datatype': datatype,
+                    'pre_value': pre_value,
+                    'pre_operator': operator
+                }
+                filter_value = PreFilterValue(filter_, {'operand': pre_value, 'operator': operator})
+                self.assertEqual(filter_value.to_sql_values(), {})
+                self.assertEqual(
+                    str(filter_value.to_sql_filter().build_expression()),
+                    'exists_field IS NOT NULL'
+                )
+
     def test_pre_filter_value_array(self):
         pre_value = ['yes', 'maybe']
         filter_ = {


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Follow up from https://github.com/dimagi/commcare-hq/pull/29076/files to also fix the check for dates to exist/not null.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
If someone uses pre fitler for date for NOT null values, it should work now.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Test has been added for it.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Should be safe to merge this since it is a bug fix and does not effect any other filter/datatype

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
