### PR TITLE
Have run_all_management_command run in a certain order

### DIFF
--- a/custom/covid/management/commands/run_all_management_command.py
+++ b/custom/covid/management/commands/run_all_management_command.py
@@ -10,12 +10,12 @@ DEVICE_ID = __name__ + ".run_all_management_command"
 
 def run_command(command, *args, location=None, inactive_location=None):
     try:
-        if location is None:
-            call_command(command, *args)
-        if inactive_location is None:
+        if inactive_location is not None:
+            call_command(command, *args, location=location, inactive_location=inactive_location)
+        elif location is not None:
             call_command(command, *args, location=location)
         else:
-            call_command(command, *args, location=location, inactive_location=inactive_location)
+            call_command(command, *args)
     except Exception as e:
         return False, command, args, e
     return True, command, args, None

--- a/custom/covid/management/commands/run_all_management_command.py
+++ b/custom/covid/management/commands/run_all_management_command.py
@@ -28,12 +28,12 @@ class Command(BaseCommand):
         parser.add_argument('--only-inactive', action='store_true', default=False)
 
     def handle(self, csv_file, **options):
-        domains = set()
+        domains = []
         location_ids = {}
         with open(csv_file, newline='') as file:
             reader = csv.DictReader(file)
             for row in reader:
-                domains.add(row['domain'])
+                domains.append(row['domain'])
                 locations = {'active': {}, 'inactive': ''}
                 if row['non_traveler_active_location_id'] != '':
                     locations['active']['non_traveler'] = (row['non_traveler_active_location_id'])
@@ -41,6 +41,11 @@ class Command(BaseCommand):
                     locations['active']['traveler'] = (row['traveler_active_location_id'])
                 locations['inactive'] = row['inactive_location_id']
                 location_ids[row['domain']] = locations
+
+        if len(set(domains)) != len(domains):
+            domains = set(domains)
+            print("Rows with duplicate domains were found from csv file. The commands for each domains will"
+                  " run differently than the order of the csv file.")
 
         total_jobs = []
         jobs = []

--- a/custom/covid/management/commands/run_all_management_command.py
+++ b/custom/covid/management/commands/run_all_management_command.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
         else:
             for domain in domains:
                 jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact',
-                                       location=location_ids[domain]['traveler']))
+                                       location=location_ids[domain]['active']['traveler']))
                 jobs.append(pool.spawn(run_command, 'add_hq_user_id_to_case', domain, 'checkin'))
                 jobs.append(pool.spawn(run_command, 'update_owner_ids', domain, 'investigation'))
                 jobs.append(pool.spawn(run_command, 'update_owner_ids', domain, 'checkin'))


### PR DESCRIPTION
## Summary
Last night, it came up that it would be better just for timing purposes if we knew what order the script would run in. I also made small tweaks that were small bugs I found while testing. 

## Product Description
I changed `domains` to be a list instead of a set, but then added a check for duplicates. In the situation where there is a duplicate, it will just run domains as a `set` and notify the user.
One [this commit](https://github.com/dimagi/commcare-hq/commit/49a809d74fc7117eaf8eeb7d1e7ffec1ee75475f) I said there was not logic change, but what I mean to say was that the functionality was the same. 

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan
I am not requesting QA

### Safety story
Hoping to run on a test domain before the run tonight

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
