### PR TITLE
Add supplementary reports

### DIFF
--- a/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_hcm_3years_6years.json
+++ b/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_hcm_3years_6years.json
@@ -1,0 +1,324 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "config": {
+    "table_id": "static-suppl_nutrition_hcm_3y_6y_v1",
+    "display_name": "Supplementary Nutrition HCM (for 3 years - 6 years) V1 (Static)",
+    "referenced_doc_type": "XFormInstance",
+    "base_item_expression": {
+      "type": "property_path",
+      "property_path": [
+        "form",
+        "update_cases_of_attended_children"
+      ]
+    },
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "xmlns"
+          },
+          "property_value": "http://openrosa.org/formdesigner/87149AFE-1EE9-4C80-AE07-FD12FA808D83"
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "app_id"
+          },
+          "property_value": "b3c758f7c79e47e3a503115894f18503"
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "type": "expression",
+        "column_id": "username",
+        "display_name": "username",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "username"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "userID",
+        "display_name": "userID",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      },
+      {
+        "display_name": "flw_id",
+        "datatype": "string",
+        "expression": {
+          "type": "named",
+          "name": "user_location_id"
+        },
+        "type": "expression",
+        "column_id": "flw_id"
+      },
+      {
+        "display_name": "supervisor_id",
+        "datatype": "string",
+        "expression": {
+          "location_id_expression": {
+            "type": "named",
+            "name": "user_location_id"
+          },
+          "type": "location_parent_id"
+        },
+        "type": "expression",
+        "column_id": "supervisor_id"
+      },
+      {
+        "type": "expression",
+        "column_id": "received_on",
+        "display_name": "received_on",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "received_on"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "completed_time",
+        "display_name": "completed_time",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "timeEnd"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "nutrition_center_open_today",
+        "display_name": "nutrition_center_open_today",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "nutrition_center_open_today"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "child_care_case_id",
+        "display_name": "child_care_case_id",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "child_case_id"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "child_case_id",
+        "display_name": "child_case_id",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "_id"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "current_month_hcm_days_calc",
+        "display_name": "current_month_hcm_days_calc",
+        "datatype": "integer",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "current_month_hcm_days_calc"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "member_gender",
+        "display_name": "member_gender",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "member_gender"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "member_residential_status",
+        "display_name": "member_residential_status",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "member_residential_status"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "disability",
+        "display_name": "disability",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "disability"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "family_unit_caste",
+        "display_name": "family_unit_caste",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "family_unit_caste"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "family_unit_religion",
+        "display_name": "family_unit_religion",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "family_unit_religion"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      }
+    ],
+    "named_expressions": {
+      "user_location_id": {
+        "datatype": "string",
+        "value_expression": {
+          "type": "property_name",
+          "property_name": "location_id"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareUser",
+        "doc_id_expression": {
+          "type": "root_doc",
+          "expression": {
+            "datatype": "string",
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      },
+      "member_case": {
+        "type": "indexed_case",
+        "case_expression": {
+          "type": "related_doc",
+          "related_doc_type": "CommCareCase",
+          "doc_id_expression": {
+            "type": "property_path",
+            "property_path": [
+              "child_case_id"
+            ]
+          },
+          "value_expression": {
+            "type": "identity"
+          }
+        },
+        "index": "parent"
+      }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "supervisor_id",
+          "flw_id"
+        ]
+      }
+    ]
+  }
+}

--- a/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_6months_3years.json
+++ b/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_6months_3years.json
@@ -1,0 +1,326 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "config": {
+    "table_id": "static-suppl_nutrition_thr_6mo_3y_v1",
+    "display_name": "Supplementary Nutrition THR (for 6 months - 3 years) V1 (Static)",
+    "referenced_doc_type": "XFormInstance",
+    "base_item_expression": {
+      "type": "property_path",
+      "property_path": [
+        "form",
+        "thr_details_group",
+        "update_cases_of_children_received_thr"
+      ]
+    },
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "xmlns"
+          },
+          "property_value": "http://openrosa.org/formdesigner/116A78AD-E839-4BD4-BA13-A534A4A85B3B"
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "app_id"
+          },
+          "property_value": "b3c758f7c79e47e3a503115894f18503"
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "type": "expression",
+        "column_id": "username",
+        "display_name": "username",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "username"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "userID",
+        "display_name": "userID",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      },
+      {
+        "display_name": "flw_id",
+        "datatype": "string",
+        "expression": {
+          "type": "named",
+          "name": "user_location_id"
+        },
+        "type": "expression",
+        "column_id": "flw_id"
+      },
+      {
+        "display_name": "supervisor_id",
+        "datatype": "string",
+        "expression": {
+          "location_id_expression": {
+            "type": "named",
+            "name": "user_location_id"
+          },
+          "type": "location_parent_id"
+        },
+        "type": "expression",
+        "column_id": "supervisor_id"
+      },
+      {
+        "type": "expression",
+        "column_id": "received_on",
+        "display_name": "received_on",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "received_on"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "completed_time",
+        "display_name": "completed_time",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "timeEnd"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "child_care_case_id",
+        "display_name": "child_care_case_id",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "child_case_id"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "child_case_id",
+        "display_name": "child_case_id",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "_id"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "number_of_days_thr_given",
+        "display_name": "number_of_days_thr_given",
+        "datatype": "integer",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "thr_details_group",
+              "number_of_days_thr_given"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "current_month_thr_days_calc",
+        "display_name": "current_month_thr_days_calc",
+        "datatype": "integer",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "current_month_thr_days_calc"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "member_gender",
+        "display_name": "member_gender",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "member_gender"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "member_residential_status",
+        "display_name": "member_residential_status",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "member_residential_status"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "disability",
+        "display_name": "disability",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "disability"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "family_unit_caste",
+        "display_name": "family_unit_caste",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "family_unit_caste"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "family_unit_religion",
+        "display_name": "family_unit_religion",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "family_unit_religion"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      }
+    ],
+    "named_expressions": {
+      "user_location_id": {
+        "datatype": "string",
+        "value_expression": {
+          "type": "property_name",
+          "property_name": "location_id"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareUser",
+        "doc_id_expression": {
+          "type": "root_doc",
+          "expression": {
+            "datatype": "string",
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      },
+      "member_case": {
+        "type": "indexed_case",
+        "case_expression": {
+          "type": "related_doc",
+          "related_doc_type": "CommCareCase",
+          "doc_id_expression": {
+            "type": "property_path",
+            "property_path": [
+              "child_case_id"
+            ]
+          },
+          "value_expression": {
+            "type": "identity"
+          }
+        },
+        "index": "parent"
+      }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "supervisor_id",
+          "flw_id"
+        ]
+      }
+    ]
+  }
+}

--- a/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_pw_lw.json
+++ b/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_pw_lw.json
@@ -1,0 +1,343 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "config": {
+    "table_id": "static-suppl_nutrition_thr_pw_lw_v1",
+    "display_name": "Supplementary Nutrition THR (for Pregnant/Lactating Women) V1 (Static)",
+    "referenced_doc_type": "XFormInstance",
+    "base_item_expression": {
+      "type": "property_path",
+      "property_path": [
+        "form",
+        "thr_details_group",
+        "update_cases_of_women_received_thr"
+      ]
+    },
+    "configured_filter": {
+      "type": "and",
+      "filters": [
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "xmlns"
+          },
+          "property_value": "http://openrosa.org/formdesigner/4FAB81D4-BBAF-424E-8DB1-96478791DB01"
+        },
+        {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "app_id"
+          },
+          "property_value": "b3c758f7c79e47e3a503115894f18503"
+        }
+      ]
+    },
+    "configured_indicators": [
+      {
+        "type": "expression",
+        "column_id": "username",
+        "display_name": "username",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "username"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "userID",
+        "display_name": "userID",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      },
+      {
+        "display_name": "flw_id",
+        "datatype": "string",
+        "expression": {
+          "type": "named",
+          "name": "user_location_id"
+        },
+        "type": "expression",
+        "column_id": "flw_id"
+      },
+      {
+        "display_name": "supervisor_id",
+        "datatype": "string",
+        "expression": {
+          "location_id_expression": {
+            "type": "named",
+            "name": "user_location_id"
+          },
+          "type": "location_parent_id"
+        },
+        "type": "expression",
+        "column_id": "supervisor_id"
+      },
+      {
+        "type": "expression",
+        "column_id": "received_on",
+        "display_name": "received_on",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "received_on"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "completed_time",
+        "display_name": "completed_time",
+        "datatype": "datetime",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "timeEnd"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "maternal_care_case_id",
+        "display_name": "maternal_care_case_id",
+        "datatype": "string",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "women_case_id"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "woman_case_id",
+        "display_name": "woman_case_id",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "_id"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "number_of_days_thr_given",
+        "display_name": "number_of_days_thr_given",
+        "datatype": "integer",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "thr_details_group",
+              "number_of_days_thr_given"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "current_month_thr_days_calc",
+        "display_name": "current_month_thr_days_calc",
+        "datatype": "integer",
+        "expression": {
+          "type": "property_path",
+          "property_path": [
+            "current_month_thr_days_calc"
+          ]
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "edd",
+        "display_name": "edd",
+        "datatype": "date",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "edd"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "add",
+        "display_name": "add",
+        "datatype": "date",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "add"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "member_residential_status",
+        "display_name": "member_residential_status",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "member_residential_status"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "disability",
+        "display_name": "disability",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "disability"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "family_unit_caste",
+        "display_name": "family_unit_caste",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "family_unit_caste"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "family_unit_religion",
+        "display_name": "family_unit_religion",
+        "datatype": "string",
+        "expression": {
+          "type": "nested",
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "family_unit_religion"
+          },
+          "argument_expression": {
+            "type": "named",
+            "name": "member_case"
+          }
+        }
+      }
+    ],
+    "named_expressions": {
+      "user_location_id": {
+        "datatype": "string",
+        "value_expression": {
+          "type": "property_name",
+          "property_name": "location_id"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareUser",
+        "doc_id_expression": {
+          "type": "root_doc",
+          "expression": {
+            "datatype": "string",
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "meta",
+              "userID"
+            ]
+          }
+        }
+      },
+      "member_case": {
+        "type": "indexed_case",
+        "case_expression": {
+          "type": "related_doc",
+          "related_doc_type": "CommCareCase",
+          "doc_id_expression": {
+            "type": "property_path",
+            "property_path": [
+              "women_case_id"
+            ]
+          },
+          "value_expression": {
+            "type": "identity"
+          }
+        },
+        "index": "parent"
+      }
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "supervisor_id",
+          "flw_id"
+        ]
+      }
+    ]
+  }
+}

--- a/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_pw_lw.json
+++ b/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_pw_lw.json
@@ -201,7 +201,7 @@
           },
           "argument_expression": {
             "type": "named",
-            "name": "member_case"
+            "name": "maternal_care_case"
           }
         }
       },
@@ -218,7 +218,7 @@
           },
           "argument_expression": {
             "type": "named",
-            "name": "member_case"
+            "name": "maternal_care_case"
           }
         }
       },
@@ -313,20 +313,24 @@
           }
         }
       },
+      "maternal_care_case": {
+        "value_expression": {
+          "type": "identity"
+        },
+        "type": "related_doc",
+        "related_doc_type": "CommCareCase",
+        "doc_id_expression": {
+          "type": "property_path",
+          "property_path": [
+            "women_case_id"
+          ]
+        }
+      },
       "member_case": {
         "type": "indexed_case",
         "case_expression": {
-          "type": "related_doc",
-          "related_doc_type": "CommCareCase",
-          "doc_id_expression": {
-            "type": "property_path",
-            "property_path": [
-              "women_case_id"
-            ]
-          },
-          "value_expression": {
-            "type": "identity"
-          }
+          "type": "named",
+          "name": "maternal_care_case"
         },
         "index": "parent"
       }

--- a/custom/nutrition_project/ucr/reports/hcm_3years_6years_v1.json
+++ b/custom/nutrition_project/ucr/reports/hcm_3years_6years_v1.json
@@ -1,0 +1,133 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "report_id": "static-hcm_3y_6y_v1",
+  "data_source_table": "static-suppl_nutrition_hcm_3y_6y_v1",
+  "config": {
+    "title": "Supplementary Nutrition HCM (for 3 years - 6 years) V1 (Static)",
+    "description": "Monthly Supplementary Nutrition per child per month",
+    "visible": true,
+    "aggregation_columns": [
+      "child_case_id",
+      "supervisor_id",
+      "flw_id",
+      "month",
+      "member_residential_status",
+      "member_gender",
+      "disability",
+      "family_unit_caste",
+      "family_unit_religion"
+    ],
+    "filters": [
+      {
+        "display": "Filter by FLW",
+        "slug": "flw_id",
+        "type": "dynamic_choice_list",
+        "field": "userID",
+        "choice_provider": {
+          "type": "location"
+        },
+        "ancestor_expression": {
+          "field": "supervisor_id",
+          "location_type": "supervisor"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "datatype": "string"
+      },
+      {
+        "type": "numeric",
+        "slug": "current_month_hcm_days_calc",
+        "field": "current_month_hcm_days_calc",
+        "display": "HCM given in a month",
+        "datatype": "integer"
+      }
+    ],
+    "columns": [
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "completed_time",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "Supervisor ID",
+        "column_id": "supervisor_id",
+        "type": "field",
+        "field": "supervisor_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "FLW ID",
+        "column_id": "flw_id",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Residential Status",
+        "column_id": "member_residential_status",
+        "type": "field",
+        "field": "member_residential_status",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Gender",
+        "column_id": "member_gender",
+        "type": "field",
+        "field": "member_gender",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Disability",
+        "column_id": "disability",
+        "type": "field",
+        "field": "disability",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Caste",
+        "column_id": "family_unit_caste",
+        "type": "field",
+        "field": "family_unit_caste",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Religion",
+        "column_id": "family_unit_religion",
+        "type": "field",
+        "field": "family_unit_religion",
+        "aggregation": "simple"
+      },
+      {
+        "display": "child_case_id",
+        "column_id": "child_case_id",
+        "type": "field",
+        "field": "child_case_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "HCM Days",
+        "column_id": "current_month_hcm_days_calc",
+        "type": "array_agg_last_value",
+        "field": "current_month_hcm_days_calc",
+        "order_by_col": "completed_time",
+        "comment": "pick the most recent value of the aggregated hcm given in the month"
+      }
+    ]
+  },
+  "doc_type": "ReportConfiguration"
+}

--- a/custom/nutrition_project/ucr/reports/thr_6months_3years_v1.json
+++ b/custom/nutrition_project/ucr/reports/thr_6months_3years_v1.json
@@ -1,0 +1,133 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "report_id": "static-thr_6mo_3y_v1",
+  "data_source_table": "static-suppl_nutrition_thr_6mo_3y_v1",
+  "config": {
+    "title": "Supplementary Nutrition THR (for 6 months - 3 years) V1 (Static)",
+    "description": "Monthly Supplementary Nutrition per child per month",
+    "visible": true,
+    "aggregation_columns": [
+      "child_case_id",
+      "supervisor_id",
+      "flw_id",
+      "month",
+      "member_residential_status",
+      "member_gender",
+      "disability",
+      "family_unit_caste",
+      "family_unit_religion"
+    ],
+    "filters": [
+      {
+        "display": "Filter by FLW",
+        "slug": "flw_id",
+        "type": "dynamic_choice_list",
+        "field": "userID",
+        "choice_provider": {
+          "type": "location"
+        },
+        "ancestor_expression": {
+          "field": "supervisor_id",
+          "location_type": "supervisor"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "datatype": "string"
+      },
+      {
+        "type": "numeric",
+        "slug": "current_month_thr_days_calc",
+        "field": "current_month_thr_days_calc",
+        "display": "THR days equivalent given in a month",
+        "datatype": "integer"
+      }
+    ],
+    "columns": [
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "completed_time",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "Supervisor ID",
+        "column_id": "supervisor_id",
+        "type": "field",
+        "field": "supervisor_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "FLW ID",
+        "column_id": "flw_id",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Residential Status",
+        "column_id": "member_residential_status",
+        "type": "field",
+        "field": "member_residential_status",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Gender",
+        "column_id": "member_gender",
+        "type": "field",
+        "field": "member_gender",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Disability",
+        "column_id": "disability",
+        "type": "field",
+        "field": "disability",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Caste",
+        "column_id": "family_unit_caste",
+        "type": "field",
+        "field": "family_unit_caste",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Religion",
+        "column_id": "family_unit_religion",
+        "type": "field",
+        "field": "family_unit_religion",
+        "aggregation": "simple"
+      },
+      {
+        "display": "child_case_id",
+        "column_id": "child_case_id",
+        "type": "field",
+        "field": "child_case_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "THR Days",
+        "column_id": "current_month_thr_days_calc",
+        "type": "array_agg_last_value",
+        "field": "current_month_thr_days_calc",
+        "order_by_col": "completed_time",
+        "comment": "pick the most recent value of the aggregated thr given in the month"
+      }
+    ]
+  },
+  "doc_type": "ReportConfiguration"
+}

--- a/custom/nutrition_project/ucr/reports/thr_lw_v1.json
+++ b/custom/nutrition_project/ucr/reports/thr_lw_v1.json
@@ -1,0 +1,133 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "report_id": "static-thr_lw_v1",
+  "data_source_table": "static-suppl_nutrition_thr_pw_lw_v1",
+  "config": {
+    "title": "Supplementary Nutrition THR (for Lactating Women) V1 (Static)",
+    "description": "Monthly Supplementary Nutrition per woman per month",
+    "visible": true,
+    "aggregation_columns": [
+      "woman_case_id",
+      "supervisor_id",
+      "flw_id",
+      "month",
+      "member_residential_status",
+      "disability",
+      "family_unit_caste",
+      "family_unit_religion"
+    ],
+    "filters": [
+      {
+        "display": "Filter by FLW",
+        "slug": "flw_id",
+        "type": "dynamic_choice_list",
+        "field": "userID",
+        "choice_provider": {
+          "type": "location"
+        },
+        "ancestor_expression": {
+          "field": "supervisor_id",
+          "location_type": "supervisor"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "datatype": "string"
+      },
+      {
+        "type": "numeric",
+        "slug": "current_month_thr_days_calc",
+        "field": "current_month_thr_days_calc",
+        "display": "THR days equivalent given in a month",
+        "datatype": "integer"
+      },
+      {
+        "type": "pre",
+        "field": "add",
+        "slug": "add",
+        "pre_value": "",
+        "pre_operator": "!=",
+        "datatype": "date"
+      }
+    ],
+    "columns": [
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "completed_time",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "Supervisor ID",
+        "column_id": "supervisor_id",
+        "type": "field",
+        "field": "supervisor_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "FLW ID",
+        "column_id": "flw_id",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Residential Status",
+        "column_id": "member_residential_status",
+        "type": "field",
+        "field": "member_residential_status",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Disability",
+        "column_id": "disability",
+        "type": "field",
+        "field": "disability",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Caste",
+        "column_id": "family_unit_caste",
+        "type": "field",
+        "field": "family_unit_caste",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Religion",
+        "column_id": "family_unit_religion",
+        "type": "field",
+        "field": "family_unit_religion",
+        "aggregation": "simple"
+      },
+      {
+        "display": "woman_case_id",
+        "column_id": "woman_case_id",
+        "type": "field",
+        "field": "woman_case_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "THR Days",
+        "column_id": "current_month_thr_days_calc",
+        "type": "array_agg_last_value",
+        "field": "current_month_thr_days_calc",
+        "order_by_col": "completed_time",
+        "comment": "pick the most recent value of the aggregated thr given in the month"
+      }
+    ]
+  },
+  "doc_type": "ReportConfiguration"
+}

--- a/custom/nutrition_project/ucr/reports/thr_pw_v1.json
+++ b/custom/nutrition_project/ucr/reports/thr_pw_v1.json
@@ -1,0 +1,140 @@
+{
+  "domains": [
+    "india-nutrition-project"
+  ],
+  "server_environment": [
+    "india"
+  ],
+  "report_id": "static-thr_pw_v1",
+  "data_source_table": "static-suppl_nutrition_thr_pw_lw_v1",
+  "config": {
+    "title": "Supplementary Nutrition THR (for Pregnant Women) V1 (Static)",
+    "description": "Monthly Supplementary Nutrition per woman per month",
+    "visible": true,
+    "aggregation_columns": [
+      "woman_case_id",
+      "supervisor_id",
+      "flw_id",
+      "month",
+      "member_residential_status",
+      "disability",
+      "family_unit_caste",
+      "family_unit_religion"
+    ],
+    "filters": [
+      {
+        "display": "Filter by FLW",
+        "slug": "flw_id",
+        "type": "dynamic_choice_list",
+        "field": "userID",
+        "choice_provider": {
+          "type": "location"
+        },
+        "ancestor_expression": {
+          "field": "supervisor_id",
+          "location_type": "supervisor"
+        },
+        "datatype": "string"
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "datatype": "string"
+      },
+      {
+        "type": "numeric",
+        "slug": "current_month_thr_days_calc",
+        "field": "current_month_thr_days_calc",
+        "display": "THR days equivalent given in a month",
+        "datatype": "integer"
+      },
+      {
+        "type": "pre",
+        "field": "add",
+        "slug": "add",
+        "pre_value": "",
+        "datatype": "date"
+      },
+      {
+        "type": "pre",
+        "field": "edd",
+        "slug": "edd",
+        "pre_value": "",
+        "pre_operator": "!=",
+        "datatype": "date"
+      }
+    ],
+    "columns": [
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "completed_time",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "Supervisor ID",
+        "column_id": "supervisor_id",
+        "type": "field",
+        "field": "supervisor_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "FLW ID",
+        "column_id": "flw_id",
+        "type": "field",
+        "field": "flw_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Residential Status",
+        "column_id": "member_residential_status",
+        "type": "field",
+        "field": "member_residential_status",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Disability",
+        "column_id": "disability",
+        "type": "field",
+        "field": "disability",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Caste",
+        "column_id": "family_unit_caste",
+        "type": "field",
+        "field": "family_unit_caste",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Religion",
+        "column_id": "family_unit_religion",
+        "type": "field",
+        "field": "family_unit_religion",
+        "aggregation": "simple"
+      },
+      {
+        "display": "woman_case_id",
+        "column_id": "woman_case_id",
+        "type": "field",
+        "field": "woman_case_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "THR Days",
+        "column_id": "current_month_thr_days_calc",
+        "type": "array_agg_last_value",
+        "field": "current_month_thr_days_calc",
+        "order_by_col": "completed_time",
+        "comment": "pick the most recent value of the aggregated thr given in the month"
+      }
+    ]
+  },
+  "doc_type": "ReportConfiguration"
+}


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Adding more reports after https://github.com/dimagi/commcare-hq/pull/29056/files, for supplementary nutrition for different age groups. Better to review by commit.

Note: The base for finding the information needed for these reports is that, each time the service is given, the app calculates the number of days for which the service has been given so far in a month, so the aggregated value already calculated when the form is filled and is available in the form and the case. This value is stored in the data source and by using it we avoid summing up at the report, and just use the most recent value for this metric entered for a case to know the number of days a service was given to a case.
The app needs to filter for cases that have received sufficient nutrition (>25 days in a month) or insufficient(<25), which it gets by filtering on the value for this already aggregated column in the data source.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This PR just adds a new data source and report for the project. It is not really live so there should be no scale implications of this as well.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Ideally this should not be rolled back because apps would be using it.

- [ ] This PR can be reverted after deploy with no further considerations 
