### PR TITLE
Couch to SQL migration fixes

### DIFF
--- a/corehq/apps/couch_sql_migration/README.md
+++ b/corehq/apps/couch_sql_migration/README.md
@@ -167,6 +167,8 @@ https://dimagi-dev.atlassian.net/servicedesk/customer/portal/1
 
 ## Support request template
 
+Subject: XXXXXXX forms & cases migration
+
 We are planning to migrate the XXXXXXX domain forms and cases from Couch to SQL. No need to mention Couch or SQL to the customer though, to them it's maintenance we need to do to keep our systems operating at peak performance.
 
 The XXXXXXX domain currently has about XXXXXXX forms, which we expect to take about XXXXXXX to migrate. The following operations will be disabled while the migration is in progress:

--- a/corehq/apps/couch_sql_migration/casepatch.py
+++ b/corehq/apps/couch_sql_migration/casepatch.py
@@ -127,6 +127,8 @@ class PatchCase:
     def indices(self):
         diffs = [d for d in self.diffs if d.path[0] == "indices"]
         if not diffs:
+            if is_missing_in_sql(self.diffs):
+                yield from self.case.indices
             return
         for diff in diffs:
             if diff.path != ["indices", "[*]"]:

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -1279,15 +1279,21 @@ def _iter_docs(domain, doc_type, resume_key, stopper):
         event_handler=MigrationPaginationEventHandler(domain, stopper)
     )
     if rows.state.is_resume() and rows.state.to_json().get("kwargs"):
-        log.info("iteration state: %r", rows.state.to_json()["kwargs"])
+        log.debug("iteration state: %r", rows.state.to_json()["kwargs"])
     row = None
+    log_message = log.debug
     try:
         for row in rows:
             yield row[row_key]
+    except:  # noqa E772
+        log_message = logging.info
+        raise
     finally:
         final_state = rows.state.to_json().get("kwargs")
         if final_state:
-            log.info("final iteration state: %r", final_state)
+            if stopper.clean_break:
+                log_message = logging.info
+            log_message("final iteration state: %r", final_state)
 
 
 _iter_docs.chunk_size = 1000

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -267,12 +267,12 @@ class Command(BaseCommand):
                 forms=self.forms,
             )
         except CleanBreak:
-            print("migration stopped")
+            log.info("migration stopped")
             sys.exit(1)
 
         has_diffs = self.print_stats(domain, short=True, diffs_only=True)
         if self.live_migrate:
-            print("Live migration completed.")
+            log.info("Live migration completed.")
         if has_diffs:
             print("\nRun `diff` or `stats [--verbose]` for more details.\n")
             sys.exit(1)

--- a/corehq/apps/couch_sql_migration/missingdocs.py
+++ b/corehq/apps/couch_sql_migration/missingdocs.py
@@ -53,6 +53,7 @@ def find_missing_docs(domain, state_dir, live_migrate=False, resume=True, progre
                 for doc_id in missing_ids(doc_type):
                     statedb.add_missing_docs(doc_type, [doc_id])
                     dd_count(f"commcare.couchsqlmigration.{entity}.has_diff")
+    log.info("missing docs scan%s complete", "" if resume else " (rebuild)")
 
 
 def recheck_missing_docs(domain, state_dir):

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -314,14 +314,18 @@ def step_calculator(length, granularity):
     """
     def should_update(i):
         assert i, "divide by zero protection"
-        nonlocal next_update
+        nonlocal next_update, max_wait
         now = datetime.now()
         if now > next_update:
             rate = i / (now - start).total_seconds()  # iterations / second
-            secs = min(max(twice_per_dot / rate, 0.1), 300)  # seconds / dot / 2
+            secs = min(max(twice_per_dot / rate, 0.1), max_wait)  # seconds / dot / 2
             next_update = now + timedelta(seconds=secs)
+            if secs == max_wait < 300:
+                max_wait = min(max_wait * 2, 300)
             return True
         return False
+    # start with short delay to compensate for excessive initial estimates
+    max_wait = 10
     twice_per_dot = max(length / granularity, 1) / 2  # iterations / dot / 2
     start = next_update = datetime.now()
     return should_update


### PR DESCRIPTION
Review by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] This PR can be reverted after deploy with no further considerations 
