### PR TITLE
Pollish Export Settings UI

### DIFF
--- a/corehq/apps/enterprise/forms.py
+++ b/corehq/apps/enterprise/forms.py
@@ -9,6 +9,7 @@ from crispy_forms.bootstrap import PrependedText, StrictButton
 from crispy_forms.helper import FormHelper
 
 from corehq.apps.hqwebapp import crispy as hqcrispy
+from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput
 from corehq.toggles import DEFAULT_EXPORT_SETTINGS
 from corehq.apps.export.models.export_settings import ExportFileType
 
@@ -40,7 +41,12 @@ class EnterpriseSettingsForm(forms.Form):
     )
 
     forms_auto_convert = forms.BooleanField(
-        label=ugettext_lazy("Automatically convert dates and multimedia links for Excel"),
+        label=ugettext_lazy("Excel Date & Multimedia Format"),
+        widget=BootstrapCheckboxInput(
+            inline_label=ugettext_lazy(
+                "Automatically convert dates and multimedia links for Excel"
+            ),
+        ),
         required=False,
         help_text=ugettext_lazy("Leaving this checked will ensure dates appear in excel format. "
                                 "Otherwise they will appear as a normal text format. This also allows "
@@ -48,7 +54,12 @@ class EnterpriseSettingsForm(forms.Form):
     )
 
     forms_auto_format_cells = forms.BooleanField(
-        label=ugettext_lazy("Automatically format cells for Excel 2007+"),
+        label=ugettext_lazy("Excel Cell Format"),
+        widget=BootstrapCheckboxInput(
+            inline_label=ugettext_lazy(
+                "Automatically format cells for Excel 2007+"
+            ),
+        ),
         required=False,
         help_text=ugettext_lazy("If this setting is not selected, your export will be in Excel's generic format. "
                                 "If you enable this setting, Excel will format dates, integers, decimals, "
@@ -56,7 +67,12 @@ class EnterpriseSettingsForm(forms.Form):
     )
 
     forms_expand_checkbox = forms.BooleanField(
-        label=ugettext_lazy("Expand checkbox questions"),
+        label=ugettext_lazy("Checkbox Format"),
+        widget=BootstrapCheckboxInput(
+            inline_label=ugettext_lazy(
+                "Expand checkbox questions"
+            ),
+        ),
         required=False,
     )
 
@@ -68,7 +84,12 @@ class EnterpriseSettingsForm(forms.Form):
     )
 
     cases_auto_convert = forms.BooleanField(
-        label=ugettext_lazy("Automatically convert dates and multimedia links for Excel"),
+        label=ugettext_lazy("Excel Date & Multimedia Format"),
+        widget=BootstrapCheckboxInput(
+            inline_label=ugettext_lazy(
+                "Automatically convert dates and multimedia links for Excel"
+            ),
+        ),
         required=False,
         help_text=ugettext_lazy("Leaving this checked will ensure dates appear in excel format. "
                                 "Otherwise they will appear as a normal text format. This also allows "
@@ -76,7 +97,13 @@ class EnterpriseSettingsForm(forms.Form):
     )
 
     odata_expand_checkbox = forms.BooleanField(
-        label=ugettext_lazy("Expand checkbox questions"),
+        label=ugettext_lazy("Checkbox Format"),
+        widget=BootstrapCheckboxInput(
+            inline_label=ugettext_lazy(
+                "Expand checkbox questions"
+            ),
+        ),
+        help_text=ugettext_lazy("Only applies to form exports."),
         required=False,
     )
 
@@ -123,30 +150,20 @@ class EnterpriseSettingsForm(forms.Form):
                         crispy.Div(
                             crispy.Field('forms_filetype'),
                         ),
-                        crispy.Div(
-                            crispy.Field('forms_auto_convert'),
-                        ),
-                        crispy.Div(
-                            crispy.Field('forms_auto_format_cells')
-                        ),
-                        crispy.Div(
-                            crispy.Field('forms_expand_checkbox')
-                        ),
+                        PrependedText('forms_auto_convert', ''),
+                        PrependedText('forms_auto_format_cells', ''),
+                        PrependedText('forms_expand_checkbox', ''),
                     ),
                     crispy.Fieldset(
                         _("Edit Default Case Export Settings"),
                         crispy.Div(
                             crispy.Field('cases_filetype')
                         ),
-                        crispy.Div(
-                            crispy.Field('cases_auto_convert'),
-                        ),
+                        PrependedText('cases_auto_convert', ''),
                     ),
                     crispy.Fieldset(
                         _("Edit Default OData Export Settings"),
-                        crispy.Div(
-                            crispy.Field('odata_expand_checkbox'),
-                        ),
+                        PrependedText('odata_expand_checkbox', ''),
                     ),
                 )
             )


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Used new widget for checkboxes to align with text. Added labels at the left most margin to align with our styleguide.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
DEFAULT_EXPORT_SETTINGS
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
This has already been QAed, these are solely UI changes.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
