### PR TITLE
Final step to make run_all_management_command use gevent

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -29,6 +29,7 @@ def main():
         GeventCommand('migrate_multiple_domains_from_couch_to_sql', http_adapter_pool_size=32),
         GeventCommand('run_aggregation_query'),
         GeventCommand('send_pillow_retry_queue_through_pillows'),
+        GeventCommand('run_all_management_command'),
     )
     _patch_gevent_if_required(sys.argv, GEVENT_COMMANDS)
 


### PR DESCRIPTION
## Summary
This part needs to be added so [run_all_management_command](https://github.com/dimagi/commcare-hq/blob/master/custom/covid/management/commands/run_all_management_command.py) actually runs as we want it to. 

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan
I am not requesting QA

### Safety story
It will run this on test domains.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
