### PR TITLE
Don't always recreate shadow children

### DIFF
--- a/corehq/apps/app_manager/tests/test_handle_shadow_child_modules.py
+++ b/corehq/apps/app_manager/tests/test_handle_shadow_child_modules.py
@@ -63,9 +63,11 @@ class HandleShadowChildModulesTest(TestCase):
         )
 
         # Calling the command again should not make new modules
+        shadow_child_module_id = app.modules[3].unique_id
         handle_shadow_child_modules(app, app.get_module_by_unique_id(self.shadow_module.unique_id))
         app = Application.get(app.get_id)
         self.assertEqual(len(app.modules), 4)
+        self.assertEqual(app.modules[3].unique_id, shadow_child_module_id)
 
     def test_deletes_module_child_removed(self):
         # Create new module

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -474,20 +474,33 @@ def handle_shadow_child_modules(app, shadow_parent):
         if m.root_module_id == shadow_parent.source_module_id
         and m.module_type != 'shadow'
     ]
+    source_module_children_ids = [
+        source_module_child.unique_id for source_module_child in source_module_children
+    ]
 
     shadow_parent_children = [
         m for m in app.get_modules()
         if m.root_module_id == shadow_parent.unique_id
+    ]  # All the child shadows that already exist
+
+    # Delete child modules that no longer have a source
+    unneeded_module_ids = [
+        child.unique_id for child in shadow_parent_children
+        if child.source_module_id not in source_module_children_ids
     ]
+    for unneeded_module_id in unneeded_module_ids:
+        changes = True
+        app.delete_module(unneeded_module_id)
 
-    # Delete unneeded modules
-    for child in shadow_parent_children:
-        if child.source_module_id not in source_module_children:
-            changes = True
-            app.delete_module(child.unique_id)
-
-    # Add new modules
-    for source_child in source_module_children:
+    # We need to create child modules for those source children that don't have them
+    existing_child_shadow_sources = [
+        child.source_module_id for child in shadow_parent_children
+    ]  # The set of source children ids that already have shadows
+    needed_modules = [
+        source_child for source_child in source_module_children
+        if source_child.unique_id not in existing_child_shadow_sources
+    ]
+    for source_child in needed_modules:
         changes = True
         new_shadow = ShadowModule.new_module(source_child.default_name(app=app), app.default_language)
         new_shadow.source_module_id = source_child.unique_id


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-695
Whenever there was a change to a source module, we would delete and recreate the child, leading to any configuration in the new children to be deleted. Now we only delete modules that no longer have a source, and create those modules that need to be created. 

I'm a bit surprised this wasn't caught during initial QA, although this feature is a bit esoteric. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Shadow modules

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This area of code is reasonably well tested, and I've done a bunch of clicking around to ensure this hasn't changed the core behaviour of this. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
