### PR TITLE
Prompt before deleting duplicate users

### DIFF
--- a/corehq/apps/cleanup/management/commands/delete_duplicate_users.py
+++ b/corehq/apps/cleanup/management/commands/delete_duplicate_users.py
@@ -25,6 +25,11 @@ class Command(BaseCommand):
             return
 
         print(f'Found {len(duplicate_users)} usernames with duplicates')
+        answer = input("Enter action [delete, print, quit]: ")
+        if answer != "delete":
+            if answer == "print":
+                print("Usernames:", ", ".join(u for u in duplicate_users))
+            return
         all_user_id = list(itertools.chain.from_iterable(duplicate_users.values()))
         user_ids_with_forms = get_users_with_forms(domain, all_user_id)
 


### PR DESCRIPTION
Make it a bit safer to run the command by allowing an escape hatch if the number of users found does not match expectations. Also add a way to print affected usernames before deleting.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] This PR can be reverted after deploy with no further considerations 
