### PR TITLE
Added caching for Marionette templates

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -5,6 +5,7 @@
  */
 
 hqDefine("cloudcare/js/formplayer/app", function () {
+    Marionette.setRenderer(Marionette.TemplateCache.render);
     var FormplayerFrontend = new Marionette.Application();
     var showError = hqImport('cloudcare/js/util').showError;
     var showHTMLError = hqImport('cloudcare/js/util').showHTMLError;

--- a/corehq/apps/cloudcare/templates/formplayer/dependencies.html
+++ b/corehq/apps/cloudcare/templates/formplayer/dependencies.html
@@ -8,6 +8,7 @@
   <script src="{% static 'backbone.radio/build/backbone.radio.min.js' %}"></script>
   <script src="{% static 'backbone.marionette/lib/backbone.marionette.js' %}"></script>
   <script src="{% static 'marionette.approuter/lib/marionette.approuter.min.js' %}"></script>
+  <script src="{% static 'marionette.templatecache/lib/marionette.templatecache.min.js' %}"></script>
   <script src="{% static 'nprogress/nprogress.js' %}"></script>
   <script src="{% static 'moment/min/moment.min.js' %}"></script>
   <script src="{% static 'jquery-textchange/jquery.textchange.js' %}"></script>

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
         "leaflet": "0.7.7",
         "less": "3.10.3",
         "marionette.approuter": "^1.0.2",
+        "marionette.templatecache": "^1.0.0",
         "markdown-it": "12.0.4",
         "modernizr": "^3.11.3",
         "moment": "2.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -502,6 +502,13 @@ backbone.marionette@4.1.3:
   dependencies:
     backbone.radio "^2.0.0"
 
+"backbone.marionette@^4.0.0, 4.0.0-beta.1":
+  version "4.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/backbone.marionette/-/backbone.marionette-4.0.0-beta.1.tgz#793528fc5c60620200e2440e6dcd04ba16c3aab3"
+  integrity sha1-eTUo/FxgYgIA4kQObc0EuhbDqrM=
+  dependencies:
+    backbone.radio "^2.0.0"
+
 backbone.radio@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/backbone.radio/-/backbone.radio-2.0.0.tgz#bbe8672b373e313f99f36d2fbcf583fe77d04f42"
@@ -3595,6 +3602,13 @@ marionette.approuter@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/marionette.approuter/-/marionette.approuter-1.0.2.tgz#bd45b801762fea4ec5caa9505640413596cc432c"
   integrity sha512-XjcKb1Y6KROCmdZxO/rtOdRhd3Hfrs+7zWjtfiuCFS3VZa2IQjNgKUuIGmaKDZte2AmKRRMaPvXMh22nKYFh8A==
+
+marionette.templatecache@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/marionette.templatecache/-/marionette.templatecache-1.0.0.tgz#579b9a53b1b6428f8f0a0071cff2175a2d71e65b"
+  integrity sha1-V5uaU7G2Qo+PCgBxz/IXWi1x5ls=
+  dependencies:
+    backbone.marionette "^4.0.0, 4.0.0-beta.1"
 
 markdown-it@12.0.4:
   version "12.0.4"


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-282

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

Not requesting QA.

### Safety story
Straightforward change as described in docs: https://github.com/marionettejs/marionette.templatecache#using-the-renderer-with-marionette

Smoke tested locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
