### PR TITLE
ignore blank repeats in forms

### DIFF
--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -244,7 +244,7 @@ def zip_form_data_and_questions(relative_data, questions, path_context='',
                             absolute_data=absolute_data,
                         ),
                     )
-                    for entry in node
+                    for entry in node if entry
                 ],
                 **question_data
             )

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -244,7 +244,7 @@ def zip_form_data_and_questions(relative_data, questions, path_context='',
                             absolute_data=absolute_data,
                         ),
                     )
-                    for entry in node if entry
+                    for entry in node if entry or children
                 ],
                 **question_data
             )

--- a/corehq/apps/reports/tests/test_readable_formdata.py
+++ b/corehq/apps/reports/tests/test_readable_formdata.py
@@ -257,6 +257,55 @@ class ReadableFormdataTest(SimpleTestCase):
             json.dumps([FormQuestionResponse(q).to_json() for q in expected])
         )
 
+    def test_repeat_empty(self):
+        questions_json = [{
+            'tag': 'repeat',
+            'type': 'Repeat',
+            'label': 'Repeat',
+            'value': '/data/question12',
+        }]
+        form_data = {
+            "@uiVersion": "1",
+            "@xmlns": "http://openrosa.org/formdesigner/432B3A7F-6EEE-4033-8740-ACCB0804C4FC",
+            "@name": "Untitled Form",
+            "#type": "data",
+            "question12": [
+                "", ""
+            ],
+            "meta": {
+                "@xmlns": "http://openrosa.org/jr/xforms",
+                "username": "danny",
+                "instanceID": "172981b6-5eeb-4be8-bbc7-ad52f808e803",
+                "userID": "a07d4bd967a9c205287f767509600931",
+                "timeEnd": "2014-04-28T18:27:05Z",
+                "appVersion": {
+                    "@xmlns": "http://commcarehq.org/xforms",
+                    "#text": "CommCare ODK, version \"2.11.0\"(29272). App v8. CommCare Version 2.11. Build 29272, built on: February-14-2014"
+                },
+                "timeStart": "2014-04-28T18:26:38Z",
+                "deviceID": "990004280784863"
+            },
+            "@version": "8"
+        }
+
+        expected = [{
+            'tag': 'repeat',
+            'type': 'Repeat',
+            'label': 'Repeat',
+            'value': '/data/question12',
+            'response': None,
+            'calculate': None,
+            'children': [],
+        }]
+        actual = get_readable_form_data(
+            form_data,
+            [FormQuestionResponse(q) for q in questions_json]
+        )
+        self.assertJSONEqual(
+            json.dumps([q.to_json() for q in actual]),
+            json.dumps([FormQuestionResponse(q).to_json() for q in expected])
+        )
+
     def _test_corpus(self, slug):
         xform_file = os.path.join(
             os.path.dirname(__file__),


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SAAS-11867

https://sentry.io/organizations/dimagi/issues/2222366477/

Creating a form with an empty repeat group can cause the rendering of the form to fail (see above sentry error).

One question is whether this should display some kind of empty repeat in the rendered form since the user did 'add repeats', it's just that the repeats are blank.

Example data below:

### App Form XML
(non-relevant sections removed)
```xml
...
<instance>
    <data ...>
        <empty_repeat jr:template="" />
    </data>
</instance>
...
```

### Submitted XML
(non-relevant sections removed)
```xml
<data ...>
	<empty_repeat/>
	<empty_repeat/>
    ...
</data>
```

### Submitted form JSON
(non-relevant sections removed)
```json
{
    "form": {
        "empty_repeat": [
            "",
            ""
        ]
    }
}
```

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Test case added

### Rollback instructions
- [X] This PR can be reverted after deploy with no further considerations 
