### PR TITLE
Handled unauthorized user logouts

### DIFF
--- a/corehq/apps/hqwebapp/login_handlers.py
+++ b/corehq/apps/hqwebapp/login_handlers.py
@@ -5,6 +5,8 @@ from corehq.apps.hqwebapp.models import UserAccessLog
 
 from dimagi.utils.web import get_ip
 
+UNKNOWN_USER = 'unknown_user'
+
 
 @receiver(user_login_failed)
 def handle_failed_login(sender, credentials, request, token_failure=False, **kwargs):
@@ -18,7 +20,8 @@ def handle_login(sender, request, user, **kwargs):
 
 @receiver(user_logged_out)
 def handle_logout(sender, request, user, **kwargs):
-    handle_access_event(UserAccessLog.TYPE_LOGOUT, request, user.username)
+    user_id = user.username if user else UNKNOWN_USER
+    handle_access_event(UserAccessLog.TYPE_LOGOUT, request, user_id)
 
 
 def handle_access_event(event_type, request, user_id):

--- a/corehq/apps/hqwebapp/login_handlers.py
+++ b/corehq/apps/hqwebapp/login_handlers.py
@@ -5,8 +5,6 @@ from corehq.apps.hqwebapp.models import UserAccessLog
 
 from dimagi.utils.web import get_ip
 
-UNKNOWN_USER = 'unknown_user'
-
 
 @receiver(user_login_failed)
 def handle_failed_login(sender, credentials, request, token_failure=False, **kwargs):
@@ -20,7 +18,9 @@ def handle_login(sender, request, user, **kwargs):
 
 @receiver(user_logged_out)
 def handle_logout(sender, request, user, **kwargs):
-    user_id = user.username if user else UNKNOWN_USER
+    # User can be None when the user is not authorized.
+    # See: https://docs.djangoproject.com/en/3.1/ref/contrib/auth/#django.contrib.auth.signals.user_logged_out
+    user_id = user.username if user else ''
     _handle_access_event(UserAccessLog.TYPE_LOGOUT, request, user_id)
 
 

--- a/corehq/apps/hqwebapp/login_handlers.py
+++ b/corehq/apps/hqwebapp/login_handlers.py
@@ -10,21 +10,21 @@ UNKNOWN_USER = 'unknown_user'
 
 @receiver(user_login_failed)
 def handle_failed_login(sender, credentials, request, token_failure=False, **kwargs):
-    handle_access_event(UserAccessLog.TYPE_FAILURE, request, credentials['username'])
+    _handle_access_event(UserAccessLog.TYPE_FAILURE, request, credentials['username'])
 
 
 @receiver(user_logged_in)
 def handle_login(sender, request, user, **kwargs):
-    handle_access_event(UserAccessLog.TYPE_LOGIN, request, user.username)
+    _handle_access_event(UserAccessLog.TYPE_LOGIN, request, user.username)
 
 
 @receiver(user_logged_out)
 def handle_logout(sender, request, user, **kwargs):
     user_id = user.username if user else UNKNOWN_USER
-    handle_access_event(UserAccessLog.TYPE_LOGOUT, request, user_id)
+    _handle_access_event(UserAccessLog.TYPE_LOGOUT, request, user_id)
 
 
-def handle_access_event(event_type, request, user_id):
+def _handle_access_event(event_type, request, user_id):
     ip_address = ''
     agent = ''
     path = ''

--- a/corehq/apps/hqwebapp/tests/test_login_handlers.py
+++ b/corehq/apps/hqwebapp/tests/test_login_handlers.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User
 from corehq.apps.hqwebapp.models import UserAccessLog
 
 from corehq.apps.hqwebapp.login_handlers import handle_failed_login, \
-    handle_login, handle_logout, handle_access_event
+    handle_login, handle_logout, _handle_access_event
 
 
 class TestLoginAccessHandler(TestCase):
@@ -12,13 +12,13 @@ class TestLoginAccessHandler(TestCase):
         factory = RequestFactory()
         request = factory.post('/login')
 
-        handle_access_event('some_event', request, 'test_user')
+        _handle_access_event('some_event', request, 'test_user')
 
         log_entry = UserAccessLog.objects.filter(user_id='test_user').first()
         self.assertIsNone(log_entry.user_agent)
 
     def test_missing_request_logs_empty_attributes(self):
-        handle_access_event('some_event', None, 'test_user')
+        _handle_access_event('some_event', None, 'test_user')
 
         log_entry = UserAccessLog.objects.filter(user_id='test_user').first()
         self.assertIsNone(log_entry.ip)

--- a/corehq/apps/hqwebapp/tests/test_login_handlers.py
+++ b/corehq/apps/hqwebapp/tests/test_login_handlers.py
@@ -65,10 +65,10 @@ class TestHandleLogout(TestCase):
         self.assertEqual(log_entry.path, '/logout')
         self.assertEqual(str(log_entry.timestamp), '2020-01-02 03:20:15')
 
-    def test_no_user_is_logged_with_unknown_user(self):
+    def test_no_user_is_logged_with_empty_user_id(self):
         handle_logout('any_source', self.request, user=None)
 
-        unknown_logouts = UserAccessLog.objects.filter(user_id='unknown_user')
+        unknown_logouts = UserAccessLog.objects.filter(user_id='')
         self.assertEqual(unknown_logouts.count(), 1)
 
 


### PR DESCRIPTION
## Summary
Fixing an issue uncovered via [Sentry](https://sentry.io/organizations/dimagi/issues/2222384893), where an anonymous user who attempts to logout provides `None` instead of a valid user.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

_test_login_handlers:TestHandleLogout.test_no_user_is_logged_with_unknown_user_ handles the regression test.

### QA Plan

No need for QA

### Safety story

The logout signal doesn't impede the normal application flow, so it has limited impact.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
