### PR TITLE
Admin site tweaks for FHIR

### DIFF
--- a/corehq/apps/data_dictionary/models.py
+++ b/corehq/apps/data_dictionary/models.py
@@ -26,7 +26,7 @@ class CaseType(models.Model):
         unique_together = ('domain', 'name')
 
     def __str__(self):
-        return self.name or repr(self)
+        return self.name or super().__str__()
 
     @classmethod
     def get_or_create(cls, domain, case_type):

--- a/corehq/apps/data_dictionary/models.py
+++ b/corehq/apps/data_dictionary/models.py
@@ -68,7 +68,9 @@ class CaseProperty(models.Model):
         unique_together = ('case_type', 'name')
 
     def __str__(self):
-        return f'{self.case_type}.{self.name}' if self.name else repr(self)
+        if self.name and self.case_type.name:
+            return f'{self.case_type.name}.{self.name}'
+        return super().__str__()
 
     @classmethod
     def get_or_create(cls, name, case_type, domain):

--- a/corehq/motech/fhir/admin.py
+++ b/corehq/motech/fhir/admin.py
@@ -1,25 +1,87 @@
+import json
+
 from django.contrib import admin
 
 from corehq.motech.fhir.models import FHIRResourceType, FHIRResourceProperty
 
 
-class FHIRResourceTypeAdmin(admin.ModelAdmin):
-    model = FHIRResourceType
-    list_display = (
-        'name',
-        'case_type',
-        'domain',
-    )
-    list_filter = ('domain',)
+def _domain(obj):
+    return obj.resource_type.domain
+
+
+def _case_property(obj):
+    case_type = obj.resource_type.case_type.name
+    if obj.case_property:
+        return f'{case_type}.{obj.case_property.name}'
+    if 'case_property' in obj.value_source_config:
+        return f"{case_type}.{obj.value_source_config['case_property']}"
+    return ''
 
 
 class FHIRResourcePropertyAdmin(admin.ModelAdmin):
     model = FHIRResourceProperty
-    list_display = [
+    list_display = (
+        _domain,
         'resource_type',
-        'case_property_name'
-    ]
+        'value_source_jsonpath',
+        _case_property
+    )
+    list_display_links = (
+        _domain,
+        'resource_type',
+        'value_source_jsonpath',
+    )
     list_filter = ('resource_type__domain',)
+    list_select_related = ('resource_type', 'resource_type__case_type')
+
+    def has_add_permission(self, request):
+        # Domains are difficult to manage with this interface. Create
+        # using the Data Dictionary, and edit in Admin.
+        return False
+
+
+class FHIRResourcePropertyInline(admin.TabularInline):
+    model = FHIRResourceProperty
+    verbose_name_plural = 'FHIR resource properties'
+    fields = ('calculated_value_source', 'value_source_config',)
+    readonly_fields = ('calculated_value_source',)
+
+    def calculated_value_source(self, obj):
+        if not (obj.case_property and obj.jsonpath):
+            return ''
+
+        value_source_config = {
+            'case_property': obj.case_property.name,
+            'jsonpath': obj.jsonpath,
+        }
+        if obj.value_map:
+            value_source_config['value_map'] = obj.value_map
+
+        return json.dumps(value_source_config, indent=2)
+
+
+class FHIRResourceTypeAdmin(admin.ModelAdmin):
+    model = FHIRResourceType
+    list_display = (
+        'domain',
+        'name',
+        'case_type',
+    )
+    list_display_links = (
+        'domain',
+        'name',
+        'case_type',
+    )
+    list_filter = ('domain',)
+
+    # Allows for creating resource properties without having to deal
+    # with domains.
+    inlines = [FHIRResourcePropertyInline]
+
+    def has_add_permission(self, request):
+        # Domains are difficult to manage with this interface. Create
+        # using the Data Dictionary, and edit in Admin.
+        return False
 
 
 admin.site.register(FHIRResourceType, FHIRResourceTypeAdmin)

--- a/corehq/motech/fhir/models.py
+++ b/corehq/motech/fhir/models.py
@@ -115,6 +115,12 @@ class FHIRResourceProperty(models.Model):
     # do what you need.
     value_source_config = JSONField(null=True, blank=True, default=None)
 
+    def __str__(self):
+        jsonpath = self.value_source_jsonpath
+        if jsonpath.startswith('$.'):
+            jsonpath = jsonpath[2:]
+        return f'{self.resource_type.name}.{jsonpath}'
+
     def save(self, *args, **kwargs):
         if (
             self.case_property
@@ -139,15 +145,12 @@ class FHIRResourceProperty(models.Model):
         return self.resource_type.case_type
 
     @property
-    def case_property_name(self) -> Optional[str]:
-        if self.case_property:
-            return self.case_property.name
-        if (
-            self.value_source_config
-            and 'case_property' in self.value_source_config
-        ):
-            return self.value_source_config['case_property']
-        return None
+    def value_source_jsonpath(self) -> str:
+        if self.jsonpath:
+            return self.jsonpath
+        if 'jsonpath' in self.value_source_config:
+            return self.value_source_config['jsonpath']
+        return ''
 
     def get_value_source(self) -> ValueSource:
         """


### PR DESCRIPTION
## Summary

Context: [QA-2716](https://dimagi-dev.atlassian.net/browse/QA-2716)

QA on FHIR has shown that we may need to make it a bit easier for superusers to use the Django admin site to configure FHIR resources. (e.g. For casting data types.)

This change is to make that *a little* bit easier. It also fixes a bug that occurs when a CaseType name is blank.

List of resource properties:
![image](https://user-images.githubusercontent.com/708421/110640974-1ddf3680-81ba-11eb-8777-1a6c6e3a61e5.png)

Advanced configuration of resource properties:
![image](https://user-images.githubusercontent.com/708421/110641283-7f070a00-81ba-11eb-978e-b999c92ccdf0.png)


cc @Ben-Talbot 


## Feature Flag
"FHIR Integration"


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story

Changes only affect the Django admin site.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
