### PR TITLE
mark domain decorators.py as high risk

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -25,6 +25,7 @@ rules:
       - 'corehq/pillows/mappings/**'
       - 'corehq/apps/hqwebapp/templates/hqwebapp/includes/core_libraries.html'
       - 'corehq/apps/hqwebapp/static/hqwebapp/js/requirejs_config.js'
+      - 'corehq/apps/domain/decorators.py'
 
   - labels: ['Risk: Medium']
     patterns:


### PR DESCRIPTION
## Summary
marks domain/decorators.py as high risk when it's modified

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Improves safety!

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
