### PR TITLE
Added get_case_property()

### DIFF
--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -20,7 +20,7 @@ def needs_update(case):
 
 
 def find_owner_id(case, accessor):
-    checkin_case = accessor.get_case(case.assigned_to_primary_checkin_case_id)
+    checkin_case = accessor.get_case(case.get_case_property('assigned_to_primary_checkin_case_id'))
     return checkin_case.get_case_property('hq_user_id')
 
 


### PR DESCRIPTION
## Summary
caused error when running on testing domain

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
test coverage is there for this command

### QA Plan
I am not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
