### PR TITLE
Tell the user how many users they can filter on in monitoring reports

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -31,6 +31,7 @@ from corehq.apps.locations.permissions import (
     location_safe,
 )
 from corehq.apps.reports import util
+from corehq.apps.reports.const import USER_QUERY_LIMIT
 from corehq.apps.reports.analytics.esaccessors import (
     get_active_case_counts_by_owner,
     get_case_counts_closed_by_user,
@@ -716,7 +717,9 @@ class SubmissionsByFormReport(WorkerMonitoringFormReportTableBase,
             self.domain, self.request.GET.getlist(EMWF.slug), self.request.couch_user,
         ) and not export:
             raise BadRequestError(
-                _('Query selects too many users. Please modify your filters to select fewer users')
+                _('Query selects too many users. Please modify your filters to select fewer than {} users').format(
+                    USER_QUERY_LIMIT,
+                )
             )
         selected_users = self.selected_simplified_users
         track_es_report_load(self.domain, self.slug, len(self.selected_simplified_users))


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I was faced with this error, and went grepping through the codebase to see how many users I needed to reduce by. 
Figured that was useful information for end users too. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
