### PR TITLE
Allow showing labels and ids at the same time

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/summary/models.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/models.js
@@ -228,14 +228,18 @@ hqDefine('app_manager/js/summary/models',[
 
         // Handling of id/label switcher
         self.showLabels = ko.observable(true);
-        self.showIds = ko.computed(function () {
-            return !self.showLabels();
-        });
-        self.turnLabelsOn = function () {
-            self.showLabels(true);
+        self.showIds = ko.observable(false);
+        self.toggleLabels = function () {
+            if (self.showLabels() && !self.showIds()) {
+                self.showIds(true);
+            }
+            self.showLabels(!self.showLabels());
         };
-        self.turnIdsOn = function () {
-            self.showLabels(false);
+        self.toggleIds = function () {
+            if (self.showIds() && !self.showLabels()) {
+                self.showLabels(true);
+            }
+            self.showIds(!self.showIds());
         };
 
         // App diff controls
@@ -275,6 +279,19 @@ hqDefine('app_manager/js/summary/models',[
             return question.label;  // hidden values don't have translations
         };
 
+        self.questionLabel = function (question) {
+            var text = "";
+            if (self.showLabels()) {
+                text += self.translateQuestion(question);
+            }
+            if (self.showLabels() && self.showIds()) {
+                text += " ";
+            }
+            if (self.showIds()) {
+                text += question.value;
+            }
+            return text;
+        };
         // Create "module -> form" link/text markup
         self.formNameMap = options.form_name_map;
         self.readOnly = options.read_only;

--- a/corehq/apps/app_manager/templates/app_manager/base_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/base_summary.html
@@ -139,10 +139,10 @@
   {# Question label/id switcher #}
   <script type="text/html" id="label-id-toggle">
     <div class="btn-group btn-group-separated" role="group" >
-      <button type="button" class="btn btn-default" data-bind="click: turnLabelsOn, css: { 'active': showLabels }">
+      <button type="button" class="btn btn-default" data-bind="click: toggleLabels, css: { 'active': showLabels }">
         {% trans "Labels" %}
       </button>
-      <button type="button" class="btn btn-default" data-bind="click: turnIdsOn, css: { 'active': showIds }">
+      <button type="button" class="btn btn-default" data-bind="click: toggleIds, css: { 'active': showIds }">
         {% trans "Question IDs" %}
       </button>
     </div>

--- a/corehq/apps/app_manager/templates/app_manager/form_summary_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_summary_base.html
@@ -98,10 +98,10 @@
     <span data-bind="css: getDiffClass('type'), popover: getDiffPopover(changes['type'], 'type')">
       <i data-bind="attr: { 'class': $root.questionIcon($data) }"></i>
       <!-- ko ifnot: $root.readOnly -->
-      <a data-bind="attr: { 'href': $parents[$parents.length - 3].url + hashtagValue }, css: getDiffClass('translations'), text: $root.showIds() ? value :  $root.translateQuestion($data), popover: getDiffPopover(changes['translations'], 'translations')" target="_blank"></a>
-      <!-- /ko  -->
+      <a data-bind="attr: { 'href': $parents[$parents.length - 3].url + hashtagValue }, css: getDiffClass('translations'), text: $root.questionLabel($data), popover: getDiffPopover(changes['translations'], 'translations')" target="_blank"></a>
+      <!-- /ko -->
       <!-- ko if: $root.readOnly -->
-      <span data-bind="text: $root.showIds() ? value :  $root.translateQuestion($data), css: getDiffClass('translations'), popover: getDiffPopover(changes['translations'], 'translations')"></span>
+      <span data-bind="text: $root.questionLabel($data), css: getDiffClass('translations'), popover: getDiffPopover(changes['translations'], 'translations')"></span>
       <!-- /ko -->
       <!-- ko if: required -->
       <sup class="text-muted" data-bind="css: getDiffClass('required'), popover: getDiffPopover(changes['required'], 'required')">{% trans "required" %}</sup>
@@ -174,11 +174,8 @@
     <!-- /ko -->
     <!-- ko if: options.length -->
     <ol data-bind="foreach: options ">
-      <li data-bind="visible: $root.showIds">
-        <span data-bind="text: value, css: $parent.getOptionsDiffClass(value), popover: $parent.getDiffPopover($parent.changes['options'][value], 'options')"></span>
-      </li>
-      <li data-bind="visible: $root.showLabels">
-        <span data-bind="text: $root.translateQuestion($data), css: $parent.getOptionsDiffClass(value), popover: $parent.getDiffPopover($parent.changes['options'][value], 'options')"></span>
+      <li>
+        <span data-bind="text: $root.questionLabel($data), css: $parent.getOptionsDiffClass(value), popover: $parent.getDiffPopover($parent.changes['options'][value], 'options')"></span>
       </li>
     </ol>
     <!-- /ko -->

--- a/corehq/apps/app_manager/templates/app_manager/partials/load_save_questions.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/load_save_questions.html
@@ -1,10 +1,10 @@
 <ul class="fa-ul" data-bind="foreach: {{ questions }}"><!-- Each of these is an object containing a condition and a question -->
   <li>
     <i data-bind="attr: {'class': $root.questionIcon(question)}"></i>
-    <!-- ko text: $root.showIds() ? question.value :  $root.translateQuestion(question) --><!-- /ko -->
+    <!-- ko text: $root.questionLabel(question)  --><!-- /ko -->
     <!-- ko if: question.options -->
     <ul data-bind="foreach: question.options">
-      <li data-bind="text: $root.showIds() ? value :  $root.translateQuestion($data)"></li>
+      <li data-bind="text: $root.questionLabel($data)"></li>
     </ul>
     <!-- /ko -->
     <!-- ko if: condition || question.calculate -->


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
From this [doc](https://docs.google.com/document/d/1Lp7iIo1mly-a5ARnx2TWLLWRESXQsL9UajjPnUA_mgg/edit#heading=h.t3p7kgv4wogf), the biggest recommendation was to show both question labels and question ids at the same time. 

Here's a 🎁 

![Peek 2021-02-16 14-39](https://user-images.githubusercontent.com/146896/108112937-cfc88e80-7064-11eb-9c28-c828eeebf65d.gif)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
In the form and case summaries and the app diff tool clicking the "question ID" and "label" buttons will now show either, or both, at the same time. 

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
I clicked around extensively. This is all javascript / html changes. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
