### PR TITLE
Add new sum when templates

### DIFF
--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -68,12 +68,17 @@ from corehq.apps.userreports.reports.sum_when_templates import (
     YearRangeTemplateSpec,
 )
 from custom.nutrition_project.ucr.sum_when_templates import (
+    BreastfeedingSpec,
     ChildDeathSpec,
     ChildDeliverySpec,
     ChildLowBirthWeightSpec,
     ChildWeighedSpec,
+    ComplementaryFeedingStartedCheckSpec,
     GenderAndResidentTypeSpec,
+    ImmediateBreastfeedingInitiatedSpec,
+    LatestBMICategorySpec,
     NutritionCenterOpenTodaySpec,
+    OnTimeVisitCheckSpec,
     WomanDeathSpec,
     WomanDeathTypeSpec,
 )
@@ -200,6 +205,11 @@ class SumWhenTemplateFactory(object):
         WomanDeathTypeSpec.type.choices[0]: WomanDeathTypeSpec,
         GenderAndResidentTypeSpec.type.choices[0]: GenderAndResidentTypeSpec,
         NutritionCenterOpenTodaySpec.type.choices[0]: NutritionCenterOpenTodaySpec,
+        OnTimeVisitCheckSpec.type.choices[0]: OnTimeVisitCheckSpec,
+        BreastfeedingSpec.type.choices[0]: BreastfeedingSpec,
+        ImmediateBreastfeedingInitiatedSpec.type.choices[0]: ImmediateBreastfeedingInitiatedSpec,
+        ComplementaryFeedingStartedCheckSpec.type.choices[0]: ComplementaryFeedingStartedCheckSpec,
+        LatestBMICategorySpec.type.choices[0]: LatestBMICategorySpec,
     }
 
     @classmethod

--- a/custom/nutrition_project/ucr/sum_when_templates.py
+++ b/custom/nutrition_project/ucr/sum_when_templates.py
@@ -43,3 +43,28 @@ class GenderAndResidentTypeSpec(SumWhenTemplateSpec):
 class NutritionCenterOpenTodaySpec(SumWhenTemplateSpec):
     type = TypeProperty("india-nutrition-project_nutrition_center_open_today")
     expression = "nutrition_center_open_today = ?"
+
+
+class OnTimeVisitCheckSpec(SumWhenTemplateSpec):
+    type = TypeProperty("india-nutrition-project_on_time_visit_check")
+    expression = "on_time_visit_check = ?"
+
+
+class BreastfeedingSpec(SumWhenTemplateSpec):
+    type = TypeProperty("india-nutrition-project_breastfeeding")
+    expression = "breastfeeding = ?"
+
+
+class ImmediateBreastfeedingInitiatedSpec(SumWhenTemplateSpec):
+    type = TypeProperty("india-nutrition-project_immediate_breastfeeding_initiated")
+    expression = "immediate_breastfeeding_initiated = ?"
+
+
+class ComplementaryFeedingStartedCheckSpec(SumWhenTemplateSpec):
+    type = TypeProperty("india-nutrition-project_cf_started_check")
+    expression = "cf_started_check = ?"
+
+
+class LatestBMICategorySpec(SumWhenTemplateSpec):
+    type = TypeProperty("india-nutrition-project_latest_bmi_category")
+    expression = "latest_bmi_category = ?"


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Just adding some new sum when templates needed for new set of reports on the nutrition project.
For reports from [this doc](https://docs.google.com/spreadsheets/d/1iEycw9ReuWUCmEkajTlM5Ti9uUdmDt7wC0ceG_aGkFg/edit#gid=1495299136) that says they need a template.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`UCR_SUM_WHEN_TEMPLATES`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Safe code changes that will be used only in dynamic reports as of now, where they will be tested and then be used in static reports in code.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
