### PR TITLE
Added condition if a domain does not have a traveler active location

### DIFF
--- a/custom/covid/management/commands/run_all_management_command.py
+++ b/custom/covid/management/commands/run_all_management_command.py
@@ -52,15 +52,22 @@ class Command(BaseCommand):
         pool = Pool(20)
         if options["only_inactive"]:
             for domain in domains:
-                jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact',
-                                       location=location_ids[domain]['active']['traveler'],
-                                       inactive_location=location_ids[domain]['inactive']))
+                if 'traveler' in location_ids[domain]['active']:
+                    jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact',
+                                           location=location_ids[domain]['active']['traveler'],
+                                           inactive_location=location_ids[domain]['inactive']))
+                else:
+                    jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact',
+                                           inactive_location=location_ids[domain]['inactive']))
             pool.join()
             total_jobs.extend(jobs)
         else:
             for domain in domains:
-                jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact',
-                                       location=location_ids[domain]['active']['traveler']))
+                if 'traveler' in location_ids[domain]['active']:
+                    jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact',
+                                           location=location_ids[domain]['active']['traveler']))
+                else:
+                    jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact'))
                 jobs.append(pool.spawn(run_command, 'add_hq_user_id_to_case', domain, 'checkin'))
                 jobs.append(pool.spawn(run_command, 'update_owner_ids', domain, 'investigation'))
                 jobs.append(pool.spawn(run_command, 'update_owner_ids', domain, 'checkin'))

--- a/custom/covid/management/commands/run_all_management_command.py
+++ b/custom/covid/management/commands/run_all_management_command.py
@@ -52,22 +52,19 @@ class Command(BaseCommand):
         pool = Pool(20)
         if options["only_inactive"]:
             for domain in domains:
+                kwargs = {'inactive_location': location_ids[domain]['inactive']}
                 if 'traveler' in location_ids[domain]['active']:
-                    jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact',
-                                           location=location_ids[domain]['active']['traveler'],
-                                           inactive_location=location_ids[domain]['inactive']))
-                else:
-                    jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact',
-                                           inactive_location=location_ids[domain]['inactive']))
+                    kwargs['location'] = location_ids[domain]['active']['traveler']
+                jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact',
+                                       **kwargs))
             pool.join()
             total_jobs.extend(jobs)
         else:
             for domain in domains:
+                kwargs = {}
                 if 'traveler' in location_ids[domain]['active']:
-                    jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact',
-                                           location=location_ids[domain]['active']['traveler']))
-                else:
-                    jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact'))
+                    kwargs['location'] = location_ids[domain]['active']['traveler']
+                jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact', **kwargs))
                 jobs.append(pool.spawn(run_command, 'add_hq_user_id_to_case', domain, 'checkin'))
                 jobs.append(pool.spawn(run_command, 'update_owner_ids', domain, 'investigation'))
                 jobs.append(pool.spawn(run_command, 'update_owner_ids', domain, 'checkin'))


### PR DESCRIPTION
## Summary
CO doesn't have a traveler active location, so I'm having them upload the csv with that column blank. This just adds an if statement so it doesn't error out.

## Product Description
I was thinking of just setting the value in the dict with a default of `None`, but then later in the script it would call `add_assingment_cases` with that `None` location. This would not cause it to error out, but rather print out "Warning no location entered". I figured when running the master script, I would rather not have it called and print out those warnings so I went with this route. 


## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan
I am not requesting QA

### Safety story
This will be run on test domains prior to prod domains

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
