### PR TITLE
removed mark_safe usages in settings

### DIFF
--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -4,7 +4,7 @@ from django import forms
 from django.conf import settings
 from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.postgres.forms import SimpleArrayField
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 
@@ -31,12 +31,9 @@ from corehq.apps.users.models import CouchUser, HQApiKey
 
 
 class HQPasswordChangeForm(PasswordChangeForm):
-
     new_password1 = forms.CharField(label=_('New password'),
                                     widget=forms.PasswordInput(),
-                                    help_text=mark_safe("""
-                                    <span data-bind="text: passwordHelp, css: color">
-                                    """))
+                                    help_text='<span data-bind="text: passwordHelp, css: color">')
 
     def __init__(self, user, *args, **kwargs):
 
@@ -288,7 +285,7 @@ class HQApiKeyForm(forms.Form):
             ),
             hqcrispy.FormActions(
                 StrictButton(
-                    mark_safe('<i class="fa fa-plus"></i> {}'.format(ugettext_lazy("Generate New API Key"))),
+                    format_html('<i class="fa fa-plus"></i> {}', _("Generate New API Key")),
                     css_class='btn btn-primary',
                     type='submit'
                 )


### PR DESCRIPTION
## Summary
Removing/sanitizing `mark_safe` references as part of [SAAS-11853](https://dimagi-dev.atlassian.net/browse/SAAS-11853)

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests were created, as this didn't change the underlying behavior -- these remove the Bandit warnings, but were not themselves XSS issues.

### Safety story

Verified these changes via local testing -- in particular, that `mark_safe()` is unnecessary for the `help_text` attribute.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
