### PR TITLE
formpalyer docker revamp

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -25,6 +25,7 @@ import six.moves.urllib.parse
 import six.moves.urllib.request
 from text_unidecode import unidecode
 
+from corehq.apps.formplayer_api.utils import get_formplayer_url
 from corehq.util.metrics import metrics_counter
 from dimagi.utils.logging import notify_error
 from dimagi.utils.web import get_url_base, json_response
@@ -216,7 +217,7 @@ class FormplayerMain(View):
             "domain_is_on_trial": domain_is_on_trial(domain),
             "mapbox_access_token": settings.MAPBOX_ACCESS_TOKEN,
             "username": request.couch_user.username,
-            "formplayer_url": settings.FORMPLAYER_URL,
+            "formplayer_url": get_formplayer_url(for_js=True),
             "single_app_mode": False,
             "home_url": reverse(self.urlname, args=[domain]),
             "environment": WEB_APPS_ENVIRONMENT,
@@ -278,7 +279,7 @@ class FormplayerPreviewSingleApp(View):
             "apps": [_format_app_doc(app)],
             "mapbox_access_token": settings.MAPBOX_ACCESS_TOKEN,
             "username": request.user.username,
-            "formplayer_url": settings.FORMPLAYER_URL,
+            "formplayer_url": get_formplayer_url(for_js=True),
             "single_app_mode": True,
             "home_url": reverse(self.urlname, args=[domain, app_id]),
             "environment": WEB_APPS_ENVIRONMENT,
@@ -298,7 +299,7 @@ class PreviewAppView(TemplateView):
         app = get_app(request.domain, kwargs.pop('app_id'))
         return self.render_to_response({
             'app': _format_app_doc(app.to_json()),
-            'formplayer_url': settings.FORMPLAYER_URL,
+            'formplayer_url': get_formplayer_url(for_js=True),
             "mapbox_access_token": settings.MAPBOX_ACCESS_TOKEN,
             "environment": PREVIEW_APP_ENVIRONMENT,
             "integrations": integration_contexts(request.domain),
@@ -407,7 +408,7 @@ def form_context(request, domain, app_id, module_id, form_id):
 
     root_context = {
         'form_url': form_url,
-        'formplayer_url': settings.FORMPLAYER_URL,
+        'formplayer_url': get_formplayer_url(for_js=True),
     }
     if instance_id:
         try:

--- a/corehq/apps/formplayer_api/utils.py
+++ b/corehq/apps/formplayer_api/utils.py
@@ -7,7 +7,7 @@ from dimagi.utils.web import get_url_base
 def get_formplayer_url(for_js=False):
     if for_js:
         # use different URL for JS if supplied - required for Docker usage
-        return getattr(settings, 'FORMPLAYER_URL_JS', settings.FORMPLAYER_URL)
+        return getattr(settings, 'FORMPLAYER_URL_WEBAPPS', settings.FORMPLAYER_URL)
     formplayer_url = settings.FORMPLAYER_URL
     if not formplayer_url.startswith('http'):
         formplayer_url = '{}{}'.format(get_url_base(), formplayer_url)

--- a/corehq/apps/formplayer_api/utils.py
+++ b/corehq/apps/formplayer_api/utils.py
@@ -4,7 +4,10 @@ from corehq.apps.formplayer_api.exceptions import FormplayerAPIException
 from dimagi.utils.web import get_url_base
 
 
-def get_formplayer_url():
+def get_formplayer_url(for_js=False):
+    if for_js:
+        # use different URL for JS if supplied - required for Docker usage
+        return getattr(settings, 'FORMPLAYER_URL_JS', settings.FORMPLAYER_URL)
     formplayer_url = settings.FORMPLAYER_URL
     if not formplayer_url.startswith('http'):
         formplayer_url = '{}{}'.format(get_url_base(), formplayer_url)

--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -34,8 +34,6 @@ services:
       service: formplayer
     environment:
         COMMCARE_HOST: "http://web:8000"
-        COMMCARE_ALTERNATE_ORIGINS: "http://localhost:8000,http://127.0.0.1:8000"
-        EXTERNAL_REQUEST_MODE: "replace-host"
     links:
       - postgres
       - redis

--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -75,8 +75,6 @@ services:
     extends:
       file: hq-compose-services.yml
       service: kafka
-    environment:
-      KAFKA_ADVERTISED_HOST_NAME: "kafka"
 
   minio:
     extends:

--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -33,15 +33,15 @@ services:
       file: hq-compose.yml
       service: formplayer
     environment:
-      WEB_HOST: "web"
+        COMMCARE_HOST: "http://web:8000"
+        COMMCARE_ALTERNATE_ORIGINS: "http://localhost:8000,http://127.0.0.1:8000"
+        EXTERNAL_REQUEST_MODE: "replace-host"
     links:
       - postgres
-      - couch
       - redis
-    expose:
-      - 8010
     ports:
-      - "8010:8010"
+      - "8080:8080"
+      - "8081:8081"
 
   postgres:
     extends:
@@ -77,6 +77,8 @@ services:
     extends:
       file: hq-compose-services.yml
       service: kafka
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: "kafka"
 
   minio:
     extends:

--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -5,16 +5,14 @@ services:
     extends:
       file: hq-compose.yml
       service: formplayer
-    environment:
-      WEB_HOST: "dockerhost"
     links:
       - postgres
-      - couch
       - redis
     expose:
-      - 8010
+      - 8080
     ports:
-      - "8010:8010"
+      - "8080:8080"
+      - "8081:8081"
 
   postgres:
     extends:

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -103,7 +103,7 @@ services:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-zookeeper:}/opt/zookeeper-3.4.13/data
 
   kafka:
-      image: wurstmeister/kafka:0.8.2.2-1
+      image: wurstmeister/kafka:2.13-2.6.0
       ports:
         - "9092:9092"
       environment:

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -112,6 +112,7 @@ services:
           KAFKA_BROKER_ID: 1
           KAFKA_ADVERTISED_PORT: 9092
           CUSTOM_INIT_SCRIPT: "curl https://raw.githubusercontent.com/vishnubob/wait-for-it/c096cface5fbd9f2d6b037391dfecae6fde1362e/wait-for-it.sh > wait.sh && chmod +x ./wait.sh && ./wait.sh zookeeper:2181 || exit 1"
+          KAFKA_ADVERTISED_HOST_NAME: "kafka"
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock
         - ${VOLUME_PREFIX}${BLANK_IF_TESTS-kafka:}/kafka/kafka-logs-1

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -41,6 +41,7 @@ services:
       COMMCARE_HOST: "http://host.docker.internal:8000"
       COMMCARE_ALTERNATE_ORIGINS: "http://localhost:8000,http://127.0.0.1:8000"
       AUTH_KEY: "secretkey"
+      EXTERNAL_REQUEST_MODE: "replace-host"
     expose:
       - "8080"
       - "8081"

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -38,9 +38,12 @@ services:
   formplayer:
     image: dimagi/formplayer
     environment:
-      WEB_HOST: "dockerhost"
+      COMMCARE_HOST: "http://host.docker.internal:8000"
+      COMMCARE_ALTERNATE_ORIGINS: "http://localhost:8000,http://127.0.0.1:8000"
+      AUTH_KEY: "secretkey"
     expose:
-      - "8010"
+      - "8080"
+      - "8081"
 
   postgres:
     image: dimagi/docker-postgresql

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -235,7 +235,7 @@ if os.environ.get("COMMCAREHQ_BOOTSTRAP") == "yes":
     COMPRESS_OFFLINE = False
 
     FORMPLAYER_URL = 'http://formplayer:8080'
-    FORMPLAYER_URL_JS = 'http://localhost:8080'
+    FORMPLAYER_URL_WEBAPPS = 'http://localhost:8080'
 
     CCHQ_API_THROTTLE_REQUESTS = 200
     CCHQ_API_THROTTLE_TIMEFRAME = 10

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -234,7 +234,8 @@ if os.environ.get("COMMCAREHQ_BOOTSTRAP") == "yes":
 
     COMPRESS_OFFLINE = False
 
-    FORMPLAYER_URL = 'http://formplayer:8010'
+    FORMPLAYER_URL = 'http://formplayer:8080'
+    FORMPLAYER_URL_JS = 'http://localhost:8080'
 
     CCHQ_API_THROTTLE_REQUESTS = 200
     CCHQ_API_THROTTLE_TIMEFRAME = 10

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -180,32 +180,36 @@ AUDIT_ADMIN_VIEWS = False
 SECRET_KEY = 'secrettravis'
 
 # No logging
+
 LOCAL_LOGGING_CONFIG = {
-    'handlers': {
-        'null': {
-            'level': 'DEBUG',
-            'class': 'logging.NullHandler',
-        }
-    },
     'loggers': {
         '': {
-            'level': 'CRITICAL',
-            'handler': 'null',
-            'propagate': True,
+            'level': 'ERROR',
+            'handler': 'console',
+            'propagate': False,
         },
-        'pillowtop': {
-            'level': 'CRITICAL',
-            'handler': 'null',
-            'propagate': True,
+        'django': {
+            'handler': 'console',
+            'level': 'ERROR',
+            'propagate': False,
         },
         'notify': {
-            'level': 'CRITICAL',
-            'handler': 'null',
-            'propagate': True,
+            'level': 'ERROR',
+            'handler': 'console',
+            'propagate': False,
         },
+        'kafka': {
+            'level': 'ERROR',
+            'handler': 'console',
+            'propagate': False,
+        },
+        'commcare_auth': {
+            'level': 'ERROR',
+            'handler': 'console',
+            'propagate': False,
+        }
     }
 }
-
 
 PHONE_TIMEZONES_HAVE_BEEN_PROCESSED = True
 PHONE_TIMEZONES_SHOULD_BE_PROCESSED = True

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -138,6 +138,7 @@ function bootstrap() {
                 ./manage.py sync_couch_views &&
                 ./manage.py migrate --noinput &&
                 ./manage.py compilejsi18n &&
+                ./manage.py create_kafka_topics &&
                 ./manage.py make_superuser admin@example.com"
 }
 


### PR DESCRIPTION
## Summary
Most of the changes here only impact the docker-compose files or docker localsettings. The only HQ change is to allow specifying and separate formplayer URL for web apps since web apps communicates with formplayer from the browser which is outside of the docker network.

Formplayer PR: https://github.com/dimagi/formplayer/pull/909

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
