### PR TITLE
Web Apps: Replace Select2 comboboxes with more accessible SelectWoo.

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -560,7 +560,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         };
         self.renderSelect2 = function () {
             var $input = $('#' + self.entryId);
-            $input.select2(_.extend({
+            $input.selectWoo(_.extend({
                 allowClear: true,
                 placeholder: self.placeholderText,
                 escapeMarkup: function (m) { return DOMPurify.sanitize(m); },

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -305,6 +305,11 @@ hqDefine("cloudcare/js/form_entry/fullform-ui", function () {
 
         self.submitForm = function () {
             $.publish('formplayer.' + Const.SUBMIT, self);
+
+            // Workaround for selectWoo. Elements are kept alive indefinitely
+            // by a keydown handler on the document, so we remove them on
+            // submission.
+            $(document).off('keydown');
         };
 
         self.nextQuestion = function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -46,7 +46,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             'change': 'render',
         },
 
-        onBeforeRender: function() {
+        onBeforeRender: function () {
             // Remove focus from any selectWoos that already exist because
             // they will be replaced in onRender. When overwritten selectWoos
             // think they have focus, they can respond to keypresses and

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -183,6 +183,11 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         submitAction: function (e) {
             e.preventDefault();
             FormplayerFrontend.trigger("menu:query", this.getAnswers());
+
+            // Workaround for selectWoo. Elements are kept alive indefinitely
+            // by a keydown handler on the document, so we remove them on
+            // submission.
+            $(document).off('keydown');
         },
 
         setStickyQueryInputs: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -46,12 +46,30 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             'change': 'render',
         },
 
+        onBeforeRender: function() {
+            // Remove focus from any selectWoos that already exist because
+            // they will be replaced in onRender. When overwritten selectWoos
+            // think they have focus, they can respond to keypresses and
+            // spontaneously pop up and hide part of the HQ container.
+            if (this.selectWoos) {
+                this.selectWoos.forEach(function (selectWoo) {
+                    selectWoo.trigger('blur');
+                });
+            }
+        },
+
         onRender: function () {
-            this.ui.valueDropdown.select2({
+            var selectW = this.ui.valueDropdown.selectWoo({
                 allowClear: true,
                 placeholder: " ",   // required for allowClear to work
                 escapeMarkup: function (m) { return DOMPurify.sanitize(m); },
             });
+            if (selectW.length > 0) {
+                if (!this.selectWoos) {
+                    this.selectWoos = [];
+                }
+                this.selectWoos.push(selectW.data('select2'));
+            }
             this.ui.hqHelp.hqHelp();
             this.ui.dateRange.daterangepicker({
                 locale: {
@@ -140,12 +158,12 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     if (choices) {
                         var $field = $($fields.get(i)),
                             value = parseInt(response.models[i].get('value'));
-                        $field.select2('close');    // force close dropdown, the set below can interfere with this when clearing selection
+                        $field.selectWoo('close');    // force close dropdown, the set below can interfere with this when clearing selection
                         self.collection.models[i].set({
                             itemsetChoices: choices,
                             value: value,
                         });
-                        $field.trigger('change.select2');
+                        $field.trigger('change.selectWoo');
                     }
                 }
                 self.setStickyQueryInputs();
@@ -157,7 +175,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 fields = $(".query-field");
             fields.each(function () {
                 this.value = '';
-                $(this).trigger('change.select2');
+                $(this).trigger('change.selectWoo');
             });
             self.setStickyQueryInputs();
         },

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -13,6 +13,7 @@
   {{ block.super }}
   <script src="{% static 'datatables.net/js/jquery.dataTables.min.js' %}"></script>
   <script src="{% static 'datatables-bootstrap3/BS3/assets/js/datatables.js' %}"></script>
+  <script src="{% static 'select-woo/dist/js/selectWoo.full.min.js' %}"></script>
   <style id="persistent-cell-layout-style"></style>
   <style id="persistent-cell-grid-style"></style>
   <style id="list-cell-layout-style"></style>
@@ -40,6 +41,10 @@
           rel="stylesheet"
           media="all"
           href="{% static 'datatables.net-dt/css/jquery.dataTables.min.css' %}"/>
+    <link type="text/css"
+          rel="stylesheet"
+          media="all"
+          href="{% static 'select-woo/dist/css/selectWoo.min.css' %}" />
     <link rel="stylesheet" href="{% static 'cloudcare/css/webforms.css' %}">
     <link rel="stylesheet" href="{% static 'bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css' %}"/>
   {% endcompress %}

--- a/corehq/apps/cloudcare/templates/cloudcare/spec/form_entry/mocha.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/spec/form_entry/mocha.html
@@ -5,12 +5,12 @@
   <link type="text/css"
         rel="stylesheet"
         media="all"
-        href="{% static 'select2/dist/css/select2.min.css' %}" />
+        href="{% static 'select-woo/dist/css/selectWoo.min.css' %}" />
 {% endblock %}
 
 {% block dependencies %}
   {% include "formplayer/dependencies.html" %}
-  <script src="{% static 'select2/dist/js/select2.full.min.js' %}"></script>
+  <script src="{% static 'select-woo/dist/js/selectWoo.full.min.js' %}"></script>
   <script src="{% static 'jasmine-fixture/dist/jasmine-fixture.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/cloudcare/templates/preview_app/base.html
+++ b/corehq/apps/cloudcare/templates/preview_app/base.html
@@ -12,7 +12,7 @@
       <link type="text/css"
             rel="stylesheet"
             media="all"
-            href="{% static 'select2/dist/css/select2.min.css' %}" />
+            href="{% static 'select-woo/dist/css/selectWoo.min.css' %}" />
   {% endcompress %}
 {% endblock %}
 
@@ -82,7 +82,7 @@
 
 {% block js %}{{ block.super }}
   {% compress js %}
-    <script src="{% static 'select2/dist/js/select2.full.min.js' %}"></script>
+    <script src="{% static 'select-woo/dist/js/selectWoo.full.min.js' %}"></script>
     <script src="{% static 'app_manager/js/app_manager_utils.js' %}"></script>
     <script src="{% static 'cloudcare/js/preview_app/preview_app.js' %}"></script>
     <script src="{% static 'cloudcare/js/preview_app/main.js' %}"></script>

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
         "quicksearch": "DeuxHuitHuit/quicksearch#2.2.1",
         "requirejs": "2.3.6",
         "select2": "4.0.0",
+        "select-woo": "1.0.1",
         "topojson": "3.0.2",
         "uglify-js": "2.8.29",
         "ui-select": "npm:ui-select#0.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,6 +193,11 @@ align-text@^0.1.1, align-text@^0.1.3:
     longest "^1.0.1"
     repeat-string "^1.5.2"
 
+almond@~0.3.1:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/almond/-/almond-0.3.3.tgz#a0e7c95ac7624d6417b4494b1e68bff693168a20"
+  integrity sha1-oOfJWsdiTWQXtElLHmi/9pMWiiA=
+
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
@@ -2997,7 +3002,7 @@ jquery-migrate@1.2.1:
   resolved "https://registry.yarnpkg.com/jquery-migrate/-/jquery-migrate-1.2.1.tgz#e1056ad970fb22d5009e2d4d77cf709b78f04768"
   integrity sha1-4QVq2XD7ItUAni1Nd89wm3jwR2g=
 
-"jquery-mousewheel@>= 3.1.13":
+"jquery-mousewheel@>= 3.1.13", jquery-mousewheel@~3.1.13:
   version "3.1.13"
   resolved "https://registry.yarnpkg.com/jquery-mousewheel/-/jquery-mousewheel-3.1.13.tgz#06f0335f16e353a695e7206bf50503cb523a6ee5"
   integrity sha1-BvAzXxbjU6aV5yBr9QUDy1I6buU=
@@ -5289,6 +5294,14 @@ samsam@1.x, samsam@^1.1.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
   integrity sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==
+
+select-woo@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/select-woo/-/select-woo-1.0.1.tgz#8221fc50860cb64c0e1adb6bafe90a90e8bb3f8d"
+  integrity sha512-9Q/P3spksx/HSNG9OCKQbHgBnUkMLNvyZF5wC4Ww2VT0G/FuUNzZ5En1VWbmMdWVCt/HL999kRdzySe5wfmb5w==
+  dependencies:
+    almond "~0.3.1"
+    jquery-mousewheel "~3.1.13"
 
 select2@4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Summary
This is the second attempt to use SelectWoo. The first attempt caused a bug where comboboxes popped up outside of the HQ container.
https://dimagi-dev.atlassian.net/browse/USH-760

[Link to the previous, reverted, PR.](https://github.com/dimagi/commcare-hq/pull/29022)

## Product Description
This change should only affect the behavior when a screen reader is used. It should cause the screen reader to announce the items in the dropdown listbox and it should be possible to navigate through the items with up/down arrows and select one with the Enter key.

There are two issues we discovered with SelectWoo that are fixed by this change. The first issue is that SelectWoo elements are referenced in an event handler attached to the top-level document, so until the document is replaced those elements are kept alive long after their form is submitted or their case claim query is executed. Web Apps avoids replacing the document, so we need to remove those event handlers somewhere. In this PR, we remove the handlers at submission time.

The second issue is related to the first. Case claim search creates duplicate SelectWoo elements to reflect changes in search criteria. The elements that get replaced are still live due to the first issue and they may respond to an Enter key press by popping up on top of the HQ container. We prevent this by telling the replaced elements that they don't have focus so they won't pop up.

### QA Plan

[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-2699)

The original change was reviewed and approved by an expert screen reader user, so I don't think this one will need to be.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
