### PR TITLE
Ce/multi upload

### DIFF
--- a/corehq/apps/user_importer/tasks.py
+++ b/corehq/apps/user_importer/tasks.py
@@ -87,5 +87,5 @@ def parallel_user_import(domain, user_specs, group_specs, upload_user):
                 subtask.get(timeout=1, disable_sync_subtasks=False)
             except TimeoutError:
                 incomplete = True
-            subtask_progress = get_task_progress(subtask).current or 0
-            DownloadBase.set_progress(task, subtask_progress, total)
+            subtask_progress += get_task_progress(subtask).current or 0
+        DownloadBase.set_progress(task, subtask_progress, total)

--- a/corehq/apps/user_importer/tasks.py
+++ b/corehq/apps/user_importer/tasks.py
@@ -87,5 +87,24 @@ def parallel_user_import(domain, user_specs, group_specs, upload_user):
                 subtask.get(timeout=1, disable_sync_subtasks=False)
             except TimeoutError:
                 incomplete = True
-            subtask_progress += get_task_progress(subtask).current or 0
+                subtask_progress += get_task_progress(subtask).current or 0
+            else:
+                # The task is done, just count the rows in the result
+                subtask_progress += len(subtask.result['messages']['rows'])
         DownloadBase.set_progress(task, subtask_progress, total)
+
+    # all tasks are done, collect results
+    rows = []
+    errors = []
+    for subtask in task_list:
+        rows.extend(subtask.result['messages']['rows'])
+        errors.extend(subtask.result['messages']['errors'])
+
+    messages = {
+        'rows': rows,
+        'errors': errors
+    }
+
+    return {
+        'messages': messages
+    }

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1077,8 +1077,8 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
             )
         else:
             upload_record = UserUploadRecord(
-                domain=domain,
-                user_id=upload_user.user_id
+                domain=self.domain,
+                user_id=request.couch_user.user_id
             )
             upload_record.save()
 

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -31,7 +31,6 @@ from django_prbac.exceptions import PermissionDenied
 from django_prbac.utils import has_privilege
 from djng.views.mixins import JSONResponseMixin, allow_remote_invocation
 from memoized import memoized
-from celery import group
 
 from casexml.apps.phone.models import SyncLogSQL
 from couchexport.models import Format

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1068,10 +1068,16 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
 
         task_ref = expose_cached_download(payload=None, expiry=1 * 60 * 60, file_extension=None)
         if PARALLEL_USER_IMPORTS.enabled(self.domain):
+            if list(self.group_specs):
+                messages.error(
+                    request,
+                    _("Groups are not allowed with parallel user import. Please upload them separately")
+                )
+                return HttpResponseRedirect(reverse(UploadCommCareUsers.urlname, args=[self.domain]))
+
             task = parallel_user_import.delay(
                 self.domain,
                 list(self.user_specs),
-                list(self.group_specs),
                 request.couch_user
             )
         else:

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1930,6 +1930,13 @@ GAEN_OTP_SERVER = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN]
 )
 
+PARALLEL_USER_IMPORTS = StaticToggle(
+    'parallel_user_imports',
+    'COVID: Process user imports in parallel on a dedicated queue',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN]
+)
+
 RESTRICT_LOGIN_AS = StaticToggle(
     'restrict_login_as',
     'COVID: Limit allowed users for login as',


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This allows user imports to happen in parallel in a dedicated queue with a specific feature flag. It is mostly so USH can do a giant import very quickly later this week, but it could also be useful in segregating the load from their user imports if we want to leave it in place.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
PARALLEL_USER_IMPORTS

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Everything new is behind a flag.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
