### PR TITLE
Moved UCR error into body of soft assert instead of subject

### DIFF
--- a/corehq/apps/userreports/decorators.py
+++ b/corehq/apps/userreports/decorators.py
@@ -34,7 +34,7 @@ def catch_and_raise_exceptions(func):
             if isinstance(error, TableNotFoundWarning):
                 raise error
             if not settings.UNIT_TESTING:
-                _soft_assert(False, str(e))
+                _soft_assert(False, msg=f"UserReportsError: {str(e)[:50]}...", obj=str(e))
             raise UserReportsError(str(e))
     return _inner
 


### PR DESCRIPTION
## Summary
These errors can include the full SQL query, which can be large enough to get the email rejected.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

I doubt there's test coverage.

### QA Plan

Not requesting QA.

### Safety story

Small change to error handling parameters. Tested locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
