### PR TITLE
Prevent admin site users linking across domains

### DIFF
--- a/corehq/motech/fhir/admin.py
+++ b/corehq/motech/fhir/admin.py
@@ -34,6 +34,8 @@ class FHIRResourcePropertyAdmin(admin.ModelAdmin):
     list_filter = ('resource_type__domain',)
     list_select_related = ('resource_type', 'resource_type__case_type')
 
+    readonly_fields = ('resource_type', 'case_property')
+
     def has_add_permission(self, request):
         # Domains are difficult to manage with this interface. Create
         # using the Data Dictionary, and edit in Admin.


### PR DESCRIPTION
## Summary

Tiny. Sets two foreign key fields as read-only in the Django admin site to prevent users from accidentally linking a record in one domain to a record in a different domain.


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story

* Admin site only
* Only behavior change is to disable existing, dangerous functionality


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
