### PR TITLE
Add THR report

### DIFF
--- a/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_v1.json
@@ -1,0 +1,200 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "config": {
+    "table_id": "static-suppl_nutrition_thr_v1",
+    "display_name": "Supplementary Nutrition THR V1 (Static)",
+    "referenced_doc_type": "XFormInstance",
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "type": "or",
+          "filters": [
+            {
+              "type": "boolean_expression",
+              "operator": "eq",
+              "expression": {
+                "type": "property_name",
+                "property_name": "xmlns"
+              },
+              "property_value": "http://openrosa.org/formdesigner/4FAB81D4-BBAF-424E-8DB1-96478791DB01"
+            },
+            {
+              "type": "boolean_expression",
+              "operator": "eq",
+              "expression": {
+                "type": "property_name",
+                "property_name": "xmlns"
+              },
+              "property_value": "http://openrosa.org/formdesigner/116A78AD-E839-4BD4-BA13-A534A4A85B3B"
+            }
+          ]
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "app_id"
+          },
+          "property_value": "b3c758f7c79e47e3a503115894f18503"
+        },
+        {
+          "type": "or",
+          "filters": [
+            {
+              "type": "boolean_expression",
+              "operator": "eq",
+              "expression": {
+                "type": "property_path",
+                "property_path": [
+                  "form",
+                  "nutrition_services_to_pw_lw_check"
+                ]
+              },
+              "property_value": "thr_type_snd"
+            },
+            {
+              "type": "boolean_expression",
+              "operator": "eq",
+              "expression": {
+                "type": "property_path",
+                "property_path": [
+                  "form",
+                  "thr_given_to_children_0_3_check"
+                ]
+              },
+              "property_value": "yes"
+            }
+          ]
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "type": "expression",
+        "column_id": "username",
+        "display_name": "username",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "username"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "userID",
+        "display_name": "userID",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "userID"
+          ]
+        }
+      },
+      {
+        "display_name": "flw_id",
+        "datatype": "string",
+        "expression": {
+          "type": "named",
+          "name": "user_location_id"
+        },
+        "type": "expression",
+        "column_id": "flw_id"
+      },
+      {
+        "display_name": "supervisor_id",
+        "datatype": "string",
+        "expression": {
+          "location_id_expression": {
+            "type": "named",
+            "name": "user_location_id"
+          },
+          "type": "location_parent_id"
+        },
+        "type": "expression",
+        "column_id": "supervisor_id"
+      },
+      {
+        "type": "expression",
+        "column_id": "received_on",
+        "display_name": "received_on",
+        "datatype": "datetime",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "received_on"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "completed_time",
+        "display_name": "completed_time",
+        "datatype": "datetime",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "timeEnd"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "day",
+        "display_name": "day",
+        "datatype": "date",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "timeEnd"
+          ]
+        }
+      }
+    ],
+    "named_expressions": {
+      "user_location_id": {
+        "datatype": "string",
+        "value_expression": {
+          "type": "property_name",
+          "property_name": "location_id"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareUser",
+        "doc_id_expression": {
+          "datatype": "string",
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "userID"
+          ]
+        }
+      }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "supervisor_id",
+          "flw_id"
+        ]
+      }
+    ]
+  }
+}

--- a/custom/nutrition_project/ucr/reports/thr_report_v1.json
+++ b/custom/nutrition_project/ucr/reports/thr_report_v1.json
@@ -1,0 +1,77 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "report_id": "static-thr_report_v1",
+  "data_source_table": "static-suppl_nutrition_thr_v1",
+  "config": {
+    "title": "Total days THR provided V1 (Static)",
+    "description": "Total days THR provided per flw per month",
+    "visible": true,
+    "aggregation_columns": [
+      "supervisor_id",
+      "flw_id",
+      "month"
+    ],
+    "filters": [
+      {
+        "display": "Filter by FLW",
+        "slug": "flw_id",
+        "type": "dynamic_choice_list",
+        "field": "userID",
+        "choice_provider": {
+          "type": "location"
+        },
+        "ancestor_expression": {
+          "field": "supervisor_id",
+          "location_type": "supervisor"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "datatype": "string"
+      }
+    ],
+    "columns": [
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "completed_time",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "Supervisor ID",
+        "column_id": "supervisor_id",
+        "type": "field",
+        "field": "supervisor_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "FLW ID",
+        "column_id": "flw_id",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Count",
+        "column_id": "count",
+        "type": "field",
+        "field": "day",
+        "aggregation": "count_unique"
+      }
+    ]
+  },
+  "doc_type": "ReportConfiguration"
+}


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Similar to https://github.com/dimagi/commcare-hq/pull/29144, add a report for No. of Days THR was given.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This PR just adds a new data source and report for the project. It is not really live so there should be no scale implications of this as well.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Ideally this should not be rolled back because apps would be using it.

- [ ] This PR can be reverted after deploy with no further considerations 
