### PR TITLE
Fix motech clean_logs to run once, not every minute for the whole day

### DIFF
--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -52,7 +52,7 @@ logging = get_task_logger(__name__)
 
 
 @periodic_task(
-    run_every=crontab(day_of_month=27),
+    run_every=crontab(day_of_month=27, hour=6, minute=0),
     queue=settings.CELERY_PERIODIC_QUEUE,
 )
 def clean_logs():


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No test coverage

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story

This is very minor change that will have a huge effect, but couldn't make things worse. Right now this task runs every minute of every hour of the day because the default is minute=* hour=*.

Also I can run

```
$ ./manage.py shell
In [1]: from corehq.motech.repeaters.tasks import clean_logs
```
with no error, so there's no like egregious syntax error that's going to break everything.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
