### PR TITLE
[SSO] Alert created_by user on first time visiting a Domain that recently auto-trusted their new IdP

### DIFF
--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -175,6 +175,14 @@ class IdentityProvider(models.Model):
             ).exists()
         return is_active_member
 
+    def clear_domain_caches(self, domain):
+        """
+        Clear all caches associated with a Domain and this IdentityProvider
+        :param domain: String (the Domain name)
+        """
+        IdentityProvider.does_domain_trust_this_idp.clear(self, domain)
+        IdentityProvider.is_domain_an_active_member.clear(self, domain)
+
     @classmethod
     def domain_has_editable_identity_provider(cls, domain):
         owner = BillingAccount.get_account_by_domain(domain)

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -183,6 +183,26 @@ class IdentityProvider(models.Model):
         IdentityProvider.does_domain_trust_this_idp.clear(self, domain)
         IdentityProvider.is_domain_an_active_member.clear(self, domain)
 
+    def create_trust_with_domain(self, domain, username):
+        """
+        This creates a TrustedIdentityProvider relationship between the Domain
+        and the current Identity Provider.
+        :param domain: String (the Domain name)
+        :param username: String (the username of the user creating this agreement)
+        :return: Boolean (True if a new trust was created, False if it already exists)
+        """
+        if not TrustedIdentityProvider.objects.filter(
+            domain=domain, identity_provider=self
+        ).exists():
+            TrustedIdentityProvider.objects.create(
+                domain=domain,
+                identity_provider=self,
+                acknowledged_by=username,
+            )
+            self.clear_domain_caches(domain)
+            return True
+        return False
+
     @classmethod
     def domain_has_editable_identity_provider(cls, domain):
         owner = BillingAccount.get_account_by_domain(domain)

--- a/corehq/apps/sso/tests/generator.py
+++ b/corehq/apps/sso/tests/generator.py
@@ -1,5 +1,7 @@
 from django_prbac.models import Role
 
+from django.contrib.sessions.middleware import SessionMiddleware
+
 from corehq.apps.accounting.models import (
     SoftwarePlan,
     SoftwarePlanEdition,
@@ -64,3 +66,11 @@ def get_enterprise_plan():
         role=Role.objects.first(),
         product_rate=first_product_rate
     )
+
+
+@unit_testing_only
+def create_request_session(request, use_sso=False):
+    SessionMiddleware().process_request(request)
+    request.session.save()
+    if use_sso:
+        request.session['samlSessionIndex'] = '_7c84c96e-8774-4e64-893c-06f91d285100'

--- a/corehq/apps/sso/tests/test_request_helpers.py
+++ b/corehq/apps/sso/tests/test_request_helpers.py
@@ -54,9 +54,7 @@ def test_is_request_using_sso_true():
     Testing the successful criteria for an sso request.
     """
     request = RequestFactory().get('/sso/test')
-    request.session = {
-        'samlSessionIndex': '_7c84c96e-8774-4e64-893c-06f91d285100',
-    }
+    generator.create_request_session(request, use_sso=True)
     eq(is_request_using_sso(request), True)
 
 
@@ -65,7 +63,7 @@ def test_is_request_using_sso_false_with_session():
     Testing the usual case for non-sso requests.
     """
     request = RequestFactory().get('/sso/test')
-    request.session = {}
+    generator.create_request_session(request)
     eq(is_request_using_sso(request), False)
 
 
@@ -136,9 +134,7 @@ class TestIsRequestBlockedFromViewingDomainDueToSso(TestCase):
     def setUp(self):
         super().setUp()
         self.request = RequestFactory().get('/sso/test')
-        self.request.session = {
-            'samlSessionIndex': '_7c84c96e-8774-4e64-893c-06f91d285100',
-        }
+        generator.create_request_session(self.request, use_sso=True)
         self.request.user = self.user
 
     def tearDown(self):

--- a/corehq/apps/sso/utils/message_helpers.py
+++ b/corehq/apps/sso/utils/message_helpers.py
@@ -1,0 +1,21 @@
+from django.utils.translation import ugettext as _
+from django.utils.html import format_html
+
+
+def get_success_message_for_trusted_idp(idp, domain_obj):
+    """
+    Small utility to return a success message that a TrustedIdentityProvider
+    relationship was established between an Identity Provider and a Domain.
+
+    :param idp: IdentityProvider
+    :param domain_obj: Domain object
+    :return: String (the final message)
+    """
+    return format_html(
+        _('{idp} is now trusted as an identity provider for users '
+          'who are members of the project space "{domain}". '
+          '<a href="{learn_more}">Learn More</a>'),
+        idp=idp.name,
+        domain=domain_obj.name,
+        learn_more='#',  # todo include learn more link
+    )


### PR DESCRIPTION
## Summary
This PR makes sure that when an SSO-logged in user visits their own domain (which isn't associated with their Identity Provider) for the first time, a `TrustedIdentityProvider` is automatically established and a message is shown to the user to indicate what has happened.

Associated ticket:
https://dimagi-dev.atlassian.net/browse/SAAS-11779

## Feature Flag
`ENTERPRISE_SSO`

## Product Description
Example of success message:
<img width="1658" alt="Screen Shot 2021-03-08 at 2 32 14 PM" src="https://user-images.githubusercontent.com/716573/110394853-b8147280-8032-11eb-82b9-130975d4a10e.png">

## Safety Assurance
- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Updated SSO tests to match changes. Lot's of test coverage in this app.

### QA Plan
No QA for this yet.

### Safety story
This is a feature-flagged part of our codebase that is still in development and unused by any real users. Also, there are lots of tests! ^_^

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
