### PR TITLE
[sso] small test cleanup

### DIFF
--- a/corehq/apps/sso/tests/generator.py
+++ b/corehq/apps/sso/tests/generator.py
@@ -9,14 +9,11 @@ from corehq.apps.sso.models import (
 
 
 @unit_testing_only
-def create_idp(account=None, include_certs=False):
-    if not account:
-        account = get_billing_account_for_idp()
-    idp_slug = data_gen.arbitrary_unique_name()[:20]
+def create_idp(slug, account, include_certs=False):
     idp = IdentityProvider(
         name=f"Azure AD for {account.name}",
-        slug=idp_slug,
-        owner=account
+        slug=slug,
+        owner=account,
     )
     idp.save()
     if include_certs:

--- a/corehq/apps/sso/tests/test_decorators.py
+++ b/corehq/apps/sso/tests/test_decorators.py
@@ -18,7 +18,7 @@ class TestDecorators(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.idp = generator.create_idp(self.account, include_certs=True)
+        self.idp = generator.create_idp('vaultwax', self.account, include_certs=True)
 
         self.request = RequestFactory().get('/sso/test')
         self.request_args = (self.idp.slug, )

--- a/corehq/apps/sso/tests/test_tasks.py
+++ b/corehq/apps/sso/tests/test_tasks.py
@@ -22,7 +22,7 @@ class TestSSOTasks(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.idp = generator.create_idp(self.account)
+        self.idp = generator.create_idp('vaultwax', self.account)
 
     def test_create_rollover_service_provider_x509_certificates(self):
         self.idp.create_service_provider_certificate()


### PR DESCRIPTION
## Summary
quickly addressing https://github.com/dimagi/commcare-hq/pull/28938#discussion_r564769590
and making `create_idp` require an explicit `slug` and `account` to be passed in

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
these are only changes to tests.

### QA Plan
test change only. no need for qa

### Safety story
test change only

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
