### PR TITLE
Updated couch to sql migration verification to not quit on first error

### DIFF
--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -184,13 +184,13 @@ class PopulateSQLCommand(BaseCommand):
             if not verify_only:
                 self._migrate_doc(doc)
             if not skip_verify:
-                self._verify_doc(doc)
+                self._verify_doc(doc, exit=not verify_only)
 
         logger.info(f"Processed {self.doc_index} documents")
         if not skip_verify:
             logger.info(f"Found {self.diff_count} differences")
 
-    def _verify_doc(self, doc):
+    def _verify_doc(self, doc, exit=True):
         try:
             couch_id_name = getattr(self.sql_class(), '_migration_couch_id_name', 'couch_id')
             obj = self.sql_class().objects.get(**{couch_id_name: doc["_id"]})
@@ -198,7 +198,8 @@ class PopulateSQLCommand(BaseCommand):
             if diff:
                 logger.info(f"Doc {getattr(obj, couch_id_name)} has differences:\n{diff}")
                 self.diff_count += 1
-                exit(1)
+                if exit:
+                    exit(1)
         except self.sql_class().DoesNotExist:
             pass    # ignore, the difference in total object count has already been displayed
 


### PR DESCRIPTION
## Summary
Minor.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No specific test coverage for this, it's a verification management command.

### QA Plan

Minor change to management command, not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
