### PR TITLE
Removed UCR soft assert

### DIFF
--- a/corehq/apps/userreports/decorators.py
+++ b/corehq/apps/userreports/decorators.py
@@ -33,8 +33,6 @@ def catch_and_raise_exceptions(func):
             error = translate_programming_error(e)
             if isinstance(error, TableNotFoundWarning):
                 raise error
-            if not settings.UNIT_TESTING:
-                _soft_assert(False, msg=f"UserReportsError: {str(e)[:50]}...", obj=str(e))
             raise UserReportsError(str(e))
     return _inner
 

--- a/corehq/apps/userreports/decorators.py
+++ b/corehq/apps/userreports/decorators.py
@@ -2,8 +2,6 @@ import hashlib
 import inspect
 from functools import wraps
 
-from django.conf import settings
-
 from sqlagg import ColumnNotFoundException
 from sqlalchemy.exc import ProgrammingError
 
@@ -12,11 +10,6 @@ from corehq.apps.userreports.exceptions import (
     TableNotFoundWarning,
     UserReportsError,
     translate_programming_error,
-)
-from corehq.util.soft_assert import soft_assert
-
-_soft_assert = soft_assert(
-    exponential_backoff=True,
 )
 
 


### PR DESCRIPTION
## Summary
More aggressive followup for https://github.com/dimagi/commcare-hq/pull/29195 - these are stored in sentry, and no one noticed them missing for months, so I'm just going to remove the soft assert.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Unlikely.

### QA Plan

No QA.

### Safety story
Very limited change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
