### PR TITLE
Corrected add_assignment_cases command

### DIFF
--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -1,6 +1,7 @@
 import uuid
 from xml.etree import cElementTree as ElementTree
 
+from corehq.form_processor.exceptions import CaseNotFound
 from custom.covid.management.commands.update_cases import CaseUpdateCommand
 
 from casexml.apps.case.mock import CaseBlock
@@ -20,8 +21,13 @@ def needs_update(case):
 
 
 def find_owner_id(case, accessor):
-    checkin_case = accessor.get_case(case.get_case_property('assigned_to_primary_checkin_case_id'))
-    return checkin_case.get_case_property('hq_user_id')
+    try:
+        checkin_case = accessor.get_case(case.get_case_property('assigned_to_primary_checkin_case_id'))
+        return checkin_case.get_case_property('hq_user_id')
+    except CaseNotFound:
+        print("CaseNotFound: case:{} no matching case for this case's "
+              "assigned_to_primary_checkin_case_id".format(case.case_id))
+        return None
 
 
 class Command(CaseUpdateCommand):
@@ -53,10 +59,13 @@ class Command(CaseUpdateCommand):
                 skip_count += 1
             elif needs_update(case):
                 new_owner_id = find_owner_id(case, accessor)
-                if case.get_case_property('is_assigned_primary') == 'yes':
-                    case_blocks.append(self.case_block(case, new_owner_id, 'primary'))
-                elif case.get_case_property('is_assigned_temp') == 'yes':
-                    case_blocks.append(self.case_block(case, new_owner_id, 'temp'))
+                if new_owner_id is None:
+                    skip_count += 1
+                else:
+                    if case.get_case_property('is_assigned_primary') == 'yes':
+                        case_blocks.append(self.case_block(case, new_owner_id, 'primary'))
+                    elif case.get_case_property('is_assigned_temp') == 'yes':
+                        case_blocks.append(self.case_block(case, new_owner_id, 'temp'))
         print(f"{len(case_blocks)} to update in {domain}, {skip_count} cases have skipped because they're closed"
               f" or in an inactive location")
 

--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -15,8 +15,8 @@ DEVICE_ID = __name__ + ".add_assignment_cases"
 
 
 def needs_update(case):
-    return case.get_case_property('is_assigned_primary') != 'yes' or \
-        case.get_case_property('is_assigned_temp') != 'yes'
+    return case.get_case_property('is_assigned_primary') == 'yes' or \
+        case.get_case_property('is_assigned_temp') == 'yes'
 
 
 def find_owner_id(case, accessor):
@@ -53,9 +53,9 @@ class Command(CaseUpdateCommand):
                 skip_count += 1
             elif needs_update(case):
                 new_owner_id = find_owner_id(case, accessor)
-                if case.get_case_property('is_assigned_primary') != 'yes':
+                if case.get_case_property('is_assigned_primary') == 'yes':
                     case_blocks.append(self.case_block(case, new_owner_id, 'primary'))
-                elif case.get_case_property('is_assigned_temp') != 'yes':
+                elif case.get_case_property('is_assigned_temp') == 'yes':
                     case_blocks.append(self.case_block(case, new_owner_id, 'temp'))
         print(f"{len(case_blocks)} to update in {domain}, {skip_count} cases have skipped because they're closed"
               f" or in an inactive location")

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -175,6 +175,12 @@ class CaseCommandsTest(TestCase):
                                          "is_assigned_primary": 'yes',
                                          "assigned_to_primary_checkin_case_id": checkin_case_id},
         )
+        patient_case_not_real_assigned_case_id = uuid.uuid4().hex
+        self.submit_case_block(
+            True, patient_case_not_real_assigned_case_id, user_id=self.user_id, owner_id='active-location',
+            case_type='patient', update={"is_assigned_temp": 'yes',
+                                         "assigned_to_primary_checkin_case_id": None},
+        )
         patient_case_not_primary_or_temp_id = uuid.uuid4().hex
         self.submit_case_block(
             True, patient_case_not_primary_or_temp_id, user_id=self.user_id, owner_id='active-location',


### PR DESCRIPTION
## Summary
This was previously snatching the wrong cases that did not have `assigned_to_primary_checkin_case_id`


## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
There is test coverage in test_management_commands

### QA Plan
I am not requesting QA

### Safety story
This will be tested on testing domains before rolling out to all domains

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
