### PR TITLE
Shows notification message for EOF navigation

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -93,6 +93,10 @@ hqDefine("cloudcare/js/formplayer/router", function () {
             urlObject = Util.CloudcareUrl.fromJson(Util.encodedUrlToObject(currentFragment));
             response.appId = urlObject.appId;
 
+             if (response.notification) {
+                FormplayerFrontend.getChannel().request("handleNotification", response.notification);
+             }
+
             // When the response gets parsed, it will automatically trigger form
             // entry if it is a form response.
             menuCollection = hqImport("cloudcare/js/formplayer/menus/collections")(


### PR DESCRIPTION
## Summary

https://dimagi-dev.atlassian.net/browse/USH-646

Notification message in web apps get skipped today for end of form navigation workflows. This PR makes a simple fix to show these notifications. 


## Product Description

Fixes web apps notification display for end of form navigation

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None

### Safety story

Very minor UI level change to display notification message using the existing code construct for notification message in normal workflow. Locally tested to make sure nothing breaks.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
