### PR TITLE
Checks is current_status is 'closed' for add_assingment_cases

### DIFF
--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -55,7 +55,7 @@ class Command(CaseUpdateCommand):
         case_blocks = []
         skip_count = 0
         for case in accessor.iter_cases(case_ids):
-            if case.closed:
+            if case.get_case_property('current_status') == 'closed':
                 skip_count += 1
             elif needs_update(case):
                 new_owner_id = find_owner_id(case, accessor)


### PR DESCRIPTION
## Summary
We want to specifically look at the `current_status` case property for patient and contact cases and skip if that is equal to closed. 

## Product Description
This change will miss the next big test run, so not needed immediately, but hopefully by EOD Tuesday (2/16)

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
This command has test coverage in `run_all_managment_commands.py`

### QA Plan
I am not requesting QA

### Safety story
This will be tested on test domains before the real deal

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
