### PR TITLE
Renamed Application.master_id => origin_id

### DIFF
--- a/corehq/apps/app_manager/management/commands/add_resource_overrides.py
+++ b/corehq/apps/app_manager/management/commands/add_resource_overrides.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
         linked_build = wrap_app(doc)
         log_prefix = "{}{} app {}, build {}".format("[DRY RUN] " if self.dry_run else "",
                                                     linked_build.domain,
-                                                    linked_build.master_id,
+                                                    linked_build.origin_id,
                                                     linked_build.get_id)
 
         if not linked_build.upstream_app_id or not linked_build.upstream_version:
@@ -66,7 +66,7 @@ class Command(BaseCommand):
         current_overrides = {
             pre_id: override.post_id
             for pre_id, override
-            in get_xform_resource_overrides(linked_build.domain, linked_build.master_id).items()
+            in get_xform_resource_overrides(linked_build.domain, linked_build.origin_id).items()
         }
         if set(override_map.items()) - set(current_overrides.items()):
             logger.info("{}: Found {} overrides, updating with {}".format(log_prefix,
@@ -74,7 +74,7 @@ class Command(BaseCommand):
                                                                           len(override_map)))
             if not self.dry_run:
                 try:
-                    add_xform_resource_overrides(linked_build.domain, linked_build.master_id, override_map)
+                    add_xform_resource_overrides(linked_build.domain, linked_build.origin_id, override_map)
                 except ResourceOverrideError as e:
                     logger.error("{}".format(str(e)))   # skip log_prefix, error message has same info
         else:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5674,8 +5674,8 @@ class LinkedApplication(Application):
         if self.domain_link:
             versions = get_latest_master_releases_versions(self.domain_link)
             # Use self.get_master_app_briefs to limit return value by family_id
-            origin_ids = [b.id for b in self.get_master_app_briefs()]
-            return {key: value for key, value in versions.items() if key in origin_ids}
+            upstream_ids = [b.id for b in self.get_master_app_briefs()]
+            return {key: value for key, value in versions.items() if key in upstream_ids}
         return {}
 
     @memoized

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4069,9 +4069,8 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
         return self._id
 
     @property
-    def master_id(self):
-        """Return the ID of the 'master' app. For app builds this is the ID
-        of the app they were built from otherwise it's just the app's ID."""
+    def origin_id(self):
+        # For app builds this is the ID of the app they were built from. Otherwise, it's just the app's ID.
         return self.copy_of or self._id
 
     def is_deleted(self):
@@ -4152,8 +4151,8 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
     @memoized
     def get_latest_build(self):
         return self.view('app_manager/applications',
-            startkey=[self.domain, self.master_id, {}],
-            endkey=[self.domain, self.master_id],
+            startkey=[self.domain, self.origin_id, {}],
+            endkey=[self.domain, self.origin_id],
             include_docs=True,
             limit=1,
             descending=True,
@@ -4964,7 +4963,7 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
             'app_profile': app_profile,
             'cc_user_domain': cc_user_domain(self.domain),
             'include_media_suite': with_media,
-            'uniqueid': self.master_id,
+            'uniqueid': self.origin_id,
             'name': self.name,
             'descriptor': "Profile File",
             'build_profile_id': build_profile_id,
@@ -5675,13 +5674,13 @@ class LinkedApplication(Application):
         if self.domain_link:
             versions = get_latest_master_releases_versions(self.domain_link)
             # Use self.get_master_app_briefs to limit return value by family_id
-            master_ids = [b.id for b in self.get_master_app_briefs()]
-            return {key: value for key, value in versions.items() if key in master_ids}
+            origin_ids = [b.id for b in self.get_master_app_briefs()]
+            return {key: value for key, value in versions.items() if key in origin_ids}
         return {}
 
     @memoized
     def get_latest_build_from_upstream(self, upstream_app_id):
-        build_ids = get_build_ids(self.domain, self.master_id)
+        build_ids = get_build_ids(self.domain, self.origin_id)
         for build_id in build_ids:
             build_doc = Application.get_db().get(build_id)
             if build_doc.get('upstream_app_id') == upstream_app_id:
@@ -5734,7 +5733,7 @@ def import_app(app_id_or_source, domain, source_properties=None, request=None, c
     app.date_created = datetime.datetime.utcnow()
     app.cloudcare_enabled = domain_has_privilege(domain, privileges.CLOUDCARE)
     if source_domain == domain:
-        app.family_id = source_app.master_id
+        app.family_id = source_app.origin_id
 
     report_map = get_static_report_mapping(source_domain, domain)
     if report_map:
@@ -5860,7 +5859,7 @@ class GlobalAppConfig(models.Model):
 
     @classmethod
     def by_app(cls, app):
-        model = cls.by_app_id(app.domain, app.master_id)
+        model = cls.by_app_id(app.domain, app.origin_id)
         model._app = app
         return model
 
@@ -5883,7 +5882,7 @@ class GlobalAppConfig(models.Model):
     def app(self):
         if not self._app:
             app = get_app(self.domain, self.app_id, latest=True, target='release')
-            assert self.app_id == app.master_id, "this class doesn't handle copy app ids"
+            assert self.app_id == app.origin_id, "this class doesn't handle copy app ids"
             self._app = app
         return self._app
 

--- a/corehq/apps/app_manager/suite_xml/post_process/resources.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/resources.py
@@ -90,7 +90,7 @@ class ResourceOverrideHelper(PostProcessor):
         """
         Applies manual overrides of resource ids.
         """
-        overrides_by_pre_id = get_xform_resource_overrides(self.app.domain, self.app.master_id)
+        overrides_by_pre_id = get_xform_resource_overrides(self.app.domain, self.app.origin_id)
         resources = getattr(self.suite, FormResourceContributor.section_name)
         for resource in resources:
             if resource.id in overrides_by_pre_id:

--- a/corehq/apps/app_manager/tests/test_suite_resource_overrides.py
+++ b/corehq/apps/app_manager/tests/test_suite_resource_overrides.py
@@ -23,7 +23,7 @@ class SuiteResourceOverridesTest(TestCase, TestXmlMixin):
 
     def test_overrides(self):
         forms = list(self.factory.app.get_module(0).get_forms())
-        add_xform_resource_overrides(self.factory.app.domain, self.factory.app.master_id, {
+        add_xform_resource_overrides(self.factory.app.domain, self.factory.app.origin_id, {
             forms[0].unique_id: '123',
             forms[1].unique_id: '456',
         })
@@ -53,7 +53,7 @@ class SuiteResourceOverridesTest(TestCase, TestXmlMixin):
 
     def test_duplicate_overrides_raises(self):
         forms = list(self.factory.app.get_module(0).get_forms())
-        add_xform_resource_overrides(self.factory.app.domain, self.factory.app.master_id, {
+        add_xform_resource_overrides(self.factory.app.domain, self.factory.app.origin_id, {
             forms[0].unique_id: '123',
             forms[1].unique_id: '456',
             forms[2].unique_id: '456',
@@ -63,17 +63,17 @@ class SuiteResourceOverridesTest(TestCase, TestXmlMixin):
 
     def test_copy_xform_resource_overrides(self):
         forms = list(self.factory.app.get_module(0).get_forms())
-        add_xform_resource_overrides(self.factory.app.domain, self.factory.app.master_id, {
+        add_xform_resource_overrides(self.factory.app.domain, self.factory.app.origin_id, {
             forms[0].unique_id: '123',
             forms[1].unique_id: '456',
         })
 
-        copy_xform_resource_overrides(self.factory.app.domain, self.factory.app.master_id, {
+        copy_xform_resource_overrides(self.factory.app.domain, self.factory.app.origin_id, {
             forms[0].unique_id: '321',
             '123': '987',
         })
 
-        overrides = get_xform_resource_overrides(self.factory.app.domain, self.factory.app.master_id)
+        overrides = get_xform_resource_overrides(self.factory.app.domain, self.factory.app.origin_id)
         self.assertEqual({o.pre_id: o.post_id for o in overrides.values()}, {
             forms[0].unique_id: '123',
             forms[1].unique_id: '456',

--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -99,7 +99,7 @@ class TestGlobalAppConfig(TestCase):
             app_config = self.app.global_app_config
             app_config.apk_prompt = config
             app_config.save()
-            config = GlobalAppConfig.by_app_id(self.domain, self.app.master_id)
+            config = GlobalAppConfig.by_app_id(self.domain, self.app.origin_id)
             self.assertEqual(
                 config.get_latest_apk_version(),
                 response
@@ -119,7 +119,7 @@ class TestGlobalAppConfig(TestCase):
             app_config = self.app.global_app_config
             app_config.apk_prompt = config
             app_config.save()
-            config = GlobalAppConfig.by_app_id(self.domain, self.app.master_id)
+            config = GlobalAppConfig.by_app_id(self.domain, self.app.origin_id)
             self.assertEqual(
                 config.get_latest_apk_version(),
                 response
@@ -140,7 +140,7 @@ class TestGlobalAppConfig(TestCase):
             app_config = self.app.global_app_config
             app_config.app_prompt = config
             app_config.save()
-            config = GlobalAppConfig.by_app_id(self.domain, self.app.master_id)
+            config = GlobalAppConfig.by_app_id(self.domain, self.app.origin_id)
             self.assertEqual(
                 config.get_latest_app_version(build_profile_id),
                 response
@@ -160,7 +160,7 @@ class TestGlobalAppConfig(TestCase):
             app_config = self.app.global_app_config
             app_config.app_prompt = config
             app_config.save()
-            config = GlobalAppConfig.by_app_id(self.domain, self.app.master_id)
+            config = GlobalAppConfig.by_app_id(self.domain, self.app.origin_id)
             self.assertEqual(
                 config.get_latest_app_version(build_profile_id=''),
                 response

--- a/corehq/apps/app_manager/views/app_summary.py
+++ b/corehq/apps/app_manager/views/app_summary.py
@@ -51,9 +51,9 @@ class AppSummaryView(LoginAndDomainMixin, BasePageView, ApplicationViewMixin):
             'app_langs': app.langs,
             'app_id': app.id,
             'app_name': app.name,
-            'read_only': is_linked_app(app) or app.id != app.master_id,
+            'read_only': is_linked_app(app) or app.id != app.origin_id,
             'app_version': app.version,
-            'latest_app_id': app.master_id,
+            'latest_app_id': app.origin_id,
         }
 
     @property
@@ -111,7 +111,7 @@ class FormSummaryDiffView(AppSummaryView):
 
     @property
     def app(self):
-        return self.get_app(self.first_app.master_id)
+        return self.get_app(self.first_app.origin_id)
 
     @property
     def first_app(self):
@@ -125,7 +125,7 @@ class FormSummaryDiffView(AppSummaryView):
     def page_context(self):
         context = super(FormSummaryDiffView, self).page_context
 
-        if self.first_app.master_id != self.second_app.master_id:
+        if self.first_app.origin_id != self.second_app.origin_id:
             # This restriction is somewhat arbitrary, as you might want to
             # compare versions between two different apps on the same domain.
             # However, it breaks a bunch of assumptions in the UI
@@ -138,7 +138,7 @@ class FormSummaryDiffView(AppSummaryView):
 
         context.update({
             'page_type': 'form_diff',
-            'app_id': self.app.master_id,
+            'app_id': self.app.origin_id,
             'first': first,
             'second': second,
         })

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -474,14 +474,14 @@ def _create_linked_app(request, app_id, build_id, from_domain, to_domain, link_a
         messages.error(request, _("Creating linked app failed. {}").format(error))
         return HttpResponseRedirect(reverse_util('app_settings', params={}, args=[from_domain, app_id]))
 
-    linked_app = create_linked_app(from_domain, from_app.master_id, to_domain, link_app_name)
+    linked_app = create_linked_app(from_domain, from_app.origin_id, to_domain, link_app_name)
     try:
         update_linked_app(linked_app, from_app, request.couch_user.get_id)
     except AppLinkError as e:
         linked_app.delete()
         messages.error(request, str(e))
         return HttpResponseRedirect(reverse_util('app_settings', params={},
-                                                 args=[from_domain, from_app.master_id]))
+                                                 args=[from_domain, from_app.origin_id]))
 
     messages.success(request, _('Application successfully copied and linked.'))
     return HttpResponseRedirect(reverse_util('app_settings', params={}, args=[to_domain, linked_app.get_id]))

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -340,7 +340,7 @@ def update_linked_app(app, master_app_id_or_build, user_id):
             ))
     else:
         master_build = master_app_id_or_build
-    master_app_id = master_build.master_id
+    master_app_id = master_build.origin_id
 
     previous = app.get_latest_build_from_upstream(master_app_id)
     if (

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -257,7 +257,7 @@ class FormplayerPreviewSingleApp(View):
             raise Http404()
 
         role = request.couch_user.get_role(domain)
-        if role and not role.permissions.view_web_app(app.master_id):
+        if role and not role.permissions.view_web_app(app.origin_id):
             raise Http404()
 
         def _default_lang():

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1847,7 +1847,7 @@ class FormExportDataSchema(ExportDataSchema):
         xform_schema = cls._generate_schema_from_xform(
             xform,
             app.langs,
-            app.master_id,  # If it's not a copy, must be current
+            app.origin_id,  # If it's not a copy, must be current
             app.version,
         )
 
@@ -2156,18 +2156,18 @@ class CaseExportDataSchema(ExportDataSchema):
         case_schemas.append(cls._generate_schema_from_case_property_mapping(
             case_property_mapping,
             parent_types,
-            app.master_id,  # If not copy, must be current app
+            app.origin_id,  # If not copy, must be current app
             app.version,
         ))
         if any([relationship_tuple[1] in ['parent', 'host'] for relationship_tuple in parent_types]):
             case_schemas.append(cls._generate_schema_for_parent_case(
-                app.master_id,
+                app.origin_id,
                 app.version,
             ))
 
         case_schemas.append(cls._generate_schema_for_case_history(
             case_property_mapping,
-            app.master_id,
+            app.origin_id,
             app.version,
         ))
         case_schemas.append(current_schema)

--- a/corehq/apps/hqadmin/templates/hqadmin/app_build_timings.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/app_build_timings.html
@@ -14,10 +14,10 @@
   <div class="container-fluid">
     <h1>App Build Timings</h1>
     <h4>
-      <a href="{% url 'view_app' app.domain app.master_id %}">
+      <a href="{% url 'view_app' app.domain app.origin_id %}">
         {{ app.name }}
       </a>
-      <small>{{ app.master_id }}</small>
+      <small>{{ app.origin_id }}</small>
     </h4>
 
     <div class="row">

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -254,7 +254,7 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
 
     app = get_app_cached(domain, app_id) if app_id else None
     if app:
-        error_response = check_authorization(domain, couch_user, app.master_id)
+        error_response = check_authorization(domain, couch_user, app.origin_id)
         if error_response:
             return error_response, None
     restore_config = RestoreConfig(
@@ -303,8 +303,8 @@ def heartbeat(request, domain, app_build_id):
         # If it's not a valid master app id, find it by talking to couch
         app = get_app_cached(domain, app_build_id)
         notify_exception(request, 'Received an invalid heartbeat request')
-        master_app_id = app.master_id if app else None
-        info = GlobalAppConfig.get_latest_version_info(domain, app.master_id, build_profile_id)
+        master_app_id = app.origin_id if app else None
+        info = GlobalAppConfig.get_latest_version_info(domain, app.origin_id, build_profile_id)
 
     info["app_id"] = app_id
     if master_app_id:
@@ -391,7 +391,7 @@ def get_recovery_measures_cached(domain, app_id):
 @require_GET
 @toggles.MOBILE_RECOVERY_MEASURES.required_decorator()
 def recovery_measures(request, domain, build_id):
-    app_id = get_app_cached(domain, build_id).master_id
+    app_id = get_app_cached(domain, build_id).origin_id
     response = {
         "latest_apk_version": get_default_build_spec().version,
         "latest_ccz_version": get_latest_released_app_version(domain, app_id),

--- a/corehq/apps/reminders/util.py
+++ b/corehq/apps/reminders/util.py
@@ -102,7 +102,7 @@ def get_form_list(domain):
             for m in latest_app.get_modules():
                 for f in m.get_forms():
                     form_list.append({
-                        "code": get_combined_id(latest_app.master_id, f.unique_id),
+                        "code": get_combined_id(latest_app.origin_id, f.unique_id),
                         "name": f.full_path_name,
                     })
     return form_list

--- a/docs/apps/terminology.rst
+++ b/docs/apps/terminology.rst
@@ -13,8 +13,7 @@ the id of an older build, since saved builds are essentially read-only.
 In saved builds, ``copy_of`` contains the primary app's id, while it's
 ``None`` for the primary app itself. If you need to be flexible about
 finding primary app's id on an object that might be either an app or a
-build, use the property
-`master_id <https://github.com/dimagi/commcare-hq/blob/fd9f7aa24f25093683e17a69bb4a14f44d0e15b7/corehq/apps/app_manager/models.py#L4007>`__.
+build, use the property ``origin_id``.
 
 Within code, "build" should always refer to a saved build, but "app" is
 used for both the current app and saved builds. The ambiguity of "app"


### PR DESCRIPTION
## Summary
This identifier is confusing, given that it's also used in linked project spaces. We're moving towards using `upstream`/`downstream` naming in linked project spaces, but that's going to take some time. In the meantime, let's make this less confusing.

Dear reviewers: the changes related to resource overrides are low-risk - resource overrides are ICDS-only and can be removed, I just haven't gotten there yet. If you grep the code base for `master_id` now, it should only turn up code related to linked reports / linked project spaces.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

A fair amount of this either updates tests or is tested.

### QA Plan

Not requesting QA.

### Safety story
The code changes here are pretty minor. I'm primarily relying on code review and and automated tests, but I'll do some local smoke testing of app summary and creating linked apps.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
