### PR TITLE
Clean up urlsanitize tests and comments

### DIFF
--- a/corehq/util/urlsanitize/test/test_urlsanitize.py
+++ b/corehq/util/urlsanitize/test/test_urlsanitize.py
@@ -6,28 +6,33 @@ from ..urlsanitize import PossibleSSRFAttempt, sanitize_user_input_url, CannotRe
 RAISE = object()
 RETURN = object()
 
-GOOGLE_IP = ipaddress.ip_address(socket.gethostbyname('google.com'))
+GOOGLE_IP = SUITE = None  # set in setup_module
 
-SUITE = [
-    ('https://google.com/', (RETURN, GOOGLE_IP)),
-    ('http://google.com/', (RETURN, GOOGLE_IP)),
-    ('http://google.com', (RETURN, GOOGLE_IP)),
-    ('http://foo.example.com/', (RAISE, CannotResolveHost())),
-    ('http://localhost/', (RAISE, PossibleSSRFAttempt('is_loopback'))),
-    ('http://Localhost/', (RAISE, PossibleSSRFAttempt('is_loopback'))),
-    ('http://169.254.169.254/latest/meta-data', (RAISE, PossibleSSRFAttempt('is_link_local'))),
-    ('http://2852039166/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
-    ('http://7147006462/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
-    ('http://0xA9.0xFE.0xA9.0xFE/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
-    ('http://0x41414141A9FEA9FE/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
-    ('http://0xA9FEA9FE/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
-    ('http://0251.0376.0251.0376/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
-    ('http://0251.00376.000251.0000376/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
-    ('http://169.254.169.254.xip.io/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
-    ('http://A.8.8.8.8.1time.169.254.169.254.1time.repeat.rebind.network/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
-    ('http://10.124.10.11', (RAISE, PossibleSSRFAttempt('is_private'))),
-    ('some-non-url', (RAISE, InvalidURL())),
-]
+
+def setup_module():
+    global GOOGLE_IP, SUITE
+
+    GOOGLE_IP = ipaddress.ip_address(socket.gethostbyname('google.com'))
+    SUITE = [
+        ('https://google.com/', (RETURN, GOOGLE_IP)),
+        ('http://google.com/', (RETURN, GOOGLE_IP)),
+        ('http://google.com', (RETURN, GOOGLE_IP)),
+        ('http://foo.example.com/', (RAISE, CannotResolveHost())),
+        ('http://localhost/', (RAISE, PossibleSSRFAttempt('is_loopback'))),
+        ('http://Localhost/', (RAISE, PossibleSSRFAttempt('is_loopback'))),
+        ('http://169.254.169.254/latest/meta-data', (RAISE, PossibleSSRFAttempt('is_link_local'))),
+        ('http://2852039166/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
+        ('http://7147006462/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
+        ('http://0xA9.0xFE.0xA9.0xFE/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
+        ('http://0x41414141A9FEA9FE/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
+        ('http://0xA9FEA9FE/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
+        ('http://0251.0376.0251.0376/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
+        ('http://0251.00376.000251.0000376/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
+        ('http://169.254.169.254.xip.io/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
+        ('http://A.8.8.8.8.1time.169.254.169.254.1time.repeat.rebind.network/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
+        ('http://10.124.10.11', (RAISE, PossibleSSRFAttempt('is_private'))),
+        ('some-non-url', (RAISE, InvalidURL())),
+    ]
 
 
 def test_example_suite():

--- a/corehq/util/urlsanitize/test/test_urlsanitize.py
+++ b/corehq/util/urlsanitize/test/test_urlsanitize.py
@@ -53,7 +53,3 @@ def test_example_suite():
                         f"sanitize_url({input_url!r} should raise {value.__class__.__name__}({str(value)}) raised {value.__class__.__name__}({str(e)})"
         else:
             raise Exception("result in suite should be RETURN or RAISE")
-
-
-if __name__ == '__main__':
-    test_example_suite()

--- a/corehq/util/urlsanitize/test/test_urlsanitize.py
+++ b/corehq/util/urlsanitize/test/test_urlsanitize.py
@@ -31,7 +31,6 @@ def setup_module():
         ('http://0251.0376.0251.0376/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
         ('http://0251.00376.000251.0000376/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
         ('http://169.254.169.254.xip.io/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
-        ('http://A.8.8.8.8.1time.169.254.169.254.1time.repeat.rebind.network/', (RAISE, PossibleSSRFAttempt('is_link_local'))),
         ('http://10.124.10.11', (RAISE, PossibleSSRFAttempt('is_private'))),
         ('some-non-url', (RAISE, InvalidURL())),
     ]
@@ -52,3 +51,15 @@ def test_example_suite():
                     sanitize_user_input_url(input_url)
         else:
             raise Exception("result in suite should be RETURN or RAISE")
+
+
+def test_rebinding():
+    """
+    this test doesn't do much, it just checks that a known rebinding endpoint
+    and checks the output is one of the two expected values
+    """
+    url = 'http://A.8.8.8.8.1time.169.254.169.254.1time.repeat.rebind.network/'
+    try:
+        eq(sanitize_user_input_url(url), ipaddress.IPv4Address('8.8.8.8'))  # this is one possible output
+    except PossibleSSRFAttempt as e:
+        eq(e.reason, 'is_link_local')

--- a/corehq/util/urlsanitize/urlsanitize.py
+++ b/corehq/util/urlsanitize/urlsanitize.py
@@ -9,6 +9,7 @@ def sanitize_user_input_url(url):
 
     raise PossibleSSRFAttempt if the url resolves to a non-public ip address
     raise CannotResolveHost if the url host does not resolve
+    raise InvalidURL if `url` can't be parsed as a URL (i.e. if it doesn't even "look" like a URL)
     """
     parsed_url = urlparse(url)
     hostname = parsed_url.hostname


### PR DESCRIPTION
## Summary
Prompted by feedback on https://github.com/dimagi/commcare-hq/pull/28967.

## Feature Flag
None

## Product Description
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Test-only PR

### QA Plan
No QA

### Safety story
This PR only changes tests (and a comment), and I checked that the tests after these changes can still be trivially made to fail by editing the examples to be incorrect (so I didn't like silently break the tests ability to test). As long as the tests pass there's no real way this could effect production
 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
