### PR TITLE
Update_case_index_relationship: case_ids include just open cases for contact cases

### DIFF
--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -55,7 +55,10 @@ class Command(CaseUpdateCommand):
     def update_cases(self, domain, case_type, user_id):
         inactive_location = self.extra_options['inactive_location']
         accessor = CaseAccessors(domain)
-        case_ids = accessor.get_case_ids_in_domain(case_type)
+        if case_type == 'contact':
+            case_ids = accessor.get_open_case_ids_in_domain_by_type(case_type)
+        else:
+            case_ids = accessor.get_case_ids_in_domain(case_type)
         print(f"Found {len(case_ids)} {case_type} cases in {domain}")
         traveler_location_id = self.extra_options['location']
 


### PR DESCRIPTION
## Summary
Noticed for NY it was running on more cases than necessary-- running on also the closed cases hurt anything just took longer than expected. This change just applies to `contact` cases

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
This is test coverage for this command

### QA Plan
I am not requesting QA

### Safety story
This will be run on test domains before the CO casedb migration

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
