### PR TITLE
[SSO] Add user-friendly view when a user tries to access domain that doesn't trust IdP

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -29,6 +29,9 @@ from corehq.apps.sso.utils.request_helpers import (
     is_request_blocked_from_viewing_domain_due_to_sso,
     is_request_using_sso,
 )
+from corehq.apps.sso.utils.view_helpers import (
+    render_untrusted_identity_provider_for_domain_view,
+)
 from dimagi.utils.django.request import mutable_querydict
 from dimagi.utils.web import json_response
 
@@ -111,8 +114,7 @@ def login_and_domain_required(view_func):
                   and is_request_blocked_from_viewing_domain_due_to_sso(req, domain_obj)):
                 # Important! Make sure this is always the final check prior
                 # to returning call_view() below
-                # todo, show more user-friendly view
-                return HttpResponseForbidden()
+                return render_untrusted_identity_provider_for_domain_view(req, domain_obj)
             else:
                 return call_view()
         elif user.is_superuser:

--- a/corehq/apps/sso/templates/sso/permissions/untrusted_identity_provider_for_domain.html
+++ b/corehq/apps/sso/templates/sso/permissions/untrusted_identity_provider_for_domain.html
@@ -1,0 +1,16 @@
+{% extends 'hqwebapp/base_page.html' %}
+{% load i18n %}
+
+{% block page_content %}
+  <p>
+    {% blocktrans %}
+      The identity provider used to authenticate your account, {{ identity_provider }},
+      is not trusted by this project space.
+    {% endblocktrans %}
+  </p>
+  <p>
+    {% blocktrans %}
+      Please contact a project administrator to restore access.
+    {% endblocktrans %}
+  </p>
+{% endblock %}

--- a/corehq/apps/sso/utils/view_helpers.py
+++ b/corehq/apps/sso/utils/view_helpers.py
@@ -1,0 +1,32 @@
+from django.shortcuts import render
+
+from django.utils.translation import ugettext as _
+from corehq.apps.sso.models import IdentityProvider
+
+
+def render_untrusted_identity_provider_for_domain_view(request, domain):
+    """
+    This is a "faux" view that doesn't map to a url, but returns a rendered
+    page response which alerts the user that they do not have access (based
+    on unmet sso requirements) to view this Domain.
+
+    :param request: HttpRequest
+    :param domain: Domain (object)
+    :return: HttpResponse
+    """
+    identity_provider = IdentityProvider.get_active_identity_provider_by_username(
+        request.user.username
+    )
+    template = "sso/permissions/untrusted_identity_provider_for_domain.html"
+    context = {
+        'section': {
+            'page_name': domain.name,
+        },
+        'current_page': {
+            'title': _("Untrusted Identity Provider"),
+            'page_name': _("Untrusted Identity Provider"),
+        },
+        'domain': domain.name,
+        'identity_provider': identity_provider.name,
+    }
+    return render(request, template, context)


### PR DESCRIPTION
## Summary
This is the UI followup to https://github.com/dimagi/commcare-hq/pull/29276
Work is part of this ticket https://dimagi-dev.atlassian.net/browse/SAAS-11780

NOTE: `Risk: High` label set because the `domain/decorators.py` view has been modified. However, all work is carefully behind a feature flag.

When an SSO user visits a domain that doesn't trust their Identity Provider, they should still be able to navigate out of that view (not just a blank screen that a `HttpResponseForbidden` returns), and there should be a message alerting the user to contact the administrator of that project to restore access.

## Feature Flag
`ENTERPRISE_SSO`

## Product Description
Renders a page that looks like this whenever a user signed in through SSO attempts to visit a domain that does not trust their identity provider:
<img width="1673" alt="Screen Shot 2021-03-03 at 5 19 56 PM" src="https://user-images.githubusercontent.com/716573/109985780-c0834b00-7cca-11eb-866a-c195fe4396be.png">


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
No test for this rendered view, but there are tons of tests for SSO.

### QA Plan
No QA needed yet, as all development is behind a feature flag.

### Safety story
SSO has lots of tests for the most critical functionality

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
