### PR TITLE
FHIR_INTEGRATION feature flag

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -2042,3 +2042,11 @@ PRIME_FORMPLAYER_DBS = StaticToggle(
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN]
 )
+
+
+FHIR_INTEGRATION = StaticToggle(
+    'fhir_integration',
+    'FHIR: Enable setting up FHIR integration',
+    TAG_SOLUTIONS_LIMITED,
+    namespaces=[NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
## Summary

Literally just a feature flag, copy-pasted from [a commit](https://github.com/dimagi/commcare-hq/pull/29210/commits/298c7e392fdcdd74bf9be23b56371c2cf3f0f5e1) by @mkangia and added to toggles.py in exactly the same place, in the hope of avoiding merge conflicts.

## Feature Flag

FHIR_INTEGRATION

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story

Literally just a feature flag.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
