### PR TITLE
Added "inactive" optional argument for update_case_index_relationship command

### DIFF
--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -46,11 +46,12 @@ class Command(CaseUpdateCommand):
 
     def update_cases(self, domain, case_type, user_id):
         accessor = CaseAccessors(domain)
-        if self.location is None:
+        location_id = self.extra_options['location']
+        if location_id is None:
             case_ids = []
             print("Warning: no active location was entered")
         else:
-            case_ids = accessor.get_open_case_ids_in_domain_by_type(case_type, owner_ids=[self.location])
+            case_ids = accessor.get_open_case_ids_in_domain_by_type(case_type, owner_ids=[location_id])
 
         case_blocks = []
         skip_count = 0

--- a/custom/covid/management/commands/run_all_management_command.py
+++ b/custom/covid/management/commands/run_all_management_command.py
@@ -8,12 +8,14 @@ from django.core.management import call_command
 DEVICE_ID = __name__ + ".run_all_management_command"
 
 
-def run_command(command, *args, location=None):
+def run_command(command, *args, location=None, inactive_location=None):
     try:
         if location is None:
             call_command(command, *args)
-        else:
+        if inactive_location is None:
             call_command(command, *args, location=location)
+        else:
+            call_command(command, *args, location=location, inactive_location=inactive_location)
     except Exception as e:
         return False, command, args, e
     return True, command, args, None

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -51,11 +51,11 @@ class Command(CaseUpdateCommand):
         ).as_xml(), encoding='utf-8').decode('utf-8')
 
     def update_cases(self, domain, case_type, user_id):
-        inactive_location = self.inactive_location
+        inactive_location = self.extra_options['inactive_location']
         accessor = CaseAccessors(domain)
         case_ids = get_case_ids(accessor, case_type, inactive_location)
         print(f"Found {len(case_ids)} {case_type} cases in {domain}")
-        traveler_location_id = self.location
+        traveler_location_id = self.extra_options['location']
 
         case_blocks = []
         skip_count = 0

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -32,6 +32,12 @@ def get_owner_id(case_type):
     return None
 
 
+def get_case_ids(accessor, case_type, inactive_location):
+    if inactive_location:
+        return accessor.get_open_case_ids_in_domain_by_type(case_type, owner_ids=[inactive_location])
+    return accessor.get_case_ids_in_domain(case_type)
+
+
 class Command(CaseUpdateCommand):
     help = ("Updates all case indices of a specfied case type to use an extension relationship instead of parent.")
 
@@ -45,8 +51,9 @@ class Command(CaseUpdateCommand):
         ).as_xml(), encoding='utf-8').decode('utf-8')
 
     def update_cases(self, domain, case_type, user_id):
+        inactive_location = self.inactive_location
         accessor = CaseAccessors(domain)
-        case_ids = accessor.get_case_ids_in_domain(case_type)
+        case_ids = get_case_ids(accessor, case_type, inactive_location)
         print(f"Found {len(case_ids)} {case_type} cases in {domain}")
         traveler_location_id = self.location
 
@@ -70,3 +77,4 @@ class Command(CaseUpdateCommand):
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument('--location', type=str, default=None)
+        parser.add_argument('--inactive-location', type=str, default=None)

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -17,8 +17,9 @@ DEVICE_ID = __name__ + ".update_case_index_relationship"
 
 def should_skip(case, traveler_location_id):
     if traveler_location_id is None:
-        return len(case.indices) != 1
-    return len(case.indices) != 1 or case.get_case_property('owner_id') == traveler_location_id
+        return len(case.indices) != 1 or case.get_case_property('has_index_case') == 'no'
+    return len(case.indices) != 1 or case.get_case_property('owner_id') == traveler_location_id \
+        or case.get_case_property('has_index_case') == 'no'
 
 
 def needs_update(case):

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -15,11 +15,12 @@ BATCH_SIZE = 100
 DEVICE_ID = __name__ + ".update_case_index_relationship"
 
 
-def should_skip(case, traveler_location_id):
+def should_skip(case, case_type, traveler_location_id):
+    if case_type == 'contact' and case.get_case_property('has_index_case') == 'no':
+        return True
     if traveler_location_id is None:
-        return len(case.indices) != 1 or case.get_case_property('has_index_case') == 'no'
-    return len(case.indices) != 1 or case.get_case_property('owner_id') == traveler_location_id \
-        or case.get_case_property('has_index_case') == 'no'
+        return len(case.indices) != 1
+    return len(case.indices) != 1 or case.get_case_property('owner_id') == traveler_location_id
 
 
 def needs_update(case):
@@ -61,7 +62,7 @@ class Command(CaseUpdateCommand):
         case_blocks = []
         skip_count = 0
         for case in accessor.iter_cases(case_ids):
-            if should_skip(case, traveler_location_id):
+            if should_skip(case, case_type, traveler_location_id):
                 skip_count += 1
             elif needs_update(case):
                 owner_id = get_owner_id(case_type)

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -14,6 +14,7 @@ class CaseUpdateCommand(BaseCommand):
 
     def __init__(self):
         self.location = None
+        self.inactive_location = None
 
     def case_block(self):
         raise NotImplementedError()
@@ -46,6 +47,7 @@ class CaseUpdateCommand(BaseCommand):
             user_id = SYSTEM_USER_ID
 
         self.location = options.get('location')
+        self.inactive_location = options.get('inactive_location')
 
         for domain in domains:
             print(f"Processing {domain}")

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -45,8 +45,9 @@ class CaseUpdateCommand(BaseCommand):
         else:
             user_id = SYSTEM_USER_ID
 
-        self.extra_options['location'] = options.get('location')
-        self.extra_options['inactive_location'] = options.get('inactive_location')
+        options.pop("and_linked")
+        options.pop("username")
+        self.extra_options = options
 
         for domain in domains:
             print(f"Processing {domain}")

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -13,8 +13,7 @@ class CaseUpdateCommand(BaseCommand):
     """
 
     def __init__(self):
-        self.location = None
-        self.inactive_location = None
+        self.extra_options = {}
 
     def case_block(self):
         raise NotImplementedError()
@@ -46,8 +45,8 @@ class CaseUpdateCommand(BaseCommand):
         else:
             user_id = SYSTEM_USER_ID
 
-        self.location = options.get('location')
-        self.inactive_location = options.get('inactive_location')
+        self.extra_options['location'] = options.get('location')
+        self.extra_options['inactive_location'] = options.get('inactive_location')
 
         for domain in domains:
             print(f"Processing {domain}")

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -99,6 +99,11 @@ class CaseCommandsTest(TestCase):
             True, lab_result_case_id, user_id=self.user_id, owner_id='owner1', case_type='lab_result',
             index={'patient': ('patient', patient_case_id, 'child')}
         )
+        excluded_case_id = uuid.uuid4().hex
+        self.submit_case_block(
+            True, excluded_case_id, user_id=self.user_id, owner_id='owner1', case_type='lab_result',
+            index={'patient': ('patient', patient_case_id, 'child')}, update={"has_index_case": 'no'},
+        )
 
         lab_result_case = self.case_accessor.get_case(lab_result_case_id)
         self.assertEqual(lab_result_case.indices[0].referenced_type, 'patient')
@@ -109,6 +114,8 @@ class CaseCommandsTest(TestCase):
         lab_result_case = self.case_accessor.get_case(lab_result_case_id)
         self.assertEqual(lab_result_case.indices[0].relationship, 'extension')
         self.assertEqual(lab_result_case.get_case_property('owner_id'), '-')
+        excluded_case = self.case_accessor.get_case(excluded_case_id)
+        self.assertEqual(excluded_case.indices[0].relationship, 'child')
 
     def test_update_case_index_relationship_with_location(self):
         location_type = LocationType.objects.create(

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -99,11 +99,6 @@ class CaseCommandsTest(TestCase):
             True, lab_result_case_id, user_id=self.user_id, owner_id='owner1', case_type='lab_result',
             index={'patient': ('patient', patient_case_id, 'child')}
         )
-        excluded_case_id = uuid.uuid4().hex
-        self.submit_case_block(
-            True, excluded_case_id, user_id=self.user_id, owner_id='owner1', case_type='lab_result',
-            index={'patient': ('patient', patient_case_id, 'child')}, update={"has_index_case": 'no'},
-        )
 
         lab_result_case = self.case_accessor.get_case(lab_result_case_id)
         self.assertEqual(lab_result_case.indices[0].referenced_type, 'patient')
@@ -114,8 +109,6 @@ class CaseCommandsTest(TestCase):
         lab_result_case = self.case_accessor.get_case(lab_result_case_id)
         self.assertEqual(lab_result_case.indices[0].relationship, 'extension')
         self.assertEqual(lab_result_case.get_case_property('owner_id'), '-')
-        excluded_case = self.case_accessor.get_case(excluded_case_id)
-        self.assertEqual(excluded_case.indices[0].relationship, 'child')
 
     def test_update_case_index_relationship_with_location(self):
         location_type = LocationType.objects.create(
@@ -145,6 +138,12 @@ class CaseCommandsTest(TestCase):
             index={'patient': ('patient', patient_case_id, 'child')}
         )
 
+        excluded_case_id = uuid.uuid4().hex
+        self.submit_case_block(
+            True, excluded_case_id, user_id=self.user_id, owner_id='owner1', case_type='contact',
+            index={'patient': ('patient', patient_case_id, 'child')}, update={"has_index_case": 'no'},
+        )
+
         traveler_case = self.case_accessor.get_case(traveler_case_id)
         self.assertEqual(traveler_case.indices[0].referenced_type, 'patient')
         self.assertEqual(traveler_case.indices[0].relationship, 'child')
@@ -155,6 +154,8 @@ class CaseCommandsTest(TestCase):
         self.assertEqual(traveler_case.indices[0].relationship, 'child')
         non_traveler_case = self.case_accessor.get_case(non_traveler_case_id)
         self.assertEqual(non_traveler_case.indices[0].relationship, 'extension')
+        excluded_case = self.case_accessor.get_case(excluded_case_id)
+        self.assertEqual(excluded_case.indices[0].relationship, 'child')
 
     def test_update_case_index_relationship_with_inactive_location(self):
         location_type = LocationType.objects.create(


### PR DESCRIPTION
## Summary
An option is needed to run on just the inactive location. An added requirement also is to exclude any contact case where has_index_case = 'no'.

## Product Description
I decided to modify the script rather than creating a new one because I realized a lot of the functionality would be repeated otherwise. Same with adding it for the 'run_all_management_command'-- I replaced the other flag to just run `update_case_index_relationship` to run just that command with the inactive location because that's the real use case now. 

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
I added an additional test using the '--inactive' flag

### QA Plan
I am not requesting QA

### Safety story
this will be run on a test domain prior to the big run.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
