### PR TITLE
Removed changing the owner_id in update_case_index_relationship

### DIFF
--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -30,7 +30,6 @@ class Command(CaseUpdateCommand):
         return ElementTree.tostring(CaseBlock.deprecated_init(
             create=False,
             case_id=case.case_id,
-            owner_id='-',
             index={index.identifier: (index.referenced_type, index.referenced_id, "extension")},
         ).as_xml()).decode('utf-8')
 


### PR DESCRIPTION
## Summary
Clarification was made that the `owner_id` should not be changed as part of the casedb migration.

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan
I am not requesting QA

### Safety story
This script will be run on test domains before rolling out for the migration.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
