### PR TITLE
Updated enterprise permissions page to disallow a mirror whose source…

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1281,3 +1281,17 @@ class CommCareUserFilterForm(forms.Form):
 
 class CreateDomainPermissionsMirrorForm(forms.Form):
     mirror_domain = forms.CharField(label=ugettext_lazy('Project Space'), max_length=30, required=True)
+
+    def __init__(self, *args, **kwargs):
+        if 'domain' not in kwargs:
+            raise Exception('Expected kwargs: domain')
+        self.domain = kwargs.pop('domain', None)
+        super().__init__(*args, **kwargs)
+
+    def clean_mirror_domain(self):
+        mirror_domain = self.data.get('mirror_domain')
+        if self.domain == mirror_domain:
+            raise forms.ValidationError(_("""
+                Enterprise permissions cannot be granted from a project space to itself.
+            """))
+        return mirror_domain

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -675,10 +675,10 @@ def delete_domain_permission_mirror(request, domain, mirror):
 @require_superuser
 @require_POST
 def create_domain_permission_mirror(request, domain):
-    form = CreateDomainPermissionsMirrorForm(request.POST)
+    form = CreateDomainPermissionsMirrorForm(domain=request.domain, data=request.POST)
     if form.is_valid():
         mirror_domain_name = form.cleaned_data.get("mirror_domain")
-        mirror_domain = Domain.get_by_name(form.cleaned_data.get("mirror_domain"))
+        mirror_domain = Domain.get_by_name(mirror_domain_name)
         if mirror_domain is not None:
             mirror = DomainPermissionsMirror(source=domain, mirror=mirror_domain_name)
             mirror.save()
@@ -688,8 +688,8 @@ def create_domain_permission_mirror(request, domain):
             message = _('Please enter a valid project space.')
             messages.error(request, message.format())
     else:
-        message = _('An error occurred while trying to add the project space.')
-        messages.error(request, message.format())
+        for field, message in form.errors.items():
+            messages.error(request, message)
     redirect = reverse(DomainPermissionsMirrorView.urlname, args=[domain])
     return HttpResponseRedirect(redirect)
 


### PR DESCRIPTION
… is itself

## Summary
This isn't a valid use case and may have been related to issues logging in this morning for a domain that did have a mirror like this set up: https://sentry.io/organizations/dimagi/issues/2245600851/

## Feature Flag
Enterprise Permissions

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

Not requesting QA.

### Safety story
Minor change to superuser-only page. Tested locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
