### PR TITLE
Add sum when templates

### DIFF
--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -66,6 +66,16 @@ from corehq.apps.userreports.reports.sum_when_templates import (
     YearRangeTemplateSpec,
 )
 
+from custom.nutrition_project.ucr.sum_when_templates import (
+    ChildDeliverySpec,
+    ChildWeighedSpec,
+    ChildLowBirthWeightSpec,
+    ChildDeathSpec,
+    WomanDeathSpec,
+    WomanDeathTypeSpec,
+    ResidentTypeSpec,
+)
+
 
 class ReportColumnFactory(object):
     class_map = {
@@ -178,6 +188,15 @@ class SumWhenTemplateFactory(object):
         'referral_health_problem_5_problems': ReferralHealthProblem5ProblemsSpec,
         'under_x_months': UnderXMonthsTemplateSpec,
         'year_range': YearRangeTemplateSpec,
+
+        # India Nutrition Project templates
+        ChildDeliverySpec.type.choices[0]: ChildDeliverySpec,
+        ChildWeighedSpec.type.choices[0]: ChildWeighedSpec,
+        ChildLowBirthWeightSpec.type.choices[0]: ChildLowBirthWeightSpec,
+        ChildDeathSpec.type.choices[0]: ChildDeathSpec,
+        WomanDeathSpec.type.choices[0]: WomanDeathSpec,
+        WomanDeathTypeSpec.type.choices[0]: WomanDeathTypeSpec,
+        ResidentTypeSpec.type.choices[0]: ResidentTypeSpec,
     }
 
     @classmethod

--- a/custom/nutrition_project/ucr/sum_when_templates.py
+++ b/custom/nutrition_project/ucr/sum_when_templates.py
@@ -9,7 +9,7 @@ class ChildDeliverySpec(SumWhenTemplateSpec):
 
 class ChildWeighedSpec(SumWhenTemplateSpec):
     type = TypeProperty("india-nutrition-project_child_weighed")
-    expression = "gender = ? AND residential_status = ? AND child_safe_and_alive = 'yes AND weight is NOT NULL"
+    expression = "gender = ? AND residential_status = ? AND child_safe_and_alive = 'yes' AND weight is NOT NULL"
 
 
 class ChildLowBirthWeightSpec(SumWhenTemplateSpec):

--- a/custom/nutrition_project/ucr/sum_when_templates.py
+++ b/custom/nutrition_project/ucr/sum_when_templates.py
@@ -1,0 +1,38 @@
+from corehq.apps.userreports.reports.sum_when_templates import SumWhenTemplateSpec
+from corehq.apps.userreports.specs import TypeProperty
+
+
+class ChildDeliverySpec(SumWhenTemplateSpec):
+    type = TypeProperty("india-nutrition-project_child_delivery")
+    expression = "gender = ? AND residential_status = ? AND child_safe_and_alive = ?"
+
+
+class ChildWeighedSpec(SumWhenTemplateSpec):
+    type = TypeProperty("india-nutrition-project_child_weighed")
+    expression = "gender = ? AND residential_status = ? AND child_safe_and_alive = 'yes AND weight is NOT NULL"
+
+
+class ChildLowBirthWeightSpec(SumWhenTemplateSpec):
+    type = TypeProperty("india-nutrition-project_child_low_birth_weight")
+    expression = "gender = ? AND residential_status = ? AND child_safe_and_alive = 'yes' AND " \
+                 "weight is NOT NULL AND low_birth_weight = 'yes'"
+
+
+class ChildDeathSpec(SumWhenTemplateSpec):
+    type = TypeProperty("india-nutrition-project_child_death")
+    expression = "gender = ? AND residential_status = ? AND death_date - dob BETWEEN ? AND ?"
+
+
+class WomanDeathSpec(SumWhenTemplateSpec):
+    type = TypeProperty("india-nutrition-project_woman_death")
+    expression = "gender = 'F' AND residential_status = ? AND age_at_death_yrs >= ?"
+
+
+class WomanDeathTypeSpec(SumWhenTemplateSpec):
+    type = TypeProperty("india-nutrition-project_woman_death_type")
+    expression = "gender = 'F' AND residential_status = ? AND female_death_type = ?"
+
+
+class ResidentTypeSpec(SumWhenTemplateSpec):
+    type = TypeProperty("india-nutrition-project_resident_type")
+    expression = "gender = ? AND residential_status = ?"


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Since we are reverting in https://github.com/dimagi/commcare-hq/pull/29188, the expressions would stop working in the dynamic reports but still keep working in static reports. The app is using static reports but dynamic reports are still used for investigation and further dev work.
I have also added https://github.com/dimagi/commcare-hq/pull/29189, but going to hold off merging that until this is deployed and tested on dynamic reports.

For the naming, I prefixed with the domain name, so that there is no conflict with the existing templates that were added for ICDS [here](https://github.com/dimagi/commcare-hq/blob/408ebc14c805e30cb0ccae863b8096b5748735ae/corehq/apps/userreports/reports/sum_when_templates.py) or generally with others we would add. 
I am open to suggestions to move the icds ones to icds_core directory.

Additionally, I used `ChildDeliverySpec.type.choices[0]` instead of writing the property value again. That makes the dictionary look weird so i am open to keep it how it was if that seems better.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`UCR_SUM_WHEN_TEMPLATES`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No visible changes to any user

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Is applicable for only one domain, which wont use these new templates right away. Need them deployed to test on dynamic reports.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Ideally, this should not be rolled back since apps would be using it. But okay to revert in case this breaks anything

- [ ] This PR can be reverted after deploy with no further considerations 
