### PR TITLE
DHIS2: Support "coordinate" and "geometry" in enrollments

### DIFF
--- a/corehq/motech/dhis2/schema.py
+++ b/corehq/motech/dhis2/schema.py
@@ -52,6 +52,7 @@ def get_event_schema() -> dict:
     True
 
     """
+    coordinate_schema = get_coordinate_schema()
     note_schema = get_note_schema()
     relationship_schema = get_relationship_schema()
     return {
@@ -60,10 +61,7 @@ def get_event_schema() -> dict:
         SchemaOptional("attributeOptionCombo"): id_schema,
         SchemaOptional("completedBy"): str,
         SchemaOptional("completedDate"): date_schema,
-        SchemaOptional("coordinate"): {
-            "latitude": float,
-            "longitude": float,
-        },
+        SchemaOptional("coordinate"): coordinate_schema,
         SchemaOptional("created"): datetime_schema,
         SchemaOptional("createdAtClient"): datetime_schema,
         "dataValues": [{
@@ -133,7 +131,9 @@ def get_tracked_entity_schema() -> dict:
     Returns the schema of a tracked entity instance.
     """
     attribute_schema = get_attribute_schema()
+    coordinate_schema = get_coordinate_schema()
     event_schema = get_event_schema()
+    geometry_schema = get_geometry_schema()
     note_schema = get_note_schema()
     relationship_schema = get_relationship_schema()
     return {
@@ -147,10 +147,12 @@ def get_tracked_entity_schema() -> dict:
             SchemaOptional("createdAtClient"): datetime_schema,
             SchemaOptional("completedBy"): str,
             SchemaOptional("completedDate"): date_schema,
+            SchemaOptional("coordinate"): coordinate_schema,
             SchemaOptional("deleted"): bool,
             SchemaOptional("enrollment"): id_schema,
             SchemaOptional("enrollmentDate"): date_schema,
             SchemaOptional("events"): [event_schema],
+            SchemaOptional("geometry"): geometry_schema,
             SchemaOptional("incidentDate"): date_schema,
             SchemaOptional("lastUpdated"): datetime_schema,
             SchemaOptional("lastUpdatedAtClient"): datetime_schema,
@@ -165,10 +167,7 @@ def get_tracked_entity_schema() -> dict:
             SchemaOptional("trackedEntityType"): id_schema,
         }],
         SchemaOptional("featureType"): str,
-        SchemaOptional("geometry"): {
-            "type": str,
-            "coordinates": [float],
-        },
+        SchemaOptional("geometry"): geometry_schema,
         SchemaOptional("inactive"): bool,
         SchemaOptional("lastUpdated"): datetime_schema,
         SchemaOptional("lastUpdatedAtClient"): datetime_schema,
@@ -177,4 +176,18 @@ def get_tracked_entity_schema() -> dict:
         SchemaOptional("relationships"): [relationship_schema],
         SchemaOptional("trackedEntityInstance"): id_schema,
         "trackedEntityType": id_schema,
+    }
+
+
+def get_coordinate_schema():
+    return {
+        "latitude": float,
+        "longitude": float,
+    }
+
+
+def get_geometry_schema():
+    return {
+        "type": str,
+        "coordinates": [float],
     }


### PR DESCRIPTION
## Summary

Context: [Jira](https://dimagi-dev.atlassian.net/browse/SC-1296)

Fixes a bug where DHIS2 is returning a tracked entity instance whose enrollments include "coordinate" and "geometry" properties, and when CommCare updated it and sent it back to DHIS2 it was failing validation because CommCare did not recognize those properties. This change adds the properties to the schema.

cc @avazirna


## Feature Flag

DHIS2 integration


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story

Small change to schema definition to make it less restrictive. Will not affect payloads that already pass validation.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
