### PR TITLE
Fixed EOF nav to menus in shadow child menus

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -262,8 +262,8 @@ class EndOfFormNavigationWorkflow(object):
                 frame_children.extend(frame_children_for_module(module_.root_module))
 
             if include_user_selections:
-                this_module_children = self.helper.get_frame_children(id_strings.form_command(module_.get_form(0)),
-                                                                      module_, module_only=True)
+                command = self._get_first_command(module_)
+                this_module_children = self.helper.get_frame_children(command, module_, module_only=True)
                 for child in this_module_children:
                     if child not in frame_children:
                         frame_children.append(child)
@@ -320,7 +320,7 @@ class EndOfFormNavigationWorkflow(object):
 
                 if target_module in module.get_child_modules():
                     parent_frame_children = self.helper.get_frame_children(
-                        id_strings.form_command(module.get_form(0)), module, module_only=True)
+                        self._get_first_command(module), module, module_only=True)
 
                     # exclude frame children from the child module if they are already
                     # supplied by the parent module
@@ -372,6 +372,11 @@ class EndOfFormNavigationWorkflow(object):
                     raise SuiteValidationError("Unable to link form '{}', missing variable '{}'".format(
                         form.default_name(), child.id
                     ))
+
+    def _get_first_command(self, module):
+        if module.module_type == "shadow":
+            module = module.source_module
+        return id_strings.form_command(module.get_form(0))
 
 
 class CaseListFormStackFrames(namedtuple('CaseListFormStackFrames', 'case_created case_not_created')):

--- a/corehq/apps/app_manager/tests/app_factory.py
+++ b/corehq/apps/app_manager/tests/app_factory.py
@@ -58,14 +58,11 @@ class AppFactory(object):
         module.unique_id = '{}_module'.format(slug)
         module.case_type = case_type
 
-        def get_unique_id(module_or_form):
-            return module_or_form if isinstance(module_or_form, str) else module_or_form.unique_id
-
         if parent_module:
-            module.root_module_id = get_unique_id(parent_module)
+            module.root_module_id = self.unique_id(parent_module)
 
         if case_list_form:
-            module.case_list_form.form_id = get_unique_id(case_list_form)
+            module.case_list_form.form_id = self.unique_id(case_list_form)
 
         self.slugs[module.unique_id] = slug
 
@@ -77,10 +74,12 @@ class AppFactory(object):
     def new_advanced_module(self, slug, case_type, with_form=True, parent_module=None, case_list_form=None):
         return self.new_module(AdvancedModule, slug, case_type, with_form, parent_module, case_list_form)
 
-    def new_shadow_module(self, slug, source_module, with_form=True, shadow_module_version=2):
+    def new_shadow_module(self, slug, source_module, with_form=True, shadow_module_version=2, parent_module=None):
         module = self.app.add_module(ShadowModule.new_module('{} module'.format(slug), None))
         module.unique_id = '{}_module'.format(slug)
         module.source_module_id = source_module.unique_id
+        if parent_module:
+            module.root_module_id = self.unique_id(parent_module)
         module.shadow_module_version = shadow_module_version
         self.slugs[module.unique_id] = slug
         return (module, self.new_form(module)) if with_form else module
@@ -104,6 +103,9 @@ class AppFactory(object):
         form = module.new_shadow_form('{} form {}'.format(slug, index), None)
         form.unique_id = '{}_form_{}'.format(slug, index)
         return form
+
+    def unique_id(self, module_or_form):
+        return module_or_form if isinstance(module_or_form, str) else module_or_form.unique_id
 
     @staticmethod
     def form_requires_case(form, case_type=None, parent_case_type=None, update=None, preload=None):

--- a/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-module-in-root.xml
+++ b/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-module-in-root.xml
@@ -211,4 +211,56 @@
       </create>
     </stack>
   </entry>
+  <entry>
+    <command id="m6-f0">
+      <text>
+        <locale id="forms.m1f0"/>
+      </text>
+    </command>
+    <session>
+      <datum function="uuid()" id="case_id_new_patient_0"/>
+    </session>
+    <stack>
+      <create>
+        <command value="'m6'"/>
+      </create>
+    </stack>
+  </entry>
+  <entry>
+    <command id="m6-f1">
+      <text>
+        <locale id="forms.m1f1"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <datum detail-confirm="m6_case_long" detail-select="m6_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id"/>
+    </session>
+    <stack>
+      <create>
+        <command value="'m6'"/>
+        <command value="'m1-f1'"/>
+      </create>
+    </stack>
+  </entry>
+  <entry>
+    <command id="m7-f0">
+      <text>
+        <locale id="forms.m5f0"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <datum function="uuid()" id="case_id_new_patient_0"/>
+      <datum detail-confirm="m7_case_long" detail-select="m7_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id"/>
+    </session>
+    <stack>
+      <create>
+        <command value="'m6'"/>
+        <command value="'m7'"/>
+        <command value="'m5-f0'"/>
+        <datum id="case_id_new_patient_0" value="uuid()"/>
+      </create>
+    </stack>
+  </entry>
 </partial>

--- a/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-module.xml
+++ b/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-module.xml
@@ -200,4 +200,53 @@
       </create>
     </stack>
   </entry>
+  <entry>
+    <command id="m6-f0">
+      <text>
+        <locale id="forms.m1f0"/>
+      </text>
+    </command>
+    <session>
+      <datum function="uuid()" id="case_id_new_patient_0"/>
+    </session>
+    <stack>
+      <create>
+        <command value="'m6'"/>
+      </create>
+    </stack>
+  </entry>
+  <entry>
+    <command id="m6-f1">
+      <text>
+        <locale id="forms.m1f1"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <datum detail-confirm="m6_case_long" detail-select="m6_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id"/>
+    </session>
+    <stack>
+      <create>
+        <command value="'m6'"/>
+      </create>
+    </stack>
+  </entry>
+  <entry>
+    <command id="m7-f0">
+      <text>
+        <locale id="forms.m5f0"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <datum function="uuid()" id="case_id_new_patient_0"/>
+      <datum detail-confirm="m7_case_long" detail-select="m7_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id"/>
+    </session>
+    <stack>
+      <create>
+        <command value="'m6'"/>
+        <command value="'m7'"/>
+      </create>
+    </stack>
+  </entry>
 </partial>

--- a/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-previous.xml
+++ b/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-previous.xml
@@ -221,4 +221,56 @@
       </create>
     </stack>
   </entry>
+  <entry>
+    <command id="m6-f0">
+      <text>
+        <locale id="forms.m1f0"/>
+      </text>
+    </command>
+    <session>
+      <datum function="uuid()" id="case_id_new_patient_0"/>
+    </session>
+    <stack>
+      <create>
+        <command value="'m6'"/>
+      </create>
+    </stack>
+  </entry>
+  <entry>
+    <command id="m6-f1">
+      <text>
+        <locale id="forms.m1f1"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <datum detail-confirm="m6_case_long" detail-select="m6_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id"/>
+    </session>
+    <stack>
+      <create>
+        <command value="'m6'"/>
+        <command value="'m1-f1'"/>
+      </create>
+    </stack>
+  </entry>
+  <entry>
+    <command id="m7-f0">
+      <text>
+        <locale id="forms.m5f0"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <datum function="uuid()" id="case_id_new_patient_0"/>
+      <datum detail-confirm="m7_case_long" detail-select="m7_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id"/>
+    </session>
+    <stack>
+      <create>
+        <command value="'m6'"/>
+        <command value="'m7'"/>
+        <command value="'m5-f0'"/>
+        <datum id="case_id_new_patient_0" value="uuid()"/>
+      </create>
+    </stack>
+  </entry>
 </partial>

--- a/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-root.xml
+++ b/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-root.xml
@@ -175,4 +175,46 @@
       <create/>
     </stack>
   </entry>
+  <entry>
+    <command id="m6-f0">
+      <text>
+        <locale id="forms.m1f0"/>
+      </text>
+    </command>
+    <session>
+      <datum function="uuid()" id="case_id_new_patient_0"/>
+    </session>
+    <stack>
+      <create/>
+    </stack>
+  </entry>
+  <entry>
+    <command id="m6-f1">
+      <text>
+        <locale id="forms.m1f1"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <datum detail-confirm="m6_case_long" detail-select="m6_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id"/>
+    </session>
+    <stack>
+      <create/>
+    </stack>
+  </entry>
+  <entry>
+    <command id="m7-f0">
+      <text>
+        <locale id="forms.m5f0"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <datum function="uuid()" id="case_id_new_patient_0"/>
+      <datum detail-confirm="m7_case_long" detail-select="m7_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id"/>
+    </session>
+    <stack>
+      <create/>
+    </stack>
+  </entry>
  </partial>

--- a/corehq/apps/app_manager/tests/test_form_workflow.py
+++ b/corehq/apps/app_manager/tests/test_form_workflow.py
@@ -362,6 +362,9 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         m5, m5f0 = factory.new_basic_module('m5', 'patient', parent_module=m1)
         factory.form_requires_case(m5f0)
 
+        m6 = factory.new_shadow_module('shadow_module', m1, with_form=False)
+        factory.new_shadow_module('shadow_child', m5, with_form=False, parent_module=m6)
+
         for module in factory.app.get_modules():
             for form in module.get_forms():
                 form.post_form_workflow = mode


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/QA-2518

## Feature Flag
Shadow menus

## Product Description
Fixes bug where making a new build would fail if the app contained a form that used end of form navigation to redirect to a specific module **and** that form's menu had a parent menu **and** the app had a shadow menu shadowing that menu.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Tests in this PR.

### QA Plan

This came up as a qabug, so QA will verify, though I may deploy beforehand because this is interfering with USH app building and only affects a very specific app configuration.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
