### PR TITLE
Revert "Create support for referencing the owner_id property"

### DIFF
--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -1,5 +1,6 @@
 import logging
 from collections import defaultdict, deque, namedtuple
+from itertools import chain
 
 from memoized import memoized
 
@@ -187,18 +188,6 @@ def _flatten_case_properties(case_properties_by_case_type):
                 case_property=case_property_parts[-1]
             ))
     return result
-
-
-def _clean_case_type_properties(case_properties_by_case_type):
-    for case_properties in case_properties_by_case_type.values():
-        _replace_properties_with_attributes(case_properties)
-
-
-def _replace_properties_with_attributes(case_properties):
-    for prop in list(case_properties):
-        if prop == 'owner_id':
-            case_properties.remove(prop)
-            case_properties.add('@owner_id')
 
 
 def _propagate_and_normalize_case_properties(case_properties_by_case_type, parent_type_map,
@@ -413,8 +402,6 @@ class ParentCasePropertyBuilder(object):
 
         for case_properties in case_properties_by_case_type.values():
             case_properties.update(self.defaults)
-
-        _clean_case_type_properties(case_properties_by_case_type)
 
         if self.exclude_invalid_properties:
             from corehq.apps.app_manager.helpers.validators import validate_property

--- a/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
@@ -10,7 +10,6 @@ from corehq.apps.app_manager.app_schemas.case_properties import (
     _CaseTypeEquivalence,
     _CaseTypeRef,
     get_case_properties,
-    _replace_properties_with_attributes
 )
 from corehq.apps.app_manager.models import (
     AdvancedModule,
@@ -44,17 +43,6 @@ class GetCasePropertiesTest(SimpleTestCase, TestXmlMixin):
                 'bar': '/data/question2',
             })
             self.assertCaseProperties(factory.app, 'house', ['foo', 'bar'])
-
-    def test_owner_id_maps_to_attribute(self):
-        factory = AppFactory()
-        # Create form1 which uses case type 'house'
-        module1, form1 = factory.new_module(Module, 'open_case', 'house')
-        # Form1 updates house.owner_id
-        factory.form_requires_case(form1, case_type='house', update={
-            'owner_id': 'new_owner'
-        })
-        # Verify that the actual case property is '@owner_id', not 'owner_id'
-        self.assertCaseProperties(factory.app, 'house', ['@owner_id'])
 
     def test_case_sharing(self):
         factory1 = AppFactory()
@@ -193,15 +181,3 @@ class DocTests(SimpleTestCase):
     def test_doctests(self):
         results = doctest.testmod(corehq.apps.app_manager.app_schemas.case_properties)
         self.assertEqual(results.failed, 0)
-
-
-class ReplacePropertyWithAttributesTests(SimpleTestCase):
-    def test_replaces_owner_id_with_attribute(self):
-        case_properties = {'owner_id'}
-        _replace_properties_with_attributes(case_properties)
-        self.assertSetEqual(case_properties, {'@owner_id'})
-
-    def test_replacement_preserves_other_names(self):
-        case_properties = {'@one', 'owner_id', '@two'}
-        _replace_properties_with_attributes(case_properties)
-        self.assertSetEqual(case_properties, {'@one', '@owner_id', '@two'})

--- a/corehq/apps/app_manager/app_schemas/tests/test_schema.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_schema.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 
 from django.test import SimpleTestCase
 
@@ -11,6 +12,7 @@ from corehq.apps.app_manager.app_schemas.session_schema import (
 )
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.app_manager.tests.app_factory import AppFactory
+from corehq.util.test_utils import flag_enabled
 
 
 @patch('corehq.apps.app_manager.app_schemas.casedb_schema.get_case_property_description_dict',
@@ -298,13 +300,6 @@ class SchemaTest(SimpleTestCase):
                     "phone_number": {},
                 },
             })
-
-    def test_casedb_schema_maps_owner_id_to_attribute_with_name(self):
-        form = self.add_form("owner_case_type", {"owner_id": "new_owner"})
-        schema = get_casedb_schema(form)
-        structure = schema['subsets'][0]['structure']
-        self.assertIn('@owner_id', structure)
-        self.assertEqual(structure['@owner_id']['name'], 'owner_id')
 
     # -- helpers --
 

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -121,11 +121,11 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
             "property_value": self.case_type,
         }
         self.assertEqual(expected_filter, builder.filter)
-        expected_property_names = {
+        expected_property_names = [
             "closed", "closed_on", "first_name", "last_name", "modified_on", "name", "opened_on",
-            "@owner_id", "user_id", "computed/owner_name", "computed/user_name",
-        }
-        self.assertSetEqual(expected_property_names, set(builder.data_source_properties.keys()))
+            "owner_id", "user_id", "computed/owner_name", "computed/user_name",
+        ]
+        self.assertEqual(expected_property_names, list(builder.data_source_properties.keys()))
         owner_name_prop = builder.data_source_properties['computed/owner_name']
         self.assertEqual('computed/owner_name', owner_name_prop.get_id())
         self.assertEqual('Case Owner', owner_name_prop.get_text())


### PR DESCRIPTION
Reverts dimagi/commcare-hq#28931

While this solved the narrow issue of easy references, it is breaking reports [SUPPORT-7942](https://dimagi-dev.atlassian.net/browse/SUPPORT-7942). Reverting until we have enough time to fully investigate a proper fix.