### PR TITLE
Fixed 'Removed include_closed option from case claim' to not return c…

### DIFF
--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -54,10 +54,14 @@ class CaseSearchCriteria(object):
         return search_es
 
     def _assemble_optional_search_params(self):
+        self._add_include_closed()
         self._add_xpath_query()
         self._add_owner_id()
         self._add_blacklisted_owner_ids()
         self._add_case_property_queries()
+
+    def _add_include_closed(self):
+        self.search_es = self.search_es.is_closed(False)
 
     def _add_xpath_query(self):
         query = self.criteria.pop(CASE_SEARCH_XPATH_QUERY_KEY, None)

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -50,18 +50,15 @@ class CaseSearchCriteria(object):
         search_es = (CaseSearchES()
                      .domain(self.domain)
                      .case_type(self.case_type)
+                     .is_closed(False)
                      .size(CASE_SEARCH_MAX_RESULTS))
         return search_es
 
     def _assemble_optional_search_params(self):
-        self._add_include_closed()
         self._add_xpath_query()
         self._add_owner_id()
         self._add_blacklisted_owner_ids()
         self._add_case_property_queries()
-
-    def _add_include_closed(self):
-        self.search_es = self.search_es.is_closed(False)
 
     def _add_xpath_query(self):
         query = self.criteria.pop(CASE_SEARCH_XPATH_QUERY_KEY, None)

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -64,6 +64,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
                     "filter": [
                         {'term': {'domain.exact': 'swashbucklers'}},
                         {"term": {"type.exact": "case_type"}},
+                        {"term": {"closed": False}},
                         {
                             "bool": {
                                 "must_not": {
@@ -155,6 +156,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
                     "filter": [
                         {'term': {'domain.exact': 'swashbucklers'}},
                         {"term": {"type.exact": "case_type"}},
+                        {"term": {"closed": False}},
                         {"match_all": {}}
                     ],
                     "must": {


### PR DESCRIPTION
…losed cases

## Summary
Followup for https://github.com/dimagi/commcare-hq/pull/29095 which has not yet been deployed to prod.

The previous PR has been deployed to india, so I'll deploy this fix there.

## Feature Flag
Case search & claim

## Product Description
No need to announce, fixes bug that isn't live yet.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

~~This isn't tested.~~ There is test coverage. I incorrectly updated the tests in the previous PR.

### QA Plan

Straightforward bug, tested locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
