### PR TITLE
[sso] addressing prior PR feedback related to Admin UIs in PR #29180

### DIFF
--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -162,11 +162,14 @@ class ServiceProviderDetailsForm(forms.Form):
     @property
     def service_provider_help_block(self):
         help_link = "#"  # todo
-        help_text = _('<a href="{}">Please read this guide</a> on how to set up '
-                      'CommCare HQ with Azure AD.<br />You will need the following '
-                      'information:').format(help_link)
+        help_text = format_html(
+            _('<a href="{}">Please read this guide</a> on how to set up '
+              'CommCare HQ with Azure AD.<br />You will need the following '
+              'information:'),
+            help_link
+        )
         return crispy.HTML(
-            f'<p class="help-block">{help_text}</p>'
+            format_html('<p class="help-block">{}</p>', help_text)
         )
 
     @property
@@ -193,7 +196,10 @@ class ServiceProviderDetailsForm(forms.Form):
             shown_fields.extend([
                 hqcrispy.B3TextField(
                     'sp_public_cert',
-                    f'<a href="?sp_cert_public" target="_blank">{download}</a>',
+                    format_html(
+                        '<a href="?sp_cert_public" target="_blank">{}</a>',
+                        download
+                    ),
                 ),
                 hqcrispy.B3TextField(
                     'sp_public_cert_expiration',
@@ -205,9 +211,9 @@ class ServiceProviderDetailsForm(forms.Form):
         if self.show_rollover_cert:
             shown_fields.append(hqcrispy.B3TextField(
                 'sp_rollover_cert',
-                (f'<a href="?sp_rollover_cert_public" target="_blank">{download}</a>'
-                    if self.idp.sp_rollover_cert_public
-                    else _("Not needed/generated yet.")),
+                (format_html('<a href="?sp_rollover_cert_public" target="_blank">{}</a>', download)
+                 if self.idp.sp_rollover_cert_public
+                 else _("Not needed/generated yet.")),
             ))
         return shown_fields
 
@@ -296,8 +302,11 @@ class EditIdentityProviderAdminForm(forms.Form):
                         _('Primary Configuration'),
                         hqcrispy.B3TextField(
                             'owner',
-                            f'<a href="{account_link}">'
-                            f'{identity_provider.owner.name}</a>'
+                            format_html(
+                                '<a href="{}">{}</a>',
+                                account_link,
+                                identity_provider.owner.name
+                            )
                         ),
                         'name',
                         twbscrispy.PrependedText('is_editable', ''),

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -35,7 +35,7 @@ def _check_is_editable_requirements(identity_provider):
             _("Please make sure you specify at "
               "least one Authenticated Email Domain.")
         )
-    if not identity_provider.sso_exempt_users:
+    if not identity_provider.get_sso_exempt_users():
         raise forms.ValidationError(
             _("Please make sure you have specified at least one "
               "enterprise admin that is exempt from SSO.")

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -148,13 +148,14 @@ class ServiceProviderDetailsForm(forms.Form):
         required=False,
     )
 
-    def __init__(self, identity_provider, *args, **kwargs):
+    def __init__(self, identity_provider, show_public_cert=True,
+                 show_rollover_cert=True, show_help_block=True, *args, **kwargs):
         self.idp = identity_provider
         # todo eventually have a setting for IdentityProvider toggles based on
         #  whether SP signing is enforced (dependent on client's Azure tier)
-        self.show_public_cert = kwargs.pop('show_public_cert', True)
-        self.show_rollover_cert = kwargs.pop('show_rollover_cert', True)
-        self.show_help_block = kwargs.pop('show_help_block', True)
+        self.show_public_cert = show_public_cert
+        self.show_rollover_cert = show_rollover_cert
+        self.show_help_block = show_help_block
 
         super().__init__(*args, **kwargs)
 

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -477,7 +477,6 @@ class SSOEnterpriseSettingsForm(forms.Form):
                             ", ".join(identity_provider.get_email_domains()),
                         ),
                         twbscrispy.PrependedText('is_active', ''),
-                        'sso_exempt_users',
                     ),
                     css_class="panel-body"
                 ),

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -30,7 +30,7 @@ def _validate_or_raise_slugify_error(slug):
 
 
 def _check_is_editable_requirements(identity_provider):
-    if not identity_provider.email_domains:
+    if not identity_provider.get_email_domains():
         raise forms.ValidationError(
             _("Please make sure you specify at "
               "least one Authenticated Email Domain.")
@@ -464,7 +464,7 @@ class SSOEnterpriseSettingsForm(forms.Form):
                         ),
                         hqcrispy.B3TextField(
                             'linked_email_domains',
-                            ", ".join(identity_provider.email_domains),
+                            ", ".join(identity_provider.get_email_domains()),
                         ),
                         twbscrispy.PrependedText('is_active', ''),
                         'sso_exempt_users',

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -124,8 +124,7 @@ class IdentityProvider(models.Model):
             identity_provider=self
         ).values_list('email_domain', flat=True).all()
 
-    @property
-    def sso_exempt_users(self):
+    def get_sso_exempt_users(self):
         return UserExemptFromSingleSignOn.objects.filter(
             email_domain__identity_provider=self,
         ).values_list('username', flat=True)

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -118,8 +118,7 @@ class IdentityProvider(models.Model):
         self.date_sp_rollover_cert_expiration = None
         self.save()
 
-    @property
-    def email_domains(self):
+    def get_email_domains(self):
         return AuthenticatedEmailDomain.objects.filter(
             identity_provider=self
         ).values_list('email_domain', flat=True).all()

--- a/corehq/apps/sso/templates/sso/enterprise_admin/manage_sso.html
+++ b/corehq/apps/sso/templates/sso/enterprise_admin/manage_sso.html
@@ -36,7 +36,7 @@
               {{ idp.name }}
             </td>
             <td>
-              {{ idp.email_domains|join:", " }}
+              {{ idp.get_email_domains|join:", " }}
             </td>
             <td>
               {% if idp.is_active %}

--- a/corehq/apps/sso/views/accounting_admin.py
+++ b/corehq/apps/sso/views/accounting_admin.py
@@ -6,6 +6,7 @@ from django.utils.decorators import method_decorator
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import ugettext as _, ugettext_lazy
+from django.utils.html import format_html
 
 from corehq.apps.accounting.dispatcher import AccountingAdminInterfaceDispatcher
 from corehq.apps.accounting.filters import (
@@ -68,7 +69,7 @@ class IdentityProviderInterface(AddItemInterface):
         def _idp_to_row(idp):
             edit_url = reverse(EditIdentityProviderAdminView.urlname, args=(idp.id,))
             return [
-                f'<a href="{edit_url}">{idp.name}</a>',
+                format_html('<a href="{}">{}</a>', edit_url, idp.name),
                 idp.slug,
                 "Open" if idp.is_editable else "Closed",
                 "Active" if idp.is_active else "Inactive",


### PR DESCRIPTION
## Summary
This PR addresses the following PR feedback from https://github.com/dimagi/commcare-hq/pull/29180
- https://github.com/dimagi/commcare-hq/pull/29180#discussion_r578700535 (explicit kwargs)
- https://github.com/dimagi/commcare-hq/pull/29180#discussion_r578711818 (get methods instead of properties)
- https://github.com/dimagi/commcare-hq/pull/29180#discussion_r578721106 (and other `format_html` comments)
- minor cleanup of a leftover field in crispy forms layout

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Code changes are well tested.

### QA Plan
None needed yet. 

### Safety story
Not an active feature and behind a feature flag (`ENTERPRISE_SSO`)

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
