### PR TITLE
Remove DEFAULT_EXPORT_SETTINGS feature flag

### DIFF
--- a/corehq/apps/enterprise/forms.py
+++ b/corehq/apps/enterprise/forms.py
@@ -10,7 +10,6 @@ from crispy_forms.helper import FormHelper
 
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput
-from corehq.toggles import DEFAULT_EXPORT_SETTINGS
 from corehq.apps.export.models.export_settings import ExportFileType
 
 
@@ -118,7 +117,7 @@ class EnterpriseSettingsForm(forms.Form):
             "restrict_signup_message": self.account.restrict_signup_message,
         }
 
-        if self.export_settings and DEFAULT_EXPORT_SETTINGS.enabled(self.username):
+        if self.export_settings:
             kwargs['initial'].update(self.export_settings.as_dict())
 
         super(EnterpriseSettingsForm, self).__init__(*args, **kwargs)
@@ -142,31 +141,30 @@ class EnterpriseSettingsForm(forms.Form):
             )
         )
 
-        if DEFAULT_EXPORT_SETTINGS.enabled(self.username):
-            self.helper.layout.append(
-                crispy.Div(
-                    crispy.Fieldset(
-                        _("Edit Default Form Export Settings"),
-                        crispy.Div(
-                            crispy.Field('forms_filetype'),
-                        ),
-                        PrependedText('forms_auto_convert', ''),
-                        PrependedText('forms_auto_format_cells', ''),
-                        PrependedText('forms_expand_checkbox', ''),
+        self.helper.layout.append(
+            crispy.Div(
+                crispy.Fieldset(
+                    _("Edit Default Form Export Settings"),
+                    crispy.Div(
+                        crispy.Field('forms_filetype'),
                     ),
-                    crispy.Fieldset(
-                        _("Edit Default Case Export Settings"),
-                        crispy.Div(
-                            crispy.Field('cases_filetype')
-                        ),
-                        PrependedText('cases_auto_convert', ''),
+                    PrependedText('forms_auto_convert', ''),
+                    PrependedText('forms_auto_format_cells', ''),
+                    PrependedText('forms_expand_checkbox', ''),
+                ),
+                crispy.Fieldset(
+                    _("Edit Default Case Export Settings"),
+                    crispy.Div(
+                        crispy.Field('cases_filetype')
                     ),
-                    crispy.Fieldset(
-                        _("Edit Default OData Export Settings"),
-                        PrependedText('odata_expand_checkbox', ''),
-                    ),
-                )
+                    PrependedText('cases_auto_convert', ''),
+                ),
+                crispy.Fieldset(
+                    _("Edit Default OData Export Settings"),
+                    PrependedText('odata_expand_checkbox', ''),
+                ),
             )
+        )
 
         self.helper.layout.append(
             hqcrispy.FormActions(
@@ -190,7 +188,7 @@ class EnterpriseSettingsForm(forms.Form):
         account.restrict_signup_message = self.cleaned_data.get('restrict_signup_message', '')
         account.save()
 
-        if self.export_settings and DEFAULT_EXPORT_SETTINGS.enabled(self.username):
+        if self.export_settings:
             # forms
             self.export_settings.forms_filetype = self.cleaned_data.get(
                 'forms_filetype',

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -44,7 +44,7 @@ from corehq.apps.domain.decorators import (
 )
 
 from corehq.apps.accounting.utils.subscription import get_account_or_404
-from corehq.apps.export.utils import get_default_export_settings_for_user
+from corehq.apps.export.utils import get_default_export_settings_if_applicable
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.const import USER_DATE_FORMAT
 
@@ -115,7 +115,7 @@ def enterprise_dashboard_email(request, domain, slug):
 @login_and_domain_required
 def enterprise_settings(request, domain):
     account = get_account_or_404(request, domain)
-    export_settings = get_default_export_settings_for_user(request.user.username, domain)
+    export_settings = get_default_export_settings_if_applicable(domain)
 
     if request.method == 'POST':
         form = EnterpriseSettingsForm(request.POST, domain=domain, account=account,
@@ -142,7 +142,7 @@ def enterprise_settings(request, domain):
 @require_POST
 def edit_enterprise_settings(request, domain):
     account = get_account_or_404(request, domain)
-    export_settings = get_default_export_settings_for_user(request.user.username, domain)
+    export_settings = get_default_export_settings_if_applicable(domain)
     form = EnterpriseSettingsForm(request.POST, username=request.user.username, domain=domain,
                                   account=account, export_settings=export_settings)
 

--- a/corehq/apps/export/tests/test_export_utils.py
+++ b/corehq/apps/export/tests/test_export_utils.py
@@ -42,16 +42,6 @@ class TestExportUtils(TestCase):
         if current_subscription.plan_version.plan.edition != plan:
             current_subscription.change_plan(DefaultProductPlan.get_default_plan_version(plan))
 
-    def test_default_export_settings_no_ff_enabled(self):
-        """
-        Default export settings are only available if the feature flag is enabled
-        NOTE: no decorator to enable DEFAULT_EXPORT_SETTINGS feature flag
-        """
-        self.update_subscription(SoftwarePlanEdition.ENTERPRISE)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
-        self.assertIsNone(settings)
-
-    @flag_enabled('DEFAULT_EXPORT_SETTINGS')
     def test_default_export_settings_community_domain(self):
         """
         Verify COMMUNITY software plans do not have access to default export settings
@@ -60,7 +50,6 @@ class TestExportUtils(TestCase):
         settings = get_default_export_settings_for_user(self.user.username, self.domain)
         self.assertIsNone(settings)
 
-    @flag_enabled('DEFAULT_EXPORT_SETTINGS')
     def test_default_export_settings_standard_domain(self):
         """
         Verify STANDARD software plans do not have access to default export settings
@@ -69,7 +58,6 @@ class TestExportUtils(TestCase):
         settings = get_default_export_settings_for_user(self.user.username, self.domain)
         self.assertIsNone(settings)
 
-    @flag_enabled('DEFAULT_EXPORT_SETTINGS')
     def test_default_export_settings_pro_domain(self):
         """
         Verify PRO software plans do not have access to default export settings
@@ -78,7 +66,6 @@ class TestExportUtils(TestCase):
         settings = get_default_export_settings_for_user(self.user.username, self.domain)
         self.assertIsNone(settings)
 
-    @flag_enabled('DEFAULT_EXPORT_SETTINGS')
     def test_default_export_settings_advanced_domain(self):
         """
         Verify ADVANCED software plans do not have access to default export settings
@@ -87,7 +74,6 @@ class TestExportUtils(TestCase):
         settings = get_default_export_settings_for_user(self.user.username, self.domain)
         self.assertIsNone(settings)
 
-    @flag_enabled('DEFAULT_EXPORT_SETTINGS')
     def test_default_export_settings_reseller_domain(self):
         """
         Verify RESELLER software plans do not have access to default export settings
@@ -96,7 +82,6 @@ class TestExportUtils(TestCase):
         settings = get_default_export_settings_for_user(self.user.username, self.domain)
         self.assertIsNone(settings)
 
-    @flag_enabled('DEFAULT_EXPORT_SETTINGS')
     def test_default_export_settings_managed_hosting_domain(self):
         """
         Verify MANAGED_HOSTING software plans do not have access to default export settings
@@ -105,7 +90,6 @@ class TestExportUtils(TestCase):
         settings = get_default_export_settings_for_user(self.user.username, self.domain)
         self.assertIsNone(settings)
 
-    @flag_enabled('DEFAULT_EXPORT_SETTINGS')
     def test_default_export_settings_enterprise_domain(self):
         """
         Verify software plan editions that do have access to default export settings

--- a/corehq/apps/export/tests/test_export_utils.py
+++ b/corehq/apps/export/tests/test_export_utils.py
@@ -5,9 +5,8 @@ from django.test import TestCase
 from corehq.apps.accounting.models import SoftwarePlanEdition, Subscription, DefaultProductPlan, BillingAccount, \
     SubscriptionAdjustment
 from corehq.apps.domain.models import Domain
-from corehq.apps.export.utils import get_default_export_settings_for_user
+from corehq.apps.export.utils import get_default_export_settings_if_applicable
 from corehq.apps.users.models import WebUser
-from corehq.util.test_utils import flag_enabled
 
 
 class TestExportUtils(TestCase):
@@ -47,7 +46,7 @@ class TestExportUtils(TestCase):
         Verify COMMUNITY software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.COMMUNITY)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
+        settings = get_default_export_settings_if_applicable(self.domain)
         self.assertIsNone(settings)
 
     def test_default_export_settings_standard_domain(self):
@@ -55,7 +54,7 @@ class TestExportUtils(TestCase):
         Verify STANDARD software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.STANDARD)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
+        settings = get_default_export_settings_if_applicable(self.domain)
         self.assertIsNone(settings)
 
     def test_default_export_settings_pro_domain(self):
@@ -63,7 +62,7 @@ class TestExportUtils(TestCase):
         Verify PRO software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.PRO)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
+        settings = get_default_export_settings_if_applicable(self.domain)
         self.assertIsNone(settings)
 
     def test_default_export_settings_advanced_domain(self):
@@ -71,7 +70,7 @@ class TestExportUtils(TestCase):
         Verify ADVANCED software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.ADVANCED)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
+        settings = get_default_export_settings_if_applicable(self.domain)
         self.assertIsNone(settings)
 
     def test_default_export_settings_reseller_domain(self):
@@ -79,7 +78,7 @@ class TestExportUtils(TestCase):
         Verify RESELLER software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.RESELLER)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
+        settings = get_default_export_settings_if_applicable(self.domain)
         self.assertIsNone(settings)
 
     def test_default_export_settings_managed_hosting_domain(self):
@@ -87,7 +86,7 @@ class TestExportUtils(TestCase):
         Verify MANAGED_HOSTING software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.MANAGED_HOSTING)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
+        settings = get_default_export_settings_if_applicable(self.domain)
         self.assertIsNone(settings)
 
     def test_default_export_settings_enterprise_domain(self):
@@ -96,5 +95,5 @@ class TestExportUtils(TestCase):
         are able to create a DefaultExportSettings instance
         """
         self.update_subscription(SoftwarePlanEdition.ENTERPRISE)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
+        settings = get_default_export_settings_if_applicable(self.domain)
         self.assertIsNotNone(settings)

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -54,7 +54,7 @@ def get_export(export_type, domain, export_id=None, username=None):
     raise Exception("Unexpected export type received %s" % export_type)
 
 
-def get_default_export_settings_for_user(username, domain):
+def get_default_export_settings_if_applicable(domain):
     """
     Only creates settings if the the subscription level supports it
     """
@@ -62,7 +62,7 @@ def get_default_export_settings_for_user(username, domain):
     current_subscription = Subscription.get_active_subscription_by_domain(domain)
     # currently only available for enterprise customers
     supported_editions = [SoftwarePlanEdition.ENTERPRISE]
-    if current_subscription.plan_version.plan.edition in supported_editions:
+    if current_subscription and current_subscription.plan_version.plan.edition in supported_editions:
         from corehq.apps.export.models import DefaultExportSettings
         settings = DefaultExportSettings.objects.get_or_create(account=current_subscription.account)[0]
 

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -57,11 +57,7 @@ def get_export(export_type, domain, export_id=None, username=None):
 def get_default_export_settings_for_user(username, domain):
     """
     Only creates settings if the the subscription level supports it
-    Currently only available to Enterprise accounts with the DEFAULT_EXPORT_SETTINGS FF enabled
     """
-    if not toggles.DEFAULT_EXPORT_SETTINGS.enabled(username):
-        return None
-
     settings = None
     current_subscription = Subscription.get_active_subscription_by_domain(domain)
     # currently only available for enterprise customers

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -41,7 +41,7 @@ from corehq.apps.export.models import (
     FormExportDataSchema,
     FormExportInstance,
 )
-from corehq.apps.export.utils import get_default_export_settings_for_user
+from corehq.apps.export.utils import get_default_export_settings_if_applicable
 from corehq.apps.export.views.utils import (
     DailySavedExportMixin,
     DashboardFeedMixin,
@@ -260,7 +260,7 @@ class CreateNewCustomFormExportView(BaseExportView):
         app_id = request.GET.get('app_id')
         xmlns = request.GET.get('export_tag').strip('"')
 
-        export_settings = get_default_export_settings_for_user(request.user.username, self.domain)
+        export_settings = get_default_export_settings_if_applicable(self.domain)
         schema = self.get_export_schema(self.domain, app_id, xmlns)
         self.export_instance = self.create_new_export_instance(schema, export_settings=export_settings)
 
@@ -285,7 +285,7 @@ class CreateNewCustomCaseExportView(BaseExportView):
     def get(self, request, *args, **kwargs):
         case_type = request.GET.get('export_tag').strip('"')
 
-        export_settings = get_default_export_settings_for_user(request.user.username, self.domain)
+        export_settings = get_default_export_settings_if_applicable(self.domain)
         schema = self.get_export_schema(self.domain, None, case_type)
         self.export_instance = self.create_new_export_instance(schema, export_settings=export_settings)
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1986,16 +1986,6 @@ APP_ANALYTICS = StaticToggle(
     help_link="https://confluence.dimagi.com/display/ccinternal/App+Analytics",
 )
 
-DEFAULT_EXPORT_SETTINGS = StaticToggle(
-    'default_export_settings',
-    'Allow enterprise admin to set default export settings',
-    TAG_PRODUCT,
-    namespaces=[NAMESPACE_USER],
-    description="""
-    Allows an enterprise admin to set default export settings for all domains under the enterprise account.
-    """
-)
-
 ENTERPRISE_SSO = StaticToggle(
     'enterprise_sso',
     'Enable Enterprise SSO options for the users specified in this list.',


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
As requested [here](https://dimagi-dev.atlassian.net/browse/SAAS-11474?focusedCommentId=127481), I am removing the `DEFAULT_EXPORT_SETTINGS` feature flag to make this generally available to enterprise customers. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Removing DEFAULT_EXPORT_SETTINGS
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests for each software plan and whether or not they have access to default export settings.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
[Requested QA](https://dimagi-dev.atlassian.net/browse/QA-2728)
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested that works as expected for enterprise customers.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
