### PR TITLE
Add catch for ValidationError for add_hq_user_id_to_case

### DIFF
--- a/custom/covid/management/commands/add_hq_user_id_to_case.py
+++ b/custom/covid/management/commands/add_hq_user_id_to_case.py
@@ -32,11 +32,11 @@ class Command(CaseUpdateCommand):
         for case in accessor.iter_cases(case_ids):
             username_of_associated_mobile_workers = case.get_case_property('username')
             try:
-                user_id_of_mobile_worker = username_to_user_id(normalize_username(
-                    username_of_associated_mobile_workers, domain))
+                normalized_username = normalize_username(username_of_associated_mobile_workers, domain)
             except ValidationError:
                 skip_count += 1
                 continue
+            user_id_of_mobile_worker = username_to_user_id(normalized_username)
             if user_id_of_mobile_worker:
                 case_blocks.append(self.case_block(case, user_id_of_mobile_worker))
             else:

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -66,6 +66,10 @@ class CaseCommandsTest(TestCase):
             True, checkin_case_id, user_id=user_id, case_type='checkin',
             update={"username": new_mobile_worker.raw_username, "hq_user_id": None}
         )
+        checkin_case_no_username_id = uuid.uuid4().hex
+        self.submit_case_block(
+            True, checkin_case_no_username_id, user_id=user_id, case_type='checkin', update={"hq_user_id": None}
+        )
         lab_result_case_id = uuid.uuid4().hex
         self.submit_case_block(
             True, lab_result_case_id, user_id=user_id, case_type='lab_result',
@@ -78,8 +82,10 @@ class CaseCommandsTest(TestCase):
         call_command('add_hq_user_id_to_case', self.domain, 'checkin')
 
         checkin_case = self.case_accessor.get_case(checkin_case_id)
+        checkin_case_no_username = self.case_accessor.get_case(checkin_case_no_username_id)
         lab_result_case = self.case_accessor.get_case(lab_result_case_id)
         self.assertEqual(checkin_case.get_case_property('hq_user_id'), user_id)
+        self.assertEqual(checkin_case_no_username.hq_user_id, '')
         self.assertEqual(lab_result_case.hq_user_id, '')
 
     def test_update_case_index_relationship(self):


### PR DESCRIPTION
## Summary
When running on test domains, there was an instance where the command failed because the username was `None`. This fix will now let it just skip that case and move on without failing the command. An `if` statement was in place in case `username_to_user_id` returned `None`, but not covering the ValidationError called in `normalize_username`

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
I updated the `test_add_hq_user_id_to_case` test in `test_management_commands.py` to include the case of a username = `None`

### QA Plan
I am not requesting QA

### Safety story
This will be rerun on the test domains prior to the big run.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
