### PR TITLE
Add new domain to india nutrition project reports

### DIFF
--- a/custom/nutrition_project/ucr/data_sources/death_records_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/death_records_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"
@@ -20,15 +21,6 @@
             "property_name": "xmlns"
           },
           "property_value": "http://openrosa.org/formdesigner/09B1E7B3-BB57-4A51-8CD3-114F1054F18E"
-        },
-        {
-          "type": "boolean_expression",
-          "operator": "eq",
-          "expression": {
-            "type": "property_name",
-            "property_name": "app_id"
-          },
-          "property_value": "b3c758f7c79e47e3a503115894f18503"
         },
         {
           "type": "boolean_expression",

--- a/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/deliveries_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"
@@ -29,15 +30,6 @@
             "property_name": "xmlns"
           },
           "property_value": "http://openrosa.org/formdesigner/F8AE9C85-38E3-4B84-BD16-0198C4907FD9"
-        },
-        {
-          "type": "boolean_expression",
-          "operator": "eq",
-          "expression": {
-            "type": "property_name",
-            "property_name": "app_id"
-          },
-          "property_value": "b3c758f7c79e47e3a503115894f18503"
         }
       ]
     },

--- a/custom/nutrition_project/ucr/data_sources/member_cases_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/member_cases_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"

--- a/custom/nutrition_project/ucr/data_sources/member_registrations_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/member_registrations_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"
@@ -21,17 +22,6 @@
             "datatype": null
           },
           "property_value": "http://openrosa.org/formdesigner/F33C77FE-3F75-4714-A9FA-ED88A5298C40",
-          "comment": null
-        },
-        {
-          "type": "boolean_expression",
-          "operator": "eq",
-          "expression": {
-            "type": "property_name",
-            "property_name": "app_id",
-            "datatype": null
-          },
-          "property_value": "b3c758f7c79e47e3a503115894f18503",
           "comment": null
         }
       ]

--- a/custom/nutrition_project/ucr/data_sources/nutrition_delivery_children_3_to_6_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/nutrition_delivery_children_3_to_6_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"
@@ -20,15 +21,6 @@
             "property_name": "xmlns"
           },
           "property_value": "http://openrosa.org/formdesigner/87149AFE-1EE9-4C80-AE07-FD12FA808D83"
-        },
-        {
-          "type": "boolean_expression",
-          "operator": "eq",
-          "expression": {
-            "type": "property_name",
-            "property_name": "app_id"
-          },
-          "property_value": "b3c758f7c79e47e3a503115894f18503"
         }
       ]
     },

--- a/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/pregnancy_registrations_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"
@@ -20,15 +21,6 @@
             "property_name": "xmlns"
           },
           "property_value": "http://openrosa.org/formdesigner/C598D396-C69A-4F1B-84FD-92B582DDC57D"
-        },
-        {
-          "type": "boolean_expression",
-          "operator": "eq",
-          "expression": {
-            "type": "property_name",
-            "property_name": "app_id"
-          },
-          "property_value": "b3c758f7c79e47e3a503115894f18503"
         }
       ]
     },

--- a/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_hcm_3years_6years.json
+++ b/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_hcm_3years_6years.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"
@@ -27,15 +28,6 @@
             "property_name": "xmlns"
           },
           "property_value": "http://openrosa.org/formdesigner/87149AFE-1EE9-4C80-AE07-FD12FA808D83"
-        },
-        {
-          "type": "boolean_expression",
-          "operator": "eq",
-          "expression": {
-            "type": "property_name",
-            "property_name": "app_id"
-          },
-          "property_value": "b3c758f7c79e47e3a503115894f18503"
         }
       ]
     },

--- a/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_hcm_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_hcm_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"
@@ -34,15 +35,6 @@
               "property_value": "http://openrosa.org/formdesigner/109A04AF-409E-48B9-A2B0-C52B4CE72D91"
             }
           ]
-        },
-        {
-          "type": "boolean_expression",
-          "operator": "eq",
-          "expression": {
-            "type": "property_name",
-            "property_name": "app_id"
-          },
-          "property_value": "b3c758f7c79e47e3a503115894f18503"
         },
         {
           "type": "or",

--- a/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_6months_3years.json
+++ b/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_6months_3years.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"
@@ -28,15 +29,6 @@
             "property_name": "xmlns"
           },
           "property_value": "http://openrosa.org/formdesigner/116A78AD-E839-4BD4-BA13-A534A4A85B3B"
-        },
-        {
-          "type": "boolean_expression",
-          "operator": "eq",
-          "expression": {
-            "type": "property_name",
-            "property_name": "app_id"
-          },
-          "property_value": "b3c758f7c79e47e3a503115894f18503"
         }
       ]
     },

--- a/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_pw_lw.json
+++ b/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_pw_lw.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"
@@ -28,15 +29,6 @@
             "property_name": "xmlns"
           },
           "property_value": "http://openrosa.org/formdesigner/4FAB81D4-BBAF-424E-8DB1-96478791DB01"
-        },
-        {
-          "type": "boolean_expression",
-          "operator": "eq",
-          "expression": {
-            "type": "property_name",
-            "property_name": "app_id"
-          },
-          "property_value": "b3c758f7c79e47e3a503115894f18503"
         }
       ]
     },

--- a/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/supplementary_nutrition_thr_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"
@@ -34,15 +35,6 @@
               "property_value": "http://openrosa.org/formdesigner/116A78AD-E839-4BD4-BA13-A534A4A85B3B"
             }
           ]
-        },
-        {
-          "type": "boolean_expression",
-          "operator": "eq",
-          "expression": {
-            "type": "property_name",
-            "property_name": "app_id"
-          },
-          "property_value": "b3c758f7c79e47e3a503115894f18503"
         },
         {
           "type": "or",

--- a/custom/nutrition_project/ucr/data_sources/weight_and_height_records_v1.json
+++ b/custom/nutrition_project/ucr/data_sources/weight_and_height_records_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"
@@ -20,15 +21,6 @@
             "property_name": "xmlns"
           },
           "property_value": "http://openrosa.org/formdesigner/6595DEFD-60DA-4102-A704-F400D40F5F05"
-        },
-        {
-          "type": "boolean_expression",
-          "operator": "eq",
-          "expression": {
-            "type": "property_name",
-            "property_name": "app_id"
-          },
-          "property_value": "b3c758f7c79e47e3a503115894f18503"
         },
         {
           "type": "not",

--- a/custom/nutrition_project/ucr/reports/deaths_v1.json
+++ b/custom/nutrition_project/ucr/reports/deaths_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"

--- a/custom/nutrition_project/ucr/reports/deliveries_v1.json
+++ b/custom/nutrition_project/ucr/reports/deliveries_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"

--- a/custom/nutrition_project/ucr/reports/delivery_deaths_v1.json
+++ b/custom/nutrition_project/ucr/reports/delivery_deaths_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"

--- a/custom/nutrition_project/ucr/reports/growth_monitoring_v1.json
+++ b/custom/nutrition_project/ucr/reports/growth_monitoring_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"

--- a/custom/nutrition_project/ucr/reports/hcm_3years_6years_v1.json
+++ b/custom/nutrition_project/ucr/reports/hcm_3years_6years_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"

--- a/custom/nutrition_project/ucr/reports/hcm_report_v1.json
+++ b/custom/nutrition_project/ucr/reports/hcm_report_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"

--- a/custom/nutrition_project/ucr/reports/member_cases_v1.json
+++ b/custom/nutrition_project/ucr/reports/member_cases_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"

--- a/custom/nutrition_project/ucr/reports/member_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/member_registrations_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"

--- a/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
+++ b/custom/nutrition_project/ucr/reports/number_of_days_center_open_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"

--- a/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
+++ b/custom/nutrition_project/ucr/reports/pregnancy_registrations_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"

--- a/custom/nutrition_project/ucr/reports/thr_6months_3years_v1.json
+++ b/custom/nutrition_project/ucr/reports/thr_6months_3years_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"

--- a/custom/nutrition_project/ucr/reports/thr_lw_v1.json
+++ b/custom/nutrition_project/ucr/reports/thr_lw_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"

--- a/custom/nutrition_project/ucr/reports/thr_pw_v1.json
+++ b/custom/nutrition_project/ucr/reports/thr_pw_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"

--- a/custom/nutrition_project/ucr/reports/thr_report_v1.json
+++ b/custom/nutrition_project/ucr/reports/thr_report_v1.json
@@ -1,6 +1,7 @@
 {
   "domains": [
-    "india-nutrition-project"
+    "india-nutrition-project",
+    "mh-mis-staging"
   ],
   "server_environment": [
     "india"


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Nutrition project will serve as template for similar projects. We are now creating first project space from it on India itself. This just adds the nutrition project reports and data sources to the new project space. 
We had check for `app_id` to limit to the nutrition project space which is not needed anymore and hence is also removed in this PR.
I confirmed that the form XMLNS remains the same on copying app, so no changes needed there.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Changes limited to only one project space.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
