### PR TITLE
Fix Default Export Settings bug

### DIFF
--- a/corehq/apps/enterprise/forms.py
+++ b/corehq/apps/enterprise/forms.py
@@ -93,6 +93,7 @@ class EnterpriseSettingsForm(forms.Form):
     def __init__(self, *args, **kwargs):
         self.domain = kwargs.pop('domain', None)
         self.account = kwargs.pop('account', None)
+        self.username = kwargs.pop('username', None)
         self.export_settings = kwargs.pop('export_settings', None)
         kwargs['initial'] = {
             "restrict_domain_creation": self.account.restrict_domain_creation,
@@ -100,7 +101,7 @@ class EnterpriseSettingsForm(forms.Form):
             "restrict_signup_message": self.account.restrict_signup_message,
         }
 
-        if self.export_settings and DEFAULT_EXPORT_SETTINGS.enabled(self.domain):
+        if self.export_settings and DEFAULT_EXPORT_SETTINGS.enabled(self.username):
             kwargs['initial'].update(self.export_settings.as_dict())
 
         super(EnterpriseSettingsForm, self).__init__(*args, **kwargs)
@@ -124,7 +125,7 @@ class EnterpriseSettingsForm(forms.Form):
             )
         )
 
-        if DEFAULT_EXPORT_SETTINGS.enabled(self.domain):
+        if DEFAULT_EXPORT_SETTINGS.enabled(self.username):
             self.helper.layout.append(
                 crispy.Div(
                     crispy.Fieldset(
@@ -188,7 +189,7 @@ class EnterpriseSettingsForm(forms.Form):
         account.restrict_signup_message = self.cleaned_data.get('restrict_signup_message', '')
         account.save()
 
-        if self.export_settings and DEFAULT_EXPORT_SETTINGS.enabled(self.domain):
+        if self.export_settings and DEFAULT_EXPORT_SETTINGS.enabled(self.username):
             # forms
             self.export_settings.forms_filetype = self.cleaned_data.get(
                 'forms_filetype',

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -44,7 +44,7 @@ from corehq.apps.domain.decorators import (
 )
 
 from corehq.apps.accounting.utils.subscription import get_account_or_404
-from corehq.apps.export.utils import get_default_export_settings_for_domain
+from corehq.apps.export.utils import get_default_export_settings_for_user
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.const import USER_DATE_FORMAT
 
@@ -115,13 +115,14 @@ def enterprise_dashboard_email(request, domain, slug):
 @login_and_domain_required
 def enterprise_settings(request, domain):
     account = get_account_or_404(request, domain)
-    export_settings = get_default_export_settings_for_domain(domain)
+    export_settings = get_default_export_settings_for_user(request.user.username, domain)
 
     if request.method == 'POST':
         form = EnterpriseSettingsForm(request.POST, domain=domain, account=account,
-                                      export_settings=export_settings)
+                                      username=request.user.username, export_settings=export_settings)
     else:
-        form = EnterpriseSettingsForm(domain=domain, account=account, export_settings=export_settings)
+        form = EnterpriseSettingsForm(domain=domain, account=account, username=request.user.username,
+                                      export_settings=export_settings)
 
     context = {
         'account': account,
@@ -141,8 +142,9 @@ def enterprise_settings(request, domain):
 @require_POST
 def edit_enterprise_settings(request, domain):
     account = get_account_or_404(request, domain)
-    export_settings = get_default_export_settings_for_domain(domain)
-    form = EnterpriseSettingsForm(request.POST, domain=domain, account=account, export_settings=export_settings)
+    export_settings = get_default_export_settings_for_user(request.user.username, domain)
+    form = EnterpriseSettingsForm(request.POST, username=request.user.username, domain=domain,
+                                  account=account, export_settings=export_settings)
 
     if form.is_valid():
         form.save(account)

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -89,10 +89,7 @@ from corehq.apps.export.dbaccessors import (
     get_latest_case_export_schema,
     get_latest_form_export_schema,
 )
-from corehq.apps.export.utils import (
-    get_default_export_settings_for_domain,
-    is_occurrence_deleted,
-)
+from corehq.apps.export.utils import is_occurrence_deleted
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.products.models import SQLProduct
 from corehq.apps.reports.daterange import get_daterange_start_end_dates
@@ -828,16 +825,16 @@ class ExportInstance(BlobMixin, Document):
         return None
 
     @classmethod
-    def _new_from_schema(cls, schema):
+    def _new_from_schema(cls, schema, export_settings=None):
         raise NotImplementedError()
 
     @classmethod
-    def generate_instance_from_schema(cls, schema, saved_export=None, auto_select=True):
+    def generate_instance_from_schema(cls, schema, saved_export=None, auto_select=True, export_settings=None):
         """Given an ExportDataSchema, this will generate an ExportInstance"""
         if saved_export:
             instance = saved_export
         else:
-            instance = cls._new_from_schema(schema)
+            instance = cls._new_from_schema(schema, export_settings)
 
         instance.name = instance.name or instance.defaults.get_default_instance_name(schema)
         instance.app_id = schema.app_id
@@ -1121,14 +1118,13 @@ class CaseExportInstance(ExportInstance):
         return self.case_type
 
     @classmethod
-    def _new_from_schema(cls, schema):
-        settings = get_default_export_settings_for_domain(schema.domain)
-        if settings is not None:
+    def _new_from_schema(cls, schema, export_settings=None):
+        if export_settings is not None:
             return cls(
                 domain=schema.domain,
                 case_type=schema.case_type,
-                export_format=settings.cases_filetype,
-                transform_dates=settings.cases_auto_convert,
+                export_format=export_settings.cases_filetype,
+                transform_dates=export_settings.cases_auto_convert,
             )
         else:
             return cls(
@@ -1199,18 +1195,17 @@ class FormExportInstance(ExportInstance):
         return xmlns_to_name(self.domain, self.xmlns, self.app_id)
 
     @classmethod
-    def _new_from_schema(cls, schema):
-        settings = get_default_export_settings_for_domain(schema.domain)
-        if settings is not None:
+    def _new_from_schema(cls, schema, export_settings=None):
+        if export_settings is not None:
             return cls(
                 domain=schema.domain,
                 xmlns=schema.xmlns,
                 app_id=schema.app_id,
-                export_format=settings.forms_filetype,
-                transform_dates=settings.forms_auto_convert,
-                format_data_in_excel=settings.forms_auto_format_cells,
-                include_errors=settings.forms_include_duplicates,
-                split_multiselects=settings.forms_expand_checkbox,
+                export_format=export_settings.forms_filetype,
+                transform_dates=export_settings.forms_auto_convert,
+                format_data_in_excel=export_settings.forms_auto_format_cells,
+                include_errors=export_settings.forms_include_duplicates,
+                split_multiselects=export_settings.forms_expand_checkbox,
             )
         else:
             return cls(
@@ -1243,7 +1238,7 @@ class SMSExportInstance(ExportInstance):
     name = "Messages"
 
     @classmethod
-    def _new_from_schema(cls, schema):
+    def _new_from_schema(cls, schema, export_settings=None):
         main_table = TableConfiguration(
             label='Messages',
             path=MAIN_TABLE,

--- a/corehq/apps/export/tests/test_export_instance.py
+++ b/corehq/apps/export/tests/test_export_instance.py
@@ -91,12 +91,13 @@ class TestFormExportInstanceGeneration(SimpleTestCase):
             ],
         )
 
-    def _generate_instance(self, build_ids_and_versions, saved_export=None):
+    def _generate_instance(self, build_ids_and_versions, saved_export=None, export_settings=None):
         with mock.patch(
                 'corehq.apps.export.models.new.get_latest_app_ids_and_versions',
                 return_value=build_ids_and_versions):
 
-            return FormExportInstance.generate_instance_from_schema(self.schema, saved_export=saved_export)
+            return FormExportInstance.generate_instance_from_schema(self.schema, saved_export=saved_export,
+                                                                    export_settings=export_settings)
 
     def test_generate_instance_from_schema(self, _, __):
         """Only questions that are in the main table and of the same version should be shown"""
@@ -189,9 +190,7 @@ class TestFormExportInstanceGeneration(SimpleTestCase):
             forms_include_duplicates=True,
             forms_expand_checkbox=True
         )
-        with mock.patch('corehq.apps.export.models.new.get_default_export_settings_for_domain') as m:
-            m.return_value = mock_settings
-            instance = self._generate_instance({self.app_id: 3})
+        instance = self._generate_instance({self.app_id: 3}, export_settings=mock_settings)
 
         self.assertEqual(instance.export_format, Format.CSV)
         self.assertEqual(instance.transform_dates, False)

--- a/corehq/apps/export/tests/test_export_utils.py
+++ b/corehq/apps/export/tests/test_export_utils.py
@@ -5,7 +5,8 @@ from django.test import TestCase
 from corehq.apps.accounting.models import SoftwarePlanEdition, Subscription, DefaultProductPlan, BillingAccount, \
     SubscriptionAdjustment
 from corehq.apps.domain.models import Domain
-from corehq.apps.export.utils import get_default_export_settings_for_domain
+from corehq.apps.export.utils import get_default_export_settings_for_user
+from corehq.apps.users.models import WebUser
 from corehq.util.test_utils import flag_enabled
 
 
@@ -14,6 +15,8 @@ class TestExportUtils(TestCase):
     def setUp(self):
         super(TestExportUtils, self).setUp()
         self.domain = Domain.get_or_create_with_name('test-export-utils', is_active=True)
+        self.user = WebUser.create(self.domain.name, "export-settings-user", "*******",
+                                   None, None, is_admin=True)
         self.account, _ = BillingAccount.get_or_create_account_by_domain(
             self.domain.name,
             created_by='webuser@test.com'
@@ -45,7 +48,7 @@ class TestExportUtils(TestCase):
         NOTE: no decorator to enable DEFAULT_EXPORT_SETTINGS feature flag
         """
         self.update_subscription(SoftwarePlanEdition.ENTERPRISE)
-        settings = get_default_export_settings_for_domain(self.domain)
+        settings = get_default_export_settings_for_user(self.user.username, self.domain)
         self.assertIsNone(settings)
 
     @flag_enabled('DEFAULT_EXPORT_SETTINGS')
@@ -54,7 +57,7 @@ class TestExportUtils(TestCase):
         Verify COMMUNITY software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.COMMUNITY)
-        settings = get_default_export_settings_for_domain(self.domain)
+        settings = get_default_export_settings_for_user(self.user.username, self.domain)
         self.assertIsNone(settings)
 
     @flag_enabled('DEFAULT_EXPORT_SETTINGS')
@@ -63,7 +66,7 @@ class TestExportUtils(TestCase):
         Verify STANDARD software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.STANDARD)
-        settings = get_default_export_settings_for_domain(self.domain)
+        settings = get_default_export_settings_for_user(self.user.username, self.domain)
         self.assertIsNone(settings)
 
     @flag_enabled('DEFAULT_EXPORT_SETTINGS')
@@ -72,7 +75,7 @@ class TestExportUtils(TestCase):
         Verify PRO software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.PRO)
-        settings = get_default_export_settings_for_domain(self.domain)
+        settings = get_default_export_settings_for_user(self.user.username, self.domain)
         self.assertIsNone(settings)
 
     @flag_enabled('DEFAULT_EXPORT_SETTINGS')
@@ -81,7 +84,7 @@ class TestExportUtils(TestCase):
         Verify ADVANCED software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.ADVANCED)
-        settings = get_default_export_settings_for_domain(self.domain)
+        settings = get_default_export_settings_for_user(self.user.username, self.domain)
         self.assertIsNone(settings)
 
     @flag_enabled('DEFAULT_EXPORT_SETTINGS')
@@ -90,7 +93,7 @@ class TestExportUtils(TestCase):
         Verify RESELLER software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.RESELLER)
-        settings = get_default_export_settings_for_domain(self.domain)
+        settings = get_default_export_settings_for_user(self.user.username, self.domain)
         self.assertIsNone(settings)
 
     @flag_enabled('DEFAULT_EXPORT_SETTINGS')
@@ -99,7 +102,7 @@ class TestExportUtils(TestCase):
         Verify MANAGED_HOSTING software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.MANAGED_HOSTING)
-        settings = get_default_export_settings_for_domain(self.domain)
+        settings = get_default_export_settings_for_user(self.user.username, self.domain)
         self.assertIsNone(settings)
 
     @flag_enabled('DEFAULT_EXPORT_SETTINGS')
@@ -109,5 +112,5 @@ class TestExportUtils(TestCase):
         are able to create a DefaultExportSettings instance
         """
         self.update_subscription(SoftwarePlanEdition.ENTERPRISE)
-        settings = get_default_export_settings_for_domain(self.domain)
+        settings = get_default_export_settings_for_user(self.user.username, self.domain)
         self.assertIsNotNone(settings)

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -54,12 +54,12 @@ def get_export(export_type, domain, export_id=None, username=None):
     raise Exception("Unexpected export type received %s" % export_type)
 
 
-def get_default_export_settings_for_domain(domain):
+def get_default_export_settings_for_user(username, domain):
     """
     Only creates settings if the the subscription level supports it
     Currently only available to Enterprise accounts with the DEFAULT_EXPORT_SETTINGS FF enabled
     """
-    if not toggles.DEFAULT_EXPORT_SETTINGS.enabled(domain):
+    if not toggles.DEFAULT_EXPORT_SETTINGS.enabled(username):
         return None
 
     settings = None

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -41,7 +41,7 @@ from corehq.apps.export.models import (
     FormExportDataSchema,
     FormExportInstance,
 )
-from corehq.apps.export.utils import get_default_export_settings_for_domain
+from corehq.apps.export.utils import get_default_export_settings_for_user
 from corehq.apps.export.views.utils import (
     DailySavedExportMixin,
     DashboardFeedMixin,
@@ -253,15 +253,16 @@ class CreateNewCustomFormExportView(BaseExportView):
         from corehq.apps.export.views.list import FormExportListView
         return FormExportListView
 
-    def create_new_export_instance(self, schema):
-        return self.export_instance_cls.generate_instance_from_schema(schema)
+    def create_new_export_instance(self, schema, export_settings=None):
+        return self.export_instance_cls.generate_instance_from_schema(schema, export_settings=export_settings)
 
     def get(self, request, *args, **kwargs):
         app_id = request.GET.get('app_id')
         xmlns = request.GET.get('export_tag').strip('"')
 
+        export_settings = get_default_export_settings_for_user(request.user.username, self.domain)
         schema = self.get_export_schema(self.domain, app_id, xmlns)
-        self.export_instance = self.create_new_export_instance(schema)
+        self.export_instance = self.create_new_export_instance(schema, export_settings=export_settings)
 
         return super(CreateNewCustomFormExportView, self).get(request, *args, **kwargs)
 
@@ -278,14 +279,15 @@ class CreateNewCustomCaseExportView(BaseExportView):
         from corehq.apps.export.views.list import CaseExportListView
         return CaseExportListView
 
-    def create_new_export_instance(self, schema):
-        return self.export_instance_cls.generate_instance_from_schema(schema)
+    def create_new_export_instance(self, schema, export_settings=None):
+        return self.export_instance_cls.generate_instance_from_schema(schema, export_settings=export_settings)
 
     def get(self, request, *args, **kwargs):
         case_type = request.GET.get('export_tag').strip('"')
 
+        export_settings = get_default_export_settings_for_user(request.user.username, self.domain)
         schema = self.get_export_schema(self.domain, None, case_type)
-        self.export_instance = self.create_new_export_instance(schema)
+        self.export_instance = self.create_new_export_instance(schema, export_settings=export_settings)
 
         return super(CreateNewCustomCaseExportView, self).get(request, *args, **kwargs)
 
@@ -317,7 +319,7 @@ class CreateODataCaseFeedView(ODataFeedMixin, CreateNewCustomCaseExportView):
     urlname = 'new_odata_case_feed'
     page_title = ugettext_lazy("Create OData Case Feed")
 
-    def create_new_export_instance(self, schema):
+    def create_new_export_instance(self, schema, export_settings=None):
         export_instance = super(CreateODataCaseFeedView, self).create_new_export_instance(schema)
         clean_odata_columns(export_instance)
         return export_instance
@@ -328,10 +330,12 @@ class CreateODataFormFeedView(ODataFeedMixin, CreateNewCustomFormExportView):
     urlname = 'new_odata_form_feed'
     page_title = ugettext_lazy("Create OData Form Feed")
 
-    def create_new_export_instance(self, schema):
-        export_instance = super(CreateODataFormFeedView, self).create_new_export_instance(schema)
+    def create_new_export_instance(self, schema, export_settings=None):
+        export_instance = super(CreateODataFormFeedView, self).create_new_export_instance(
+            schema,
+            export_settings=export_settings
+        )
         # odata settings only apply to form exports
-        export_settings = get_default_export_settings_for_domain(schema.domain)
         if export_settings:
             export_instance.include_errors = export_settings.odata_include_duplicates
             export_instance.split_multiselects = export_settings.odata_expand_checkbox

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -320,7 +320,10 @@ class CreateODataCaseFeedView(ODataFeedMixin, CreateNewCustomCaseExportView):
     page_title = ugettext_lazy("Create OData Case Feed")
 
     def create_new_export_instance(self, schema, export_settings=None):
-        export_instance = super(CreateODataCaseFeedView, self).create_new_export_instance(schema)
+        export_instance = super(CreateODataCaseFeedView, self).create_new_export_instance(
+            schema,
+            export_settings=export_settings
+        )
         clean_odata_columns(export_instance)
         return export_instance
 

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -213,8 +213,8 @@ class ODataFeedMixin(object):
             """),
         }
 
-    def create_new_export_instance(self, schema):
-        instance = super(ODataFeedMixin, self).create_new_export_instance(schema)
+    def create_new_export_instance(self, schema, export_settings=None):
+        instance = super(ODataFeedMixin, self).create_new_export_instance(schema, export_settings=export_settings)
         instance.is_odata_config = True
         instance.transform_dates = False
         return instance

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -145,8 +145,11 @@ class DailySavedExportMixin(object):
         self._priv_check()
         return super(DailySavedExportMixin, self).dispatch(*args, **kwargs)
 
-    def create_new_export_instance(self, schema):
-        instance = super(DailySavedExportMixin, self).create_new_export_instance(schema)
+    def create_new_export_instance(self, schema, export_settings=None):
+        instance = super(DailySavedExportMixin, self).create_new_export_instance(
+            schema,
+            export_settings=export_settings
+        )
         instance.is_daily_saved_export = True
 
         span = datespan_from_beginning(self.domain_object, get_timezone(self.domain, self.request.couch_user))
@@ -177,8 +180,11 @@ class DashboardFeedMixin(DailySavedExportMixin):
         if not domain_has_privilege(self.domain, EXCEL_DASHBOARD):
             raise Http404
 
-    def create_new_export_instance(self, schema):
-        instance = super(DashboardFeedMixin, self).create_new_export_instance(schema)
+    def create_new_export_instance(self, schema, export_settings=None):
+        instance = super(DashboardFeedMixin, self).create_new_export_instance(
+            schema,
+            export_settings=export_settings
+        )
         instance.export_format = "html"
         return instance
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -2000,7 +2000,7 @@ DEFAULT_EXPORT_SETTINGS = StaticToggle(
     'default_export_settings',
     'Allow enterprise admin to set default export settings',
     TAG_PRODUCT,
-    namespaces=[NAMESPACE_DOMAIN],
+    namespaces=[NAMESPACE_USER],
     description="""
     Allows an enterprise admin to set default export settings for all domains under the enterprise account.
     """


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Addresses this [Sentry error](https://sentry.io/organizations/dimagi/issues/2231076285/?environment=staging&project=136860&query=is%3Aunresolved) that occurred due to not including the `export_settings` arg that was introduced in [this PR](https://github.com/dimagi/commcare-hq/pull/29177/).

Reverted the original PR since it was merged into master but not yet deployed. This reverts that the merge of the revert, and fixes the underlying issue. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
