### PR TITLE
Fix submission time in worker activity reports

### DIFF
--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -47,14 +47,14 @@ def get_last_submission_time_for_users(domain, user_ids, datespan, es_instance_a
         FormES(es_instance_alias=es_instance_alias)
         .domain(domain)
         .user_id(user_ids)
-        .completed(gte=datespan.startdate.date(), lte=datespan.enddate.date())
+        .submitted(gte=datespan.startdate.date(), lte=datespan.enddate.date())
         .aggregation(
             TermsAggregation('user_id', 'form.meta.userID').aggregation(
                 TopHitsAggregation(
                     'top_hits_last_form_submissions',
-                    'form.meta.timeEnd',
+                    'received_on',
                     is_ascending=False,
-                    include='form.meta.timeEnd',
+                    include='received_on',
                 )
             )
         )
@@ -65,7 +65,7 @@ def get_last_submission_time_for_users(domain, user_ids, datespan, es_instance_a
     buckets_dict = aggregations.user_id.buckets_dict
     result = {}
     for user_id, bucket in buckets_dict.items():
-        result[user_id] = convert_to_date(bucket.top_hits_last_form_submissions.hits[0]['form']['meta']['timeEnd'])
+        result[user_id] = convert_to_date(bucket.top_hits_last_form_submissions.hits[0]['received_on'])
     return result
 
 

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -348,7 +348,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         start = datetime(2013, 7, 1)
         end = datetime(2013, 7, 30)
 
-        self._send_form_to_es(completion_time=datetime(2013, 7, 2))
+        self._send_form_to_es(received_on=datetime(2013, 7, 2))
 
         results = get_last_submission_time_for_users(self.domain, ['cruella_deville'], DateSpan(start, end))
         self.assertEqual(results['cruella_deville'], datetime(2013, 7, 2).date())


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-11619

In Work Activity Reports we were showing Form Completion Time instead of Form Submission Time in `Last Form Submission` column.
The PR fixes that to show Form submission time. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Updated the tests that tests the change.
<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested on local and staging and updated tests for the same.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
