### PR TITLE
Add report for deaths

### DIFF
--- a/custom/nutrition_project/ucr/data_sources/death_records_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/death_records_v1.json
@@ -1,0 +1,283 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "config": {
+    "table_id": "static-death_records_v1",
+    "display_name": "Death Records V1 (Static)",
+    "referenced_doc_type": "XFormInstance",
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "xmlns"
+          },
+          "property_value": "http://openrosa.org/formdesigner/09B1E7B3-BB57-4A51-8CD3-114F1054F18E"
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "app_id"
+          },
+          "property_value": "b3c758f7c79e47e3a503115894f18503"
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "remove_family_member_group",
+              "member_removal_reason"
+            ]
+          },
+          "property_value": "death"
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "type": "expression",
+        "column_id": "username",
+        "display_name": "username",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "username"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "userID",
+        "display_name": "userID",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "userID"
+          ]
+        }
+      },
+      {
+        "display_name": "flw_id",
+        "datatype": "string",
+        "expression": {
+          "type": "named",
+          "name": "user_location_id"
+        },
+        "type": "expression",
+        "column_id": "flw_id"
+      },
+      {
+        "display_name": "supervisor_id",
+        "datatype": "string",
+        "expression": {
+          "location_id_expression": {
+            "type": "named",
+            "name": "user_location_id"
+          },
+          "type": "location_parent_id"
+        },
+        "type": "expression",
+        "column_id": "supervisor_id"
+      },
+      {
+        "type": "expression",
+        "column_id": "received_on",
+        "display_name": "received_on",
+        "datatype": "datetime",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "received_on"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "completed_time",
+        "display_name": "completed_time",
+        "datatype": "datetime",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "timeEnd"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "member_case_id",
+        "display_name": "member_case_id",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "case_load_member_0",
+            "case",
+            "@case_id"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "residential_status",
+        "display_name": "residential_status",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "member_residential_status"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "gender",
+        "display_name": "gender",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "member_gender"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "dob",
+        "display_name": "dob",
+        "datatype": "date",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "member_dob"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "death_date",
+        "display_name": "death_date",
+        "datatype": "date",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "remove_family_member_group",
+            "death_details_group",
+            "member_death_date"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "age_at_death_yrs",
+        "display_name": "age_at_death_yrs",
+        "datatype": "integer",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "remove_family_member_group",
+            "death_details_group",
+            "age_at_death_yrs"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "female_death_type",
+        "display_name": "female_death_type",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "remove_family_member_group",
+            "death_details_group",
+            "female_death_type"
+          ]
+        }
+      }
+    ],
+    "named_expressions": {
+      "user_location_id": {
+        "datatype": "string",
+        "value_expression": {
+          "type": "property_name",
+          "property_name": "location_id"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareUser",
+        "doc_id_expression": {
+          "datatype": "string",
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "userID"
+          ]
+        }
+      },
+      "member_case": {
+        "value_expression": {
+          "type": "identity"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareCase",
+        "doc_id_expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "case_load_member_0",
+            "case",
+            "@case_id"
+          ]
+        }
+      }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "supervisor_id",
+          "flw_id"
+        ]
+      }
+    ]
+  }
+}

--- a/custom/nutrition_project/ucr/reports/deaths_v1.json
+++ b/custom/nutrition_project/ucr/reports/deaths_v1.json
@@ -1,0 +1,317 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "report_id": "static-deaths_v1",
+  "data_source_table": "static-death_records_v1",
+  "config": {
+    "title": "Deaths V1 (Static)",
+    "description": "Deaths per flw per month",
+    "visible": true,
+    "aggregation_columns": [
+      "supervisor_id",
+      "flw_id",
+      "month"
+    ],
+    "filters": [
+      {
+        "display": "Filter by FLW",
+        "slug": "flw_id",
+        "type": "dynamic_choice_list",
+        "field": "userID",
+        "choice_provider": {
+          "type": "location"
+        },
+        "ancestor_expression": {
+          "field": "supervisor_id",
+          "location_type": "supervisor"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "datatype": "string"
+      }
+    ],
+    "columns": [
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "completed_time",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "Supervisor ID",
+        "column_id": "supervisor_id",
+        "type": "field",
+        "field": "supervisor_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "FLW ID",
+        "column_id": "flw_id",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Count",
+        "column_id": "count",
+        "type": "field",
+        "field": "doc_id",
+        "aggregation": "count"
+      },
+      {
+        "display": "M_temp_resident_neonatal_death",
+        "column_id": "M_temp_resident_neonatal_death",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'M' AND residential_status = 'temp_resident' AND death_date - dob BETWEEN 0 AND 28",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_permanent_resident_neonatal_death",
+        "column_id": "M_permanent_resident_neonatal_death",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'M' AND residential_status = 'permanent_resident' AND death_date - dob BETWEEN 0 AND 28",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temp_resident_neonatal_death",
+        "column_id": "F_temp_resident_neonatal_death",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'F' AND residential_status = 'temp_resident' AND death_date - dob BETWEEN 0 AND 28",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident_neonatal_death",
+        "column_id": "F_permanent_resident_neonatal_death",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'F' AND residential_status = 'permanent_resident' AND death_date - dob BETWEEN 0 AND 28",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_temp_resident_post_neonatal_death",
+        "column_id": "M_temp_resident_post_neonatal_death",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'M' AND residential_status = 'temp_resident' AND death_date - dob BETWEEN 29 AND 364",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_permanent_resident_post_neonatal_death",
+        "column_id": "M_permanent_resident_post_neonatal_death",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'M' AND residential_status = 'permanent_resident' AND death_date - dob BETWEEN 29 AND 364",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temp_resident_post_neonatal_death",
+        "column_id": "F_temp_resident_post_neonatal_death",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'F' AND residential_status = 'temp_resident' AND death_date - dob BETWEEN 29 AND 364",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident_post_neonatal_death",
+        "column_id": "F_permanent_resident_post_neonatal_death",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'F' AND residential_status = 'permanent_resident' AND death_date - dob BETWEEN 29 AND 364",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_temp_resident_child_death",
+        "column_id": "M_temp_resident_child_death",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'M' AND residential_status = 'temp_resident' AND death_date - dob BETWEEN 365 AND 1826",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "M_permanent_resident_child_death",
+        "column_id": "M_permanent_resident_child_death",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'M' AND residential_status = 'permanent_resident' AND death_date - dob BETWEEN 365 AND 1826",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temp_resident_child_death",
+        "column_id": "F_temp_resident_child_death",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'F' AND residential_status = 'temp_resident' AND death_date - dob BETWEEN 365 AND 1826",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident_child_death",
+        "column_id": "F_permanent_resident_child_death",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'F' AND residential_status = 'permanent_resident' AND death_date - dob BETWEEN 365 AND 1826",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temp_resident_women_death",
+        "column_id": "F_temp_resident_women_death",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'F' AND residential_status = 'temp_resident' AND age_at_death_yrs >= 11",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident_women_death",
+        "column_id": "F_permanent_resident_women_death",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'F' AND residential_status = 'permanent_resident' AND age_at_death_yrs >= 11",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident_women_death_pregnancy",
+        "column_id": "F_permanent_resident_women_death_pregnancy",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'F' AND residential_status = 'permanent_resident' AND female_death_type = 'pregnancy'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident_women_death_delivery",
+        "column_id": "F_permanent_resident_women_death_delivery",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'F' AND residential_status = 'permanent_resident' AND female_death_type = 'delivery'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_permanent_resident_women_death_pnc",
+        "column_id": "F_permanent_resident_women_death_pnc",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'F' AND residential_status = 'permanent_resident' AND female_death_type = 'pnc'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temp_resident_women_death_pregnancy",
+        "column_id": "F_temp_resident_women_death_pregnancy",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'F' AND residential_status = 'temp_resident' AND female_death_type = 'pregnancy'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temp_resident_women_death_delivery",
+        "column_id": "F_temp_resident_women_death_delivery",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'F' AND residential_status = 'temp_resident' AND female_death_type = 'delivery'",
+            1
+          ]
+        ],
+        "else_": 0
+      },
+      {
+        "display": "F_temp_resident_women_death_pnc",
+        "column_id": "F_temp_resident_women_death_pnc",
+        "type": "sum_when",
+        "whens": [
+          [
+            "gender = 'F' AND residential_status = 'temp_resident' AND female_death_type = 'pnc'",
+            1
+          ]
+        ],
+        "else_": 0
+      }
+    ]
+  },
+  "doc_type": "ReportConfiguration"
+}


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Adding more reports after [https://github.com/dimagi/commcare-hq/pull/29056/files](https://github.com/dimagi/commcare-hq/pull/29056/files)
This PR,
Adds a data source and then report for deaths.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This PR just adds a new data source and report for the project. It is not really live so there should be no scale implications of this as well.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Ideally this should not be rolled back because apps would be using it.

- [ ] This PR can be reverted after deploy with no further considerations 
