### PR TITLE
Format request body

### DIFF
--- a/corehq/motech/models.py
+++ b/corehq/motech/models.py
@@ -1,12 +1,12 @@
 import json
 import re
-from typing import Callable, Optional, Any
+from typing import Any, Callable, Optional
 
-import attr
 from django.db import models
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
+import attr
 import jsonfield
 
 import corehq.motech.auth
@@ -32,7 +32,7 @@ from corehq.motech.const import (
     PASSWORD_PLACEHOLDER,
 )
 from corehq.motech.utils import b64_aes_decrypt, b64_aes_encrypt
-from corehq.util import as_text
+from corehq.util import as_json_text, as_text
 
 
 @attr.s(auto_attribs=True, frozen=True, kw_only=True)
@@ -262,7 +262,7 @@ class RequestLog(models.Model):
             request_url=log_entry.url,
             request_headers=log_entry.headers,
             request_params=log_entry.params,
-            request_body=as_text(log_entry.data),
+            request_body=as_json_text(log_entry.data),
             request_error=log_entry.error,
             response_status=log_entry.response_status,
             response_headers=log_entry.response_headers,

--- a/corehq/motech/tests/test_models.py
+++ b/corehq/motech/tests/test_models.py
@@ -9,9 +9,13 @@ from mock import Mock, patch
 
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import pp_json
 from corehq.motech.const import ALGO_AES, PASSWORD_PLACEHOLDER
-from corehq.motech.models import ConnectionSettings, RequestLog, RequestLogEntry
+from corehq.motech.models import (
+    ConnectionSettings,
+    RequestLog,
+    RequestLogEntry,
+)
 from corehq.motech.requests import get_basic_requests
-from corehq.util import as_text
+from corehq.util import as_json_text, as_text
 
 TEST_API_URL = 'http://example.com:9080/api/'
 TEST_API_USERNAME = 'admin'
@@ -67,7 +71,7 @@ class UnpackRequestArgsTests(SimpleTestCase):
             domain=TEST_DOMAIN,
             log_level=logging.INFO,
             payload_id=None,
-            request_body=as_text(request_body),
+            request_body=as_json_text(request_body),
             request_error=self.error_message,
             request_headers=self.request_headers,
             request_method=self.request_method,

--- a/corehq/motech/tests/test_models.py
+++ b/corehq/motech/tests/test_models.py
@@ -258,6 +258,12 @@ class TestRequestLogFormatting(TestCase):
         template_value = pp_json(request_log.request_body)
         self.assertEqual(template_value, "{'hello': Decimal('1.0')}")
 
+    def test_request_body_none(self):
+        entry = self.get_entry(request_body=None)
+        request_log = RequestLog.log(level=logging.DEBUG, log_entry=entry)
+        template_value = pp_json(request_log.request_body)
+        self.assertEqual(template_value, '')
+
     @staticmethod
     def get_entry(request_body):
         return RequestLogEntry(

--- a/corehq/util/__init__.py
+++ b/corehq/util/__init__.py
@@ -1,3 +1,4 @@
+import json as stdlib_json  # Don't conflict with `corehq.util.json`
 from traceback import format_exception_only
 
 from django.utils.functional import Promise
@@ -46,3 +47,12 @@ def as_text(value):
         lines = format_exception_only(type(value), value)
         return "\n".join(x.rstrip("\n") for x in lines)
     return repr(value)
+
+
+def as_json_text(value):
+    if isinstance(value, dict):
+        try:
+            return stdlib_json.dumps(value, indent=2)
+        except TypeError:
+            pass
+    return as_text(value)

--- a/corehq/util/__init__.py
+++ b/corehq/util/__init__.py
@@ -50,6 +50,8 @@ def as_text(value):
 
 
 def as_json_text(value):
+    if value is None:
+        return ''
     if isinstance(value, dict):
         try:
             return stdlib_json.dumps(value, indent=2)


### PR DESCRIPTION
## Summary

Small.

Resolves a *super annoying* issue when reading API request logs.

This change dumps JSON request bodies as JSON strings, instead of as string representations of Python dictionaries.

fyi @avazirna @karmuno 

### Context

Currently, if the body of an API request is JSON, it is rendered in the API Request Log details page as a long one-line string of a Python dictionary. You need to ...

1. copy-and-paste it into an editor, 
2. search-and-replace quotation marks, `True`, `False`, and `None`, 
3. and then prettify it

... before you can read it.

This change is not going to help with reading old request logs. (I considered that briefly. We could use `eval()` to parse the string back into a dictionary, and then dump it as JSON, but the idea of using `eval()` shut that idea down quickly. Dumping the dictionary as a JSON string before saving it to the DB seems like a better idea than fixing the mistake when retrieving it.)


## Product Description

(Only visible to people who configure or manage integrations.) Makes outgoing data (more) readable.


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Change includes tests. If I've missed anything, please point it out.


### Safety story

Small cosmetic change.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
