### PR TITLE
Removed mark_safe usages in translations

### DIFF
--- a/corehq/apps/translations/app_translations/download.py
+++ b/corehq/apps/translations/app_translations/download.py
@@ -2,7 +2,6 @@ import re
 from collections import OrderedDict
 
 from django.utils.encoding import force_text
-from django.utils.safestring import mark_safe
 
 from corehq.apps.app_manager.exceptions import XFormException
 from corehq.apps.app_manager.models import ReportModule
@@ -352,7 +351,7 @@ def get_form_question_label_name_media(langs, form):
                         part = part.replace('&', '&amp;')
                         part = part.replace('<', '&lt;')
                         part = part.replace('>', '&gt;')
-                        value += mark_safe(part)
+                        value += part
                 itext_items[text_id][(lang, value_form)] = value
 
     app = form.get_app()


### PR DESCRIPTION
## Summary
A one-line fix removing an unnecessary `mark_safe` from bulk translations

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Existing tests passed, no new tests were needed as the previous tag did nothing.

### Safety story

Locally tested that bulk app translations, including those with tags, still behave as previously.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
