### PR TITLE
[SSO] Block users from viewing Domain if logged in with SSO and Domain does not Trust IdP

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -25,6 +25,10 @@ from oauth2_provider.oauth2_backends import get_oauthlib_core
 from corehq.apps.domain.auth import HQApiKeyAuthentication
 from tastypie.http import HttpUnauthorized
 
+from corehq.apps.sso.utils.request_helpers import (
+    is_request_blocked_from_viewing_domain_due_to_sso,
+    is_request_using_sso,
+)
 from dimagi.utils.django.request import mutable_querydict
 from dimagi.utils.web import json_response
 
@@ -50,6 +54,7 @@ from corehq.toggles import (
     IS_CONTRACTOR,
     PUBLISH_CUSTOM_REPORTS,
     TWO_FACTOR_SUPERUSER_ROLLOUT,
+    ENTERPRISE_SSO,
 )
 from corehq.util.soft_assert import soft_assert
 from django_digest.decorators import httpdigest
@@ -102,6 +107,12 @@ def login_and_domain_required(view_func):
                 return TemplateResponse(request=req, template='two_factor/core/otp_required.html', status=403)
             elif not _can_access_project_page(req):
                 return _redirect_to_project_access_upgrade(req)
+            elif (ENTERPRISE_SSO.enabled_for_request(req)  # safety check. next line was not formally QA'd yet
+                  and is_request_blocked_from_viewing_domain_due_to_sso(req, domain_obj)):
+                # Important! Make sure this is always the final check prior
+                # to returning call_view() below
+                # todo, show more user-friendly view
+                return HttpResponseForbidden()
             else:
                 return call_view()
         elif user.is_superuser:
@@ -111,6 +122,12 @@ def login_and_domain_required(view_func):
                 return no_permissions(req, message=msg)
             if not _can_access_project_page(req):
                 return _redirect_to_project_access_upgrade(req)
+            if (ENTERPRISE_SSO.enabled_for_request(req)  # safety check. next line was not formally QA'd yet
+                    and is_request_using_sso(req)):
+                # We will not support SSO for superusers at this time
+                return HttpResponseForbidden(
+                    "SSO support is not currently available for superusers."
+                )
             return call_view()
         elif couch_user.is_web_user() and domain_obj.allow_domain_requests:
             from corehq.apps.users.views import DomainRequestView

--- a/corehq/apps/sso/async_handlers.py
+++ b/corehq/apps/sso/async_handlers.py
@@ -11,6 +11,7 @@ from corehq.apps.sso.models import (
     IdentityProvider,
     UserExemptFromSingleSignOn,
 )
+from corehq.apps.sso.utils.user_helpers import get_email_domain_from_username
 
 
 class Select2IdentityProviderHandler(BaseSelect2AsyncHandler):
@@ -173,7 +174,7 @@ class SSOExemptUsersAdminAsyncHandler(BaseLinkedObjectAsyncHandler):
     @property
     @memoized
     def email_domain(self):
-        try:
-            return self.username.split('@')[1]
-        except IndexError:
+        email_domain = get_email_domain_from_username(self.username)
+        if not email_domain:
             raise AsyncHandlerError("Please enter in a valid email.")
+        return email_domain

--- a/corehq/apps/sso/backends.py
+++ b/corehq/apps/sso/backends.py
@@ -2,6 +2,7 @@ from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.models import User
 
 from corehq.apps.sso.models import IdentityProvider, AuthenticatedEmailDomain
+from corehq.apps.sso.utils.user_helpers import get_email_domain_from_username
 
 
 class SsoBackend(ModelBackend):
@@ -24,9 +25,8 @@ class SsoBackend(ModelBackend):
             request.sso_login_error = f"This Identity Provider {idp_slug} is not active."
             return None
 
-        try:
-            email_domain = username.split('@', 1)[1]
-        except IndexError:
+        email_domain = get_email_domain_from_username(username)
+        if not email_domain:
             # not a valid username
             request.sso_login_error = f"Username {username} is not valid."
             return None

--- a/corehq/apps/sso/exceptions.py
+++ b/corehq/apps/sso/exceptions.py
@@ -1,2 +1,6 @@
 class ServiceProviderCertificateError(Exception):
     pass
+
+
+class SingleSignOnError(Exception):
+    pass

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -4,6 +4,7 @@ from corehq.apps.accounting.models import BillingAccount, Subscription
 from corehq.apps.sso import certificates
 from corehq.apps.sso.exceptions import ServiceProviderCertificateError
 from corehq.apps.sso.utils.user_helpers import get_email_domain_from_username
+from corehq.util.quickcache import quickcache
 
 
 class IdentityProviderType:
@@ -140,6 +141,7 @@ class IdentityProvider(models.Model):
             is_active=True
         ).values_list('subscriber__domain', flat=True))
 
+    @quickcache(['self.slug', 'domain'])
     def is_domain_an_active_member(self, domain):
         """
         Checks whether the given Domain is an Active Member of the current
@@ -157,6 +159,7 @@ class IdentityProvider(models.Model):
             subscriber__domain=domain,
         ).exists()
 
+    @quickcache(['self.slug', 'domain'])
     def does_domain_trust_this_idp(self, domain):
         """
         Checks whether the given Domain trusts this Identity Provider.

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 
-from corehq.apps.accounting.models import BillingAccount
+from corehq.apps.accounting.models import BillingAccount, Subscription
 from corehq.apps.sso import certificates
 from corehq.apps.sso.exceptions import ServiceProviderCertificateError
 
@@ -127,6 +127,17 @@ class IdentityProvider(models.Model):
         return UserExemptFromSingleSignOn.objects.filter(
             email_domain__identity_provider=self,
         ).values_list('username', flat=True)
+
+    def get_active_projects(self):
+        """
+        Returns a list of active domains/project spaces for this identity
+        provider.
+        :return: list of strings (domain names)
+        """
+        return list(Subscription.visible_objects.filter(
+            account=self.owner,
+            is_active=True
+        ).values_list('subscriber__domain', flat=True))
 
     @classmethod
     def domain_has_editable_identity_provider(cls, domain):

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from corehq.apps.accounting.models import BillingAccount, Subscription
 from corehq.apps.sso import certificates
 from corehq.apps.sso.exceptions import ServiceProviderCertificateError
+from corehq.apps.sso.utils.user_helpers import get_email_domain_from_username
 
 
 class IdentityProviderType:
@@ -152,10 +153,9 @@ class IdentityProvider(models.Model):
         :param username: (string)
         :return: IdentityProvider or None
         """
-        try:
-            email_domain = username.split('@')[1]
-        except IndexError:
-            # malformed email
+        email_domain = get_email_domain_from_username(username)
+        if not email_domain:
+            # malformed username/email
             return None
         try:
             authenticated_email_domain = AuthenticatedEmailDomain.objects.get(

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -144,6 +144,28 @@ class IdentityProvider(models.Model):
         owner = BillingAccount.get_account_by_domain(domain)
         return cls.objects.filter(owner=owner, is_editable=True).exists()
 
+    @classmethod
+    def get_active_identity_provider_by_username(cls, username):
+        """
+        Returns the active Identity Provider associated with a user's email
+        domain or None.
+        :param username: (string)
+        :return: IdentityProvider or None
+        """
+        try:
+            email_domain = username.split('@')[1]
+        except IndexError:
+            # malformed email
+            return None
+        try:
+            authenticated_email_domain = AuthenticatedEmailDomain.objects.get(
+                email_domain=email_domain
+            )
+            idp = authenticated_email_domain.identity_provider
+        except AuthenticatedEmailDomain.DoesNotExist:
+            return None
+        return idp if idp.is_active else None
+
 
 class AuthenticatedEmailDomain(models.Model):
     """

--- a/corehq/apps/sso/tests/generator.py
+++ b/corehq/apps/sso/tests/generator.py
@@ -47,7 +47,7 @@ def get_billing_account_for_idp():
 
 
 @unit_testing_only
-def get_enterprise_plan_for_tests():
+def get_enterprise_plan():
     enterprise_plan = SoftwarePlan.objects.create(
         name="Helping Earth INGO Enterprise Plan",
         description="Enterprise plan for Helping Earth",

--- a/corehq/apps/sso/tests/generator.py
+++ b/corehq/apps/sso/tests/generator.py
@@ -1,5 +1,4 @@
 from corehq.apps.sso import certificates
-from dimagi.utils.data import generator as data_gen
 from corehq.apps.accounting.tests import generator as accounting_gen
 
 from corehq.util.test_utils import unit_testing_only

--- a/corehq/apps/sso/tests/generator.py
+++ b/corehq/apps/sso/tests/generator.py
@@ -1,3 +1,12 @@
+from django_prbac.models import Role
+
+from corehq.apps.accounting.models import (
+    SoftwarePlan,
+    SoftwarePlanEdition,
+    SoftwarePlanVisibility,
+    SoftwareProductRate,
+    SoftwarePlanVersion,
+)
 from corehq.apps.sso import certificates
 from corehq.apps.accounting.tests import generator as accounting_gen
 
@@ -34,4 +43,24 @@ def get_billing_account_for_idp():
     dimagi_user = accounting_gen.create_arbitrary_web_user_name(is_dimagi=True)
     return accounting_gen.billing_account(
         dimagi_user, billing_contact, is_customer_account=True
+    )
+
+
+@unit_testing_only
+def get_enterprise_plan_for_tests():
+    enterprise_plan = SoftwarePlan.objects.create(
+        name="Helping Earth INGO Enterprise Plan",
+        description="Enterprise plan for Helping Earth",
+        edition=SoftwarePlanEdition.ENTERPRISE,
+        visibility=SoftwarePlanVisibility.INTERNAL,
+        is_customer_software_plan=True,
+    )
+    first_product_rate = SoftwareProductRate.objects.create(
+        monthly_fee=3000,
+        name="HQ Enterprise"
+    )
+    return SoftwarePlanVersion.objects.create(
+        plan=enterprise_plan,
+        role=Role.objects.first(),
+        product_rate=first_product_rate
     )

--- a/corehq/apps/sso/tests/test_request_helpers.py
+++ b/corehq/apps/sso/tests/test_request_helpers.py
@@ -90,7 +90,7 @@ class TestIsRequestBlockedFromViewingDomainDueToSso(TestCase):
             "helping-earth-001",
             is_active=True
         )
-        enterprise_plan = generator.get_enterprise_plan_for_tests()
+        enterprise_plan = generator.get_enterprise_plan()
         Subscription.new_domain_subscription(
             account=cls.account,
             domain=cls.domain.name,

--- a/corehq/apps/sso/tests/test_request_helpers.py
+++ b/corehq/apps/sso/tests/test_request_helpers.py
@@ -1,0 +1,238 @@
+from testil import eq
+from django.test import TestCase, RequestFactory, override_settings
+
+from corehq.apps.accounting.models import Subscription
+from corehq.apps.domain.models import Domain
+from corehq.apps.sso.exceptions import SingleSignOnError
+from corehq.apps.sso.models import (
+    AuthenticatedEmailDomain,
+    IdentityProvider,
+    TrustedIdentityProvider,
+)
+from corehq.apps.sso.utils.request_helpers import (
+    get_request_data,
+    is_request_using_sso,
+    is_request_blocked_from_viewing_domain_due_to_sso,
+)
+from corehq.apps.users.models import WebUser
+from corehq.apps.sso.tests import generator
+
+
+@override_settings(SAML2_DEBUG=False)
+def test_get_request_data():
+    request = RequestFactory().get('/sso/test')
+    request.META = {
+        'HTTP_HOST': 'test.org',
+        'PATH_INFO': '/sso/test',
+        'SERVER_PORT': '999',
+    }
+    request.POST = {
+        'post_data': 'test',
+    }
+    request.GET = {
+        'get_data': 'test',
+    }
+    eq(
+        get_request_data(request),
+        {
+            'https': 'on',
+            'http_host': 'test.org',
+            'script_name': '/sso/test',
+            'server_port': '443',
+            'get_data': {
+                'get_data': 'test',
+            },
+            'post_data': {
+                'post_data': 'test',
+            }
+        }
+    )
+
+
+def test_is_request_using_sso_true():
+    """
+    Testing the successful criteria for an sso request.
+    """
+    request = RequestFactory().get('/sso/test')
+    request.session = {
+        'samlSessionIndex': '_7c84c96e-8774-4e64-893c-06f91d285100',
+    }
+    eq(is_request_using_sso(request), True)
+
+
+def test_is_request_using_sso_false_with_session():
+    """
+    Testing the usual case for non-sso requests.
+    """
+    request = RequestFactory().get('/sso/test')
+    request.session = {}
+    eq(is_request_using_sso(request), False)
+
+
+def test_is_request_using_sso_false_without_session():
+    """
+    Make sure this call is safe even when session is missing from the request.
+    """
+    request = RequestFactory().get('/sso/test')
+    eq(is_request_using_sso(request), False)
+
+
+class TestIsRequestBlockedFromViewingDomainDueToSso(TestCase):
+    """
+    This test verifies what criteria must be met to block an SSO logged in
+    User from viewing a Domain.
+    """
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.account = generator.get_billing_account_for_idp()
+        cls.domain = Domain.get_or_create_with_name(
+            "helping-earth-001",
+            is_active=True
+        )
+        enterprise_plan = generator.get_enterprise_plan_for_tests()
+        Subscription.new_domain_subscription(
+            account=cls.account,
+            domain=cls.domain.name,
+            plan_version=enterprise_plan,
+        )
+        cls.user = WebUser.create(
+            cls.domain.name, 'jorge@helpingearth.org', 'testpwd', None, None
+        )
+        cls.idp = generator.create_idp('helping-earth', cls.account)
+        cls.idp.is_active = True
+        cls.idp.save()
+        AuthenticatedEmailDomain.objects.create(
+            email_domain='helpingearth.org',
+            identity_provider=cls.idp,
+        )
+
+        cls.domain_created_by_user = Domain.get_or_create_with_name(
+            "my-test-project",
+            is_active=True
+        )
+        cls.domain_created_by_user.creating_user = cls.user.username
+        cls.domain_created_by_user.save()
+
+        cls.external_domain = Domain.get_or_create_with_name(
+            "vaultwax-001",
+            is_active=True
+        )
+        cls.user_without_idp = WebUser.create(
+            cls.external_domain.name, 'b@vaultwax.com', 'testpwd', None, None
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        AuthenticatedEmailDomain.objects.all().delete()
+        IdentityProvider.objects.all().delete()
+        cls.user_without_idp.delete(None)
+        cls.user.delete(None)
+        cls.domain_created_by_user.delete()
+        cls.external_domain.delete()
+        cls.domain.delete()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        self.request = RequestFactory().get('/sso/test')
+        self.request.session = {
+            'samlSessionIndex': '_7c84c96e-8774-4e64-893c-06f91d285100',
+        }
+        self.request.user = self.user
+
+    def tearDown(self):
+        TrustedIdentityProvider.objects.all().delete()
+        super().tearDown()
+
+    def test_returns_false_if_request_is_not_using_sso(self):
+        """
+        A request not using SSO should never be blocked by SSO requirements.
+        """
+        request = RequestFactory().get('/sso/test')
+        self.assertFalse(
+            is_request_blocked_from_viewing_domain_due_to_sso(
+                request,
+                self.domain
+            )
+        )
+        request.session = {}
+        self.assertFalse(
+            is_request_blocked_from_viewing_domain_due_to_sso(
+                request,
+                self.domain
+            )
+        )
+
+    def test_raises_error_if_request_uses_sso_but_user_does_not_have_idp(self):
+        """
+        This should never be a state that we get into, and if we do there
+        is something seriously wrong that we need to look into ASAP.
+
+        `is_request_blocked_from_viewing_domain_due_to_sso` should raise
+        a `SingleSignOnError` if the request meets sso requirements, but the
+        signed in user does not map to an Identity Provider.
+        """
+        self.request.user = self.user_without_idp
+        with self.assertRaises(SingleSignOnError):
+            self.assertFalse(
+                is_request_blocked_from_viewing_domain_due_to_sso(
+                    self.request,
+                    self.domain
+                )
+            )
+
+    def test_returns_false_if_domain_belongs_to_idp_account_owner(self):
+        """
+        If a domain has an active subscription owned by the account that
+        owns the Identity Provider the user has signed in with, the request
+        should not be blocked.
+        """
+        self.assertFalse(
+            is_request_blocked_from_viewing_domain_due_to_sso(
+                self.request,
+                self.domain
+            )
+        )
+
+    def test_returns_false_if_domain_trusts_identity_provider(self):
+        """
+        If a domain trusts the Identity Provider that the requesting user is
+        signed in with, the request should not be blocked.
+        """
+        TrustedIdentityProvider.objects.create(
+            domain=self.external_domain.name,
+            identity_provider=self.idp,
+            acknowledged_by='b@hrs.org'
+        )
+        self.assertFalse(
+            is_request_blocked_from_viewing_domain_due_to_sso(
+                self.request,
+                self.external_domain
+            )
+        )
+
+    def test_returns_false_if_user_created_domain(self):
+        """
+        If a user is the creating_user of a domain, then their request should
+        not be blocked.
+        """
+        self.assertFalse(
+            is_request_blocked_from_viewing_domain_due_to_sso(
+                self.request,
+                self.domain_created_by_user
+            )
+        )
+
+    def test_returns_true_if_external_domain_does_not_trust_idp(self):
+        """
+        If a domain not belonging to the Identity Provider owner does not
+        trust the Identity Provider, and the user is logged in with sso
+        under that Identity Provider, their request should be blocked.
+        """
+        self.assertTrue(
+            is_request_blocked_from_viewing_domain_due_to_sso(
+                self.request,
+                self.external_domain
+            )
+        )

--- a/corehq/apps/sso/tests/test_request_helpers.py
+++ b/corehq/apps/sso/tests/test_request_helpers.py
@@ -142,6 +142,19 @@ class TestIsRequestBlockedFromViewingDomainDueToSso(TestCase):
         self.request.user = self.user
 
     def tearDown(self):
+        # clear the quickcache
+        IdentityProvider.does_domain_trust_this_idp.clear(
+            self.idp,
+            self.external_domain.name
+        )
+        IdentityProvider.does_domain_trust_this_idp.clear(
+            self.idp,
+            self.domain.name
+        )
+        IdentityProvider.does_domain_trust_this_idp.clear(
+            self.idp,
+            self.domain_created_by_user.name
+        )
         TrustedIdentityProvider.objects.all().delete()
         super().tearDown()
 

--- a/corehq/apps/sso/utils/request_helpers.py
+++ b/corehq/apps/sso/utils/request_helpers.py
@@ -62,6 +62,8 @@ def is_request_blocked_from_viewing_domain_due_to_sso(request, domain_obj):
         # owns this domain, a Trust will be created automatically and a message
         # will be displayed to the user.
         # todo mechanism for displaying message to user
+        # todo remember to handle clearing quickcache for
+        #  does_domain_trust_this_idp
         return False
 
     # None of the above criteria was met so the user is definitely blocked!

--- a/corehq/apps/sso/utils/request_helpers.py
+++ b/corehq/apps/sso/utils/request_helpers.py
@@ -30,7 +30,7 @@ def get_request_data(request):
 
 
 def is_request_using_sso(request):
-    return bool(hasattr(request, 'session') and request.session.get('samlSessionIndex', None))
+    return bool(hasattr(request, 'session') and request.session.get('samlSessionIndex'))
 
 
 def is_request_blocked_from_viewing_domain_due_to_sso(request, domain_obj):

--- a/corehq/apps/sso/utils/request_helpers.py
+++ b/corehq/apps/sso/utils/request_helpers.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from corehq.apps.sso.exceptions import SingleSignOnError
 from corehq.apps.sso.models import (
     IdentityProvider,
-    TrustedIdentityProvider,
 )
 
 
@@ -54,14 +53,7 @@ def is_request_blocked_from_viewing_domain_due_to_sso(request, domain_obj):
             f"to be associated with an Identity Provider!"
         )
 
-    if domain_obj.name in idp.get_active_projects():
-        # The domain is owned by the owner of the Identity Provider
-        return False
-
-    if TrustedIdentityProvider.objects.filter(
-        domain=domain_obj.name, identity_provider=idp
-    ).exists():
-        # An administrator of this domain has trusted this Identity Provider
+    if idp.does_domain_trust_this_idp(domain_obj.name):
         return False
 
     if domain_obj.creating_user == username:

--- a/corehq/apps/sso/utils/request_helpers.py
+++ b/corehq/apps/sso/utils/request_helpers.py
@@ -23,3 +23,7 @@ def get_request_data(request):
         'get_data': request.GET.copy(),
         'post_data': request.POST.copy(),
     }
+
+
+def is_request_using_sso(request):
+    return bool(hasattr(request, 'session') and request.session.get('samlSessionIndex', None))

--- a/corehq/apps/sso/utils/user_helpers.py
+++ b/corehq/apps/sso/utils/user_helpers.py
@@ -1,0 +1,15 @@
+def get_email_domain_from_username(username):
+    """
+    A quick utility for getting an Email Domain from a username
+    (the last part of the email after the '@' sign)
+    :param username: String
+    :return: String username
+    """
+    split_username = username.split('@')
+    if len(split_username) < 2:
+        # Not a real email address with an expected email domain.
+        return None
+    # we take the last split because `@` is technically an allowed character if
+    # inside a quoted string.
+    # See https://en.wikipedia.org/wiki/Email_address#Local-part
+    return split_username[-1]

--- a/corehq/apps/sso/utils/user_helpers.py
+++ b/corehq/apps/sso/utils/user_helpers.py
@@ -3,7 +3,7 @@ def get_email_domain_from_username(username):
     A quick utility for getting an Email Domain from a username
     (the last part of the email after the '@' sign)
     :param username: String
-    :return: String username
+    :return: Domain name string. `None` if there is no domain name.
     """
     split_username = username.split('@')
     if len(split_username) < 2:


### PR DESCRIPTION
## Summary
NOTE to anyone reviewing this PR due to the `Risk: High` tag. The offending commit is this https://github.com/dimagi/commcare-hq/pull/29276/commits/4bf78e81158e73e745a1426ce738d66c2bb685a1
As you will see, the change to the `login_and_domain_required` decorator is very carefully feature-flagged, so there should not be a concern that un-QA'd code would ever run.

This is the first part of this ticket 
https://dimagi-dev.atlassian.net/browse/SAAS-11780

This PR introduces a change to the `login_and_domain_required` decorator which blocks the `request` to view a domain if the `request.user` is logged in with SSO and does not meet sso requirements.

One of the following must be true, otherwise, the request is considered blocked:
- The `Domain` being accessed is under an active `Subscription` belonging to the `BillingAccount` owner of the `IdentityProvider` the SSO user is logged in under.
- The `Domain` has established a `TrustedIdentityProvider` relationship with the `IdentityProvider` the SSO user is logged in under.
- The user is the `creating_user` of the `Domain` which is being accessed.

## Feature Flag
carefully feature-flagged with `ENTERPRISE_SSO`

## Product Description
No active user-facing changes here.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
New tests have been added to ensure these new utilities work as expected.

### QA Plan
No QA needed due to feature flagging, see safety story below.

### Safety story
The new functionality introduced in the very crucial `login_and_domain_required` decorator has been carefully feature-flagged under `ENTERPRISE_SSO` to ensure that un-QA'd code is never run.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
