### PR TITLE
Fix some edge cases in forms & cases Couch to SQL migration

### DIFF
--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -87,14 +87,15 @@ def diff_cases(couch_cases, log_cases=False):
     for sql_case in get_sql_cases(case_ids):
         case_id = sql_case.case_id
         sql_case_ids.add(case_id)
-        couch_case, diffs, changes = diff_case(sql_case, couch_cases[case_id], dd_count)
+        doc_type = couch_cases[case_id]['doc_type']
+        diffs, changes = diff_case(sql_case, couch_cases[case_id], dd_count)
         if diffs:
             dd_count("commcare.couchsqlmigration.case.has_diff")
         if changes:
             dd_count("commcare.couchsqlmigration.case.did_change")
         data.doc_ids.append(case_id)
-        data.diffs.append((couch_case['doc_type'], case_id, diffs))
-        data.changes.append((couch_case['doc_type'], case_id, changes))
+        data.diffs.append((doc_type, case_id, diffs))
+        data.changes.append((doc_type, case_id, changes))
         if log_cases:
             log.info("case %s -> %s diffs", case_id, len(diffs))
 
@@ -115,15 +116,15 @@ def diff_case(sql_case, couch_case, dd_count):
     diffs = check_domains(case_id, couch_case, sql_json)
     changes = []
     if diffs:
-        return couch_case, diffs, changes
+        return diffs, changes
     diffs = diff(couch_case, sql_json)
     if diffs:
         if is_case_patched(case_id, diffs):
-            return couch_case, [], []
+            return [], []
         form_diffs = diff_case_forms(couch_case, sql_json)
         if form_diffs:
             diffs.extend(form_diffs)
-            return couch_case, diffs, changes
+            return diffs, changes
         original_couch_case = couch_case
         dd_count("commcare.couchsqlmigration.case.rebuild.couch")
         try:
@@ -141,12 +142,12 @@ def diff_case(sql_case, couch_case, dd_count):
                 dd_count("commcare.couchsqlmigration.case.rebuild.error")
                 log.warning(f"Case {case_id} rebuild SQL -> {type(err).__name__}: {err}")
             if not diffs and is_case_patched(case_id, diff(original_couch_case, sql_json)):
-                return original_couch_case, [], []
+                return [], []
         if diffs:
             diffs.extend(diff_case_forms(couch_case, sql_json))
         else:
             changes = diffs_to_changes(diff(original_couch_case, sql_json), "rebuild case")
-    return couch_case, diffs, changes
+    return diffs, changes
 
 
 def check_domains(case_id, couch_json, sql_json):

--- a/corehq/apps/couch_sql_migration/casepatch.py
+++ b/corehq/apps/couch_sql_migration/casepatch.py
@@ -105,8 +105,8 @@ class PatchCase:
             self._dynamic_properties = props
             if props or has_known_props(self.diffs) or self.indices:
                 updates.append(const.CASE_ACTION_UPDATE)
-            if self._should_close():
-                updates.append(const.CASE_ACTION_CLOSE)
+        if self._should_close():
+            updates.append(const.CASE_ACTION_CLOSE)
 
     def __hash__(self):
         return hash(self.case_id)
@@ -115,8 +115,10 @@ class PatchCase:
         return getattr(self.case, name)
 
     def _should_close(self):
-        return (self.case.closed
-            and any(d.path == ["closed"] and not d.new_value for d in self.diffs))
+        return self.case.closed and (
+            any(d.path == ["closed"] and not d.new_value for d in self.diffs)
+            or is_missing_in_sql(self.diffs)
+        )
 
     def dynamic_case_properties(self):
         return self._dynamic_properties

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -229,7 +229,6 @@ class CouchSqlDomainMigrator:
                 process_form(doc)
 
     def _migrate_form(self, couch_form, case_ids, **kw):
-        set_local_domain_sql_backend_override(self.domain)
         form_id = couch_form.form_id
         self._migrate_form_and_associated_models(couch_form, **kw)
         self.case_diff_queue.update(case_ids, form_id)
@@ -238,6 +237,7 @@ class CouchSqlDomainMigrator:
         """
         Copies `couch_form` into a new sql form
         """
+        set_local_domain_sql_backend_override(self.domain)
         sql_form = None
         try:
             assert couch_form.domain == self.domain, couch_form.form_id
@@ -351,6 +351,7 @@ class CouchSqlDomainMigrator:
                 pool.spawn(copy_case, doc)
 
     def _copy_unprocessed_case(self, doc):
+        set_local_domain_sql_backend_override(self.domain)
         couch_case = CommCareCase.wrap(doc)
         log.debug('Processing doc: %(doc_type)s(%(_id)s)', doc)
         try:

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -301,7 +301,7 @@ class CouchSqlDomainMigrator:
             sql_json = sql_form_to_json(sql_form)
             self.statedb.save_form_diffs(couch_json, sql_json)
         else:
-            self.statedb.add_missing_docs("XFormInstance", [couch_form.form_id])
+            self.statedb.add_missing_docs(couch_form.doc_type, [couch_form.form_id])
 
     def _get_case_stock_result(self, sql_form, couch_form):
         case_stock_result = None

--- a/corehq/apps/couch_sql_migration/diffrule.py
+++ b/corehq/apps/couch_sql_migration/diffrule.py
@@ -12,7 +12,19 @@ class AnyType:
     __hash__ = None
 
 
+class NotDeletedType:
+
+    def __eq__(self, other):
+        return not other.endswith("-Deleted")
+
+    def __repr__(self):
+        return "NOT_DELETED"
+
+    __hash__ = None
+
+
 ANY = AnyType()
+NOT_DELETED = NotDeletedType()
 
 
 @attr.s

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -85,7 +85,7 @@ from corehq.util.test_utils import (
 from .. import casedifftool
 from .. import couchsqlmigration as mod
 from ..asyncforms import get_case_ids
-from ..diffrule import ANY
+from ..diffrule import ANY, NOT_DELETED
 from ..management.commands.migrate_domain_from_couch_to_sql import (
     CACHED,
     COMMIT,
@@ -1957,7 +1957,7 @@ class Diff:
     path = attr.ib(default=ANY)
     old = attr.ib(default=ANY)
     new = attr.ib(default=ANY)
-    kind = attr.ib(default=ANY)
+    kind = attr.ib(default=NOT_DELETED)
     reason = attr.ib(default=ANY)
     __hash__ = None
 


### PR DESCRIPTION
## Summary

:tropical_fish: Review by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Tests were added for each edge-case/fix except for the gevent/threading issue, which was tested manually since it seems quite difficult to write an automated test for that.

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
