### PR TITLE
Always return `None` if a resource has no data

### DIFF
--- a/corehq/motech/fhir/models.py
+++ b/corehq/motech/fhir/models.py
@@ -177,8 +177,8 @@ def build_fhir_resource(
     fhir_version: str = FHIR_VERSION_4_0_1,
 ) -> Optional[dict]:
     """
-    Builds a FHIR resource using data from ``case``. Returns ``None`` if
-    mappings do not exist.
+    Builds a FHIR resource for ``case``. Returns ``None`` if there are
+    no mappings or they return no values.
 
     Used by the FHIR API.
     """
@@ -186,7 +186,7 @@ def build_fhir_resource(
     if resource_type is None:
         return None
     info = get_case_trigger_info(case, resource_type)
-    return _build_fhir_resource(info, resource_type)
+    return build_fhir_resource_for_info(info, resource_type)
 
 
 def build_fhir_resource_for_info(
@@ -194,26 +194,14 @@ def build_fhir_resource_for_info(
     resource_type: FHIRResourceType,
 ) -> Optional[dict]:
     """
-    Builds a FHIR resource using data from ``info``. Returns ``None`` if
-    mappings do not exist, or if there is no data to forward.
-
-    Used by ``FHIRRepeater``.
+    Builds a FHIR resource for ``info``. Returns ``None`` if there are
+    no mappings or they return no values.
     """
-    return _build_fhir_resource(info, resource_type, skip_empty=True)
-
-
-def _build_fhir_resource(
-    info: CaseTriggerInfo,
-    resource_type: FHIRResourceType,
-    *,
-    skip_empty: bool = False,
-) -> Optional[dict]:
-
     fhir_resource = {}
     for prop in resource_type.properties.all():
         value_source = prop.get_value_source()
         value_source.set_external_value(fhir_resource, info)
-    if not fhir_resource and skip_empty:
+    if not fhir_resource:
         return None
 
     fhir_resource = deepmerge({

--- a/corehq/motech/fhir/tests/test_model_functions.py
+++ b/corehq/motech/fhir/tests/test_model_functions.py
@@ -11,8 +11,8 @@ from ..const import FHIR_VERSION_4_0_1
 from ..models import (
     FHIRResourceProperty,
     FHIRResourceType,
-    _build_fhir_resource,
     build_fhir_resource,
+    build_fhir_resource_for_info,
     deepmerge,
     get_case_trigger_info,
     get_resource_type_or_none,
@@ -124,7 +124,7 @@ class TestBuildFHIRResource(TestCase):
         with self.assertNumQueries(0):
             info = get_case_trigger_info(self.case, resource_type)
         with self.assertNumQueries(0):
-            _build_fhir_resource(info, resource_type)
+            build_fhir_resource_for_info(info, resource_type)
 
 
 def test_deepmerge():


### PR DESCRIPTION
## Summary

This is one of a pair of pull requests that implement two possible solutions to a problem.
[The other one](https://github.com/dimagi/commcare-hq/pull/29342)

**Context:** [QA-2736](https://dimagi-dev.atlassian.net/browse/QA-2736)

**TL;DR:** If a user requests a FHIR resource via the FHIR API, and that resource has no data, either we return `{"id": <case ID>, "resourceType": <resource type>}` or a validation error will be raised if the resource type has other required properties.

I am opening this as a draft pull request because it feels like the wrong solution, but opening it anyway for the sake of discussion.

This change returns `None` to the API if mappings exist, but they return no values. The API will presumably respond to the user with a 404.

But this might not be the best outcome. If mappings exist, it would be reasonable to believe that the administrator intends to return something. If the mappings result in no values, that's a problem, but the problem lies with the administrator, so a silent 404 will hide the problem.

This PR tries to determine the intent of a hypothetical administrator. I am not confident that I've nail it. Do you have any thoughts?


## Feature Flag
"FHIR Integration"


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story

The FHIR API has not been released.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
