### PR TITLE
Remove unnecessary block that adds filters and date_range again

### DIFF
--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -368,9 +368,6 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
         mock_request.bypass_two_factor = True
 
         mock_query_string_parts = [self.query_string, 'filterSet=true']
-        if self.is_configurable_report:
-            mock_query_string_parts.append(urlencode(self.filters, True))
-            mock_query_string_parts.append(urlencode(self.get_date_range(), True))
         mock_request.GET = QueryDict('&'.join(mock_query_string_parts))
 
         # Make sure the request gets processed by PRBAC Middleware


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Immediate fix for this [support ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11772). More work still to be done with properly raising an error.

The [method](https://github.com/dimagi/commcare-hq/blob/d483cd32fe8148cc23bab1c429d2e3958cff8d0c/corehq/apps/saved_reports/models.py#L235-L242) `query_string` is called regardless of if the report is configurable or not. That method adds the config's `id`, `filters` and `date_range` to form the `query_string`.

The code following this does essentially the same thing (minus the id). See [here](https://github.com/dimagi/commcare-hq/blob/c09418bdd17214a807d3d6daecee6b743fd8b6ad/corehq/apps/saved_reports/models.py#L371-L373). If there are already a lot of filters, adding duplicates of all of the filters will likely result in the query being too large. I have not determined how to raise an error if this occurs yet, but have confirmed that this fixes the empty reports associated with the support ticket.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
This seems like a safe removal of code, but if reviewers feel it is necessary to QA I'm ok with that.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
