### PR TITLE
Bump known good version of DHIS2

### DIFF
--- a/corehq/motech/dhis2/const.py
+++ b/corehq/motech/dhis2/const.py
@@ -58,4 +58,4 @@ LOCATION_DHIS_ID = 'dhis_id'
 # (Used for updating cases with their tracked entity instance ID.)
 XMLNS_DHIS2 = 'http://commcarehq.org/dhis2-integration'
 
-DHIS2_MAX_VERSION = "2.33.0"
+DHIS2_MAX_VERSION = "2.35.1"


### PR DESCRIPTION
## Summary

This just bumps the known good version of DHIS2, based on testing with the HMHB project.

To deal with this proactively, we need to create a comprehensive test suite. The Jira ticket for that is here: https://dimagi-dev.atlassian.net/browse/SC-1261


## Feature Flag
"DHIS2 integration"


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story

This constant is used for determining whether to send a warning notification when we integrate with versions of DHIS2 higher than its value. It does not affect any other behaviour.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
