### PR TITLE
OpenMRS Repeater cleanup

### DIFF
--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -400,7 +400,7 @@ def find_or_create_patient(requests, domain, info, openmrs_config):
         return patient
 
 
-def get_patient(requests, domain, info, openmrs_config):
+def get_patient(requests, info, openmrs_config):
     for id_ in openmrs_config.case_config.match_on_ids:
         identifier_config: JsonDict = openmrs_config.case_config.patient_identifiers[id_]
         identifier_case_property = identifier_config["case_property"]
@@ -412,9 +412,9 @@ def get_patient(requests, domain, info, openmrs_config):
                 # The patient associated with the case has been merged with
                 # another patient in OpenMRS, or deleted. Delete the OpenMRS
                 # identifier on the case, and try again.
-                delete_case_property(domain, info.case_id, identifier_case_property)
+                delete_case_property(info.domain, info.case_id, identifier_case_property)
                 info.extra_fields[identifier_case_property] = None
-                return get_patient(requests, domain, info, openmrs_config)
+                return get_patient(requests, info, openmrs_config)
             return patient
 
     # Definitive IDs did not match a patient in OpenMRS.

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -237,7 +237,7 @@ def send_openmrs_data(requests, domain, form_json, openmrs_config, case_trigger_
     for info in case_trigger_infos:
         assert isinstance(info, CaseTriggerInfo)
         try:
-            patient = get_patient(requests, domain, info, openmrs_config)
+            patient = get_patient(requests, info, openmrs_config)
         except (RequestException, HTTPError) as err:
             errors.append(_(
                 "Unable to create an OpenMRS patient for case "

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -206,8 +206,6 @@ class OpenmrsRepeater(CaseRepeater):
         try:
             response = send_openmrs_data(
                 requests,
-                self.domain,
-                payload,
                 self.openmrs_config,
                 case_trigger_infos,
             )
@@ -217,7 +215,7 @@ class OpenmrsRepeater(CaseRepeater):
         return response
 
 
-def send_openmrs_data(requests, domain, form_json, openmrs_config, case_trigger_infos):
+def send_openmrs_data(requests, openmrs_config, case_trigger_infos):
     """
     Updates an OpenMRS patient and (optionally) creates visits.
 
@@ -277,7 +275,7 @@ def send_openmrs_data(requests, domain, form_json, openmrs_config, case_trigger_
             )
         workflow.append(
             CreateVisitsEncountersObsTask(
-                requests, info, form_json, openmrs_config, patient['person']['uuid']
+                requests, info, openmrs_config, patient['person']['uuid']
             ),
         )
 

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -277,7 +277,7 @@ def send_openmrs_data(requests, domain, form_json, openmrs_config, case_trigger_
             )
         workflow.append(
             CreateVisitsEncountersObsTask(
-                requests, domain, info, form_json, openmrs_config, patient['person']['uuid']
+                requests, info, form_json, openmrs_config, patient['person']['uuid']
             ),
         )
 

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -710,7 +710,7 @@ class VoidedPatientTests(TestCase, TestFileMixin):
         voided_patient = self.get_json("voided_patient")
         get_patient_mock.return_value = voided_patient
 
-        patient = get_patient(requests, DOMAIN, info, openmrs_config)
+        patient = get_patient(requests, info, openmrs_config)
 
         self.assertEqual(info.extra_fields, {"external_id": None})
         case_block_re = strip_xml(f"""

--- a/corehq/motech/openmrs/tests/test_workflow_tasks.py
+++ b/corehq/motech/openmrs/tests/test_workflow_tasks.py
@@ -237,7 +237,6 @@ def get_form_config_dict():
 def get_task(info, form_json, form_config_dict):
     return CreateVisitsEncountersObsTask(
         requests=None,
-        domain="test-domain",
         info=info,
         form_json=form_json,
         openmrs_config=OpenmrsConfig.wrap({

--- a/corehq/motech/openmrs/tests/test_workflow_tasks.py
+++ b/corehq/motech/openmrs/tests/test_workflow_tasks.py
@@ -11,7 +11,10 @@ from corehq.motech.openmrs.workflow_tasks import (
     CreateVisitsEncountersObsTask,
     get_values_for_concept,
 )
-from corehq.motech.value_source import CaseTriggerInfo
+from corehq.motech.value_source import (
+    CaseTriggerInfo,
+    get_form_question_values,
+)
 
 
 def test_concept_directions():
@@ -27,12 +30,9 @@ def test_concept_directions():
     info = CaseTriggerInfo(
         domain="test-domain",
         case_id="c0ffee",
-        form_question_values={
-            "/data/pneumonia": "no",
-            "/data/malnutrition": "no",
-        }
+        form_question_values=get_form_question_values(form_json),
     )
-    task = get_task(info, form_json, form_config_dict)
+    task = get_task(info, form_config_dict)
     values_for_concepts = get_values_for_concept(form_config, task.info)
     eq(values_for_concepts, {
         # "direction": "out"
@@ -59,12 +59,9 @@ def test_start_stop_datetime_export():
     info = CaseTriggerInfo(
         domain="test-domain",
         case_id="c0ffee",
-        form_question_values={
-            "/data/visit_datetime": "2018-01-01T12:00:00.00000Z",
-            "/metadata/timeEnd": "2019-12-16T12:36:00.00000Z",
-        }
+        form_question_values=get_form_question_values(form_json),
     )
-    task = get_task(info, form_json, form_config_dict)
+    task = get_task(info, form_config_dict)
     start_datetime, stop_datetime = task._get_start_stop_datetime(
         OpenmrsFormConfig.wrap(form_config_dict)
     )
@@ -87,8 +84,12 @@ def test_start_stop_datetime_import():
             "meta": {"timeEnd": "2019-12-16T12:36:00.00000Z"},
         }
     }
-    info = CaseTriggerInfo(domain="test-domain", case_id="c0ffee")
-    task = get_task(info, form_json, form_config_dict)
+    info = CaseTriggerInfo(
+        domain="test-domain",
+        case_id="c0ffee",
+        form_question_values=get_form_question_values(form_json),
+    )
+    task = get_task(info, form_config_dict)
     start_datetime, stop_datetime = task._get_start_stop_datetime(
         OpenmrsFormConfig.wrap(form_config_dict)
     )
@@ -234,11 +235,10 @@ def get_form_config_dict():
     }
 
 
-def get_task(info, form_json, form_config_dict):
+def get_task(info, form_config_dict):
     return CreateVisitsEncountersObsTask(
         requests=None,
         info=info,
-        form_json=form_json,
         openmrs_config=OpenmrsConfig.wrap({
             "case_config": {},
             "form_configs": [form_config_dict],

--- a/corehq/motech/openmrs/workflow_tasks.py
+++ b/corehq/motech/openmrs/workflow_tasks.py
@@ -125,11 +125,9 @@ class SyncPatientIdentifiersTask(WorkflowTask):
 
 class CreateVisitsEncountersObsTask(WorkflowTask):
 
-    def __init__(self, requests, domain, info, form_json, openmrs_config, person_uuid):
+    def __init__(self, requests, info, openmrs_config, person_uuid):
         self.requests = requests
-        self.domain = domain
         self.info = info
-        self.form_json = form_json
         self.openmrs_config = openmrs_config
         self.person_uuid = person_uuid
 
@@ -162,7 +160,8 @@ class CreateVisitsEncountersObsTask(WorkflowTask):
                 start_datetime = value_source.serialize(cc_start_datetime)
                 stop_datetime = value_source.serialize(cc_stop_datetime)
                 return start_datetime, stop_datetime
-        cc_start_datetime = string_to_utc_datetime(self.form_json['form']['meta']['timeEnd'])
+        cc_start_datetime = string_to_utc_datetime(
+            self.info.form_question_values['/metadata/timeEnd'])
         cc_stop_datetime = cc_start_datetime + timedelta(days=1) - timedelta(seconds=1)
         start_datetime = to_omrs_datetime(cc_start_datetime)
         stop_datetime = to_omrs_datetime(cc_stop_datetime)
@@ -182,7 +181,7 @@ class CreateVisitsEncountersObsTask(WorkflowTask):
             # Location". Use that, if it exists.
         )
         for form_config in self.openmrs_config.form_configs:
-            if form_config.xmlns == self.form_json['form']['@xmlns']:
+            if form_config.xmlns == self.info.form_question_values['/metadata/xmlns']:
                 start_datetime, stop_datetime = self._get_start_stop_datetime(form_config)
                 subtasks.append(
                     CreateOptionalVisitTask(


### PR DESCRIPTION
## Summary

Cleans up unnecessary parameters around OpenmrsRepeater. 

Easier to review by commit. :blowfish: 

## Feature Flag

"OpenMRS Integration"


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Automated test coverage

This change is covered by tests.

Changes include modifying tests to use `get_form_question_values()` to reflect the behaviour of the code under the change.


### Safety story

* Changes are covered by tests.
* Only affects OpenMRS data forwarding, not all repeaters.
* If anything goes wrong, payloads will be resent if the change is reverted within 5 days.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
