### PR TITLE
FHIRRepeater part 3

### DIFF
--- a/corehq/apps/data_dictionary/models.py
+++ b/corehq/apps/data_dictionary/models.py
@@ -41,9 +41,16 @@ class CaseType(models.Model):
             return case_type_obj
 
     def save(self, *args, **kwargs):
-        from .util import get_data_dict_case_types
+        from .util import get_data_dict_case_types, get_case_type_obj
         get_data_dict_case_types.clear(self.domain)
+        get_case_type_obj.clear(self.domain, self.name)
         return super(CaseType, self).save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        from .util import get_data_dict_case_types, get_case_type_obj
+        get_data_dict_case_types.clear(self.domain)
+        get_case_type_obj.clear(self.domain, self.name)
+        return super().delete(*args, **kwargs)
 
 
 class CaseProperty(models.Model):

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -1,5 +1,6 @@
 from itertools import groupby
 from operator import attrgetter
+from typing import Optional
 
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext
@@ -169,3 +170,11 @@ def get_data_dict_props_by_case_type(domain):
 def get_data_dict_case_types(domain):
     case_types = CaseType.objects.filter(domain=domain).values_list('name', flat=True)
     return set(case_types)
+
+
+@quickcache(['domain', 'name'])
+def get_case_type_obj(domain, name) -> Optional[CaseType]:
+    try:
+        return CaseType.objects.get(domain=domain, name=name)
+    except CaseType.DoesNotExist:
+        return None

--- a/corehq/motech/dhis2/views.py
+++ b/corehq/motech/dhis2/views.py
@@ -16,14 +16,13 @@ from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from corehq.motech.dhis2.dbaccessors import get_dataset_maps
 from corehq.motech.dhis2.dhis2_config import Dhis2EntityConfig, Dhis2FormConfig
-from corehq.motech.dhis2.forms import (
-    Dhis2ConfigForm,
-    Dhis2EntityConfigForm,
-)
+from corehq.motech.dhis2.forms import Dhis2ConfigForm, Dhis2EntityConfigForm
 from corehq.motech.dhis2.models import DataSetMap, DataValueMap
 from corehq.motech.dhis2.repeaters import Dhis2EntityRepeater, Dhis2Repeater
 from corehq.motech.dhis2.tasks import send_datasets
 from corehq.motech.models import ConnectionSettings
+from corehq.motech.repeaters.forms import GenericRepeaterForm
+from corehq.motech.repeaters.views import AddRepeaterView, EditRepeaterView
 
 
 @method_decorator(require_permission(Permissions.edit_motech), name='dispatch')
@@ -163,3 +162,31 @@ def config_dhis2_entity_repeater(request, domain, repeater_id):
         'repeater_id': repeater_id,
         'case_configs': case_configs,
     })
+
+
+class AddDhis2RepeaterView(AddRepeaterView):
+    urlname = 'new_dhis2_repeater$'
+    repeater_form_class = GenericRepeaterForm
+    page_title = ugettext_lazy("Forward Forms to DHIS2 as Anonymous Events")
+    page_name = ugettext_lazy("Forward Forms to DHIS2 as Anonymous Events")
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname, args=[self.domain])
+
+
+class EditDhis2RepeaterView(EditRepeaterView, AddDhis2RepeaterView):
+    urlname = 'edit_dhis2_repeater'
+    page_title = ugettext_lazy("Edit DHIS2 Anonymous Event Repeater")
+
+
+class AddDhis2EntityRepeaterView(AddDhis2RepeaterView):
+    urlname = 'new_dhis2_entity_repeater$'
+    repeater_form_class = GenericRepeaterForm
+    page_title = ugettext_lazy("Forward Cases to DHIS2 as Tracked Entities")
+    page_name = ugettext_lazy("Forward Cases to DHIS2 as Tracked Entities")
+
+
+class EditDhis2EntityRepeaterView(EditRepeaterView, AddDhis2EntityRepeaterView):
+    urlname = 'edit_dhis2_entity_repeater'
+    page_title = ugettext_lazy("Edit DHIS2 Tracked Entity Repeater")

--- a/corehq/motech/fhir/const.py
+++ b/corehq/motech/fhir/const.py
@@ -3,6 +3,19 @@ FHIR_VERSIONS = [
     (FHIR_VERSION_4_0_1, 'R4'),
 ]
 
+# See https://www.hl7.org/fhir/valueset-bundle-type.html
+FHIR_BUNDLE_TYPES = {
+    'document',
+    'message',
+    'transaction',
+    'transaction-response',
+    'batch',
+    'batch-response',
+    'history',
+    'searchset',
+    'collection',
+}
+
 # The XMLNS to use for forms for data imported from a remote FHIR
 # service. e.g. Setting `external_id` on a case to its FHIR ID, or cases
 # created or updated in CommCare via our FHIR API. This is to prevent

--- a/corehq/motech/fhir/const.py
+++ b/corehq/motech/fhir/const.py
@@ -2,3 +2,9 @@ FHIR_VERSION_4_0_1 = '4.0.1'
 FHIR_VERSIONS = [
     (FHIR_VERSION_4_0_1, 'R4'),
 ]
+
+# The XMLNS to use for forms for data imported from a remote FHIR
+# service. e.g. Setting `external_id` on a case to its FHIR ID, or cases
+# created or updated in CommCare via our FHIR API. This is to prevent
+# FHIRRepeater from sending data from a FHIR service back again.
+XMLNS_FHIR = 'http://commcarehq.org/x/fhir/engine-read'

--- a/corehq/motech/fhir/const.py
+++ b/corehq/motech/fhir/const.py
@@ -21,3 +21,13 @@ FHIR_BUNDLE_TYPES = {
 # created or updated in CommCare via our FHIR API. This is to prevent
 # FHIRRepeater from sending data from a FHIR service back again.
 XMLNS_FHIR = 'http://commcarehq.org/x/fhir/engine-read'
+
+# The URI to identify CommCare as the system responsible for allocating
+# case IDs. See https://www.hl7.org/fhir/datatypes.html#Identifier
+SYSTEM_URI_CASE_ID = 'http://commcarehq.org/x/fhir/case-id'
+
+
+FHIR_DATA_TYPE_LIST_OF_STRING = 'fhir_list_of_string'
+FHIR_DATA_TYPES = (
+    FHIR_DATA_TYPE_LIST_OF_STRING,
+)

--- a/corehq/motech/fhir/forms.py
+++ b/corehq/motech/fhir/forms.py
@@ -1,0 +1,18 @@
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+from corehq.motech.repeaters.forms import GenericRepeaterForm
+
+from .const import FHIR_VERSION_4_0_1, FHIR_VERSIONS
+
+
+class FHIRRepeaterForm(GenericRepeaterForm):
+    fhir_version = forms.ChoiceField(
+        label=_('FHIR version'),
+        choices=FHIR_VERSIONS,
+        initial=FHIR_VERSION_4_0_1,
+    )
+
+    def get_ordered_crispy_form_fields(self):
+        fields = super().get_ordered_crispy_form_fields()
+        return fields + ['fhir_version']

--- a/corehq/motech/fhir/matchers.py
+++ b/corehq/motech/fhir/matchers.py
@@ -1,0 +1,245 @@
+from collections import namedtuple
+from decimal import Decimal
+from typing import Iterable, List, Optional, Type
+
+import attr
+
+from corehq.motech.finders import le_days_diff, le_levenshtein_percent
+from jsonpath_ng.ext.parser import parse as jsonpath_parse
+
+from corehq.motech.utils import simplify_list
+
+CandidateScore = namedtuple('CandidateScore', 'candidate score')
+
+
+class DuplicateWarning(Warning):
+    pass
+
+
+class ResourceMatcher:
+    """
+    Finds matching FHIR resources.
+
+    The properties of resources are compared. Each matching property has
+    a weight. The sum of the weights give a score. If the score is
+    greater than 1, the resources are considered a match.
+
+    If more than one candidate matches, but one has a significantly
+    higher score than the rest, it is the match. Otherwise a
+    ``DuplicateWarning`` exception is raised.
+    """
+
+    property_weights: List['PropertyWeight']
+    confidence_margin = 0.5
+
+    def __init__(self, resource: dict):
+        self.resource = resource
+
+    def find_match(self, candidates: Iterable[dict]):
+        matches = self.find_matches(candidates, keep_dups=False)
+        match = simplify_list(matches)
+        if isinstance(match, list):
+            raise DuplicateWarning('Duplicate matches found for resource '
+                                   f'{self.resource}')
+        return match
+
+    def find_matches(self, candidates: Iterable[dict], *, keep_dups=True):
+        """
+        Returns a list of matches.
+
+        If ``keep_dups`` is False, allows for an arbitrary number of
+        candidates but only returns the best two, or fewer.
+        """
+
+        def top_two(list_):
+            return sorted(list_, key=lambda l: l.score, reverse=True)[:2]
+
+        candidates_scores = []
+        for candidate in candidates:
+            score = self.get_score(candidate)
+            if score >= 1:
+                candidates_scores.append(CandidateScore(candidate, score))
+            if not keep_dups:
+                candidates_scores = top_two(candidates_scores)
+
+        if len(candidates_scores) > 1:
+            best, second = top_two(candidates_scores)
+            if best.score / second.score >= 1 + self.confidence_margin:
+                return [best.candidate]
+        return [cs.candidate for cs in candidates_scores]
+
+    def get_score(self, candidate):
+        return sum(self.iter_weights(candidate))
+
+    def iter_weights(self, candidate):
+        for pw in self.property_weights:
+            is_match = pw.method.is_match(self.resource, candidate)
+            if is_match is None:
+                # method was unable to compare values
+                continue
+            yield pw.weight if is_match else -1 * pw.negative_weight
+
+
+class ComparisonMethod:
+    """
+    A method of comparing resource properties.
+    """
+
+    def __init__(self, jsonpath: str):
+        self.jsonpath = jsonpath_parse(jsonpath)
+
+    def is_match(self, resource: dict, candidate: dict) -> Optional[bool]:
+        a = simplify_list([x.value for x in self.jsonpath.find(resource)])
+        b = simplify_list([x.value for x in self.jsonpath.find(candidate)])
+        if a is None or b is None:
+            return None
+        return self.compare(a, b)
+
+    @staticmethod
+    def compare(a, b) -> bool:
+        raise NotImplementedError
+
+
+class IsEqual(ComparisonMethod):
+
+    @staticmethod
+    def compare(a, b):
+        return a == b
+
+
+class GivenName(ComparisonMethod):
+
+    @staticmethod
+    def compare(a, b):
+        return any(a_name == b_name for a_name, b_name in zip(a, b))
+
+
+class Age(ComparisonMethod):
+
+    @staticmethod
+    def compare(a, b):
+        max_days = 364
+        return le_days_diff(max_days, a, b)
+
+
+class OrganizationName(ComparisonMethod):
+
+    @staticmethod
+    def compare(a, b):
+        percent = 0.2
+        return le_levenshtein_percent(percent, a.lower(), b.lower())
+
+
+class NegativeIdentifier(ComparisonMethod):
+    """
+    Returns False if the identifier system is the same, and the
+    identifier value is not close.
+
+    Used for giving a negative score to candidates with different IDs
+    from the same system.
+    """
+
+    @staticmethod
+    def compare(a, b):
+        system_a, value_a = a.split('|')
+        system_b, value_b = b.split('|')
+        return not (
+            system_a == system_b
+            and not le_levenshtein_percent(0.2, value_a, value_b)
+        )
+
+
+def _value_ge_zero(instance, attrib, value):
+    return value >= 0
+
+
+@attr.s
+class PropertyWeight:
+    """
+    Associates a matching property with a weight
+    """
+    jsonpath = attr.ib(type=str)
+    weight = attr.ib(type=Decimal, validator=_value_ge_zero)
+    method_class = attr.ib(type=Type[ComparisonMethod], default=IsEqual)
+    # Score negatively if values are different
+    negative_weight = attr.ib(type=Decimal,
+                              default=Decimal('0'),
+                              validator=_value_ge_zero)
+
+    @property
+    def method(self):
+        return self.method_class(self.jsonpath)
+
+
+class PersonMatcher(ResourceMatcher):
+    """
+    Finds matching FHIR Persons
+    """
+    property_weights = [
+        PropertyWeight(
+            '$.identifier[0].system + "|" + $.identifier[0].value',
+            Decimal('0.8'),
+        ),
+        PropertyWeight(
+            '$.identifier[0].system + "|" + $.identifier[0].value',
+            Decimal('0'),
+            NegativeIdentifier,
+            negative_weight=Decimal('1.1'),
+        ),
+        PropertyWeight('$.name[0].given', Decimal('0.3'), GivenName),
+        # PropertyWeight('$.name[0].given', 0.1, AnyGivenName),
+        PropertyWeight('$.name[0].family', Decimal('0.4')),
+        PropertyWeight('$.telecom[0].value', Decimal('0.4')),
+        PropertyWeight(
+            '$.gender',
+            Decimal('0.05'),
+            negative_weight=Decimal('0.6')
+        ),
+        PropertyWeight('$.birthDate', Decimal('0.1')),
+        PropertyWeight(
+            '$.birthDate',
+            Decimal('0.05'),
+            Age,
+            negative_weight=Decimal('0.2')
+        ),
+    ]
+
+
+class PatientMatcher(ResourceMatcher):
+    """
+    Finds matching FHIR Patients
+    """
+    property_weights = PersonMatcher.property_weights + [
+        PropertyWeight('$.multipleBirthInteger', Decimal('0.1'))
+    ]
+
+
+class OrganizationMatcher(ResourceMatcher):
+    property_weights = [
+        PropertyWeight('$.name', Decimal('0.8'), OrganizationName),
+        PropertyWeight('$.telecom[0].value', Decimal('0.4')),
+    ]
+
+
+def get_matcher(resource: dict) -> ResourceMatcher:
+    """
+    Returns a subclass of ``ResourceMatcher`` instantiated with
+    ``resource``.
+
+    .. IMPORTANT::
+       ``get_matcher()`` assumes that subclasses of ``ResourceMatcher``
+       are named for the resource type they are implemented for.
+       e.g. ``PatientMatcher`` matches Patient resources.
+
+    """
+    suffix = len('Matcher')
+    classes_by_resource_type = {cls.__name__[:-suffix]: cls
+                                for cls in ResourceMatcher.__subclasses__()}
+    try:
+        matcher_class = classes_by_resource_type[resource['resourceType']]
+    except KeyError:
+        raise NotImplementedError(
+            'ResourceMatcher not implemented for resource type '
+            f"{resource['resourceType']!r}"
+        )
+    return matcher_class(resource)

--- a/corehq/motech/fhir/matchers.py
+++ b/corehq/motech/fhir/matchers.py
@@ -219,27 +219,3 @@ class OrganizationMatcher(ResourceMatcher):
         PropertyWeight('$.name', Decimal('0.8'), OrganizationName),
         PropertyWeight('$.telecom[0].value', Decimal('0.4')),
     ]
-
-
-def get_matcher(resource: dict) -> ResourceMatcher:
-    """
-    Returns a subclass of ``ResourceMatcher`` instantiated with
-    ``resource``.
-
-    .. IMPORTANT::
-       ``get_matcher()`` assumes that subclasses of ``ResourceMatcher``
-       are named for the resource type they are implemented for.
-       e.g. ``PatientMatcher`` matches Patient resources.
-
-    """
-    suffix = len('Matcher')
-    classes_by_resource_type = {cls.__name__[:-suffix]: cls
-                                for cls in ResourceMatcher.__subclasses__()}
-    try:
-        matcher_class = classes_by_resource_type[resource['resourceType']]
-    except KeyError:
-        raise NotImplementedError(
-            'ResourceMatcher not implemented for resource type '
-            f"{resource['resourceType']!r}"
-        )
-    return matcher_class(resource)

--- a/corehq/motech/fhir/migrations/0002_fhirresourcetype.py
+++ b/corehq/motech/fhir/migrations/0002_fhirresourcetype.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_dictionary', '0007_property_type_choices'),
+        ('fhir', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='fhirresourcetype',
+            name='template',
+            field=jsonfield.fields.JSONField(default=dict),
+        ),
+        migrations.AlterUniqueTogether(
+            name='fhirresourcetype',
+            unique_together={('case_type', 'fhir_version')},
+        ),
+    ]

--- a/corehq/motech/fhir/models.py
+++ b/corehq/motech/fhir/models.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.db import models
 
 from jsonfield import JSONField
+from jsonschema import RefResolver, ValidationError, validate
 
 from casexml.apps.case.models import CommCareCase
 
@@ -55,12 +56,8 @@ class FHIRResourceType(models.Model):
         '#/definitions/Patient'
 
         """
-        ver = dict(FHIR_VERSIONS)[self.fhir_version].lower()
-        schema_file = f'{self.name}.schema.json'
-        path = os.path.join(settings.BASE_DIR, 'corehq', 'motech', 'fhir',
-                            'json-schema', ver, schema_file)
         try:
-            with open(path, 'r') as file:
+            with open(self._schema_file, 'r') as file:
                 return json.load(file)
         except FileNotFoundError:
             raise ConfigurationError(
@@ -70,14 +67,34 @@ class FHIRResourceType(models.Model):
 
     @classmethod
     def get_names(cls, version=FHIR_VERSION_4_0_1):
-        ver = dict(FHIR_VERSIONS)[version].lower()
-        path = os.path.join(settings.BASE_DIR, 'corehq', 'motech', 'fhir',
-                            'json-schema', ver)
+        schema_dir = get_schema_dir(version)
         ext = len('.schema.json')
-        return [n[:-ext] for n in os.listdir(path)]
+        return [n[:-ext] for n in os.listdir(schema_dir)]
 
     def validate_resource(self, fhir_resource):
-        pass
+        schema = self.get_json_schema()
+        resolver = RefResolver(base_uri=f'file://{self._schema_file}',
+                               referrer=schema)
+        try:
+            validate(fhir_resource, schema, resolver=resolver)
+        except ValidationError as err:
+            raise ConfigurationError(
+                f'Validation failed for resource {fhir_resource!r}: {err}'
+            ) from err
+
+    @property
+    def _schema_file(self):
+        return os.path.join(self._schema_dir, f'{self.name}.schema.json')
+
+    @property
+    def _schema_dir(self):
+        return get_schema_dir(self.fhir_version)
+
+
+def get_schema_dir(version):
+    ver = dict(FHIR_VERSIONS)[version].lower()
+    return os.path.join(settings.BASE_DIR, 'corehq', 'motech', 'fhir',
+                        'json-schema', ver)
 
 
 class FHIRResourceProperty(models.Model):

--- a/corehq/motech/fhir/models.py
+++ b/corehq/motech/fhir/models.py
@@ -20,6 +20,7 @@ from corehq.motech.value_source import (
     ValueSource,
     as_value_source,
 )
+from corehq.motech.fhir import serializers  # noqa # pylint: disable=unused-import
 
 from .const import FHIR_VERSION_4_0_1, FHIR_VERSIONS
 

--- a/corehq/motech/fhir/models.py
+++ b/corehq/motech/fhir/models.py
@@ -235,7 +235,11 @@ def _build_fhir_resource(
     return fhir_resource
 
 
-def get_case_trigger_info(case):
+def get_case_trigger_info(
+    case: Union[CommCareCase, CommCareCaseSQL],
+    case_block: Optional[dict] = None,
+    form_question_values: Optional[dict] = None,
+) -> CaseTriggerInfo:
     """
     Returns ``CaseTriggerInfo`` instance for ``case``.
 
@@ -244,14 +248,36 @@ def get_case_trigger_info(case):
     ``CaseTriggerInfo`` packages case (and form) data for use by
     ``ValueSource``.
     """
+    if case_block is None:
+        case_block = {}
+    else:
+        assert case_block['@case_id'] == case.case_id
+    if form_question_values is None:
+        form_question_values = {}
+
+    case_create = case_block.get('create') or {}
+    case_update = case_block.get('update') or {}
+
     case_type = get_case_type_obj(case.domain, case.type)
     assert case_type, f'CaseType not found for case type {case.type!r}'
     prop_names = [p.name for p in case_type.properties.all()]
+    extra_fields = {p: case.get_case_property(p) for p in prop_names}
+    # Include external_id because `get_bundle_entries()` uses it
+    # to determine whether to PUT or POST.
+    extra_fields['external_id'] = case.get_case_property('external_id')
+
     return CaseTriggerInfo(
         domain=case.domain,
         case_id=case.case_id,
         type=case.type,
-        extra_fields={p: case.get_case_property(p) for p in prop_names},
+        name=case.name,
+        owner_id=case.owner_id,
+        modified_by=case.modified_by,
+        updates={**case_create, **case_update},
+        created='create' in case_block if case_block else None,
+        closed='close' in case_block if case_block else None,
+        extra_fields=extra_fields,
+        form_question_values=form_question_values,
     )
 
 

--- a/corehq/motech/fhir/models.py
+++ b/corehq/motech/fhir/models.py
@@ -31,7 +31,10 @@ class FHIRResourceType(models.Model):
 
     # `template` offers a way to define a FHIR resource if it cannot be
     # built using only mapped case properties.
-    template = JSONField(null=True, blank=True, default=None)
+    template = JSONField(default=dict)
+
+    class Meta:
+        unique_together = ('case_type', 'fhir_version')
 
     def __str__(self):
         return self.name

--- a/corehq/motech/fhir/models.py
+++ b/corehq/motech/fhir/models.py
@@ -10,14 +10,16 @@ from jsonfield import JSONField
 from casexml.apps.case.models import CommCareCase
 
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
+from corehq.apps.data_dictionary.util import get_case_type_obj
 from corehq.form_processor.models import CommCareCaseSQL
 from corehq.motech.exceptions import ConfigurationError
-from corehq.motech.fhir.const import FHIR_VERSION_4_0_1, FHIR_VERSIONS
 from corehq.motech.value_source import (
     CaseTriggerInfo,
     ValueSource,
     as_value_source,
 )
+
+from .const import FHIR_VERSION_4_0_1, FHIR_VERSIONS
 
 
 class FHIRResourceType(models.Model):
@@ -72,6 +74,9 @@ class FHIRResourceType(models.Model):
                             'json-schema', ver)
         ext = len('.schema.json')
         return [n[:-ext] for n in os.listdir(path)]
+
+    def validate_resource(self, fhir_resource):
+        pass
 
 
 class FHIRResourceProperty(models.Model):
@@ -146,33 +151,81 @@ class FHIRResourceProperty(models.Model):
         return as_value_source(value_source_config)
 
 
-def build_fhir_resource(case, version=FHIR_VERSION_4_0_1):
-    case_type = CaseType.objects.get(
-        domain=case.domain,
-        name=case.type,
-    )
-    info = get_case_trigger_info(case, case_type)
-    resource_type = (FHIRResourceType.objects
-                     .prefetch_related('properties__case_property')
-                     .get(case_type=case_type, fhir_version=version))
-    fhir_resource = resource_type.template or {}
+def build_fhir_resource(
+    case: Union[CommCareCase, CommCareCaseSQL],
+    fhir_version: str = FHIR_VERSION_4_0_1,
+) -> Optional[dict]:
+    """
+    Builds a FHIR resource using data from ``case``. Returns ``None`` if
+    mappings do not exist.
+
+    Used by the FHIR API.
+    """
+    try:
+        info = get_case_trigger_info(case)
+    except AssertionError:
+        return None
+    return _build_fhir_resource(info, fhir_version)
+
+
+def build_fhir_resource_for_info(
+    info: CaseTriggerInfo,
+    fhir_version: str,
+) -> Optional[dict]:
+    """
+    Builds a FHIR resource using data from ``info``. Returns ``None`` if
+    mappings do not exist, or if there is no data to forward.
+
+    Used by ``FHIRRepeater``.
+    """
+    return _build_fhir_resource(info, fhir_version)
+
+
+def _build_fhir_resource(
+    info: CaseTriggerInfo,
+    fhir_version: str,
+) -> Optional[dict]:
+
+    case_type = get_case_type_obj(info.domain, info.type)
+    if not case_type:
+        return None
+
+    try:
+        resource_type = (
+            FHIRResourceType.objects
+            .prefetch_related('properties__case_property')
+            .get(case_type=case_type, fhir_version=fhir_version)
+        )
+    except FHIRResourceType.DoesNotExist:
+        return None
+
+    fhir_resource = {
+        **resource_type.template,
+        'id': info.case_id,
+        'resourceType': resource_type.name,  # Always required
+    }
     for prop in resource_type.properties.all():
         value_source = prop.get_value_source()
         value_source.set_external_value(fhir_resource, info)
+    resource_type.validate_resource(fhir_resource)
     return fhir_resource
 
 
-def get_case_trigger_info(
-        case: Union[CommCareCase, CommCareCaseSQL],
-        case_type: CaseType,
-) -> CaseTriggerInfo:
+def get_case_trigger_info(case):
     """
-    CaseTriggerInfo packages case (and form) data for use by ValueSource
+    Returns ``CaseTriggerInfo`` instance for ``case``.
+
+    Ignores case properties that aren't in the Data Dictionary.
+
+    ``CaseTriggerInfo`` packages case (and form) data for use by
+    ``ValueSource``.
     """
+    case_type = get_case_type_obj(case.domain, case.type)
+    assert case_type, f'CaseType not found for case type {case.type!r}'
     prop_names = [p.name for p in case_type.properties.all()]
     return CaseTriggerInfo(
         domain=case.domain,
         case_id=case.case_id,
         type=case.type,
-        updates={p: case.get_case_property(p) for p in prop_names},
+        extra_fields={p: case.get_case_property(p) for p in prop_names},
     )

--- a/corehq/motech/fhir/repeater_helpers.py
+++ b/corehq/motech/fhir/repeater_helpers.py
@@ -1,26 +1,98 @@
-from typing import List, Optional
+from typing import List, Tuple
+
+from django.conf import settings
+from django.contrib.sites.models import Site
+from requests import Response
 
 from corehq.motech.requests import Requests
 from corehq.motech.value_source import CaseTriggerInfo
 
+from .const import FHIR_BUNDLE_TYPES, FHIR_VERSIONS
+from .models import build_fhir_resource_for_info
+
 
 def register_patients(
     requests: Requests,
-    case_trigger_infos: List[CaseTriggerInfo],
-    fhir_version: str,
+    info_resources_list: List[tuple],
 ):
     raise NotImplementedError
 
 
-def get_fhir_bundle(
+def get_info_resources_list(
     case_trigger_infos: List[CaseTriggerInfo],
     fhir_version: str,
-) -> Optional[dict]:
-    raise NotImplementedError
+) -> List[Tuple[CaseTriggerInfo, dict]]:
+    """
+    Returns pairs of CaseTriggerInfo + the FHIR resource they map to.
+    """
+    results = []
+    for info in case_trigger_infos:
+        resource = build_fhir_resource_for_info(info, fhir_version)
+        if resource:
+            # We return `info` with `resource` because
+            # `get_bundle_entries()` will need both.
+            results.append((info, resource))
+    return results
 
 
-def send_bundle(
+def send_resources(
     requests: Requests,
-    bundle: dict,
-):
-    raise NotImplementedError
+    info_resources_list: List[tuple],
+    fhir_version: str,
+) -> Response:
+    entries = get_bundle_entries(info_resources_list, fhir_version)
+    bundle = create_bundle(entries, bundle_type='transaction')
+    response = requests.post('/', json=bundle)
+    return response
+
+
+def get_bundle_entries(
+    info_resources_list: List[tuple],
+    fhir_version: str,
+) -> List[dict]:
+    entries = []
+    for info, resource in info_resources_list:
+        external_id = info.extra_fields['external_id']
+        if external_id:
+            request = {
+                'method': 'PUT',
+                'url': f"{resource['resourceType']}/{external_id}",
+            }
+        else:
+            request = {
+                'method': 'POST',
+                'url': f"{resource['resourceType']}/",
+            }
+        url = get_full_url(info.domain, resource, fhir_version)
+        entries.append({
+            'fullUrl': url,
+            'resource': resource,
+            'request': request,
+        })
+    return entries
+
+
+def create_bundle(
+    entries: List[dict],
+    bundle_type: str,
+) -> dict:
+    if bundle_type not in FHIR_BUNDLE_TYPES:
+        raise ValueError(f'Unknown FHIR Bundle type {bundle_type!r}')
+    return {
+        'type': bundle_type,
+        'entry': entries,
+        'resourceType': 'Bundle',
+    }
+
+
+def get_full_url(
+    domain: str,
+    resource: dict,
+    fhir_version: str,
+) -> str:
+    # TODO: Use `absolute_reverse` as soon as we have an API view
+    proto = 'http' if settings.DEBUG else 'https'
+    host = Site.objects.get_current().domain
+    ver = dict(FHIR_VERSIONS)[fhir_version].lower()
+    return (f'{proto}://{host}/a/{domain}/api'
+            f"/fhir/{ver}/{resource['resourceType']}/{resource['id']}")

--- a/corehq/motech/fhir/repeater_helpers.py
+++ b/corehq/motech/fhir/repeater_helpers.py
@@ -1,0 +1,26 @@
+from typing import List, Optional
+
+from corehq.motech.requests import Requests
+from corehq.motech.value_source import CaseTriggerInfo
+
+
+def register_patients(
+    requests: Requests,
+    case_trigger_infos: List[CaseTriggerInfo],
+    fhir_version: str,
+):
+    raise NotImplementedError
+
+
+def get_fhir_bundle(
+    case_trigger_infos: List[CaseTriggerInfo],
+    fhir_version: str,
+) -> Optional[dict]:
+    raise NotImplementedError
+
+
+def send_bundle(
+    requests: Requests,
+    bundle: dict,
+):
+    raise NotImplementedError

--- a/corehq/motech/fhir/repeaters.py
+++ b/corehq/motech/fhir/repeaters.py
@@ -1,0 +1,117 @@
+from django.utils.translation import ugettext_lazy as _
+
+from memoized import memoized
+
+from casexml.apps.case.xform import extract_case_blocks
+from couchforms.signals import successful_form_received
+from dimagi.ext.couchdbkit import StringProperty
+
+from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.apps.data_dictionary.models import CaseType
+from corehq.form_processor.interfaces.dbaccessors import (
+    CaseAccessors,
+    FormAccessors,
+)
+from corehq.motech.repeater_helpers import RepeaterResponse
+from corehq.motech.repeaters.models import CaseRepeater
+from corehq.motech.repeaters.repeater_generators import (
+    FormDictPayloadGenerator,
+)
+from corehq.motech.repeaters.signals import create_repeat_records
+from corehq.motech.utils import pformat_json
+from corehq.motech.value_source import (
+    CaseTriggerInfo,
+    get_form_question_values,
+)
+from corehq.privileges import DATA_FORWARDING
+from corehq.toggles import FHIR_INTEGRATION
+
+from .const import FHIR_VERSION_4_0_1, XMLNS_FHIR
+from .repeater_helpers import get_fhir_bundle, register_patients, send_bundle
+
+
+class FHIRRepeater(CaseRepeater):
+    class Meta:
+        app_label = 'repeaters'
+
+    friendly_name = _('Forward Cases to a FHIR API')
+    payload_generator_classes = (FormDictPayloadGenerator,)
+    include_app_id_param = False
+    _has_config = False
+
+    fhir_version = StringProperty(default=FHIR_VERSION_4_0_1)
+
+    @memoized
+    def payload_doc(self, repeat_record):
+        return FormAccessors(repeat_record.domain).get_form(repeat_record.payload_id)
+
+    @property
+    def form_class_name(self):
+        # The class name used to determine which edit form to use
+        return self.__class__.__name__
+
+    @classmethod
+    def available_for_domain(cls, domain):
+        return (domain_has_privilege(domain, DATA_FORWARDING)
+                and FHIR_INTEGRATION.enabled(domain))
+
+    def allowed_to_forward(self, payload):
+        # When we update a case's external_id to their ID on a remote
+        # FHIR service, the form is submitted with XMLNS_FHIR. This
+        # check makes sure that we don't send the update back to FHIR.
+        return payload.xmlns != XMLNS_FHIR
+
+    def send_request(self, repeat_record, payload):
+        """
+        Generates FHIR resources from ``payload``, and sends them as a
+        FHIR transaction bundle. If there are patients that need to be
+        registered, that is done first.
+
+        Returns an HTTP response-like object. If the payload has nothing
+        to send, returns True.
+        """
+        response = True
+        requests = self.connection_settings.get_requests(repeat_record.payload_id)
+        case_trigger_infos = self.get_case_trigger_infos(payload)
+        try:
+            register_patients(requests, case_trigger_infos, self.fhir_version)
+            bundle = get_fhir_bundle(case_trigger_infos, self.fhir_version)
+            if bundle:
+                response = send_bundle(requests, bundle)
+        except Exception as err:
+            requests.notify_exception(str(err))
+            return RepeaterResponse(400, 'Bad Request', pformat_json(str(err)))
+        return response
+
+    def get_case_trigger_infos(self, form_json):
+        case_trigger_infos = []
+        case_blocks = extract_case_blocks(form_json)
+        case_ids = [case_block['@case_id'] for case_block in case_blocks]
+        cases = CaseAccessors(self.domain).get_cases(case_ids, ordered=True)
+        for case, case_block in zip(cases, case_blocks):
+            assert case_block['@case_id'] == case.case_id
+            case_type = CaseType.objects.get(domain=case.domain, name=case.type)
+            prop_names = [p.name for p in case_type.properties.all()]
+            case_create = case_block.get('create') or {}
+            case_update = case_block.get('update') or {}
+            case_trigger_infos.append(CaseTriggerInfo(
+                domain=self.domain,
+                case_id=case.case_id,
+                type=case.type,
+                name=case.name,
+                owner_id=case.owner_id,
+                modified_by=case.modified_by,
+                updates={**case_create, **case_update},
+                created='create' in case_block,
+                closed='close' in case_block,
+                extra_fields={p: case.get_case_property(p) for p in prop_names},
+                form_question_values=get_form_question_values(form_json),
+            ))
+        return case_trigger_infos
+
+
+def create_fhir_repeat_records(sender, xform, **kwargs):
+    create_repeat_records(FHIRRepeater, xform)
+
+
+successful_form_received.connect(create_fhir_repeat_records)

--- a/corehq/motech/fhir/searchers.py
+++ b/corehq/motech/fhir/searchers.py
@@ -1,0 +1,199 @@
+from typing import Generator, List, Type, Union
+
+import attr
+from jsonpath_ng.ext.parser import parse as jsonpath_parse
+
+from corehq.motech.requests import Requests
+from corehq.motech.utils import simplify_list
+
+from .const import SYSTEM_URI_CASE_ID
+
+
+class ResourceSearcher:
+    """
+    Searches a remote FHIR API in increasingly broad terms.
+
+    Used in conjunction with ResourceMatcher to find matching resources.
+    """
+    # A list of searches, and for each one, the list of search params to
+    # filter by
+    search_search_params: List[List['SearchParam']]
+
+    def __init__(self, requests: Requests, resource: dict):
+        self.requests = requests
+        self.resource = resource
+
+    def iter_searches(self) -> Generator:
+        # Separate out searches so that the caller can stop if they find
+        # the resource they need with a narrow search, before trying a
+        # broader search.
+        return (Search(self.requests, self.resource, search_params)
+                for search_params in self.search_search_params)
+
+
+class Search:
+    def __init__(self, requests, resource, search_params: List['SearchParam']):
+        self.requests = requests
+        self.resource = resource
+        self.search_params = search_params
+
+    def iter_candidates(self) -> Generator[dict, None, None]:
+        for request_params in self.get_request_params(self.search_params):
+            # One search usually involves one dictionary of request
+            # params, but can involve many. e.g. Searching for a
+            # patient by each of their given names is done with a series
+            # of requests.
+            response = self.requests.get(
+                f"{self.resource['resourceType']}/",
+                params=request_params,
+            )
+            searchset_bundle = response.json()
+            yield from self.iter_searchset(searchset_bundle)
+
+    def get_request_params(self, search_params: List['SearchParam']) -> List[dict]:
+        request_params = [{}]
+        for sp in search_params:
+            value = sp.param.get_value(self.resource)
+            if value is None:
+                continue
+            elif isinstance(value, list):
+                request_params = multiply(request_params, sp.param_name, value)
+            else:
+                update_all(request_params, sp.param_name, value)
+        return request_params
+
+    def iter_searchset(self, searchset) -> Generator[dict, None, None]:
+        if 'entry' in searchset:
+            for entry in searchset['entry']:
+                yield entry.get('resource', {})
+        # TODO: Support pagination
+
+
+class ParamHelper:
+
+    def __init__(self, jsonpath: str):
+        self.jsonpath = jsonpath_parse(jsonpath)
+
+    def get_value(self, resource: dict):
+        value = simplify_list([x.value for x in self.jsonpath.find(resource)])
+        return None if value is None else self.prepare_value(value)
+
+    @staticmethod
+    def prepare_value(value) -> Union[str, List[str]]:
+        return str(value)
+
+
+class GivenName(ParamHelper):
+
+    @staticmethod
+    def prepare_value(value):
+        """
+        ``value`` is a list of given names. Returns a string by joining
+        given names with " ".
+        """
+        return ' '.join(value)
+
+
+class EachGivenName(ParamHelper):
+
+    @staticmethod
+    def prepare_value(value):
+        """
+        ``value`` is a list of given names. Returns a list of unique
+        given names. ``Search.iter_candidates()`` will send a request
+        for each one.
+        """
+        return simplify_list(list(set(value)))
+
+
+@attr.s(auto_attribs=True)
+class SystemCode:
+    """
+    A search parameter value that is made up of a system and a code.
+
+    e.g. To search by case ID, we use the "identifier" param, and
+    provide both the case ID under "code" and a URI for CommCare under
+    "system".
+    """
+    system: str
+    code: str
+
+    def __str__(self):
+        if self.system and self.code:
+            return f'{self.system}|{self.code}'
+        return self.system or self.code or ''
+
+
+class SystemCodeParam(ParamHelper):
+
+    @staticmethod
+    def prepare_value(value):
+        """
+        ``value`` is a dictionary with "system" and "value" keys.
+        """
+        system_code = SystemCode(system=value['system'], code=value['value'])
+        return str(system_code)
+
+
+@attr.s(auto_attribs=True)
+class SearchParam:
+    param_name: str  # e.g. "given"
+    jsonpath: str  # e.g. "$.name[0].given"
+    param_class: Type[ParamHelper] = ParamHelper
+
+    @property
+    def param(self):
+        return self.param_class(self.jsonpath)
+
+
+class PatientSearcher(ResourceSearcher):
+    search_search_params = [
+        # First search: Case name and case ID
+        [
+            SearchParam('name', '$.name[0].text'),
+            SearchParam(
+                param_name='identifier',
+                jsonpath=f"$.identifier[?system='{SYSTEM_URI_CASE_ID}']",
+                param_class=SystemCodeParam,
+            ),
+        ],
+
+        # Second search: Personal details
+        [
+            SearchParam('given', '$.name[0].given', GivenName),
+            SearchParam('family', '$.name[0].family'),
+            SearchParam('gender', '$.gender'),
+            SearchParam('birthdate', '$.birthDate'),
+            # SearchParam('email', '$.telecom', EmailParam),
+            # SearchParam('phone', '$.telecom', PhoneParam),
+            # SearchParam('address-country', ...),
+            # SearchParam('address-state', ...),
+            # SearchParam('address-city', ...),
+        ],
+
+        # Third time's the charm: Broad searches by names
+        [
+            SearchParam('given', '$.name[0].given', EachGivenName),
+            SearchParam('family', '$.name[0].family'),
+        ],
+    ]
+
+
+def update_all(dicts: List[dict], key, value):
+    for dict_ in dicts:
+        dict_[key] = value
+
+
+def multiply(dicts: List[dict], key, values: list) -> List[dict]:
+    """
+    Duplicates and updates ``dicts`` for each value in ``values``.
+
+    >>> multiply([{'foo': 1}], key='bar', values=[2, 3])
+    [{'foo': 1, 'bar': 2}, {'foo': 1, 'bar': 3}]
+
+    """
+    return [
+        {**dict_, **{key: value}}
+        for dict_ in dicts
+        for value in values
+    ]

--- a/corehq/motech/fhir/serializers.py
+++ b/corehq/motech/fhir/serializers.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from corehq.motech.const import COMMCARE_DATA_TYPE_TEXT
+from corehq.motech.fhir.const import FHIR_DATA_TYPE_LIST_OF_STRING
+
+from corehq.motech.serializers import serializers
+
+
+def join_strings(value: List[str]) -> str:
+    return ' '.join(value)
+
+
+def split_string(value: str) -> List[str]:
+    return value.split(' ')
+
+
+serializers.update({
+    # (from_data_type, to_data_type): function
+    (FHIR_DATA_TYPE_LIST_OF_STRING, COMMCARE_DATA_TYPE_TEXT): join_strings,
+    (COMMCARE_DATA_TYPE_TEXT, FHIR_DATA_TYPE_LIST_OF_STRING): split_string,
+})

--- a/corehq/motech/fhir/tests/test_matchers.py
+++ b/corehq/motech/fhir/tests/test_matchers.py
@@ -1,0 +1,125 @@
+from decimal import Decimal
+from uuid import uuid4
+
+from django.test import SimpleTestCase
+
+from nose.tools import assert_equal
+
+from ..const import SYSTEM_URI_CASE_ID
+from ..matchers import (
+    GivenName,
+    NegativeIdentifier,
+    OrganizationMatcher,
+    OrganizationName,
+    PatientMatcher,
+    PersonMatcher,
+    PropertyWeight,
+)
+
+
+def test_given_name_method():
+    # Tests the GivenName ComparisonMethod as used by PersonMatcher
+    pw = PropertyWeight('$.name[0].given', Decimal('0.3'), GivenName)
+    assert pw in PersonMatcher.property_weights
+    method = pw.method
+
+    john = {'name': [{'given': 'Henry John Colchester'.split()}]}
+    for resource, candidate, expected in [
+        (john, {'name': [{'given': ['H.', 'John']}]}, True),
+        (john, {'name': [{'given': ['H.', 'J.', 'C.']}]}, False),
+        (john, {'name': [{'given': ['Henry']}]}, True),
+        (john, {'name': [{'given': ['John']}]}, False),
+        (john, {'name': [{'given': ['Eric', 'John', 'Marwood']}]}, True),
+    ]:
+        yield check_method, method, resource, candidate, expected
+
+
+def test_organization_name_method():
+    # Tests the OrganizationName method as used by OrganizationMatcher
+    pw = PropertyWeight('$.name', Decimal('0.8'), OrganizationName)
+    assert pw in OrganizationMatcher.property_weights
+    method = pw.method
+
+    dimagi = {'name': 'Dimagi'}
+    for resource, candidate, expected in [
+        (dimagi, {'name': 'Dimagi'}, True),
+        (dimagi, {'name': 'DiMaggi'}, True),
+        (dimagi, {'name': 'Di Maggi'}, False),
+        (dimagi, {'name': 'dimCGI'}, True),
+    ]:
+        yield check_method, method, resource, candidate, expected
+
+
+def check_method(method, a, b, expected):
+    result = method.is_match(a, b)
+    assert_equal(result, expected)
+
+
+def test_negative_identifier():
+    for a, b, expected in [
+        ('name|Beth Harmon', 'name|Elizabeth Harmon', False),
+        ('name|Beth', 'name|Beth', True),
+        ('name|Elizabeth Harmon', 'name|Elisabeth Harmon', True),
+        ('given_name|Elizabeth', 'family_name|Harmon', True),
+    ]:
+        yield check_compare, NegativeIdentifier, a, b, expected
+
+
+def check_compare(method_class, a, b, expected):
+    result = method_class.compare(a, b)
+    assert_equal(result, expected)
+
+
+class TestPatientCandidates(SimpleTestCase):
+
+    def test_with_commcare_id(self):
+        case_id = uuid4().hex
+        patient = {
+            'id': case_id,
+            'name': [{
+                'text': 'Beth Harmon',
+                'given': ['Elizabeth'],
+                'family': 'Harmon',
+            }],
+            'identifier': [{
+                'system': SYSTEM_URI_CASE_ID,
+                'value': case_id,
+            }]
+        }
+        candidates = [
+            {
+                'id': '1',
+                'name': [{
+                    'given': ['Elizabeth'],
+                    'family': 'Harmon',
+                }],
+                'identifier': [{
+                    'system': SYSTEM_URI_CASE_ID,
+                    'value': uuid4().hex,
+                }],
+            },
+            {
+                'id': '2',
+                'name': [{'given': ['Jolene']}],
+                'identifier': [{
+                    'system': SYSTEM_URI_CASE_ID,
+                    'value': case_id,
+                }],
+            },
+            {
+                'id': '3',
+                'name': [{'family': 'Harmon'}],
+                'identifier': [{
+                    'system': SYSTEM_URI_CASE_ID,
+                    'value': case_id,
+                }],
+            },
+        ]
+        matcher = PatientMatcher(patient)
+        matches = matcher.find_matches(candidates)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0]['id'], '3')
+
+        scores = [matcher.get_score(c) for c in candidates]
+        expected = [Decimal('-0.4'), Decimal('0.8'), Decimal('1.2')]
+        self.assertEqual(scores, expected)

--- a/corehq/motech/fhir/tests/test_model_functions.py
+++ b/corehq/motech/fhir/tests/test_model_functions.py
@@ -4,11 +4,13 @@ from django.test import TestCase
 
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
 from corehq.form_processor.models import CommCareCaseSQL
-from corehq.motech.fhir.models import (
+from ..const import FHIR_VERSION_4_0_1
+from ..models import (
     FHIRResourceProperty,
     FHIRResourceType,
-    build_fhir_resource,
+    _build_fhir_resource,
     get_case_trigger_info,
+    build_fhir_resource,
 )
 
 DOMAIN = 'test-domain'
@@ -35,11 +37,11 @@ class TestGetCaseTriggerInfo(TestCase):
                 'vier': 4, 'vyf': 5, 'ses': 6,
             }
         )
-        info = get_case_trigger_info(case, self.case_type)
+        info = get_case_trigger_info(case)
         for name in ('een', 'twee', 'drie'):
-            self.assertIn(name, info.updates)
+            self.assertIn(name, info.extra_fields)
         for name in ('vier', 'vyf', 'ses'):
-            self.assertNotIn(name, info.updates)
+            self.assertNotIn(name, info.extra_fields)
 
 
 class TestBuildFHIRResource(TestCase):
@@ -47,24 +49,28 @@ class TestBuildFHIRResource(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.set_up_case_type()
-        cls.set_up_resource_type()
+        case_type = CaseType.objects.create(domain=DOMAIN, name='mother')
+        resource_type = FHIRResourceType.objects.create(
+            domain=DOMAIN,
+            case_type=case_type,
+            name='Patient',
+        )
+        for name, jsonpath in [
+            ('name', '$.name[0].text'),
+            ('first_name', '$.name[0].given[0]'),
+            ('honorific', '$.name[0].prefix[0]'),
+            ('date_of_birth', '$.birthDate'),
+        ]:
+            prop = CaseProperty.objects.create(case_type=case_type, name=name)
+            FHIRResourceProperty.objects.create(
+                resource_type=resource_type,
+                case_property=prop,
+                jsonpath=jsonpath,
+            )
 
-    @classmethod
-    def set_up_case_type(cls):
-        cls.case_type = CaseType.objects.create(domain=DOMAIN, name='mother')
-
-        cls.name = CaseProperty.objects.create(
-            case_type=cls.case_type, name='name')
-        cls.first_name = CaseProperty.objects.create(
-            case_type=cls.case_type, name='first_name')
-        cls.honorific = CaseProperty.objects.create(
-            case_type=cls.case_type, name='honorific')
-        cls.date_of_birth = CaseProperty.objects.create(
-            case_type=cls.case_type, name='date_of_birth')
-
+        cls.case_id = str(uuid4())
         cls.case = CommCareCaseSQL(
-            case_id=str(uuid4()),
+            case_id=cls.case_id,
             domain=DOMAIN,
             type='mother',
             name='Mehter Plethwih',
@@ -77,48 +83,24 @@ class TestBuildFHIRResource(TestCase):
         )
 
     @classmethod
-    def set_up_resource_type(cls):
-        resource_type = FHIRResourceType.objects.create(
-            case_type=cls.case_type,
-            name='Patient',
-        )
-        FHIRResourceProperty.objects.create(
-            resource_type=resource_type,
-            case_property=cls.name,
-            jsonpath='$.name[0].text',
-        )
-        FHIRResourceProperty.objects.create(
-            resource_type=resource_type,
-            case_property=cls.first_name,
-            jsonpath='$.name[0].given[0]',
-        )
-        FHIRResourceProperty.objects.create(
-            resource_type=resource_type,
-            case_property=cls.honorific,
-            jsonpath='$.name[0].prefix[0]',
-        )
-        FHIRResourceProperty.objects.create(
-            resource_type=resource_type,
-            case_property=cls.date_of_birth,
-            jsonpath='$.birthDate',
-        )
-
-    @classmethod
     def tearDownClass(cls):
-        cls.case_type.delete()
+        CaseType.objects.filter(domain=DOMAIN, name='mother').delete()
         super().tearDownClass()
 
     def test_build_fhir_resource(self):
         resource = build_fhir_resource(self.case)
         self.assertEqual(resource, {
+            'id': self.case_id,
             'name': [{
                 'text': 'Mehter Plethwih',
                 'prefix': ['Mehter'],
                 'given': ['Plethwih'],
             }],
             'birthDate': '1970-01-01',
+            'resourceType': 'Patient',
         })
 
     def test_num_queries(self):
-        with self.assertNumQueries(5):
-            build_fhir_resource(self.case)
+        info = get_case_trigger_info(self.case)
+        with self.assertNumQueries(3):
+            _build_fhir_resource(info, FHIR_VERSION_4_0_1)

--- a/corehq/motech/fhir/tests/test_patient_reg.py
+++ b/corehq/motech/fhir/tests/test_patient_reg.py
@@ -1,0 +1,181 @@
+import random
+import string
+from collections import namedtuple
+from datetime import datetime, timedelta
+from unittest import SkipTest
+from uuid import uuid4
+
+from django.conf import settings
+from django.test import TestCase
+
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
+from corehq.apps.accounting.utils import clear_plan_version_cache
+from corehq.apps.data_dictionary.models import CaseProperty, CaseType
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.receiverwrapper.util import submit_form_locally
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.motech.models import ConnectionSettings
+
+from ..models import FHIRResourceProperty, FHIRResourceType
+from ..repeaters import FHIRRepeater
+
+DOMAIN = ''.join([random.choice(string.ascii_lowercase) for __ in range(20)])
+CASE_ID = str(uuid4())
+INSTANCE_ID = str(uuid4())
+
+# This test was run with a SMART-on-FHIR HAPI FHIR Docker image:
+#     $ docker run -it -p 8425:8080 smartonfhir/hapi-5:r4-synthea
+# See https://hub.docker.com/u/smartonfhir/
+BASE_URL = 'http://localhost:8425/hapi-fhir-jpaserver/fhir/'
+
+
+ResponseMock = namedtuple('ResponseMock', 'status_code reason')
+
+
+class TestPatientRegistration(TestCase, DomainSubscriptionMixin):
+    """
+    Submits an XForm, and tracks progress to a FHIR server.
+
+    Requires Celery to be running for ``process_repeat_record()`` task.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        # @skip still executes tearDownClass() (?!) This does not:
+        raise SkipTest('Requires local HAPI FHIR instance')
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.set_up_domain()
+        cls.set_up_case_type()
+        cls.set_up_repeater()
+
+        cls._debug = settings.DEBUG
+        settings.DEBUG = True  # urlsanitize to allow localhost URLs
+        post_xform()
+
+    @classmethod
+    def set_up_domain(cls):
+        cls.domain_obj = create_domain(DOMAIN)
+        cls.setup_subscription(DOMAIN, SoftwarePlanEdition.PRO)
+
+    @classmethod
+    def set_up_case_type(cls):
+        case_type = CaseType.objects.create(domain=DOMAIN, name='mother')
+        resource_type = FHIRResourceType.objects.create(
+            domain=DOMAIN,
+            case_type=case_type,
+            name='Patient',
+        )
+        for name, jsonpath in [
+            ('name', '$.name[0].text'),
+            ('first_name', '$.name[0].given[0]'),
+            ('honorific', '$.name[0].prefix[0]'),
+            ('date_of_birth', '$.birthDate'),
+        ]:
+            prop = CaseProperty.objects.create(case_type=case_type, name=name)
+            FHIRResourceProperty.objects.create(
+                resource_type=resource_type,
+                case_property=prop,
+                jsonpath=jsonpath,
+            )
+
+    @classmethod
+    def set_up_repeater(cls):
+        cls.conn = ConnectionSettings.objects.create(
+            domain=DOMAIN,
+            name='Fhirplace',
+            url=BASE_URL,
+        )
+        cls.repeater = FHIRRepeater(
+            domain=DOMAIN,
+            connection_settings_id=cls.conn.id,
+        )
+        cls.repeater.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tear_down_fhir_patient()
+
+        settings.DEBUG = cls._debug
+        cls.repeater.delete()
+        cls.conn.delete()
+
+        CaseType.objects.filter(domain=DOMAIN, name='mother').delete()
+
+        cls.teardown_subscriptions()
+        cls.domain_obj.delete()
+        clear_plan_version_cache()
+        super().tearDownClass()
+
+    @classmethod
+    def tear_down_fhir_patient(cls):
+        requests = cls.conn.get_requests()
+        search_response = requests.get('Patient?given=Plethwih')
+        searchset_bundle = search_response.json()
+        for entry in searchset_bundle.get('entry', []):
+            # This DELETE request adheres to [the FHIR API standard](
+            # http://hl7.org/implement/standards/fhir/http.html#delete)
+            # but fails:
+            # ca.uhn.fhir.rest.server.exceptions.InvalidRequestException:
+            # URL path has unexpected token '219155' at the end:
+            # http://localhost:8080/hapi-fhir-jpaserver/fhir/Patient/219155
+            requests.delete(entry['fullUrl'])
+
+    def test_external_id(self):
+        case = CaseAccessors(DOMAIN).get_case(CASE_ID)
+        self.assertTrue(bool(case.external_id))
+
+    def test_remote_search(self):
+        requests = self.conn.get_requests()
+        search_response = requests.get('Patient?given=Plethwih')
+        searchset_bundle = search_response.json()
+        self.assertGreater(searchset_bundle['total'], 0)
+
+
+def post_xform():
+
+    def isoformat(dt):
+        return dt.isoformat(timespec='milliseconds') + 'Z'
+
+    user_id = str(uuid4())
+    just_now = datetime.utcnow()
+    time_start = isoformat(just_now - timedelta(minutes=2))
+    time_end = isoformat(just_now - timedelta(minutes=1))
+    date_modified = isoformat(just_now)
+
+    xform = f"""<?xml version='1.0' ?>
+<data xmlns="https://www.commcarehq.org/test/TestPatientRegistration/">
+  <honorific>Mehter</honorific>
+  <first_name>Plethwih</first_name>
+  <name>Mehter Plethwih</name>
+  <date_of_birth>1970-01-01</date_of_birth>
+
+  <tx:case case_id="{CASE_ID}"
+           date_modified="{date_modified}"
+           user_id="{user_id}"
+           xmlns:tx="http://commcarehq.org/case/transaction/v2">
+    <tx:create>
+      <tx:case_name>Mehter Plethwih</tx:case_name>
+      <tx:owner_id>{user_id}</tx:owner_id>
+      <tx:case_type>mother</tx:case_type>
+    </tx:create>
+    <tx:update>
+      <tx:honorific>Mehter</tx:honorific>
+      <tx:first_name>Plethwih</tx:first_name>
+      <tx:date_of_birth>1970-01-01</tx:date_of_birth>
+    </tx:update>
+  </tx:case>
+
+  <jr:meta xmlns:jr="http://dev.commcarehq.org/jr/xforms">
+    <jr:deviceID>TestPatientRegistration</jr:deviceID>
+    <jr:timeStart>{time_start}</jr:timeStart>
+    <jr:timeEnd>{time_end}</jr:timeEnd>
+    <jr:username>admin</jr:username>
+    <jr:userID>testy.mctestface</jr:userID>
+    <jr:instanceID>{INSTANCE_ID}</jr:instanceID>
+  </jr:meta>
+</data>
+"""
+    submit_form_locally(xform, DOMAIN)

--- a/corehq/motech/fhir/tests/test_repeater_helpers.py
+++ b/corehq/motech/fhir/tests/test_repeater_helpers.py
@@ -1,0 +1,204 @@
+import random
+import string
+from datetime import datetime
+from uuid import uuid4
+
+from django.test import TestCase
+
+from casexml.apps.case.models import CommCareCase
+from casexml.apps.case.sharedmodels import CommCareCaseIndex
+
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
+from corehq.apps.accounting.utils import clear_plan_version_cache
+from corehq.apps.data_dictionary.models import CaseProperty, CaseType
+from corehq.apps.domain.shortcuts import create_domain
+
+from ..const import FHIR_VERSION_4_0_1
+from ..models import (
+    FHIRResourceProperty,
+    FHIRResourceType,
+    get_case_trigger_info,
+)
+from ..repeater_helpers import get_info_resources_list
+
+DOMAIN = ''.join([random.choice(string.ascii_lowercase) for __ in range(20)])
+
+
+class TestGetInfoResourcesListOneCase(TestCase, DomainSubscriptionMixin):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = create_domain(DOMAIN)
+        cls.setup_subscription(DOMAIN, SoftwarePlanEdition.PRO)
+
+        cls.case_type = CaseType.objects.create(
+            domain=DOMAIN, name='person')
+        name = CaseProperty.objects.create(
+            case_type=cls.case_type, name='name')
+
+        resource_type = FHIRResourceType.objects.create(
+            domain=DOMAIN, case_type=cls.case_type, name='Patient')
+        FHIRResourceProperty.objects.create(
+            resource_type=resource_type,
+            case_property=name,
+            jsonpath='$.name[0].text',
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.case_type.delete()
+        cls.teardown_subscriptions()
+        cls.domain_obj.delete()
+        clear_plan_version_cache()
+        super().tearDownClass()
+
+    def setUp(self):
+        now = datetime.utcnow()
+        self.case_id = str(uuid4())
+        self.case = CommCareCase(
+            _id=self.case_id,
+            domain=DOMAIN,
+            type='person',
+            name='Ted',
+            owner_id=str(uuid4()),
+            modified_on=now,
+            server_modified_on=now,
+        )
+        self.case.save()
+
+    def tearDown(self):
+        self.case.delete()
+
+    def test_get_info_resources_list(self):
+        case_trigger_infos = [get_case_trigger_info(self.case)]
+        [(info, resource)] = get_info_resources_list(
+            case_trigger_infos,
+            FHIR_VERSION_4_0_1,
+        )
+        self.assertEqual(resource, {
+            'id': self.case_id,
+            'name': [{'text': 'Ted'}],
+            'resourceType': 'Patient'
+        })
+
+
+class TestGetInfoResourcesListSubCases(TestCase, DomainSubscriptionMixin):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = create_domain(DOMAIN)
+        cls.setup_subscription(DOMAIN, SoftwarePlanEdition.PRO)
+
+        cls.person_case_type = CaseType.objects.create(
+            domain=DOMAIN, name='person')
+        name = CaseProperty.objects.create(
+            case_type=cls.person_case_type, name='name')
+
+        resource_type_for_person = FHIRResourceType.objects.create(
+            domain=DOMAIN, case_type=cls.person_case_type, name='Patient')
+        FHIRResourceProperty.objects.create(
+            resource_type=resource_type_for_person,
+            case_property=name,
+            jsonpath='$.name[0].text',
+        )
+        FHIRResourceProperty.objects.create(
+            resource_type=resource_type_for_person,
+            value_source_config={
+                'subcase_value_source': {
+                    'case_property': 'given_names',
+                    # Use counter1 to skip the name set by the parent case
+                    'jsonpath': '$.name[{counter1}].given[0]',
+                },
+                'case_types': ['person_name'],
+            }
+        )
+        FHIRResourceProperty.objects.create(
+            resource_type=resource_type_for_person,
+            value_source_config={
+                'subcase_value_source': {
+                    'case_property': 'family_name',
+                    'jsonpath': '$.name[{counter1}].family',
+                },
+                'case_types': ['person_name'],
+            }
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.person_case_type.delete()
+        cls.teardown_subscriptions()
+        cls.domain_obj.delete()
+        clear_plan_version_cache()
+        super().tearDownClass()
+
+    def setUp(self):
+        now = datetime.utcnow()
+        self.parent_case_id = str(uuid4())
+        self.parent_case = CommCareCase(
+            _id=self.parent_case_id,
+            domain=DOMAIN,
+            type='person',
+            name='Ted',
+            owner_id=str(uuid4()),
+            modified_on=now,
+            server_modified_on=now,
+        )
+        self.parent_case.save()
+
+        self.child_case_1 = CommCareCase(
+            case_id='111111111',
+            domain=DOMAIN,
+            type='person_name',
+            name='Theodore',
+            given_names='Theodore John',
+            family_name='Kaczynski',
+            indices=[CommCareCaseIndex(
+                identifier='parent',
+                referenced_type='person',
+                referenced_id=self.parent_case_id,
+            )],
+            owner_id=str(uuid4()),
+            modified_on=now,
+            server_modified_on=now,
+        )
+        self.child_case_1.save()
+        self.child_case_2 = CommCareCase(
+            case_id='222222222',
+            domain=DOMAIN,
+            type='person_name',
+            name='Unabomber',
+            given_names='Unabomber',
+            indices=[CommCareCaseIndex(
+                identifier='parent',
+                referenced_type='person',
+                referenced_id=self.parent_case_id,
+            )],
+            owner_id=str(uuid4()),
+            modified_on=now,
+            server_modified_on=now,
+        )
+        self.child_case_2.save()
+
+    def tearDown(self):
+        self.child_case_1.delete()
+        self.child_case_2.delete()
+        self.parent_case.delete()
+
+    def test_get_info_resources_list(self):
+        case_trigger_infos = [get_case_trigger_info(self.parent_case)]
+        [(info, resource)] = get_info_resources_list(
+            case_trigger_infos,
+            FHIR_VERSION_4_0_1,
+        )
+        self.assertEqual(resource, {
+            'id': self.parent_case_id,
+            'name': [
+                {'text': 'Ted'},
+                {'given': ['Theodore John'], 'family': 'Kaczynski'},
+                {'given': ['Unabomber']},
+            ],
+            'resourceType': 'Patient',
+        })

--- a/corehq/motech/fhir/tests/test_repeater_helpers.py
+++ b/corehq/motech/fhir/tests/test_repeater_helpers.py
@@ -13,8 +13,9 @@ from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
 from corehq.apps.accounting.utils import clear_plan_version_cache
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.motech.const import COMMCARE_DATA_TYPE_TEXT
 
-from ..const import FHIR_VERSION_4_0_1
+from ..const import FHIR_DATA_TYPE_LIST_OF_STRING, FHIR_VERSION_4_0_1
 from ..models import (
     FHIRResourceProperty,
     FHIRResourceType,
@@ -110,7 +111,9 @@ class TestGetInfoResourcesListSubCases(TestCase, DomainSubscriptionMixin):
                 'subcase_value_source': {
                     'case_property': 'given_names',
                     # Use counter1 to skip the name set by the parent case
-                    'jsonpath': '$.name[{counter1}].given[0]',
+                    'jsonpath': '$.name[{counter1}].given',
+                    'commcare_data_type': COMMCARE_DATA_TYPE_TEXT,
+                    'external_data_type': FHIR_DATA_TYPE_LIST_OF_STRING,
                 },
                 'case_types': ['person_name'],
             }
@@ -197,7 +200,7 @@ class TestGetInfoResourcesListSubCases(TestCase, DomainSubscriptionMixin):
             'id': self.parent_case_id,
             'name': [
                 {'text': 'Ted'},
-                {'given': ['Theodore John'], 'family': 'Kaczynski'},
+                {'given': ['Theodore', 'John'], 'family': 'Kaczynski'},
                 {'given': ['Unabomber']},
             ],
             'resourceType': 'Patient',

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -1,0 +1,23 @@
+from django.utils.translation import ugettext_lazy as _
+
+from corehq.motech.repeaters.views import AddRepeaterView, EditRepeaterView
+
+from .forms import FHIRRepeaterForm
+
+
+class AddFHIRRepeaterView(AddRepeaterView):
+    urlname = 'add_fhir_repeater'
+    repeater_form_class = FHIRRepeaterForm
+    page_title = _('Forward Cases to a FHIR API')
+    page_name = _('Forward Cases to a FHIR API')
+
+    def set_repeater_attr(self, repeater, cleaned_data):
+        repeater = super().set_repeater_attr(repeater, cleaned_data)
+        repeater.fhir_version = (self.add_repeater_form
+                                 .cleaned_data['fhir_version'])
+        return repeater
+
+
+class EditFHIRRepeaterView(EditRepeaterView, AddFHIRRepeaterView):
+    urlname = 'edit_fhir_repeater'
+    page_title = _('Edit FHIR Repeater')

--- a/corehq/motech/openmrs/forms.py
+++ b/corehq/motech/openmrs/forms.py
@@ -1,10 +1,14 @@
 from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy
 
+from crispy_forms import bootstrap as twbscrispy
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
 
+from corehq.apps.locations.forms import LocationSelectWidget
+from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter
 from corehq.apps.userreports.ui.fields import JsonField
 from corehq.motech.openmrs.const import (
     ADDRESS_PROPERTIES,
@@ -13,6 +17,7 @@ from corehq.motech.openmrs.const import (
     NAME_PROPERTIES,
     PERSON_PROPERTIES,
 )
+from corehq.motech.repeaters.forms import CaseRepeaterForm
 
 
 class OpenmrsConfigForm(forms.Form):
@@ -99,3 +104,54 @@ class OpenmrsImporterForm(forms.Form):
                                                'name (e.g. "givenName familyName")'))
     column_map = JsonField(label=_('Map columns to properties'), required=True, expected_type=list,
                            help_text=_('e.g. [{"column": "givenName", "property": "first_name"}, ...]'))
+
+
+class OpenmrsRepeaterForm(CaseRepeaterForm):
+    location_id = forms.CharField(
+        label=ugettext_lazy("Location"),
+        required=False,
+        help_text=ugettext_lazy(
+            'Cases at this location and below will be forwarded. '
+            'Leave empty if this is the only OpenMRS Forwarder'
+        ),
+    )
+    atom_feed_enabled = forms.BooleanField(
+        label=ugettext_lazy('Atom feed enabled'),
+        required=False,
+        help_text=ugettext_lazy(
+            'Poll Atom feed for changes made in OpenMRS/Bahmni'
+        ),
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(OpenmrsRepeaterForm, self).__init__(*args, **kwargs)
+        self.fields['location_id'].widget = LocationSelectWidget(
+            self.domain, id='id_location_id')
+        self.fields['location_id'].help_text = (
+            ExpandedMobileWorkerFilter.location_search_help)
+
+    def get_ordered_crispy_form_fields(self):
+        fields = super(OpenmrsRepeaterForm, self).get_ordered_crispy_form_fields()
+        return fields + [
+            'location_id',
+            twbscrispy.PrependedText('atom_feed_enabled', ''),
+        ]
+
+    def clean(self):
+        cleaned_data = super(OpenmrsRepeaterForm, self).clean()
+        white_listed_case_types = cleaned_data.get('white_listed_case_types', [])
+        atom_feed_enabled = cleaned_data.get('atom_feed_enabled', False)
+        location_id = cleaned_data.get('location_id', None)
+        if atom_feed_enabled:
+            if len(white_listed_case_types) != 1:
+                raise ValidationError(ugettext_lazy(
+                    'Specify a single case type so that CommCare can add '
+                    'cases using the Atom feed for patients created in '
+                    'OpenMRS/Bahmni.'
+                ))
+            if not location_id:
+                raise ValidationError(ugettext_lazy(
+                    'Specify a location so that CommCare can set an owner for '
+                    'cases added via the Atom feed.'
+                ))
+        return cleaned_data

--- a/corehq/motech/openmrs/urls.py
+++ b/corehq/motech/openmrs/urls.py
@@ -8,7 +8,6 @@ from corehq.motech.openmrs.views import (
     openmrs_raw_api,
     openmrs_test_fire,
 )
-from corehq.motech.repeaters.views.repeaters import AddOpenmrsRepeaterView
 
 urlpatterns = [
     url(

--- a/corehq/motech/openmrs/views.py
+++ b/corehq/motech/openmrs/views.py
@@ -19,7 +19,11 @@ from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from corehq.motech.const import PASSWORD_PLACEHOLDER
 from corehq.motech.openmrs.dbaccessors import get_openmrs_importers_by_domain
-from corehq.motech.openmrs.forms import OpenmrsConfigForm, OpenmrsImporterForm
+from corehq.motech.openmrs.forms import (
+    OpenmrsConfigForm,
+    OpenmrsImporterForm,
+    OpenmrsRepeaterForm,
+)
 from corehq.motech.openmrs.models import ColumnMapping, OpenmrsImporter
 from corehq.motech.openmrs.openmrs_config import (
     OpenmrsCaseConfig,
@@ -32,6 +36,7 @@ from corehq.motech.openmrs.repeater_helpers import (
 from corehq.motech.openmrs.repeaters import OpenmrsRepeater
 from corehq.motech.openmrs.tasks import import_patients_to_domain
 from corehq.motech.repeaters.models import RepeatRecord
+from corehq.motech.repeaters.views import AddCaseRepeaterView, EditRepeaterView
 from corehq.motech.utils import b64_aes_encrypt
 
 
@@ -200,3 +205,23 @@ class OpenmrsImporterView(BaseProjectSettingsView):
             'openmrs_importers': openmrs_importers,
             'form': OpenmrsImporterForm(),  # Use an unbound form to render openmrs_importer_template.html
         }
+
+
+class AddOpenmrsRepeaterView(AddCaseRepeaterView):
+    urlname = 'new_openmrs_repeater$'
+    repeater_form_class = OpenmrsRepeaterForm
+    page_title = ugettext_lazy("Forward to OpenMRS")
+    page_name = ugettext_lazy("Forward to OpenMRS")
+
+    def set_repeater_attr(self, repeater, cleaned_data):
+        repeater = super().set_repeater_attr(repeater, cleaned_data)
+        repeater.location_id = (self.add_repeater_form
+                                .cleaned_data['location_id'])
+        repeater.atom_feed_enabled = (self.add_repeater_form
+                                      .cleaned_data['atom_feed_enabled'])
+        return repeater
+
+
+class EditOpenmrsRepeaterView(EditRepeaterView, AddOpenmrsRepeaterView):
+    urlname = 'edit_openmrs_repeater'
+    page_title = ugettext_lazy("Edit OpenMRS Repeater")

--- a/corehq/motech/repeaters/forms.py
+++ b/corehq/motech/repeaters/forms.py
@@ -10,11 +10,7 @@ from memoized import memoized
 
 from corehq.apps.es.users import UserES
 from corehq.apps.hqwebapp import crispy as hqcrispy
-from corehq.apps.locations.forms import LocationSelectWidget
-from corehq.apps.reports.analytics.esaccessors import (
-    get_case_types_for_domain,
-)
-from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter
+from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain
 from corehq.apps.users.util import raw_username
 from corehq.motech.models import ConnectionSettings
 from corehq.motech.repeaters.models import Repeater
@@ -155,49 +151,4 @@ class CaseRepeaterForm(GenericRepeaterForm):
             raise ValidationError(_('Unknown case-type'))
         if not set(black_listed_users).issubset([t[0] for t in self.user_choices]):
             raise ValidationError(_('Unknown user'))
-        return cleaned_data
-
-
-class OpenmrsRepeaterForm(CaseRepeaterForm):
-    location_id = forms.CharField(
-        label=_("Location"),
-        required=False,
-        help_text=_(
-            'Cases at this location and below will be forwarded. '
-            'Leave empty if this is the only OpenMRS Forwarder'
-        )
-    )
-    atom_feed_enabled = forms.BooleanField(
-        label=_('Atom feed enabled'),
-        required=False,
-        help_text=_('Poll Atom feed for changes made in OpenMRS/Bahmni'),
-    )
-
-    def __init__(self, *args, **kwargs):
-        super(OpenmrsRepeaterForm, self).__init__(*args, **kwargs)
-        self.fields['location_id'].widget = LocationSelectWidget(self.domain, id='id_location_id')
-        self.fields['location_id'].help_text = ExpandedMobileWorkerFilter.location_search_help
-
-    def get_ordered_crispy_form_fields(self):
-        fields = super(OpenmrsRepeaterForm, self).get_ordered_crispy_form_fields()
-        return fields + [
-            'location_id',
-            twbscrispy.PrependedText('atom_feed_enabled', ''),
-        ]
-
-    def clean(self):
-        cleaned_data = super(OpenmrsRepeaterForm, self).clean()
-        white_listed_case_types = cleaned_data.get('white_listed_case_types', [])
-        atom_feed_enabled = cleaned_data.get('atom_feed_enabled', False)
-        location_id = cleaned_data.get('location_id', None)
-        if atom_feed_enabled:
-            if len(white_listed_case_types) != 1:
-                raise ValidationError(_(
-                    'Specify a single case type so that CommCare can add cases using the Atom feed for patients '
-                    'created in OpenMRS/Bahmni.'
-                ))
-            if not location_id:
-                raise ValidationError(_(
-                    'Specify a location so that CommCare can set an owner for cases added via the Atom feed.'
-                ))
         return cleaned_data

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -420,9 +420,7 @@ class FormDictPayloadGenerator(BasePayloadGenerator):
     format_label = _('Python dictionary')
 
     def get_payload(self, repeat_record, form) -> dict:
-        from corehq.apps.api.util import form_to_es_form
-        es_form = form_to_es_form(form, include_attachments=True)
-        return {'form': es_form.form_data}
+        return form.to_json()
 
     @property
     def content_type(self):

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -415,6 +415,20 @@ class FormRepeaterJsonPayloadGenerator(BasePayloadGenerator):
         return self.get_payload(None, _get_test_form(domain))
 
 
+class FormDictPayloadGenerator(BasePayloadGenerator):
+    format_name = 'form_dict'
+    format_label = _('Python dictionary')
+
+    def get_payload(self, repeat_record, form) -> dict:
+        from corehq.apps.api.util import form_to_es_form
+        es_form = form_to_es_form(form, include_attachments=True)
+        return {'form': es_form.form_data}
+
+    @property
+    def content_type(self):
+        return 'application/x-python'
+
+
 class UserPayloadGenerator(BasePayloadGenerator):
 
     @property

--- a/corehq/motech/repeaters/views/__init__.py
+++ b/corehq/motech/repeaters/views/__init__.py
@@ -7,18 +7,11 @@ from .repeat_records import (
 )
 from .repeaters import (
     AddCaseRepeaterView,
-    AddDhis2EntityRepeaterView,
-    AddDhis2RepeaterView,
     AddFormRepeaterView,
-    AddOpenmrsRepeaterView,
     AddRepeaterView,
     DomainForwardingOptionsView,
     EditCaseRepeaterView,
-    EditDhis2RepeaterView,
     EditFormRepeaterView,
-    EditOpenmrsRepeaterView,
-    EditDhis2EntityRepeaterView,
-    EditDhis2RepeaterView,
     EditRepeaterView,
     drop_repeater,
     pause_repeater,

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -1,8 +1,7 @@
-import json
 from collections import namedtuple
 
 from django.contrib import messages
-from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
@@ -14,28 +13,19 @@ from memoized import memoized
 from corehq import privileges, toggles
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.domain.decorators import domain_admin_required
-from corehq.apps.domain.views.settings import (
-    BaseAdminProjectSettingsView,
-    BaseProjectSettingsView,
-)
+from corehq.apps.domain.views.settings import BaseAdminProjectSettingsView
 from corehq.apps.users.decorators import (
     require_can_edit_web_users,
     require_permission,
 )
 from corehq.apps.users.models import Permissions
 from corehq.motech.const import PASSWORD_PLACEHOLDER
-from corehq.motech.requests import simple_post
 
-from ..forms import (
-    CaseRepeaterForm,
-    FormRepeaterForm,
-    GenericRepeaterForm,
-    OpenmrsRepeaterForm,
-)
+from ..forms import CaseRepeaterForm, FormRepeaterForm, GenericRepeaterForm
 from ..models import Repeater, RepeatRecord, get_all_repeater_types
-from ..repeater_generators import RegisterGenerator
 
-RepeaterTypeInfo = namedtuple('RepeaterTypeInfo', 'class_name friendly_name has_config instances')
+RepeaterTypeInfo = namedtuple('RepeaterTypeInfo',
+                              'class_name friendly_name has_config instances')
 
 
 class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
@@ -46,13 +36,19 @@ class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
     @method_decorator(require_permission(Permissions.edit_motech))
     @method_decorator(requires_privilege_with_fallback(privileges.DATA_FORWARDING))
     def dispatch(self, request, *args, **kwargs):
-        return super(BaseProjectSettingsView, self).dispatch(request, *args, **kwargs)
+        return super().dispatch(request, *args, **kwargs)
 
     @property
     def repeater_types_info(self):
         return [
-            RepeaterTypeInfo(r.__name__, r.friendly_name, r._has_config, r.by_domain(self.domain))
-            for r in get_all_repeater_types().values() if r.available_for_domain(self.domain)
+            RepeaterTypeInfo(
+                class_name=r.__name__,
+                friendly_name=r.friendly_name,
+                has_config=r._has_config,
+                instances=r.by_domain(self.domain),
+            )
+            for r in get_all_repeater_types().values()
+            if r.available_for_domain(self.domain)
         ]
 
     @property
@@ -166,67 +162,9 @@ class AddRepeaterView(BaseRepeaterView):
 
     def post_save(self, request, repeater):
         messages.success(request, _("Forwarding set up to %s" % repeater.url))
-        return HttpResponseRedirect(reverse(DomainForwardingOptionsView.urlname, args=[self.domain]))
-
-
-class AddFormRepeaterView(AddRepeaterView):
-    urlname = 'add_form_repeater'
-    repeater_form_class = FormRepeaterForm
-
-    @property
-    def page_url(self):
-        return reverse(self.urlname, args=[self.domain])
-
-    def set_repeater_attr(self, repeater, cleaned_data):
-        repeater = super(AddFormRepeaterView, self).set_repeater_attr(repeater, cleaned_data)
-        repeater.include_app_id_param = self.add_repeater_form.cleaned_data['include_app_id_param']
-        return repeater
-
-
-class AddCaseRepeaterView(AddRepeaterView):
-    urlname = 'add_case_repeater'
-    repeater_form_class = CaseRepeaterForm
-
-    @property
-    def page_url(self):
-        return reverse(self.urlname, args=[self.domain])
-
-    def set_repeater_attr(self, repeater, cleaned_data):
-        repeater = super(AddCaseRepeaterView, self).set_repeater_attr(repeater, cleaned_data)
-        repeater.white_listed_case_types = self.add_repeater_form.cleaned_data['white_listed_case_types']
-        repeater.black_listed_users = self.add_repeater_form.cleaned_data['black_listed_users']
-        return repeater
-
-
-class AddOpenmrsRepeaterView(AddCaseRepeaterView):
-    urlname = 'new_openmrs_repeater$'
-    repeater_form_class = OpenmrsRepeaterForm
-    page_title = ugettext_lazy("Forward to OpenMRS")
-    page_name = ugettext_lazy("Forward to OpenMRS")
-
-    def set_repeater_attr(self, repeater, cleaned_data):
-        repeater = super(AddOpenmrsRepeaterView, self).set_repeater_attr(repeater, cleaned_data)
-        repeater.location_id = self.add_repeater_form.cleaned_data['location_id']
-        repeater.atom_feed_enabled = self.add_repeater_form.cleaned_data['atom_feed_enabled']
-        return repeater
-
-
-class AddDhis2RepeaterView(AddRepeaterView):
-    urlname = 'new_dhis2_repeater$'
-    repeater_form_class = GenericRepeaterForm
-    page_title = ugettext_lazy("Forward Forms to DHIS2 as Anonymous Events")
-    page_name = ugettext_lazy("Forward Forms to DHIS2 as Anonymous Events")
-
-    @property
-    def page_url(self):
-        return reverse(self.urlname, args=[self.domain])
-
-
-class AddDhis2EntityRepeaterView(AddDhis2RepeaterView):
-    urlname = 'new_dhis2_entity_repeater$'
-    repeater_form_class = GenericRepeaterForm
-    page_title = ugettext_lazy("Forward Cases to DHIS2 as Tracked Entities")
-    page_name = ugettext_lazy("Forward Cases to DHIS2 as Tracked Entities")
+        return HttpResponseRedirect(
+            reverse(DomainForwardingOptionsView.urlname, args=[self.domain])
+        )
 
 
 class EditRepeaterView(BaseRepeaterView):
@@ -239,10 +177,12 @@ class EditRepeaterView(BaseRepeaterView):
 
     @property
     def page_url(self):
-        # The EditRepeaterView url routes to the correct edit form for its subclasses. It does this with
-        # `repeater_type` in r'^forwarding/(?P<repeater_type>\w+)/edit/(?P<repeater_id>\w+)/$'
+        # The EditRepeaterView url routes to the correct edit form for
+        # its subclasses. It does this with `repeater_type` in
+        # r'^forwarding/(?P<repeater_type>\w+)/edit/(?P<repeater_id>\w+)/$'
         # See corehq/apps/domain/urls.py for details.
-        return reverse(EditRepeaterView.urlname, args=[self.domain, self.repeater_type, self.repeater_id])
+        return reverse(EditRepeaterView.urlname,
+                       args=[self.domain, self.repeater_type, self.repeater_id])
 
     @property
     @memoized
@@ -278,20 +218,28 @@ class EditRepeaterView(BaseRepeaterView):
         messages.success(request, _("Repeater Successfully Updated"))
         if self.request.GET.get('repeater_type'):
             return HttpResponseRedirect(
-                (reverse(self.urlname, args=[self.domain, repeater.get_id]) +
-                 '?repeater_type=' + self.kwargs['repeater_type'])
+                reverse(self.urlname, args=[self.domain, repeater.get_id])
+                + '?repeater_type=' + self.kwargs['repeater_type']
             )
         else:
-            return HttpResponseRedirect(reverse(self.urlname, args=[self.domain, repeater.get_id]))
+            return HttpResponseRedirect(
+                reverse(self.urlname, args=[self.domain, repeater.get_id])
+            )
 
 
-class EditCaseRepeaterView(EditRepeaterView, AddCaseRepeaterView):
-    urlname = 'edit_case_repeater'
-    page_title = ugettext_lazy("Edit Case Repeater")
+class AddFormRepeaterView(AddRepeaterView):
+    urlname = 'add_form_repeater'
+    repeater_form_class = FormRepeaterForm
 
     @property
     def page_url(self):
-        return reverse(AddCaseRepeaterView.urlname, args=[self.domain])
+        return reverse(self.urlname, args=[self.domain])
+
+    def set_repeater_attr(self, repeater, cleaned_data):
+        repeater = super().set_repeater_attr(repeater, cleaned_data)
+        repeater.include_app_id_param = (
+            self.add_repeater_form.cleaned_data['include_app_id_param'])
+        return repeater
 
 
 class EditFormRepeaterView(EditRepeaterView, AddFormRepeaterView):
@@ -303,19 +251,30 @@ class EditFormRepeaterView(EditRepeaterView, AddFormRepeaterView):
         return reverse(AddFormRepeaterView.urlname, args=[self.domain])
 
 
-class EditOpenmrsRepeaterView(EditRepeaterView, AddOpenmrsRepeaterView):
-    urlname = 'edit_openmrs_repeater'
-    page_title = ugettext_lazy("Edit OpenMRS Repeater")
+class AddCaseRepeaterView(AddRepeaterView):
+    urlname = 'add_case_repeater'
+    repeater_form_class = CaseRepeaterForm
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname, args=[self.domain])
+
+    def set_repeater_attr(self, repeater, cleaned_data):
+        repeater = super().set_repeater_attr(repeater, cleaned_data)
+        repeater.white_listed_case_types = (
+            self.add_repeater_form.cleaned_data['white_listed_case_types'])
+        repeater.black_listed_users = (
+            self.add_repeater_form.cleaned_data['black_listed_users'])
+        return repeater
 
 
-class EditDhis2RepeaterView(EditRepeaterView, AddDhis2RepeaterView):
-    urlname = 'edit_dhis2_repeater'
-    page_title = ugettext_lazy("Edit DHIS2 Anonymous Event Repeater")
+class EditCaseRepeaterView(EditRepeaterView, AddCaseRepeaterView):
+    urlname = 'edit_case_repeater'
+    page_title = ugettext_lazy("Edit Case Repeater")
 
-
-class EditDhis2EntityRepeaterView(EditRepeaterView, AddDhis2EntityRepeaterView):
-    urlname = 'edit_dhis2_entity_repeater'
-    page_title = ugettext_lazy("Edit DHIS2 Tracked Entity Repeater")
+    @property
+    def page_url(self):
+        return reverse(AddCaseRepeaterView.urlname, args=[self.domain])
 
 
 @require_POST
@@ -325,7 +284,9 @@ def drop_repeater(request, domain, repeater_id):
     rep = Repeater.get(repeater_id)
     rep.retire()
     messages.success(request, "Forwarding stopped!")
-    return HttpResponseRedirect(reverse(DomainForwardingOptionsView.urlname, args=[domain]))
+    return HttpResponseRedirect(
+        reverse(DomainForwardingOptionsView.urlname, args=[domain])
+    )
 
 
 @require_POST
@@ -335,7 +296,9 @@ def pause_repeater(request, domain, repeater_id):
     rep = Repeater.get(repeater_id)
     rep.pause()
     messages.success(request, "Forwarding paused!")
-    return HttpResponseRedirect(reverse(DomainForwardingOptionsView.urlname, args=[domain]))
+    return HttpResponseRedirect(
+        reverse(DomainForwardingOptionsView.urlname, args=[domain])
+    )
 
 
 @require_POST
@@ -345,4 +308,6 @@ def resume_repeater(request, domain, repeater_id):
     rep = Repeater.get(repeater_id)
     rep.resume()
     messages.success(request, "Forwarding resumed!")
-    return HttpResponseRedirect(reverse(DomainForwardingOptionsView.urlname, args=[domain]))
+    return HttpResponseRedirect(
+        reverse(DomainForwardingOptionsView.urlname, args=[domain])
+    )

--- a/corehq/motech/urls.py
+++ b/corehq/motech/urls.py
@@ -1,23 +1,25 @@
 from django.conf.urls import url
 
 from corehq.motech.dhis2.views import (
+    AddDhis2EntityRepeaterView,
+    AddDhis2RepeaterView,
+    EditDhis2EntityRepeaterView,
+    EditDhis2RepeaterView,
     config_dhis2_entity_repeater,
     config_dhis2_repeater,
 )
-from corehq.motech.openmrs.views import config_openmrs_repeater
+from corehq.motech.openmrs.views import (
+    AddOpenmrsRepeaterView,
+    EditOpenmrsRepeaterView,
+    config_openmrs_repeater,
+)
 from corehq.motech.repeaters.views import (
     AddCaseRepeaterView,
-    AddDhis2EntityRepeaterView,
-    AddDhis2RepeaterView,
     AddFormRepeaterView,
-    AddOpenmrsRepeaterView,
     AddRepeaterView,
     DomainForwardingOptionsView,
     EditCaseRepeaterView,
-    EditDhis2EntityRepeaterView,
-    EditDhis2RepeaterView,
     EditFormRepeaterView,
-    EditOpenmrsRepeaterView,
     EditRepeaterView,
     drop_repeater,
     pause_repeater,

--- a/corehq/motech/urls.py
+++ b/corehq/motech/urls.py
@@ -8,6 +8,7 @@ from corehq.motech.dhis2.views import (
     config_dhis2_entity_repeater,
     config_dhis2_repeater,
 )
+from corehq.motech.fhir.views import AddFHIRRepeaterView, EditFHIRRepeaterView
 from corehq.motech.openmrs.views import (
     AddOpenmrsRepeaterView,
     EditOpenmrsRepeaterView,
@@ -54,6 +55,8 @@ urlpatterns = [
         {'repeater_type': 'Dhis2Repeater'}, name=AddDhis2RepeaterView.urlname),
     url(r'^forwarding/new/Dhis2EntityRepeater/$', AddDhis2EntityRepeaterView.as_view(),
         {'repeater_type': 'Dhis2EntityRepeater'}, name=AddDhis2EntityRepeaterView.urlname),
+    url(r'^forwarding/new/FHIRRepeater/$', AddFHIRRepeaterView.as_view(),
+        {'repeater_type': 'FHIRRepeater'}, name=AddFHIRRepeaterView.urlname),
     url(r'^forwarding/new/SearchByParamsRepeater/$', AddCaseRepeaterView.as_view(),
         {'repeater_type': 'SearchByParamsRepeater'}, name=AddCaseRepeaterView.urlname),
     url(r'^forwarding/new/ReferCaseRepeater/$', AddCaseRepeaterView.as_view(),
@@ -72,6 +75,8 @@ urlpatterns = [
         {'repeater_type': 'Dhis2Repeater'}, name=EditDhis2RepeaterView.urlname),
     url(r'^forwarding/edit/Dhis2EntityRepeater/(?P<repeater_id>\w+)/$', EditDhis2EntityRepeaterView.as_view(),
         {'repeater_type': 'Dhis2EntityRepeater'}, name=EditDhis2EntityRepeaterView.urlname),
+    url(r'^forwarding/edit/FHIRRepeater/(?P<repeater_id>\w+)/$', EditFHIRRepeaterView.as_view(),
+        {'repeater_type': 'FHIRRepeater'}, name=EditFHIRRepeaterView.urlname),
     url(r'^forwarding/edit/(?P<repeater_type>\w+)/(?P<repeater_id>\w+)/$', EditRepeaterView.as_view(),
         name=EditRepeaterView.urlname),
 

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -1,6 +1,6 @@
 import json
 from base64 import b64decode, b64encode
-from typing import Optional
+from typing import Optional, Sequence
 
 from django.conf import settings
 
@@ -168,3 +168,22 @@ def get_endpoint_url(
     if endpoint is None:
         return base_url
     return '/'.join((base_url.rstrip('/'), endpoint.lstrip('/')))
+
+
+def simplify_list(seq: Sequence):
+    """
+    Reduces ``seq`` to its only element, or ``None`` if it is empty.
+
+    >>> simplify_list([1])
+    1
+    >>> simplify_list([1, 2, 3])
+    [1, 2, 3]
+    >>> type(simplify_list([]))
+    <class 'NoneType'>
+
+    """
+    if len(seq) == 1:
+        return seq[0]
+    if not seq:
+        return None
+    return seq

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -22,8 +22,10 @@ from corehq.motech.const import (
     DIRECTION_IMPORT,
     DIRECTIONS,
 )
-from corehq.motech.exceptions import ConfigurationError, JsonpathError
-from corehq.motech.serializers import serializers
+
+from .exceptions import ConfigurationError, JsonpathError
+from .serializers import serializers
+from .utils import simplify_list
 
 
 @attr.s
@@ -137,12 +139,7 @@ class ValueSource:
             raise JsonpathError from err
         matches = jsonpath.find(external_data)
         values = [m.value for m in matches]
-        if not values:
-            return None
-        elif len(values) == 1:
-            return values[0]
-        else:
-            return values
+        return simplify_list(values)
 
     def set_external_value(self, external_data: dict, info: CaseTriggerInfo):
         """

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -66,6 +66,7 @@ jsonobject==0.9.9
 # jsonpath-ng with support for "wherenot" operator, and building documents
 # Upgrade when changes merged upstream
 jsonpath-ng @ https://github.com/kaapstorm/python-jsonpath-rw/raw/wherenot+find_or_create/wheel/jsonpath_ng-1.5.2.2-py3-none-any.whl
+jsonschema~=3.2
 kafka-python==1.4.7
 kombu==4.2.2.post1
 billiard!=3.5.0.5  # Should be resolved in celery 4.3: https://github.com/celery/billiard/issues/260

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -15,7 +15,9 @@ architect==0.5.6
 argparse==1.4.0
     # via unittest2
 attrs==18.2.0
-    # via -r base-requirements.in
+    # via
+    #   -r base-requirements.in
+    #   jsonschema
 babel==2.8.0
     # via
     #   django-phonenumber-field
@@ -272,7 +274,9 @@ idna==2.10
 imagesize==1.2.0
     # via sphinx
 importlib-metadata==2.0.0
-    # via flake8
+    # via
+    #   flake8
+    #   jsonschema
 intervaltree==3.1.0
     # via ddtrace
 ipdb==0.11
@@ -315,6 +319,8 @@ jsonobject==0.9.9
     #   git-build-branch
     #   jsonobject-couchdbkit
 https://github.com/kaapstorm/python-jsonpath-rw/raw/wherenot+find_or_create/wheel/jsonpath_ng-1.5.2.2-py3-none-any.whl
+    # via -r base-requirements.in
+jsonschema==3.2.0
     # via -r base-requirements.in
 kafka-python==1.4.7
     # via -r base-requirements.in
@@ -442,6 +448,8 @@ pyphen==0.9.5
     # via weasyprint
 pyrepl==0.9.0
     # via fancycompleter
+pyrsistent==0.17.3
+    # via jsonschema
 pysocks==1.7.1
     # via twilio
 pystache==0.5.4
@@ -557,6 +565,7 @@ six==1.15.0
     #   jsonobject
     #   jsonobject-couchdbkit
     #   jsonpath-ng
+    #   jsonschema
     #   mock
     #   packaging
     #   protobuf
@@ -707,6 +716,7 @@ setuptools==50.3.0
     #   gunicorn
     #   ipdb
     #   ipython
+    #   jsonschema
     #   protobuf
     #   python-levenshtein
     #   python-termstyle

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -13,7 +13,9 @@ amqp==2.6.1
 architect==0.5.6
     # via -r base-requirements.in
 attrs==18.2.0
-    # via -r base-requirements.in
+    # via
+    #   -r base-requirements.in
+    #   jsonschema
 babel==2.8.0
     # via
     #   django-phonenumber-field
@@ -227,6 +229,8 @@ idna==2.10
     #   requests
 imagesize==1.2.0
     # via sphinx
+importlib-metadata==3.4.0
+    # via jsonschema
 intervaltree==3.1.0
     # via ddtrace
 iso8601==0.1.13
@@ -254,6 +258,8 @@ jsonobject==0.9.9
     #   -r base-requirements.in
     #   jsonobject-couchdbkit
 https://github.com/kaapstorm/python-jsonpath-rw/raw/wherenot+find_or_create/wheel/jsonpath_ng-1.5.2.2-py3-none-any.whl
+    # via -r base-requirements.in
+jsonschema==3.2.0
     # via -r base-requirements.in
 kafka-python==1.4.7
     # via -r base-requirements.in
@@ -338,6 +344,8 @@ pyparsing==2.4.7
     # via packaging
 pyphen==0.9.5
     # via weasyprint
+pyrsistent==0.17.3
+    # via jsonschema
 pysocks==1.7.1
     # via twilio
 pystache==0.5.4
@@ -436,6 +444,7 @@ six==1.15.0
     #   jsonobject
     #   jsonobject-couchdbkit
     #   jsonpath-ng
+    #   jsonschema
     #   mock
     #   protobuf
     #   python-dateutil
@@ -498,6 +507,8 @@ turn-python==0.0.1
     # via -r base-requirements.in
 twilio==6.5.1
     # via -r base-requirements.in
+typing-extensions==3.7.4.3
+    # via importlib-metadata
 ua-parser==0.10.0
     # via user-agents
 urllib3==1.25.10
@@ -528,6 +539,8 @@ xlrd==1.0.0
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
+zipp==3.4.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==53.0.0
@@ -536,6 +549,7 @@ setuptools==53.0.0
     #   cssselect2
     #   django-websocket-redis
     #   gunicorn
+    #   jsonschema
     #   protobuf
     #   python-levenshtein
     #   sphinx

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -11,7 +11,9 @@ amqp==2.6.1
 architect==0.5.6
     # via -r base-requirements.in
 attrs==18.2.0
-    # via -r base-requirements.in
+    # via
+    #   -r base-requirements.in
+    #   jsonschema
 babel==2.8.0
     # via
     #   django-phonenumber-field
@@ -229,6 +231,8 @@ idna==2.10
     #   -r prod-requirements.in
     #   email-validator
     #   requests
+importlib-metadata==3.4.0
+    # via jsonschema
 intervaltree==3.1.0
     # via ddtrace
 ipython-genutils==0.2.0
@@ -262,6 +266,8 @@ jsonobject==0.9.9
     #   -r base-requirements.in
     #   jsonobject-couchdbkit
 https://github.com/kaapstorm/python-jsonpath-rw/raw/wherenot+find_or_create/wheel/jsonpath_ng-1.5.2.2-py3-none-any.whl
+    # via -r base-requirements.in
+jsonschema==3.2.0
     # via -r base-requirements.in
 kafka-python==1.4.7
     # via -r base-requirements.in
@@ -364,6 +370,8 @@ pyopenssl==20.0.1
     #   ndg-httpsclient
 pyphen==0.9.5
     # via weasyprint
+pyrsistent==0.17.3
+    # via jsonschema
 pysocks==1.7.1
     # via twilio
 pystache==0.5.4
@@ -465,6 +473,7 @@ six==1.15.0
     #   jsonobject
     #   jsonobject-couchdbkit
     #   jsonpath-ng
+    #   jsonschema
     #   mock
     #   protobuf
     #   pyopenssl
@@ -519,6 +528,8 @@ turn-python==0.0.1
     # via -r base-requirements.in
 twilio==6.5.1
     # via -r base-requirements.in
+typing-extensions==3.7.4.3
+    # via importlib-metadata
 ua-parser==0.10.0
     # via user-agents
 urllib3==1.25.10
@@ -555,6 +566,8 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.9
     # via python3-saml
+zipp==3.4.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==20.2.3
@@ -566,6 +579,7 @@ setuptools==50.3.0
     #   django-websocket-redis
     #   gunicorn
     #   ipython
+    #   jsonschema
     #   protobuf
     #   python-levenshtein
     #   tinycss2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -11,7 +11,9 @@ amqp==2.6.1
 architect==0.5.6
     # via -r base-requirements.in
 attrs==18.2.0
-    # via -r base-requirements.in
+    # via
+    #   -r base-requirements.in
+    #   jsonschema
 babel==2.8.0
     # via django-phonenumber-field
 billiard==3.5.0.4
@@ -216,6 +218,8 @@ idna==2.10
     # via
     #   email-validator
     #   requests
+importlib-metadata==3.4.0
+    # via jsonschema
 intervaltree==3.1.0
     # via ddtrace
 iso8601==0.1.13
@@ -243,6 +247,8 @@ jsonobject==0.9.9
     #   -r base-requirements.in
     #   jsonobject-couchdbkit
 https://github.com/kaapstorm/python-jsonpath-rw/raw/wherenot+find_or_create/wheel/jsonpath_ng-1.5.2.2-py3-none-any.whl
+    # via -r base-requirements.in
+jsonschema==3.2.0
     # via -r base-requirements.in
 kafka-python==1.4.7
     # via -r base-requirements.in
@@ -325,6 +331,8 @@ pyopenssl==20.0.1
     # via -r sso-requirements.in
 pyphen==0.9.5
     # via weasyprint
+pyrsistent==0.17.3
+    # via jsonschema
 pysocks==1.7.1
     # via twilio
 pystache==0.5.4
@@ -423,6 +431,7 @@ six==1.15.0
     #   jsonobject
     #   jsonobject-couchdbkit
     #   jsonpath-ng
+    #   jsonschema
     #   mock
     #   protobuf
     #   pyopenssl
@@ -470,6 +479,8 @@ turn-python==0.0.1
     # via -r base-requirements.in
 twilio==6.5.1
     # via -r base-requirements.in
+typing-extensions==3.7.4.3
+    # via importlib-metadata
 ua-parser==0.10.0
     # via user-agents
 urllib3==1.25.10
@@ -502,6 +513,8 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.9
     # via python3-saml
+zipp==3.4.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==50.3.0
@@ -510,6 +523,7 @@ setuptools==50.3.0
     #   cssselect2
     #   django-websocket-redis
     #   gunicorn
+    #   jsonschema
     #   protobuf
     #   python-levenshtein
     #   tinycss2

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -13,7 +13,9 @@ architect==0.5.6
 argparse==1.4.0
     # via unittest2
 attrs==18.2.0
-    # via -r base-requirements.in
+    # via
+    #   -r base-requirements.in
+    #   jsonschema
 babel==2.8.0
     # via django-phonenumber-field
 beautifulsoup4==4.9.3
@@ -230,6 +232,8 @@ idna==2.10
     # via
     #   email-validator
     #   requests
+importlib-metadata==3.4.0
+    # via jsonschema
 intervaltree==3.1.0
     # via ddtrace
 iso8601==0.1.13
@@ -257,6 +261,8 @@ jsonobject==0.9.9
     #   -r base-requirements.in
     #   jsonobject-couchdbkit
 https://github.com/kaapstorm/python-jsonpath-rw/raw/wherenot+find_or_create/wheel/jsonpath_ng-1.5.2.2-py3-none-any.whl
+    # via -r base-requirements.in
+jsonschema==3.2.0
     # via -r base-requirements.in
 kafka-python==1.4.7
     # via -r base-requirements.in
@@ -352,6 +358,8 @@ pyopenssl==20.0.1
     # via -r sso-requirements.in
 pyphen==0.9.5
     # via weasyprint
+pyrsistent==0.17.3
+    # via jsonschema
 pysocks==1.7.1
     # via twilio
 pystache==0.5.4
@@ -455,6 +463,7 @@ six==1.15.0
     #   jsonobject
     #   jsonobject-couchdbkit
     #   jsonpath-ng
+    #   jsonschema
     #   mock
     #   protobuf
     #   pyopenssl
@@ -514,6 +523,8 @@ turn-python==0.0.1
     # via -r base-requirements.in
 twilio==6.5.1
     # via -r base-requirements.in
+typing-extensions==3.7.4.3
+    # via importlib-metadata
 ua-parser==0.10.0
     # via user-agents
 unittest2==1.1.0
@@ -548,6 +559,8 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.9
     # via python3-saml
+zipp==3.4.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==20.2.3
@@ -558,6 +571,7 @@ setuptools==50.3.0
     #   cssselect2
     #   django-websocket-redis
     #   gunicorn
+    #   jsonschema
     #   protobuf
     #   python-levenshtein
     #   tinycss2

--- a/settings.py
+++ b/settings.py
@@ -812,6 +812,7 @@ REPEATER_CLASSES = [
     'corehq.motech.repeaters.models.AppStructureRepeater',
     'corehq.motech.repeaters.models.UserRepeater',
     'corehq.motech.repeaters.models.LocationRepeater',
+    'corehq.motech.fhir.repeaters.FHIRRepeater',
     'corehq.motech.openmrs.repeaters.OpenmrsRepeater',
     'corehq.motech.dhis2.repeaters.Dhis2Repeater',
     'corehq.motech.dhis2.repeaters.Dhis2EntityRepeater',


### PR DESCRIPTION
## Summary

FHIRRepeater forwards CommCare data to remote FHIR APIs.

Builds on a few other PRs:
* #29249
* #29250
* #29258
* #29260

Commits not PRed already start from "[FHIRRepeater, form, views](https://github.com/dimagi/commcare-hq/commit/7d031a2cd79670a25dc69928872a650b120968c9)"

Opening as a draft PR because there are three outstanding tasks:
* [ ] More tests for `ResourceMatcher`
* [ ] Tests for `ResourceSearcher`
* [x] More tests to understand data types of case property values: I have noticed case property value `1.5` serialized in JSON a float, but `"1.5"` as a Decimal.


## Feature Flag

"FHIR Integration"


## Product Description

FHIR data forwarding: Forward CommCare data as FHIR resources.


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Automated test coverage

Reasonable coverage. See PR above regarding test coverage for `ResourceMatcher` and `ResourceSearcher` classes. If you notice any gaps in coverage, please comment in this PR.


### QA Plan

QA is taking place during March. QA team is briefed. They will be paying special attention to the areas not covered by automated tests, especially how FHIR interprets the payloads we send, and specifically understands the relationships between resources.


### Safety story

This code will have undergone thorough testing on Staging by the time it is merged.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
