### PR TITLE
Alter FHIRResourceType

### DIFF
--- a/corehq/motech/fhir/migrations/0002_fhirresourcetype.py
+++ b/corehq/motech/fhir/migrations/0002_fhirresourcetype.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_dictionary', '0007_property_type_choices'),
+        ('fhir', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='fhirresourcetype',
+            name='template',
+            field=jsonfield.fields.JSONField(default=dict),
+        ),
+        migrations.AlterUniqueTogether(
+            name='fhirresourcetype',
+            unique_together={('case_type', 'fhir_version')},
+        ),
+    ]

--- a/corehq/motech/fhir/models.py
+++ b/corehq/motech/fhir/models.py
@@ -31,7 +31,10 @@ class FHIRResourceType(models.Model):
 
     # `template` offers a way to define a FHIR resource if it cannot be
     # built using only mapped case properties.
-    template = JSONField(null=True, blank=True, default=None)
+    template = JSONField(default=dict)
+
+    class Meta:
+        unique_together = ('case_type', 'fhir_version')
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
## Summary

Replaces closed PR #29252

The FHIR API needs to support POST requests. POSTing a resource must result in a valid case. If resource properties can be spread over multiple case types, there is a high risk that we will get half-baked cases that will be invalid for the apps that use them. This PR restricts a case type to be mapped to one resource type for a given version of FHIR.

It also sets the default value of `FHIRResourceType.template` to `dict` to simplify the code that uses it.


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story

This model is not yet in use: The code that uses it is not yet merged into master.

The migration is safe to deploy because the table is empty in all environments except Staging.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
