### PR TITLE
[SSO] Add SsoBackend for authenticating users after a successful SAML2 handshake

### DIFF
--- a/corehq/apps/sso/backends.py
+++ b/corehq/apps/sso/backends.py
@@ -9,9 +9,8 @@ class SsoBackend(ModelBackend):
     Authenticates against an IdentityProvider and SAML2 session data.
     """
 
-    def authenticate(self, request, username=None, idp_slug=None,
-                     is_handshake_successful=False, **kwargs):
-        if not (username and idp_slug and is_handshake_successful):
+    def authenticate(self, request, username, idp_slug, is_handshake_successful):
+        if not (request and username and idp_slug and is_handshake_successful):
             return None
 
         try:

--- a/corehq/apps/sso/backends.py
+++ b/corehq/apps/sso/backends.py
@@ -19,11 +19,11 @@ class SsoBackend(ModelBackend):
             identity_provider = IdentityProvider.objects.get(slug=idp_slug)
         except IdentityProvider.DoesNotExist:
             # not sure how we would even get here, but just in case
-            request.sso_login_error = "Identity Provider does not exist."
+            request.sso_login_error = f"Identity Provider {idp_slug} does not exist."
             return None
 
         if not identity_provider.is_active:
-            request.sso_login_error = "This Identity Provider is not active."
+            request.sso_login_error = f"This Identity Provider {idp_slug} is not active."
             return None
 
         try:
@@ -40,7 +40,7 @@ class SsoBackend(ModelBackend):
             # do not continue with authentication
             request.sso_login_error = (
                 f"The Email Domain {email_domain} is not allowed to "
-                f"authenticate with this Identity Provider."
+                f"authenticate with this Identity Provider ({idp_slug})."
             )
             return None
 

--- a/corehq/apps/sso/backends.py
+++ b/corehq/apps/sso/backends.py
@@ -27,7 +27,7 @@ class SsoBackend(ModelBackend):
             return None
 
         try:
-            email_domain = username.split('@')[1]
+            email_domain = username.split('@', 1)[1]
         except IndexError:
             # not a valid username
             request.sso_login_error = f"Username {username} is not valid."

--- a/corehq/apps/sso/backends.py
+++ b/corehq/apps/sso/backends.py
@@ -9,10 +9,9 @@ class SsoBackend(ModelBackend):
     Authenticates against an IdentityProvider and SAML2 session data.
     """
 
-    def authenticate(self, request, username=None, idp_slug=None, **kwargs):
-        #  Note: when implementing ODIC or other protocols in the future,
-        #   a different request.session check can be made
-        if not (username and idp_slug and request.session.get('samlSessionIndex')):
+    def authenticate(self, request, username=None, idp_slug=None,
+                     is_handshake_successful=False, **kwargs):
+        if not (username and idp_slug and is_handshake_successful):
             return None
 
         try:

--- a/corehq/apps/sso/backends.py
+++ b/corehq/apps/sso/backends.py
@@ -1,0 +1,57 @@
+from django.contrib.auth.backends import ModelBackend
+from django.contrib.auth.models import User
+
+from corehq.apps.sso.models import IdentityProvider, AuthenticatedEmailDomain
+
+
+class SsoBackend(ModelBackend):
+    """
+    Authenticates against an IdentityProvider and SAML2 session data.
+    """
+
+    def authenticate(self, request, username=None, idp_slug=None, **kwargs):
+        #  Note: when implementing ODIC or other protocols in the future,
+        #   a different request.session check can be made
+        if not (username and idp_slug and request.session.get('samlSessionIndex')):
+            return None
+
+        try:
+            identity_provider = IdentityProvider.objects.get(slug=idp_slug)
+        except IdentityProvider.DoesNotExist:
+            # not sure how we would even get here, but just in case
+            request.sso_login_error = "Identity Provider does not exist."
+            return None
+
+        if not identity_provider.is_active:
+            request.sso_login_error = "This Identity Provider is not active."
+            return None
+
+        try:
+            email_domain = username.split('@')[1]
+        except IndexError:
+            # not a valid username
+            request.sso_login_error = f"Username {username} is not valid."
+            return None
+
+        if not AuthenticatedEmailDomain.objects.filter(
+            email_domain=email_domain, identity_provider=identity_provider
+        ).exists():
+            # if this user's email domain is not authorized by this identity
+            # do not continue with authentication
+            request.sso_login_error = (
+                f"The Email Domain {email_domain} is not allowed to "
+                f"authenticate with this Identity Provider."
+            )
+            return None
+
+        try:
+            user = User.objects.get(username=username)
+        except User.DoesNotExist:
+            # todo handle user creation based on information from request/session
+            #  do this prior to handling the invite scenario and new user scenario
+            request.sso_login_error = f"User {username} does not exist."
+            return None
+
+        request.sso_login_error = None
+        # todo what happens with 2FA required here?
+        return user

--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -109,12 +109,17 @@ class TestSsoBackend(TestCase):
             "Identity Provider doesnotexist does not exist."
         )
 
+    def _activate_idp(self):
+        self.idp.is_active = True
+        self.idp.save()
+
     def test_login_error_if_idp_not_active(self):
         """
         SsoBackend should fail to return a user if the Identity Provider
         associated with that user is not active. It should also populate
         request.sso_login_error with an error message.
         """
+        self.addCleanup(self._activate_idp)
         self.idp.is_active = False
         self.idp.save()
         user = auth.authenticate(
@@ -128,8 +133,6 @@ class TestSsoBackend(TestCase):
             self.request.sso_login_error,
             "This Identity Provider vaultwax is not active."
         )
-        self.idp.is_active = True
-        self.idp.save()
 
     def test_login_error_if_bad_username(self):
         """

--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -25,6 +25,8 @@ class TestSsoBackend(TestCase):
             cls.domain.name, 'b@vaultwax.com', 'testpwd', None, None
         )
         cls.idp = generator.create_idp('vaultwax', cls.account)
+        cls.idp.is_active = True
+        cls.idp.save()
         AuthenticatedEmailDomain.objects.create(
             email_domain='vaultwax.com',
             identity_provider=cls.idp,

--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -1,13 +1,7 @@
-from unittest import mock
-
 from django.contrib import auth
 from django.test import TestCase, RequestFactory
 
 from corehq.apps.domain.models import Domain
-from corehq.apps.sso.decorators import (
-    identity_provider_required,
-    use_saml2_auth,
-)
 from corehq.apps.sso.models import IdentityProvider, AuthenticatedEmailDomain
 from corehq.apps.sso.tests import generator
 from corehq.apps.users.models import WebUser

--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -48,9 +48,6 @@ class TestSsoBackend(TestCase):
     def setUp(self):
         super().setUp()
         self.request = RequestFactory().get('/sso/test')
-        self.request.session = {
-            'samlSessionIndex': '_7c84c96e-8774-4e64-893c-06f91d285100',
-        }
 
     def test_backend_failure_without_username(self):
         """
@@ -61,6 +58,7 @@ class TestSsoBackend(TestCase):
             auth.authenticate(
                 request=self.request,
                 idp_slug=self.idp.slug,
+                is_handshake_successful=True,
             )
 
     def test_backend_failure_without_idp_slug(self):
@@ -70,24 +68,26 @@ class TestSsoBackend(TestCase):
         """
         user = auth.authenticate(
             request=self.request,
-            username=self.user.username
+            username=self.user.username,
+            is_handshake_successful=True,
         )
         self.assertIsNone(user)
         with self.assertRaises(AttributeError):
             self.request.sso_login_error
 
-    def test_backend_failure_without_saml_session_index(self):
+    def test_backend_failure_without_is_handshake_successful_flag(self):
         """
         SsoBackend should fail to move past the first check because a
          samlSessionIndex is not present in request.session.
         """
-        del self.request.session['samlSessionIndex']
         user = auth.authenticate(
             request=self.request,
             username=self.user.username,
             idp_slug=self.idp.slug
         )
         self.assertIsNone(user)
+        with self.assertRaises(AttributeError):
+            self.request.sso_login_error
 
     def test_login_error_if_idp_doesnt_exist(self):
         """
@@ -98,7 +98,8 @@ class TestSsoBackend(TestCase):
         user = auth.authenticate(
             request=self.request,
             username=self.user.username,
-            idp_slug='doesnotexist'
+            idp_slug='doesnotexist',
+            is_handshake_successful=True,
         )
         self.assertIsNone(user)
         self.assertEqual(
@@ -117,7 +118,8 @@ class TestSsoBackend(TestCase):
         user = auth.authenticate(
             request=self.request,
             username=self.user.username,
-            idp_slug=self.idp.slug
+            idp_slug=self.idp.slug,
+            is_handshake_successful=True,
         )
         self.assertIsNone(user)
         self.assertEqual(
@@ -136,7 +138,8 @@ class TestSsoBackend(TestCase):
         user = auth.authenticate(
             request=self.request,
             username='badusername',
-            idp_slug=self.idp.slug
+            idp_slug=self.idp.slug,
+            is_handshake_successful=True,
         )
         self.assertIsNone(user)
         self.assertEqual(
@@ -153,7 +156,8 @@ class TestSsoBackend(TestCase):
         user = auth.authenticate(
             request=self.request,
             username='b@idonotexist.com',
-            idp_slug=self.idp.slug
+            idp_slug=self.idp.slug,
+            is_handshake_successful=True,
         )
         self.assertIsNone(user)
         self.assertEqual(
@@ -172,7 +176,8 @@ class TestSsoBackend(TestCase):
         user = auth.authenticate(
             request=self.request,
             username='b@vwx.link',
-            idp_slug=self.idp.slug  # note that this is self.idp, not idp_vwx
+            idp_slug=self.idp.slug,  # note that this is self.idp, not idp_vwx
+            is_handshake_successful=True,
         )
         self.assertIsNone(user)
         self.assertEqual(
@@ -193,7 +198,8 @@ class TestSsoBackend(TestCase):
         user = auth.authenticate(
             request=self.request,
             username='testnoexist@vaultwax.com',
-            idp_slug=self.idp.slug
+            idp_slug=self.idp.slug,
+            is_handshake_successful=True,
         )
         self.assertIsNone(user)
         self.assertEqual(
@@ -209,7 +215,8 @@ class TestSsoBackend(TestCase):
         user = auth.authenticate(
             request=self.request,
             username=self.user.username,
-            idp_slug=self.idp.slug
+            idp_slug=self.idp.slug,
+            is_handshake_successful=True,
         )
         self.assertIsNotNone(user)
         self.assertEqual(user.username, self.user.username)

--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -37,7 +37,8 @@ class TestSsoBackend(TestCase):
 
     def setUp(self):
         super().setUp()
-        # Identity Provider is_active is always True by default for each test
+        # some tests set is_active to False, so make sure is_active is always
+        #  True by default
         self.idp.is_active = True
         self.idp.save()
 

--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -18,11 +18,7 @@ class TestSsoBackend(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.account = generator.get_billing_account_for_idp()
-        cls.domain = Domain(
-            name="vaultwax-001",
-            is_active=True
-        )
-        cls.domain.save()
+        cls.domain = Domain.get_or_create_with_name("vaultwax-001", is_active=True)
 
         # this will be the user that's "logging in" with SAML2 via the SsoBackend
         cls.user = WebUser.create(

--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -108,7 +108,7 @@ class TestSsoBackend(TestCase):
         self.assertIsNone(user)
         self.assertEqual(
             self.request.sso_login_error,
-            "Identity Provider does not exist."
+            "Identity Provider doesnotexist does not exist."
         )
 
     def test_login_error_if_idp_not_active(self):
@@ -127,7 +127,7 @@ class TestSsoBackend(TestCase):
         self.assertIsNone(user)
         self.assertEqual(
             self.request.sso_login_error,
-            "This Identity Provider is not active."
+            "This Identity Provider vaultwax is not active."
         )
 
     def test_login_error_if_bad_username(self):
@@ -162,7 +162,7 @@ class TestSsoBackend(TestCase):
         self.assertEqual(
             self.request.sso_login_error,
             "The Email Domain idonotexist.com is not allowed to authenticate "
-            "with this Identity Provider."
+            "with this Identity Provider (vaultwax)."
         )
 
     def test_login_error_if_email_domain_is_not_authorized(self):
@@ -181,7 +181,7 @@ class TestSsoBackend(TestCase):
         self.assertEqual(
             self.request.sso_login_error,
             "The Email Domain vwx.link is not allowed to authenticate with "
-            "this Identity Provider."
+            "this Identity Provider (vaultwax)."
         )
 
     def test_login_error_if_user_does_not_exist(self):

--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -47,11 +47,6 @@ class TestSsoBackend(TestCase):
 
     def setUp(self):
         super().setUp()
-        # some tests set is_active to False, so make sure is_active is always
-        #  True by default
-        self.idp.is_active = True
-        self.idp.save()
-
         self.request = RequestFactory().get('/sso/test')
         self.request.session = {
             'samlSessionIndex': '_7c84c96e-8774-4e64-893c-06f91d285100',
@@ -129,6 +124,8 @@ class TestSsoBackend(TestCase):
             self.request.sso_login_error,
             "This Identity Provider vaultwax is not active."
         )
+        self.idp.is_active = True
+        self.idp.save()
 
     def test_login_error_if_bad_username(self):
         """

--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -57,6 +57,16 @@ class TestSsoBackend(TestCase):
             'samlSessionIndex': '_7c84c96e-8774-4e64-893c-06f91d285100',
         }
 
+    def test_backend_failure_without_username(self):
+        """
+        SsoBackend (and every backend) should fail because username was not
+        passed to authenticate()
+        """
+        with self.assertRaises(KeyError):
+            auth.authenticate(
+                request=self.request,
+                idp_slug=self.idp.slug,
+            )
 
     def test_backend_failure_without_idp_slug(self):
         """

--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -1,0 +1,231 @@
+from unittest import mock
+
+from django.contrib import auth
+from django.test import TestCase, RequestFactory
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.sso.decorators import (
+    identity_provider_required,
+    use_saml2_auth,
+)
+from corehq.apps.sso.models import IdentityProvider, AuthenticatedEmailDomain
+from corehq.apps.sso.tests import generator
+from corehq.apps.users.models import WebUser
+
+
+class TestSsoBackend(TestCase):
+    """
+    This ensures that authentication through the SsoBackend only succeeds
+    when a samlSessionIndex is present and the Identity Provider, its
+    associated email domains, and the username all meet required criteria.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.account = generator.get_billing_account_for_idp()
+        cls.domain = Domain(
+            name="vaultwax-001",
+            is_active=True
+        )
+        cls.domain.save()
+
+        # this will be the user that's "logging in" with SAML2 via the SsoBackend
+        cls.user = WebUser.create(
+            cls.domain.name, 'b@vaultwax.com', 'testpwd', None, None
+        )
+        cls.idp = generator.create_idp('vaultwax', cls.account)
+        cls.idp_two = generator.create_idp('vwx-link', cls.account)
+
+    @classmethod
+    def tearDownClass(cls):
+        IdentityProvider.objects.all().delete()
+        cls.user.delete(None)
+        cls.domain.delete()
+        cls.account.delete()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        # Identity Provider is_active is always True by default for each test
+        self.idp.is_active = True
+        self.idp.save()
+
+        self.request = RequestFactory().get('/sso/test')
+        self.request.session = {}
+
+    def tearDown(self):
+        AuthenticatedEmailDomain.objects.all().delete()
+        super().tearDown()
+
+    def _set_saml_session_index(self):
+        self.request.session['samlSessionIndex'] = '_7c84c96e-8774-4e64-893c-06f91d285100'
+
+    def test_backend_failure_without_idp_slug(self):
+        """
+        SsoBackend should fail to move past the first check because an idp_slug
+         was not passed to authenticate()
+        """
+        self._set_saml_session_index()
+        user = auth.authenticate(
+            request=self.request,
+            username=self.user.username
+        )
+        self.assertIsNone(user)
+        with self.assertRaises(AttributeError):
+            self.request.sso_login_error
+
+    def test_backend_failure_without_saml_session_index(self):
+        """
+        SsoBackend should fail to move past the first check because a
+         samlSessionIndex is not present in request.session.
+        """
+        user = auth.authenticate(
+            request=self.request,
+            username=self.user.username,
+            idp_slug=self.idp.slug
+        )
+        self.assertIsNone(user)
+
+    def test_login_error_if_idp_doesnt_exist(self):
+        """
+        SsoBackend should fail to return a user if the Identity Provider
+        slug associated with that user does not exist. It should also populate
+        request.sso_login_error with an error message.
+        """
+        self._set_saml_session_index()
+        user = auth.authenticate(
+            request=self.request,
+            username=self.user.username,
+            idp_slug='doesnotexist'
+        )
+        self.assertIsNone(user)
+        self.assertEqual(
+            self.request.sso_login_error,
+            "Identity Provider does not exist."
+        )
+
+    def test_login_error_if_idp_not_active(self):
+        """
+        SsoBackend should fail to return a user if the Identity Provider
+        associated with that user is not active. It should also populate
+        request.sso_login_error with an error message.
+        """
+        self._set_saml_session_index()
+        self.idp.is_active = False
+        self.idp.save()
+        user = auth.authenticate(
+            request=self.request,
+            username=self.user.username,
+            idp_slug=self.idp.slug
+        )
+        self.assertIsNone(user)
+        self.assertEqual(
+            self.request.sso_login_error,
+            "This Identity Provider is not active."
+        )
+
+    def test_login_error_if_bad_username(self):
+        """
+        SsoBackend should fail to return a user if the username passed to it
+        is not a valid email address (missing email domain / no `@`). It should
+        also populate request.sso_login_error with an error message.
+        """
+        self._set_saml_session_index()
+        user = auth.authenticate(
+            request=self.request,
+            username='badusername',
+            idp_slug=self.idp.slug
+        )
+        self.assertIsNone(user)
+        self.assertEqual(
+            self.request.sso_login_error,
+            "Username badusername is not valid."
+        )
+
+    def test_login_error_if_email_domain_does_not_exist(self):
+        """
+        SsoBackend should fail to return a user if the username passed to it
+        matches an email domain that is not mapped to any Identity Provider.
+        It should also populate request.sso_login_error with an error message.
+        """
+        self._set_saml_session_index()
+        user = auth.authenticate(
+            request=self.request,
+            username='b@vwx.link',
+            idp_slug=self.idp.slug
+        )
+        self.assertIsNone(user)
+        self.assertEqual(
+            self.request.sso_login_error,
+            "The Email Domain vwx.link is not allowed to authenticate with "
+            "this Identity Provider."
+        )
+
+    def test_login_error_if_email_domain_is_not_authorized(self):
+        """
+        SsoBackend should fail to return a user if the username passed to it
+        matches an email domain that exists, but is not authorized to
+        authenticate with the Identity Provider in the request. It should also
+        populate request.sso_login_error with an error message.
+        """
+        self._set_saml_session_index()
+        AuthenticatedEmailDomain.objects.create(
+            email_domain='vwx.link',
+            identity_provider=self.idp_two,  # note that this is not self.idp
+        )
+        user = auth.authenticate(
+            request=self.request,
+            username='b@vwx.link',
+            idp_slug=self.idp.slug  # note that this is self.idp, not idp_two
+        )
+        self.assertIsNone(user)
+        self.assertEqual(
+            self.request.sso_login_error,
+            "The Email Domain vwx.link is not allowed to authenticate with "
+            "this Identity Provider."
+        )
+
+    def test_login_error_if_user_does_not_exist(self):
+        """
+        SsoBackend should fail to return a user if the username passed to does
+        not exist. It should also populate request.sso_login_error with an
+        error message.
+
+        todo this test will change with additional user creation workflows
+         that will be introduced later
+        """
+        self._set_saml_session_index()
+        AuthenticatedEmailDomain.objects.create(
+            email_domain='vaultwax.com',
+            identity_provider=self.idp,
+        )
+        user = auth.authenticate(
+            request=self.request,
+            username='testnoexist@vaultwax.com',
+            idp_slug=self.idp.slug
+        )
+        self.assertIsNone(user)
+        self.assertEqual(
+            self.request.sso_login_error,
+            "User testnoexist@vaultwax.com does not exist."
+        )
+
+    def test_successful_login(self):
+        """
+        This test demonstrates the requirements necessary for a SsoBackend to
+        successfully return a user and report no login error.
+        """
+        self._set_saml_session_index()
+        AuthenticatedEmailDomain.objects.create(
+            email_domain='vaultwax.com',
+            identity_provider=self.idp,
+        )
+        user = auth.authenticate(
+            request=self.request,
+            username=self.user.username,
+            idp_slug=self.idp.slug
+        )
+        self.assertIsNotNone(user)
+        self.assertEqual(user.username, self.user.username)
+        self.assertIsNone(self.request.sso_login_error)

--- a/corehq/apps/sso/views/saml.py
+++ b/corehq/apps/sso/views/saml.py
@@ -9,7 +9,6 @@ from django.http import (
 from django.shortcuts import redirect
 from django.views.decorators.csrf import csrf_exempt
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
-from onelogin.saml2.utils import OneLogin_Saml2_Utils
 
 from corehq.apps.sso.decorators import (
     identity_provider_required,
@@ -88,8 +87,6 @@ def sso_saml_acs(request, idp_slug):
             "samlSessionIndex": request.session['samlSessionIndex'],
         }
 
-        # todo redirect here?
-        saml_relay = OneLogin_Saml2_Utils.get_self_url(request.saml2_request_data)
     else:
         error_reason = request.saml2_auth.get_last_error_reason()
 

--- a/corehq/apps/sso/views/saml.py
+++ b/corehq/apps/sso/views/saml.py
@@ -71,6 +71,7 @@ def sso_saml_acs(request, idp_slug):
             request=request,
             username=request.session['samlNameId'],
             idp_slug=idp_slug,
+            is_handshake_successful=True,
         )
 
         if user:

--- a/settings.py
+++ b/settings.py
@@ -183,6 +183,7 @@ ADD_CAPTCHA_FIELD_TO_FORMS = False
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
     'corehq.apps.domain.auth.ApiKeyFallbackBackend',
+    'corehq.apps.sso.backends.SsoBackend',
 ]
 
 PASSWORD_HASHERS = (


### PR DESCRIPTION
## Summary
This adds a new authentication backend `SsoBackend` that is used to authenticate a user after a successful SAML2 handshake. 

## Feature Flag
`ENTERPRISE_SSO`

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
New tests included for `SsoBackend`

### QA Plan
Like with all SSO work, there will be a major QA and pen test once the dev work has reached a more complete stage.

### Safety story
Note that this will not be active/accessible on production as there are no active `IdentityProvider`s, so this is 100% safe to merge without QA. 

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
