### PR TITLE
add xdsoft's datetimepicker support to the rest of HQ (not just webapps)

### DIFF
--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -166,6 +166,24 @@ def use_timepicker(view_func):
     return _wrapped
 
 
+def use_datetimepicker(view_func):
+    """Use this decorator on the dispatch method of a TemplateView subclass
+    to enable the inclusion of the datimepicker library from xdsoft.net
+    at the base template level.
+
+    Example:
+
+    @use_datetimepicker
+    def dispatch(self, request, *args, **kwargs):
+        return super(MyView, self).dispatch(request, *args, **kwargs)
+    """
+    @wraps(view_func)
+    def _wrapped(class_based_view, request, *args, **kwargs):
+        request.use_datetimepicker = True
+        return view_func(class_based_view, request, *args, **kwargs)
+    return _wrapped
+
+
 def use_maps(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
     to enable the inclusion of the maps (with sync utils) library at the base

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/requirejs_config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/requirejs_config.js
@@ -12,6 +12,8 @@ requirejs.config({
         "datatables.bootstrap": "datatables-bootstrap3/BS3/assets/js/datatables",
         "datatables.scroller": "datatables-scroller/js/dataTables.scroller",
         "datatables.colReorder": "datatables-colreorder/js/dataTables.colReorder",
+        "jquery-mousewheel": "jquery-mousewheel/jquery.mousewheel",
+        "datetimepicker": "datetimepicker/build/jquery.datetimepicker.full.min",
     },
     shim: {
         "ace-builds/src-min-noconflict/ace": { exports: "ace" },

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/requirejs_config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/requirejs_config.js
@@ -13,7 +13,6 @@ requirejs.config({
         "datatables.scroller": "datatables-scroller/js/dataTables.scroller",
         "datatables.colReorder": "datatables-colreorder/js/dataTables.colReorder",
         "jquery-mousewheel": "jquery-mousewheel/jquery.mousewheel",
-        "datetimepicker": "datetimepicker/build/jquery.datetimepicker.full.min",
     },
     shim: {
         "ace-builds/src-min-noconflict/ace": { exports: "ace" },

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -93,6 +93,15 @@
       {% endcompress %}
     {% endif %}
 
+    {% if request.use_datetimepicker %}
+      {% compress css %}
+        <link type="text/less"
+              rel="stylesheet"
+              media="screen"
+              href="{% static "datetimepicker/build/jquery.datetimepicker.min.css" %}" />
+      {% endcompress %}
+    {% endif %}
+
     {% if request.use_jquery_ui %}
       {% compress css %}
         <link type="text/css"
@@ -475,6 +484,13 @@
     {% if request.use_timepicker and not requirejs_main %}
       {% compress js %}
         <script src="{% static 'bootstrap-timepicker/js/bootstrap-timepicker.js' %}"></script>
+      {% endcompress %}
+    {% endif %}
+
+    {% if request.use_datetimepicker and not requirejs_main %}
+      {% compress js %}
+        <script src="{% static 'jquery-mousewheel/jquery.mousewheel.js' %}"></script>
+        <script src="{% static 'datetimepicker/build/jquery.datetimepicker.full.min.js' %}"></script>
       {% endcompress %}
     {% endif %}
 


### PR DESCRIPTION
## Summary
Splitting this out from https://github.com/dimagi/commcare-hq/pull/29180

This allows `xdsoft`'s `datetimepicker` widget that's currently being used in web apps to be available for the rest of HQ.

This also adds a `@use_datetimepicker` decorator for views that makes sure the required `css` is included in the base template.

## Product Description
Just allowing a new widget that already exists in webapps to be in the main require file for HQ. So if the decorator is used on a view, it will be available to use.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan
No QA needed. 

### Safety story
Code will only run if a specific decorator is used on a view.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
