### PR TITLE
Added UCRs to reports handled by linked project space user roles

### DIFF
--- a/corehq/apps/linked_domain/updates.py
+++ b/corehq/apps/linked_domain/updates.py
@@ -81,6 +81,7 @@ from corehq.apps.linked_domain.ucr import update_linked_ucr
 from corehq.apps.linked_domain.keywords import update_keyword
 from corehq.apps.locations.views import LocationFieldsView
 from corehq.apps.products.views import ProductFieldsView
+from corehq.apps.userreports.dbaccessors import get_report_configs_for_domain
 from corehq.apps.userreports.util import (
     get_static_report_mapping,
     get_ucr_class_name,
@@ -347,6 +348,11 @@ def _convert_reports_permissions(domain_link, master_results):
     """Mutates the master result docs to convert dynamic report permissions.
     """
     report_map = get_static_report_mapping(domain_link.master_domain, domain_link.linked_domain)
+    report_map.update({
+        c.report_meta.master_id: c._id
+        for c in get_report_configs_for_domain(domain_link.linked_domain)
+    })
+
     for role_def in master_results:
         new_report_perms = [
             perm for perm in role_def['permissions']['view_report_list']


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-232

## Feature Flag
Linked project spaces
UCR

## Product Description
Previously, when updating a downstream role that included access to specific reports, any UCR permissions would be lost.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

There's test coverage for updating linked roles.

### QA Plan

Not requesting QA.

### Safety story
Small change with decent automated test coverage.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
