### PR TITLE
Updated USH script to fix all "'patient'" cases

### DIFF
--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -29,10 +29,9 @@ def should_skip(case, traveler_location_id, inactive_location):
 
 def needs_update(case):
     index = case.indices[0]
-    return index.relationship == "child" and (
-        index.referenced_type == "patient"
-        or index.referenced_type == "'patient'"
-    )
+    if index.referenced_type == "'patient'":
+        return True
+    return index.relationship == "child" and index.referenced_type == "patient"
 
 
 def get_owner_id(case_type):


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-715

Minor followup for https://github.com/dimagi/commcare-hq/pull/29254: found some lab result cases with an index that uses `'patient'` with quotes but is an extension relationship instead of child. Those need to be fixed, too.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

This script has test coverage.

### QA Plan

No QA, will be running on a test domain before the real domains.

### Safety story
Minor change to management command.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
