### PR TITLE
clear user data task and management command

### DIFF
--- a/corehq/apps/formplayer_api/management/commands/clear_formplayer_dbs.py
+++ b/corehq/apps/formplayer_api/management/commands/clear_formplayer_dbs.py
@@ -1,5 +1,4 @@
 import inspect
-import inspect
 import sys
 from argparse import RawTextHelpFormatter
 from datetime import datetime
@@ -7,7 +6,9 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from django.core.management.base import BaseCommand
 
-from corehq.apps.formplayer_api.management.commands.prime_formplayer_restores import _get_user_rows, _get_users_from_csv
+from corehq.apps.formplayer_api.management.commands.prime_formplayer_restores import (
+    _get_user_rows, _get_users_from_csv
+)
 from corehq.apps.users.models import CouchUser
 from corehq.util.argparse_types import validate_integer
 from custom.covid.tasks import get_prime_restore_user_params, clear_formplayer_db_for_user
@@ -86,7 +87,10 @@ class Command(BaseCommand):
         else:
             domains = [domain.strip() for domain in domains if domain.strip()]
             synced_since = datetime.utcnow() - relativedelta(hours=last_synced_hours)
-            not_synced_since = datetime.utcnow() - relativedelta(hours=not_synced_hours) if not_synced_hours else None
+            not_synced_since = (
+                datetime.utcnow() - relativedelta(hours=not_synced_hours)
+                if not_synced_hours else None
+            )
             if dry_run_count:
                 users = list(_get_user_rows(domains, synced_since, not_synced_since, None, limit))
                 sys.stderr.write(f"\nMatched {len(users)} users for filters:\n")

--- a/corehq/apps/formplayer_api/management/commands/clear_formplayer_dbs.py
+++ b/corehq/apps/formplayer_api/management/commands/clear_formplayer_dbs.py
@@ -1,0 +1,107 @@
+import inspect
+import inspect
+import sys
+from argparse import RawTextHelpFormatter
+from datetime import datetime
+
+from dateutil.relativedelta import relativedelta
+from django.core.management.base import BaseCommand
+
+from corehq.apps.formplayer_api.management.commands.prime_formplayer_restores import _get_user_rows, _get_users_from_csv
+from corehq.apps.users.models import CouchUser
+from corehq.util.argparse_types import validate_integer
+from custom.covid.tasks import get_prime_restore_user_params, clear_formplayer_db_for_user
+
+
+class Command(BaseCommand):
+    help = inspect.cleandoc(
+        """Call the Formplayer clear-user-data API for users from CSV or matching criteria.
+        Usage:
+
+        Redirect stdout to file to allow viewing progress bar:
+        %(prog)s [args] > output.csv
+
+        ### With users in a CSV file ###
+
+        CSV Columns: "domain, username, as_user"
+
+        %(prog)s --from-csv path/to/users.csv
+
+        ### Query DB for users ###
+
+        %(prog)s --domains a b c --last-synced-days 2 --limit 1000
+
+        Use "--dry-run" and "--dry-run-count" to gauge impact of command.
+        """
+    )
+
+    def create_parser(self, *args, **kwargs):
+        # required to get nice output from `--help`
+        parser = super(Command, self).create_parser(*args, **kwargs)
+        parser.formatter_class = RawTextHelpFormatter
+        return parser
+
+    def add_arguments(self, parser):
+        parser.add_argument('--from-csv',
+                            help='Path to CSV file. Columns "domain, username, as_user". When this is supplied '
+                                 'only users in this file will be synced.')
+
+        parser.add_argument('--domains', nargs='+', help='Match users in these domains.')
+        parser.add_argument('--last-synced-hours', action=validate_integer(gt=0, lt=673), default=48,
+                            help='Match users who have synced within the given window. '
+                                 'Defaults to 48 hours. Max = 472 (4 week).')
+        parser.add_argument('--not-synced-hours', action=validate_integer(gt=0, lt=169),
+                            help='Exclude users who have synced within the given window. '
+                                 'Max = 168 (1 week).')
+
+        parser.add_argument('--limit', action=validate_integer(gt=0), help='Limit the number of users matched.')
+        parser.add_argument('--dry-run', action='store_true', help='Only print the list of users.')
+        parser.add_argument('--dry-run-count', action='store_true', help='Only print the count of matched users.')
+
+    def handle(self,
+               from_csv=None,
+               domains=None,
+               last_synced_hours=None,
+               not_synced_hours=None,
+               limit=None,
+               **options
+               ):
+        dry_run = options['dry_run']
+        dry_run_count = options['dry_run_count']
+
+        if from_csv:
+            users = _get_users_from_csv(from_csv)
+            if dry_run_count:
+                sys.stderr.write(f"\n{len(list(users))} users in CSV file '{from_csv}'\n")
+                return
+
+            for domain, request_user, as_username in users:
+                request_user_id = CouchUser.get_by_username(request_user).user_id
+                as_user_id = None
+                if as_username:
+                    as_user_id = CouchUser.get_by_username(as_username).user_id
+                sys.stdout.write(f"{domain},{request_user},{request_user_id},{as_username},{as_user_id}\n")
+                if not dry_run:
+                    clear_formplayer_db_for_user.delay(domain, request_user_id, as_user_id)
+        else:
+            domains = [domain.strip() for domain in domains if domain.strip()]
+            synced_since = datetime.utcnow() - relativedelta(hours=last_synced_hours)
+            not_synced_since = datetime.utcnow() - relativedelta(hours=not_synced_hours) if not_synced_hours else None
+            if dry_run_count:
+                users = list(_get_user_rows(domains, synced_since, not_synced_since, None, limit))
+                sys.stderr.write(f"\nMatched {len(users)} users for filters:\n")
+                sys.stderr.write(f"\tDomains: {domains or '---'}\n")
+                sys.stderr.write(f"\tSynced after: {synced_since}\n")
+                sys.stderr.write(f"\tNot Synced after: {not_synced_since}\n")
+                sys.stderr.write(f"\tLimit: {limit or '---'}\n")
+                return
+
+            users = _get_user_rows(domains, synced_since, not_synced_since, None, limit)
+
+            for domain, request_user_id, as_user_id in users:
+                request_user, as_username = get_prime_restore_user_params(request_user_id, as_user_id)
+                sys.stdout.write(f"{domain},{request_user},{request_user_id},{as_username},{as_user_id}\n")
+                if not dry_run:
+                    clear_formplayer_db_for_user.delay(
+                        domain, request_user_id, as_user_id
+                    )

--- a/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
+++ b/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
@@ -84,7 +84,7 @@ class Command(BaseCommand):
                 as_user_id = None
                 if as_username:
                     as_user_id = CouchUser.get_by_username(as_username).user_id
-                sys.stdout.write(f"{domain},{request_user},{request_user_id},{as_username},{as_user_id}")
+                sys.stdout.write(f"{domain},{request_user},{request_user_id},{as_username},{as_user_id}\n")
                 if not dry_run:
                     prime_formplayer_db_for_user.delay(
                         domain, request_user_id, as_user_id, clear_data=clear_user_data
@@ -107,7 +107,7 @@ class Command(BaseCommand):
 
             for domain, request_user_id, as_user_id in users:
                 request_user, as_username = get_prime_restore_user_params(request_user_id, as_user_id)
-                sys.stdout.write(f"{domain},{request_user},{request_user_id},{as_username},{as_user_id}")
+                sys.stdout.write(f"{domain},{request_user},{request_user_id},{as_username},{as_user_id}\n")
                 if not dry_run:
                     prime_formplayer_db_for_user.delay(
                         domain, request_user_id, as_user_id, clear_data=clear_user_data

--- a/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
+++ b/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
@@ -92,7 +92,10 @@ class Command(BaseCommand):
         else:
             domains = [domain.strip() for domain in domains if domain.strip()]
             synced_since = datetime.utcnow() - relativedelta(hours=last_synced_hours)
-            not_synced_since = datetime.utcnow() - relativedelta(hours=not_synced_hours) if not_synced_hours else None
+            not_synced_since = (
+                datetime.utcnow() - relativedelta(hours=not_synced_hours)
+                if not_synced_hours else None
+            )
             if dry_run_count:
                 users = list(_get_user_rows(domains, synced_since, not_synced_since, min_cases, limit))
                 sys.stderr.write(f"\nMatched {len(users)} users for filters:\n")

--- a/custom/covid/tasks.py
+++ b/custom/covid/tasks.py
@@ -41,12 +41,12 @@ def prime_formplayer_dbs():
     for domain in domains:
         users = get_users_for_priming(domain, date_window, date_cutoff, MIN_CASE_COUNT)
         for row in users:
-            prime_formplayer_db_for_user.delay(domain, row[0], row[1])
+            prime_formplayer_db_for_user.delay(domain, row[0], row[1], task_cutoff_hour=TASK_WINDOW_CUTOFF_HOUR)
 
 
 @no_result_task(queue='async_restore_queue', max_retries=3, bind=True, rate_limit=RATE_LIMIT)
-def prime_formplayer_db_for_user(self, domain, request_user_id, sync_user_id, clear_data=False):
-    if datetime.utcnow().hour >= TASK_WINDOW_CUTOFF_HOUR:
+def prime_formplayer_db_for_user(self, domain, request_user_id, sync_user_id, clear_data=False, task_cutoff_hour=None):
+    if task_cutoff_hour and datetime.utcnow().hour >= task_cutoff_hour:
         return
 
     request_user, as_username = get_prime_restore_user_params(request_user_id, sync_user_id)

--- a/custom/covid/tasks.py
+++ b/custom/covid/tasks.py
@@ -45,7 +45,8 @@ def prime_formplayer_dbs():
 
 
 @no_result_task(queue='async_restore_queue', max_retries=3, bind=True, rate_limit=RATE_LIMIT)
-def prime_formplayer_db_for_user(self, domain, request_user_id, sync_user_id, clear_data=False, task_cutoff_hour=None):
+def prime_formplayer_db_for_user(self, domain, request_user_id, sync_user_id,
+                                 clear_data=False, task_cutoff_hour=None):
     if task_cutoff_hour and datetime.utcnow().hour >= task_cutoff_hour:
         return
 


### PR DESCRIPTION
## Summary
Add a separate task and management command to clear user data for users on formplayer. This will be used to reduce the impact on user experience from the USH migration effort.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
