### PR TITLE
Disable ddtrace and datadog logging in tests

### DIFF
--- a/corehq/util/metrics/__init__.py
+++ b/corehq/util/metrics/__init__.py
@@ -321,5 +321,6 @@ def _global_setup():
         try:
             from ddtrace import tracer
             tracer.enabled = False
+            tracer.log.disabled = True
         except ImportError:
             pass

--- a/testsettings.py
+++ b/testsettings.py
@@ -63,12 +63,11 @@ NOSE_PLUGINS = [
 for key, value in {
     'NOSE_DB_TEST_CONTEXT': 'corehq.tests.nose.HqdbContext',
     'NOSE_NON_DB_TEST_CONTEXT': 'corehq.tests.nose.ErrorOnDbAccessContext',
-
     'NOSE_IGNORE_FILES': '^localsettings',
+    'NOSE_EXCLUDE_DIRS': 'scripts',
 
-    'NOSE_EXCLUDE_DIRS': ';'.join([
-        'scripts',
-    ]),
+    'DD_DOGSTATSD_DISABLE': 'true',
+    'DD_TRACE_ENABLED': 'false',
 }.items():
     os.environ.setdefault(key, value)
 del key, value


### PR DESCRIPTION
While running tests recently I noticed that ddtrace and datadog were logging quite frequently. I thought they had been disabled in the past, so not sure why they started showing up now?

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] This PR can be reverted after deploy with no further considerations 
