### PR TITLE
Add YAPF config and dev requirement

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,10 @@
+[style]
+based_on_style = yapf
+column_limit = 115
+indent_width = 4
+coalesce_brackets = true
+dedent_closing_brackets = true
+spaces_before_comment = 2
+split_before_arithmetic_operator = true
+split_before_bitwise_operator = true
+split_before_logical_operator = true

--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -23,5 +23,6 @@ sphinxcontrib-django~=0.5
 recommonmark
 graphviz==0.16
 
-# linting
+# linting/formatting
 flake8
+yapf

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -691,6 +691,8 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.9
     # via python3-saml
+yapf==0.30.0
+    # via -r dev-requirements.in
 zipp==3.2.0
     # via importlib-metadata
 


### PR DESCRIPTION
[YAPF](https://github.com/google/yapf) is a Python code formatter, similar to, but more configurable and less opinionated than [black](https://black.readthedocs.io/en/stable/). It is useful for reformatting code that does not comply with our style guidelines. It is often possible to apply slight manual massaging after automatic formatting to improve readability while leaving the code in a state that will not be touched on future YAPF passes. `# yapf: disable/enable` delimiters may be used if it refuses to let good code alone. Some IDEs, including PyCharm and VS Code, have extensions that make it convenient to use.

**This is meant to be a set of reasonable defaults for voluntary use of YAPF, and is not currently used to enforce anything**.

FYI @dimagi/team-commcare-hq 

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] This PR can be reverted after deploy with no further considerations 
