### PR TITLE
Change `FHIRResourceType` fields

### DIFF
--- a/corehq/motech/fhir/migrations/0002_fhirresourcetype.py
+++ b/corehq/motech/fhir/migrations/0002_fhirresourcetype.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+import django.db.models.deletion
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fhir', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='fhirresourcetype',
+            name='case_type',
+            field=models.OneToOneField(
+                on_delete=django.db.models.deletion.CASCADE,
+                to='data_dictionary.CaseType',
+            ),
+        ),
+        migrations.AlterField(
+            model_name='fhirresourcetype',
+            name='template',
+            field=jsonfield.fields.JSONField(default=dict),
+        ),
+    ]

--- a/corehq/motech/fhir/models.py
+++ b/corehq/motech/fhir/models.py
@@ -24,14 +24,14 @@ class FHIRResourceType(models.Model):
     domain = models.CharField(max_length=127, db_index=True)
     fhir_version = models.CharField(max_length=12, choices=FHIR_VERSIONS,
                                     default=FHIR_VERSION_4_0_1)
-    case_type = models.ForeignKey(CaseType, on_delete=models.CASCADE)
+    case_type = models.OneToOneField(CaseType, on_delete=models.CASCADE)
 
     # For a list of resource types, see http://hl7.org/fhir/resourcelist.html
     name = models.CharField(max_length=255)
 
     # `template` offers a way to define a FHIR resource if it cannot be
     # built using only mapped case properties.
-    template = JSONField(null=True, blank=True, default=None)
+    template = JSONField(default=dict)
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
## Summary

Changes `FHIRResourceType.case_type` to a OneToOneField, so that the FHIR API will be able to create cases on POST without resulting in half-baked cases.


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story

This model is not yet in use: The FHIR API and `FHIRRepeater` are not yet merged into master.

The migration is safe to deploy because the table is empty in all environments except Staging.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
