### PR TITLE
Added handling for None for couch to sql diff wrapping

### DIFF
--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -59,9 +59,9 @@ class PopulateSQLCommand(BaseCommand):
         couch = doc.get(name, None)
         sql = getattr(obj, name, None)
         if wrap_couch:
-            couch = wrap_couch(couch)
+            couch = wrap_couch(couch) if couch is not None else None
         if wrap_sql:
-            sql = wrap_sql(sql)
+            sql = wrap_sql(sql) if sql is not None else None
         if couch != sql:
             return f"{name}: couch value {couch!r} != sql value {sql!r}"
 


### PR DESCRIPTION
Another minor update for couch to sql migrations.

Getting `TypeError: float() argument must be a string or a number, not 'NoneType'` on prod.