### PR TITLE
Removed HIDE_MESSAGING_DASHBOARD_FROM_NON_SUPERUSERS flag

### DIFF
--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -128,7 +128,6 @@ from corehq.form_processor.utils import is_commcarecase
 from corehq.messaging.scheduling.async_handlers import SMSSettingsAsyncHandler
 from corehq.messaging.smsbackends.telerivet.models import SQLTelerivetBackend
 from corehq.messaging.smsbackends.test.models import SQLTestSMSBackend
-from corehq.messaging.util import show_messaging_dashboard
 from corehq.util.dates import iso_string_to_datetime
 from corehq.util.quickcache import quickcache
 from corehq.util.timezones.conversions import ServerTime, UserTime
@@ -145,11 +144,8 @@ SMS_CHAT_HISTORY_CHOICES = (
 
 @login_and_domain_required
 def default(request, domain):
-    if show_messaging_dashboard(domain, request.couch_user):
-        from corehq.messaging.scheduling.views import MessagingDashboardView
-        return HttpResponseRedirect(reverse(MessagingDashboardView.urlname, args=[domain]))
-    else:
-        return HttpResponseRedirect(reverse(ComposeMessageView.urlname, args=[domain]))
+    from corehq.messaging.scheduling.views import MessagingDashboardView
+    return HttpResponseRedirect(reverse(MessagingDashboardView.urlname, args=[domain]))
 
 
 class BaseMessagingSectionView(BaseDomainView):

--- a/corehq/messaging/util.py
+++ b/corehq/messaging/util.py
@@ -120,10 +120,3 @@ class MessagingRuleProgressHelper(object):
             return 100
 
         return int(round(100.0 * current / total, 0))
-
-
-def show_messaging_dashboard(domain, couch_user):
-    return (
-        not toggles.HIDE_MESSAGING_DASHBOARD_FROM_NON_SUPERUSERS.enabled(domain)
-        or couch_user.is_superuser
-    )

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -94,7 +94,6 @@ from corehq.messaging.scheduling.views import (
     MessagingDashboardView,
     UploadConditionalAlertView,
 )
-from corehq.messaging.util import show_messaging_dashboard
 from corehq.motech.dhis2.views import DataSetMapView
 from corehq.motech.openmrs.views import OpenmrsImporterView
 from corehq.motech.views import ConnectionSettingsListView, MotechLogListView
@@ -1048,11 +1047,6 @@ class MessagingTab(UITab):
 
     @property
     @memoized
-    def show_dashboard(self):
-        return show_messaging_dashboard(self.domain, self.couch_user)
-
-    @property
-    @memoized
     def messages_urls(self):
         messages_urls = []
 
@@ -1207,12 +1201,11 @@ class MessagingTab(UITab):
     def dropdown_items(self):
         result = []
 
-        if self.show_dashboard:
-            result.append(dropdown_dict(_("Dashboard"), is_header=True))
-            result.append(dropdown_dict(
-                _("Dashboard"),
-                url=reverse(MessagingDashboardView.urlname, args=[self.domain]),
-            ))
+        result.append(dropdown_dict(_("Dashboard"), is_header=True))
+        result.append(dropdown_dict(
+            _("Dashboard"),
+            url=reverse(MessagingDashboardView.urlname, args=[self.domain]),
+        ))
 
         if result:
             result.append(self.divider)
@@ -1230,10 +1223,9 @@ class MessagingTab(UITab):
         if result:
             result.append(self.divider)
 
-        view_all_view = MessagingDashboardView.urlname if self.show_dashboard else 'sms_compose_message'
         result.append(dropdown_dict(
             _("View All"),
-            url=reverse(view_all_view, args=[self.domain]),
+            url=reverse(MessagingDashboardView.urlname, args=[self.domain]),
         ))
 
         return result
@@ -1242,14 +1234,13 @@ class MessagingTab(UITab):
     def sidebar_items(self):
         items = []
 
-        if self.show_dashboard:
-            items.append((
-                _("Dashboard"),
-                [{
-                    'title': _("Dashboard"),
-                    'url': reverse(MessagingDashboardView.urlname, args=[self.domain])
-                }]
-            ))
+        items.append((
+            _("Dashboard"),
+            [{
+                'title': _("Dashboard"),
+                'url': reverse(MessagingDashboardView.urlname, args=[self.domain])
+            }]
+        ))
 
         for title, urls in (
             (_("Messages"), self.messages_urls),

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1238,14 +1238,6 @@ INBOUND_SMS_LENIENCY = StaticToggle(
 )
 
 
-HIDE_MESSAGING_DASHBOARD_FROM_NON_SUPERUSERS = StaticToggle(
-    'hide_messaging_dashboard',
-    "Hide messaging dashboard from users who are not superusers.",
-    TAG_CUSTOM,
-    [NAMESPACE_DOMAIN],
-)
-
-
 WHATSAPP_MESSAGING = StaticToggle(
     'whatsapp_messaging',
     "Default SMS to send messages via Whatsapp, where available",


### PR DESCRIPTION
## Summary
This was only used by ICDS.

## Feature Flag
Hide messaging dashboard from users who are not superusers.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

Not requesting QA.

### Safety story
Fairly low-risk code removal. Clicked around locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
