### PR TITLE
Removed unused code in users.models

### DIFF
--- a/corehq/apps/commtrack/util.py
+++ b/corehq/apps/commtrack/util.py
@@ -173,33 +173,6 @@ def due_date_monthly(day, from_end=False, past_period=0):
     return date(y, m, min(day, monthrange(y, m)[1]))
 
 
-def submit_mapping_case_block(user, index):
-    mapping = user.get_location_map_case()
-
-    if mapping:
-        caseblock = CaseBlock.deprecated_init(
-            create=False,
-            case_id=mapping.case_id,
-            index=index
-        )
-    else:
-        caseblock = CaseBlock.deprecated_init(
-            create=True,
-            case_type=const.USER_LOCATION_OWNER_MAP_TYPE,
-            case_id=location_map_case_id(user),
-            owner_id=user._id,
-            index=index,
-            case_name=const.USER_LOCATION_OWNER_MAP_TYPE.replace('-', ' '),
-            user_id=const.COMMTRACK_USERNAME,
-        )
-
-    submit_case_blocks(
-        ElementTree.tostring(caseblock.as_xml(), encoding='utf-8'),
-        user.domain,
-        device_id=__name__ + ".submit_mapping_case_block"
-    )
-
-
 def location_map_case_id(user):
     if should_use_sql_backend(user.domain):
         user_id = user.user_id

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2511,14 +2511,6 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
                 yield web_user
 
     @classmethod
-    def get_users_by_permission(cls, domain, permission):
-        user_ids = cls.ids_by_domain(domain)
-        for user_doc in iter_docs(cls.get_db(), user_ids):
-            web_user = cls.wrap(user_doc)
-            if web_user.has_permission(domain, permission):
-                yield web_user
-
-    @classmethod
     def get_dimagi_emails_by_domain(cls, domain):
         user_ids = cls.ids_by_domain(domain)
         for user_doc in iter_docs(cls.get_db(), user_ids):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2783,22 +2783,6 @@ class DomainRemovalRecord(DeleteRecord):
         user.save()
 
 
-class UserCache(object):
-
-    def __init__(self):
-        self.cache = {}
-
-    def get(self, user_id):
-        if not user_id:
-            return None
-        if user_id in self.cache:
-            return self.cache[user_id]
-        else:
-            user = CouchUser.get_by_user_id(user_id)
-            self.cache[user_id] = user
-            return user
-
-
 class AnonymousCouchUser(object):
 
     username = "public_user"

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2226,19 +2226,6 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                 "There was no linked supply point for the location."
             )
 
-    def add_location_delegate(self, location):
-        """
-        Add a single location to the delgate case access.
-
-        This will dynamically create a supply point if the supply point isn't found.
-        """
-        # todo: the dynamic supply point creation is bad and should be removed.
-        sp = SupplyInterface(self.domain).get_or_create_by_location(location)
-
-        if not location.location_type_object.administrative:
-            from corehq.apps.commtrack.util import submit_mapping_case_block
-            submit_mapping_case_block(self, self.supply_point_index_mapping(sp))
-
     def submit_location_block(self, caseblock, source):
         from corehq.apps.hqcase.utils import submit_case_blocks
 
@@ -2249,25 +2236,6 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             self.domain,
             device_id=__name__ + ".CommCareUser." + source,
         )
-
-    def remove_location_delegate(self, location):
-        """
-        Remove a single location from the case delagate access.
-        """
-
-        sp = SupplyInterface(self.domain).get_by_location(location)
-
-        mapping = self.get_location_map_case()
-
-        if not location.location_type_object.administrative:
-            if mapping and location.location_id in [loc.location_id for loc in self.locations]:
-                caseblock = CaseBlock.deprecated_init(
-                    create=False,
-                    case_id=mapping._id,
-                    index=self.supply_point_index_mapping(sp, True)
-                )
-
-                self.submit_location_block(caseblock, "remove_location_delegate")
 
     def clear_location_delegates(self):
         """


### PR DESCRIPTION
## Summary
`UserCache` was added way back in https://github.com/dimagi/commcare-hq/pull/1820 for a custom report that no longer exists.

The other functions are no longer used.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Unlikely.

### QA Plan

Not requesting QA.

### Safety story
Minor removal of dead code.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
