### PR TITLE
Added error message for failed form validation while making build

### DIFF
--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -52,6 +52,7 @@ from corehq.apps.app_manager.exceptions import (
     BuildConflictException,
     ModuleIdMissingException,
     PracticeUserException,
+    XFormValidationFailed,
 )
 from corehq.apps.app_manager.forms import PromptUpdateSettingsForm
 from corehq.apps.app_manager.models import (
@@ -308,6 +309,10 @@ def save_copy(request, domain, app_id):
         except BuildConflictException:
             return JsonResponse({
                 'error': _("There is already a version build in progress. Please wait.")
+            }, status=400)
+        except XFormValidationFailed:
+            return JsonResponse({
+                'error': _("Unable to validate forms.")
             }, status=400)
         finally:
             # To make a RemoteApp always available for building


### PR DESCRIPTION
## Summary
This is basically a dev/staging improvement, to make it more apparent when build errors are because formplayer is down.

## Product Description
Changes error message when formplayer is down and you make a new build from the generic "An error occurred" to something about being unable to validate forms.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

Not requesting QA.

### Safety story
Small, low-risk change. Verified locally I can still make a build.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
