### PR TITLE
Mjr/xss locations

### DIFF
--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -100,10 +100,8 @@ see.
 from functools import wraps
 
 from django.http import Http404
-from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy
-from django.views.generic import View
 
 from django_prbac.decorators import requires_privilege_raise404
 from tastypie.resources import Resource
@@ -113,11 +111,8 @@ from dimagi.utils.modules import to_function
 
 from corehq import privileges
 from corehq.apps.domain.decorators import (
-    domain_admin_required,
     login_and_domain_required,
 )
-from corehq.apps.domain.models import Domain
-from corehq.apps.reports.generic import GenericReportView
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import CouchUser
 

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -100,7 +100,7 @@ see.
 from functools import wraps
 
 from django.http import Http404
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy
 
 from django_prbac.decorators import requires_privilege_raise404
@@ -118,11 +118,17 @@ from corehq.apps.users.models import CouchUser
 
 from .models import SQLLocation
 
-LOCATION_ACCESS_DENIED = mark_safe(ugettext_lazy(
+
+# TODO: ugettext_lazy is likely not having the desired effect, as format_html will immediately
+# evaluate it against the current language.
+# https://docs.djangoproject.com/en/dev/topics/i18n/translation/#other-uses-of-lazy-in-delayed-translations
+# has details on how to create a delayed format_html/mark_safe
+LOCATION_ACCESS_DENIED = format_html(ugettext_lazy(
     "This project has restricted data access rules. Please contact your "
     "project administrator to be assigned access to data in this project. "
-    'More information is available <a href="{link}">here</a>.'
-).format(link="https://wiki.commcarehq.org/display/commcarepublic/Data+Access+and+User+Editing+Restrictions"))
+    'More information is available <a href="{}">here</a>.'),
+    "https://wiki.commcarehq.org/display/commcarepublic/Data+Access+and+User+Editing+Restrictions")
+
 
 LOCATION_SAFE_TASTYPIE_RESOURCES = set()
 

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -7,7 +7,7 @@ from django.http import Http404, HttpResponseRedirect
 from django.http.response import HttpResponseServerError
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.decorators import method_decorator
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 from django.views.decorators.http import require_http_methods
@@ -147,11 +147,13 @@ def check_pending_locations_import(redirect=False):
                     # redirect to import status page
                     return HttpResponseRedirect(status_url)
                 else:
-                    messages.warning(request, mark_safe(
-                        _("Organizations can't be edited until "
-                          "<a href='{}''>current bulk upload</a> "
-                          "has finished.").format(status_url)
-                    ))
+                    warning_message = format_html(
+                        _("Organizations can't be edited until the "
+                          "<a href='{}'>current bulk upload</a> "
+                          "has finished."),
+                        status_url
+                    )
+                    messages.warning(request, warning_message)
                     return view_fn(request, domain, *args, **kwargs)
             else:
                 return view_fn(request, domain, *args, **kwargs)
@@ -782,9 +784,7 @@ class EditLocationView(BaseEditLocationView):
             name = _("View {name} <small>{type}</small>")
         else:
             name = _("Edit {name} <small>{type}</small>")
-        return mark_safe(name.format(
-            name=self.location.name, type=self.location.location_type_name
-        ))
+        return format_html(name, name=self.location.name, type=self.location.location_type_name)
 
     @property
     def can_edit_commcare_users(self):


### PR DESCRIPTION
## Summary
Another one of many apps being handled as part of [SAAS-11853](https://dimagi-dev.atlassian.net/browse/SAAS-11853). Changes should be straight-forward here. Although this code wasn't actively vulnerable to XSS, removing the references to `mark_safe` makes detecting misuse of it in the future easier.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
The changes were essentially replacing `mark_safe` with `format_html`, which I felt didn't require tests.

### QA Plan

I'm confident this can skip QA.

### Safety story

Used local testing to verify the changes (particularly the warning for download-in-progress) behaved as expected.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
