### PR TITLE
add basic messaging event API

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -19,6 +19,7 @@ from tastypie.utils import dict_strip_unicode_keys
 
 from casexml.apps.stock.models import StockTransaction
 from corehq.apps.api.resources.serializers import ListToSingleObjectSerializer
+from corehq.apps.sms.models import MessagingEvent
 from phonelog.models import DeviceReportEntry
 
 from corehq import privileges
@@ -1087,3 +1088,23 @@ class ODataFormResource(BaseODataResource):
             url(r"^(?P<resource_name>{})/(?P<config_id>[\w\d_.-]+)/feed".format(
                 self._meta.resource_name), self.wrap_view('dispatch_list')),
         ]
+
+
+class MessagingEventResource(HqBaseResource, ModelResource):
+
+    class Meta(object):
+        queryset = MessagingEvent.objects.all()
+        list_allowed_methods = ['get']
+        detail_allowed_methods = ['get']
+        resource_name = 'messaging-event'
+        authentication = RequirePermissionAuthentication(Permissions.edit_data)
+        authorization = DomainAuthorization()
+        paginator_class = NoCountingPaginator
+        filtering = {
+            # this is needed for the domain filtering but any values passed in via the URL get overridden
+            "domain": ('exact',),
+            "date": ('exact', 'gt', 'gte', 'lt', 'lte', 'range'),
+            "source": ('exact',),
+            "content_type": ('exact',),
+            "status": ('exact',),
+        }

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1108,3 +1108,6 @@ class MessagingEventResource(HqBaseResource, ModelResource):
             "content_type": ('exact',),
             "status": ('exact',),
         }
+        ordering = [
+            'date',
+        ]

--- a/corehq/apps/api/tests/test_messaging_event_api.py
+++ b/corehq/apps/api/tests/test_messaging_event_api.py
@@ -4,7 +4,6 @@ from corehq.apps.api.tests.utils import APIResourceTest
 from corehq.apps.api.resources.v0_5 import (
     MessagingEventResource
 )
-from corehq.apps.sms.models import MessagingEvent
 from corehq.apps.sms.tests.data_generator import create_fake_sms
 
 
@@ -38,7 +37,7 @@ class TestMessagingEventResource(APIResourceTest):
             "source": "OTH",
             "source_id": None,
             "status": "CMP"
-          }
+        }
 
     def test_get_list_simple(self):
         self._create_sms_messages(2, randomize=False)

--- a/corehq/apps/api/tests/test_messaging_event_api.py
+++ b/corehq/apps/api/tests/test_messaging_event_api.py
@@ -1,0 +1,76 @@
+import json
+
+from corehq.apps.api.tests.utils import APIResourceTest
+from corehq.apps.api.resources.v0_5 import (
+    MessagingEventResource
+)
+from corehq.apps.sms.models import MessagingEvent
+from corehq.apps.sms.tests.data_generator import create_fake_sms
+
+
+class TestMessagingEventResource(APIResourceTest):
+    resource = MessagingEventResource
+    api_name = 'v0.5'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def _create_sms_messages(self, count, randomize, domain=None):
+        domain = domain or self.domain.name
+        for i in range(count):
+            create_fake_sms(domain, randomize=randomize)
+
+    def _serialized_messaging_event(self):
+        return {
+            "additional_error_text": None,
+            "app_id": None,
+            "content_type": "SMS",
+            "date": "2016-01-01T12:00:00",
+            "domain": "qwerty",
+            "error_code": None,
+            "form_name": None,
+            "form_unique_id": None,
+            # "id": 1,  # ids are explicitly removed from comparison
+            "recipient_id": None,
+            "recipient_type": None,
+            "resource_uri": "",
+            "source": "OTH",
+            "source_id": None,
+            "status": "CMP"
+          }
+
+    def test_get_list_simple(self):
+        self._create_sms_messages(2, randomize=False)
+        response = self._assert_auth_get_resource(self.list_endpoint)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)['objects']
+        self.assertEqual(2, len(data))
+        for result in data:
+            del result['id']  # don't bother comparing ids
+            self.assertEqual(self._serialized_messaging_event(), result)
+
+    def test_date_ordering(self):
+        self._create_sms_messages(5, randomize=True)
+        response = self._assert_auth_get_resource(f'{self.list_endpoint}?order_by=date')
+        self.assertEqual(response.status_code, 200)
+        ordered_data = json.loads(response.content)['objects']
+        self.assertEqual(5, len(ordered_data))
+        previous_date = None
+        for result in ordered_data:
+            current_date = result['date']
+            if previous_date:
+                self.assertTrue(previous_date < current_date)
+            previous_date = current_date
+
+        response = self._assert_auth_get_resource(f'{self.list_endpoint}?order_by=-date')
+        self.assertEqual(response.status_code, 200)
+        reverse_ordered_data = json.loads(response.content)['objects']
+        self.assertEqual(ordered_data, list(reversed(reverse_ordered_data)))
+
+    def test_domain_filter(self):
+        self._create_sms_messages(5, randomize=True, domain='different-one')
+        response = self._assert_auth_get_resource(f'{self.list_endpoint}?order_by=date')
+        self.assertEqual(response.status_code, 200)
+        ordered_data = json.loads(response.content)['objects']
+        self.assertEqual(0, len(ordered_data))

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -81,6 +81,7 @@ API_LIST = (
         v0_5.ODataFormResource,
         LookupTableResource,
         LookupTableItemResource,
+        v0_5.MessagingEventResource,
     )),
 )
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Context:

![image](https://user-images.githubusercontent.com/66555/110125513-0f64d980-7dcc-11eb-826c-c931eb1a9079.png)

I think USH would like to pull this data into a warehouse to do some extra analysis on their side, though it's not yet clear whether this is the right data.

I modeled this off the [device log API](https://github.com/dimagi/commcare-hq/pull/3562). Guessing before we make this API "public" (if we choose to do that) we should maybe clean it up (e.g. converting the enums to more readable values, and possibly joining in related models).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

I wasn't sure how to mark this. At the moment it is likely to be used by a single project but technically the API would be available to anyone who was able to guess the URL or is reading this PR. I don't think that's a problem unless it prevents us from making changes down the line but I wouldn't think it should do that.

Unfortunately, I don't think the infrastructure exists to feature flag an API else I'd have used a flag. Though possibly it's worth building that as it seems useful.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

New code that won't be used by anyone apart from the project.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
