### PR TITLE
send excel attachment if email rendering failed

### DIFF
--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -719,7 +719,7 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
                     }
                 )
                 if excel_files:
-                    message = "Unable to generate email report. Excel files are attached."
+                    message = _("Unable to generate email report. Excel files are attached.")
                     send_html_email_async(title, email, message,
                                           email_from=settings.DEFAULT_FROM_EMAIL,
                                           file_attachments=excel_files,

--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -718,7 +718,14 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
                         'error': er,
                     }
                 )
-                if getattr(er, 'smtp_code', None) in LARGE_FILE_SIZE_ERROR_CODES or type(er) == ESError:
+                if excel_files:
+                    message = "Unable to generate email report. Excel files are attached."
+                    send_html_email_async(title, email, message,
+                                          email_from=settings.DEFAULT_FROM_EMAIL,
+                                          file_attachments=excel_files,
+                                          smtp_exception_skip_list=LARGE_FILE_SIZE_ERROR_CODES)
+
+                elif getattr(er, 'smtp_code', None) in LARGE_FILE_SIZE_ERROR_CODES or type(er) == ESError:
                     # If the email doesn't work because it is too large to fit in the HTML body,
                     # send it as an excel attachment, by creating a mock request with the right data.
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SUPPORT-7100

When saved reports have errors rendering the html, we should send the excel attachments if we already have them, so the user receives the report. The code below what I added attempts to recreate the excel files after certain errors, and sends a link to an hq download of the file, but that is unnecessary if we already have them, and it currently does not work great for report builder reports.

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This just resends emails without the body that caused the error. Emails in this state have already failed, so if this does not complete successfully, the end user will see no difference.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
