### PR TITLE
Modified CHILD_LOCATION_TYPE in update_owner_ids command

### DIFF
--- a/custom/covid/management/commands/update_owner_ids.py
+++ b/custom/covid/management/commands/update_owner_ids.py
@@ -10,7 +10,7 @@ from custom.covid.management.commands.update_cases import CaseUpdateCommand
 
 BATCH_SIZE = 100
 DEVICE_ID = __name__ + ".update_owner_ids"
-CHILD_LOCATION_TYPE = 'Investigators'
+CHILD_LOCATION_TYPE = 'investigators'
 
 
 class Command(CaseUpdateCommand):
@@ -42,7 +42,7 @@ class Command(CaseUpdateCommand):
                 children = location_obj.get_children()
                 has_correct_child_location_type = False
                 for child_location in children:
-                    if child_location.location_type.name == CHILD_LOCATION_TYPE:
+                    if child_location.location_type.code == CHILD_LOCATION_TYPE:
                         case_blocks.append(self.case_block(case, child_location))
                         has_correct_child_location_type = True
                         break

--- a/custom/covid/management/commands/update_owner_ids.py
+++ b/custom/covid/management/commands/update_owner_ids.py
@@ -10,7 +10,7 @@ from custom.covid.management.commands.update_cases import CaseUpdateCommand
 
 BATCH_SIZE = 100
 DEVICE_ID = __name__ + ".update_owner_ids"
-CHILD_LOCATION_TYPE = 'investigators'
+CHILD_LOCATION_TYPE = 'Investigators'
 
 
 class Command(CaseUpdateCommand):

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -110,7 +110,7 @@ class CaseCommandsTest(TestCase):
         )
         investigators = LocationType.objects.create(
             domain=self.domain,
-            name='investigators',
+            name='Investigators',
         )
 
         parent_loc = SQLLocation.objects.create(


### PR DESCRIPTION
## Summary
After speaking with Kim, I learned that the project team actually specifies it spelled this way. If this variable changes a lot by project, it may be a good idea to make it a parameter for the function, but I don't see the need right now.  

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
There is test coverage for this command

### QA Plan
I am not requesting QA

### Safety story
This is being tested on testing domains before being rolled out

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
