### PR TITLE
[SSO] update sso form tests

### DIFF
--- a/corehq/apps/sso/tests/test_forms.py
+++ b/corehq/apps/sso/tests/test_forms.py
@@ -121,17 +121,20 @@ class TestEditIdentityProviderAdminForm(BaseSSOFormTest):
                                              else datetime.utcnow() + timedelta(days=30))
         self.idp.save()
 
+    def _get_post_data(self, name=None, is_editable=False, is_active=False, slug=None):
+        return {
+            'name': name if name is not None else self.idp.name,
+            'is_editable': is_editable,
+            'is_active': is_active,
+            'slug': slug or self.idp.slug,
+        }
+
     def test_bad_slug_update_is_invalid(self, *args):
         """
         Ensure that if passed a bad slug, EditIdentityProviderAdminForm raises
         a ValidationError and does not validate.
         """
-        post_data = {
-            'name': self.idp.name,
-            'is_editable': self.idp.is_editable,
-            'is_active': self.idp.is_active,
-            'slug': 'bad slug',
-        }
+        post_data = self._get_post_data(slug='bad slug')
         edit_idp_form = EditIdentityProviderAdminForm(self.idp, post_data)
         edit_idp_form.cleaned_data = post_data
         with self.assertRaises(forms.ValidationError):
@@ -151,12 +154,7 @@ class TestEditIdentityProviderAdminForm(BaseSSOFormTest):
             created_by='otheradmin@dimagi.com',
             last_modified_by='otheradmin@dimagi.com',
         )
-        post_data = {
-            'name': self.idp.name,
-            'is_editable': self.idp.is_editable,
-            'is_active': self.idp.is_active,
-            'slug': second_idp.slug,
-        }
+        post_data = self._get_post_data(slug=second_idp.slug)
         edit_idp_form = EditIdentityProviderAdminForm(self.idp, post_data)
         edit_idp_form.cleaned_data = post_data
         with self.assertRaises(forms.ValidationError):
@@ -169,12 +167,7 @@ class TestEditIdentityProviderAdminForm(BaseSSOFormTest):
         when EditIdentityProviderAdminForm validates and calls
         update_identity_provider().
         """
-        post_data = {
-            'name': self.idp.name,
-            'is_editable': self.idp.is_editable,
-            'is_active': self.idp.is_active,
-            'slug': 'vaultwax-2',
-        }
+        post_data = self._get_post_data(slug='vaultwax-2')
         edit_idp_form = EditIdentityProviderAdminForm(self.idp, post_data)
         self.assertTrue(edit_idp_form.is_valid())
         edit_idp_form.update_identity_provider(self.accounting_admin)
@@ -190,21 +183,11 @@ class TestEditIdentityProviderAdminForm(BaseSSOFormTest):
         of the IdentityProvider when EditIdentityProviderAdminForm
         validates and update_identity_provider() is called.
         """
-        bad_post_data = {
-            'name': '',
-            'is_editable': self.idp.is_active,
-            'is_active': self.idp.is_editable,
-            'slug': self.idp.slug,
-        }
+        bad_post_data = self._get_post_data(name='')
         bad_edit_idp_form = EditIdentityProviderAdminForm(self.idp, bad_post_data)
         self.assertFalse(bad_edit_idp_form.is_valid())
 
-        post_data = {
-            'name': 'new name test',
-            'is_editable': self.idp.is_active,
-            'is_active': self.idp.is_editable,
-            'slug': self.idp.slug,
-        }
+        post_data = self._get_post_data(name='new name test')
         edit_idp_form = EditIdentityProviderAdminForm(self.idp, post_data)
         self.assertTrue(edit_idp_form.is_valid())
         edit_idp_form.update_identity_provider(self.accounting_admin)
@@ -219,12 +202,7 @@ class TestEditIdentityProviderAdminForm(BaseSSOFormTest):
         calling update_identity_provider() updates the `is_editable` field on
         the IdentityProvider as expected.
         """
-        post_data = {
-            'name': self.idp.name,
-            'is_editable': True,
-            'is_active': self.idp.is_active,
-            'slug': self.idp.slug,
-        }
+        post_data = self._get_post_data(is_editable=True)
         edit_idp_form = EditIdentityProviderAdminForm(self.idp, post_data)
         edit_idp_form.cleaned_data = post_data
         with self.assertRaises(forms.ValidationError):
@@ -254,12 +232,7 @@ class TestEditIdentityProviderAdminForm(BaseSSOFormTest):
         calling update_identity_provider() updates the `is_active` field on
         the IdentityProvider as expected.
         """
-        post_data = {
-            'name': self.idp.name,
-            'is_editable': self.idp.is_active,
-            'is_active': True,
-            'slug': self.idp.slug,
-        }
+        post_data = self._get_post_data(is_active=True)
         edit_idp_form = EditIdentityProviderAdminForm(self.idp, post_data)
         edit_idp_form.cleaned_data = post_data
 

--- a/corehq/apps/sso/tests/test_forms.py
+++ b/corehq/apps/sso/tests/test_forms.py
@@ -26,11 +26,10 @@ class BaseSSOFormTest(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.account = generator.get_billing_account_for_idp()
-        cls.domain = Domain(
-            name="vaultwax-001",
+        cls.domain = Domain.get_or_create_with_name(
+            "vaultwax-001",
             is_active=True
         )
-        cls.domain.save()
         cls.accounting_admin = WebUser.create(
             cls.domain.name, 'jadmin@dimagi.com', 'testpwd', None, None
         )

--- a/corehq/apps/sso/tests/test_forms.py
+++ b/corehq/apps/sso/tests/test_forms.py
@@ -50,6 +50,10 @@ class TestCreateIdentityProviderForm(BaseSSOFormTest):
         super().tearDownClass()
 
     def test_bad_slug_is_invalid(self):
+        """
+        Ensure that a poorly formatted slug raises a ValidationError and the
+        CreateIdentityProviderForm does not validate.
+        """
         post_data = {
             'owner': self.account.id,
             'name': 'test idp',
@@ -62,6 +66,10 @@ class TestCreateIdentityProviderForm(BaseSSOFormTest):
         self.assertFalse(create_idp_form.is_valid())
 
     def test_created_identity_provider(self):
+        """
+        Ensure that a valid CreateIdentityProviderForm successfully creates an
+        IdentityProvider.
+        """
         post_data = {
             'owner': self.account.id,
             'name': 'Azure AD for Vault Wax',
@@ -114,6 +122,10 @@ class TestEditIdentityProviderAdminForm(BaseSSOFormTest):
         self.idp.save()
 
     def test_bad_slug_update_is_invalid(self, *args):
+        """
+        Ensure that if passed a bad slug, EditIdentityProviderAdminForm raises
+        a ValidationError and does not validate.
+        """
         post_data = {
             'name': self.idp.name,
             'is_editable': self.idp.is_editable,
@@ -127,6 +139,11 @@ class TestEditIdentityProviderAdminForm(BaseSSOFormTest):
         self.assertFalse(edit_idp_form.is_valid())
 
     def test_slug_update_conflict(self, *args):
+        """
+        Ensure that if another IdentityProvider exists with the same slug,
+        EditIdentityProviderAdminForm raises a ValidationError and does not
+        validate.
+        """
         second_idp = IdentityProvider.objects.create(
             owner=self.account,
             name='Azure AD for VWX',
@@ -147,6 +164,11 @@ class TestEditIdentityProviderAdminForm(BaseSSOFormTest):
         self.assertFalse(edit_idp_form.is_valid())
 
     def test_slug_and_last_modified_by_updates(self, *args):
+        """
+        Ensure that the `slug` and `last_modified_by` fields properly update
+        when EditIdentityProviderAdminForm validates and calls
+        update_identity_provider().
+        """
         post_data = {
             'name': self.idp.name,
             'is_editable': self.idp.is_editable,
@@ -163,6 +185,11 @@ class TestEditIdentityProviderAdminForm(BaseSSOFormTest):
         self.assertNotEqual(idp.created_by, self.accounting_admin.username)
 
     def test_name_updates_and_is_required(self, *args):
+        """
+        Ensure that the `name` field is both required and updates the name
+        of the IdentityProvider when EditIdentityProviderAdminForm
+        validates and update_identity_provider() is called.
+        """
         bad_post_data = {
             'name': '',
             'is_editable': self.idp.is_active,
@@ -186,6 +213,12 @@ class TestEditIdentityProviderAdminForm(BaseSSOFormTest):
         self.assertEqual(idp.name, post_data['name'])
 
     def test_is_editable_has_met_requirements_and_value_updates(self, *args):
+        """
+        Ensure that the requirements for `is_editable` are met in order for
+        EditIdentityProviderAdminForm to validate and that once it is valid,
+        calling update_identity_provider() updates the `is_editable` field on
+        the IdentityProvider as expected.
+        """
         post_data = {
             'name': self.idp.name,
             'is_editable': True,
@@ -215,6 +248,12 @@ class TestEditIdentityProviderAdminForm(BaseSSOFormTest):
         self.assertTrue(idp.is_editable)
 
     def test_is_active_has_met_requirements_and_value_updates(self, *args):
+        """
+        Ensure that the requirements for `is_active` are met in order for
+        EditIdentityProviderAdminForm to validate and that once it is valid,
+        calling update_identity_provider() updates the `is_active` field on
+        the IdentityProvider as expected.
+        """
         post_data = {
             'name': self.idp.name,
             'is_editable': self.idp.is_active,
@@ -304,6 +343,13 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
         }
 
     def test_is_active_triggers_required_fields_and_updates(self):
+        """
+        Test that if `is_active` is set to true, then related required fields
+        raise ValidationErrors if left blank. Once the requirements are met and
+        SSOEnterpriseSettingsForm validates, ensure that
+        update_identity_provider() updates the `is_active` field on
+        the IdentityProvider as expected.
+        """
         post_data = self._get_post_data(
             is_active=True, no_entity_id=True, no_login_url=True,
             no_logout_url=True, no_certificate=True, no_certificate_date=True
@@ -358,6 +404,11 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
         )
 
     def test_last_modified_by_and_fields_update_when_not_active(self):
+        """
+        Ensure that fields properly update and that `last_modified_by` updates
+        as expected when SSOEnterpriseSettingsForm validates and
+        update_identity_provider() is called.
+        """
         email_domain = AuthenticatedEmailDomain.objects.create(
             identity_provider=self.idp,
             email_domain='vaultwax.com',
@@ -386,6 +437,11 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
         )
 
     def test_date_idp_cert_expiration_with_bad_value(self):
+        """
+        Ensure that SSOEnterpriseSettingsForm raises a ValidationError if
+        `date_idp_cert_expiration` is provided with a incorrectly formatted date
+        string.
+        """
         post_data = {
             'is_active': self.idp.is_active,
             'entity_id': self.idp.entity_id,


### PR DESCRIPTION
## Summary
Sixes an issue related to this PR feedback https://github.com/dimagi/commcare-hq/pull/29180#discussion_r578637376
Adds some docstrings for added clarity later on.

Doing this as a separate PR from a PR that will follow to reduce the number of things that need to be reviewed for that PR.

## Feature Flag
`ENTERPRISE_SSO`

## Safety Assurance
- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
This improves tests!

### QA Plan
Not needed yet

### Safety story
Only touches tests.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
