### PR TITLE
Add additional find_question_id check for last path component

### DIFF
--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -380,16 +380,16 @@ def _get_question_id_for_attachment(form, attachment_name):
     if question_id_components is None:
         question_id_components = _find_path_to_question_id(form, attachment_name, use_basename=True)
 
-    try:
+    if question_id_components is not None:
         return str('-'.join(question_id_components))
-    except TypeError:
+    else:
         return None
 
 
 def _find_path_to_question_id(form, attachment_name, use_basename=False):
     """
     Returns the list of keys used to find attachment_name in the form (None if not found)
-    use_basename
+    use_basename only applies to values that are an absolute path
     """
     if not isinstance(form, dict):
         # Recursive calls should always give `form` a form value.

--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -1,49 +1,70 @@
 from django.test import SimpleTestCase
 
-from corehq.apps.reports.tasks import find_question_id
+from corehq.apps.reports.tasks import _get_question_id_for_attachment, _find_path_to_question_id
 
 
-class FindQuestionIdTests(SimpleTestCase):
+class GetQuestionIdTests(SimpleTestCase):
+    def test_returns_question_id_when_found(self):
+        form = {'attachment': 'my_attachment'}
+
+        result = _get_question_id_for_attachment(form, 'my_attachment')
+        self.assertEqual(result, 'attachment')
+
+    def test_returns_nested_question_id_when_found(self):
+        nested_form = {'attachment': 'my_attachment'}
+        form = {'nested': nested_form}
+
+        result = _get_question_id_for_attachment(form, 'my_attachment')
+        self.assertEqual(result, 'nested-attachment')
+
     def test_returns_none_when_not_found(self):
         form = {}
 
-        result = find_question_id(form, 'my_attachment')
+        result = _get_question_id_for_attachment(form, 'my_attachment')
+        self.assertIsNone(result)
+
+
+class FindPathToQuestionIdTests(SimpleTestCase):
+    def test_returns_none_when_not_found(self):
+        form = {}
+
+        result = _find_path_to_question_id(form, 'my_attachment')
         self.assertIsNone(result)
 
     def test_finds_attachment_in_property(self):
         form = {'attachment': 'my_attachment'}
 
-        result = find_question_id(form, 'my_attachment')
+        result = _find_path_to_question_id(form, 'my_attachment')
         self.assertEqual(result, ['attachment'])
 
     def test_finds_property_in_nested_form(self):
         nested_form = {'attachment': 'my_attachment'}
         form = {'nested': nested_form}
 
-        result = find_question_id(form, 'my_attachment')
+        result = _find_path_to_question_id(form, 'my_attachment')
         self.assertEqual(result, ['nested', 'attachment'])
 
     def test_finds_property_in_list(self):
         nested_form = {'attachment': 'my_attachment'}
         form = {'nested_list': [nested_form]}
 
-        result = find_question_id(form, 'my_attachment')
+        result = _find_path_to_question_id(form, 'my_attachment')
         self.assertEqual(result, ['nested_list', 'attachment'])
 
     def test_handles_invalid_list_item(self):
         form = {'bad_list': ['']}
 
-        result = find_question_id(form, 'my_attachment')
+        result = _find_path_to_question_id(form, 'my_attachment')
         self.assertIsNone(result)
 
-    def test_finds_last_path(self):
+    def test_finds_basename(self):
         form = {'attachment': '/path/to/my/attachment.ext'}
 
-        result = find_question_id(form, 'attachment.ext', last_path=True)
+        result = _find_path_to_question_id(form, 'attachment.ext', use_basename=True)
         self.assertEqual(result, ['attachment'])
 
-    def test_does_not_find_last_path(self):
+    def test_does_not_find_basename(self):
         form = {'attachment': '/path/to/my/attachment.ext'}
 
-        result = find_question_id(form, 'attachment.ext')
+        result = _find_path_to_question_id(form, 'attachment.ext')
         self.assertIsNone(result)

--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -4,67 +4,51 @@ from corehq.apps.reports.tasks import _get_question_id_for_attachment, _find_pat
 
 
 class GetQuestionIdTests(SimpleTestCase):
+
     def test_returns_question_id_when_found(self):
         form = {'attachment': 'my_attachment'}
 
         result = _get_question_id_for_attachment(form, 'my_attachment')
-        self.assertEqual(result, 'attachment')
+        self.assertEqual(result, 'attach9ment')
 
-    def test_returns_nested_question_id_when_found(self):
+    def test_returns_question_id_when_found_in_nested_form(self):
         nested_form = {'attachment': 'my_attachment'}
         form = {'nested': nested_form}
 
         result = _get_question_id_for_attachment(form, 'my_attachment')
         self.assertEqual(result, 'nested-attachment')
 
+    def test_returns_question_id_when_found_in_list(self):
+        nested_form = {'attachment': 'my_attachment'}
+        form = {'nested_list': [nested_form]}
+
+        result = _get_question_id_for_attachment(form, 'my_attachment')
+        self.assertEqual(result, 'nested_list-attachment')
+
+    def test_handles_invalid_list_item(self):
+        form = {'bad_list': ['']}
+
+        result = _get_question_id_for_attachment(form, 'my_attachment')
+        self.assertIsNone(result)
+
     def test_returns_none_when_not_found(self):
         form = {}
 
         result = _get_question_id_for_attachment(form, 'my_attachment')
         self.assertIsNone(result)
 
-
-class FindPathToQuestionIdTests(SimpleTestCase):
-    def test_returns_none_when_not_found(self):
-        form = {}
-
-        result = _find_path_to_question_id(form, 'my_attachment')
-        self.assertIsNone(result)
-
-    def test_finds_attachment_in_property(self):
-        form = {'attachment': 'my_attachment'}
-
-        result = _find_path_to_question_id(form, 'my_attachment')
-        self.assertEqual(result, ['attachment'])
-
-    def test_finds_property_in_nested_form(self):
-        nested_form = {'attachment': 'my_attachment'}
-        form = {'nested': nested_form}
-
-        result = _find_path_to_question_id(form, 'my_attachment')
-        self.assertEqual(result, ['nested', 'attachment'])
-
-    def test_finds_property_in_list(self):
-        nested_form = {'attachment': 'my_attachment'}
-        form = {'nested_list': [nested_form]}
-
-        result = _find_path_to_question_id(form, 'my_attachment')
-        self.assertEqual(result, ['nested_list', 'attachment'])
-
-    def test_handles_invalid_list_item(self):
-        form = {'bad_list': ['']}
-
-        result = _find_path_to_question_id(form, 'my_attachment')
-        self.assertIsNone(result)
-
-    def test_finds_basename(self):
+    def test_returns_question_id_when_found_as_abs_path_basename(self):
         form = {'attachment': '/path/to/my/attachment.ext'}
 
-        result = _find_path_to_question_id(form, 'attachment.ext', use_basename=True)
-        self.assertEqual(result, ['attachment'])
+        result = _get_question_id_for_attachment(form, 'attachment.ext')
+        self.assertEqual(result, 'attachment')
 
-    def test_does_not_find_basename(self):
-        form = {'attachment': '/path/to/my/attachment.ext'}
+    def test_returns_none_when_found_as_rel_path_basename(self):
+        """
+        The original bug this aims to solve only occurs for absolute paths
+        To minimize impact of the change, only look at basenames of absolute paths
+        """
+        form = {'attachment': 'path/to/my/attachment.ext'}
 
-        result = _find_path_to_question_id(form, 'attachment.ext')
+        result = _get_question_id_for_attachment(form, 'attachment.ext')
         self.assertIsNone(result)

--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -9,7 +9,7 @@ class GetQuestionIdTests(SimpleTestCase):
         form = {'attachment': 'my_attachment'}
 
         result = _get_question_id_for_attachment(form, 'my_attachment')
-        self.assertEqual(result, 'attach9ment')
+        self.assertEqual(result, 'attachment')
 
     def test_returns_question_id_when_found_in_nested_form(self):
         nested_form = {'attachment': 'my_attachment'}

--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -35,3 +35,15 @@ class FindQuestionIdTests(SimpleTestCase):
 
         result = find_question_id(form, 'my_attachment')
         self.assertIsNone(result)
+
+    def test_finds_last_path(self):
+        form = {'attachment': '/path/to/my/attachment.ext'}
+
+        result = find_question_id(form, 'attachment.ext', last_path=True)
+        self.assertEqual(result, ['attachment'])
+
+    def test_does_not_find_last_path(self):
+        form = {'attachment': '/path/to/my/attachment.ext'}
+
+        result = find_question_id(form, 'attachment.ext')
+        self.assertIsNone(result)

--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 
-from corehq.apps.reports.tasks import _get_question_id_for_attachment, _find_path_to_question_id
+from corehq.apps.reports.tasks import _get_question_id_for_attachment
 
 
 class GetQuestionIdTests(SimpleTestCase):


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[SAAS-11792](https://dimagi-dev.atlassian.net/browse/SAAS-11792)

This is _ideally_ only a temporary fix for a bug that originates on mobile. When capturing multimedia, typically mobile sets the value for the question key to the filename of the image. In this case, the absolute path of the image is being used. This results in a discrepancy between what is used in the `form.form_data` (contains absolute path) and `form.attachments` (contains filename only). 

Would like to hear from those with more context on this, but I figure this approach is low risk in that it only runs if the initial call to `find_question_id` is `None`. This does present a potential new case where a match is unintentionally found (e.g., nothing was found for `/test/last/path`, but something is found for `path`), but I'm not familiar enough to know if this is possible. 

Another concern I have is if in the time between this being deployed and the mobile release, somehow a form becomes reliant on this and once removed, causes another error/support ticket.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
