### PR TITLE
[SSO] cleanup SSO async handler tests and fix small bug

### DIFF
--- a/corehq/apps/sso/async_handlers.py
+++ b/corehq/apps/sso/async_handlers.py
@@ -86,7 +86,8 @@ class IdentityProviderAdminAsyncHandler(BaseLinkedObjectAsyncHandler):
 
     def remove_object(self):
         existing_email_domain = AuthenticatedEmailDomain.objects.filter(
-            email_domain=self.email_domain
+            email_domain=self.email_domain,
+            identity_provider=self.identity_provider,
         )
         if not existing_email_domain.exists():
             raise AsyncHandlerError(

--- a/corehq/apps/sso/tests/test_async_handlers.py
+++ b/corehq/apps/sso/tests/test_async_handlers.py
@@ -20,11 +20,10 @@ class BaseAsyncHandlerTest(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.account = generator.get_billing_account_for_idp()
-        cls.domain = Domain(
-            name="vaultwax-001",
+        cls.domain = Domain.get_or_create_with_name(
+            "vaultwax-001",
             is_active=True
         )
-        cls.domain.save()
         cls.idp_one = IdentityProvider.objects.create(
             owner=cls.account,
             name='Azure AD for Vault Wax',

--- a/corehq/apps/sso/tests/test_async_handlers.py
+++ b/corehq/apps/sso/tests/test_async_handlers.py
@@ -33,7 +33,7 @@ class BaseAsyncHandlerTest(TestCase):
             last_modified_by='someadmin@dimagi.com',
         )
         cls.idp.create_service_provider_certificate()
-        
+
         # secondary Identity Provider to test some edge cases
         cls.other_idp = IdentityProvider.objects.create(
             owner=cls.account,

--- a/corehq/apps/sso/tests/test_async_handlers.py
+++ b/corehq/apps/sso/tests/test_async_handlers.py
@@ -48,6 +48,17 @@ class BaseAsyncHandlerTest(TestCase):
         cls.account.delete()
         super().tearDownClass()
 
+    def _get_post_data(self, object_name=None):
+        """
+        The data that will populate request.POST in all the tests below.
+        :param object_name: the parameter that will be in POST.objectName
+        :return: dict for request.POST
+        """
+        return {
+            'requestContext[idpSlug]': self.idp_one.slug,
+            'objectName': object_name,
+        }
+
 
 class TestIdentityProviderAdminAsyncHandler(BaseAsyncHandlerTest):
 
@@ -69,9 +80,7 @@ class TestIdentityProviderAdminAsyncHandler(BaseAsyncHandlerTest):
             identity_provider=self.idp_one,
             email_domain='vaultwax.nl'
         )
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-        }
+        self.request.POST = self._get_post_data()
         handler = IdentityProviderAdminAsyncHandler(self.request)
         self.assertEqual(
             handler.get_linked_objects(),
@@ -86,10 +95,7 @@ class TestIdentityProviderAdminAsyncHandler(BaseAsyncHandlerTest):
             identity_provider=self.idp_one,
             email_domain='vaultwax.com'
         )
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-            'objectName': 'vaultwax.com',
-        }
+        self.request.POST = self._get_post_data('vaultwax.com')
         handler = IdentityProviderAdminAsyncHandler(self.request)
         with self.assertRaises(AsyncHandlerError):
             handler.add_object()
@@ -99,19 +105,13 @@ class TestIdentityProviderAdminAsyncHandler(BaseAsyncHandlerTest):
             identity_provider=self.idp_two,
             email_domain='vwx.link'
         )
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-            'objectName': 'vwx.link',
-        }
+        self.request.POST = self._get_post_data('vwx.link')
         handler = IdentityProviderAdminAsyncHandler(self.request)
         with self.assertRaises(AsyncHandlerError):
             handler.add_object()
 
     def test_add_object_response(self):
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-            'objectName': 'vaultwax.com',
-        }
+        self.request.POST = self._get_post_data('vaultwax.com')
         handler = IdentityProviderAdminAsyncHandler(self.request)
         self.assertEqual(
             handler.add_object_response,
@@ -121,10 +121,7 @@ class TestIdentityProviderAdminAsyncHandler(BaseAsyncHandlerTest):
         )
 
     def test_remove_object_raises_error_if_no_email_domain_exists(self):
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-            'objectName': 'vaultwax.com',
-        }
+        self.request.POST = self._get_post_data('vaultwax.com')
         handler = IdentityProviderAdminAsyncHandler(self.request)
         with self.assertRaises(AsyncHandlerError):
             handler.remove_object()
@@ -134,10 +131,7 @@ class TestIdentityProviderAdminAsyncHandler(BaseAsyncHandlerTest):
             identity_provider=self.idp_one,
             email_domain='vaultwax.com',
         )
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-            'objectName': 'vaultwax.com',
-        }
+        self.request.POST = self._get_post_data('vaultwax.com')
         handler = IdentityProviderAdminAsyncHandler(self.request)
         self.assertEqual(
             handler.get_linked_objects(),
@@ -190,9 +184,7 @@ class TestSSOExemptUsersAdminAsyncHandler(BaseAsyncHandlerTest):
             email_domain=self.email_domain,
             username='c@vaultwax.com'
         )
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-        }
+        self.request.POST = self._get_post_data()
         handler = SSOExemptUsersAdminAsyncHandler(self.request)
         self.assertEqual(
             handler.get_linked_objects(),
@@ -203,10 +195,7 @@ class TestSSOExemptUsersAdminAsyncHandler(BaseAsyncHandlerTest):
         )
 
     def test_missing_email_domain_in_username_raises_error(self):
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-            'objectName': 'bademail',
-        }
+        self.request.POST = self._get_post_data('bademail')
         handler = SSOExemptUsersAdminAsyncHandler(self.request)
         with self.assertRaises(AsyncHandlerError):
             handler.email_domain
@@ -216,37 +205,25 @@ class TestSSOExemptUsersAdminAsyncHandler(BaseAsyncHandlerTest):
             username='b@vaultwax.com',
             email_domain=self.email_domain
         )
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-            'objectName': 'b@vaultwax.com',
-        }
+        self.request.POST = self._get_post_data('b@vaultwax.com')
         handler = SSOExemptUsersAdminAsyncHandler(self.request)
         with self.assertRaises(AsyncHandlerError):
             handler.add_object()
 
     def test_add_object_raises_errors_if_email_domain_is_linked_to_different_idp(self):
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-            'objectName': 'b@vwx.link',
-        }
+        self.request.POST = self._get_post_data('b@vwx.link')
         handler = SSOExemptUsersAdminAsyncHandler(self.request)
         with self.assertRaises(AsyncHandlerError):
             handler.add_object()
 
     def test_add_object_raises_errors_if_email_domain_does_not_exist(self):
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-            'objectName': 'b@dimagi.com',
-        }
+        self.request.POST = self._get_post_data('b@dimagi.com')
         handler = SSOExemptUsersAdminAsyncHandler(self.request)
         with self.assertRaises(AsyncHandlerError):
             handler.add_object()
 
     def test_add_object_response(self):
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-            'objectName': 'b@vaultwax.com',
-        }
+        self.request.POST = self._get_post_data('b@vaultwax.com')
         handler = SSOExemptUsersAdminAsyncHandler(self.request)
         self.assertEqual(
             handler.add_object_response,
@@ -256,10 +233,7 @@ class TestSSOExemptUsersAdminAsyncHandler(BaseAsyncHandlerTest):
         )
 
     def test_remove_object_raises_error_if_username_does_not_exist(self):
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-            'objectName': 'b@vaultwax.com',
-        }
+        self.request.POST = self._get_post_data('b@vaultwax.com')
         handler = SSOExemptUsersAdminAsyncHandler(self.request)
         with self.assertRaises(AsyncHandlerError):
             handler.remove_object()
@@ -269,10 +243,7 @@ class TestSSOExemptUsersAdminAsyncHandler(BaseAsyncHandlerTest):
             username='b@vwx.link',
             email_domain=self.email_domain_two
         )
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-            'objectName': 'b@vwx.link',
-        }
+        self.request.POST = self._get_post_data('b@vwx.link')
         handler = SSOExemptUsersAdminAsyncHandler(self.request)
         with self.assertRaises(AsyncHandlerError):
             handler.remove_object()
@@ -284,10 +255,7 @@ class TestSSOExemptUsersAdminAsyncHandler(BaseAsyncHandlerTest):
         )
         self.idp_one.is_editable = True
         self.idp_one.save()
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-            'objectName': 'b@vaultwax.com',
-        }
+        self.request.POST = self._get_post_data('b@vaultwax.com')
         handler = SSOExemptUsersAdminAsyncHandler(self.request)
         with self.assertRaises(AsyncHandlerError):
             handler.remove_object()
@@ -297,10 +265,7 @@ class TestSSOExemptUsersAdminAsyncHandler(BaseAsyncHandlerTest):
             username='b@vaultwax.com',
             email_domain=self.email_domain
         )
-        self.request.POST = {
-            'requestContext[idpSlug]': self.idp_one.slug,
-            'objectName': 'b@vaultwax.com',
-        }
+        self.request.POST = self._get_post_data('b@vaultwax.com')
         handler = SSOExemptUsersAdminAsyncHandler(self.request)
         self.assertEqual(
             handler.get_linked_objects(),

--- a/corehq/apps/sso/tests/test_async_handlers.py
+++ b/corehq/apps/sso/tests/test_async_handlers.py
@@ -152,6 +152,21 @@ class TestIdentityProviderAdminAsyncHandler(BaseAsyncHandlerTest):
         with self.assertRaises(AsyncHandlerError):
             handler.remove_object()
 
+    def test_remove_object_fails_if_email_domain_is_related_to_other_idp(self):
+        """
+        Ensure that remove_object() fails when trying to remove an email domain
+        that is related to another IdentityProvider that is not the current
+        IdentityProvider.
+        """
+        AuthenticatedEmailDomain.objects.create(
+            identity_provider=self.other_idp,
+            email_domain='vwx.link'
+        )
+        self.request.POST = self._get_post_data('vwx.link')
+        handler = IdentityProviderAdminAsyncHandler(self.request)
+        with self.assertRaises(AsyncHandlerError):
+            handler.remove_object()
+
     def test_remove_object_removes_email_domain(self):
         """
         Ensure that the remove_object_response successfully removes the

--- a/corehq/apps/sso/tests/test_async_handlers.py
+++ b/corehq/apps/sso/tests/test_async_handlers.py
@@ -157,6 +157,10 @@ class TestSSOExemptUsersAdminAsyncHandler(BaseAsyncHandlerTest):
             identity_provider=cls.idp,
             email_domain='vaultwax.com',
         )
+        cls.email_domain_secondary = AuthenticatedEmailDomain.objects.create(
+            identity_provider=cls.idp,
+            email_domain='vaultwax.nl',
+        )
         cls.other_email_domain = AuthenticatedEmailDomain.objects.create(
             identity_provider=cls.other_idp,
             email_domain='vwx.link',
@@ -187,6 +191,10 @@ class TestSSOExemptUsersAdminAsyncHandler(BaseAsyncHandlerTest):
             email_domain=self.email_domain,
             username='c@vaultwax.com'
         )
+        UserExemptFromSingleSignOn.objects.create(
+            email_domain=self.email_domain_secondary,
+            username='d@vaultwax.nl'
+        )
         self.request.POST = self._get_post_data()
         handler = SSOExemptUsersAdminAsyncHandler(self.request)
         self.assertEqual(
@@ -194,6 +202,7 @@ class TestSSOExemptUsersAdminAsyncHandler(BaseAsyncHandlerTest):
             [
                 'b@vaultwax.com',
                 'c@vaultwax.com',
+                'd@vaultwax.nl',
             ]
         )
 

--- a/corehq/apps/sso/tests/test_async_handlers.py
+++ b/corehq/apps/sso/tests/test_async_handlers.py
@@ -141,7 +141,7 @@ class TestIdentityProviderAdminAsyncHandler(BaseAsyncHandlerTest):
             }
         )
 
-    def test_remove_object_raises_error_if_no_email_domain_exists(self):
+    def test_remove_object_fails_if_no_email_domain_exists(self):
         """
         Ensure that the remove_object() raises an error when trying to remove
         an email domain which does not have an AuthenticatedEmailDomain

--- a/corehq/apps/sso/tests/test_async_handlers.py
+++ b/corehq/apps/sso/tests/test_async_handlers.py
@@ -157,7 +157,7 @@ class TestSSOExemptUsersAdminAsyncHandler(BaseAsyncHandlerTest):
             identity_provider=cls.idp,
             email_domain='vaultwax.com',
         )
-        cls.email_domain_two = AuthenticatedEmailDomain.objects.create(
+        cls.other_email_domain = AuthenticatedEmailDomain.objects.create(
             identity_provider=cls.other_idp,
             email_domain='vwx.link',
         )
@@ -244,7 +244,7 @@ class TestSSOExemptUsersAdminAsyncHandler(BaseAsyncHandlerTest):
     def test_remove_object_raises_error_if_username_is_not_linked_to_idp(self):
         UserExemptFromSingleSignOn.objects.create(
             username='b@vwx.link',
-            email_domain=self.email_domain_two
+            email_domain=self.other_email_domain
         )
         self.request.POST = self._get_post_data('b@vwx.link')
         handler = SSOExemptUsersAdminAsyncHandler(self.request)


### PR DESCRIPTION
## Summary
Cleans up SSO's async handler tests based on prior feedback. New docstrings for these tests. Also fixes a small bug where an email domain belonging to a **different** `IdentityProvider` could be deleted and adds a new test to ensure this fix remains.

Making this a separate PR rather than including it with the next PR so that it's easier to follow and digest.

## Feature Flag
`ENTERPRISE_SSO`

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Improves and adds a new test!

### QA Plan
None needed yet.

### Safety story
Mostly changes to test code (improvements!) and touches a currently feature-flagged and in-development part of the codebase.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
