### PR TITLE
temporarily stop icds test in travis due to sudden failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ before_install:
   - sudo mv -v docker-compose /usr/local/bin/
 install:
   - mkdir -p $TRAVIS_BUILD_DIR/docker-volumes
-  - .travis/setup_icds.sh
 before_script:
   - docker version
   - docker-compose version


### PR DESCRIPTION
## Summary
I removed running `setup_icds.sh` from the Travis build as it appears the `deploy_key.pem` has suddenly stopped working and is causing all new builds to fail. Leaving the key and script in place for now so that someone with more familiarity can either diagnose & fix or fully remove. cc @snopoke 

FYI the error it throws is as follows:
```
$ .travis/setup_icds.sh
ICDS Setup
Agent pid 4037
Identity added: /home/travis/build/[secure]/commcare-hq/.travis/deploy_key.pem ([secure])
Cloning into '/home/travis/build/[secure]/commcare-hq/extensions/icds'...
Warning: Permanently added the RSA host key for IP address '140.82.114.4' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.
Please make sure you have the correct access rights
and the repository exists.
The command ".travis/setup_icds.sh" failed and exited with 128 during .
Your build has been stopped.
```

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Hopefully, our tests should run now.

### Safety story
Only a travis build change

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
