### PR TITLE
use correct path to date closed property in DET configs

### DIFF
--- a/corehq/apps/export/det/schema_generator.py
+++ b/corehq/apps/export/det/schema_generator.py
@@ -14,7 +14,7 @@ CASE_ID_SOURCE = 'case_id'
 # maps Case fields to the API field names used in CommCareCaseResource
 CASE_API_PATH_MAP = {
     'closed': 'closed',
-    'date_closed': 'date_closed',
+    'closed_on': 'date_closed',
     'date_modified': 'date_modified',
     'external_id': 'properties.external_id',
     'opened_on': 'properties.date_opened',

--- a/corehq/apps/export/tests/test_det_schema_generation.py
+++ b/corehq/apps/export/tests/test_det_schema_generation.py
@@ -56,7 +56,7 @@ class TestDETFCaseInstance(SimpleTestCase, TestFileMixin):
             data_by_headings_by_source_field = {
                 row['Source Field']: row for row in data_by_headings
             }
-            self.assertEqual('str2date', data_by_headings_by_source_field['properties.closed_on']['Map Via'])
+            self.assertEqual('str2date', data_by_headings_by_source_field['date_closed']['Map Via'])
             self.assertEqual(None, data_by_headings_by_source_field['properties.event_date']['Map Via'])
 
             # note: subtables not supported
@@ -82,7 +82,7 @@ class TestDETFCaseInstance(SimpleTestCase, TestFileMixin):
             self.assertEqual('str2num', data_by_headings_by_source_field['properties.event_duration']['Map Via'])
             # ensure defaults still work
             self.assertEqual(None, data_by_headings_by_source_field['properties.event_score']['Map Via'])
-            self.assertEqual('str2date', data_by_headings_by_source_field['properties.closed_on']['Map Via'])
+            self.assertEqual('str2date', data_by_headings_by_source_field['date_closed']['Map Via'])
 
 
 class TestDETFormInstance(SimpleTestCase, TestFileMixin):


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://forum.dimagi.com/t/cc-export-tool-det-files-closed-on-property-reference-seems-wrong/7986/2

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
DET schema generation

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Fixes issue where case close dates weren't properly mapped in commcare-generated DET config files.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
