### PR TITLE
Updated sticky search to work with daterange inputs

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -15,7 +15,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 return "__range__" + value.replace(separator, "__");
             }
             return value;
-        }, decodeValue = function (model, value) {
+        },
+        decodeValue = function (model, value) {
             if (!value) {
                 return value;
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -1,4 +1,4 @@
-/*global DOMPurify, Marionette */
+/*global DOMPurify, Marionette, moment */
 
 hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
     // 'hqwebapp/js/hq.helpers' is a dependency. It needs to be added
@@ -90,7 +90,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             this.ui.dateRange.on('apply.daterangepicker', function(ev, picker) {
                 $(this).val(picker.startDate.format(dateFormat) + separator + picker.endDate.format(dateFormat)).trigger('change');
             });
-            this.ui.dateRange.on('change', function(ev, picker) {
+            this.ui.dateRange.on('change', function() {
                 // Validate free-text input. Accept anything moment can recognize as a date, reformatting for ES.
                 var $input = $(this),
                     oldValue = $input.val(),

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -4,13 +4,25 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
     // 'hqwebapp/js/hq.helpers' is a dependency. It needs to be added
     // explicitly when webapps is migrated to requirejs
     var FormplayerFrontend = hqImport("cloudcare/js/formplayer/app");
+    var separator = " to ";
 
     // special format handled by CaseSearch API
-    var separator = " to ",
-    encodeDateRange = function (value) {
-        return "__range__" + value.replace(separator, "__");
-    }, decodeDateRange = function (value) {
-        return value.replace("__range__", "").replace("__", separator);
+    var encodeValue = function (model, value) {
+        if (!value) {
+            return value;
+        }
+        if (model.get("input") === "daterange") {
+            return "__range__" + value.replace(separator, "__");
+        }
+        return value;
+    }, decodeValue = function (model, value) {
+        if (!value) {
+            return value;
+        }
+        if (model.get("input") === "daterange") {
+            return value.replace("__range__", "").replace("__", separator);
+        }
+        return value;
     };
 
     var QueryView = Marionette.View.extend({
@@ -40,10 +52,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             // If input doesn't have a default value, check to see if there's a sticky value from user's last search
             if (!this.options.model.get('value')) {
                 var stickyValue = hqImport("cloudcare/js/formplayer/utils/util").getStickyQueryInputs()[this.options.model.get('id')];
-                if (stickyValue && this.options.model.get("input") == "daterange") {
-                    stickyValue = decodeDateRange(stickyValue);
-                }
-                this.options.model.set('value', stickyValue);
+                this.options.model.set('value', decodeValue(this.options.model, stickyValue));
             }
         },
 
@@ -117,14 +126,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 answers = {},
                 model = this.parentModel;
             $fields.each(function (index) {
-                var answer = null;
                 if (this.value !== '') {
-                    if (model[index].get('input') === 'daterange') {
-                        answer = encodeDateRange(this.value);
-                    } else {
-                        answer = this.value;
-                    }
-                    answers[model[index].get('id')] = answer;
+                    answers[model[index].get('id')] = encodeValue(model[index], this.value);
                 }
             });
             return answers;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -4,7 +4,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
     // 'hqwebapp/js/hq.helpers' is a dependency. It needs to be added
     // explicitly when webapps is migrated to requirejs
     var FormplayerFrontend = hqImport("cloudcare/js/formplayer/app");
-    var separator = " to ";
+    var separator = " to ",
+        dateFormat = "YYYY-MM-DD";
 
     // special format handled by CaseSearch API
     var encodeValue = function (model, value) {
@@ -76,7 +77,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             this.ui.hqHelp.hqHelp();
             this.ui.dateRange.daterangepicker({
                 locale: {
-                    format: 'YYYY-MM-DD',
+                    format: dateFormat,
                     separator: separator,
                     cancelLabel: gettext('Clear'),
                 },
@@ -87,7 +88,20 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 $(this).val('').trigger('change');
             });
             this.ui.dateRange.on('apply.daterangepicker', function(ev, picker) {
-                $(this).val(picker.startDate.format('YYYY-MM-DD') + separator + picker.endDate.format('YYYY-MM-DD')).trigger('change');
+                $(this).val(picker.startDate.format(dateFormat) + separator + picker.endDate.format(dateFormat)).trigger('change');
+            });
+            this.ui.dateRange.on('change', function(ev, picker) {
+                // Validate free-text input. Accept anything moment can recognize as a date, reformatting for ES.
+                var $input = $(this),
+                    oldValue = $input.val(),
+                    parts = _.map(oldValue.split(separator), function (v) { return moment(v); }),
+                    newValue = '';
+                if (parts.length === 2 && _.every(parts, function (part) { return part.isValid(); })) {
+                    newValue = parts[0].format(dateFormat) + separator + parts[1].format(dateFormat);
+                }
+                if (oldValue !== newValue) {
+                    $input.val(newValue).trigger('change');
+                }
             });
         },
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -8,22 +8,22 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
 
     // special format handled by CaseSearch API
     var encodeValue = function (model, value) {
-        if (!value) {
+            if (!value) {
+                return value;
+            }
+            if (model.get("input") === "daterange") {
+                return "__range__" + value.replace(separator, "__");
+            }
             return value;
-        }
-        if (model.get("input") === "daterange") {
-            return "__range__" + value.replace(separator, "__");
-        }
-        return value;
-    }, decodeValue = function (model, value) {
-        if (!value) {
+        }, decodeValue = function (model, value) {
+            if (!value) {
+                return value;
+            }
+            if (model.get("input") === "daterange") {
+                return value.replace("__range__", "").replace("__", separator);
+            }
             return value;
-        }
-        if (model.get("input") === "daterange") {
-            return value.replace("__range__", "").replace("__", separator);
-        }
-        return value;
-    };
+        };
 
     var QueryView = Marionette.View.extend({
         tagName: "tr",

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -90,7 +90,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             this.ui.dateRange.on('apply.daterangepicker', function(ev, picker) {
                 $(this).val(picker.startDate.format(dateFormat) + separator + picker.endDate.format(dateFormat)).trigger('change');
             });
-            this.ui.dateRange.on('change', function() {
+            this.ui.dateRange.on('change', function () {
                 // Validate free-text input. Accept anything moment can recognize as a date, reformatting for ES.
                 var $input = $(this),
                     oldValue = $input.val(),

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -68,7 +68,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 locale: {
                     format: 'YYYY-MM-DD',
                     separator: separator,
-                    cancelLabel: 'Clear',
+                    cancelLabel: gettext('Clear'),
                 },
                 autoUpdateInput: false,
             });


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-757

## Feature Flag
COVID: Sticky search: In web apps, save user's most recent inputs on case search & claim screen.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-2685)

### Safety story
Tested out locally that date range search still works and is sticky.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
