### PR TITLE
change_plan does not support start_date

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -927,12 +927,6 @@ class BulkUpgradeToLatestVersionForm(forms.Form):
         required=True,
         widget=forms.Textarea,
     )
-    start_date = forms.DateField(
-        label="Date When New Version Takes Effect",
-        widget=forms.DateInput(),
-        required=False,
-        help_text="If left blank this change will take effect immediately.",
-    )
 
     def __init__(self, old_plan_version, web_user, *args, **kwargs):
         self.old_plan_version = old_plan_version
@@ -946,7 +940,6 @@ class BulkUpgradeToLatestVersionForm(forms.Form):
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
                 "Upgrade All Subscriptions To Latest Version",
-                crispy.Field('start_date', css_class="date-picker"),
                 'upgrade_note',
             ),
             hqcrispy.FormActions(
@@ -963,7 +956,6 @@ class BulkUpgradeToLatestVersionForm(forms.Form):
         upgrade_subscriptions_to_latest_plan_version(
             self.old_plan_version,
             self.web_user,
-            self.cleaned_data['start_date'],
             self.cleaned_data['upgrade_note'],
         )
 
@@ -1773,7 +1765,6 @@ class SoftwarePlanVersionForm(forms.Form):
             upgrade_subscriptions_to_latest_plan_version(
                 self.plan_version,
                 self.admin_web_user,
-                datetime.date.today(),
                 upgrade_note="Immediately upgraded when creating a new version."
             )
             messages.success(

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1360,6 +1360,10 @@ class Subscription(models.Model):
         Changing a plan TERMINATES the current subscription and
         creates a NEW SUBSCRIPTION where the old plan left off.
         This is not the same thing as simply updating the subscription.
+
+        date_end is a date in the future and only applies to the NEW
+        subscription. The current subscription will always end immediately
+        (today) and the date_start of the new subscription will always be today.
         """
         from corehq.apps.analytics.tasks import track_workflow
         adjustment_method = adjustment_method or SubscriptionAdjustmentMethod.INTERNAL

--- a/corehq/apps/accounting/tests/test_admin_software_plans.py
+++ b/corehq/apps/accounting/tests/test_admin_software_plans.py
@@ -99,7 +99,6 @@ class TestUpgradeSoftwarePlanToLatestVersion(BaseAccountingTest):
         upgrade_subscriptions_to_latest_plan_version(
             self.first_version,
             self.admin_web_user,
-            datetime.date.today(),
             upgrade_note="test upgrading to latest version"
         )
         self.assertEqual(

--- a/corehq/apps/accounting/utils/software_plans.py
+++ b/corehq/apps/accounting/utils/software_plans.py
@@ -2,7 +2,7 @@ from corehq.apps.accounting.models import Subscription
 
 
 def upgrade_subscriptions_to_latest_plan_version(old_plan_version, web_user,
-                                                 date_start, upgrade_note):
+                                                 upgrade_note):
     subscriptions_needing_upgrade = Subscription.visible_objects.filter(
         is_active=True, plan_version=old_plan_version
     )
@@ -11,7 +11,6 @@ def upgrade_subscriptions_to_latest_plan_version(old_plan_version, web_user,
         subscription.change_plan(
             new_plan_version,
             note=upgrade_note,
-            date_end=date_start,
             web_user=web_user,
             service_type=subscription.service_type,
             pro_bono_status=subscription.pro_bono_status,


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SAAS-11902
There is a bug in the current multi-change plan form in the accounting admin where the `start_date` is actually applied as the `end_date` of the new subscription, rather than the `end_date` of the old subscription. (This issue is never noticed when `start_date` is left blank.

Due to the complexities surrounding checking whether there will be subscription overlaps if a `start_date` is specified in `change_plan`, this method only supports specifying an `end_date` for the NEW subscription. The old/current subscription will always terminate immediately. Note that `start_date` as an option was taken away once in the past on purpose for this very reason.

## Product Description
Affects a very specific and tested accounting admin UI. Fixes an existing bug.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Yes there is test coverage.

### QA Plan
Not needed.

### Safety story
Isolated, clean, and well-tested change to a very low-trafficked admin ui.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
