### PR TITLE
Fixed colliding names in couch to sql migration superclass

### DIFF
--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -199,7 +199,7 @@ class PopulateSQLCommand(BaseCommand):
                 logger.info(f"Doc {getattr(obj, couch_id_name)} has differences:\n{diff}")
                 self.diff_count += 1
                 if exit:
-                    exit(1)
+                    sys.exit(1)
         except self.sql_class().DoesNotExist:
             pass    # ignore, the difference in total object count has already been displayed
 


### PR DESCRIPTION
Fix `TypeError: 'bool' object is not callable`