### PR TITLE
Add growth monitoring report

### DIFF
--- a/custom/nutrition_project/ucr/data_sources/weight_and_height_records_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/weight_and_height_records_v1.json
@@ -1,0 +1,277 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "config": {
+    "table_id": "static-weight_height_v1",
+    "display_name": "Weight and Height Records V1 (Static)",
+    "referenced_doc_type": "XFormInstance",
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "xmlns"
+          },
+          "property_value": "http://openrosa.org/formdesigner/6595DEFD-60DA-4102-A704-F400D40F5F05"
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "app_id"
+          },
+          "property_value": "b3c758f7c79e47e3a503115894f18503"
+        },
+        {
+          "type": "not",
+          "filter": {
+            "type": "boolean_expression",
+            "operator": "in",
+            "expression": {
+              "type": "property_path",
+              "property_path": [
+                "form",
+                "weight_provided",
+                "last_date_weight_taken"
+              ]
+            },
+            "property_value": [
+              "",
+              null
+            ]
+          }
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "nested",
+            "argument_expression": {
+              "type": "indexed_case",
+              "case_expression": {
+                "type": "related_doc",
+                "related_doc_type": "CommCareCase",
+                "doc_id_expression": {
+                  "type": "property_path",
+                  "property_path": [
+                    "form",
+                    "form_info",
+                    "child_care_case_id"
+                  ]
+                },
+                "value_expression": {
+                  "type": "identity"
+                }
+              },
+              "index": "parent"
+            },
+            "value_expression": {
+              "type": "property_name",
+              "property_name": "member_residential_status"
+            }
+          },
+          "property_value": "permanent_resident"
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "type": "expression",
+        "column_id": "username",
+        "display_name": "username",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "username"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "userID",
+        "display_name": "userID",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "userID"
+          ]
+        }
+      },
+      {
+        "display_name": "flw_id",
+        "datatype": "string",
+        "expression": {
+          "type": "named",
+          "name": "user_location_id"
+        },
+        "type": "expression",
+        "column_id": "flw_id"
+      },
+      {
+        "display_name": "supervisor_id",
+        "datatype": "string",
+        "expression": {
+          "location_id_expression": {
+            "type": "named",
+            "name": "user_location_id"
+          },
+          "type": "location_parent_id"
+        },
+        "type": "expression",
+        "column_id": "supervisor_id"
+      },
+      {
+        "type": "expression",
+        "column_id": "received_on",
+        "display_name": "received_on",
+        "datatype": "datetime",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "received_on"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "completed_time",
+        "display_name": "completed_time",
+        "datatype": "datetime",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "timeEnd"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "child_care_case_id",
+        "display_name": "child_care_case_id",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "form_info",
+            "child_care_case_id"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "dob",
+        "display_name": "dob",
+        "datatype": "date",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "member_defaults",
+            "dob"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "gender",
+        "display_name": "gender",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "member_defaults",
+            "sex"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "last_date_weight_taken",
+        "display_name": "last_date_weight_taken",
+        "datatype": "date",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "weight_provided",
+            "last_date_weight_taken"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "zscore_grading_wfa",
+        "display_name": "zscore_grading_wfa",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "weight_provided",
+            "zscore_grading_wfa"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "zscore_grading_wfh",
+        "display_name": "zscore_grading_wfh",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "height_provided",
+            "zscore_grading_wfh"
+          ]
+        }
+      }
+    ],
+    "named_expressions": {
+      "user_location_id": {
+        "datatype": "string",
+        "value_expression": {
+          "type": "property_name",
+          "property_name": "location_id"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareUser",
+        "doc_id_expression": {
+          "datatype": "string",
+          "type": "property_path",
+          "property_path": [
+            "form",
+            "meta",
+            "userID"
+          ]
+        }
+      }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "supervisor_id",
+          "flw_id"
+        ]
+      }
+    ]
+  }
+}

--- a/custom/nutrition_project/ucr/reports/growth_monitoring_v1.json
+++ b/custom/nutrition_project/ucr/reports/growth_monitoring_v1.json
@@ -1,0 +1,131 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "report_id": "static-growth_monitoring_v1",
+  "data_source_table": "static-weight_height_v1",
+  "config": {
+    "title": "Growth Monitoring V1 (Static)",
+    "description": "Last value of indicators filled per child care case per month",
+    "visible": true,
+    "aggregation_columns": [
+      "child_care_case_id",
+      "gender",
+      "supervisor_id",
+      "flw_id",
+      "month"
+    ],
+    "filters": [
+      {
+        "display": "Filter by FLW",
+        "slug": "flw_id",
+        "type": "dynamic_choice_list",
+        "field": "userID",
+        "choice_provider": {
+          "type": "location"
+        },
+        "ancestor_expression": {
+          "field": "supervisor_id",
+          "location_type": "supervisor"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Form Completed On",
+        "slug": "completed_time",
+        "type": "date",
+        "field": "completed_time",
+        "datatype": "date"
+      },
+      {
+        "display": "Date of Birth",
+        "slug": "dob",
+        "type": "date",
+        "field": "dob",
+        "datatype": "date"
+      },
+      {
+        "display": "Gender",
+        "slug": "gender",
+        "type": "choice_list",
+        "field": "gender",
+        "datatype": "string",
+        "choices": [
+          {
+            "display": "Male",
+            "value": "M"
+          },
+          {
+            "display": "Female",
+            "value": "F"
+          }
+        ]
+      }
+    ],
+    "columns": [
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "completed_time",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "Supervisor ID",
+        "column_id": "supervisor_id",
+        "type": "field",
+        "field": "supervisor_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "FLW ID",
+        "column_id": "flw_id",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Gender",
+        "column_id": "gender",
+        "type": "field",
+        "field": "gender",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Child Care Case ID",
+        "column_id": "child_care_case_id",
+        "type": "field",
+        "field": "child_care_case_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Z Scoring WFA",
+        "column_id": "zscore_grading_wfa",
+        "type": "array_agg_last_value",
+        "field": "zscore_grading_wfa",
+         "order_by_col": "completed_time"
+      },
+      {
+        "display": "Z Scoring WFH",
+        "column_id": "zscore_grading_wfh",
+        "type": "array_agg_last_value",
+        "field": "zscore_grading_wfh",
+         "order_by_col": "completed_time"
+      }
+    ]
+  },
+  "doc_type": "ReportConfiguration"
+}

--- a/custom/nutrition_project/ucr/reports/growth_monitoring_v1.json
+++ b/custom/nutrition_project/ucr/reports/growth_monitoring_v1.json
@@ -44,35 +44,11 @@
         "datatype": "string"
       },
       {
-        "display": "Form Completed On",
-        "slug": "completed_time",
-        "type": "date",
-        "field": "completed_time",
-        "datatype": "date"
-      },
-      {
         "display": "Date of Birth",
         "slug": "dob",
         "type": "date",
         "field": "dob",
         "datatype": "date"
-      },
-      {
-        "display": "Gender",
-        "slug": "gender",
-        "type": "choice_list",
-        "field": "gender",
-        "datatype": "string",
-        "choices": [
-          {
-            "display": "Male",
-            "value": "M"
-          },
-          {
-            "display": "Female",
-            "value": "F"
-          }
-        ]
       }
     ],
     "columns": [


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Adding more reports after https://github.com/dimagi/commcare-hq/pull/29056/files
This PR,
Adds a report for growth monitoring.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This PR just adds a new data source and report for the project. It is not really live so there should be no scale implications of this as well.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Ideally this should not be rolled back because apps would be using it.

- [ ] This PR can be reverted after deploy with no further considerations 
