### PR TITLE
Updated update_case_index_relationship to allow for 'patient' indices

### DIFF
--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -29,7 +29,10 @@ def should_skip(case, traveler_location_id, inactive_location):
 
 def needs_update(case):
     index = case.indices[0]
-    return index.referenced_type == "patient" and index.relationship == "child"
+    return index.relationship == "child" and (
+        index.referenced_type == "patient"
+        or index.referenced_type == "'patient'"
+    )
 
 
 def get_owner_id(case_type):
@@ -47,7 +50,7 @@ class Command(CaseUpdateCommand):
             create=False,
             case_id=case.case_id,
             owner_id=owner_id,
-            index={index.identifier: (index.referenced_type, index.referenced_id, "extension")},
+            index={index.identifier: ("patient", index.referenced_id, "extension")},
         ).as_xml(), encoding='utf-8').decode('utf-8')
 
     def update_cases(self, domain, case_type, user_id):

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -104,11 +104,22 @@ class CaseCommandsTest(TestCase):
         self.assertEqual(lab_result_case.indices[0].referenced_type, 'patient')
         self.assertEqual(lab_result_case.indices[0].relationship, 'child')
 
+        quoted_lab_result_case_id = uuid.uuid4().hex
+        self.submit_case_block(
+            True, quoted_lab_result_case_id, user_id=self.user_id, owner_id='owner1', case_type='lab_result',
+            index={'patient': ("'patient'", patient_case_id, 'child')}
+        )
+
         call_command('update_case_index_relationship', self.domain, 'lab_result')
 
         lab_result_case = self.case_accessor.get_case(lab_result_case_id)
         self.assertEqual(lab_result_case.indices[0].relationship, 'extension')
         self.assertEqual(lab_result_case.get_case_property('owner_id'), '-')
+
+        quoted_lab_result_case = self.case_accessor.get_case(quoted_lab_result_case_id)
+        self.assertEqual(quoted_lab_result_case.indices[0].referenced_type, 'patient')
+        self.assertEqual(quoted_lab_result_case.indices[0].relationship, 'extension')
+        self.assertEqual(quoted_lab_result_case.get_case_property('owner_id'), '-')
 
     def test_update_case_index_relationship_with_location(self):
         location_type = LocationType.objects.create(


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-715

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Added in this PR.

### QA Plan

No QA. Automated test coverage should be sufficient.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
