### PR TITLE
Add max eligible counts in a month

### DIFF
--- a/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_hcm_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_hcm_v1.json
@@ -166,6 +166,46 @@
             "timeEnd"
           ]
         }
+      },
+      {
+        "type": "expression",
+        "column_id": "number_of_adolescent_beneficiaries",
+        "display_name": "number_of_adolescent_beneficiaries",
+        "datatype": "integer",
+        "expression": {
+          "type": "coalesce",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "number_of_adolescent_beneficiaries"
+            ]
+          },
+          "default_expression": {
+            "type": "constant",
+            "constant": 0
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "number_of_children",
+        "display_name": "number_of_children",
+        "datatype": "integer",
+        "expression": {
+          "type": "coalesce",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "number_of_children"
+            ]
+          },
+          "default_expression": {
+            "type": "constant",
+            "constant": 0
+          }
+        }
       }
     ],
     "named_expressions": {

--- a/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_v1.json
@@ -166,6 +166,46 @@
             "timeEnd"
           ]
         }
+      },
+      {
+        "type": "expression",
+        "column_id": "number_of_children_0_3",
+        "display_name": "number_of_children_0_3",
+        "datatype": "integer",
+        "expression": {
+          "type": "coalesce",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "number_of_children_0_3"
+            ]
+          },
+          "default_expression": {
+            "type": "constant",
+            "constant": 0
+          }
+        }
+      },
+      {
+        "type": "expression",
+        "column_id": "number_of_pw_lm",
+        "display_name": "number_of_pw_lm",
+        "datatype": "integer",
+        "expression": {
+          "type": "coalesce",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "number_of_pw_lm"
+            ]
+          },
+          "default_expression": {
+            "type": "constant",
+            "constant": 0
+          }
+        }
       }
     ],
     "named_expressions": {

--- a/custom/nutrition_project/ucr/reports/hcm_report_v1.json
+++ b/custom/nutrition_project/ucr/reports/hcm_report_v1.json
@@ -65,6 +65,20 @@
         "aggregation": "simple"
       },
       {
+        "display": "Number of Children eligible",
+        "column_id": "number_of_children",
+        "type": "field",
+        "field": "number_of_children",
+        "aggregation": "max"
+      },
+      {
+        "display": "Number of Adolescent Beneficiaries eligible",
+        "column_id": "number_of_adolescent_beneficiaries",
+        "type": "field",
+        "field": "number_of_adolescent_beneficiaries",
+        "aggregation": "max"
+      },
+      {
         "display": "Count",
         "column_id": "count",
         "type": "field",

--- a/custom/nutrition_project/ucr/reports/thr_report_v1.json
+++ b/custom/nutrition_project/ucr/reports/thr_report_v1.json
@@ -65,6 +65,20 @@
         "aggregation": "simple"
       },
       {
+        "display": "Number of Children (0-3) eligible",
+        "column_id": "number_of_children_0_3",
+        "type": "field",
+        "field": "number_of_children_0_3",
+        "aggregation": "max"
+      },
+      {
+        "display": "Number of PW/LM eligible",
+        "column_id": "number_of_pw_lm",
+        "type": "field",
+        "field": "number_of_pw_lm",
+        "aggregation": "max"
+      },
+      {
         "display": "Count",
         "column_id": "count",
         "type": "field",


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Requirement at https://dimagi-dev.atlassian.net/browse/QA-2578?focusedCommentId=120679, modified to use "max" instead of array agg. 
There are definitely edge cases this approach will fail at but it's something we have agreed to begin with to get the number of eligible beneficiaries for a service. Ideally this would have come from a case DS, but we are not going the path of monthly data sources, so this seems the only available approach as of now.

Link to dynamic reports
1. https://india.commcarehq.org/a/india-nutrition-project/configurable_reports/reports/edit/bf4a3fac204345fd6f1e8662b4697a1b/
2. https://india.commcarehq.org/a/india-nutrition-project/configurable_reports/reports/edit/bf4a3fac204345fd6f1e8662b4b70d63/

ToDo post deploy:
update on https://dimagi-dev.atlassian.net/browse/QA-2578

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Only limited to one project and the change in expressions were tested in a dynamic report.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
