### PR TITLE
Revert "Serve reports from cache only if file is served as response"

### DIFF
--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -649,6 +649,7 @@ class GenericReportView(object):
         return json_response(self.json_dict)
 
     @property
+    @request_cache()
     def export_response(self):
         """
         Intention: Not to be overridden in general.
@@ -659,15 +660,9 @@ class GenericReportView(object):
             export_all_rows_task.delay(self.__class__, self.__getstate__())
             return HttpResponse()
         else:
-            # We only want to cache the responses which serve files directly
-            # The response which return 200 and emails the reports should not be cached
-            self._export_response_direct()
-
-    @request_cache()
-    def _export_response_direct(self):
-        temp = io.BytesIO()
-        export_from_tables(self.export_table, temp, self.export_format)
-        return export_response(temp, self.export_format, self.export_name)
+            temp = io.BytesIO()
+            export_from_tables(self.export_table, temp, self.export_format)
+            return export_response(temp, self.export_format, self.export_name)
 
     @property
     @request_cache()


### PR DESCRIPTION
Reverts dimagi/commcare-hq#29071

This introduced a bug where the `export_response` property returns `None` instead of the response value, which [breaks the Django view](https://sentry.io/organizations/dimagi/issues/1611340779/?project=136860).