### PR TITLE
Removed old band-aid from build_requirejs

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -74,9 +74,6 @@ class Command(ResourceStaticCommand):
             # and pass in the file contents, since get_hash does another read.
             file_hash = self.get_hash(filename)
 
-            if module['name'] == "users/js/bundle":
-                file_hash = uuid4().hex
-
             # Overwrite source map reference. Source maps are accessed on the CDN,
             # so they need to have the version hash appended.
             with open(filename, 'r') as fin:


### PR DESCRIPTION
## Summary
I [said](https://github.com/dimagi/commcare-hq/pull/28470#discussion_r483172638) I had a plan to remove this, but looks like I was mistaken.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

No QA.

### Safety story
Minor change to management command.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
