### PR TITLE
Add inddex reports to iita-fcms-nigeria and cambodia-arch-3-study domains

### DIFF
--- a/custom/inddex/ucr/data_sources/food_consumption_indicators.json
+++ b/custom/inddex/ucr/data_sources/food_consumption_indicators.json
@@ -1,5 +1,6 @@
 {
     "domains": [
+        "cambodia-arch-3-study",
         "iita-fcms-nigeria",
         "inddex-multilingual",
         "inddex-multi-vn",

--- a/custom/inddex/ucr/data_sources/food_consumption_indicators.json
+++ b/custom/inddex/ucr/data_sources/food_consumption_indicators.json
@@ -1,5 +1,6 @@
 {
     "domains": [
+        "iita-fcms-nigeria",
         "inddex-multilingual",
         "inddex-multi-vn",
         "inddex-reports",

--- a/settings.py
+++ b/settings.py
@@ -2000,6 +2000,7 @@ DOMAIN_MODULE_MAP = {
     'inddex-reports': 'custom.inddex',
     'inddex-multilingual': 'custom.inddex',
     'inddex-multi-vn': 'custom.inddex',
+    'iita-fcms-nigeria': 'custom.inddex',
 
     'ccqa': 'custom.ccqa',
 }

--- a/settings.py
+++ b/settings.py
@@ -2001,6 +2001,7 @@ DOMAIN_MODULE_MAP = {
     'inddex-multilingual': 'custom.inddex',
     'inddex-multi-vn': 'custom.inddex',
     'iita-fcms-nigeria': 'custom.inddex',
+    'cambodia-arch-3-study': 'custom.inddex',
 
     'ccqa': 'custom.ccqa',
 }


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Adds the custom inddex reports to a new domain. 
I based this on: https://github.com/dimagi/commcare-hq/pull/27178
https://dimagi-dev.atlassian.net/browse/SC-1178

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
This is specific to the `iita-fcms-nigeria` domain on prod

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This just shows an existing report in a new domain. The blast radius will be limited to the `iita-fcms-nigeria` domain if anything goes wrong. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
