### PR TITLE
Es/case list api

### DIFF
--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -36,7 +36,11 @@ class CaseSearchES(CaseES):
 
     @property
     def builtin_filters(self):
-        return [case_property_filter, blacklist_owner_id] + super(CaseSearchES, self).builtin_filters
+        return [
+            case_property_filter,
+            blacklist_owner_id,
+            external_id,
+        ] + super(CaseSearchES, self).builtin_filters
 
     def case_property_query(self, case_property_name, value, clause=queries.MUST, fuzzy=False):
         """
@@ -268,6 +272,10 @@ def _base_property_query(case_property_name, query):
 
 def blacklist_owner_id(owner_id):
     return filters.NOT(owner(owner_id))
+
+
+def external_id(external_id):
+    return filters.term('external_id', external_id)
 
 
 def flatten_result(hit, include_score=False):

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -40,6 +40,7 @@ class CaseSearchES(CaseES):
             case_property_filter,
             blacklist_owner_id,
             external_id,
+            indexed_on,
         ] + super(CaseSearchES, self).builtin_filters
 
     def case_property_query(self, case_property_name, value, clause=queries.MUST, fuzzy=False):
@@ -276,6 +277,10 @@ def blacklist_owner_id(owner_id):
 
 def external_id(external_id):
     return filters.term('external_id', external_id)
+
+
+def indexed_on(gt=None, gte=None, lt=None, lte=None, eq=None):
+    return filters.date_range('@indexed_on', gt=None, gte=None, lt=None, lte=None, eq=None)
 
 
 def flatten_result(hit, include_score=False):

--- a/corehq/apps/es/cases.py
+++ b/corehq/apps/es/cases.py
@@ -29,6 +29,7 @@ class CaseES(HQESQuery):
             closed_range,
             modified_range,
             server_modified_range,
+            case_name,
             is_closed,
             case_type,
             owner,
@@ -55,6 +56,10 @@ def modified_range(gt=None, gte=None, lt=None, lte=None):
 
 def server_modified_range(gt=None, gte=None, lt=None, lte=None):
     return filters.date_range('server_modified_on', gt, gte, lt, lte)
+
+
+def case_name(name):
+    return filters.term('name.exact', name)
 
 
 def is_closed(closed=True):

--- a/corehq/apps/hqcase/api/core.py
+++ b/corehq/apps/hqcase/api/core.py
@@ -70,5 +70,3 @@ class SubmissionError(Exception):
     def __init__(self, msg, form_id):
         self.form_id = form_id
         super().__init__(msg)
-
-

--- a/corehq/apps/hqcase/api/core.py
+++ b/corehq/apps/hqcase/api/core.py
@@ -1,0 +1,40 @@
+def serialize_case(case):
+    """Serializes a case for the V0.6 Case API"""
+    return {
+        "domain": case.domain,
+        "@case_id": case.case_id,
+        "@case_type": case.type,
+        "case_name": case.name,
+        "external_id": case.external_id,
+        "@owner_id": case.owner_id,
+        "date_opened": _isoformat(case.opened_on),
+        "last_modified": _isoformat(case.modified_on),
+        "server_last_modified": _isoformat(case.server_modified_on),
+        "closed": case.closed,
+        "date_closed": _isoformat(case.closed_on),
+        "properties": dict(case.dynamic_case_properties()),
+        "indices": {
+            index.identifier: {
+                "case_id": index.referenced_id,
+                "@case_type": index.referenced_type,
+                "@relationship": index.relationship,
+            }
+            for index in case.indices
+        }
+    }
+
+
+def _isoformat(value):
+    return value.isoformat() if value else None
+
+
+class UserError(Exception):
+    pass
+
+
+class SubmissionError(Exception):
+    def __init__(self, msg, form_id):
+        self.form_id = form_id
+        super().__init__(msg)
+
+

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -1,0 +1,11 @@
+from corehq.apps.es import CaseSearchES
+
+from .core import UserError, serialize_es_case
+
+
+def get_list(domain, params):
+    res = (CaseSearchES()
+           .domain(domain)
+           .run()
+           .hits)
+    return [serialize_es_case(case) for case in res]

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -63,6 +63,7 @@ FILTERS.update(chain(*[
     _to_date_filters('server_last_modified', case_es.server_modified_range),
     _to_date_filters('date_opened', case_es.opened_range),
     _to_date_filters('date_closed', case_es.closed_range),
+    _to_date_filters('indexed_on', case_search.indexed_on),
 ]))
 
 

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -16,7 +16,7 @@ CUSTOM_PROPERTY_PREFIX = 'property.'
 
 
 def _to_boolean(val):
-    return val.lower() not in [''] + list(FALSE_STRINGS)
+    return not (val == '' or val.lower() in FALSE_STRINGS)
 
 
 def _to_int(val, param_name):

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -14,6 +14,7 @@ DEFAULT_PAGE_SIZE = 20
 MAX_PAGE_SIZE = 5000
 CUSTOM_PROPERTY_PREFIX = 'property.'
 
+
 def _to_boolean(val):
     return val.lower() not in [''] + list(FALSE_STRINGS)
 

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -2,10 +2,36 @@ from corehq.apps.es import CaseSearchES
 
 from .core import UserError, serialize_es_case
 
+DEFAULT_PAGE_SIZE = 20
+MAX_PAGE_SIZE = 5000
+
+# TODO:
+# external_id
+# case_type
+# owner_id
+# case_name
+# last_modified_by_user_id
+# closed
+# last_modified_start
+# last_modified_end
+# server_last_modified_start
+# server_last_modified_end
+# date_opened_start
+# date_opened_end
+# date_closed_start
+# date_closed_end
+
 
 def get_list(domain, params):
-    res = (CaseSearchES()
-           .domain(domain)
-           .run()
-           .hits)
-    return [serialize_es_case(case) for case in res]
+    start = params.pop('offset', 0)
+    page_size = params.pop('limit', DEFAULT_PAGE_SIZE)
+    if page_size > MAX_PAGE_SIZE:
+        raise UserError(f"You cannot request more than {MAX_PAGE_SIZE} cases per request.")
+
+    query = (CaseSearchES()
+             .domain(domain)
+             .size(page_size)
+             .start(start)
+             .sort("@indexed_on"))
+
+    return [serialize_es_case(case) for case in query.run().hits]

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -78,19 +78,19 @@ def get_list(domain, params):
              .start(start)
              .sort("@indexed_on"))
 
-    for k, v in params.items():
-        if k.startswith(CUSTOM_PROPERTY_PREFIX):
-            query = query.filter(_get_custom_property_filter(k, v))
-        elif k in FILTERS:
-            query = query.filter(FILTERS[k](v))
+    for key, val in params.items():
+        if key.startswith(CUSTOM_PROPERTY_PREFIX):
+            query = query.filter(_get_custom_property_filter(key, val))
+        elif key in FILTERS:
+            query = query.filter(FILTERS[key](val))
         else:
-            raise UserError(f"'{k}' is not a valid parameter.")
+            raise UserError(f"'{key}' is not a valid parameter.")
 
     return [serialize_es_case(case) for case in query.run().hits]
 
 
-def _get_custom_property_filter(k, v):
-    prop = k[len(CUSTOM_PROPERTY_PREFIX):]
-    if v == "":
+def _get_custom_property_filter(key, val):
+    prop = key[len(CUSTOM_PROPERTY_PREFIX):]
+    if val == "":
         return case_search.case_property_missing(prop)
-    return case_search.exact_case_property_text_query(prop, v)
+    return case_search.exact_case_property_text_query(prop, val)

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -31,7 +31,7 @@ def _make_date_filter(date_filter, param):
     def filter_fn(val):
         try:
             # If it's only a date, don't turn it into a datetime
-            val = datetime.date.fromisoformat(val)
+            val = datetime.datetime.strptime(val, '%Y-%m-%d').date()
         except ValueError:
             try:
                 val = parse(val)

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -5,6 +5,14 @@ from .core import UserError, serialize_es_case
 DEFAULT_PAGE_SIZE = 20
 MAX_PAGE_SIZE = 5000
 
+
+def _to_int(val, param_name):
+    try:
+        return int(val)
+    except ValueError:
+        raise UserError(f"'{val}' is not a valid value for '{param_name}'")
+
+
 # TODO:
 # external_id
 # case_type
@@ -23,8 +31,8 @@ MAX_PAGE_SIZE = 5000
 
 
 def get_list(domain, params):
-    start = params.pop('offset', 0)
-    page_size = params.pop('limit', DEFAULT_PAGE_SIZE)
+    start = _to_int(params.pop('offset', 0), 'offset')
+    page_size = _to_int(params.pop('limit', DEFAULT_PAGE_SIZE), 'limit')
     if page_size > MAX_PAGE_SIZE:
         raise UserError(f"You cannot request more than {MAX_PAGE_SIZE} cases per request.")
 

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -1,3 +1,8 @@
+import datetime
+from itertools import chain
+
+from dateutil.parser import parse
+
 from dimagi.utils.parsing import FALSE_STRINGS
 
 from corehq.apps.es import case_search
@@ -9,11 +14,40 @@ DEFAULT_PAGE_SIZE = 20
 MAX_PAGE_SIZE = 5000
 
 
+def _to_boolean(val):
+    return val.lower() not in [''] + list(FALSE_STRINGS)
+
+
 def _to_int(val, param_name):
     try:
         return int(val)
     except ValueError:
         raise UserError(f"'{val}' is not a valid value for '{param_name}'")
+
+
+def _make_date_filter(date_filter, param):
+
+    def filter_fn(val):
+        try:
+            # If it's only a date, don't turn it into a datetime
+            val = datetime.date.fromisoformat(val)
+        except ValueError:
+            try:
+                val = parse(val)
+            except ValueError:
+                raise UserError(f"Cannot parse datetime '{val}'")
+        return date_filter(**{param: val})
+
+    return filter_fn
+
+
+def _to_date_filters(field, date_filter):
+    return [
+        (f'{field}.gt', _make_date_filter(date_filter, 'gt')),
+        (f'{field}.gte', _make_date_filter(date_filter, 'gte')),
+        (f'{field}.lte', _make_date_filter(date_filter, 'lte')),
+        (f'{field}.lt', _make_date_filter(date_filter, 'lt')),
+    ]
 
 
 FILTERS = {
@@ -22,15 +56,13 @@ FILTERS = {
     'owner_id': case_es.owner,
     'case_name': case_es.case_name,
     'closed': lambda val: case_es.is_closed(_to_boolean(val)),
-    # last_modified_start
-    # last_modified_end
-    # server_last_modified_start
-    # server_last_modified_end
-    # date_opened_start
-    # date_opened_end
-    # date_closed_start
-    # date_closed_end
 }
+FILTERS.update(chain(*[
+    _to_date_filters('last_modified', case_es.modified_range),
+    _to_date_filters('server_last_modified', case_es.server_modified_range),
+    _to_date_filters('date_opened', case_es.opened_range),
+    _to_date_filters('date_closed', case_es.closed_range),
+]))
 
 
 def get_list(domain, params):
@@ -51,7 +83,3 @@ def get_list(domain, params):
         query = query.filter(FILTERS[k](v))
 
     return [serialize_es_case(case) for case in query.run().hits]
-
-
-def _to_boolean(val):
-    return val.lower() not in [''] + list(FALSE_STRINGS)

--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -9,7 +9,7 @@ from casexml.apps.case.mock import CaseBlock, IndexAttrs
 from corehq.apps.hqcase.utils import CASEBLOCK_CHUNKSIZE, submit_case_blocks
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
-from .core import UserError
+from .core import SubmissionError, UserError
 
 
 def is_simple_dict(d):

--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -9,35 +9,7 @@ from casexml.apps.case.mock import CaseBlock, IndexAttrs
 from corehq.apps.hqcase.utils import CASEBLOCK_CHUNKSIZE, submit_case_blocks
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
-
-def serialize_case(case):
-    """Serializes a case for the V0.6 Case API"""
-    return {
-        "domain": case.domain,
-        "@case_id": case.case_id,
-        "@case_type": case.type,
-        "case_name": case.name,
-        "external_id": case.external_id,
-        "@owner_id": case.owner_id,
-        "date_opened": _isoformat(case.opened_on),
-        "last_modified": _isoformat(case.modified_on),
-        "server_last_modified": _isoformat(case.server_modified_on),
-        "closed": case.closed,
-        "date_closed": _isoformat(case.closed_on),
-        "properties": dict(case.dynamic_case_properties()),
-        "indices": {
-            index.identifier: {
-                "case_id": index.referenced_id,
-                "@case_type": index.referenced_type,
-                "@relationship": index.relationship,
-            }
-            for index in case.indices
-        }
-    }
-
-
-def _isoformat(value):
-    return value.isoformat() if value else None
+from .core import UserError
 
 
 def is_simple_dict(d):
@@ -125,16 +97,6 @@ class JsonCaseUpdate(BaseJsonCaseChange):
 
     def get_case_id(self):
         return self.case_id
-
-
-class UserError(Exception):
-    pass
-
-
-class SubmissionError(Exception):
-    def __init__(self, msg, form_id):
-        self.form_id = form_id
-        super().__init__(msg)
 
 
 def handle_case_update(domain, data, user, device_id, case_id=None):

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -54,7 +54,7 @@ class TestCaseListAPI(TestCase):
                 case_type='team',
                 case_name=name,
                 external_id=name,
-                owner_id='owner',
+                owner_id='team_owner',
                 create=True,
             ))
 
@@ -70,11 +70,13 @@ class TestCaseListAPI(TestCase):
                 case_type='person',
                 case_name=name,
                 external_id=external_id,
-                owner_id='owner',
+                owner_id='person_owner',
                 create=True,
                 update=properties,
                 index={'parent': IndexAttrs('team', team_id, 'child')}
             ))
+
+        case_blocks[-1].close = True  # close Ned Pepper
 
         _, cases = submit_case_blocks([cb.as_text() for cb in case_blocks], domain=cls.domain)
 
@@ -92,6 +94,14 @@ class TestCaseListAPI(TestCase):
 @generate_cases([
     ("", ['good_guys', 'bad_guys', 'mattie', 'rooster', 'laboeuf', 'chaney', 'ned']),
     ("limit=2", ['good_guys', 'bad_guys']),
+    ("external_id=mattie", ['mattie']),
+    ("external_id=the-man-with-no-name", []),
+    ("case_type=team", ["good_guys", "bad_guys"]),
+    ("owner_id=person_owner", ['mattie', 'rooster', 'laboeuf', 'chaney', 'ned']),
+    ("case_name=Mattie Ross", ["mattie"]),
+    ("case_name=Mattie+Ross", ["mattie"]),
+    ("case_name=Mattie", []),
+    ("closed=true", ["ned"]),
 ], TestCaseListAPI)
 def test_case_list_queries(self, querystring, expected):
     params = QueryDict(querystring).dict()

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -130,6 +130,9 @@ def test_case_list_queries(self, querystring, expected):
     (f"limit={MAX_PAGE_SIZE + 2}", f"You cannot request more than {MAX_PAGE_SIZE} cases per request."),
     ("date_opened.lt=bad-datetime", "Cannot parse datetime 'bad-datetime'"),
     ("date_opened.lt=2020-02-30", "Cannot parse datetime '2020-02-30'"),
+    ("password=1234", "'password' is not a valid parameter."),
+    ("case_name.gte=a", "'case_name.gte' is not a valid parameter."),
+    ("date_opened=2020-01-30", "'date_opened' is not a valid parameter."),
 ], TestCaseListAPI)
 def test_bad_requests(self, querystring, error_msg):
     with self.assertRaises(UserError) as e:

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -63,7 +63,7 @@ class TestCaseListAPI(TestCase):
         for external_id, name, properties, team_id in [
                 ('mattie', "Mattie Ross", {}, good_id),
                 ('rooster', "Reuben Cogburn", {"alias": "Rooster"}, good_id),
-                ('laboeuf', "LaBoeuf", {}, good_id),
+                ('laboeuf', "LaBoeuf", {"alias": ""}, good_id),
                 ('chaney', "Tom Chaney", {"alias": "The Coward"}, bad_id),
                 ('ned', "Ned Pepper", {"alias": "Lucky Ned"}, bad_id),
         ]:
@@ -112,6 +112,11 @@ class TestCaseListAPI(TestCase):
     ("date_opened.gt=1878-02-18&date_opened.lt=1878-02-20", ["laboeuf"]),
     ("date_opened.gt=1878-02-19T11:00:00&date_opened.lt=1878-02-19T13:00:00", ["laboeuf"]),
     ("date_opened.lt=1878-02-18&date_opened.gt=1878-02-19", []),
+    ("property.alias=Rooster", ["rooster"]),
+    ("property.alias=rooster", []),
+    ('property.foo {"test": "json"}=bar', []),  # This is escaped as expected
+    ('property.foo={"test": "json"}', []),  # This is escaped as expected
+    ("case_type=person&property.alias=", ["mattie", "laboeuf"]),
 ], TestCaseListAPI)
 def test_case_list_queries(self, querystring, expected):
     params = QueryDict(querystring).dict()

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -117,6 +117,7 @@ class TestCaseListAPI(TestCase):
     ('property.foo {"test": "json"}=bar', []),  # This is escaped as expected
     ('property.foo={"test": "json"}', []),  # This is escaped as expected
     ("case_type=person&property.alias=", ["mattie", "laboeuf"]),
+    ('xpath=(alias="Rooster" or name="Mattie Ross")', ["mattie", "rooster"]),
 ], TestCaseListAPI)
 def test_case_list_queries(self, querystring, expected):
     params = QueryDict(querystring).dict()
@@ -133,6 +134,9 @@ def test_case_list_queries(self, querystring, expected):
     ("password=1234", "'password' is not a valid parameter."),
     ("case_name.gte=a", "'case_name.gte' is not a valid parameter."),
     ("date_opened=2020-01-30", "'date_opened' is not a valid parameter."),
+    ('xpath=gibberish',
+     "Bad XPath: Your search query is required to have at least one boolean "
+     "operator (>, >=, <, <=, =, !=)"),
 ], TestCaseListAPI)
 def test_bad_requests(self, querystring, error_msg):
     with self.assertRaises(UserError) as e:

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -21,7 +21,7 @@ from corehq.util.test_utils import (
 )
 
 from ..api.core import UserError
-from ..api.get_list import get_list
+from ..api.get_list import get_list, MAX_PAGE_SIZE
 from ..utils import submit_case_blocks
 
 
@@ -127,7 +127,7 @@ def test_case_list_queries(self, querystring, expected):
 
 @generate_cases([
     ("limit=nolimitz", "'nolimitz' is not a valid value for 'limit'"),
-    ("limit=10000", "You cannot request more than 5000 cases per request."),
+    (f"limit={MAX_PAGE_SIZE + 2}", f"You cannot request more than {MAX_PAGE_SIZE} cases per request."),
     ("date_opened.lt=bad-datetime", "Cannot parse datetime 'bad-datetime'"),
     ("date_opened.lt=2020-02-30", "Cannot parse datetime '2020-02-30'"),
 ], TestCaseListAPI)

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -1,0 +1,79 @@
+import uuid
+
+from django.test import TestCase
+
+from casexml.apps.case.mock import CaseBlock
+from pillowtop.es_utils import initialize_index_and_mapping
+
+from corehq import privileges
+from corehq.apps.es.tests.utils import es_test
+from corehq.elastic import get_es_new, send_to_elasticsearch
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
+from corehq.pillows.case_search import transform_case_for_elasticsearch
+from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
+from corehq.util.elastic import ensure_index_deleted
+from corehq.util.test_utils import (
+    generate_cases,
+    privilege_enabled,
+    trap_extra_setup,
+)
+
+from ..api.get_list import get_list
+from ..utils import submit_case_blocks
+
+
+@es_test
+@privilege_enabled(privileges.API_ACCESS)
+class TestCaseListAPI(TestCase):
+    domain = 'testcaselistapi'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.cases = cls._mk_cases([
+            ('mattie', "Mattie Ross", {}),
+            ('rooster', "Reuben Cogburn", {"alias": "Rooster"}),
+            ('laboeuf', "LaBoeuf", {}),
+            ('chaney', "Tom Chaney", {"alias": "The Coward"}),
+            ('ned', "Ned Pepper", {"alias": "Lucky Ned"}),
+        ])
+
+        cls.es = get_es_new()
+        with trap_extra_setup(ConnectionError):
+            initialize_index_and_mapping(cls.es, CASE_SEARCH_INDEX_INFO)
+        for case in cls.cases:
+            send_to_elasticsearch(
+                'case_search',
+                transform_case_for_elasticsearch(case.to_json())
+            )
+        cls.es.indices.refresh(CASE_SEARCH_INDEX_INFO.index)
+
+    @classmethod
+    def _mk_cases(cls, case_specs):
+        _, cases = submit_case_blocks([
+            CaseBlock(
+                case_id=str(uuid.uuid4()),
+                case_type='person',
+                case_name=name,
+                external_id=external_id,
+                owner_id='owner',
+                create=True,
+                update=properties,
+            ).as_text()
+            for external_id, name, properties in case_specs
+        ], domain=cls.domain)
+        return cases
+
+    @classmethod
+    def tearDownClass(cls):
+        FormProcessorTestUtils.delete_all_cases()
+        ensure_index_deleted(CASE_SEARCH_INDEX_INFO.index)
+        super().tearDownClass()
+
+
+@generate_cases([
+    ({}, ['mattie', 'rooster', 'laboeuf', 'chaney', 'ned']),
+], TestCaseListAPI)
+def test_case_list_queries(self, params, expected):
+    actual = [c['external_id'] for c in get_list(self.domain, params)]
+    self.assertItemsEqual(actual, expected)

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -67,54 +67,6 @@ class TestCaseAPI(TestCase):
         ).as_text()], domain=self.domain)
         return cases[0]
 
-    def test_serialize_case(self):
-        parent_case_id = self._make_case().case_id
-        xform, cases = submit_case_blocks([CaseBlock(
-            case_id=str(uuid.uuid4()),
-            case_type='match',
-            case_name='Harmon/Luchenko',
-            owner_id='harmon',
-            external_id='14',
-            create=True,
-            update={'winner': 'Harmon'},
-            index={
-                'parent': IndexAttrs(case_type='player', case_id=parent_case_id, relationship='child')
-            },
-        ).as_text()], domain=self.domain)
-        case = cases[0]
-
-        case.opened_on = datetime(2021, 2, 18, 10, 59)
-        case.modified_on = datetime(2021, 2, 18, 10, 59)
-        case.server_modified_on = datetime(2021, 2, 18, 10, 59)
-
-        self.assertEqual(
-            serialize_case(case),
-            {
-                "domain": self.domain,
-                "@case_id": case.case_id,
-                "@case_type": "match",
-                "case_name": "Harmon/Luchenko",
-                "external_id": "14",
-                "@owner_id": "harmon",
-                "date_opened": "2021-02-18T10:59:00",
-                "last_modified": "2021-02-18T10:59:00",
-                "server_last_modified": "2021-02-18T10:59:00",
-                "closed": False,
-                "date_closed": None,
-                "properties": {
-                    "winner": "Harmon",
-                },
-                "indices": {
-                    "parent": {
-                        "case_id": parent_case_id,
-                        "@case_type": "player",
-                        "@relationship": "child",
-                    }
-                }
-            }
-
-        )
-
     def _create_case(self, body):
         return self.client.post(
             reverse('case_api', args=(self.domain,)),

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -1,5 +1,4 @@
 import uuid
-from datetime import datetime
 
 from django.test import TestCase
 from django.urls import reverse
@@ -19,7 +18,6 @@ from corehq.form_processor.tests.utils import (
 )
 from corehq.util.test_utils import privilege_enabled
 
-from ..api.core import serialize_case
 from ..utils import submit_case_blocks
 
 

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from django.test import TestCase
 from django.urls import reverse
 
-from casexml.apps.case.mock import CaseBlock, IndexAttrs
+from casexml.apps.case.mock import CaseBlock
 
 from corehq import privileges
 from corehq.apps.domain.shortcuts import create_domain

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -19,7 +19,7 @@ from corehq.form_processor.tests.utils import (
 )
 from corehq.util.test_utils import privilege_enabled
 
-from ..api import serialize_case
+from ..api.core import serialize_case
 from ..utils import submit_case_blocks
 
 

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -135,6 +135,17 @@ class TestCaseAPI(TestCase):
         # for the time being, the implementation is the same
         return self._create_case(body)
 
+    def test_simple_get(self):
+        case_id = self._make_case().case_id
+        res = self.client.get(reverse('case_api', args=(self.domain, case_id)))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json()['@case_id'], case_id)
+
+    def test_case_not_found(self):
+        res = self.client.get(reverse('case_api', args=(self.domain, 'fake_id')))
+        self.assertEqual(res.status_code, 404)
+        self.assertEqual(res.json()['error'], "Case 'fake_id' not found")
+
     def test_create_case(self):
         res = self._create_case({
             # notable exclusions: case_id, date_opened, date_modified

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -96,6 +96,19 @@ class TestCaseAPI(TestCase):
         self.assertEqual(res.status_code, 404)
         self.assertEqual(res.json()['error'], "Case 'fake_id' not found")
 
+    def test_case_on_other_domain(self):
+        case_id = str(uuid.uuid4())
+        submit_case_blocks([CaseBlock(
+            case_id=case_id,
+            case_type='player',
+            case_name='Judit Polgár',
+            create=True,
+            update={}
+        ).as_text()], domain='other_domain')
+        res = self.client.get(reverse('case_api', args=(self.domain, case_id)))
+        self.assertEqual(res.status_code, 404)
+        self.assertEqual(res.json()['error'], f"Case '{case_id}' not found")
+
     def test_create_case(self):
         res = self._create_case({
             # notable exclusions: case_id, date_opened, date_modified

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -215,6 +215,22 @@ class TestCaseAPI(TestCase):
         self.assertEqual(res.json()['error'], "No case found with ID 'notarealcaseid'")
         self.assertEqual(self.case_accessor.get_case_ids_in_domain(), [])
 
+    def test_update_case_on_other_domain(self):
+        case_id = str(uuid.uuid4())
+        submit_case_blocks([CaseBlock(
+            case_id=case_id,
+            case_type='player',
+            case_name='Judit Polgár',
+            create=True,
+            update={}
+        ).as_text()], domain='other_domain')
+
+        res = self._update_case(case_id, {
+            '@owner_id': 'stealing_this_case',
+        })
+        self.assertEqual(res.json()['error'], f"No case found with ID '{case_id}'")
+        self.assertEqual(self.case_accessor.get_case_ids_in_domain(), [])
+
     def test_create_child_case(self):
         parent_case = self._make_case()
         res = self._create_case({

--- a/corehq/apps/hqcase/tests/test_serialization.py
+++ b/corehq/apps/hqcase/tests/test_serialization.py
@@ -11,6 +11,7 @@ from corehq.apps.es.case_search import CaseSearchES
 from corehq.apps.es.tests.utils import es_test
 from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.pillows.case_search import transform_case_for_elasticsearch
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
@@ -54,7 +55,10 @@ class TestAPISerialization(TestCase):
                 owner_id='harmon',
                 external_id='14',
                 create=True,
-                update={'winner': 'Harmon'},
+                update={
+                    'winner': 'Harmon',
+                    'accuracy': '84.3',
+                },
                 index={
                     'parent': IndexAttrs(case_type='player', case_id=cls.parent_case_id, relationship='child')
                 },
@@ -85,6 +89,7 @@ class TestAPISerialization(TestCase):
         ensure_index_deleted(CASE_SEARCH_INDEX_INFO.index)
         super().tearDownClass()
 
+    @run_with_all_backends
     def test_serialization(self):
         self.assertEqual(
             serialize_case(self.case),
@@ -102,6 +107,7 @@ class TestAPISerialization(TestCase):
                 "date_closed": None,
                 "properties": {
                     "winner": "Harmon",
+                    'accuracy': '84.3',
                 },
                 "indices": {
                     "parent": {
@@ -113,6 +119,7 @@ class TestAPISerialization(TestCase):
             }
         )
 
+    @run_with_all_backends
     def test_es_serialization(self):
         es_case = CaseSearchES().doc_id(self.case.case_id).run().hits[0]
         self.assertEqual(serialize_case(self.case), serialize_es_case(es_case))

--- a/corehq/apps/hqcase/tests/test_serialization.py
+++ b/corehq/apps/hqcase/tests/test_serialization.py
@@ -7,14 +7,14 @@ from casexml.apps.case.mock import CaseBlock, IndexAttrs
 from pillowtop.es_utils import initialize_index_and_mapping
 
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.es.case_search import CaseSearchES, flatten_result
+from corehq.apps.es.case_search import CaseSearchES
 from corehq.apps.es.tests.utils import es_test
 from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.pillows.case_search import transform_case_for_elasticsearch
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
-from corehq.util.test_utils import create_and_save_a_case, trap_extra_setup
+from corehq.util.test_utils import trap_extra_setup
 
 from ..api.core import serialize_case, serialize_es_case
 from ..utils import submit_case_blocks

--- a/corehq/apps/hqcase/tests/test_serialization.py
+++ b/corehq/apps/hqcase/tests/test_serialization.py
@@ -1,0 +1,92 @@
+import uuid
+from datetime import datetime
+
+from django.test import TestCase
+
+from casexml.apps.case.mock import CaseBlock, IndexAttrs
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.util.test_utils import create_and_save_a_case
+
+from ..api.core import serialize_case
+from ..utils import submit_case_blocks
+
+
+class TestAPISerialization(TestCase):
+    domain = 'test-update-cases'
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = create_domain(cls.domain)
+        cls.case_accessor = CaseAccessors(cls.domain)
+
+        cls.parent_case_id = str(uuid.uuid4())
+        case_id = str(uuid.uuid4())
+        xform, cases = submit_case_blocks([
+            CaseBlock(
+                case_id=cls.parent_case_id,
+                case_type='player',
+                case_name='Elizabeth Harmon',
+                external_id='1',
+                owner_id='methuen_home',
+                create=True,
+                update={
+                    'sport': 'chess',
+                    'rank': '1600',
+                    'dob': '1948-11-02',
+                }
+            ).as_text(),
+            CaseBlock(
+                case_id=case_id,
+                case_type='match',
+                case_name='Harmon/Luchenko',
+                owner_id='harmon',
+                external_id='14',
+                create=True,
+                update={'winner': 'Harmon'},
+                index={
+                    'parent': IndexAttrs(case_type='player', case_id=cls.parent_case_id, relationship='child')
+                },
+            ).as_text()
+        ], domain=cls.domain)
+
+        cls.case = cls.case_accessor.get_case(case_id)
+        cls.case.opened_on = datetime(2021, 2, 18, 10, 59)
+        cls.case.modified_on = datetime(2021, 2, 18, 10, 59)
+        cls.case.server_modified_on = datetime(2021, 2, 18, 10, 59)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+    def test_serialization(self):
+        self.assertEqual(
+            serialize_case(self.case),
+            {
+                "domain": self.domain,
+                "@case_id": self.case.case_id,
+                "@case_type": "match",
+                "case_name": "Harmon/Luchenko",
+                "external_id": "14",
+                "@owner_id": "harmon",
+                "date_opened": "2021-02-18T10:59:00",
+                "last_modified": "2021-02-18T10:59:00",
+                "server_last_modified": "2021-02-18T10:59:00",
+                "closed": False,
+                "date_closed": None,
+                "properties": {
+                    "winner": "Harmon",
+                },
+                "indices": {
+                    "parent": {
+                        "case_id": self.parent_case_id,
+                        "@case_type": "player",
+                        "@relationship": "child",
+                    }
+                }
+            }
+        )

--- a/corehq/apps/hqcase/tests/test_serialization.py
+++ b/corehq/apps/hqcase/tests/test_serialization.py
@@ -4,15 +4,23 @@ from datetime import datetime
 from django.test import TestCase
 
 from casexml.apps.case.mock import CaseBlock, IndexAttrs
+from pillowtop.es_utils import initialize_index_and_mapping
 
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.es.case_search import CaseSearchES, flatten_result
+from corehq.apps.es.tests.utils import es_test
+from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.util.test_utils import create_and_save_a_case
+from corehq.pillows.case_search import transform_case_for_elasticsearch
+from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
+from corehq.util.elastic import ensure_index_deleted
+from corehq.util.test_utils import create_and_save_a_case, trap_extra_setup
 
-from ..api.core import serialize_case
+from ..api.core import serialize_case, serialize_es_case
 from ..utils import submit_case_blocks
 
 
+@es_test
 class TestAPISerialization(TestCase):
     domain = 'test-update-cases'
     maxDiff = None
@@ -53,14 +61,28 @@ class TestAPISerialization(TestCase):
             ).as_text()
         ], domain=cls.domain)
 
+        cls.parent_case = cls.case_accessor.get_case(cls.parent_case_id)
         cls.case = cls.case_accessor.get_case(case_id)
-        cls.case.opened_on = datetime(2021, 2, 18, 10, 59)
-        cls.case.modified_on = datetime(2021, 2, 18, 10, 59)
-        cls.case.server_modified_on = datetime(2021, 2, 18, 10, 59)
+        for case in [cls.case, cls.parent_case]:
+            # Patch datetimes for test consistency
+            case.opened_on = datetime(2021, 2, 18, 10, 59)
+            case.modified_on = datetime(2021, 2, 18, 10, 59)
+            case.server_modified_on = datetime(2021, 2, 18, 10, 59)
+
+        cls.es = get_es_new()
+        with trap_extra_setup(ConnectionError):
+            initialize_index_and_mapping(cls.es, CASE_SEARCH_INDEX_INFO)
+        for case in [cls.case, cls.parent_case]:
+            send_to_elasticsearch(
+                'case_search',
+                transform_case_for_elasticsearch(cls.case.to_json())
+            )
+        cls.es.indices.refresh(CASE_SEARCH_INDEX_INFO.index)
 
     @classmethod
     def tearDownClass(cls):
         cls.domain_obj.delete()
+        ensure_index_deleted(CASE_SEARCH_INDEX_INFO.index)
         super().tearDownClass()
 
     def test_serialization(self):
@@ -73,9 +95,9 @@ class TestAPISerialization(TestCase):
                 "case_name": "Harmon/Luchenko",
                 "external_id": "14",
                 "@owner_id": "harmon",
-                "date_opened": "2021-02-18T10:59:00",
-                "last_modified": "2021-02-18T10:59:00",
-                "server_last_modified": "2021-02-18T10:59:00",
+                "date_opened": "2021-02-18T10:59:00.000000Z",
+                "last_modified": "2021-02-18T10:59:00.000000Z",
+                "server_last_modified": "2021-02-18T10:59:00.000000Z",
                 "closed": False,
                 "date_closed": None,
                 "properties": {
@@ -90,3 +112,7 @@ class TestAPISerialization(TestCase):
                 }
             }
         )
+
+    def test_es_serialization(self):
+        es_case = CaseSearchES().doc_id(self.case.case_id).run().hits[0]
+        self.assertEqual(serialize_case(self.case), serialize_es_case(es_case))

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -98,6 +98,8 @@ def case_api(request, domain, case_id=None):
 def _handle_individual_get(request, case_id):
     try:
         case = CaseAccessors(request.domain).get_case(case_id)
+        if case.domain != request.domain:
+            raise CaseNotFound()
     except CaseNotFound:
         return JsonResponse({'error': f"Case '{case_id}' not found"}, status=404)
     return JsonResponse(serialize_case(case))

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -21,7 +21,8 @@ from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.utils import should_use_sql_backend
 
-from .api import SubmissionError, UserError, handle_case_update, serialize_case
+from .api.core import SubmissionError, UserError, serialize_case
+from .api.updates import handle_case_update
 from .tasks import delete_exploded_case_task, explode_case_task
 
 

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -103,7 +103,7 @@ def _handle_individual_get(request, case_id):
 
 
 def _handle_list_view(request):
-    cases = get_list(request.domain, dict(request.GET))
+    cases = get_list(request.domain, request.GET.dict())
     return JsonResponse(cases)
 
 


### PR DESCRIPTION
## Summary

https://docs.google.com/document/d/1upMFrcItnyxVkD2NoBzpO6pTJRMncYVRVQcrvF5Gfj0/edit#
Next phase of work on the new case API, following up from https://github.com/dimagi/commcare-hq/pull/29208

This PR introduces the GET methods.  Everything is still superuser only.

I'm particularly interested in other ways users might break this API, causing 500s or somehow doing query injections.

## Feature Flag
superuser only

## Product Description
Adds a new Case API with support for filtering on case properties.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

This is new code and it includes tests

### QA Plan

Pending remaining work

### Safety story

Shouldn't affect any existing functionality - it's new, standalone, and superuser-only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
