### PR TITLE
Progress bar reflects current number of user downloads in multi-domain download

### DIFF
--- a/corehq/apps/users/bulk_download.py
+++ b/corehq/apps/users/bulk_download.py
@@ -179,6 +179,7 @@ def parse_mobile_users(domain, user_filters, task=None, total_count=None):
     if domains_list != [domain]:
         is_multi_domain_download = True
 
+    current_user_downloaded_count = 0
     for current_domain in domains_list:
         for n, user in enumerate(get_commcare_users_by_filters(current_domain, user_filters)):
             group_memoizer = load_memoizer(current_domain)
@@ -191,7 +192,8 @@ def parse_mobile_users(domain, user_filters, task=None, total_count=None):
             user_groups_length = max(user_groups_length, len(group_names))
             max_location_length = max(max_location_length, len(user_dict["location_code"]))
             if task:
-                DownloadBase.set_progress(task, n, total_count)
+                DownloadBase.set_progress(task, n + current_user_downloaded_count, total_count)
+        current_user_downloaded_count += n + 1
 
     user_headers = [
         'username', 'password', 'name', 'phone-number', 'email',


### PR DESCRIPTION
Bug was found with [this ticket](https://dimagi-dev.atlassian.net/browse/USH-657). The progress bar "restarted" back to 0 for each domain which is super misleading. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[Filter bulk user download](https://www.commcarehq.org/hq/flags/edit/filtered_bulk_user_download/)

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I am certain that this PR will not introduce a regression for the reasons below

### QA Plan
I am not requesting QA

### Safety story
I locally tested this feature on one and multiple domains

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
