### PR TITLE
FHIRRepeater part 1

### DIFF
--- a/corehq/motech/dhis2/views.py
+++ b/corehq/motech/dhis2/views.py
@@ -16,14 +16,13 @@ from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from corehq.motech.dhis2.dbaccessors import get_dataset_maps
 from corehq.motech.dhis2.dhis2_config import Dhis2EntityConfig, Dhis2FormConfig
-from corehq.motech.dhis2.forms import (
-    Dhis2ConfigForm,
-    Dhis2EntityConfigForm,
-)
+from corehq.motech.dhis2.forms import Dhis2ConfigForm, Dhis2EntityConfigForm
 from corehq.motech.dhis2.models import DataSetMap, DataValueMap
 from corehq.motech.dhis2.repeaters import Dhis2EntityRepeater, Dhis2Repeater
 from corehq.motech.dhis2.tasks import send_datasets
 from corehq.motech.models import ConnectionSettings
+from corehq.motech.repeaters.forms import GenericRepeaterForm
+from corehq.motech.repeaters.views import AddRepeaterView, EditRepeaterView
 
 
 @method_decorator(require_permission(Permissions.edit_motech), name='dispatch')
@@ -163,3 +162,31 @@ def config_dhis2_entity_repeater(request, domain, repeater_id):
         'repeater_id': repeater_id,
         'case_configs': case_configs,
     })
+
+
+class AddDhis2RepeaterView(AddRepeaterView):
+    urlname = 'new_dhis2_repeater$'
+    repeater_form_class = GenericRepeaterForm
+    page_title = ugettext_lazy("Forward Forms to DHIS2 as Anonymous Events")
+    page_name = ugettext_lazy("Forward Forms to DHIS2 as Anonymous Events")
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname, args=[self.domain])
+
+
+class EditDhis2RepeaterView(EditRepeaterView, AddDhis2RepeaterView):
+    urlname = 'edit_dhis2_repeater'
+    page_title = ugettext_lazy("Edit DHIS2 Anonymous Event Repeater")
+
+
+class AddDhis2EntityRepeaterView(AddDhis2RepeaterView):
+    urlname = 'new_dhis2_entity_repeater$'
+    repeater_form_class = GenericRepeaterForm
+    page_title = ugettext_lazy("Forward Cases to DHIS2 as Tracked Entities")
+    page_name = ugettext_lazy("Forward Cases to DHIS2 as Tracked Entities")
+
+
+class EditDhis2EntityRepeaterView(EditRepeaterView, AddDhis2EntityRepeaterView):
+    urlname = 'edit_dhis2_entity_repeater'
+    page_title = ugettext_lazy("Edit DHIS2 Tracked Entity Repeater")

--- a/corehq/motech/openmrs/forms.py
+++ b/corehq/motech/openmrs/forms.py
@@ -1,10 +1,14 @@
 from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy
 
+from crispy_forms import bootstrap as twbscrispy
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
 
+from corehq.apps.locations.forms import LocationSelectWidget
+from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter
 from corehq.apps.userreports.ui.fields import JsonField
 from corehq.motech.openmrs.const import (
     ADDRESS_PROPERTIES,
@@ -13,6 +17,7 @@ from corehq.motech.openmrs.const import (
     NAME_PROPERTIES,
     PERSON_PROPERTIES,
 )
+from corehq.motech.repeaters.forms import CaseRepeaterForm
 
 
 class OpenmrsConfigForm(forms.Form):
@@ -99,3 +104,54 @@ class OpenmrsImporterForm(forms.Form):
                                                'name (e.g. "givenName familyName")'))
     column_map = JsonField(label=_('Map columns to properties'), required=True, expected_type=list,
                            help_text=_('e.g. [{"column": "givenName", "property": "first_name"}, ...]'))
+
+
+class OpenmrsRepeaterForm(CaseRepeaterForm):
+    location_id = forms.CharField(
+        label=ugettext_lazy("Location"),
+        required=False,
+        help_text=ugettext_lazy(
+            'Cases at this location and below will be forwarded. '
+            'Leave empty if this is the only OpenMRS Forwarder'
+        ),
+    )
+    atom_feed_enabled = forms.BooleanField(
+        label=ugettext_lazy('Atom feed enabled'),
+        required=False,
+        help_text=ugettext_lazy(
+            'Poll Atom feed for changes made in OpenMRS/Bahmni'
+        ),
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(OpenmrsRepeaterForm, self).__init__(*args, **kwargs)
+        self.fields['location_id'].widget = LocationSelectWidget(
+            self.domain, id='id_location_id')
+        self.fields['location_id'].help_text = (
+            ExpandedMobileWorkerFilter.location_search_help)
+
+    def get_ordered_crispy_form_fields(self):
+        fields = super(OpenmrsRepeaterForm, self).get_ordered_crispy_form_fields()
+        return fields + [
+            'location_id',
+            twbscrispy.PrependedText('atom_feed_enabled', ''),
+        ]
+
+    def clean(self):
+        cleaned_data = super(OpenmrsRepeaterForm, self).clean()
+        white_listed_case_types = cleaned_data.get('white_listed_case_types', [])
+        atom_feed_enabled = cleaned_data.get('atom_feed_enabled', False)
+        location_id = cleaned_data.get('location_id', None)
+        if atom_feed_enabled:
+            if len(white_listed_case_types) != 1:
+                raise ValidationError(ugettext_lazy(
+                    'Specify a single case type so that CommCare can add '
+                    'cases using the Atom feed for patients created in '
+                    'OpenMRS/Bahmni.'
+                ))
+            if not location_id:
+                raise ValidationError(ugettext_lazy(
+                    'Specify a location so that CommCare can set an owner for '
+                    'cases added via the Atom feed.'
+                ))
+        return cleaned_data

--- a/corehq/motech/openmrs/urls.py
+++ b/corehq/motech/openmrs/urls.py
@@ -8,7 +8,6 @@ from corehq.motech.openmrs.views import (
     openmrs_raw_api,
     openmrs_test_fire,
 )
-from corehq.motech.repeaters.views.repeaters import AddOpenmrsRepeaterView
 
 urlpatterns = [
     url(

--- a/corehq/motech/openmrs/views.py
+++ b/corehq/motech/openmrs/views.py
@@ -19,7 +19,11 @@ from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from corehq.motech.const import PASSWORD_PLACEHOLDER
 from corehq.motech.openmrs.dbaccessors import get_openmrs_importers_by_domain
-from corehq.motech.openmrs.forms import OpenmrsConfigForm, OpenmrsImporterForm
+from corehq.motech.openmrs.forms import (
+    OpenmrsConfigForm,
+    OpenmrsImporterForm,
+    OpenmrsRepeaterForm,
+)
 from corehq.motech.openmrs.models import ColumnMapping, OpenmrsImporter
 from corehq.motech.openmrs.openmrs_config import (
     OpenmrsCaseConfig,
@@ -32,6 +36,7 @@ from corehq.motech.openmrs.repeater_helpers import (
 from corehq.motech.openmrs.repeaters import OpenmrsRepeater
 from corehq.motech.openmrs.tasks import import_patients_to_domain
 from corehq.motech.repeaters.models import RepeatRecord
+from corehq.motech.repeaters.views import AddCaseRepeaterView, EditRepeaterView
 from corehq.motech.utils import b64_aes_encrypt
 
 
@@ -200,3 +205,23 @@ class OpenmrsImporterView(BaseProjectSettingsView):
             'openmrs_importers': openmrs_importers,
             'form': OpenmrsImporterForm(),  # Use an unbound form to render openmrs_importer_template.html
         }
+
+
+class AddOpenmrsRepeaterView(AddCaseRepeaterView):
+    urlname = 'new_openmrs_repeater$'
+    repeater_form_class = OpenmrsRepeaterForm
+    page_title = ugettext_lazy("Forward to OpenMRS")
+    page_name = ugettext_lazy("Forward to OpenMRS")
+
+    def set_repeater_attr(self, repeater, cleaned_data):
+        repeater = super().set_repeater_attr(repeater, cleaned_data)
+        repeater.location_id = (self.add_repeater_form
+                                .cleaned_data['location_id'])
+        repeater.atom_feed_enabled = (self.add_repeater_form
+                                      .cleaned_data['atom_feed_enabled'])
+        return repeater
+
+
+class EditOpenmrsRepeaterView(EditRepeaterView, AddOpenmrsRepeaterView):
+    urlname = 'edit_openmrs_repeater'
+    page_title = ugettext_lazy("Edit OpenMRS Repeater")

--- a/corehq/motech/repeaters/forms.py
+++ b/corehq/motech/repeaters/forms.py
@@ -10,11 +10,7 @@ from memoized import memoized
 
 from corehq.apps.es.users import UserES
 from corehq.apps.hqwebapp import crispy as hqcrispy
-from corehq.apps.locations.forms import LocationSelectWidget
-from corehq.apps.reports.analytics.esaccessors import (
-    get_case_types_for_domain,
-)
-from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter
+from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain
 from corehq.apps.users.util import raw_username
 from corehq.motech.models import ConnectionSettings
 from corehq.motech.repeaters.models import Repeater
@@ -155,49 +151,4 @@ class CaseRepeaterForm(GenericRepeaterForm):
             raise ValidationError(_('Unknown case-type'))
         if not set(black_listed_users).issubset([t[0] for t in self.user_choices]):
             raise ValidationError(_('Unknown user'))
-        return cleaned_data
-
-
-class OpenmrsRepeaterForm(CaseRepeaterForm):
-    location_id = forms.CharField(
-        label=_("Location"),
-        required=False,
-        help_text=_(
-            'Cases at this location and below will be forwarded. '
-            'Leave empty if this is the only OpenMRS Forwarder'
-        )
-    )
-    atom_feed_enabled = forms.BooleanField(
-        label=_('Atom feed enabled'),
-        required=False,
-        help_text=_('Poll Atom feed for changes made in OpenMRS/Bahmni'),
-    )
-
-    def __init__(self, *args, **kwargs):
-        super(OpenmrsRepeaterForm, self).__init__(*args, **kwargs)
-        self.fields['location_id'].widget = LocationSelectWidget(self.domain, id='id_location_id')
-        self.fields['location_id'].help_text = ExpandedMobileWorkerFilter.location_search_help
-
-    def get_ordered_crispy_form_fields(self):
-        fields = super(OpenmrsRepeaterForm, self).get_ordered_crispy_form_fields()
-        return fields + [
-            'location_id',
-            twbscrispy.PrependedText('atom_feed_enabled', ''),
-        ]
-
-    def clean(self):
-        cleaned_data = super(OpenmrsRepeaterForm, self).clean()
-        white_listed_case_types = cleaned_data.get('white_listed_case_types', [])
-        atom_feed_enabled = cleaned_data.get('atom_feed_enabled', False)
-        location_id = cleaned_data.get('location_id', None)
-        if atom_feed_enabled:
-            if len(white_listed_case_types) != 1:
-                raise ValidationError(_(
-                    'Specify a single case type so that CommCare can add cases using the Atom feed for patients '
-                    'created in OpenMRS/Bahmni.'
-                ))
-            if not location_id:
-                raise ValidationError(_(
-                    'Specify a location so that CommCare can set an owner for cases added via the Atom feed.'
-                ))
         return cleaned_data

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -420,9 +420,7 @@ class FormDictPayloadGenerator(BasePayloadGenerator):
     format_label = _('Python dictionary')
 
     def get_payload(self, repeat_record, form) -> dict:
-        from corehq.apps.api.util import form_to_es_form
-        es_form = form_to_es_form(form, include_attachments=True)
-        return {'form': es_form.form_data}
+        return form.to_json()
 
     @property
     def content_type(self):

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -415,6 +415,20 @@ class FormRepeaterJsonPayloadGenerator(BasePayloadGenerator):
         return self.get_payload(None, _get_test_form(domain))
 
 
+class FormDictPayloadGenerator(BasePayloadGenerator):
+    format_name = 'form_dict'
+    format_label = _('Python dictionary')
+
+    def get_payload(self, repeat_record, form) -> dict:
+        from corehq.apps.api.util import form_to_es_form
+        es_form = form_to_es_form(form, include_attachments=True)
+        return {'form': es_form.form_data}
+
+    @property
+    def content_type(self):
+        return 'application/x-python'
+
+
 class UserPayloadGenerator(BasePayloadGenerator):
 
     @property

--- a/corehq/motech/repeaters/tests/test_payload_generators.py
+++ b/corehq/motech/repeaters/tests/test_payload_generators.py
@@ -1,0 +1,184 @@
+import json
+import random
+import string
+from datetime import datetime
+from decimal import Decimal
+from typing import Tuple
+from uuid import uuid4
+
+from django.test import TestCase
+
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
+from corehq.apps.accounting.utils import clear_plan_version_cache
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.receiverwrapper.util import submit_form_locally
+from corehq.form_processor.interfaces.dbaccessors import FormAccessors
+from corehq.motech.repeater_helpers import (
+    get_relevant_case_updates_from_form_json,
+)
+from corehq.motech.repeaters.repeater_generators import (
+    BasePayloadGenerator,
+    FormDictPayloadGenerator,
+    FormRepeaterJsonPayloadGenerator,
+)
+from corehq.motech.value_source import (
+    CaseTriggerInfo,
+    get_form_question_values,
+)
+
+DOMAIN = ''.join([random.choice(string.ascii_lowercase) for __ in range(20)])
+
+
+class TestDataTypes(TestCase, DomainSubscriptionMixin):
+    """
+    Test that data types returned by FormDictPayloadGenerator match
+    those returned by FormRepeaterJsonPayloadGenerator.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = create_domain(DOMAIN)
+        cls.setup_subscription(DOMAIN, SoftwarePlanEdition.PRO)
+
+        xform_id = uuid4().hex
+        case_id = uuid4().hex
+        post_xform(xform_id, case_id)
+        cls.form = FormAccessors(DOMAIN).get_form(xform_id)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.teardown_subscriptions()
+        cls.domain_obj.delete()
+        clear_plan_version_cache()
+        super().tearDownClass()
+
+    def test_form_json_decimal(self):
+        """
+        When a decimal is taken from form JSON or a case block, it is a
+        ``str``. When it is taken from a case property, it is a ``Decimal``.
+        """
+        gen = FormRepeaterJsonPayloadGenerator(None)
+        form_dict, info = self.get_payload_info(gen)
+
+        # Test value from form_json
+        self.assertIsInstance(form_dict['form']['decimal'], str)
+        self.assertIsInstance(info.form_question_values['/data/decimal'], str)
+        # Test value from case block
+        self.assertIsInstance(info.updates['decimal'], str)
+        # Test value from case property
+        self.assertIsInstance(info.extra_fields['decimal'], Decimal)  # <--
+
+    def test_form_dict_decimal(self):
+        """
+        When a decimal is taken from form JSON or a case block, it is a
+        ``str``. When it is taken from a case property, it is a ``Decimal``.
+        """
+        gen = FormDictPayloadGenerator(None)
+        form_dict, info = self.get_payload_info(gen)
+
+        self.assertIsInstance(form_dict['form']['decimal'], str)
+        self.assertIsInstance(info.form_question_values['/data/decimal'], str)
+        self.assertIsInstance(info.updates['decimal'], str)
+        self.assertIsInstance(info.extra_fields['decimal'], Decimal)  # <--
+
+    def test_form_json_integer(self):
+        """
+        When an integer is taken from form JSON or a case block, it is a
+        ``str``. When it is taken from a case property, it is still a ``str``.
+        """
+        gen = FormRepeaterJsonPayloadGenerator(None)
+        form_dict, info = self.get_payload_info(gen)
+
+        self.assertIsInstance(form_dict['form']['year'], str)
+        self.assertIsInstance(info.form_question_values['/data/year'], str)
+        self.assertIsInstance(info.updates['year'], str)
+        self.assertIsInstance(info.extra_fields['year'], str)  # <--
+
+    def test_form_dict_integer(self):
+        """
+        When an integer is taken from form JSON or a case block, it is a
+        ``str``. When it is taken from a case property, it is still a ``str``.
+        """
+        gen = FormDictPayloadGenerator(None)
+        form_dict, info = self.get_payload_info(gen)
+
+        self.assertIsInstance(form_dict['form']['year'], str)
+        self.assertIsInstance(info.form_question_values['/data/year'], str)
+        self.assertIsInstance(info.updates['year'], str)
+        self.assertIsInstance(info.extra_fields['year'], str)  # <--
+
+    def test_form_json_multiplechoice(self):
+        gen = FormRepeaterJsonPayloadGenerator(None)
+        form_dict, info = self.get_payload_info(gen)
+
+        self.assertIsInstance(form_dict['form']['breakfast'], str)
+        self.assertIsInstance(info.form_question_values['/data/breakfast'], str)
+        self.assertIsInstance(info.updates['breakfast'], str)
+        self.assertIsInstance(info.extra_fields['breakfast'], str)
+
+    def test_form_dict_multiplechoice(self):
+        gen = FormDictPayloadGenerator(None)
+        form_dict, info = self.get_payload_info(gen)
+
+        self.assertIsInstance(form_dict['form']['breakfast'], str)
+        self.assertIsInstance(info.form_question_values['/data/breakfast'], str)
+        self.assertIsInstance(info.updates['breakfast'], str)
+        self.assertIsInstance(info.extra_fields['breakfast'], str)
+
+    def get_payload_info(
+        self,
+        payload_generator: BasePayloadGenerator,
+    ) -> Tuple[dict, CaseTriggerInfo]:
+        payload = payload_generator.get_payload(None, self.form)
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        [info] = get_relevant_case_updates_from_form_json(
+            DOMAIN,
+            payload,
+            case_types=None,
+            extra_fields=['year', 'breakfast', 'decimal'],
+            form_question_values=get_form_question_values(payload),
+        )
+        return payload, info
+
+
+def post_xform(xform_id, case_id):
+    user_id = uuid4().hex
+    now_str = datetime.utcnow().isoformat(timespec='milliseconds') + 'Z'
+    xform = f"""<?xml version='1.0' ?>
+<data xmlns="https://commcarehq.org/test/TestDataTypes/">
+
+    <name>spam</name>
+    <year>1970</year>
+    <breakfast>spam egg spam spam bacon spam</breakfast>
+    <decimal>4.4</decimal>
+
+    <ctx:case case_id="{case_id}"
+              date_modified="{now_str}"
+              user_id="{user_id}"
+              xmlns:ctx="http://commcarehq.org/case/transaction/v2">
+      <ctx:create>
+        <ctx:case_type>sketch</ctx:case_type>
+        <ctx:case_name>spam</ctx:case_name>
+        <ctx:owner_id>{user_id}</ctx:owner_id>
+      </ctx:create>
+      <ctx:update>
+        <ctx:year>1970</ctx:year>
+        <ctx:breakfast>spam egg spam spam bacon spam</ctx:breakfast>
+        <ctx:decimal>4.4</ctx:decimal>
+      </ctx:update>
+    </ctx:case>
+
+    <jrm:meta xmlns:jrm="http://commcarehq.org/jr/xforms">
+        <jrm:deviceID>TestDataTypes</jrm:deviceID>
+        <jrm:timeStart>{now_str}</jrm:timeStart>
+        <jrm:timeEnd>{now_str}</jrm:timeEnd>
+        <jrm:username>admin</jrm:username>
+        <jrm:userID>testy.mctestface</jrm:userID>
+        <jrm:instanceID>{xform_id}</jrm:instanceID>
+    </jrm:meta>
+</data>
+"""
+    submit_form_locally(xform, DOMAIN)

--- a/corehq/motech/repeaters/views/__init__.py
+++ b/corehq/motech/repeaters/views/__init__.py
@@ -7,18 +7,11 @@ from .repeat_records import (
 )
 from .repeaters import (
     AddCaseRepeaterView,
-    AddDhis2EntityRepeaterView,
-    AddDhis2RepeaterView,
     AddFormRepeaterView,
-    AddOpenmrsRepeaterView,
     AddRepeaterView,
     DomainForwardingOptionsView,
     EditCaseRepeaterView,
-    EditDhis2RepeaterView,
     EditFormRepeaterView,
-    EditOpenmrsRepeaterView,
-    EditDhis2EntityRepeaterView,
-    EditDhis2RepeaterView,
     EditRepeaterView,
     drop_repeater,
     pause_repeater,

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -1,8 +1,7 @@
-import json
 from collections import namedtuple
 
 from django.contrib import messages
-from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
@@ -14,28 +13,19 @@ from memoized import memoized
 from corehq import privileges, toggles
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.domain.decorators import domain_admin_required
-from corehq.apps.domain.views.settings import (
-    BaseAdminProjectSettingsView,
-    BaseProjectSettingsView,
-)
+from corehq.apps.domain.views.settings import BaseAdminProjectSettingsView
 from corehq.apps.users.decorators import (
     require_can_edit_web_users,
     require_permission,
 )
 from corehq.apps.users.models import Permissions
 from corehq.motech.const import PASSWORD_PLACEHOLDER
-from corehq.motech.requests import simple_post
 
-from ..forms import (
-    CaseRepeaterForm,
-    FormRepeaterForm,
-    GenericRepeaterForm,
-    OpenmrsRepeaterForm,
-)
+from ..forms import CaseRepeaterForm, FormRepeaterForm, GenericRepeaterForm
 from ..models import Repeater, RepeatRecord, get_all_repeater_types
-from ..repeater_generators import RegisterGenerator
 
-RepeaterTypeInfo = namedtuple('RepeaterTypeInfo', 'class_name friendly_name has_config instances')
+RepeaterTypeInfo = namedtuple('RepeaterTypeInfo',
+                              'class_name friendly_name has_config instances')
 
 
 class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
@@ -46,13 +36,19 @@ class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
     @method_decorator(require_permission(Permissions.edit_motech))
     @method_decorator(requires_privilege_with_fallback(privileges.DATA_FORWARDING))
     def dispatch(self, request, *args, **kwargs):
-        return super(BaseProjectSettingsView, self).dispatch(request, *args, **kwargs)
+        return super().dispatch(request, *args, **kwargs)
 
     @property
     def repeater_types_info(self):
         return [
-            RepeaterTypeInfo(r.__name__, r.friendly_name, r._has_config, r.by_domain(self.domain))
-            for r in get_all_repeater_types().values() if r.available_for_domain(self.domain)
+            RepeaterTypeInfo(
+                class_name=r.__name__,
+                friendly_name=r.friendly_name,
+                has_config=r._has_config,
+                instances=r.by_domain(self.domain),
+            )
+            for r in get_all_repeater_types().values()
+            if r.available_for_domain(self.domain)
         ]
 
     @property
@@ -166,67 +162,9 @@ class AddRepeaterView(BaseRepeaterView):
 
     def post_save(self, request, repeater):
         messages.success(request, _("Forwarding set up to %s" % repeater.url))
-        return HttpResponseRedirect(reverse(DomainForwardingOptionsView.urlname, args=[self.domain]))
-
-
-class AddFormRepeaterView(AddRepeaterView):
-    urlname = 'add_form_repeater'
-    repeater_form_class = FormRepeaterForm
-
-    @property
-    def page_url(self):
-        return reverse(self.urlname, args=[self.domain])
-
-    def set_repeater_attr(self, repeater, cleaned_data):
-        repeater = super(AddFormRepeaterView, self).set_repeater_attr(repeater, cleaned_data)
-        repeater.include_app_id_param = self.add_repeater_form.cleaned_data['include_app_id_param']
-        return repeater
-
-
-class AddCaseRepeaterView(AddRepeaterView):
-    urlname = 'add_case_repeater'
-    repeater_form_class = CaseRepeaterForm
-
-    @property
-    def page_url(self):
-        return reverse(self.urlname, args=[self.domain])
-
-    def set_repeater_attr(self, repeater, cleaned_data):
-        repeater = super(AddCaseRepeaterView, self).set_repeater_attr(repeater, cleaned_data)
-        repeater.white_listed_case_types = self.add_repeater_form.cleaned_data['white_listed_case_types']
-        repeater.black_listed_users = self.add_repeater_form.cleaned_data['black_listed_users']
-        return repeater
-
-
-class AddOpenmrsRepeaterView(AddCaseRepeaterView):
-    urlname = 'new_openmrs_repeater$'
-    repeater_form_class = OpenmrsRepeaterForm
-    page_title = ugettext_lazy("Forward to OpenMRS")
-    page_name = ugettext_lazy("Forward to OpenMRS")
-
-    def set_repeater_attr(self, repeater, cleaned_data):
-        repeater = super(AddOpenmrsRepeaterView, self).set_repeater_attr(repeater, cleaned_data)
-        repeater.location_id = self.add_repeater_form.cleaned_data['location_id']
-        repeater.atom_feed_enabled = self.add_repeater_form.cleaned_data['atom_feed_enabled']
-        return repeater
-
-
-class AddDhis2RepeaterView(AddRepeaterView):
-    urlname = 'new_dhis2_repeater$'
-    repeater_form_class = GenericRepeaterForm
-    page_title = ugettext_lazy("Forward Forms to DHIS2 as Anonymous Events")
-    page_name = ugettext_lazy("Forward Forms to DHIS2 as Anonymous Events")
-
-    @property
-    def page_url(self):
-        return reverse(self.urlname, args=[self.domain])
-
-
-class AddDhis2EntityRepeaterView(AddDhis2RepeaterView):
-    urlname = 'new_dhis2_entity_repeater$'
-    repeater_form_class = GenericRepeaterForm
-    page_title = ugettext_lazy("Forward Cases to DHIS2 as Tracked Entities")
-    page_name = ugettext_lazy("Forward Cases to DHIS2 as Tracked Entities")
+        return HttpResponseRedirect(
+            reverse(DomainForwardingOptionsView.urlname, args=[self.domain])
+        )
 
 
 class EditRepeaterView(BaseRepeaterView):
@@ -239,10 +177,12 @@ class EditRepeaterView(BaseRepeaterView):
 
     @property
     def page_url(self):
-        # The EditRepeaterView url routes to the correct edit form for its subclasses. It does this with
-        # `repeater_type` in r'^forwarding/(?P<repeater_type>\w+)/edit/(?P<repeater_id>\w+)/$'
+        # The EditRepeaterView url routes to the correct edit form for
+        # its subclasses. It does this with `repeater_type` in
+        # r'^forwarding/(?P<repeater_type>\w+)/edit/(?P<repeater_id>\w+)/$'
         # See corehq/apps/domain/urls.py for details.
-        return reverse(EditRepeaterView.urlname, args=[self.domain, self.repeater_type, self.repeater_id])
+        return reverse(EditRepeaterView.urlname,
+                       args=[self.domain, self.repeater_type, self.repeater_id])
 
     @property
     @memoized
@@ -278,20 +218,28 @@ class EditRepeaterView(BaseRepeaterView):
         messages.success(request, _("Repeater Successfully Updated"))
         if self.request.GET.get('repeater_type'):
             return HttpResponseRedirect(
-                (reverse(self.urlname, args=[self.domain, repeater.get_id]) +
-                 '?repeater_type=' + self.kwargs['repeater_type'])
+                reverse(self.urlname, args=[self.domain, repeater.get_id])
+                + '?repeater_type=' + self.kwargs['repeater_type']
             )
         else:
-            return HttpResponseRedirect(reverse(self.urlname, args=[self.domain, repeater.get_id]))
+            return HttpResponseRedirect(
+                reverse(self.urlname, args=[self.domain, repeater.get_id])
+            )
 
 
-class EditCaseRepeaterView(EditRepeaterView, AddCaseRepeaterView):
-    urlname = 'edit_case_repeater'
-    page_title = ugettext_lazy("Edit Case Repeater")
+class AddFormRepeaterView(AddRepeaterView):
+    urlname = 'add_form_repeater'
+    repeater_form_class = FormRepeaterForm
 
     @property
     def page_url(self):
-        return reverse(AddCaseRepeaterView.urlname, args=[self.domain])
+        return reverse(self.urlname, args=[self.domain])
+
+    def set_repeater_attr(self, repeater, cleaned_data):
+        repeater = super().set_repeater_attr(repeater, cleaned_data)
+        repeater.include_app_id_param = (
+            self.add_repeater_form.cleaned_data['include_app_id_param'])
+        return repeater
 
 
 class EditFormRepeaterView(EditRepeaterView, AddFormRepeaterView):
@@ -303,19 +251,30 @@ class EditFormRepeaterView(EditRepeaterView, AddFormRepeaterView):
         return reverse(AddFormRepeaterView.urlname, args=[self.domain])
 
 
-class EditOpenmrsRepeaterView(EditRepeaterView, AddOpenmrsRepeaterView):
-    urlname = 'edit_openmrs_repeater'
-    page_title = ugettext_lazy("Edit OpenMRS Repeater")
+class AddCaseRepeaterView(AddRepeaterView):
+    urlname = 'add_case_repeater'
+    repeater_form_class = CaseRepeaterForm
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname, args=[self.domain])
+
+    def set_repeater_attr(self, repeater, cleaned_data):
+        repeater = super().set_repeater_attr(repeater, cleaned_data)
+        repeater.white_listed_case_types = (
+            self.add_repeater_form.cleaned_data['white_listed_case_types'])
+        repeater.black_listed_users = (
+            self.add_repeater_form.cleaned_data['black_listed_users'])
+        return repeater
 
 
-class EditDhis2RepeaterView(EditRepeaterView, AddDhis2RepeaterView):
-    urlname = 'edit_dhis2_repeater'
-    page_title = ugettext_lazy("Edit DHIS2 Anonymous Event Repeater")
+class EditCaseRepeaterView(EditRepeaterView, AddCaseRepeaterView):
+    urlname = 'edit_case_repeater'
+    page_title = ugettext_lazy("Edit Case Repeater")
 
-
-class EditDhis2EntityRepeaterView(EditRepeaterView, AddDhis2EntityRepeaterView):
-    urlname = 'edit_dhis2_entity_repeater'
-    page_title = ugettext_lazy("Edit DHIS2 Tracked Entity Repeater")
+    @property
+    def page_url(self):
+        return reverse(AddCaseRepeaterView.urlname, args=[self.domain])
 
 
 @require_POST
@@ -325,7 +284,9 @@ def drop_repeater(request, domain, repeater_id):
     rep = Repeater.get(repeater_id)
     rep.retire()
     messages.success(request, "Forwarding stopped!")
-    return HttpResponseRedirect(reverse(DomainForwardingOptionsView.urlname, args=[domain]))
+    return HttpResponseRedirect(
+        reverse(DomainForwardingOptionsView.urlname, args=[domain])
+    )
 
 
 @require_POST
@@ -335,7 +296,9 @@ def pause_repeater(request, domain, repeater_id):
     rep = Repeater.get(repeater_id)
     rep.pause()
     messages.success(request, "Forwarding paused!")
-    return HttpResponseRedirect(reverse(DomainForwardingOptionsView.urlname, args=[domain]))
+    return HttpResponseRedirect(
+        reverse(DomainForwardingOptionsView.urlname, args=[domain])
+    )
 
 
 @require_POST
@@ -345,4 +308,6 @@ def resume_repeater(request, domain, repeater_id):
     rep = Repeater.get(repeater_id)
     rep.resume()
     messages.success(request, "Forwarding resumed!")
-    return HttpResponseRedirect(reverse(DomainForwardingOptionsView.urlname, args=[domain]))
+    return HttpResponseRedirect(
+        reverse(DomainForwardingOptionsView.urlname, args=[domain])
+    )

--- a/corehq/motech/urls.py
+++ b/corehq/motech/urls.py
@@ -1,23 +1,25 @@
 from django.conf.urls import url
 
 from corehq.motech.dhis2.views import (
+    AddDhis2EntityRepeaterView,
+    AddDhis2RepeaterView,
+    EditDhis2EntityRepeaterView,
+    EditDhis2RepeaterView,
     config_dhis2_entity_repeater,
     config_dhis2_repeater,
 )
-from corehq.motech.openmrs.views import config_openmrs_repeater
+from corehq.motech.openmrs.views import (
+    AddOpenmrsRepeaterView,
+    EditOpenmrsRepeaterView,
+    config_openmrs_repeater,
+)
 from corehq.motech.repeaters.views import (
     AddCaseRepeaterView,
-    AddDhis2EntityRepeaterView,
-    AddDhis2RepeaterView,
     AddFormRepeaterView,
-    AddOpenmrsRepeaterView,
     AddRepeaterView,
     DomainForwardingOptionsView,
     EditCaseRepeaterView,
-    EditDhis2EntityRepeaterView,
-    EditDhis2RepeaterView,
     EditFormRepeaterView,
-    EditOpenmrsRepeaterView,
     EditRepeaterView,
     drop_repeater,
     pause_repeater,


### PR DESCRIPTION
## Summary

Small. Preparatory work for FHIRRepeater.

:blowfish: The first commit moves a few things to where they belong. The second two create a light-weight payload generator for repeaters that use form JSON instead of sending the payload immediately.

(That payload generator will be useful for a few other repeaters. I'll follow up once FHIRRepeater is out the way.)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story

The refactor commit doesn't change any code; it just moves it. The payload generator isn't used yet.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
