### PR TITLE
auditcare write once

### DIFF
--- a/corehq/apps/auditcare/middleware.py
+++ b/corehq/apps/auditcare/middleware.py
@@ -62,16 +62,7 @@ class AuditMiddleware:
         try:
             response = self.get_response(request)
         finally:
-            audit_doc = getattr(request, 'audit_doc', None)
-            if audit_doc:
-                if not audit_doc.user:
-                    if hasattr(request, 'audit_user'):
-                        audit_doc.user = request.audit_user
-                    elif hasattr(request, 'couch_user'):
-                        audit_doc.user = request.couch_user.username
-                if response is not None:
-                    audit_doc.status_code = response.status_code
-                audit_doc.save()
+            self._update_audit(request, response)
         return response
 
     def should_audit(self, view_func):
@@ -89,3 +80,15 @@ class AuditMiddleware:
                 and view_name.startswith(('django.contrib.admin', 'reversion.admin'))
             )
         )
+
+    def _update_audit(self, request, response):
+        audit_doc = getattr(request, 'audit_doc', None)
+        if audit_doc:
+            if not audit_doc.user:
+                if hasattr(request, 'audit_user'):
+                    audit_doc.user = request.audit_user
+                elif hasattr(request, 'couch_user'):
+                    audit_doc.user = request.couch_user.username
+            if response is not None:
+                audit_doc.status_code = response.status_code
+            audit_doc.save()

--- a/corehq/apps/auditcare/models.py
+++ b/corehq/apps/auditcare/models.py
@@ -150,7 +150,6 @@ class NavigationEventAudit(AuditEvent):
             audit.session_key = request.session.session_key
             audit.extra = extra
             audit.view_kwargs = view_kwargs
-            audit.save()
             return audit
         except Exception:
             log.exception("NavigationEventAudit.audit_view error")

--- a/corehq/apps/auditcare/models.py
+++ b/corehq/apps/auditcare/models.py
@@ -152,8 +152,8 @@ class NavigationEventAudit(AuditEvent):
             audit.view_kwargs = view_kwargs
             audit.save()
             return audit
-        except Exception as ex:
-            log.error("NavigationEventAudit.audit_view error: %s", ex)
+        except Exception:
+            log.exception("NavigationEventAudit.audit_view error")
 
 
 ACCESS_LOGIN = 'login'

--- a/corehq/apps/auditcare/tests/test_middleware.py
+++ b/corehq/apps/auditcare/tests/test_middleware.py
@@ -103,8 +103,6 @@ class TestAuditMiddleware(SimpleTestCase):
         with configured_middleware(settings, get_response) as ware:
             ware(self.request)
         audit_doc = self.request.audit_doc
-        self.assertEqual(audit_doc.status_code, 200)
-        self.assertEqual(audit_doc.user, "username")
         self.assertEqual(audit_doc.save_count, 1)
 
     def test_should_save_audit_doc_on_error(self):
@@ -171,12 +169,12 @@ Settings = Config(
 )
 
 
+def default_get_response(request):
+    return Config(status_code=200)
+
+
 @contextmanager
-def configured_middleware(settings=Settings, get_response=None):
-    response = Config(status_code=200)
-    if get_response is None:
-        def get_response(request):
-            return response
+def configured_middleware(settings=Settings, get_response=default_get_response):
     with patch.object(mod.NavigationEventAudit, "audit_view", fake_audit), \
             patch.object(mod, "settings", settings):
         yield mod.AuditMiddleware(get_response)

--- a/corehq/apps/auditcare/tests/test_middleware.py
+++ b/corehq/apps/auditcare/tests/test_middleware.py
@@ -69,30 +69,57 @@ class TestAuditMiddleware(SimpleTestCase):
         assert not hasattr(self.request, "audit_doc")
 
     def test_process_response_with_audit_doc_with_user(self):
-        self.request.audit_doc = audit_doc = fake_audit_doc(user="username")
+        self.request.audit_doc = audit_doc = FakeAuditDoc(user="username")
         with configured_middleware() as ware:
             ware(self.request)
         self.assertEqual(audit_doc.status_code, 200)
         self.assertEqual(audit_doc.user, "username")
-        self.assertEqual(audit_doc.save.count, 1)
+        self.assertEqual(audit_doc.save_count, 1)
 
     def test_process_response_with_audit_doc_and_audit_user(self):
-        self.request.audit_doc = audit_doc = fake_audit_doc(user=None)
+        self.request.audit_doc = audit_doc = FakeAuditDoc(user=None)
         self.request.audit_user = "audit_user"
         with configured_middleware() as ware:
             ware(self.request)
         self.assertEqual(audit_doc.status_code, 200)
         self.assertEqual(audit_doc.user, "audit_user")
-        self.assertEqual(audit_doc.save.count, 1)
+        self.assertEqual(audit_doc.save_count, 1)
 
     def test_process_response_with_audit_doc_and_couch_user(self):
-        self.request.audit_doc = audit_doc = fake_audit_doc(user=None)
+        self.request.audit_doc = audit_doc = FakeAuditDoc(user=None)
         self.request.couch_user = Config(username="couch_user")
         with configured_middleware() as ware:
             ware(self.request)
         self.assertEqual(audit_doc.status_code, 200)
         self.assertEqual(audit_doc.user, "couch_user")
-        self.assertEqual(audit_doc.save.count, 1)
+        self.assertEqual(audit_doc.save_count, 1)
+
+    def test_should_save_audit_doc_exactly_once(self):
+        def get_response(request):
+            ware.process_view(request, view, ARGS, KWARGS)
+            return Config(status_code=200)
+        view = make_view()
+        settings = Settings(AUDIT_ALL_VIEWS=True)
+        with configured_middleware(settings, get_response) as ware:
+            ware(self.request)
+        audit_doc = self.request.audit_doc
+        self.assertEqual(audit_doc.status_code, 200)
+        self.assertEqual(audit_doc.user, "username")
+        self.assertEqual(audit_doc.save_count, 1)
+
+    def test_should_save_audit_doc_on_error(self):
+        def get_response(request):
+            ware.process_view(request, view, ARGS, KWARGS)
+            raise UnhandledError
+        view = make_view()
+        settings = Settings(AUDIT_ALL_VIEWS=True)
+        with configured_middleware(settings, get_response) as ware, \
+                self.assertRaises(UnhandledError):
+            ware(self.request)
+        audit_doc = self.request.audit_doc
+        self.assertFalse(hasattr(audit_doc, "status_code"))
+        self.assertEqual(audit_doc.user, "username")
+        self.assertEqual(audit_doc.save_count, 1)
 
     def assert_audit(self, request):
         audit_doc = getattr(request, "audit_doc", None)
@@ -126,9 +153,18 @@ def test_make_admin_view_class():
     eq(func.__module__, "django.contrib.admin")
 
 
+class FakeAuditDoc(Config):
+
+    def save(self):
+        if "save_count" in self:
+            self.save_count += 1
+        else:
+            self.save_count = 1
+
+
 ARGS = ()  # positional view args are not audited, therefore are empty
 KWARGS = {"non": "empty", "and": "audited", "view": "kwargs"}
-EXPECTED_AUDIT = Config(user="username", view_kwargs=KWARGS)
+EXPECTED_AUDIT = FakeAuditDoc(user="username", view_kwargs=KWARGS)
 Settings = Config(
     AUDIT_MODULES=default_settings.AUDIT_MODULES,
     AUDIT_VIEWS=default_settings.AUDIT_VIEWS,
@@ -136,11 +172,14 @@ Settings = Config(
 
 
 @contextmanager
-def configured_middleware(settings=Settings):
+def configured_middleware(settings=Settings, get_response=None):
     response = Config(status_code=200)
+    if get_response is None:
+        def get_response(request):
+            return response
     with patch.object(mod.NavigationEventAudit, "audit_view", fake_audit), \
             patch.object(mod, "settings", settings):
-        yield mod.AuditMiddleware(lambda request: response)
+        yield mod.AuditMiddleware(get_response)
 
 
 def make_view(name="the_view", module="corehq.apps.auditcare.views"):
@@ -156,11 +195,8 @@ def make_view(name="the_view", module="corehq.apps.auditcare.views"):
 
 
 def fake_audit(request, user, view_func, view_kwargs, extra={}):
-    return Config(user=user, view_kwargs=view_kwargs)
+    return FakeAuditDoc(user=user, view_kwargs=view_kwargs)
 
 
-def fake_audit_doc(**kwargs):
-    def save():
-        save.count += 1
-    save.count = 0
-    return Config(save=save, **kwargs)
+class UnhandledError(Exception):
+    pass

--- a/corehq/apps/auditcare/tests/test_models.py
+++ b/corehq/apps/auditcare/tests/test_models.py
@@ -1,0 +1,20 @@
+from django.test import RequestFactory, TestCase
+from testil import Config
+
+from corehq.apps.auditcare.models import NavigationEventAudit
+
+from .test_middleware import make_view
+
+
+class TestNavigationEventAudit(TestCase):
+
+    def setUp(self):
+        self.request = RequestFactory().get("/path", {"key": "value"})
+        self.request.session = Config(session_key="abc")
+
+    def test_audit_view_should_not_save(self):
+        view = make_view()
+        event = NavigationEventAudit.audit_view(self.request, "username", view, {})
+        if event._id is not None:
+            self.addCleanup(event.delete)
+        self.assertIsNone(event._id)

--- a/corehq/apps/auditcare/tests/test_models.py
+++ b/corehq/apps/auditcare/tests/test_models.py
@@ -1,4 +1,4 @@
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, SimpleTestCase
 from testil import Config
 
 from corehq.apps.auditcare.models import NavigationEventAudit
@@ -6,7 +6,7 @@ from corehq.apps.auditcare.models import NavigationEventAudit
 from .test_middleware import make_view
 
 
-class TestNavigationEventAudit(TestCase):
+class TestNavigationEventAudit(SimpleTestCase):
 
     def setUp(self):
         self.request = RequestFactory().get("/path", {"key": "value"})
@@ -15,6 +15,4 @@ class TestNavigationEventAudit(TestCase):
     def test_audit_view_should_not_save(self):
         view = make_view()
         event = NavigationEventAudit.audit_view(self.request, "username", view, {})
-        if event._id is not None:
-            self.addCleanup(event.delete)
         self.assertIsNone(event._id)


### PR DESCRIPTION
Previously auditcare saved the doc twice for every navigation audit event. This is inefficient, and because of the high volume it created a lot of garbage to be cleaned up by the database. This changes `NavigationAuditEvent.audit_view` and `AuditMiddleware` so there is exactly one save per request.

Also added sentry error handling to `NavigationAuditEvent.audit_view` since I want to know about errors that are happening in there.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Tests have been added to verify the new behavior.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
