### PR TITLE
Removed MULTI_MASTER_BYPASS_VERSION_CHECK flag

### DIFF
--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -163,8 +163,8 @@ class CommCareFeatureSupportMixin(object):
     def enable_multi_master(self):
         return (
             self._require_minimum_version('2.47.4')
-            or toggles.MULTI_MASTER_BYPASS_VERSION_CHECK.enabled(self.domain)
-        ) and toggles.MULTI_MASTER_LINKED_DOMAINS.enabled(self.domain)
+            and toggles.MULTI_MASTER_LINKED_DOMAINS.enabled(self.domain)
+        )
 
     @property
     def enable_search_prompt_appearance(self):

--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -70,11 +70,6 @@ class CopyApplicationForm(forms.Form):
         domain_obj = Domain.get_by_name(domain)
         if domain_obj is None:
             raise forms.ValidationError("A valid project space is required.")
-        if toggles.MULTI_MASTER_BYPASS_VERSION_CHECK.enabled(domain):
-            raise forms.ValidationError("""
-                Copying an app to a domain that uses multi-master linked apps and bypasses
-                the minimum CommCare version check requires developer intervention.
-            """)
         return domain
 
     def clean(self):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1575,14 +1575,6 @@ MULTI_MASTER_LINKED_DOMAINS = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-MULTI_MASTER_BYPASS_VERSION_CHECK = StaticToggle(
-    'MULTI_MASTER_BYPASS_VERSION_CHECK',
-    "Bypass minimum CommCare version check for multi master usage. For use only by ICDS.",
-    TAG_CUSTOM,
-    [NAMESPACE_DOMAIN],
-    relevant_environments={"icds", "icds-staging"}
-)
-
 SUMOLOGIC_LOGS = DynamicallyPredictablyRandomToggle(
     'sumologic_logs',
     'Send logs to sumologic',


### PR DESCRIPTION
## Summary
This was an ICDS-only flag, removing.

## Feature Flag
Bypass minimum CommCare version check for multi master usage. For use only by ICDS

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Little if any.

### QA Plan

Not requesting QA.

### Safety story
Minor code removal. Tested locally that both regular app copy and linked app creation still work.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
