### PR TITLE
ValueSource supports case relationships

### DIFF
--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 from datetime import datetime
+from unittest.mock import patch
 from uuid import uuid4
 
 from couchdbkit import ResourceNotFound
@@ -367,3 +368,32 @@ def set_case_property_directly(case, property_name, value):
         case.case_json[property_name] = value
     else:
         setattr(case, property_name, value)
+
+
+def create_case(case) -> CommCareCaseSQL:
+    form = XFormInstanceSQL(
+        form_id=uuid4().hex,
+        xmlns='http://commcarehq.org/formdesigner/form-processor',
+        received_on=case.server_modified_on,
+        user_id=case.owner_id,
+        domain=case.domain,
+    )
+    transaction = CaseTransaction(
+        type=CaseTransaction.TYPE_FORM,
+        form_id=form.form_id,
+        case=case,
+        server_date=case.server_modified_on,
+    )
+    with patch.object(FormProcessorSQL, "publish_changes_to_kafka"):
+        case.track_create(transaction)
+        processed_forms = ProcessedForms(form, [])
+        FormProcessorSQL.save_processed_models(processed_forms, [case])
+    return CaseAccessorSQL.get_case(case.case_id)
+
+
+def create_case_with_index(case, index) -> CommCareCaseSQL:
+    case = create_case(case)
+    index.case = case
+    case.track_create(index)
+    CaseAccessorSQL.save_case(case)
+    return case

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -397,3 +397,9 @@ def create_case_with_index(case, index) -> CommCareCaseSQL:
     case.track_create(index)
     CaseAccessorSQL.save_case(case)
     return case
+
+
+def delete_all_xforms_and_cases(domain):
+    assert settings.UNIT_TESTING
+    FormProcessorTestUtils.delete_all_xforms(domain)
+    FormProcessorTestUtils.delete_all_cases(domain)

--- a/corehq/motech/tests/test_value_source.py
+++ b/corehq/motech/tests/test_value_source.py
@@ -251,18 +251,24 @@ class DirectionTests(SimpleTestCase):
         self.assertTrue(value_source.can_export)
 
 
-class AsJsonObjectTests(SimpleTestCase):
+class TestAsValueSourceSchema(SimpleTestCase):
 
-    def test_constant_value_schema_validates_constant_string(self):
-        json_object = as_value_source({"value": "spam"})
-        self.assertIsInstance(json_object, ConstantValue)
-
-    def test_case_property_constant_value(self):
-        json_object = as_value_source({
-            "case_property": "spam",
+    def test_as_constant_value(self):
+        value_source = as_value_source({
             "value": "spam",
         })
-        self.assertIsInstance(json_object, CasePropertyConstantValue)
+        self.assertIsInstance(value_source, ConstantValue)
+
+    def test_as_case_property_constant_value(self):
+        value_source = as_value_source({
+            "value": "spam",
+            "case_property": "spam",
+        })
+        self.assertIsInstance(value_source, CasePropertyConstantValue)
+
+    def test_type_error(self):
+        with self.assertRaises(TypeError):
+            as_value_source({})
 
 
 class FormUserAncestorLocationFieldTests(SimpleTestCase):
@@ -363,12 +369,6 @@ class TestSupercaseValueSourceValidation(SimpleTestCase):
                 'supercase_value_source': {},
             })
 
-    def test_supercase_value_source_missing(self):
-        with self.assertRaises(TypeError):
-            as_value_source({
-                'supercase_value_source': {},
-            })
-
 
 class TestSubcaseValueSourceValidation(SimpleTestCase):
 
@@ -397,10 +397,6 @@ class TestSubcaseValueSourceValidation(SimpleTestCase):
             as_value_source({
                 'subcase_value_source': {},
             })
-
-    def test_subcase_value_source_missing(self):
-        with self.assertRaises(TypeError):
-            as_value_source({})
 
 
 class AsValueSourceTests(SimpleTestCase):

--- a/corehq/motech/tests/test_value_source.py
+++ b/corehq/motech/tests/test_value_source.py
@@ -1,12 +1,15 @@
 import doctest
-import warnings
+from datetime import datetime, timedelta
+from uuid import uuid4
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
 import attr
 from schema import Use
 
 import corehq.motech.value_source
+from casexml.apps.case.models import CommCareCase
+from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from corehq.motech.const import (
     COMMCARE_DATA_TYPE_DECIMAL,
     COMMCARE_DATA_TYPE_INTEGER,
@@ -23,9 +26,12 @@ from corehq.motech.value_source import (
     CaseTriggerInfo,
     ConstantValue,
     FormUserAncestorLocationField,
+    SubcaseValueSource,
+    SupercaseValueSource,
     ValueSource,
     as_value_source,
     get_form_question_values,
+    get_case_trigger_info_for_case,
 )
 
 
@@ -315,6 +321,88 @@ class CaseOwnerAncestorLocationFieldTests(SimpleTestCase):
             as_value_source({"location_field": "dhis_id"})
 
 
+class TestSupercaseValueSourceValidation(SimpleTestCase):
+
+    def test_supercase_value_source(self):
+        value_source = as_value_source({
+            'supercase_value_source': {'case_property': 'foo'},
+        })
+        self.assertIsInstance(value_source, SupercaseValueSource)
+
+    def test_identifier(self):
+        value_source = as_value_source({
+            'supercase_value_source': {'case_property': 'foo'},
+            'identifier': 'bar',
+        })
+        self.assertIsInstance(value_source, SupercaseValueSource)
+
+    def test_referenced_type(self):
+        value_source = as_value_source({
+            'supercase_value_source': {'case_property': 'foo'},
+            'referenced_type': 'bar',
+        })
+        self.assertIsInstance(value_source, SupercaseValueSource)
+
+    def test_relationship(self):
+        value_source = as_value_source({
+            'supercase_value_source': {'case_property': 'foo'},
+            'relationship': 'extension',
+        })
+        self.assertIsInstance(value_source, SupercaseValueSource)
+
+    def test_relationship_invalid(self):
+        with self.assertRaises(TypeError):
+            as_value_source({
+                'supercase_value_source': {'case_property': 'foo'},
+                'relationship': 'invalid',
+            })
+
+    def test_supercase_value_source_empty(self):
+        with self.assertRaises(TypeError):
+            as_value_source({
+                'supercase_value_source': {},
+            })
+
+    def test_supercase_value_source_missing(self):
+        with self.assertRaises(TypeError):
+            as_value_source({
+                'supercase_value_source': {},
+            })
+
+
+class TestSubcaseValueSourceValidation(SimpleTestCase):
+
+    def test_subcase_value_source(self):
+        value_source = as_value_source({
+            'subcase_value_source': {'case_property': 'foo'},
+        })
+        self.assertIsInstance(value_source, SubcaseValueSource)
+
+    def test_case_types(self):
+        value_source = as_value_source({
+            'subcase_value_source': {'case_property': 'foo'},
+            'case_types': ['bar'],
+        })
+        self.assertIsInstance(value_source, SubcaseValueSource)
+
+    def test_is_closed(self):
+        value_source = as_value_source({
+            'subcase_value_source': {'case_property': 'foo'},
+            'is_closed': False,
+        })
+        self.assertIsInstance(value_source, SubcaseValueSource)
+
+    def test_subcase_value_source_empty(self):
+        with self.assertRaises(TypeError):
+            as_value_source({
+                'subcase_value_source': {},
+            })
+
+    def test_subcase_value_source_missing(self):
+        with self.assertRaises(TypeError):
+            as_value_source({})
+
+
 class AsValueSourceTests(SimpleTestCase):
 
     def test_as_value_source(self):
@@ -334,6 +422,217 @@ class AsValueSourceTests(SimpleTestCase):
         self.assertEqual(data, {"test_value": 10})
         self.assertIsInstance(value_source, StringValueSource)
         self.assertEqual(value_source.test_value, "10")
+
+
+class TestSubcaseValueSourceSetExternalValue(TestCase):
+
+    domain = 'lincoln-montana'
+
+    def setUp(self):
+        now = datetime.utcnow()
+        owner_id = str(uuid4())
+        self.host_case_id = str(uuid4())
+        self.host_case = CommCareCase(
+            _id=self.host_case_id,
+            domain=self.domain,
+            type='person',
+            name='Ted',
+            owner_id=owner_id,
+            modified_on=now,
+            server_modified_on=now,
+        )
+        self.host_case.save()
+
+        self.ext_case_1 = CommCareCase(
+            case_id='111111111',
+            domain=self.domain,
+            type='person_name',
+            name='Theodore',
+            given_names='Theodore John',
+            family_name='Kaczynski',
+            indices=[CommCareCaseIndex(
+                identifier='host',
+                referenced_type='person',
+                referenced_id=self.host_case_id,
+                relationship='extension',
+            )],
+            owner_id=owner_id,
+            modified_on=now,
+            server_modified_on=now,
+        )
+        self.ext_case_1.save()
+
+        self.ext_case_2 = CommCareCase(
+            case_id='222222222',
+            domain=self.domain,
+            type='person_name',
+            name='Unabomber',
+            given_names='Unabomber',
+            indices=[CommCareCaseIndex(
+                identifier='host',
+                referenced_type='person',
+                referenced_id=self.host_case_id,
+                relationship='extension',
+            )],
+            owner_id=owner_id,
+            modified_on=now,
+            server_modified_on=now,
+        )
+        self.ext_case_2.save()
+
+    def tearDown(self):
+        self.ext_case_1.delete()
+        self.ext_case_2.delete()
+        self.host_case.delete()
+
+    def test_set_external_data(self):
+        value_source_configs = [{
+            'case_property': 'name',
+            'jsonpath': '$.name[0].text',
+        }, {
+            'subcase_value_source': {
+                'case_property': 'given_names',
+                # Use counter1 to skip the name set by the parent case
+                'jsonpath': '$.name[{counter1}].given[0]',
+            },
+            'case_types': ['person_name'],
+        }, {
+            'subcase_value_source': {
+                'case_property': 'family_name',
+                'jsonpath': '$.name[{counter1}].family',
+            },
+            'case_types': ['person_name'],
+        }]
+
+        external_data = {}
+        case_trigger_info = get_case_trigger_info_for_case(
+            self.host_case,
+            value_source_configs,
+        )
+        for value_source_config in value_source_configs:
+            value_source = as_value_source(value_source_config)
+            value_source.set_external_value(external_data, case_trigger_info)
+
+        self.assertEqual(external_data, {
+            'name': [
+                {'text': 'Ted'},
+                {'given': ['Theodore John'], 'family': 'Kaczynski'},
+                {'given': ['Unabomber']},
+            ],
+        })
+
+
+class TestSupercaseValueSourceSetExternalValue(TestCase):
+
+    domain = 'quarantinewhile'
+
+    def setUp(self):
+        now = datetime.utcnow()
+        yesterday = now - timedelta(days=1)
+        owner_id = str(uuid4())
+        self.parent_case_id = str(uuid4())
+        self.parent_case = CommCareCase(
+            _id=self.parent_case_id,
+            domain=self.domain,
+            type='person',
+            name='Joe',
+            owner_id=owner_id,
+            modified_on=yesterday,
+            server_modified_on=yesterday,
+        )
+        self.parent_case.save()
+
+        self.child_case_1 = CommCareCase(
+            case_id='111111111',
+            domain=self.domain,
+            type='temperature',
+            value='36.2',
+            indices=[CommCareCaseIndex(
+                identifier='parent',
+                referenced_type='person',
+                referenced_id=self.parent_case_id,
+                relationship='child',
+            )],
+            owner_id=owner_id,
+            modified_on=yesterday,
+            server_modified_on=yesterday,
+        )
+        self.child_case_1.save()
+
+        self.child_case_2 = CommCareCase(
+            case_id='222222222',
+            domain=self.domain,
+            type='temperature',
+            value='36.6',
+            indices=[CommCareCaseIndex(
+                identifier='parent',
+                referenced_type='person',
+                referenced_id=self.parent_case_id,
+                relationship='child',
+            )],
+            owner_id=owner_id,
+            modified_on=now,
+            server_modified_on=now,
+        )
+        self.child_case_2.save()
+
+    def tearDown(self):
+        self.child_case_1.delete()
+        self.child_case_2.delete()
+        self.parent_case.delete()
+
+    def test_set_external_data(self):
+        value_source_configs = [{
+            'case_property': 'value',
+            'jsonpath': '$.valueQuantity.value',
+            'external_data_type': COMMCARE_DATA_TYPE_DECIMAL,
+        }, {
+            'value': 'degrees Celsius',
+            'jsonpath': '$.valueQuantity.unit',
+        }, {
+            'supercase_value_source': {
+                'case_property': 'case_id',
+                'jsonpath': '$.subject.reference',
+            },
+            'identifier': 'parent',
+            'referenced_type': 'person',
+        }, {
+            'supercase_value_source': {
+                'case_property': 'name',
+                'jsonpath': '$.subject.display',
+            },
+            'identifier': 'parent',
+            'referenced_type': 'person',
+        }]
+
+        resources = []
+        for case in (self.child_case_1, self.child_case_2):
+            external_data = {}
+            info = get_case_trigger_info_for_case(case, value_source_configs)
+            for value_source_config in value_source_configs:
+                value_source = as_value_source(value_source_config)
+                value_source.set_external_value(external_data, info)
+            resources.append(external_data)
+
+        self.assertEqual(resources, [{
+            'subject': {
+                'reference': self.parent_case_id,
+                'display': 'Joe',
+            },
+            'valueQuantity': {
+                'value': 36.2,  # case 1
+                'unit': 'degrees Celsius',
+            },
+        }, {
+            'subject': {
+                'reference': self.parent_case_id,
+                'display': 'Joe',
+            },
+            'valueQuantity': {
+                'value': 36.6,  # case 2
+                'unit': 'degrees Celsius',
+            },
+        }])
 
 
 def test_doctests():

--- a/corehq/motech/tests/test_value_source.py
+++ b/corehq/motech/tests/test_value_source.py
@@ -12,6 +12,7 @@ from corehq.form_processor.models import CommCareCaseIndexSQL, CommCareCaseSQL
 from corehq.form_processor.tests.utils import (
     create_case,
     create_case_with_index,
+    delete_all_xforms_and_cases,
     use_sql_backend,
 )
 from corehq.motech.const import (
@@ -486,9 +487,7 @@ class TestSubcaseValueSourceSetExternalValue(TestCase):
         self.ext_case_2 = create_case_with_index(case, index)
 
     def tearDown(self):
-        self.ext_case_1.delete()
-        self.ext_case_2.delete()
-        self.host_case.delete()
+        delete_all_xforms_and_cases(self.domain)
 
     def test_set_external_data(self):
         value_source_configs = [{
@@ -586,9 +585,7 @@ class TestSupercaseValueSourceSetExternalValue(TestCase):
         self.child_case_2 = create_case_with_index(case, index)
 
     def tearDown(self):
-        self.child_case_1.delete()
-        self.child_case_2.delete()
-        self.parent_case.delete()
+        delete_all_xforms_and_cases(self.domain)
 
     def test_set_external_data(self):
         value_source_configs = [{

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -4,7 +4,7 @@ import attr
 from jsonobject.containers import JsonDict
 from jsonpath_ng.ext.parser import parse as parse_jsonpath
 from schema import Optional as SchemaOptional
-from schema import Or, Schema, SchemaError
+from schema import And, Or, Schema, SchemaError
 
 from couchforms.const import TAG_FORM, TAG_META
 
@@ -204,16 +204,10 @@ class CaseProperty(ValueSource):
     """
     case_property: str
 
-    class IsNotBlank:
-        def validate(self, data):
-            if isinstance(data, str) and len(data):
-                return data
-            raise SchemaError(f"Value cannot be blank.")
-
     @classmethod
     def get_schema_params(cls) -> Tuple[Tuple, Dict]:
         (schema, *other_args), kwargs = super().get_schema_params()
-        schema.update({"case_property": cls.IsNotBlank()})
+        schema.update({"case_property": And(str, len)})
         return (schema, *other_args), kwargs
 
     def get_commcare_value(self, case_trigger_info: CaseTriggerInfo) -> Any:

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import attr
 from jsonobject.containers import JsonDict
@@ -10,6 +10,7 @@ from couchforms.const import TAG_FORM, TAG_META
 
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.cases import get_owner_id, get_wrapped_owner
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.const import (
     COMMCARE_DATA_TYPE_DECIMAL,
     COMMCARE_DATA_TYPE_INTEGER,
@@ -154,6 +155,9 @@ class ValueSource:
             raise ConfigurationError(f"{self} is not configured to navigate "
                                      "external data")
         value = self.get_value(info)
+        if value is None:
+            # Don't set external value if CommCare has no value
+            return
         try:
             jsonpath = parse_jsonpath(self.jsonpath)
         except Exception as err:
@@ -445,6 +449,124 @@ class CasePropertyConstantValue(ConstantValue, CaseProperty):
     pass
 
 
+@attr.s(auto_attribs=True, kw_only=True)
+class SupercaseValueSource(ValueSource):
+    """
+    A reference to a list of parent/host cases.
+
+    Evaluates nested ValueSource config, allowing for recursion.
+    """
+    supercase_value_source: dict
+
+    # Optional filters for indices
+    identifier: Optional[str] = None
+    referenced_type: Optional[str] = None
+    # relationship: Optional[Literal['child', 'extension']] = None  # Py3.8+
+    relationship: Optional[str] = None
+
+    @classmethod
+    def get_schema_params(cls) -> Tuple[Tuple, Dict]:
+        (schema, *other_args), kwargs = super().get_schema_params()
+        schema.update({
+            'supercase_value_source': And(dict, len),
+            SchemaOptional('identifier'): str,
+            SchemaOptional('referenced_type'): str,
+            SchemaOptional('relationship'): lambda r: r in ('child', 'extension'),
+        })
+        return (schema, *other_args), kwargs
+
+    def get_commcare_value(self, info):
+        values = []
+        for supercase_info in self._iter_supercase_info(info):
+            value_source = as_value_source(self.supercase_value_source)
+            value = value_source.get_commcare_value(supercase_info)
+            values.append(value)
+        return values
+
+    def get_import_value(self, external_data):
+        # OpenMRS Atom feed and FHIR API must build case blocks for
+        # related cases for this to be implemented
+        raise NotImplementedError
+
+    def set_external_value(self, external_data, info):
+        for i, supercase_info in enumerate(self._iter_supercase_info(info)):
+            value_source = as_value_source(self.supercase_value_source)
+            _subs_counters(value_source, i)
+            value_source.set_external_value(external_data, supercase_info)
+
+    def _iter_supercase_info(self, info: CaseTriggerInfo):
+
+        def filter_index(idx):
+            return (
+                (not self.identifier or idx.identifier == self.identifier)
+                and (not self.referenced_type or idx.referenced_type == self.referenced_type)
+                and (not self.relationship or idx.relationship == self.relationship)
+            )
+
+        case_accessor = CaseAccessors(info.domain)
+        case = case_accessor.get_case(info.case_id)
+        for index in case.indices:
+            if filter_index(index):
+                supercase = case_accessor.get_case(index.referenced_id)
+                yield get_case_trigger_info_for_case(
+                    supercase,
+                    [self.supercase_value_source],
+                )
+
+
+@attr.s(auto_attribs=True, kw_only=True)
+class SubcaseValueSource(ValueSource):
+    """
+    A reference to a list of child/extension cases.
+
+    Evaluates nested ValueSource config, allowing for recursion.
+    """
+    subcase_value_source: dict
+    case_types: Optional[List[str]] = None
+    is_closed: Optional[bool] = None
+
+    @classmethod
+    def get_schema_params(cls) -> Tuple[Tuple, Dict]:
+        (schema, *other_args), kwargs = super().get_schema_params()
+        schema.update({
+            'subcase_value_source': And(dict, len),
+            SchemaOptional('case_types'): list,
+            SchemaOptional('is_closed'): bool,
+        })
+        return (schema, *other_args), kwargs
+
+    def get_commcare_value(self, info: CaseTriggerInfo) -> Any:
+        values = []
+        for subcase_info in self._iter_subcase_info(info):
+            value_source = as_value_source(self.subcase_value_source)
+            value = value_source.get_commcare_value(subcase_info)
+            values.append(value)
+        return values
+
+    def get_import_value(self, external_data):
+        # OpenMRS Atom feed and FHIR API must build case blocks for
+        # related cases for this to be implemented
+        raise NotImplementedError
+
+    def set_external_value(self, external_data, info):
+        for i, subcase_info in enumerate(self._iter_subcase_info(info)):
+            value_source = as_value_source(self.subcase_value_source)
+            _subs_counters(value_source, i)
+            value_source.set_external_value(external_data, subcase_info)
+
+    def _iter_subcase_info(self, info: CaseTriggerInfo):
+        subcases = CaseAccessors(info.domain).get_reverse_indexed_cases(
+            [info.case_id],
+            self.case_types,
+            self.is_closed,
+        )
+        for subcase in subcases:
+            yield get_case_trigger_info_for_case(
+                subcase,
+                [self.subcase_value_source],
+            )
+
+
 def as_value_source(
     value_source_config: Union[dict, JsonDict],
 ) -> ValueSource:
@@ -569,3 +691,46 @@ def get_owner_location(domain, owner_id):
         return owner
     location_id = owner.get_location_id(domain)
     return SQLLocation.by_location_id(location_id) if location_id else None
+
+
+def get_case_trigger_info_for_case(case, value_source_configs):
+    case_properties = [c['case_property'] for c in value_source_configs
+                       if 'case_property' in c]
+    extra_fields = {p: case.get_case_property(p) for p in case_properties}
+    return CaseTriggerInfo(
+        domain=case.domain,
+        case_id=case.case_id,
+        type=case.type,
+        name=case.name,
+        owner_id=case.owner_id,
+        modified_by=case.modified_by,
+        extra_fields=extra_fields,
+    )
+
+
+def _subs_counters(value_source, counter0):
+    """
+    Substitutes "{counter0}" and "{counter1}" in value_source.jsonpath.
+
+    counter0 is a 0-indexed counter and counter1 is a 1-indexed counter.
+    They are used for incrementing indices.
+
+    >>> vs = as_value_source({
+    ...     'case_property': 'name',
+    ...     'jsonpath': '$.name[{counter0}].text',
+    ... })
+    >>> _subs_counters(vs, 3)
+    >>> vs.jsonpath
+    '$.name[3].text'
+
+    """
+    if counter0 is None:
+        return
+    if value_source.jsonpath and (
+        '{counter0}' in value_source.jsonpath
+        or '{counter1}' in value_source.jsonpath
+    ):
+        value_source.jsonpath = value_source.jsonpath.format(
+            counter0=counter0,
+            counter1=counter0 + 1,
+        )


### PR DESCRIPTION
## Summary

`ValueSource` is used by integrations to configure where to get the values to be exported. (Mostly, values come from form questions and case properties, but they can also be constants, location metadata, etc.)

This change allows `ValueSource` to support getting values from parent/host/indexed cases ("supercases") and child/extension/reverse-indexed cases ("subcases").


### Why?

HQ's FHIR API, and data forwarding to other FHIR APIs, need to be able to build out a FHIR resource using data from super- and subcases.


### What?

To understand what is happening, it is probably best to start with the unit tests, `TestSubcaseValueSourceSetExternalValue` and `TestSupercaseValueSourceSetExternalValue`. (They're at the bottom of the test module.)

1. Take a look at the expected result in the `assertEqual()` at the end.
2. Look at the case data in the `setUp()` method.
3. Compare those with the `value_source_configs` at the start of the test method.

You will see that the `set_external_value()` methods of the two new `ValueSource` subclasses are recursively calling `set_external_value()` on super/subcases, after setting up the context they need.

Subtleties not to miss:
* `set_external_value()` traverses its `external_data` parameter, and adds nodes that are missing. In order to prevent each subcase from overwriting the data of the previous subcase, we can use `counter0` and `counter1` string template variables. The `_subs_counters` function uses `string.format()` to replace them with an index. `TestSubcaseValueSourceSetExternalValue` includes an example of how that works.
* In the context of the FHIR API, these "value source configs" are associated with only one case type.
  + In the subcase example, these will be `FHIRResourceProperty.value_source_config` for the `FHIRResourceType` that maps to "person" (the host case type). 
  + In the supercase example, these will be `FHIRResourceProperty.value_source_config` for the `FHIRResourceType` that maps to "temperature" (the child case type).

I am also happy to schedule a call to dive into the `ValueSource` class for more context.

pinging @millerdev Completely optional to review. But you probably have more context on the `ValueSource` class than other devs.


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Automated test coverage

PR includes test coverage. Please point out if you find anything that tests should include.


### Safety story

* Automated test coverage is good.
* Does not affect existing functionality


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
