### PR TITLE
Test claiming a case from a different domain fails

### DIFF
--- a/corehq/apps/ota/tests/test_claim.py
+++ b/corehq/apps/ota/tests/test_claim.py
@@ -11,6 +11,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.exceptions import CaseNotFound
 
 DOMAIN = 'test_domain'
 USERNAME = 'lina.stern@ras.ru'
@@ -110,6 +111,15 @@ class CaseClaimTests(TestCase):
         self._close_case(claim_id)
         first_claim = get_first_claim(DOMAIN, self.user.user_id, self.host_case_id)
         self.assertIsNone(first_claim)
+
+    @run_with_all_backends
+    def test_claim_case_other_domain(self):
+        malicious_domain = 'malicious_domain'
+        create_domain(malicious_domain)
+        claim_id = claim_case(malicious_domain, self.user.user_id, self.host_case_id,
+                              host_type=self.host_case_type, host_name=self.host_case_name)
+        with self.assertRaises(CaseNotFound):
+            CaseAccessors(malicious_domain).get_case(claim_id)
 
     def _close_case(self, case_id):
         case_block = CaseBlock.deprecated_init(

--- a/corehq/apps/ota/tests/test_claim.py
+++ b/corehq/apps/ota/tests/test_claim.py
@@ -115,7 +115,8 @@ class CaseClaimTests(TestCase):
     @run_with_all_backends
     def test_claim_case_other_domain(self):
         malicious_domain = 'malicious_domain'
-        create_domain(malicious_domain)
+        domain_obj = create_domain(malicious_domain)
+        self.addCleanup(domain_obj.delete)
         claim_id = claim_case(malicious_domain, self.user.user_id, self.host_case_id,
                               host_type=self.host_case_type, host_name=self.host_case_name)
         with self.assertRaises(CaseNotFound):


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Adding a test to ensure claims across domains are safe. There might be a better way to raise this issue (currently `submit_case_blocks` just silently an error which isn't handled anywhere), but this at least ensures the correct behaviour. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Test only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
