### PR TITLE
Mjr/xss app manager

### DIFF
--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -87,7 +87,7 @@ def html_trans_prefix_delim(name, langs=["default"]):
 
 @register.filter
 def html_name(name):
-    return mark_safe(html.strip_tags(name) or EMPTY_LABEL)
+    return html.strip_tags(name) or EMPTY_LABEL
 
 
 @register.simple_tag

--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -92,43 +92,61 @@ def html_name(name):
 
 @register.simple_tag
 def input_trans(name, langs=None, input_name='name', input_id=None, data_bind=None):
+    options = _get_dynamic_input_trans_options(name, langs=langs)
+    input_id_attribute = format_html("id='{}'", input_id) if input_id else ""
+    data_bind_attribute = format_html("data-bind='{}'", data_bind) if data_bind else ""
+
+    options.update({
+        "input_name": input_name,
+        "input_id_attribute": input_id_attribute,
+        "data_bind_attribute": data_bind_attribute
+    })
+
     template = '''
         <input type="text"
-               name="{}" {} {}
+               name="{input_name}" {input_id_attribute} {data_bind_attribute}
                class="form-control"
-               value="%(value)s"
-               placeholder="%(placeholder)s" />
-    '''.format(
-        input_name,
-        f"id='{input_id}'" if input_id else "",
-        f"data-bind='{data_bind}'" if data_bind else "")
-    return _input_trans(template, name, langs=langs)
+               value="{value}"
+               placeholder="{placeholder}" />
+    '''
+
+    return format_html(template, **options)
 
 
 @register.simple_tag
 def inline_edit_trans(name, langs=None, url='', saveValueName='', postSave='',
         containerClass='', iconClass='', readOnlyClass='', disallow_edit='false'):
+    options = _get_dynamic_input_trans_options(name, langs=langs, allow_blank=False)
+    options.update({
+        'url': url,
+        'saveValueName': saveValueName,
+        'containerClass': containerClass,
+        'iconClass': iconClass,
+        'readOnlyClass': readOnlyClass,
+        'postSave': postSave,
+        'disallow_edit': disallow_edit
+    })
+
     template = '''
         <inline-edit params="
             name: 'name',
-            value: '%(value)s',
-            placeholder: '%(placeholder)s',
+            value: '{value}',
+            placeholder: '{placeholder}',
             nodeName: 'input',
-            lang: '%(lang)s',
-            url: '{}',
-            saveValueName: '{}',
-            containerClass: '{}',
-            iconClass: '{}',
-            readOnlyClass: '{}',
-            postSave: {},
-            disallow_edit: {},
+            lang: '{lang}',
+            url: '{url}',
+            saveValueName: '{saveValueName}',
+            containerClass: '{containerClass}',
+            iconClass: '{iconClass}',
+            readOnlyClass: '{readOnlyClass}',
+            postSave: {postSave},
+            disallow_edit: {disallow_edit},
         "></inline-edit>
-    '''.format(url, saveValueName, containerClass, iconClass, readOnlyClass, postSave, disallow_edit)
-    return _input_trans(template, name, langs=langs, allow_blank=False)
+    '''
+    return format_html(template, **options)
 
 
-# template may have replacements for lang, placeholder, and value
-def _input_trans(template, name, langs=None, allow_blank=True):
+def _get_dynamic_input_trans_options(name, langs=None, allow_blank=True):
     if langs is None:
         langs = ["default"]
     placeholder = _("Untitled")
@@ -149,7 +167,7 @@ def _input_trans(template, name, langs=None, allow_blank=True):
                 options['lang'] = lang
             break
     options = {key: html.escapejs(value) for (key, value) in options.items()}
-    return mark_safe(template % options)
+    return options
 
 
 @register.filter

--- a/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
+++ b/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
@@ -1,8 +1,15 @@
 from lxml.html import fragment_fromstring
 from django.test import SimpleTestCase
-from ...templatetags.xforms_extras import \
-    html_trans, html_trans_prefix, html_trans_prefix_delim, clean_trans, trans, \
-    html_name, input_trans, inline_edit_trans
+from ...templatetags.xforms_extras import (
+    html_trans,
+    html_trans_prefix,
+    html_trans_prefix_delim,
+    clean_trans,
+    trans,
+    html_name,
+    input_trans,
+    inline_edit_trans
+)
 
 
 class TestTransFilter(SimpleTestCase):
@@ -11,7 +18,7 @@ class TestTransFilter(SimpleTestCase):
         result = trans(empty_translation_dict)
         self.assertEqual(result, '')
 
-    def test_unspecified_language_includes_tag(self):
+    def test_unspecified_language_includes_indicator(self):
         translation_dict = {'en': 'English Output'}
         result = trans(translation_dict)
         self.assertEqual(result, 'English Output [en] ')
@@ -21,50 +28,50 @@ class TestTransFilter(SimpleTestCase):
         result = trans(translation_dict, include_lang=False)
         self.assertEqual(result, 'English Output')
 
-    def test_primary_language_excludes_tag(self):
+    def test_primary_language_excludes_indicator(self):
         translation_dict = {'en': 'English Output'}
         langs = ['en']
         result = trans(translation_dict, langs=langs)
         self.assertEqual(result, 'English Output')
 
-    def test_secondary_language_includes_tag(self):
+    def test_secondary_language_includes_indicator(self):
         translation_dict = {'en': 'English Output'}
         langs = ['por', 'en']
         result = trans(translation_dict, langs=langs)
         self.assertEqual(result, 'English Output [en] ')
 
-    def test_do_not_use_delimiter_includes_html_tag(self):
+    def test_do_not_use_delimiter_includes_html_indicator(self):
         translation_dict = {'en': 'English Output'}
         result = trans(translation_dict, use_delim=False)
         self.assertEqual(result,
             'English Output <span class="btn btn-xs btn-info btn-langcode-preprocessed">en</span> ')
 
-    def test_prefix_puts_tag_in_front_of_translation(self):
+    def test_prefix_puts_indicator_in_front_of_translation(self):
         translation_dict = {'en': 'English Output'}
         result = trans(translation_dict, prefix=True)
         self.assertEqual(result, ' [en] English Output')
 
-    def test_strip_tags_removes_tags_from_html_tag(self):
+    def test_strip_tags_removes_tags_from_html_indicator(self):
         translation_dict = {'en': 'English Output'}
         result = trans(translation_dict, use_delim=False, strip_tags=True)
         self.assertEqual(result, 'English Output en ')
 
 
 class TestHTMLTransFilter(SimpleTestCase):
-    def test_primary_language_includes_no_tag(self):
+    def test_primary_language_includes_no_indicator(self):
         name_dict = {'en': 'English Output'}
         langs = ['en']
         result = html_trans(name_dict, langs)
         self.assertEqual(result, 'English Output')
 
-    def test_non_primary_includes_appended_tag(self):
+    def test_non_primary_includes_appended_indicator(self):
         name_dict = {'por': 'Portuguese Output'}
         langs = ['en', 'por']
         result = html_trans(name_dict, langs)
         unpadded_result = ' '.join(result.split())
         self.assertEqual(unpadded_result, 'Portuguese Output por')
 
-    def test_no_language_returns_first_available_with_appended_tag(self):
+    def test_no_language_returns_first_available_with_appended_indicator(self):
         name_dict = {'en': 'English Output'}
         result = html_trans(name_dict)
         unpadded_result = ' '.join(result.split())
@@ -94,13 +101,13 @@ class TestHTMLTransFilter(SimpleTestCase):
 
 
 class TestHTMLTransPrefixFilter(SimpleTestCase):
-    def test_primary_language_includes_no_tag(self):
+    def test_primary_language_includes_no_indicator(self):
         name_dict = {'en': 'English Output'}
         langs = ['en']
         result = html_trans_prefix(name_dict, langs)
         self.assertEqual(result, 'English Output')
 
-    def test_non_primary_language_includes_prepended_html_tag(self):
+    def test_non_primary_language_includes_prepended_html_indicator(self):
         name_dict = {'por': 'Portuguese Output'}
         langs = ['en', 'por']
         result = html_trans_prefix(name_dict, langs)
@@ -108,7 +115,7 @@ class TestHTMLTransPrefixFilter(SimpleTestCase):
         self.assertEqual(unpadded_result,
             '<span class="btn btn-xs btn-info btn-langcode-preprocessed">por</span> Portuguese Output')
 
-    def test_default_language_includes_prepended_html_tag(self):
+    def test_default_language_includes_prepended_html_indicator(self):
         name_dict = {'en': 'English Output'}
         result = html_trans_prefix(name_dict)
         unpadded_result = ' '.join(result.split())
@@ -123,19 +130,19 @@ class TestHTMLTransPrefixFilter(SimpleTestCase):
 
 
 class TestHTMLTransPrefixDelimFilter(SimpleTestCase):
-    def test_primary_language_includes_no_tag(self):
+    def test_primary_language_includes_no_indicator(self):
         name_dict = {'en': 'English Output'}
         langs = ['en']
         result = html_trans_prefix_delim(name_dict, langs)
         self.assertEqual(result, 'English Output')
 
-    def test_non_primary_language_includes_prepended_tag(self):
+    def test_non_primary_language_includes_prepended_indicator(self):
         name_dict = {'por': 'Portuguese Output'}
         langs = ['en', 'por']
         result = html_trans_prefix_delim(name_dict, langs)
         self.assertEqual(result, ' [por] Portuguese Output')
 
-    def test_default_language_includes_prepended_tag(self):
+    def test_default_language_includes_prepended_indicator(self):
         name_dict = {'en': 'English Output'}
         result = html_trans_prefix_delim(name_dict)
         self.assertEqual(result, ' [en] English Output')
@@ -148,19 +155,19 @@ class TestHTMLTransPrefixDelimFilter(SimpleTestCase):
 
 
 class TestCleanTransFilter(SimpleTestCase):
-    def test_primary_language_includes_no_tag(self):
+    def test_primary_language_includes_no_indicator(self):
         name_dict = {'en': 'English Output'}
         langs = ['en']
         result = clean_trans(name_dict, langs)
         self.assertEqual(result, 'English Output')
 
-    def test_non_primary_language_includes_no_tag(self):
+    def test_non_primary_language_includes_no_indicator(self):
         name_dict = {'por': 'Portuguese Output'}
         langs = ['en', 'por']
         result = clean_trans(name_dict, langs)
         self.assertEqual(result, 'Portuguese Output')
 
-    def test_default_language_includes_no_tag(self):
+    def test_default_language_includes_no_indicator(self):
         name_dict = {'en': 'English Output'}
         result = clean_trans(name_dict)
         self.assertEqual(result, 'English Output')

--- a/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
+++ b/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
@@ -1,6 +1,51 @@
 from django.test import SimpleTestCase
 from ...templatetags.xforms_extras import \
-    html_trans, html_trans_prefix, html_trans_prefix_delim, clean_trans
+    html_trans, html_trans_prefix, html_trans_prefix_delim, clean_trans, trans
+
+
+class TestTransFilter(SimpleTestCase):
+    def test_no_translations_returns_empty(self):
+        empty_translation_dict = {}
+        result = trans(empty_translation_dict)
+        self.assertEqual(result, '')
+
+    def test_unspecified_language_includes_tag(self):
+        translation_dict = {'en': 'English Output'}
+        result = trans(translation_dict)
+        self.assertEqual(result, 'English Output [en] ')
+
+    def test_exclude_language_only_outputs_translation(self):
+        translation_dict = {'en': 'English Output'}
+        result = trans(translation_dict, include_lang=False)
+        self.assertEqual(result, 'English Output')
+
+    def test_primary_language_excludes_tag(self):
+        translation_dict = {'en': 'English Output'}
+        langs = ['en']
+        result = trans(translation_dict, langs=langs)
+        self.assertEqual(result, 'English Output')
+
+    def test_secondary_language_includes_tag(self):
+        translation_dict = {'en': 'English Output'}
+        langs = ['por', 'en']
+        result = trans(translation_dict, langs=langs)
+        self.assertEqual(result, 'English Output [en] ')
+
+    def test_do_not_use_delimiter_includes_html_tag(self):
+        translation_dict = {'en': 'English Output'}
+        result = trans(translation_dict, use_delim=False)
+        self.assertEqual(result,
+            'English Output <span class="btn btn-xs btn-info btn-langcode-preprocessed">en</span> ')
+
+    def test_prefix_puts_tag_in_front_of_translation(self):
+        translation_dict = {'en': 'English Output'}
+        result = trans(translation_dict, prefix=True)
+        self.assertEqual(result, ' [en] English Output')
+
+    def test_strip_tags_removes_tags_from_html_tag(self):
+        translation_dict = {'en': 'English Output'}
+        result = trans(translation_dict, use_delim=False, strip_tags=True)
+        self.assertEqual(result, 'English Output en ')
 
 
 class TestHTMLTransFilter(SimpleTestCase):
@@ -22,6 +67,28 @@ class TestHTMLTransFilter(SimpleTestCase):
         result = html_trans(name_dict)
         unpadded_result = ' '.join(result.split())
         self.assertEqual(unpadded_result, 'English Output en')
+
+    # NOTE: This test only documents existing behavior.
+    # I think it's likely that stripping was only meant to remove the markup surrounding the language,
+    # and that the user input should just be escaped
+    def test_strips_tags(self):
+        name_dict = {'en': '<b>Bold Tag</b>'}
+        langs = ['en']
+        result = html_trans(name_dict, langs)
+        self.assertEqual(result, 'Bold Tag')
+
+    def test_strips_tag_of_non_primary_language(self):
+        name_dict = {'por': 'Portuguese Output'}
+        langs = ['en', 'por']
+        result = html_trans(name_dict, langs)
+        self.assertEqual(result, 'Portuguese Output por ')
+
+    # NOTE: More existing behavior. Given that it strips out other tags, this seems unintentional
+    def test_empty_mapping_returns_empty_span(self):
+        name_dict = {}
+        langs = ['en', 'por']
+        result = html_trans(name_dict, langs)
+        self.assertEqual(result, '<span class="label label-info">Empty</span>')
 
 
 class TestHTMLTransPrefixFilter(SimpleTestCase):
@@ -46,6 +113,12 @@ class TestHTMLTransPrefixFilter(SimpleTestCase):
         self.assertEqual(unpadded_result,
             '<span class="btn btn-xs btn-info btn-langcode-preprocessed">en</span> English Output')
 
+    def test_empty_mapping_returns_empty_span(self):
+        name_dict = {}
+        langs = ['en', 'por']
+        result = html_trans_prefix(name_dict, langs)
+        self.assertEqual(result, '<span class="label label-info">Empty</span>')
+
 
 class TestHTMLTransPrefixDelimFilter(SimpleTestCase):
     def test_primary_language_includes_no_tag(self):
@@ -64,6 +137,12 @@ class TestHTMLTransPrefixDelimFilter(SimpleTestCase):
         name_dict = {'en': 'English Output'}
         result = html_trans_prefix_delim(name_dict)
         self.assertEqual(result, ' [en] English Output')
+
+    def test_empty_mapping_returns_empty_span(self):
+        name_dict = {}
+        langs = ['en', 'por']
+        result = html_trans_prefix_delim(name_dict, langs)
+        self.assertEqual(result, '<span class="label label-info">Empty</span>')
 
 
 class TestCleanTransFilter(SimpleTestCase):

--- a/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
+++ b/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
@@ -1,0 +1,85 @@
+from django.test import SimpleTestCase
+from ...templatetags.xforms_extras import \
+    html_trans, html_trans_prefix, html_trans_prefix_delim, clean_trans
+
+
+class TestHTMLTransFilter(SimpleTestCase):
+    def test_primary_language_includes_no_tag(self):
+        name_dict = {'en': 'English Output'}
+        langs = ['en']
+        result = html_trans(name_dict, langs)
+        self.assertEqual(result, 'English Output')
+
+    def test_non_primary_includes_appended_tag(self):
+        name_dict = {'por': 'Portuguese Output'}
+        langs = ['en', 'por']
+        result = html_trans(name_dict, langs)
+        unpadded_result = ' '.join(result.split())
+        self.assertEqual(unpadded_result, 'Portuguese Output por')
+
+    def test_no_language_returns_first_available_with_appended_tag(self):
+        name_dict = {'en': 'English Output'}
+        result = html_trans(name_dict)
+        unpadded_result = ' '.join(result.split())
+        self.assertEqual(unpadded_result, 'English Output en')
+
+
+class TestHTMLTransPrefixFilter(SimpleTestCase):
+    def test_primary_language_includes_no_tag(self):
+        name_dict = {'en': 'English Output'}
+        langs = ['en']
+        result = html_trans_prefix(name_dict, langs)
+        self.assertEqual(result, 'English Output')
+
+    def test_non_primary_language_includes_prepended_html_tag(self):
+        name_dict = {'por': 'Portuguese Output'}
+        langs = ['en', 'por']
+        result = html_trans_prefix(name_dict, langs)
+        unpadded_result = ' '.join(result.split())
+        self.assertEqual(unpadded_result,
+            '<span class="btn btn-xs btn-info btn-langcode-preprocessed">por</span> Portuguese Output')
+
+    def test_default_language_includes_prepended_html_tag(self):
+        name_dict = {'en': 'English Output'}
+        result = html_trans_prefix(name_dict)
+        unpadded_result = ' '.join(result.split())
+        self.assertEqual(unpadded_result,
+            '<span class="btn btn-xs btn-info btn-langcode-preprocessed">en</span> English Output')
+
+
+class TestHTMLTransPrefixDelimFilter(SimpleTestCase):
+    def test_primary_language_includes_no_tag(self):
+        name_dict = {'en': 'English Output'}
+        langs = ['en']
+        result = html_trans_prefix_delim(name_dict, langs)
+        self.assertEqual(result, 'English Output')
+
+    def test_non_primary_language_includes_prepended_tag(self):
+        name_dict = {'por': 'Portuguese Output'}
+        langs = ['en', 'por']
+        result = html_trans_prefix_delim(name_dict, langs)
+        self.assertEqual(result, ' [por] Portuguese Output')
+
+    def test_default_language_includes_prepended_tag(self):
+        name_dict = {'en': 'English Output'}
+        result = html_trans_prefix_delim(name_dict)
+        self.assertEqual(result, ' [en] English Output')
+
+
+class TestCleanTransFilter(SimpleTestCase):
+    def test_primary_language_includes_no_tag(self):
+        name_dict = {'en': 'English Output'}
+        langs = ['en']
+        result = clean_trans(name_dict, langs)
+        self.assertEqual(result, 'English Output')
+
+    def test_non_primary_language_includes_no_tag(self):
+        name_dict = {'por': 'Portuguese Output'}
+        langs = ['en', 'por']
+        result = clean_trans(name_dict, langs)
+        self.assertEqual(result, 'Portuguese Output')
+
+    def test_default_language_includes_no_tag(self):
+        name_dict = {'en': 'English Output'}
+        result = clean_trans(name_dict)
+        self.assertEqual(result, 'English Output')

--- a/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
+++ b/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
@@ -1,6 +1,7 @@
 from django.test import SimpleTestCase
 from ...templatetags.xforms_extras import \
-    html_trans, html_trans_prefix, html_trans_prefix_delim, clean_trans, trans
+    html_trans, html_trans_prefix, html_trans_prefix_delim, clean_trans, trans, \
+    html_name
 
 
 class TestTransFilter(SimpleTestCase):
@@ -162,3 +163,14 @@ class TestCleanTransFilter(SimpleTestCase):
         name_dict = {'en': 'English Output'}
         result = clean_trans(name_dict)
         self.assertEqual(result, 'English Output')
+
+
+class TestHTMLNameFilter(SimpleTestCase):
+    def test_strips_tags(self):
+        result = html_name('<b>Name</b>')
+        self.assertEqual(result, 'Name')
+
+    # NOTE: Documenting existing behavior. This looks like a bug, given it strips tags otherwise
+    def test_no_name_returns_empty_label(self):
+        result = html_name('')
+        self.assertEqual(result, '<span class="label label-info">Empty</span>')

--- a/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
+++ b/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
@@ -1,7 +1,8 @@
+from lxml.html import fragment_fromstring
 from django.test import SimpleTestCase
 from ...templatetags.xforms_extras import \
     html_trans, html_trans_prefix, html_trans_prefix_delim, clean_trans, trans, \
-    html_name
+    html_name, input_trans, inline_edit_trans
 
 
 class TestTransFilter(SimpleTestCase):
@@ -174,3 +175,198 @@ class TestHTMLNameFilter(SimpleTestCase):
     def test_no_name_returns_empty_label(self):
         result = html_name('')
         self.assertEqual(result, '<span class="label label-info">Empty</span>')
+
+
+class TestInlineEditTransFilter(SimpleTestCase):
+    @staticmethod
+    def generate_markup_fragment(
+        name_dict={'en': 'English Output'},
+        langs=['en'],
+        url='test-url',
+        saveValueName='saveValue',
+        postSave='postSave',
+        containerClass='containerClass',
+        iconClass='iconClass',
+        readOnlyClass='readOnlyClass',
+        disallow_edit='false'
+    ):
+        markup = inline_edit_trans(
+            name_dict,
+            langs,
+            url,
+            saveValueName,
+            postSave,
+            containerClass,
+            iconClass,
+            readOnlyClass,
+            disallow_edit
+        )
+
+        return fragment_fromstring(markup)
+
+    @classmethod
+    def generate_params(cls, **kwargs):
+        fragment = cls.generate_markup_fragment(**kwargs)
+        return cls.dict_from_params(fragment.attrib['params'])
+
+    @staticmethod
+    def dict_from_params(params):
+        unsplitPairs = params.split(',')
+        pairs = [
+            [token.strip() for token in pair.split(':')]
+            for pair in unsplitPairs]
+        pairs = [pair for pair in pairs if len(pair) == 2]
+        return dict(pairs)
+
+    def test_creates_inline_edit_tag(self):
+        fragment = self.generate_markup_fragment()
+        self.assertEqual(fragment.tag, 'inline-edit')
+
+    def test_all_parameters(self):
+        params = self.generate_params(
+            name_dict={'en': 'English Output'},
+            langs=['en'],
+            url='test-url',
+            saveValueName='saveValue',
+            postSave='postSave',
+            containerClass='containerClass',
+            iconClass='iconClass',
+            readOnlyClass='readOnlyClass',
+            disallow_edit='false'
+        )
+
+        self.assertEqual(params['name'], "'name'")
+        self.assertEqual(params['nodeName'], "'input'")
+        self.assertEqual(params['url'], "'test-url'")
+        self.assertEqual(params['saveValueName'], "'saveValue'")
+        self.assertEqual(params['containerClass'], "'containerClass'")
+        self.assertEqual(params['iconClass'], "'iconClass'")
+        self.assertEqual(params['readOnlyClass'], "'readOnlyClass'")
+        self.assertEqual(params['postSave'], 'postSave')
+        self.assertEqual(params['disallow_edit'], 'false')
+
+    def test_primary_language(self):
+        params = self.generate_params(
+            name_dict={'en': 'English Output'},
+            langs=['en']
+        )
+
+        self.assertEqual(params['value'], "'English Output'")
+        self.assertEqual(params['placeholder'], "'English Output'")
+        self.assertEqual(params['lang'], "''")
+
+    def test_secondary_language(self):
+        params = self.generate_params(
+            name_dict={'por': 'Portuguese Output'},
+            langs=['en', 'por']
+        )
+
+        self.assertEqual(params['value'], "''")
+        self.assertEqual(params['placeholder'], "'Portuguese Output'")
+        self.assertEqual(params['lang'], "'por'")
+
+    def test_no_available_translation(self):
+        params = self.generate_params(
+            name_dict={'en': 'English Output'},
+            langs=[]
+        )
+
+        self.assertEqual(params['value'], "''")
+        self.assertEqual(params['placeholder'], "'English Output'")
+        self.assertEqual(params['lang'], "''")
+
+    def test_uses_javascript_escaping_on_value_and_placeholder(self):
+        params = self.generate_params(
+            name_dict={'en': 'English; Output'},
+            langs=['en']
+        )
+
+        self.assertEqual(params['value'], "'English\\u003B Output'")
+        self.assertEqual(params['placeholder'], "'English\\u003B Output'")
+
+
+class TestInputTransFilter(SimpleTestCase):
+    @staticmethod
+    def generate_markup_fragment(
+        name_dict={'en': 'English Output'},
+        langs=['en'],
+        input_name='name',
+        input_id='test_id',
+        data_bind='data_binding'
+    ):
+        markup = input_trans(
+            name=name_dict,
+            langs=langs,
+            input_name=input_name,
+            input_id=input_id,
+            data_bind=data_bind)
+
+        return fragment_fromstring(markup)
+
+    def test_creates_input_tag(self):
+        fragment = self.generate_markup_fragment()
+        self.assertEqual(fragment.tag, 'input')
+
+    def test_fills_all_attributes(self):
+        fragment = self.generate_markup_fragment(
+            name_dict={'en': 'English Output'},
+            langs=['en'],
+            input_name='name',
+            input_id='test_id',
+            data_bind='data_binding'
+        )
+
+        self.assertEqual(fragment.attrib['type'], 'text')
+        self.assertEqual(fragment.attrib['name'], 'name')
+        self.assertEqual(fragment.attrib['id'], 'test_id')
+        self.assertEqual(fragment.attrib['data-bind'], 'data_binding')
+        self.assertEqual(fragment.attrib['class'], 'form-control')
+        self.assertEqual(fragment.attrib['value'], 'English Output')
+        self.assertEqual(fragment.attrib['placeholder'], '')
+
+    def test_primary_language_populates_value(self):
+        fragment = self.generate_markup_fragment(
+            name_dict={'en': 'English Output'},
+            langs=['en']
+        )
+
+        self.assertEqual(fragment.attrib['value'], 'English Output')
+        self.assertEqual(fragment.attrib['placeholder'], '')
+
+    def test_secondary_language_ignores_value_and_populates_placeholder(self):
+        fragment = self.generate_markup_fragment(
+            name_dict={'por': 'Portuguese Output'},
+            langs=['en', 'por']
+        )
+
+        self.assertEqual(fragment.attrib['value'], '')
+        self.assertEqual(fragment.attrib['placeholder'], 'Portuguese Output')
+
+    def test_no_id_contains_no_id_attribute(self):
+        fragment = self.generate_markup_fragment(input_name=None)
+
+        self.assertFalse('input_id' in fragment.attrib)
+
+    def test_no_data_binding_contains_no_data_binding(self):
+        fragment = self.generate_markup_fragment(data_bind=None)
+
+        self.assertFalse('data-bind' in fragment.attrib)
+
+    # NOTE: documenting existing behavior -- I think this was a side effect
+    # of the parsing logic also being used elsewhere, and I doubt 'value' is meant to have javascript-escaping
+    def test_escapes_value_using_javascript_notation(self):
+        fragment = self.generate_markup_fragment(
+            name_dict={'en': 'English; Output'},
+            langs=['en']
+        )
+
+        self.assertEqual(fragment.attrib['value'], 'English\\u003B Output')
+
+    # NOTE: documenting existing behavior -- it is unlikely this needs to be javascript-escaped
+    def test_escapes_placeholder_using_javascript_notation(self):
+        fragment = self.generate_markup_fragment(
+            name_dict={'por': 'Portuguese; Output'},
+            langs=['en', 'por']
+        )
+
+        self.assertEqual(fragment.attrib['placeholder'], 'Portuguese\\u003B Output')

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1353,7 +1353,7 @@ def _init_biometrics_identify_module(app, lang, enroll_form_id):
 
     form_name = _("Followup with Person")
 
-    output_tag = mark_safe(  # nosec: no user-input
+    output_tag = mark_safe(  # nosec: no user input
         "<output value=\"instance('casedb')/casedb/case[@case_id = "
         "instance('commcaresession')/session/data/case_id]/case_name\" "
         "vellum:value=\"#case/case_name\" />"

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -15,6 +15,7 @@ from django.http import (
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy
 from django.utils.translation import ugettext as _
 from django.views import View
@@ -1352,18 +1353,20 @@ def _init_biometrics_identify_module(app, lang, enroll_form_id):
 
     form_name = _("Followup with Person")
 
+    output_tag = mark_safe(  # nosec: no user-input
+        "<output value=\"instance('casedb')/casedb/case[@case_id = "
+        "instance('commcaresession')/session/data/case_id]/case_name\" "
+        "vellum:value=\"#case/case_name\" />"
+    )
+
     context = {
         'xmlns_uuid': generate_xmlns(),
         'form_name': form_name,
         'lang': lang,
-        'placeholder_label': mark_safe(_(
+        'placeholder_label': format_html(_(
             "This is your follow up form for {}. Delete this label and add "
             "questions for any follow up visits."
-        ).format(
-            "<output value=\"instance('casedb')/casedb/case[@case_id = "
-            "instance('commcaresession')/session/data/case_id]/case_name\" "
-            "vellum:value=\"#case/case_name\" />"
-        ))
+        ), output_tag)
     }
     attachment = render_to_string(
         "app_manager/simprints_followup_form.xml",


### PR DESCRIPTION
## Summary
This is one of many apps that will need to be handled as part of [SAAS-11853](https://dimagi-dev.atlassian.net/browse/SAAS-11853).  This included writing many tests to establish baseline behavior, as I wasn't sure how the existing code was intended to behave.  The intent is to either eliminate our use of `mark_safe`, or to restrict it to only sections that truly need it. Note that we will eventually use [Bandit](https://bandit.readthedocs.io/en/latest/) to catch these issues in the future, which is why there are some `# nosec` comments in the request -- they tell Bandit to ignore the commented line.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

For non-simplistic refactoring, there are now detailed tests under `test_xforms_extras.py`

### QA Plan

I'm leaving this outside of QA for now. I think it likely makes sense to try to bundle a few modules together for QA, rather than requesting smoke tests for every XSS change. This should not be merged until that QA pass happens, however.

### Safety story

Because it is essentially a refactor (the only behavior change is restricting code which is marked as safe), this can be rolled back with no issues.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
