### PR TITLE
Redo of "create metrics for failed logins" -- Temporarily ignoring mobile workers

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -534,7 +534,7 @@ def check_lockout(fn):
             return fn(request, *args, **kwargs)
 
         user = CouchUser.get_by_username(username)
-        if user and user.is_locked_out() and user.supports_lockout():
+        if user and user.is_locked_out():
             return json_response({"error": _("maximum password attempts exceeded")}, status_code=401)
         else:
             return fn(request, *args, **kwargs)

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -20,6 +20,7 @@ from two_factor.forms import AuthenticationTokenForm, BackupTokenForm
 
 from corehq.apps.domain.forms import NoAutocompleteMixin
 from corehq.apps.users.models import CouchUser
+from corehq.util.metrics import metrics_counter
 
 LOCKOUT_MESSAGE = mark_safe(_('Sorry - you have attempted to login with an incorrect password too many times. Please <a href="/accounts/password_reset_email/">click here</a> to reset your password or contact the domain administrator.'))
 
@@ -52,12 +53,14 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
             cleaned_data = super(EmailAuthenticationForm, self).clean()
         except ValidationError:
             user = CouchUser.get_by_username(username)
-            if user and user.is_locked_out() and user.supports_lockout():
+            if user and user.is_locked_out():
+                metrics_counter('commcare.auth.lockouts')
                 raise ValidationError(LOCKOUT_MESSAGE)
             else:
                 raise
         user = CouchUser.get_by_username(username)
-        if user and user.is_locked_out() and user.supports_lockout():
+        if user and user.is_locked_out():
+            metrics_counter('commcare.auth.lockouts')
             raise ValidationError(LOCKOUT_MESSAGE)
         return cleaned_data
 
@@ -296,14 +299,20 @@ class HQAuthenticationTokenForm(AuthenticationTokenForm):
         try:
             cleaned_data = super(HQAuthenticationTokenForm, self).clean()
         except ValidationError:
-            user_login_failed.send(sender=__name__, credentials={'username': self.user.username})
+            user_login_failed.send(sender=__name__, credentials={'username': self.user.username},
+                token_failure=True)
             couch_user = CouchUser.get_by_username(self.user.username)
-            if couch_user and couch_user.is_locked_out() and couch_user.supports_lockout():
+            if couch_user and couch_user.is_locked_out():
+                metrics_counter('commcare.auth.token_lockout')
                 raise ValidationError(LOCKOUT_MESSAGE)
             else:
                 raise
+
+        # Handle the edge-case where the user enters a correct token
+        # after being locked out
         couch_user = CouchUser.get_by_username(self.user.username)
-        if couch_user and couch_user.is_locked_out() and couch_user.supports_lockout():
+        if couch_user and couch_user.is_locked_out():
+            metrics_counter('commcare.auth.lockouts')
             raise ValidationError(LOCKOUT_MESSAGE)
         return cleaned_data
 
@@ -314,13 +323,19 @@ class HQBackupTokenForm(BackupTokenForm):
         try:
             cleaned_data = super(HQBackupTokenForm, self).clean()
         except ValidationError:
-            user_login_failed.send(sender=__name__, credentials={'username': self.user.username})
+            user_login_failed.send(sender=__name__, credentials={'username': self.user.username},
+                token_failure=True)
             couch_user = CouchUser.get_by_username(self.user.username)
-            if couch_user and couch_user.is_locked_out() and couch_user.supports_lockout():
+            if couch_user and couch_user.is_locked_out():
+                metrics_counter('commcare.auth.token_lockout')
                 raise ValidationError(LOCKOUT_MESSAGE)
             else:
                 raise
+
+        # Handle the edge-case where the user enters a correct token
+        # after being locked out
         couch_user = CouchUser.get_by_username(self.user.username)
-        if couch_user and couch_user.is_locked_out() and couch_user.supports_lockout():
+        if couch_user and couch_user.is_locked_out():
+            metrics_counter('commcare.auth.lockouts')
             raise ValidationError(LOCKOUT_MESSAGE)
         return cleaned_data

--- a/corehq/apps/hqwebapp/signals.py
+++ b/corehq/apps/hqwebapp/signals.py
@@ -47,7 +47,7 @@ def add_failed_attempt(sender, credentials, token_failure=False, **kwargs):
         'result': lockout_result
     })
 
-    if not locked_out:
+    if not locked_out and user.supports_lockout():
         if user.attempt_date == date.today():
             user.login_attempts += 1
         else:

--- a/corehq/apps/hqwebapp/signals.py
+++ b/corehq/apps/hqwebapp/signals.py
@@ -5,6 +5,7 @@ from django.contrib.auth.signals import user_logged_in, user_login_failed
 from django.dispatch import receiver
 
 from corehq.apps.users.models import CouchUser
+from corehq.util.metrics import metrics_counter
 
 
 def clear_login_attempts(user):
@@ -26,9 +27,27 @@ def clear_failed_logins_and_unlock_account(sender, request, user, **kwargs):
 
 
 @receiver(user_login_failed)
-def add_failed_attempt(sender, credentials, **kwargs):
-    user = CouchUser.get_by_username(credentials['username'])
-    if user and not user.is_locked_out() and user.supports_lockout():
+def add_failed_attempt(sender, credentials, token_failure=False, **kwargs):
+    user = CouchUser.get_by_username(credentials['username'], strict=True)
+    if not user:
+        metrics_counter('commcare.auth.invalid_user')
+        return
+
+    if token_failure:
+        metrics_counter('commcare.auth.invalid_token')
+
+    locked_out = user.is_locked_out()
+
+    if locked_out:
+        lockout_result = 'locked_out'
+    else:
+        lockout_result = 'should_be_locked_out' if user.should_be_locked_out() else 'allowed_to_retry'
+
+    metrics_counter('commcare.auth.failed_attempts', tags={
+        'result': lockout_result
+    })
+
+    if not locked_out:
         if user.attempt_date == date.today():
             user.login_attempts += 1
         else:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1112,6 +1112,9 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         return self.username.endswith('@dimagi.com')
 
     def is_locked_out(self):
+        return self.supports_lockout() and self.should_be_locked_out()
+
+    def should_be_locked_out(self):
         return self.login_attempts >= MAX_LOGIN_ATTEMPTS
 
     @property

--- a/corehq/apps/users/tests/test_confirm_account.py
+++ b/corehq/apps/users/tests/test_confirm_account.py
@@ -29,6 +29,8 @@ class TestAccountConfirmation(TestCase):
         )
         # confirm user can't login
         self.assertEqual(False, self.client.login(username=self.username, password=self.password))
+        # Refresh the user after a failed login, as it will be out of date
+        self.user = CommCareUser.get_by_username(self.username)
 
     @classmethod
     def tearDownClass(cls):
@@ -44,6 +46,8 @@ class TestAccountConfirmation(TestCase):
 
         # confirm user can't login
         self.assertEqual(False, self.client.login(username=self.username, password=self.password))
+        # User is now outdated from the failed login, re-fetch
+        self.user = CommCareUser.get_by_username(self.username)
 
         new_password = 'm0r3s3cr3t!'
         self.user.confirm_account(password=new_password)


### PR DESCRIPTION
Temporarily do not record failed logins on for mobile users, as this causes a Resource Conflict