### PR TITLE
add fixture information to questions in Application API

### DIFF
--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -445,7 +445,9 @@ class ApplicationResource(BaseApplicationResource):
                         langs,
                         include_triggers=True,
                         include_groups=True,
-                        include_translations=True),
+                        include_translations=True,
+                        include_fixtures=True,
+                    ),
                     'unique_id': form_unique_id,
                 }
                 dehydrated['forms'].append(form_jvalue)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1171,13 +1171,14 @@ class FormBase(DocumentSchema):
     @quickcache(['self.source', 'langs', 'include_triggers', 'include_groups', 'include_translations'],
                 timeout=24 * 60 * 60)
     def get_questions(self, langs, include_triggers=False,
-                      include_groups=False, include_translations=False):
+                      include_groups=False, include_translations=False, include_fixtures=False):
         try:
             return XForm(self.source).get_questions(
                 langs=langs,
                 include_triggers=include_triggers,
                 include_groups=include_groups,
                 include_translations=include_translations,
+                include_fixtures=include_fixtures,
             )
         except XFormException as e:
             raise XFormException(_('Error in form "{}": {}').format(trans(self.name), e))

--- a/corehq/apps/app_manager/tests/data/form_with_fixtures.xml
+++ b/corehq/apps/app_manager/tests/data/form_with_fixtures.xml
@@ -28,7 +28,7 @@
             <label ref="jr:itext('lookup-table-label')"/>
             <itemset nodeset="instance('country')/country_list/country">
                 <label ref="name"/>
-                <value ref="name"/>
+                <value ref="id"/>
             </itemset>
         </select1>
     </h:body>

--- a/corehq/apps/app_manager/tests/data/form_with_fixtures.xml
+++ b/corehq/apps/app_manager/tests/data/form_with_fixtures.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms"
+        xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+    <h:head>
+        <h:title>Form with Lookup Table Question</h:title>
+        <model>
+            <instance>
+                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
+                      xmlns="http://openrosa.org/formdesigner/2FDA1C1F-D04C-43A9-86FB-08B6B065D1E9" uiVersion="1"
+                      version="1" name="Form with Lookup Table Question">
+                    <lookup-table/>
+                </data>
+            </instance>
+            <instance src="jr://fixture/item-list:country" id="country"/>
+            <bind vellum:nodeset="#form/lookup-table" nodeset="/data/lookup-table"/>
+            <itext>
+                <translation lang="en" default="">
+                    <text id="lookup-table-label">
+                        <value>I'm a lookup table!</value>
+                    </text>
+                </translation>
+            </itext>
+        </model>
+    </h:head>
+    <h:body>
+        <select1 vellum:ref="#form/lookup-table" ref="/data/lookup-table" appearance="Survey">
+            <label ref="jr:itext('lookup-table-label')"/>
+            <itemset nodeset="instance('country')/country_list/country">
+                <label ref="name"/>
+                <value ref="name"/>
+            </itemset>
+        </select1>
+    </h:body>
+</h:html>

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -298,11 +298,11 @@ class GetFormQuestionsTest(SimpleTestCase, TestFileMixin):
             "comment": None,
             "constraint": None,
             "fixture_data": {
-                "instance": "jr://fixture/item-list:country",
+                "instance_id": "country",
+                "instance_ref": "jr://fixture/item-list:country",
                 "nodeset": "instance('country')/country_list/country",
                 "label_ref": "name",
                 "value_ref": "id",
-
             },
             "group": None,
             "hashtagValue": "#form/lookup-table",

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -298,6 +298,7 @@ class GetFormQuestionsTest(SimpleTestCase, TestFileMixin):
             "comment": None,
             "constraint": None,
             "fixture_data": {
+                "instance": "jr://fixture/item-list:country",
                 "nodeset": "instance('country')/country_list/country",
                 "label_ref": "name",
                 "value_ref": "id",

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -285,3 +285,29 @@ class GetFormQuestionsTest(SimpleTestCase, TestFileMixin):
 
         self.assertEqual(repeat_question['repeat'], '/data/a_repeat')
         self.assertEqual(repeat_question['group'], '/data/a_repeat')
+
+    def test_fixture_references(self):
+        form_with_fixtures = self.app.new_form(
+            self.app.get_module(0).id,
+            name="Form with Fixtures",
+            lang='en',
+            attachment=self.get_xml('form_with_fixtures').decode('utf-8')
+        )
+        questions = form_with_fixtures.get_questions(['en'])
+        self.assertEqual(questions[0], {
+            "comment": None,
+            "constraint": None,
+            "group": None,
+            "hashtagValue": "#form/lookup-table",
+            "is_group": False,
+            "label": "I'm a lookup table!",
+            "label_ref": "lookup-table-label",
+            "options": [],
+            "relevant": None,
+            "repeat": None,
+            "required": False,
+            "setvalue": None,
+            "tag": "select1",
+            "type": "Select",
+            "value": "/data/lookup-table"
+        })

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -297,7 +297,7 @@ class GetFormQuestionsTest(SimpleTestCase, TestFileMixin):
         self.assertEqual(questions[0], {
             "comment": None,
             "constraint": None,
-            "fixture_data": {
+            "data_source": {
                 "instance_id": "country",
                 "instance_ref": "jr://fixture/item-list:country",
                 "nodeset": "instance('country')/country_list/country",

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -293,10 +293,16 @@ class GetFormQuestionsTest(SimpleTestCase, TestFileMixin):
             lang='en',
             attachment=self.get_xml('form_with_fixtures').decode('utf-8')
         )
-        questions = form_with_fixtures.get_questions(['en'])
+        questions = form_with_fixtures.get_questions(['en'], include_fixtures=True)
         self.assertEqual(questions[0], {
             "comment": None,
             "constraint": None,
+            "fixture_data": {
+                "nodeset": "instance('country')/country_list/country",
+                "label_ref": "name",
+                "value_ref": "id",
+
+            },
             "group": None,
             "hashtagValue": "#form/lookup-table",
             "is_group": False,

--- a/corehq/apps/app_manager/tests/test_xform_parsing.py
+++ b/corehq/apps/app_manager/tests/test_xform_parsing.py
@@ -46,6 +46,13 @@ class XFormParsingTest(SimpleTestCase, TestXmlMixin):
         original.normalize_itext()
         self.assertXmlEqual(original.render(), self.get_xml('itext_form_normalized'))
 
+    def test_get_external_instances(self):
+        form_with_fixtures = XForm(self.get_xml('form_with_fixtures').decode('utf-8'))
+        instances = form_with_fixtures.get_external_instances()
+        self.assertEqual(instances, {
+            'country': 'jr://fixture/item-list:country'
+        })
+
 
 class ItextValueTest(SimpleTestCase):
 

--- a/corehq/apps/app_manager/tests/test_xform_parsing.py
+++ b/corehq/apps/app_manager/tests/test_xform_parsing.py
@@ -1,6 +1,7 @@
 from django.test import SimpleTestCase
 
 from corehq.apps.app_manager.tests.util import TestXmlMixin
+from corehq.apps.app_manager.util import extract_instance_id_from_nodeset_ref
 from corehq.apps.app_manager.xform import (
     ItextValue,
     WrappedNode,
@@ -52,6 +53,32 @@ class XFormParsingTest(SimpleTestCase, TestXmlMixin):
         self.assertEqual(instances, {
             'country': 'jr://fixture/item-list:country'
         })
+
+    def test_extract_instance_id_from_nodeset(self):
+        self.assertEqual(
+            'country',
+            extract_instance_id_from_nodeset_ref("instance('country')/country_list/country"),
+        )
+        self.assertEqual(
+            'first',
+            extract_instance_id_from_nodeset_ref("instance('first')/instance('second')country_list/country"),
+        )
+        self.assertEqual(
+            None,
+            extract_instance_id_from_nodeset_ref("foo('country')/country_list/country"),
+        )
+        self.assertEqual(
+            None,
+            extract_instance_id_from_nodeset_ref("foo/country_list/country"),
+        )
+        self.assertEqual(
+            None,
+            extract_instance_id_from_nodeset_ref(""),
+        )
+        self.assertEqual(
+            None,
+            extract_instance_id_from_nodeset_ref(None),
+        )
 
 
 class ItextValueTest(SimpleTestCase):

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -673,5 +673,5 @@ def extract_instance_id_from_nodeset_ref(nodeset):
     # note: for simplicity, this only returns the first instance ref in the event there are multiple.
     # if that's ever a problem this method could be changed in the future to return a list
     if nodeset:
-        matches = re.findall("instance\('(.*?)'\)", nodeset)
+        matches = re.findall(r"instance\('(.*?)'\)", nodeset)
         return matches[0] if matches else None

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -667,3 +667,11 @@ def _get_app_ids_by_form_unique_id(domain):
                     raise AppManagerException("Could not identify app for form {}".format(form.unique_id))
                 app_ids[form.unique_id] = app.get_id
     return app_ids
+
+
+def extract_instance_id_from_nodeset_ref(nodeset):
+    # note: for simplicity, this only returns the first instance ref in the event there are multiple.
+    # if that's ever a problem this method could be changed in the future to return a list
+    if nodeset:
+        matches = re.findall("instance\('(.*?)'\)", nodeset)
+        return matches[0] if matches else None

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1053,11 +1053,14 @@ class XForm(WrappedNode):
 
             if include_fixtures and cnode.node.find('{f}itemset').exists():
                 itemset_node = cnode.node.find('{f}itemset')
-                question['fixture_data'] = {
-                    'nodeset': itemset_node.attrib.get('nodeset'),
-                    'label_ref': itemset_node.find('{f}label').attrib.get('ref'),
-                    'value_ref': itemset_node.find('{f}value').attrib.get('ref'),
+                fixture_data = {
+                    'nodeset': itemset_node.attrib.get('nodeset')
                 }
+                if itemset_node.find('{f}label').exists():
+                    fixture_data['label_ref'] = itemset_node.find('{f}label').attrib.get('ref')
+                if itemset_node.find('{f}value').exists():
+                    fixture_data['value_ref'] = itemset_node.find('{f}value').attrib.get('ref')
+                question['fixture_data'] = fixture_data
 
             if cnode.items is not None:
                 question['options'] = [_get_select_question_option(item) for item in cnode.items]

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1085,7 +1085,7 @@ class XForm(WrappedNode):
                     fixture_data['instance_id'] = fixture_id
                     fixture_data['instance_ref'] = external_instances.get(fixture_id)
 
-                question['fixture_data'] = fixture_data
+                question['data_source'] = fixture_data
 
             if cnode.items is not None:
                 question['options'] = [_get_select_question_option(item) for item in cnode.items]

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -971,6 +971,22 @@ class XForm(WrappedNode):
 
         return list(self.translations().keys())
 
+    def get_external_instances(self):
+        """
+        Get a dictionary of all "external" instances, like:
+        {
+          "country": "jr://fixture/item-list:country"
+        }
+        """
+        instance_nodes = self.model_node.findall('{f}instance')
+        instance_dict = {}
+        for instance_node in instance_nodes:
+            instance_id = instance_node.attrib.get('id')
+            src = instance_node.attrib.get('src')
+            if instance_id and src:
+                instance_dict[instance_id] = src
+        return instance_dict
+
     def get_questions(self, langs, include_triggers=False,
                       include_groups=False, include_translations=False,
                       exclude_select_with_itemsets=False, include_fixtures=False):

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -973,7 +973,7 @@ class XForm(WrappedNode):
 
     def get_questions(self, langs, include_triggers=False,
                       include_groups=False, include_translations=False,
-                      exclude_select_with_itemsets=False):
+                      exclude_select_with_itemsets=False, include_fixtures=False):
         """
         parses out the questions from the xform, into the format:
         [{"label": label, "tag": tag, "value": value}, ...]
@@ -987,9 +987,9 @@ class XForm(WrappedNode):
         :param include_groups: When set will return repeats and group questions
         :param include_translations: When set to True will return all the translations for the question
         :param exclude_select_with_itemsets: exclude select/multi-select with itemsets
+        :param include_fixtures: add fixture data for questions that we can infer it from
         """
         from corehq.apps.app_manager.util import first_elem
-
         def _get_select_question_option(item):
             translation = self._get_label_text(item, langs)
             try:
@@ -1050,6 +1050,14 @@ class XForm(WrappedNode):
             }
             if include_translations:
                 question["translations"] = self._get_label_translations(node, langs)
+
+            if include_fixtures and cnode.node.find('{f}itemset').exists():
+                itemset_node = cnode.node.find('{f}itemset')
+                question['fixture_data'] = {
+                    'nodeset': itemset_node.attrib.get('nodeset'),
+                    'label_ref': itemset_node.find('{f}label').attrib.get('ref'),
+                    'value_ref': itemset_node.find('{f}value').attrib.get('ref'),
+                }
 
             if cnode.items is not None:
                 question['options'] = [_get_select_question_option(item) for item in cnode.items]


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Closes #29170

This adds the following new data for questions that reference fixtures in formbuilder:

```
"data_source": {
  "instance_id": "long-sequence",
  "instance_ref": "jr://fixture/item-list:long-sequence",              
  "label_ref": "x",
  "nodeset": "instance('long-sequence')/long-sequence_list/long-sequence",
  "value_ref": "y"
}
```

@ctsims I used a slightly different API than what you proposed, to provide more information and work with the primitives in the form instead of parsing out the "long-sequence" from the nodeset reference. Thinking that it'd be easier to offer more flexibility and let our consumers handle parsing if they need it.

Also I thought it was safe to just add this data without an additional URL param or API version, since it's only new data, and will only be present if the form had fixture references.

Recommend reviewing by commit.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

I added test coverage and manually tested every edge case I could think of. Also the only code that (currently) calls the new functionality is the API, though other things that reference form questions like app summary might benefit from it down the line.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Added tests, and we have lots of regression tests for the modified code.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
