### PR TITLE
 Add fhir resource get/search views

### DIFF
--- a/corehq/motech/fhir/urls.py
+++ b/corehq/motech/fhir/urls.py
@@ -1,7 +1,11 @@
 from django.conf.urls import url
 
-from corehq.motech.fhir.views import get_view
+from corehq.motech.fhir.views import (
+    get_view,
+    search_view,
+)
 
 urlpatterns = [
+    url(r'^fhir/R4/(?P<resource_type>\w+)/$', search_view, name="fhir_search"),
     url(r'^fhir/R4/(?P<resource_type>\w+)/(?P<resource_id>\w+)$', get_view, name="fhir_get_view"),
 ]

--- a/corehq/motech/fhir/urls.py
+++ b/corehq/motech/fhir/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+
+from corehq.motech.fhir.views import get_view
+
+urlpatterns = [
+    url(r'^fhir/R4/(?P<resource_type>\w+)/(?P<resource_id>\w+)$', get_view, name="fhir_get_view"),
+]

--- a/corehq/motech/fhir/urls.py
+++ b/corehq/motech/fhir/urls.py
@@ -6,6 +6,7 @@ from corehq.motech.fhir.views import (
 )
 
 urlpatterns = [
-    url(r'^fhir/R4/(?P<resource_type>\w+)/$', search_view, name="fhir_search"),
-    url(r'^fhir/R4/(?P<resource_type>\w+)/(?P<resource_id>[\w\-]+)$', get_view, name="fhir_get_view"),
+    url(r'^fhir/(?P<fhir_version_name>\w+)/(?P<resource_type>\w+)/$', search_view, name="fhir_search"),
+    url(r'^fhir/(?P<fhir_version_name>\w+)/(?P<resource_type>\w+)/(?P<resource_id>[\w\-]+)/$', get_view,
+        name="fhir_get_view"),
 ]

--- a/corehq/motech/fhir/urls.py
+++ b/corehq/motech/fhir/urls.py
@@ -7,5 +7,5 @@ from corehq.motech.fhir.views import (
 
 urlpatterns = [
     url(r'^fhir/R4/(?P<resource_type>\w+)/$', search_view, name="fhir_search"),
-    url(r'^fhir/R4/(?P<resource_type>\w+)/(?P<resource_id>\w+)$', get_view, name="fhir_get_view"),
+    url(r'^fhir/R4/(?P<resource_type>\w+)/(?P<resource_id>[\w\-]+)$', get_view, name="fhir_get_view"),
 ]

--- a/corehq/motech/fhir/utils.py
+++ b/corehq/motech/fhir/utils.py
@@ -1,6 +1,6 @@
-from corehq.motech.fhir.views import get_view
 from corehq.util.view_utils import absolute_reverse
 
 
 def resource_url(domain, resource_type, case_id):
+    from corehq.motech.fhir.views import get_view
     return absolute_reverse(get_view, args=(domain, resource_type, case_id))

--- a/corehq/motech/fhir/utils.py
+++ b/corehq/motech/fhir/utils.py
@@ -1,0 +1,6 @@
+from corehq.motech.fhir.views import get_view
+from corehq.util.view_utils import absolute_reverse
+
+
+def resource_url(domain, resource_type, case_id):
+    return absolute_reverse(get_view, args=(domain, resource_type, case_id))

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -10,6 +10,7 @@ from corehq.apps.domain.decorators import (
 )
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.motech.exceptions import ConfigurationError
 from corehq.motech.repeaters.views import AddRepeaterView, EditRepeaterView
 from corehq.util.view_utils import absolute_reverse, get_case_or_404
 
@@ -61,7 +62,12 @@ def get_view(request, domain, fhir_version_name, resource_type, resource_id):
             case_type__name=case.type
     ).exists():
         return JsonResponse(status=400, data={'message': "Invalid Resource Type"})
-    resource = build_fhir_resource(case)
+    try:
+        resource = build_fhir_resource(case)
+    except ConfigurationError:
+        return JsonResponse(status=500, data={
+            'message': 'FHIR configuration error. Please notify administrator.'
+        })
     return JsonResponse(resource)
 
 

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -11,7 +11,7 @@ from corehq.apps.domain.decorators import (
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.repeaters.views import AddRepeaterView, EditRepeaterView
-from corehq.util.view_utils import absolute_reverse
+from corehq.util.view_utils import absolute_reverse, get_case_or_404
 
 from .const import FHIR_VERSIONS
 from .forms import FHIRRepeaterForm
@@ -52,12 +52,7 @@ def get_view(request, domain, fhir_version_name, resource_type, resource_id):
     fhir_version = _get_fhir_version(fhir_version_name)
     if not fhir_version:
         return JsonResponse(status=400, data={'message': "Unsupported FHIR version"})
-    try:
-        case = CaseAccessors(domain).get_case(resource_id)
-        if case.is_deleted:
-            return JsonResponse(status=400, data={'message': f"Resource with ID {resource_id} was removed"})
-    except CaseNotFound:
-        return JsonResponse(status=400, data={'message': f"Could not find resource with ID {resource_id}"})
+    case = get_case_or_404(domain, resource_id)
 
     if not FHIRResourceType.objects.filter(
             domain=domain,

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -12,11 +12,12 @@ from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.exceptions import ConfigurationError
 from corehq.motech.repeaters.views import AddRepeaterView, EditRepeaterView
-from corehq.util.view_utils import absolute_reverse, get_case_or_404
+from corehq.util.view_utils import get_case_or_404
 
 from .const import FHIR_VERSIONS
 from .forms import FHIRRepeaterForm
 from .models import FHIRResourceType, build_fhir_resource
+from .utils import resource_url
 
 
 class AddFHIRRepeaterView(AddRepeaterView):
@@ -108,7 +109,7 @@ def search_view(request, domain, fhir_version_name, resource_type):
     }
     for case in cases:
         response["entry"].append({
-            "fullUrl": absolute_reverse(get_view, args=(domain, resource_type, case.case_id)),
+            "fullUrl": resource_url(domain, resource_type, case.case_id),
             "search": {
                 "mode": "match"
             }

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -61,12 +61,8 @@ def get_view(request, domain, fhir_version_name, resource_type, resource_id):
             case_type__name=case.type
     ).exists():
         return JsonResponse(status=400, data={'message': "Invalid Resource Type"})
-    response = {
-        'resourceType': resource_type,
-        'id': resource_id
-    }
-    response.update(build_fhir_resource(case))
-    return JsonResponse(response)
+    resource = build_fhir_resource(case)
+    return JsonResponse(resource)
 
 
 @require_GET

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -55,8 +55,11 @@ def get_view(request, domain, resource_type, resource_id):
     except CaseNotFound:
         return JsonResponse(status=400, data={'message': f"Could not find resource with ID {resource_id}"})
 
-    if case.type not in (FHIRResourceType.objects.filter(domain=domain, name=resource_type).
-                         values_list('case_type__name', flat=True)):
+    if not FHIRResourceType.objects.filter(
+            domain=domain,
+            name=resource_type,
+            case_type__name=case.type
+    ).exists():
         return JsonResponse(status=400, data={'message': "Invalid Resource Type"})
     response = {
         'resourceType': resource_type,

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -5,7 +5,7 @@ from django.views.decorators.http import require_GET
 
 from corehq import toggles
 from corehq.apps.domain.decorators import (
-    login_and_domain_required,
+    login_or_api_key,
     require_superuser,
 )
 from corehq.form_processor.exceptions import CaseNotFound
@@ -45,7 +45,7 @@ class EditFHIRRepeaterView(EditRepeaterView, AddFHIRRepeaterView):
 
 
 @require_GET
-@login_and_domain_required
+@login_or_api_key
 @require_superuser
 @toggles.FHIR_INTEGRATION.required_decorator()
 def get_view(request, domain, fhir_version_name, resource_type, resource_id):
@@ -70,7 +70,7 @@ def get_view(request, domain, fhir_version_name, resource_type, resource_id):
 
 
 @require_GET
-@login_and_domain_required
+@login_or_api_key
 @require_superuser
 @toggles.FHIR_INTEGRATION.required_decorator()
 def search_view(request, domain, fhir_version_name, resource_type):

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -10,6 +10,7 @@ from corehq.apps.domain.decorators import (
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.repeaters.views import AddRepeaterView, EditRepeaterView
+from corehq.util.view_utils import absolute_reverse
 
 from .forms import FHIRRepeaterForm
 from .models import FHIRResourceType, build_fhir_resource
@@ -60,4 +61,42 @@ def get_view(request, domain, resource_type, resource_id):
         'id': resource_id
     }
     response.update(build_fhir_resource(case))
+    return JsonResponse(response)
+
+
+@login_and_domain_required
+@require_superuser
+@toggles.FHIR_INTEGRATION.required_decorator()
+def search_view(request, domain, resource_type):
+    patient_case_id = request.GET.get('patient_id')
+    if not patient_case_id:
+        return JsonResponse(status=400, data={'message': "Please pass patient_id"})
+    case_accessor = CaseAccessors(domain)
+    try:
+        patient_case = case_accessor.get_case(patient_case_id)
+        if patient_case.is_deleted:
+            return JsonResponse(status=400, data={'message': f"Patient with ID {patient_case_id} was removed"})
+    except CaseNotFound:
+        return JsonResponse(status=400, data={'message': f"Could not find patient with ID {patient_case_id}"})
+
+    case_types_for_resource_type = list(FHIRResourceType.objects.filter(domain=domain, name=resource_type).
+                                        values_list('case_type__name', flat=True))
+    if not case_types_for_resource_type:
+        return JsonResponse(status=400,
+                            data={'message': f"Resource type {resource_type} not available on {domain}"})
+
+    cases = case_accessor.get_reverse_indexed_cases([patient_case_id],
+                                                    case_types=case_types_for_resource_type, is_closed=False)
+    response = {
+        'resourceType': "Bundle",
+        "type": "searchset",
+        "entry": []
+    }
+    for case in cases:
+        response["entry"].append({
+            "fullUrl": absolute_reverse(get_view, args=(domain, resource_type, case.case_id)),
+            "search": {
+                "mode": "match"
+            }
+        })
     return JsonResponse(response)

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -1,9 +1,18 @@
+from django.http import JsonResponse
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
+from corehq import toggles
+from corehq.apps.domain.decorators import (
+    login_and_domain_required,
+    require_superuser,
+)
+from corehq.form_processor.exceptions import CaseNotFound
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.repeaters.views import AddRepeaterView, EditRepeaterView
 
 from .forms import FHIRRepeaterForm
+from .models import FHIRResourceType, build_fhir_resource
 
 
 class AddFHIRRepeaterView(AddRepeaterView):
@@ -30,3 +39,25 @@ class EditFHIRRepeaterView(EditRepeaterView, AddFHIRRepeaterView):
     @property
     def page_url(self):
         return reverse(self.urlname, args=[self.domain])
+
+
+@login_and_domain_required
+@require_superuser
+@toggles.FHIR_INTEGRATION.required_decorator()
+def get_view(request, domain, resource_type, resource_id):
+    try:
+        case = CaseAccessors(domain).get_case(resource_id)
+        if case.is_deleted:
+            return JsonResponse(status=400, data={'message': f"Resource with ID {resource_id} was removed"})
+    except CaseNotFound:
+        return JsonResponse(status=400, data={'message': f"Could not find resource with ID {resource_id}"})
+
+    if case.type not in (FHIRResourceType.objects.filter(domain=domain, name=resource_type).
+                         values_list('case_type__name', flat=True)):
+        return JsonResponse(status=400, data={'message': "Invalid Resource Type"})
+    response = {
+        'resourceType': resource_type,
+        'id': resource_id
+    }
+    response.update(build_fhir_resource(case))
+    return JsonResponse(response)

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -1,6 +1,7 @@
 from django.http import JsonResponse
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
+from django.views.decorators.http import require_GET
 
 from corehq import toggles
 from corehq.apps.domain.decorators import (
@@ -42,6 +43,7 @@ class EditFHIRRepeaterView(EditRepeaterView, AddFHIRRepeaterView):
         return reverse(self.urlname, args=[self.domain])
 
 
+@require_GET
 @login_and_domain_required
 @require_superuser
 @toggles.FHIR_INTEGRATION.required_decorator()
@@ -64,6 +66,7 @@ def get_view(request, domain, resource_type, resource_id):
     return JsonResponse(response)
 
 
+@require_GET
 @login_and_domain_required
 @require_superuser
 @toggles.FHIR_INTEGRATION.required_decorator()

--- a/urls.py
+++ b/urls.py
@@ -80,6 +80,7 @@ domain_specific = [
     url(r'^champ_cameroon/', include('custom.champ.urls')),
     url(r'^motech/', include('corehq.motech.urls')),
     url(r'^dhis2/', include('corehq.motech.dhis2.urls')),
+    url(r'^', include('corehq.motech.fhir.urls')),
     url(r'^openmrs/', include('corehq.motech.openmrs.urls')),
     url(r'^_base_template/$', login_and_domain_required(
         lambda request, domain: render(request, 'hqwebapp/base.html', {'domain': domain})


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Deleting my branch closed the PR but this is essentially the same as https://github.com/dimagi/commcare-hq/pull/29237
Replicating PR description.

Adds the view to GET a resource in FHIR format.
1. The URL is expected to be `.../fhir/R4/Patient/{case_id}`
2. Authentication and authorization is still not configured so putting this available only for superusers for now so that this can be QA'ed. QA would happen on staging but should be safe as well if this gets deployed. It's behind a domain-based feature flag and then only available to superusers

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`FHIR_INTEGRATION`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This adds a new URL but has authentication added. The access is only for superusers + for domains with feature flag enabled, so does not put risk of data getting accessed by unwanted users. Additionally also needs Data dictionary set up, else it just returns a 400, which too is behind an additional feature flag (`DATA_DICTIONARY`)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
