### PR TITLE
Mjr/xss misc

### DIFF
--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -1172,7 +1172,7 @@ class InitiateAddSMSBackendForm(Form):
                 InlineField('action'),
                 Div(InlineField('hq_api_id', css_class="ko-select2"), css_class='col-sm-6 col-md-6 col-lg-4'),
                 Div(StrictButton(
-                    mark_safe('<i class="fa fa-plus"></i> Add Another Gateway'),
+                    mark_safe('<i class="fa fa-plus"></i> Add Another Gateway'),  # nosec: no user input
                     css_class='btn-primary',
                     type='submit',
                     style="margin-left:5px;"

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -8,7 +8,7 @@ from django.http import (
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 from django.views.generic import View
@@ -199,10 +199,9 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
         )
 
     def _make_row(self, record):
-        checkbox = mark_safe(
-            """<input type="checkbox" class="xform-checkbox"
-            data-id="{}" name="xform_ids"/>""".format(record.get_id)
-        )
+        checkbox = format_html(
+            '<input type="checkbox" class="xform-checkbox" data-id="{}" name="xform_ids"/>',
+            record.get_id)
         row = [
             checkbox,
             self._make_state_label(record),
@@ -229,11 +228,12 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
     def headers(self):
         columns = [
             DataTablesColumn(
-                mark_safe(
-                    f"""
-                    {_('Select')}<button id="all" class="select-visible btn btn-xs btn-default">{_('all')}</button>
-                    <button id="none" class="select-none btn btn-xs btn-default">{_('none')}</button>
-                    """
+                format_html(
+                    '{}<button id="all" class="select-visible btn btn-xs btn-default">{}</button>'
+                    '<button id="none" class="select-none btn btn-xs btn-default">{}</button>',
+                    _('Select'),
+                    _('all'),
+                    _('none')
                 ),
                 sortable=False, span=3
             ),

--- a/custom/apps/crs_reports/reports.py
+++ b/custom/apps/crs_reports/reports.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 import datetime
 from django.utils.translation import ugettext_noop
-from django.utils import html
+from django.utils.html import format_html
 from casexml.apps.case.models import CommCareCase
 from django.urls import reverse, NoReverseMatch
 from django.utils.translation import ugettext as _
@@ -76,10 +76,11 @@ class HNBCReportDisplay(CaseDisplay):
     def case_link(self):
         case_id, case_name = self.case['_id'], self.case['mother_name']
         try:
-            return html.mark_safe("<a class='ajax_dialog' href='%s'>%s</a>" % (
-                html.escape(reverse('crs_details_report', args=[self.report.domain, case_id, self.report.slug])),
-                html.escape(case_name),
-            ))
+            return format_html(
+                "<a class='ajax_dialog' href='{}'>{}</a>",
+                reverse('crs_details_report', args=[self.report.domain, case_id, self.report.slug]),
+                case_name,
+            )
         except NoReverseMatch:
             return "%s (bad ID format)" % case_name
 

--- a/custom/succeed/reports/all_patients.py
+++ b/custom/succeed/reports/all_patients.py
@@ -19,7 +19,7 @@ from memoized import memoized
 from corehq.apps.cloudcare.api import get_cloudcare_app
 from corehq.apps.cloudcare.utils import webapps_module_case_form
 from corehq.apps.reports.standard import CustomProjectReport, ProjectReportParametersMixin
-from django.utils import html
+from django.utils.html import format_html
 from custom.succeed.reports import EMPTY_FIELD, CM7, CM_APP_CM_MODULE, OUTPUT_DATE_FORMAT
 from custom.succeed.utils import is_succeed_admin, SUCCEED_CM_APPNAME, has_any_role, get_app_build, SUCCEED_DOMAIN
 
@@ -82,21 +82,21 @@ def group_name(owner_id):
 def edit_link(case_id, app_dict, latest_build):
     module = app_dict['modules'][CM_APP_CM_MODULE]
     form_idx = [ix for (ix, f) in enumerate(module['forms']) if f['xmlns'] == CM7][0]
-    return html.mark_safe("<a target='_blank' class='ajax_dialog' href='%s'>Edit</a>") \
-        % html.escape(webapps_module_case_form(domain=app_dict['domain'],
-                                               app_id=latest_build,
-                                               module_id=CM_APP_CM_MODULE,
-                                               form_id=form_idx,
-                                               case_id=case_id))
+    case_form_link = webapps_module_case_form(
+        domain=app_dict['domain'],
+        app_id=latest_build,
+        module_id=CM_APP_CM_MODULE,
+        form_id=form_idx,
+        case_id=case_id)
+
+    return format_html("<a target='_blank' class='ajax_dialog' href='{}'>Edit</a>", case_form_link)
 
 
 def case_link(name, case_id):
-    url = html.escape(
-        PatientInteractionsReport.get_url(*[SUCCEED_DOMAIN]) + "?patient_id=%s" % case_id)
+    url = PatientInteractionsReport.get_url(*[SUCCEED_DOMAIN]) + "?patient_id=%s" % case_id
     if url:
         return {
-            'html': html.mark_safe("<a class='ajax_dialog' href='%s' "
-                                   "target='_blank'>%s</a>" % (url, html.escape(name))),
+            'html': format_html("<a class='ajax_dialog' href='{}' target='_blank'>{}</a>", url, name),
             'sort_key': name
         }
     else:
@@ -104,11 +104,9 @@ def case_link(name, case_id):
 
 
 def tasks(case_id):
-    url = html.escape(
-        PatientTaskListReport.get_url(*[SUCCEED_DOMAIN]) +
-        "?patient_id=%s&task_status=open" % case_id)
+    url = PatientTaskListReport.get_url(*[SUCCEED_DOMAIN]) + "?patient_id=%s&task_status=open" % case_id
     if url:
-        return html.mark_safe("<a class='ajax_dialog' href='%s' target='_blank'>Tasks</a>" % url)
+        return format_html("<a class='ajax_dialog' href='{}' target='_blank'>Tasks</a>", url)
     else:
         return "%s (bad ID format)" % case_id
 

--- a/custom/succeed/reports/patient_submissions.py
+++ b/custom/succeed/reports/patient_submissions.py
@@ -7,7 +7,7 @@ from corehq.apps.reports.sqlreport import SqlData, DatabaseColumn
 from corehq.apps.reports.standard import CustomProjectReport, ProjectReportParametersMixin
 from corehq.apps.userreports.util import get_table_name
 from custom.succeed.reports.patient_details import PatientDetailsReport
-from django.utils import html
+from django.utils.html import format_html
 
 
 class PatientSubmissionData(SqlData):
@@ -87,8 +87,10 @@ class PatientSubmissionReport(GenericTabularReport, CustomProjectReport, Project
 
     def submit_history_form_link(self, form_id, form_name):
         url = reverse('render_form_data', args=[self.domain, form_id])
-        return html.mark_safe("<a class='ajax_dialog' href='%s'"
-                              "target='_blank'>%s</a>" % (url, html.escape(form_name)))
+        return format_html(
+            "<a class='ajax_dialog' href='{}' target='_blank'>{}</a>",
+            url,
+            form_name)
 
     @property
     def report_context(self):

--- a/custom/succeed/reports/patient_task_list.py
+++ b/custom/succeed/reports/patient_task_list.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from django.utils import html
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _, ugettext_noop
 from sqlagg.base import AliasColumn
 from sqlagg.columns import SimpleColumn
@@ -38,14 +38,15 @@ class PatientTaskListReport(SqlTabularReport, CustomProjectReport, ProjectReport
 
     def get_link(self, url, field, doc_id):
         if url:
-            return html.mark_safe("<a class='ajax_dialog' href='{0}' target='_blank'>{1}</a>".format(
-                url, html.escape(field)))
+            return format_html(
+                "<a class='ajax_dialog' href='{}' target='_blank'>{}</a>",
+                url,
+                field)
         else:
             return "%s (bad ID format)" % doc_id
 
     def case_link(self, referenced_id, full_name):
-        url = html.escape(
-            PatientInfoReport.get_url(*[self.domain]) + "?patient_id=%s" % referenced_id)
+        url = PatientInfoReport.get_url(*[self.domain]) + "?patient_id=%s" % referenced_id
         return self.get_link(url, full_name, referenced_id)
 
     def get_form_url(self, app_dict, app_build_id, module_idx, form, case_id=None):
@@ -55,11 +56,12 @@ class PatientTaskListReport(SqlTabularReport, CustomProjectReport, ProjectReport
         except IndexError:
             form_idx = None
 
-        return html.escape(webapps_module_case_form(domain=self.domain,
-                                                    app_id=app_build_id,
-                                                    module_id=module_idx,
-                                                    form_id=form_idx,
-                                                    case_id=case_id))
+        return webapps_module_case_form(
+            domain=self.domain,
+            app_id=app_build_id,
+            module_id=module_idx,
+            form_id=form_idx,
+            case_id=case_id)
 
     def name_link(self, name, doc_id, is_closed):
         if is_closed == 0:

--- a/docs/class_views.rst
+++ b/docs/class_views.rst
@@ -56,7 +56,7 @@ of django's `TemplateView`.
 
         @property
         def page_name(self):
-            return mark_safe("This is a page for <strong>%s</strong>" % self.kitten.name)
+            return format_html("This is a page for <strong>{}</strong>", self.kitten.name)
 
     `page_name` will not show up in the `<title>` tags, as you can include html in this name.
 

--- a/docs/ui_helpers.rst
+++ b/docs/ui_helpers.rst
@@ -150,7 +150,7 @@ The form returned in `get_create_form()` should make use of
                 InlineField('breed'),
                 InlineField('dob'),
                 StrictButton(
-                    mark_safe('<i class="fa fa-plus"></i> %s' % "Create Puppy"),
+                    format_html('<i class="fa fa-plus"></i> {}', "Create Puppy"),
                     css_class='btn-primary',
                     type='submit'
                 )


### PR DESCRIPTION
## Summary
Part of [SAAS-11853](https://dimagi-dev.atlassian.net/browse/SAAS-11853), where we're trying to eliminate possible XSS vectors caused by `mark_safe()`.  I've grouped several smaller changes here, which are not serious candidates for XSS. Removing the `mark_safe()` calls here allows us to run static analysis for improper usage of `mark_safe()` later.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No automated tests, as this isn't changing behavior.

### QA Plan

QA shouldn't be necessary for these changes.  I also don't think a QA smoke test would hit the custom reports.

### Safety story

These changes were basically performed with an eye-check. Duplicate the offending `mark_safe()` code, replace
that version with the `format_html()` changes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
