### PR TITLE
Ignore failed mobile logins for now

### DIFF
--- a/corehq/apps/hqwebapp/signals.py
+++ b/corehq/apps/hqwebapp/signals.py
@@ -47,7 +47,7 @@ def add_failed_attempt(sender, credentials, token_failure=False, **kwargs):
         'result': lockout_result
     })
 
-    if not locked_out:
+    if not locked_out and user.supports_lockout():
         if user.attempt_date == date.today():
             user.login_attempts += 1
         else:


### PR DESCRIPTION
## Summary
A follow-up to: https://github.com/dimagi/commcare-hq/pull/29097, which had to be reverted twice, due to ResourceConflicts when mobile users failed to authenticate

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests are present, as we would like to create a fix to record failed mobile logins ASAP.

### QA Plan

This does not need to go through QA

### Safety story
I verified locally that mobile users will no longer be updated on failed logins, and that web users will be.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
