### PR TITLE
Add new member registrations

### DIFF
--- a/custom/nutrition_project/ucr/data_sources/member_registrations_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/member_registrations_v1.json
@@ -1,0 +1,191 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "config": {
+    "table_id": "static-member_registrations_v1",
+    "display_name": "Member Registrations V1 (Static)",
+    "referenced_doc_type": "XFormInstance",
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "xmlns",
+            "datatype": null
+          },
+          "property_value": "http://openrosa.org/formdesigner/F33C77FE-3F75-4714-A9FA-ED88A5298C40",
+          "comment": null
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "app_id",
+            "datatype": null
+          },
+          "property_value": "b3c758f7c79e47e3a503115894f18503",
+          "comment": null
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "type": "expression",
+        "column_id": "username",
+        "display_name": "username",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "username"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "userID",
+        "display_name": "userID",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "userID"
+          ]
+        }
+      },
+      {
+        "display_name": "FLW ID",
+        "datatype": "string",
+        "expression": {
+          "type": "named",
+          "name": "user_location_id"
+        },
+        "type": "expression",
+        "column_id": "flw_id"
+      },
+      {
+        "display_name": "Supervisor ID",
+        "datatype": "string",
+        "expression": {
+          "location_id": {
+            "type": "named",
+            "name": "user_location_id"
+          },
+          "location_type": "supervisor",
+          "location_property": "_id",
+          "type": "ancestor_location"
+        },
+        "type": "expression",
+        "column_id": "supervisor_id"
+      },
+      {
+        "type": "expression",
+        "column_id": "received_on",
+        "display_name": "received_on",
+        "datatype": "datetime",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "received_on"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "completed_time",
+        "display_name": "completed_time",
+        "datatype": "datetime",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "timeEnd"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "gender",
+        "display_name": "gender",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "family_member_registration_group",
+            "member_gender"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "residential_status",
+        "display_name": "residential_status",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "family_member_registration_group",
+            "member_residential_status"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "dob",
+        "display_name": "dob",
+        "datatype": "date",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "family_member_registration_group",
+            "member_final_dob"
+          ]
+        }
+      }
+    ],
+    "named_expressions": {
+      "user_location_id": {
+        "datatype": "string",
+        "value_expression": {
+          "type": "property_name",
+          "property_name": "location_id"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareUser",
+        "doc_id_expression": {
+          "datatype": "string",
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "userID"
+          ]
+        }
+      }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "supervisor_id",
+          "flw_id"
+        ]
+      }
+    ]
+  }
+}

--- a/custom/nutrition_project/ucr/reports/member_cases_v1.json
+++ b/custom/nutrition_project/ucr/reports/member_cases_v1.json
@@ -5,11 +5,11 @@
   "server_environment": [
     "india"
   ],
-  "report_id": "static-new_member_registrations_v1",
+  "report_id": "static-member_cases_v1",
   "data_source_table": "static-member_cases_v1",
   "config": {
-    "title": "New member registrations per month (Static)",
-    "description": "New member registrations per flw per month",
+    "title": "New member cases opened per month (Static)",
+    "description": "New member cases opened per flw per month",
     "visible": true,
     "aggregation_columns": [
       "supervisor_id",
@@ -93,7 +93,7 @@
         }
       },
       {
-        "display": "Population",
+        "display": "Count",
         "column_id": "count",
         "type": "field",
         "field": "doc_id",

--- a/custom/nutrition_project/ucr/reports/member_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/member_registrations_v1.json
@@ -1,0 +1,125 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "report_id": "static-new-member_registrations_v1",
+  "data_source_table": "static-member_registrations_v1",
+  "config": {
+    "title": "New member registrations per month (Static)",
+    "description": "New member registrations per flw per month",
+    "visible": true,
+    "aggregation_columns": [
+      "supervisor_id",
+      "flw_id",
+      "month"
+    ],
+    "filters": [
+      {
+        "display": "Filter by FLW",
+        "slug": "flw_id",
+        "type": "dynamic_choice_list",
+        "field": "flw_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "ancestor_expression": {
+          "field": "supervisor_id",
+          "location_type": "supervisor"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Date of Birth",
+        "slug": "dob",
+        "type": "date",
+        "field": "dob",
+        "datatype": "date"
+      }
+    ],
+    "columns": [
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "completed_time",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "FLW ID",
+        "column_id": "flw_id",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Count",
+        "column_id": "count",
+        "type": "field",
+        "field": "doc_id",
+        "aggregation": "count"
+      },
+      {
+        "display": "M_temporary_resident",
+        "column_id": "M_temporary_resident",
+        "type": "sum_when",
+        "whens": [
+          [
+            "residential_status = 'temp_resident' AND gender = 'M'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temporary_resident",
+        "column_id": "F_temporary_resident",
+        "type": "sum_when",
+        "whens": [
+          [
+            "residential_status = 'temp_resident' AND gender = 'F'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_permanent_resident",
+        "column_id": "M_permanent_resident",
+        "type": "sum_when",
+        "whens": [
+          [
+            "residential_status = 'permanent_resident' AND gender = 'M'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident",
+        "column_id": "F_permanent_resident",
+        "type": "sum_when",
+        "whens": [
+          [
+            "residential_status = 'permanent_resident' AND gender = 'F'",
+            1
+          ]
+        ],
+        "else_": 0
+      }
+    ]
+  },
+  "doc_type": "ReportConfiguration"
+}


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Adding more reports after https://github.com/dimagi/commcare-hq/pull/29056/files
This PR,
Updates the existing report to be named correctly as "New member cases opened per month" and add a report for actual member registrations per month. A new data source is needed, instead of reusing the case based data source that already exists to consider real registrations and not cases that entered system otherwise like live births.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This PR just adds a new data source and report for the project. It is not really live so there should be no scale implications of this as well.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Ideally this should not be rolled back because apps would be using it.

- [ ] This PR can be reverted after deploy with no further considerations 
