### PR TITLE
[ci skip] Tweak language in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@
 - [ ] All migrations are backwards compatible and won't block deploy
 - [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
 - [ ] If QA is part of the safety story, the "Awaiting QA" label is used
-- [ ] I am certain that this PR will not introduce a regression for the reasons below
+- [ ] I have confidence that this PR will not introduce a regression for the reasons below
 
 ### Automated test coverage
 


### PR DESCRIPTION
This has irked me for a while.

Declaring certainty that a change won't produce a regression seems impossibly hard, and I think this is a more achievable reflection of the intent.

## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

It is not a code file.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
