### PR TITLE
Fixed 500 on linked projects page when lookup table has been deleted

### DIFF
--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -423,13 +423,12 @@ class DomainLinkView(BaseAdminProjectSettingsView):
                 if action.model_detail:
                     detail = action.wrapped_detail
                     tag = action.wrapped_detail.tag
-                    try:
-                        fixture = fixtures.get(tag)
-                        del fixtures[tag]
-                    except KeyError:
+                    fixture = fixtures.pop(tag, None)
+                    if not fixture:
                         fixture = get_fixture_data_type_by_tag(self.domain, tag)
-                    tag_name = fixture.tag
-                    can_update = fixture.is_global
+                    if fixture:
+                        tag_name = fixture.tag
+                        can_update = fixture.is_global
                 update['name'] = f'{name} ({tag_name})'
                 update['can_update'] = can_update
             if action.model == 'report':


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-413

## Feature Flag
Linked Project Spaces

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

Not requesting QA.

### Safety story
Minor bugfix. Tested locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
