### PR TITLE
Fixed wrong case_type as param in run_all_managment_command

### DIFF
--- a/custom/covid/management/commands/run_all_management_command.py
+++ b/custom/covid/management/commands/run_all_management_command.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
         jobs = []
         pool = Pool(20)
         for domain in domains:
-            jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contacts'))
+            jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact'))
             jobs.append(pool.spawn(run_command, 'add_hq_user_id_to_case', domain, 'checkin'))
             jobs.append(pool.spawn(run_command, 'update_owner_ids', domain, 'investigation'))
             jobs.append(pool.spawn(run_command, 'update_owner_ids', domain, 'checkin'))


### PR DESCRIPTION
## Summary
It said "contacts" when the actual case_type is "contact"

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below


### QA Plan
I am not requesting QA

### Safety story
This just changes the parameter passed into the command. This will be run on test domains before the big rollout. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
