### PR TITLE
Add basic sms data generator

### DIFF
--- a/corehq/apps/sms/management/commands/generate_fake_sms_data.py
+++ b/corehq/apps/sms/management/commands/generate_fake_sms_data.py
@@ -15,4 +15,4 @@ class Command(BaseCommand):
     def handle(self, domain, num_messages, **kwargs):
         for i in range(num_messages):
             create_fake_sms(domain, randomize=True)
-        print(f'successfully created {num_messages} messages in {domain}' )
+        print(f'successfully created {num_messages} messages in {domain}')

--- a/corehq/apps/sms/management/commands/generate_fake_sms_data.py
+++ b/corehq/apps/sms/management/commands/generate_fake_sms_data.py
@@ -1,0 +1,18 @@
+from django.core.management import BaseCommand
+
+from corehq.apps.sms.tests.data_generator import create_fake_sms
+
+
+class Command(BaseCommand):
+    help = """
+        Generates a few fake SMS message models for a domain, for testing.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+        parser.add_argument('num_messages', type=int, help="The number of SMS messages to create")
+
+    def handle(self, domain, num_messages, **kwargs):
+        for i in range(num_messages):
+            create_fake_sms(domain)
+        print(f'successfully created {num_messages} messages in {domain}' )

--- a/corehq/apps/sms/management/commands/generate_fake_sms_data.py
+++ b/corehq/apps/sms/management/commands/generate_fake_sms_data.py
@@ -14,5 +14,5 @@ class Command(BaseCommand):
 
     def handle(self, domain, num_messages, **kwargs):
         for i in range(num_messages):
-            create_fake_sms(domain)
+            create_fake_sms(domain, randomize=True)
         print(f'successfully created {num_messages} messages in {domain}' )

--- a/corehq/apps/sms/tests/data_generator.py
+++ b/corehq/apps/sms/tests/data_generator.py
@@ -1,3 +1,4 @@
+import random
 from collections import namedtuple
 
 from corehq.apps.sms.models import MessagingEvent, MessagingSubEvent, SMS
@@ -9,18 +10,27 @@ SmsAndDict = namedtuple('SmsAndDict', ['sms', 'sms_dict'])
 def create_fake_sms(domain, randomize=False):
     if not randomize:
         message_date = datetime(2016, 1, 1, 12, 0)
+        source = MessagingEvent.SOURCE_OTHER
+        status = MessagingEvent.STATUS_COMPLETED
+        content_type = MessagingEvent.CONTENT_SMS
+        recipient_type = MessagingEvent.RECIPIENT_CASE
     else:
         message_date = datetime.now()
+        source = random.choice(MessagingEvent.SOURCE_CHOICES)[0]
+        status = random.choice(MessagingEvent.STATUS_CHOICES)[0]
+        content_type = random.choice(MessagingEvent.CONTENT_CHOICES)[0]
+        recipient_type = random.choice(MessagingEvent.RECIPIENT_CHOICES)[0]
+
     event = MessagingEvent.objects.create(
         domain=domain,
         date=message_date,
-        source=MessagingEvent.SOURCE_OTHER,
+        source=source,
         source_id=None,
-        content_type=MessagingEvent.CONTENT_SMS,
+        content_type=content_type,
         app_id=None,
         form_unique_id=None,
         form_name=None,
-        status=MessagingEvent.STATUS_COMPLETED,
+        status=status,
         error_code=None,
         additional_error_text=None,
         recipient_type=None,
@@ -29,15 +39,15 @@ def create_fake_sms(domain, randomize=False):
     subevent = MessagingSubEvent.objects.create(
         parent=event,
         date=message_date,
-        recipient_type=MessagingEvent.RECIPIENT_CASE,
+        recipient_type=recipient_type,
         recipient_id=None,
-        content_type=MessagingEvent.CONTENT_SMS,
+        content_type=content_type,
         app_id=None,
         form_unique_id=None,
         form_name=None,
         xforms_session=None,
         case_id=None,
-        status=MessagingEvent.STATUS_COMPLETED,
+        status=status,
         error_code=None,
         additional_error_text=None
     )

--- a/corehq/apps/sms/tests/data_generator.py
+++ b/corehq/apps/sms/tests/data_generator.py
@@ -1,0 +1,83 @@
+from collections import namedtuple
+
+from corehq.apps.sms.models import MessagingEvent, MessagingSubEvent, SMS
+from datetime import datetime
+
+
+SmsAndDict = namedtuple('SmsAndDict', ['sms', 'sms_dict'])
+
+
+def create_fake_sms(domain):
+    event = MessagingEvent.objects.create(
+        domain=domain,
+        date=datetime(2016, 1, 1, 12, 0),
+        source=MessagingEvent.SOURCE_OTHER,
+        source_id=None,
+        content_type=MessagingEvent.CONTENT_SMS,
+        app_id=None,
+        form_unique_id=None,
+        form_name=None,
+        status=MessagingEvent.STATUS_COMPLETED,
+        error_code=None,
+        additional_error_text=None,
+        recipient_type=None,
+        recipient_id=None
+    )
+    subevent = MessagingSubEvent.objects.create(
+        parent=event,
+        date=datetime(2016, 1, 1, 12, 0),
+        recipient_type=MessagingEvent.RECIPIENT_CASE,
+        recipient_id=None,
+        content_type=MessagingEvent.CONTENT_SMS,
+        app_id=None,
+        form_unique_id=None,
+        form_name=None,
+        xforms_session=None,
+        case_id=None,
+        status=MessagingEvent.STATUS_COMPLETED,
+        error_code=None,
+        additional_error_text=None
+    )
+    # Some of the values here don't apply for a simple outgoing SMS,
+    # but the point of this is to just test the serialization and that
+    # everything makes it to elasticsearch
+    sms_dict = dict(
+        domain=domain,
+        date=datetime(2016, 1, 1, 12, 0),
+        couch_recipient_doc_type='CommCareCase',
+        couch_recipient='fake-case-id',
+        phone_number='99912345678',
+        direction='O',
+        error=False,
+        system_error_message='n/a',
+        system_phone_number='00000',
+        backend_api='TEST',
+        backend_id='fake-backend-id',
+        billed=False,
+        workflow='default',
+        xforms_session_couch_id='fake-session-couch-id',
+        reminder_id='fake-reminder-id',
+        location_id='fake-location-id',
+        messaging_subevent_id=subevent.pk,
+        text='test sms text',
+        raw_text='raw text',
+        datetime_to_process=datetime(2016, 1, 1, 11, 59),
+        processed=True,
+        num_processing_attempts=1,
+        queued_timestamp=datetime(2016, 1, 1, 11, 58),
+        processed_timestamp=datetime(2016, 1, 1, 12, 1),
+        domain_scope=domain,
+        ignore_opt_out=False,
+        backend_message_id='fake-backend-message-id',
+        chat_user_id='fake-user-id',
+        invalid_survey_response=False,
+        fri_message_bank_lookup_completed=True,
+        fri_message_bank_message_id='bank-id',
+        fri_id='12345',
+        fri_risk_profile='X',
+        custom_metadata={'a': 'b'},
+    )
+    sms = SMS.objects.create(
+        **sms_dict
+    )
+    return SmsAndDict(sms=sms, sms_dict=sms_dict)

--- a/testapps/test_pillowtop/tests/test_sms_pillow.py
+++ b/testapps/test_pillowtop/tests/test_sms_pillow.py
@@ -5,6 +5,7 @@ from corehq.apps.change_feed.topics import get_topic_offset
 from corehq.apps.es.sms import SMSES
 from corehq.apps.es.tests.utils import es_test
 from corehq.apps.sms.models import MessagingEvent, MessagingSubEvent, SMS
+from corehq.apps.sms.tests.data_generator import create_fake_sms
 from corehq.elastic import get_es_new
 from corehq.pillows.mappings.sms_mapping import SMS_INDEX_INFO
 from corehq.pillows.sms import get_sql_sms_pillow
@@ -33,80 +34,6 @@ class SqlSMSPillowTest(TestCase):
         MessagingEvent.objects.filter(domain=self.domain).delete()
         super(SqlSMSPillowTest, self).tearDown()
 
-    def _create_sms(self):
-        event = MessagingEvent.objects.create(
-            domain=self.domain,
-            date=datetime(2016, 1, 1, 12, 0),
-            source=MessagingEvent.SOURCE_OTHER,
-            source_id=None,
-            content_type=MessagingEvent.CONTENT_SMS,
-            app_id=None,
-            form_unique_id=None,
-            form_name=None,
-            status=MessagingEvent.STATUS_COMPLETED,
-            error_code=None,
-            additional_error_text=None,
-            recipient_type=None,
-            recipient_id=None
-        )
-        subevent = MessagingSubEvent.objects.create(
-            parent=event,
-            date=datetime(2016, 1, 1, 12, 0),
-            recipient_type=MessagingEvent.RECIPIENT_CASE,
-            recipient_id=None,
-            content_type=MessagingEvent.CONTENT_SMS,
-            app_id=None,
-            form_unique_id=None,
-            form_name=None,
-            xforms_session=None,
-            case_id=None,
-            status=MessagingEvent.STATUS_COMPLETED,
-            error_code=None,
-            additional_error_text=None
-        )
-        # Some of the values here don't apply for a simple outgoing SMS,
-        # but the point of this is to just test the serialization and that
-        # everything makes it to elasticsearch
-        self.sms_dict = dict(
-            domain=self.domain,
-            date=datetime(2016, 1, 1, 12, 0),
-            couch_recipient_doc_type='CommCareCase',
-            couch_recipient='fake-case-id',
-            phone_number='99912345678',
-            direction='O',
-            error=False,
-            system_error_message='n/a',
-            system_phone_number='00000',
-            backend_api='TEST',
-            backend_id='fake-backend-id',
-            billed=False,
-            workflow='default',
-            xforms_session_couch_id='fake-session-couch-id',
-            reminder_id='fake-reminder-id',
-            location_id='fake-location-id',
-            messaging_subevent_id=subevent.pk,
-            text='test sms text',
-            raw_text='raw text',
-            datetime_to_process=datetime(2016, 1, 1, 11, 59),
-            processed=True,
-            num_processing_attempts=1,
-            queued_timestamp=datetime(2016, 1, 1, 11, 58),
-            processed_timestamp=datetime(2016, 1, 1, 12, 1),
-            domain_scope=self.domain,
-            ignore_opt_out=False,
-            backend_message_id='fake-backend-message-id',
-            chat_user_id='fake-user-id',
-            invalid_survey_response=False,
-            fri_message_bank_lookup_completed=True,
-            fri_message_bank_message_id='bank-id',
-            fri_id='12345',
-            fri_risk_profile='X',
-            custom_metadata={'a': 'b'},
-        )
-        self.sms = SMS.objects.create(
-            **self.sms_dict
-        )
-
     def _to_json(self, sms_dict, sms):
         result = {'_id': sms.couch_id, 'id': sms.pk}
         for k, v in sms_dict.items():
@@ -123,8 +50,9 @@ class SqlSMSPillowTest(TestCase):
         kafka_seq = get_topic_offset(topics.SMS)
 
         # create an sms
-        self._create_sms()
-        sms_json = self._to_json(self.sms_dict, self.sms)
+        sms_and_dict = create_fake_sms(self.domain)
+        self.sms = sms_and_dict.sms
+        sms_json = self._to_json(sms_and_dict.sms_dict, self.sms)
 
         # test serialization
         self.assertEqual(self.sms.to_json(), sms_json)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

I wanted to do some testing of SMS functionality and needed some local data. Maybe this will be useful for others in a similar position in the future?

Run
```
./manage.py generate_fake_sms_data sabbatical 10
```

Result:

![image](https://user-images.githubusercontent.com/66555/110121391-fe659980-7dc6-11eb-80df-38c5bdd86718.png)

review by commit.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

All dev/test code.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
