### PR TITLE
Generate and pass section-elements once that are generated repeatedly for each module

### DIFF
--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -88,6 +88,7 @@ class SuiteGenerator(object):
         else:
             training_menu = None
 
+        detail_section_elements = DetailContributor(None, self.app, self.modules).get_section_elements()
         for module in self.modules:
             self.suite.entries.extend(entries.get_module_contributions(module))
 
@@ -95,7 +96,9 @@ class SuiteGenerator(object):
                 menus.get_module_contributions(module, training_menu)
             )
 
-            self.suite.remote_requests.extend(remote_requests.get_module_contributions(module))
+            self.suite.remote_requests.extend(
+                remote_requests.get_module_contributions(module, detail_section_elements)
+            )
 
         if training_menu:
             self.suite.menus.append(training_menu)

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -511,7 +511,6 @@ def get_instances_for_module(app, module, detail_section_elements):
     """
     This method is used by CloudCare when filtering cases.
     """
-    print("get_instances_for_module ", module.id)
     modules = list(app.get_modules())
     helper = DetailsHelper(app, modules)
     details = detail_section_elements

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -507,13 +507,14 @@ def get_detail_column_infos(detail_type, detail, include_sort):
     return columns
 
 
-def get_instances_for_module(app, module, additional_xpaths=None):
+def get_instances_for_module(app, module, detail_section_elements):
     """
     This method is used by CloudCare when filtering cases.
     """
+    print("get_instances_for_module ", module.id)
     modules = list(app.get_modules())
     helper = DetailsHelper(app, modules)
-    details = DetailContributor(None, app, modules).get_section_elements()
+    details = detail_section_elements
     detail_mapping = {detail.id: detail for detail in details}
     details_by_id = detail_mapping
     detail_ids = [helper.get_detail_id_safe(module, detail_type)
@@ -521,9 +522,6 @@ def get_instances_for_module(app, module, additional_xpaths=None):
                   if enabled]
     detail_ids = [_f for _f in detail_ids if _f]
     xpaths = set()
-
-    if additional_xpaths:
-        xpaths.update(additional_xpaths)
 
     for detail_id in detail_ids:
         xpaths.update(details_by_id[detail_id].get_all_xpaths())

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -43,10 +43,11 @@ class QuerySessionXPath(InstanceXpath):
 
 
 class RemoteRequestFactory(object):
-    def __init__(self, domain, app, module):
+    def __init__(self, domain, app, module, detail_section_elements):
         self.domain = domain
         self.app = app
         self.module = module
+        self.detail_section_elements = detail_section_elements
 
     def build_remote_request(self):
         return RemoteRequest(
@@ -94,7 +95,7 @@ class RemoteRequestFactory(object):
         instances, unknown_instances = get_all_instances_referenced_in_xpaths(self.app, query_xpaths)
         # we use the module's case list/details view to select the datum so also
         # need these instances to be available
-        instances |= get_instances_for_module(self.app, self.module)
+        instances |= get_instances_for_module(self.app, self.module, self.detail_section_elements)
 
         # sorted list to prevent intermittent test failures
         return sorted(set(list(instances) + prompt_select_instances), key=lambda i: i.id)
@@ -204,7 +205,9 @@ class RemoteRequestContributor(SuiteContributorByModule):
     .. _CommCare 2.0 Suite Definition: https://github.com/dimagi/commcare/wiki/Suite20#remote-request
 
     """
-    def get_module_contributions(self, module):
+
+    def get_module_contributions(self, module, detail_section_elements):
         if module_offers_search(module):
-            return [RemoteRequestFactory(self.app.domain, self.app, module).build_remote_request()]
+            return [RemoteRequestFactory(
+                self.app.domain, self.app, module, detail_section_elements).build_remote_request()]
         return []


### PR DESCRIPTION
Improves app build times by making below optimization. 

## Summary

The improvement is achieved by a code refactor to reduce the number of times `DetailContributor(None, self.app, self.modules).get_section_elements()` is called. Currently this is generated for each module repeatedly [here](https://github.com/dimagi/commcare-hq/compare/sr/detail-cont?expand=1#diff-c54af3a0f4a4a18fddc6f88daad1351cbcecf3786b253cf5fc16f5cec252165aL516) which in turn does an expensive operation for each module. So, if n is number of modules in an app, the expensive operation gets run `n*n` time. The fix generates the elements once for all the modules and passes the copy down, making the operation run `n` times instead of `n*n`. 

This is very much noticeable for apps with lot of modules.

## Feature Flag


## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

None

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
