### PR TITLE
add initial user data source for polio

### DIFF
--- a/custom/polio_rdc/ucr/data_sources/users.json
+++ b/custom/polio_rdc/ucr/data_sources/users.json
@@ -1,0 +1,291 @@
+{
+    "domains": [
+        "polio-rdc"
+    ],
+    "server_environment": [
+        "production"
+    ],
+    "config": {
+        "table_id": "commcare_users",
+        "display_name": "Users",
+        "referenced_doc_type": "CommCareUser",
+        "description": "Data from the User Model",
+        "base_item_expression": {},
+        "configured_filter": {},
+        "validations": [],
+        "configured_indicators": [
+            {
+                "column_id": "username",
+                "comment": null,
+                "create_index": false,
+                "datatype": "string",
+                "display_name": "username",
+                "expression": {
+                    "datatype": null,
+                    "property_path": [
+                        "username"
+                    ],
+                    "type": "property_path"
+                },
+                "is_nullable": true,
+                "is_primary_key": false,
+                "transform": {},
+                "type": "expression"
+            },
+            {
+                "column_id": "first_name",
+                "comment": null,
+                "create_index": false,
+                "datatype": "string",
+                "display_name": "first_name",
+                "expression": {
+                    "datatype": null,
+                    "property_path": [
+                        "first_name"
+                    ],
+                    "type": "property_path"
+                },
+                "is_nullable": true,
+                "is_primary_key": false,
+                "transform": {},
+                "type": "expression"
+            },
+            {
+                "column_id": "last_name",
+                "comment": null,
+                "create_index": false,
+                "datatype": "string",
+                "display_name": "last_name",
+                "expression": {
+                    "datatype": null,
+                    "property_path": [
+                        "last_name"
+                    ],
+                    "type": "property_path"
+                },
+                "is_nullable": true,
+                "is_primary_key": false,
+                "transform": {},
+                "type": "expression"
+            },
+            {
+                "column_id": "email",
+                "comment": null,
+                "create_index": false,
+                "datatype": "string",
+                "display_name": "email",
+                "expression": {
+                    "datatype": null,
+                    "property_path": [
+                        "email"
+                    ],
+                    "type": "property_path"
+                },
+                "is_nullable": true,
+                "is_primary_key": false,
+                "transform": {},
+                "type": "expression"
+            },
+            {
+                "column_id": "language",
+                "comment": null,
+                "create_index": false,
+                "datatype": "string",
+                "display_name": "language",
+                "expression": {
+                    "datatype": null,
+                    "property_path": [
+                        "language"
+                    ],
+                    "type": "property_path"
+                },
+                "is_nullable": true,
+                "is_primary_key": false,
+                "transform": {},
+                "type": "expression"
+            },
+            {
+                "column_id": "last_sync",
+                "comment": null,
+                "create_index": false,
+                "datatype": "datetime",
+                "display_name": "last_sync",
+                "expression": {
+                    "datatype": null,
+                    "property_path": [
+                        "reporting_metadata",
+                        "last_sync_for_user",
+                        "sync_date"
+                    ],
+                    "type": "property_path"
+                },
+                "type": "expression"
+            },
+            {
+                "column_id": "last_app_version",
+                "comment": null,
+                "create_index": false,
+                "datatype": "string",
+                "display_name": "last_app_version",
+                "expression": {
+                    "datatype": null,
+                    "property_path": [
+                        "reporting_metadata",
+                        "last_build_for_user",
+                        "build_version"
+                    ],
+                    "type": "property_path"
+                },
+                "is_nullable": true,
+                "is_primary_key": false,
+                "transform": {},
+                "type": "expression"
+            },
+            {
+                "column_id": "is_active",
+                "comment": null,
+                "create_index": false,
+                "datatype": "small_integer",
+                "display_name": "is_active",
+                "expression": {
+                    "datatype": null,
+                    "property_path": [
+                        "is_active"
+                    ],
+                    "type": "property_path"
+                },
+                "is_nullable": true,
+                "is_primary_key": false,
+                "transform": {},
+                "type": "expression"
+            },
+            {
+                "column_id": "report_group_name",
+                "comment": null,
+                "create_index": false,
+                "datatype": "string",
+                "display_name": "report_group_name",
+                "expression": {
+                    "argument_expression": {
+                        "array_expression": {
+                            "type": "get_reporting_groups",
+                            "user_id_expression": {
+                                "datatype": null,
+                                "property_name": "doc_id",
+                                "type": "property_name"
+                            }
+                        },
+                        "index_expression": {
+                            "constant": 0,
+                            "type": "constant"
+                        },
+                        "type": "array_index"
+                    },
+                    "type": "nested",
+                    "value_expression": {
+                        "datatype": null,
+                        "property_name": "name",
+                        "type": "property_name"
+                    }
+                },
+                "is_nullable": true,
+                "is_primary_key": false,
+                "transform": {},
+                "type": "expression"
+            },
+            {
+                "column_id": "administrateur",
+                "comment": null,
+                "create_index": false,
+                "datatype": "string",
+                "display_name": "administrateur",
+                "expression": {
+                    "datatype": null,
+                    "property_path": [
+                        "user_data",
+                        "administrateur"
+                    ],
+                    "type": "property_path"
+                },
+                "is_nullable": true,
+                "is_primary_key": false,
+                "transform": {},
+                "type": "expression"
+            },
+            {
+                "column_id": "formateur",
+                "comment": null,
+                "create_index": false,
+                "datatype": "string",
+                "display_name": "formateur",
+                "expression": {
+                    "datatype": null,
+                    "property_path": [
+                        "user_data",
+                        "formateur"
+                    ],
+                    "type": "property_path"
+                },
+                "is_nullable": true,
+                "is_primary_key": false,
+                "transform": {},
+                "type": "expression"
+            },
+            {
+                "column_id": "recruteur",
+                "comment": null,
+                "create_index": false,
+                "datatype": "string",
+                "display_name": "recruteur",
+                "expression": {
+                    "datatype": null,
+                    "property_path": [
+                        "user_data",
+                        "recruteur"
+                    ],
+                    "type": "property_path"
+                },
+                "is_nullable": true,
+                "is_primary_key": false,
+                "transform": {},
+                "type": "expression"
+            },
+            {
+                "column_id": "superviseur",
+                "comment": null,
+                "create_index": false,
+                "datatype": "string",
+                "display_name": "superviseur",
+                "expression": {
+                    "datatype": null,
+                    "property_path": [
+                        "user_data",
+                        "superviseur"
+                    ],
+                    "type": "property_path"
+                },
+                "is_nullable": true,
+                "is_primary_key": false,
+                "transform": {},
+                "type": "expression"
+            },
+            {
+                "column_id": "count",
+                "comment": null,
+                "create_index": false,
+                "datatype": "small_integer",
+                "display_name": "count",
+                "expression": {
+                    "constant": 1,
+                    "type": "constant"
+                },
+                "is_nullable": true,
+                "is_primary_key": false,
+                "transform": {},
+                "type": "expression"
+            }
+        ],
+        "named_expressions": {},
+        "named_filters": {}
+    }
+}

--- a/settings.py
+++ b/settings.py
@@ -1900,6 +1900,7 @@ STATIC_DATA_SOURCES = [
     os.path.join('custom', 'inddex', 'ucr', 'data_sources', '*.json'),
 
     os.path.join('custom', 'echis_reports', 'ucr', 'data_sources', '*.json'),
+    os.path.join('custom', 'polio_rdc', 'ucr', 'data_sources', 'users.json'),
     os.path.join('custom', 'ccqa', 'ucr', 'data_sources', 'patients.json'),  # For testing static UCRs
 ]
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SC-1291

This adds a static data source for the polio project so they can get metrics from the user document.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
