### PR TITLE
get_role_name returns name 'Admin' instead of the role_qualified_id 'admin'

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2762,7 +2762,7 @@ class Invitation(models.Model):
     def get_role_name(self):
         if self.role:
             if self.role == 'admin':
-                return self.role
+                return _('Admin')
             else:
                 role_id = self.role[len('user-role:'):]
                 try:


### PR DESCRIPTION
## Summary
An issue was brought up in first part of this [QA ticket](https://dimagi-dev.atlassian.net/browse/QA-2644). This is causing issues for the PR out now for bulk uploads because `admin` is not a valid role name, however `Admin` is ([AdminUserRole](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/users/models.py#L465)).

## Product Description
This should not change the existing functionality except that for web user download and enterprise web user reports the role will now be displayed as capitalized. 

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan
This will get a look over with QA and will be tagged in the ticket above

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
