### PR TITLE
Use correct content type for xlsx

### DIFF
--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -561,6 +561,9 @@ class DownloadDETSchemaView(View):
             return HttpResponse(_('Sorry, something went wrong creating that file: {error}').format(error=e))
 
         output_file.seek(0)
-        response = HttpResponse(output_file, content_type='application/vnd.ms-excel')
+        response = HttpResponse(
+            output_file,
+            content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        )
         response['Content-Disposition'] = f'attachment; filename="{export_instance.name}-DET.xlsx"'
         return response


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Previously this file was being downloaded as `xls`, which couldn't be opened by the DET (on firefox at least).
https://stackoverflow.com/a/2938188


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Download DET config file

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
