### PR TITLE
Allow domains admins to edit SMS Gateway config

### DIFF
--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -1110,6 +1110,10 @@ class AddGatewayViewMixin(object):
         return is_superuser_or_contractor(self.request.couch_user)
 
     @property
+    def is_domain_admin(self):
+        return self.request.couch_user.is_domain_admin(self.domain)
+
+    @property
     @memoized
     def hq_api_id(self):
         return self.kwargs.get('hq_api_id')
@@ -1117,9 +1121,13 @@ class AddGatewayViewMixin(object):
     @property
     @memoized
     def backend_class(self):
-        # Superusers can create/edit any backend
+        # Superusers and domain admins can create/edit any backend
         # Regular users can only create/edit Telerivet backends for now
-        if not self.is_system_admin and self.hq_api_id != SQLTelerivetBackend.get_api_id():
+        if (
+            not self.is_system_admin
+            and not self.is_domain_admin
+            and self.hq_api_id != SQLTelerivetBackend.get_api_id()
+        ):
             raise Http404()
         backend_classes = get_sms_backend_classes()
         try:


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-11912
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This will allow domain admins to view/edit SMS gateway which was resulting in 404 before
## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This has been tested locally and I was able to access the page from domain admin accounts and superuser but not from other users.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
