### PR TITLE
Migrate forms and cases from Couch to SQL with single command

### DIFF
--- a/corehq/apps/couch_sql_migration/casepatch.py
+++ b/corehq/apps/couch_sql_migration/casepatch.py
@@ -320,7 +320,9 @@ def diff_to_json(diff, new_value=None):
 
 
 def is_patchable(diff):
-    return diff.path[0] not in UNPATCHABLE_PROPS
+    return not (diff.path[0] in UNPATCHABLE_PROPS or (
+        list(diff.path) == ["closed"] and not diff.old_value and diff.new_value
+    ))
 
 
 class CannotPatch(Exception):

--- a/corehq/apps/couch_sql_migration/casepatch.py
+++ b/corehq/apps/couch_sql_migration/casepatch.py
@@ -44,7 +44,9 @@ def patch_diffs(doc_diffs, log_cases=False):
     pending_diffs = []
     dd_count = partial(metrics_counter, tags={"domain": get_domain()})
     for kind, case_id, diffs in doc_diffs:
-        assert kind == "CommCareCase", (kind, case_id)
+        if kind != "CommCareCase":
+            log.warning("cannot patch %s: %s", kind, case_id)
+            continue
         dd_count("commcare.couchsqlmigration.case.patch")
         try:
             patch_case(case_id, diffs)

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_multiple_domains_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_multiple_domains_from_couch_to_sql.py
@@ -190,9 +190,9 @@ def format_diff_stats(stats, header=None):
         class stream:
             write = lines.append
 
-        writer = SimpleTableWriter(stream, TableRowFormatter([30, 10, 10, 10]))
+        writer = SimpleTableWriter(stream, TableRowFormatter([30, 7, 7, 7, 7]))
         writer.write_table(
-            ['Doc Type', '# Couch', '# SQL', '# Docs with Diffs'],
+            ['Doc Type', 'Docs', 'Diffs', "Missing", "Changes"],
             [(doc_type,) + stat.columns for doc_type, stat in stats.items()],
         )
     return "\n".join(lines)
@@ -208,11 +208,11 @@ class DiffStats:
         pending = f"{self.pending} pending" if self.pending else ""
         counts = self.counts
         if not counts:
-            return "?", "?", pending
-        diffs = counts.diffs + counts.changes
+            return "?", "?", "?", pending
+        changes = counts.changes
         if pending:
-            diffs = f"{diffs} + {pending}" if diffs else pending
-        return counts.total, counts.total + counts.missing, diffs
+            changes = f"{changes} + {pending}" if changes else pending
+        return counts.total, counts.diffs, counts.missing, changes
 
     @property
     def patchable(self):

--- a/corehq/apps/couch_sql_migration/tests/test_casedifftool.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casedifftool.py
@@ -11,7 +11,7 @@ from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.tzmigration.timezonemigration import MISSING
 from corehq.form_processor.backends.couch.dbaccessors import CaseAccessorCouch
-from corehq.form_processor.interfaces.dbaccessors import FormAccessors
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from corehq.form_processor.models import CommCareCaseIndexSQL
 from corehq.form_processor.utils.general import (
     clear_local_domain_sql_backend_override,
@@ -495,6 +495,31 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
         self.assert_patched_cases(["diff-case"])
         self.compare_diffs(changes=[
             Diff('change-case', 'missing', ['*'], old='*', new=MISSING, reason="deleted forms"),
+        ])
+
+    def test_patch_skips_deleted_case(self):
+        self.submit_form(make_test_form("form-1", case_id="del"))
+        self.submit_form(make_test_form("form-2", case_id="mar"))
+        case = self._get_case("del")
+        case.name = "Del"
+        case.opened_by = "someone"
+        case.save()
+        case = self._get_case("mar")
+        case.name = "Mar"
+        case.opened_by = "someone"
+        case.save()
+        CaseAccessors(self.domain.name).soft_delete_cases(["del"], datetime.utcnow())
+        self.do_migration(diffs=[
+            Diff('del', 'diff', ['name'], old='Del', kind="CommCareCase-Deleted"),
+            Diff('del', 'diff', ['opened_by'], old='someone', kind="CommCareCase-Deleted"),
+            Diff('mar', 'diff', ['name'], old='Mar'),
+            Diff('mar', 'diff', ['opened_by'], old='someone'),
+        ])
+        clear_local_domain_sql_backend_override(self.domain_name)
+        self.do_case_patch(cases="with-diffs")
+        self.compare_diffs(diffs=[
+            Diff('del', 'diff', ['name'], old='Del', kind="CommCareCase-Deleted"),
+            Diff('del', 'diff', ['opened_by'], old='someone', kind="CommCareCase-Deleted"),
         ])
 
     def test_patch_cases_with_changes(self):

--- a/corehq/apps/couch_sql_migration/tests/test_casedifftool.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casedifftool.py
@@ -375,6 +375,25 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
         self.compare_diffs()
         self.assert_patched_cases(["case-1"])
 
+    def test_patch_case_open_in_couch_closed_in_sql(self):
+        from casexml.apps.case.cleanup import close_case
+        self.submit_form(make_test_form("form-1", case_id="case-1"))
+        close_case("case-1", self.domain_name, "system", "test")
+        self.do_migration(case_diff="none")
+        with self.augmented_couch_case("case-1") as case:
+            case.closed = False
+            case.closed_by = None
+            case.closed_on = None
+            case.save()
+            self.do_case_diffs()
+        self.compare_diffs([
+            Diff('case-1', 'diff', ['closed'], old=False, new=True),
+            Diff('case-1', 'type', ['closed_on'], old=None),
+        ])
+        self.do_case_patch()
+        self.compare_diffs()
+        self.assert_patched_cases(["case-1"])
+
     def test_patch_case_closed_in_couch_missing_sql(self):
         self.submit_form(make_test_form("form-1", case_id="case-1"))
         case = CaseAccessorCouch.get_case("case-1")


### PR DESCRIPTION
## Summary
Now that patching has been used on many domains and is stable, it can be invoked automatically by the `migrate_multiple_domains_from_couch_to_sql` if there are differences after the first migration pass. It is then safe to automatically finish and commit the migration if there are no differences after patching. This reduces the number of steps required to migrate and commit a domain from 4-5 separate separate commands to a single command (when all diffs can be resolve by patching).

The two final commits are small fixes for the patching code to handle more scenarios found while running migrations.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

All code in this PR is used only by Couch to SQL management commands. Tests were added for the new patch scenarios that were fixed. There are no tests for the `migrate_multiple_domains_from_couch_to_sql`, but it was easy to test by migrating a few small test domains.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
