### PR TITLE
clear page on query

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -197,6 +197,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
                 execute: execute,
             };
             this.page = null;
+            this.search = null;
         };
 
         this.setForceManualAction = function (force) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -196,6 +196,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
                 inputs: queryDict,
                 execute: execute,
             };
+            this.page = null;
         };
 
         this.setForceManualAction = function (force) {


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This clears the page info when making a case search query analogously to how it is already done for the omni search bar (in the `setSearch` [method](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js#L187)), so that each time a search is modified, you begin again on page 1.
https://dimagi-dev.atlassian.net/browse/USH-785

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This is both a tiny change, and one I tested locally.
 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
