### PR TITLE
Add some suite functions to app build timings page

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4983,6 +4983,7 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
     def set_custom_suite(self, value):
         self.put_attachment(value, 'custom_suite.xml')
 
+    @time_method()
     def create_suite(self, build_profile_id=None):
         self.assert_app_v2()
         return SuiteGenerator(self, build_profile_id).generate_suite()

--- a/corehq/apps/app_manager/suite_xml/contributors.py
+++ b/corehq/apps/app_manager/suite_xml/contributors.py
@@ -10,6 +10,10 @@ class BaseSuiteContributor(metaclass=ABCMeta):
         self.build_profile_id = build_profile_id
         self.entries_helper = EntriesHelper(app, modules, build_profile_id=self.build_profile_id)
 
+    @property
+    def timing_context(self):
+        return self.app.timing_context
+
 
 class SectionContributor(BaseSuiteContributor, metaclass=ABCMeta):
     @abstractproperty

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -33,6 +33,7 @@ from corehq.apps.app_manager.xpath import (
     interpolate_xpath,
     session_var,
 )
+from corehq.util.timer import time_method
 
 
 class FormDatumMeta(namedtuple('FormDatumMeta', 'datum case_type requires_selection action from_parent')):
@@ -57,6 +58,7 @@ class FormDatumMeta(namedtuple('FormDatumMeta', 'datum case_type requires_select
 
 
 class EntriesContributor(SuiteContributorByModule):
+    @time_method()
     def get_module_contributions(self, module):
         return self.entries_helper.entry_for_module(module)
 

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -27,10 +27,12 @@ from corehq.apps.app_manager.xpath import (
     interpolate_xpath,
     session_var,
 )
+from corehq.util.timer import time_method
 
 
 class MenuContributor(SuiteContributorByModule):
 
+    @time_method()
     def get_module_contributions(self, module, training_menu):
         menus = []
         if hasattr(module, 'get_menus'):

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -28,6 +28,7 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
 from corehq.apps.app_manager.util import module_offers_search
 from corehq.apps.app_manager.xpath import CaseTypeXpath, InstanceXpath, interpolate_xpath
 from corehq.apps.case_search.models import CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY
+from corehq.util.timer import time_method
 from corehq.util.view_utils import absolute_reverse
 
 RESULTS_INSTANCE = 'results'  # The name of the instance where search results are stored
@@ -202,6 +203,7 @@ class RemoteRequestContributor(SuiteContributorByModule):
 
     """
 
+    @time_method()
     def get_module_contributions(self, module, detail_section_elements):
         if module_offers_search(module):
             return [RemoteRequestFactory(

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -41,7 +41,13 @@
                 click: function () { return trackClick('Compare App Versions: Clicked Version Preview'); }
                 ">
         <i class="fa fa-exchange"></i>
-        {% trans "Version Preview" %}
+        {% trans "Preview" %}
+      </a>
+    {% endif %}
+    {% if user.is_superuser %}
+      <a class="btn btn-default" href="{% url "app_build_timings" %}?app_id={{ app.id }}" target="_blank">
+        <i class="fa fa-clock-o"></i>
+        {% trans "Timing" %}
       </a>
     {% endif %}
     <button class="btn btn-primary" data-bind="

--- a/corehq/util/timer.py
+++ b/corehq/util/timer.py
@@ -217,7 +217,8 @@ def time_method():
         @wraps(fn)
         def _inner(self, *args, **kwargs):
             if self.timing_context.is_started():
-                with self.timing_context(fn.__name__):
+                tag = f"{type(self).__name__}.{fn.__name__}"
+                with self.timing_context(tag):
                     return fn(self, *args, **kwargs)
             else:
                 return fn(self, *args, **kwargs)


### PR DESCRIPTION
## Summary
Wanted this last night while looking at the time to make a new build. App build timings page now includes `create_suite` and `get_module_contributions` calls:
![Screen Shot 2021-02-10 at 11 24 17 AM](https://user-images.githubusercontent.com/1486591/107540782-6e9c4900-6b94-11eb-89f4-6e94fdd687a2.png)

Also added a "Timing" link to the releases page to get to the timings page (superuser-only):
![Screen Shot 2021-02-10 at 11 35 03 AM](https://user-images.githubusercontent.com/1486591/107540689-53313e00-6b94-11eb-9eee-18ab2a12d9db.png)

## Feature Flag
Superuser only

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None specifically of the timing code, though making new builds has extensive testing.

### QA Plan

Not requesting QA. Tested locally, admin-only page, low risk.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
