### PR TITLE
add missed column in data source

### DIFF
--- a/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
@@ -145,6 +145,23 @@
       },
       {
         "type": "expression",
+        "column_id": "mother_safe_and_alive",
+        "display_name": "mother_safe_and_alive",
+        "datatype": "string",
+        "expression": {
+          "type": "root_doc",
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "form",
+              "delivery_details",
+              "mother_safe_and_alive"
+            ]
+          }
+        }
+      },
+      {
+        "type": "expression",
         "column_id": "female_death_type",
         "display_name": "female_death_type",
         "datatype": "string",


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Missed adding the column in data source in https://github.com/dimagi/commcare-hq/pull/29295/files#diff-fde99d52232565c0ae5fb99e17e67f3f36ae2fe52d7af7e75b66c9d19c8cc3cdR46

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
