### PR TITLE
Added flag to disable web apps

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -752,6 +752,13 @@ USH_DONT_CLOSE_PATIENT_EXTENSIONS = StaticToggle(
     """
 )
 
+DISABLE_WEB_APPS = StaticToggle(
+    'disable_web_apps',
+    'Disable access to Web Apps UI',
+    TAG_INTERNAL,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
 ROLE_WEBAPPS_PERMISSIONS = StaticToggle(
     'role_webapps_permissions',
     'ICDS: Toggle which webapps to see based on role',


### PR DESCRIPTION
## Summary
Adds a flag to turn off web apps by domain:

* Adds check to cloudcare views
* To block users who are already using web apps, since changing the feature flag doesn't take effect until users' next page refresh, there's also a check in the HQ auth request.

This isn't especially graceful. Users get a plain black and white "Service unavailable" message if they navigate to web apps, and they get a "Cannot connect to formplayer" message if the flag gets flipped while they're already working in web apps. But it should be good enough for its purpose, which is to disable access during maintenance that's being performed outside of standard working hours for the projects we're turning off.

FYI @stephherbers 

## Feature Flag
Adds flag "Disable access to Web Apps UI"

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

Not requesting QA.

### Safety story

Code has a small footprint. Tested locally with flag both on and off.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
