### PR TITLE
Updated linked domains to fail when downstream app reference is ambig…

### DIFF
--- a/corehq/apps/linked_domain/applications.py
+++ b/corehq/apps/linked_domain/applications.py
@@ -1,5 +1,10 @@
+from collections import defaultdict
+
+from django.conf import settings
+
 from corehq.apps.app_manager.dbaccessors import (
     get_brief_apps_in_domain,
+    get_brief_app_docs_in_domain,
     get_build_doc_by_version,
     get_latest_released_app,
     get_latest_released_app_versions_by_app_id,
@@ -7,7 +12,7 @@ from corehq.apps.app_manager.dbaccessors import (
 )
 from corehq.apps.app_manager.exceptions import AppLinkError
 from corehq.apps.linked_domain.models import DomainLink
-from corehq.apps.linked_domain.exceptions import RemoteRequestError
+from corehq.apps.linked_domain.exceptions import MultipleDownstreamAppsError, RemoteRequestError
 from corehq.apps.linked_domain.remote_accessors import (
     get_app_by_version,
     get_brief_apps,
@@ -15,6 +20,7 @@ from corehq.apps.linked_domain.remote_accessors import (
     get_released_app,
 )
 from corehq.apps.linked_domain.util import pull_missing_multimedia_for_app
+from corehq.util.quickcache import quickcache
 
 
 def get_master_app_briefs(domain_link, family_id):
@@ -35,6 +41,28 @@ def get_master_app_by_version(domain_link, upstream_app_id, upstream_version):
 
     if app:
         return wrap_app(app)
+
+
+def get_downstream_app_id(downstream_domain, upstream_app_id):
+    downstream_ids = _get_downstream_app_id_map(downstream_domain)[upstream_app_id]
+    if not downstream_ids:
+        return None
+    if len(downstream_ids) > 1:
+        raise MultipleDownstreamAppsError
+    return downstream_ids[0]
+
+
+def get_upstream_app_ids(downstream_domain):
+    return list(_get_downstream_app_id_map(downstream_domain))
+
+
+@quickcache(vary_on=['downstream_domain'], skip_arg=lambda _: settings.UNIT_TESTING, timeout=5 * 60)
+def _get_downstream_app_id_map(downstream_domain):
+    downstream_app_ids = defaultdict(list)
+    for doc in get_brief_app_docs_in_domain(downstream_domain):
+        if doc.get("family_id"):
+            downstream_app_ids[doc["family_id"]].append(doc["_id"])
+    return downstream_app_ids
 
 
 def get_latest_master_app_release(domain_link, app_id):
@@ -75,4 +103,5 @@ def link_app(linked_app, master_domain, master_id, remote_details=None):
         except RemoteRequestError:
             raise AppLinkError('Error fetching multimedia from remote server. Please try again later.')
 
+    _get_downstream_app_id_map.clear(linked_app.domain)
     return linked_app

--- a/corehq/apps/linked_domain/exceptions.py
+++ b/corehq/apps/linked_domain/exceptions.py
@@ -2,6 +2,10 @@ class DomainLinkError(Exception):
     pass
 
 
+class MultipleDownstreamAppsError(Exception):
+    pass
+
+
 class RemoteRequestError(Exception):
     def __init__(self, status_code=None):
         self.status_code = status_code

--- a/corehq/apps/linked_domain/keywords.py
+++ b/corehq/apps/linked_domain/keywords.py
@@ -1,12 +1,10 @@
 import uuid
 
-from django.conf import settings
 from django.utils.translation import ugettext as _
 
-from corehq.apps.app_manager.dbaccessors import get_brief_app_docs_in_domain
-from corehq.apps.linked_domain.exceptions import DomainLinkError
+from corehq.apps.linked_domain.applications import get_downstream_app_id
+from corehq.apps.linked_domain.exceptions import DomainLinkError, MultipleDownstreamAppsError
 from corehq.apps.sms.models import Keyword
-from corehq.util.quickcache import quickcache
 
 
 def create_linked_keyword(domain_link, keyword_id):
@@ -72,21 +70,15 @@ def _update_actions(domain_link, linked_keyword, keyword_actions):
         keyword_action.keyword = linked_keyword
         if keyword_action.app_id is not None:
             try:
-                keyword_action.app_id = get_master_app_to_linked_app(domain_link.linked_domain)[
-                    keyword_action.app_id
-                ]
-            except KeyError:
+                app_id = get_downstream_app_id(domain_link.linked_domain, keyword_action.app_id)
+            except MultipleDownstreamAppsError:
+                raise DomainLinkError(_("Keyword {keyword} references an application that has multiple linked "
+                                        "applications. It cannot be updated.").format(
+                                            keyword=linked_keyword.keyword))
+            if not app_id:
                 raise DomainLinkError(_("Keyword {keyword} references an application "
                                         "that has not been linked to {linked_domain}").format(
                                             keyword=linked_keyword.keyword,
                                             linked_domain=domain_link.linked_domain))
+            keyword_action.app_id = app_id
         keyword_action.save()
-
-
-@quickcache(vary_on=['domain'], skip_arg=lambda _: settings.UNIT_TESTING, timeout=5 * 60)
-def get_master_app_to_linked_app(domain):
-    return {
-        doc["family_id"]: doc["_id"]
-        for doc in get_brief_app_docs_in_domain(domain)
-        if doc.get("family_id", None) is not None
-    }


### PR DESCRIPTION
…uous

## Summary
https://dimagi-dev.atlassian.net/browse/USH-167

## Feature Flag
Linked project spaces

## Product Description
This causes linked project space updates to fail if the update involves a report of keyword that references an app that is one of multiple apps created from the same upstream app. Previously, HQ would arbitrarily select one of the applications and update the report/keyword's references to that app, potentially leading to unexpected data in reports.

![Screen Shot 2021-03-03 at 9 24 42 PM](https://user-images.githubusercontent.com/1486591/109901360-ed057b80-7c66-11eb-80d2-656845d9af83.png)
![Screen Shot 2021-03-03 at 9 24 47 PM](https://user-images.githubusercontent.com/1486591/109901362-ed9e1200-7c66-11eb-826d-a5d5cacf4f40.png)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

There's decent test coverage for both linked keywords and linked reports.

### QA Plan

Not requesting QA.

### Safety story
This fixes a pretty rare edge case. Tested locally that this fixes the bug and also that you can still both pull and push reports and keywords that reference apps that **don't** fall into this edge case.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
