### PR TITLE
add secondary sort field to case exports and odata ES query

### DIFF
--- a/corehq/apps/export/esaccessors.py
+++ b/corehq/apps/export/esaccessors.py
@@ -24,7 +24,8 @@ def get_case_export_base_query(domain, case_type):
     return (CaseES(es_instance_alias=ES_EXPORT_INSTANCE)
             .domain(domain)
             .case_type(case_type)
-            .sort("opened_on"))
+            .sort("opened_on")
+            .sort('inserted_at', reset_sort=False))
 
 
 def get_sms_export_base_query(domain):


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

https://dimagi-dev.atlassian.net/browse/SAAS-11859

Lots more context in the ticket, but basically if you had a bunch of data with the same `date_opened` then duplicates could appear in your odata feeds, and I think this is why.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Should be mostly invisible, but reduce the likelihood of getting duplicate values in odata feeds.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

Uses well-worn APIs, and only adds a secondary sort index.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
