### PR TITLE
new datetimepicker (cleanup old datetimepicker EXCEPT in webapps)

### DIFF
--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -166,24 +166,6 @@ def use_timepicker(view_func):
     return _wrapped
 
 
-def use_datetimepicker(view_func):
-    """Use this decorator on the dispatch method of a TemplateView subclass
-    to enable the inclusion of the datimepicker library from xdsoft.net
-    at the base template level.
-
-    Example:
-
-    @use_datetimepicker
-    def dispatch(self, request, *args, **kwargs):
-        return super(MyView, self).dispatch(request, *args, **kwargs)
-    """
-    @wraps(view_func)
-    def _wrapped(class_based_view, request, *args, **kwargs):
-        request.use_datetimepicker = True
-        return view_func(class_based_view, request, *args, **kwargs)
-    return _wrapped
-
-
 def use_maps(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
     to enable the inclusion of the maps (with sync utils) library at the base

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/requirejs_config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/requirejs_config.js
@@ -12,7 +12,6 @@ requirejs.config({
         "datatables.bootstrap": "datatables-bootstrap3/BS3/assets/js/datatables",
         "datatables.scroller": "datatables-scroller/js/dataTables.scroller",
         "datatables.colReorder": "datatables-colreorder/js/dataTables.colReorder",
-        "jquery-mousewheel": "jquery-mousewheel/jquery.mousewheel",
     },
     shim: {
         "ace-builds/src-min-noconflict/ace": { exports: "ace" },

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/datetimepicker.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/datetimepicker.less
@@ -1,0 +1,106 @@
+/*
+ * Extra styling for the eonasdan-bootstrap-datetimepicker widget.
+ */
+
+@bootstrap-datetimepicker-width: 245px;
+
+.bootstrap-datetimepicker-widget.dropdown-menu {
+  text-align: center;
+  padding: 12px 15px 4px;
+
+  th {
+    text-align: center;
+
+    .dow {
+      padding-top: 8px;
+      padding-bottom: 8px;
+      font-size: 14px;
+    }
+  }
+
+  .datepicker,
+  .timepicker {
+    width: @bootstrap-datetimepicker-width;
+  }
+
+  .day,
+  .month,
+  .year,
+  .decade,
+  .picker-switch,
+  .prev,
+  .next,
+  .minute,
+  .hour,
+  .timepicker-hour,
+  .timepicker-minute {
+    cursor: pointer;
+    padding: 8px 10px;
+    border-radius: 4px;
+
+    &:hover {
+      background-color: @cc-bg;
+    }
+
+    &.active {
+      background-color: @cc-brand-mid;
+      color: #ffffff;
+    }
+  }
+
+  .month,
+  .year,
+  .decade {
+    font-size: 14px;
+    display: inline-block;
+    width: @bootstrap-datetimepicker-width/3 - 4;
+  }
+
+  .minute,
+  .hour {
+    font-size: 15px;
+    display: inline-block;
+    width: @bootstrap-datetimepicker-width/4 - 4;
+  }
+
+  .datepicker {
+    padding-bottom: 6px;
+  }
+
+  .timepicker {
+    padding-bottom: 15px;
+
+    a {
+      cursor: pointer;
+      padding: 8px 10px;
+      border-radius: 4px;
+
+      &:hover {
+        background-color: @cc-bg;
+      }
+    }
+
+    .btn-primary {
+      background-color: @cc-brand-mid;
+      text-align: center;
+      padding: 8px 10px;
+    }
+
+    .table-condensed {
+      font-size: 20px;
+      width: 100%;
+    }
+  }
+
+  .picker-switch {
+    font-size: 18px;
+
+    .table-condensed {
+      width: 100%;
+
+      a {
+        display: block;
+      }
+    }
+  }
+}

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/style-imports.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/style-imports.less
@@ -11,6 +11,7 @@
 @import "_hq/datagrid.less";
 @import "_hq/date_range_picker.less";
 @import "_hq/dropdowns.less";
+@import "_hq/datetimepicker.less";
 @import "_hq/facet.less";
 @import "_hq/feedback.less";
 @import "_hq/form_steps.less";

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -93,15 +93,6 @@
       {% endcompress %}
     {% endif %}
 
-    {% if request.use_datetimepicker %}
-      {% compress css %}
-        <link type="text/less"
-              rel="stylesheet"
-              media="screen"
-              href="{% static "datetimepicker/build/jquery.datetimepicker.min.css" %}" />
-      {% endcompress %}
-    {% endif %}
-
     {% if request.use_jquery_ui %}
       {% compress css %}
         <link type="text/css"
@@ -484,13 +475,6 @@
     {% if request.use_timepicker and not requirejs_main %}
       {% compress js %}
         <script src="{% static 'bootstrap-timepicker/js/bootstrap-timepicker.js' %}"></script>
-      {% endcompress %}
-    {% endif %}
-
-    {% if request.use_datetimepicker and not requirejs_main %}
-      {% compress js %}
-        <script src="{% static 'jquery-mousewheel/jquery.mousewheel.js' %}"></script>
-        <script src="{% static 'datetimepicker/build/jquery.datetimepicker.full.min.js' %}"></script>
       {% endcompress %}
     {% endif %}
 

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -17,7 +17,7 @@ from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput
 from corehq.apps.sso.models import IdentityProvider
 from corehq.apps.sso.utils import url_helpers
 
-TIME_FORMAT = "%Y/%m/%d %H:%M"
+TIME_FORMAT = "%Y/%m/%d %I:%M %p"
 
 
 def _validate_or_raise_slugify_error(slug):
@@ -441,7 +441,7 @@ class SSOEnterpriseSettingsForm(forms.Form):
             'logout_url': identity_provider.logout_url,
             'idp_cert_public': identity_provider.idp_cert_public,
             'date_idp_cert_expiration': (
-                identity_provider.date_idp_cert_expiration.strftime(TIME_FORMAT)
+                identity_provider.date_idp_cert_expiration.isoformat()
                 if identity_provider.date_idp_cert_expiration else ''
             ),
         }
@@ -492,7 +492,7 @@ class SSOEnterpriseSettingsForm(forms.Form):
                         'idp_cert_public',
                         crispy.Field(
                             'date_idp_cert_expiration',
-                            placeholder="YYYY/MM/DD HH:MM",
+                            placeholder="YYYY/MM/DD HH:MM AM/PM",
                         ),
                     ),
                     css_class="panel-body"

--- a/corehq/apps/sso/static/sso/js/enterprise_edit_identity_provider.js
+++ b/corehq/apps/sso/static/sso/js/enterprise_edit_identity_provider.js
@@ -4,7 +4,7 @@ hqDefine('sso/js/enterprise_edit_identity_provider', [
     'underscore',
     "hqwebapp/js/initial_page_data",
     'sso/js/models',
-    'jquery-mousewheel',
+    'eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min',
 ], function (
     $,
     ko,
@@ -27,7 +27,10 @@ hqDefine('sso/js/enterprise_edit_identity_provider', [
         $('#sso-exempt-user-manager').koApplyBindings(ssoExemptUserManager);
         ssoExemptUserManager.init();
 
-        // todo find different widget for this field
-        // $("#id_date_idp_cert_expiration").datetimepicker();
+        var $expDate =$("#id_date_idp_cert_expiration"),
+            initialDate = $expDate.val();
+        $expDate.datetimepicker({
+            date: initialDate,
+        });
     });
 });

--- a/corehq/apps/sso/static/sso/js/enterprise_edit_identity_provider.js
+++ b/corehq/apps/sso/static/sso/js/enterprise_edit_identity_provider.js
@@ -27,7 +27,7 @@ hqDefine('sso/js/enterprise_edit_identity_provider', [
         $('#sso-exempt-user-manager').koApplyBindings(ssoExemptUserManager);
         ssoExemptUserManager.init();
 
-        var $expDate =$("#id_date_idp_cert_expiration"),
+        var $expDate = $("#id_date_idp_cert_expiration"),
             initialDate = $expDate.val();
         $expDate.datetimepicker({
             date: initialDate,

--- a/corehq/apps/sso/views/enterprise_admin.py
+++ b/corehq/apps/sso/views/enterprise_admin.py
@@ -9,7 +9,6 @@ from django.utils.translation import ugettext as _, ugettext_lazy
 
 from corehq.apps.enterprise.views import BaseEnterpriseAdminView
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
-from corehq.apps.hqwebapp.decorators import use_datetimepicker
 from corehq.apps.sso.async_handlers import SSOExemptUsersAdminAsyncHandler
 from corehq.apps.sso.certificates import get_certificate_response
 from corehq.apps.sso.forms import SSOEnterpriseSettingsForm
@@ -41,9 +40,6 @@ class EditIdentityProviderEnterpriseView(BaseEnterpriseAdminView, AsyncHandlerMi
     async_handlers = [
         SSOExemptUsersAdminAsyncHandler,
     ]
-
-    def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
 
     @property
     def page_url(self):

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "datatables-fixedheader": "DataTables/FixedHeader#^3.1.3",
         "datatables-scroller": "DataTables/Scroller#^1.5.1",
         "datetimepicker": "npm:jquery-datetimepicker#2.5.4",
+        "eonasdan-bootstrap-datetimepicker": "4.17.49",
         "detectrtc": "1.4.0",
         "fast-levenshtein": "2.0.6",
         "font-awesome": "4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -626,7 +626,7 @@ bootstrap3-typeahead@bassjobsen/Bootstrap-3-Typeahead#~3.1.1:
   version "3.1.1"
   resolved "https://codeload.github.com/bassjobsen/Bootstrap-3-Typeahead/tar.gz/c65c829fe8411f6eadb88415d09c1e85bb4603d0"
 
-bootstrap@3.4.1:
+bootstrap@3.4.1, bootstrap@^3.3:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
   integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
@@ -1545,6 +1545,16 @@ env-paths@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
   integrity sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==
+
+eonasdan-bootstrap-datetimepicker@4.17.49:
+  version "4.17.49"
+  resolved "https://registry.yarnpkg.com/eonasdan-bootstrap-datetimepicker/-/eonasdan-bootstrap-datetimepicker-4.17.49.tgz#5534ba581c1e7eb988dbf773e2fed8a7f48cc76a"
+  integrity sha512-7KZeDpkj+A6AtPR3XjX8gAnRPUkPSfW0OmMANG1dkUOPMtLSzbyoCjDIdEcfRtQPU5X0D9Gob7wWKn0h4QWy7A==
+  dependencies:
+    bootstrap "^3.3"
+    jquery "^3.5.1"
+    moment "^2.10"
+    moment-timezone "^0.4.0"
 
 err-code@^1.0.0:
   version "1.1.2"
@@ -3041,6 +3051,11 @@ jquery@3.5.1, "jquery@>= 1.7.1", "jquery@>= 1.7.2", jquery@>=1.10, jquery@>=1.7,
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
   integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
+jquery@^3.5.1:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -3880,10 +3895,22 @@ modernizr@^3.11.3:
     requirejs "^2.3.6"
     yargs "^15.3.1"
 
+moment-timezone@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.4.1.tgz#81f598c3ad5e22cdad796b67ecd8d88d0f5baa06"
+  integrity sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=
+  dependencies:
+    moment ">= 2.6.0"
+
 moment@2.27.0, moment@^2.9.0:
   version "2.27.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
   integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
+
+"moment@>= 2.6.0", moment@^2.10:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Summary
FYI, the new and old datetimepicker widget was only limited to use in `sso` forms, so this change will only affect `sso` and nothing else. I am not going anywhere near that `xdsoft` datetimepicker in webapps because I don't want to introduce extra QA overhead for an unrelated area right now.

It is unfortunate that `xdsoft`'s datetimepicker widget both does not play well with requirejs and is largely abandoned. (see https://github.com/dimagi/commcare-hq/pull/29301) This new datetimepicker widget is a bit more up-to-date, though the bootstrap 3 version is now unmaintained in favor of bootstrap 4 (but that's a whole other discussion!)

Anyway, this seemed like the only reasonable alternative in the interim. 

Note: `Risk: High` flag coming from removing the `use_datetimepicker` decorator which is no longer needed as the stylesheet that came with this had a ton of issues coupled with our custom bootstrap 3 styling. I fixed it in our main stylesheet, so no worries there. Outside of that, I don't want to encourage the use for non-requirejs views now. :)

## Feature Flag
only affects `ENTERPRISE_SSO` 

## Product Description
<img width="288" alt="Screen Shot 2021-03-05 at 11 01 59 AM" src="https://user-images.githubusercontent.com/716573/110144279-c72ec280-7d9d-11eb-8421-e6a24eb47265.png">
<img width="310" alt="Screen Shot 2021-03-05 at 11 01 53 AM" src="https://user-images.githubusercontent.com/716573/110144284-c7c75900-7d9d-11eb-8187-40863e252519.png">


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
the small changes to sso forms are well tested

### QA Plan
none needed right now

### Safety story
small isolated change, requirejs supported library, only used by a currently inactive / in-development and feature-flagged part of our codebase.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
