### PR TITLE
Added some sorting

### DIFF
--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -255,7 +255,7 @@ class DomainLinkView(BaseAdminProjectSettingsView):
                 'master_link': self._link_context(master_link, timezone) if master_link else None,
                 'model_status': sorted(model_status, key=lambda m: m['name']),
                 'master_model_status': sorted(master_model_status, key=lambda m: m['name']),
-                'linked_domains': linked_domains,
+                'linked_domains': sorted(linked_domains, key=lambda d: d['linked_domain']),
                 'models': [
                     {'slug': model[0], 'name': model[1]}
                     for model in LINKED_MODELS

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -49,6 +49,6 @@ class CaseUpdateCommand(BaseCommand):
         options.pop("username")
         self.extra_options = options
 
-        for domain in domains:
+        for domain in sorted(domains):
             print(f"Processing {domain}")
             self.update_cases(domain, case_type, user_id)


### PR DESCRIPTION
## Product Description
Sorted linked domains listed on Project Settings > Linked Domains

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Management command has test coverage, project settings view doesn't.

### QA Plan

No QA.

### Safety story
This is pretty trivial. I tested the project spaces page locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
