### PR TITLE
add domain to HQ-generated DET schemas

### DIFF
--- a/corehq/apps/export/det/schema_generator.py
+++ b/corehq/apps/export/det/schema_generator.py
@@ -123,6 +123,7 @@ def generate_from_case_export_instance(export_instance, output_file):
 
     dd_property_types_by_name = _get_dd_property_types(export_instance.domain, export_instance.case_type)
     helper = CaseDETSchemaHelper(dd_property_types=dd_property_types_by_name)
+    main_output_table.rows.append(DETRow(source_field='domain', field='domain'))
     _add_rows_for_table(main_input_table, main_output_table, helper=helper)
     _add_id_row_if_necessary(main_output_table, CASE_ID_SOURCE)
     # todo: add rows for other tables
@@ -169,6 +170,7 @@ def generate_from_form_export_instance(export_instance, output_file):
                 filter_value=export_instance.xmlns,
                 rows=[],
             )
+            output_table.rows.append(DETRow(source_field='domain', field='domain'))
             _add_rows_for_table(input_table, output_table, helper=FormDETSchemaHelper())
             _add_id_row_if_necessary(output_table, FORM_ID_SOURCE)
         else:

--- a/corehq/apps/export/tests/test_det_schema_generation.py
+++ b/corehq/apps/export/tests/test_det_schema_generation.py
@@ -45,6 +45,9 @@ class TestDETFCaseInstance(SimpleTestCase, TestFileMixin):
             id_row = data_by_headings.pop(0)
             self.assertEqual('case_id', id_row['Source Field'])
             self.assertEqual('id', id_row['Field'])
+            domain_row = data_by_headings.pop(0)
+            self.assertEqual('domain', domain_row['Source Field'])
+            self.assertEqual('domain', domain_row['Field'])
             main_table = self.export_instance.selected_tables[0]
             self.assertEqual(len(main_table.selected_columns), len(data_by_headings))
             for i, input_column in enumerate(main_table.selected_columns):
@@ -117,6 +120,9 @@ class TestDETFormInstance(SimpleTestCase, TestFileMixin):
             id_row = data_by_headings.pop(0)
             self.assertEqual('form.meta.instanceID', id_row['Source Field'])
             self.assertEqual('id', id_row['Field'])
+            domain_row = data_by_headings.pop(0)
+            self.assertEqual('domain', domain_row['Source Field'])
+            self.assertEqual('domain', domain_row['Field'])
             main_table = self.export_instance.selected_tables[0]
             self.assertEqual(len(main_table.selected_columns), len(data_by_headings))
             # basic sanity check


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

https://confluence.dimagi.com/display/ccinternal/Download+Data+Export+Tool+Schemas+from+the+Exports+List+View?focusedCommentId=75667952#comment-75667952


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

DET schema generation

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

A "domain" property will be included by default in all HQ-generated DET config files.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Updated tests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
