### PR TITLE
use a dedicated queue for formplayer DB priming & combine with user import tasks

### DIFF
--- a/corehq/apps/user_importer/tasks.py
+++ b/corehq/apps/user_importer/tasks.py
@@ -54,13 +54,13 @@ def import_users_and_groups(domain, user_specs, group_specs, upload_user, upload
     }
 
 
-@task(serializer='pickle', queue='user_import_queue')
+@task(serializer='pickle', queue='ush_background_tasks')
 def parallel_import_task(domain, user_specs, group_specs, upload_user, upload_record_id):
     task = parallel_import_task
     return import_users_and_groups(domain, user_specs, group_specs, upload_user, upload_record_id, task)
 
 
-@task(serializer='pickle', queue='user_import_queue')
+@task(serializer='pickle', queue='ush_background_tasks')
 def parallel_user_import(domain, user_specs, upload_user):
     task = parallel_user_import
     total = len(user_specs)

--- a/custom/covid/tasks.py
+++ b/custom/covid/tasks.py
@@ -33,7 +33,7 @@ MIN_CASE_COUNT = 20000
 TASK_WINDOW_CUTOFF_HOUR = 11
 
 
-@periodic_task(run_every=crontab(minute=0, hour=8), queue=settings.CELERY_PERIODIC_QUEUE)
+@periodic_task(run_every=crontab(minute=0, hour=8), queue='ush_background_tasks')
 def prime_formplayer_dbs():
     domains = PRIME_FORMPLAYER_DBS.get_enabled_domains()
     date_window = datetime.utcnow() - relativedelta(hours=SYNC_WINDOW_HOURS)
@@ -44,7 +44,7 @@ def prime_formplayer_dbs():
             prime_formplayer_db_for_user.delay(domain, row[0], row[1], task_cutoff_hour=TASK_WINDOW_CUTOFF_HOUR)
 
 
-@no_result_task(queue='async_restore_queue', max_retries=3, bind=True, rate_limit=RATE_LIMIT)
+@no_result_task(queue='ush_background_tasks', max_retries=3, bind=True, rate_limit=RATE_LIMIT)
 def prime_formplayer_db_for_user(self, domain, request_user_id, sync_user_id,
                                  clear_data=False, task_cutoff_hour=None):
     if task_cutoff_hour and datetime.utcnow().hour >= task_cutoff_hour:
@@ -76,7 +76,7 @@ def prime_formplayer_db_for_user(self, domain, request_user_id, sync_user_id,
         metrics_counter("commcare.prime_formplayer_db.success", tags=metric_tags)
 
 
-@no_result_task(queue='async_restore_queue', max_retries=3, bind=True)
+@no_result_task(queue='ush_background_tasks', max_retries=3, bind=True)
 def clear_formplayer_db_for_user(self, domain, request_user_id, sync_user_id):
     request_user, as_username = get_prime_restore_user_params(request_user_id, sync_user_id)
 


### PR DESCRIPTION
## Summary
I've created a separate queue for the USH background tasks which at present are:
* prime / clear formplayer user data
* parallel user import

Since I don't expect these to be running at the same time it should be fine to share the same queue.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions

- [ ] This PR can be reverted after deploy with no further considerations 

This can safely be rolled back provided the `user_import_queue` has not been removed from production.
