### PR TITLE
temporarily remove datetimepicker from requirejs files while we figure out weird rjs bug

### DIFF
--- a/corehq/apps/sso/static/sso/js/enterprise_edit_identity_provider.js
+++ b/corehq/apps/sso/static/sso/js/enterprise_edit_identity_provider.js
@@ -5,7 +5,6 @@ hqDefine('sso/js/enterprise_edit_identity_provider', [
     "hqwebapp/js/initial_page_data",
     'sso/js/models',
     'jquery-mousewheel',
-    'datetimepicker/build/jquery.datetimepicker.full.min',
 ], function (
     $,
     ko,
@@ -28,6 +27,7 @@ hqDefine('sso/js/enterprise_edit_identity_provider', [
         $('#sso-exempt-user-manager').koApplyBindings(ssoExemptUserManager);
         ssoExemptUserManager.init();
 
-        $("#id_date_idp_cert_expiration").datetimepicker();
+        // todo find different widget for this field
+        // $("#id_date_idp_cert_expiration").datetimepicker();
     });
 });

--- a/corehq/apps/sso/views/enterprise_admin.py
+++ b/corehq/apps/sso/views/enterprise_admin.py
@@ -42,7 +42,6 @@ class EditIdentityProviderEnterpriseView(BaseEnterpriseAdminView, AsyncHandlerMi
         SSOExemptUsersAdminAsyncHandler,
     ]
 
-    @use_datetimepicker
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
## Summary
Require js is serving bundles in a way that is somehow giving the sso bundle to some accounting pages, causing this error.
https://dimagi-dev.atlassian.net/browse/SAAS-11925

There is something strange going on with the build of the sso bundle, as `build_requirejs` throws this:
```
atetimepicker/build/jquery.datetimepicker.full.min.js has more than one anonymous define. May be a built file from another build system like, Ender. Skipping normalization.
```
which leads us to this issue https://github.com/xdan/datetimepicker/issues/614

since `datetimepicker` looks fairly unmaintained it might be high time to find a different widget.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
fixes ongoing p2

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
