### PR TITLE
Made a separate pool for add_assignment_cases in run_management_command

### DIFF
--- a/custom/covid/management/commands/run_all_management_command.py
+++ b/custom/covid/management/commands/run_all_management_command.py
@@ -38,6 +38,7 @@ class Command(BaseCommand):
                     locations.append(row['location2'])
                 location_ids[row['domain']] = locations
 
+        total_jobs = []
         jobs = []
         pool = Pool(20)
         for domain in domains:
@@ -45,11 +46,21 @@ class Command(BaseCommand):
             jobs.append(pool.spawn(run_command, 'add_hq_user_id_to_case', domain, 'checkin'))
             jobs.append(pool.spawn(run_command, 'update_owner_ids', domain, 'investigation'))
             jobs.append(pool.spawn(run_command, 'update_owner_ids', domain, 'checkin'))
-            for location in location_ids[domain]:
-                jobs.append(pool.spawn(run_command, 'add_assignment_cases', domain, 'patient', location=location))
-                jobs.append(pool.spawn(run_command, 'add_assignment_cases', domain, 'contact', location=location))
         pool.join()
-        for job in jobs:
+        total_jobs.extend(jobs)
+
+        jobs = []
+        second_pool = Pool(20)
+        for domain in domains:
+            for location in location_ids[domain]:
+                jobs.append(second_pool.spawn(run_command, 'add_assignment_cases', domain, 'patient',
+                                              location=location))
+                jobs.append(second_pool.spawn(run_command, 'add_assignment_cases', domain, 'contact',
+                                              location=location))
+        pool.join()
+        total_jobs.extend(jobs)
+
+        for job in total_jobs:
             success, command, args, exception = job.get()
             if success:
                 print("SUCCESS: {} command for {}".format(command, args))

--- a/custom/covid/management/commands/run_all_management_command.py
+++ b/custom/covid/management/commands/run_all_management_command.py
@@ -57,7 +57,7 @@ class Command(BaseCommand):
                                               location=location))
                 jobs.append(second_pool.spawn(run_command, 'add_assignment_cases', domain, 'contact',
                                               location=location))
-        pool.join()
+        second_pool.join()
         total_jobs.extend(jobs)
 
         for job in total_jobs:


### PR DESCRIPTION
## Summary
For the scripts listed [here](https://docs.google.com/document/d/1zP-unm0YBrce33-uZJfKCiWnxgxTc7jLDKwMlwypGaE/edit#), script 2 must be run before script 5 so `hq_user_id` for check-in cases is set.

## Product Description
I added a second pool so that `add_assignment_cases` is run after `add_hq_user_id_to_case` for each domain and added `total_jobs` so each of the jobs of the pools can print at the end with the success/failure. The actual running of `add_assignment_cases` is unchanged other than having it performed by the second pool.
## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
I will not be requesting QA.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
