### PR TITLE
remove "local install" route and related code from web apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -105,7 +105,6 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
                     "menu_session_id": params.sessionId,
                     "force_manual_action": params.forceManualAction,
                     "query_data": params.queryData,
-                    "installReference": params.installReference,
                     "oneQuestionPerScreen": displayOptions.oneQuestionPerScreen,
                     "isPersistent": params.isPersistent,
                     "useLiveQuery": user.useLiveQuery,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -8,7 +8,6 @@ hqDefine("cloudcare/js/formplayer/router", function () {
             "home/:id": "landingPageApp", // Show app in landing page mode (LandingPageAppView)
             "sessions": "listSessions", //list all this user's current sessions (incomplete forms)
             "sessions/:id": "getSession",
-            "local/:path": "localInstall",
             "restore_as/:page/:query": "listUsers",
             "restore_as/:page/": "listUsers",
             "restore_as": "listUsers",
@@ -74,9 +73,6 @@ hqDefine("cloudcare/js/formplayer/router", function () {
         },
         getSession: function (sessionId) {
             FormplayerFrontend.getChannel().request("getSession", sessionId);
-        },
-        localInstall: function (path) {
-            FormplayerFrontend.trigger("localInstall", path);
         },
         /**
          * renderResponse
@@ -226,14 +222,6 @@ hqDefine("cloudcare/js/formplayer/router", function () {
             'steps': urlObject.steps,
         };
         hqImport("cloudcare/js/formplayer/menus/controller").selectMenu(options);
-    });
-
-    FormplayerFrontend.on("localInstall", function (path) {
-        var urlObject = new Util.CloudcareUrl({
-            'installReference': path,
-        });
-        Util.setUrlToObject(urlObject);
-        hqImport("cloudcare/js/formplayer/menus/controller").selectMenu(urlObject);
     });
 
     return {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -47,7 +47,7 @@ hqDefine("cloudcare/js/formplayer/router", function () {
             var urlObject = Util.CloudcareUrl.fromJson(
                 Util.encodedUrlToObject(sessionObject || Backbone.history.getFragment())
             );
-            if (!urlObject.appId && !urlObject.installReference) {
+            if (!urlObject.appId) {
                 // We can't do any menu navigation without an appId
                 FormplayerFrontend.trigger("apps:list");
             } else {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -154,7 +154,6 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
         this.search = options.search;
         this.queryData = options.queryData;
         this.singleApp = options.singleApp;
-        this.installReference = options.installReference;
         this.sortIndex = options.sortIndex;
         this.forceManualAction = options.forceManualAction;
 
@@ -246,7 +245,6 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             search: self.search,
             queryData: self.queryData || {},    // formplayer can't handle a null
             singleApp: self.singleApp,
-            installReference: self.installReference,
             sortIndex: self.sortIndex,
             forceManualAction: self.forceManualAction,
         };
@@ -264,7 +262,6 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             'search': data.search,
             'queryData': data.queryData,
             'singleApp': data.singleApp,
-            'installReference': data.installReference,
             'sortIndex': data.sortIndex,
             'forceManualAction': data.forceManualAction,
         };


### PR DESCRIPTION
## Summary
As far as I can tell this is never used but can still be called by adjusting the URL. I've examined the code and don't see any usages of the route. I also verified that the corresponding route on Formplayer has not been called in the past month.

Allowing 'local install' poses a [security risk](https://docs.google.com/document/d/13mAWSnp6Y1l-O90mJglxiA7eBUSSMoBt5t3jyViwGfU/edit).


## Safety Assurance
- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
I don't think is any coverage for this.

### QA Plan
Can QA this on staging using the regression test plan along with the associated Formplayer PR.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
