### PR TITLE
Removed soft assert

### DIFF
--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -105,10 +105,6 @@ def view_generic(request, domain, app_id, module_id=None, form_id=None,
             'domain': domain,
             'app': app,
         })
-    if not app.vellum_case_management and not app.is_remote_app():
-        # Soft assert but then continue rendering; template will contain a user-facing warning
-        _assert = soft_assert(['jschweers' + '@' + 'dimagi.com'])
-        _assert(False, 'vellum_case_management=False', {'domain': domain, 'app_id': app_id})
     if (form is not None and "usercase_preload" in getattr(form, "actions", {})
             and form.actions.usercase_preload.preload):
         _assert = soft_assert(['dmiller' + '@' + 'dimagi.com'])


### PR DESCRIPTION
## Summary
This is several years old and I ignore it.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

No QA.

### Safety story
Minor code removal.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
