### PR TITLE
Raise `ConfigurationError` if a resource has no data

### DIFF
--- a/corehq/motech/fhir/models.py
+++ b/corehq/motech/fhir/models.py
@@ -178,7 +178,8 @@ def build_fhir_resource(
 ) -> Optional[dict]:
     """
     Builds a FHIR resource using data from ``case``. Returns ``None`` if
-    mappings do not exist.
+    mappings do not exist. Raises ``ConfigurationError`` if mappings
+    returned no values; in other words, failed to build a resource.
 
     Used by the FHIR API.
     """
@@ -213,8 +214,11 @@ def _build_fhir_resource(
     for prop in resource_type.properties.all():
         value_source = prop.get_value_source()
         value_source.set_external_value(fhir_resource, info)
-    if not fhir_resource and skip_empty:
-        return None
+    if not fhir_resource:
+        if skip_empty:
+            return None
+        else:
+            raise ConfigurationError('Resource has no data')
 
     fhir_resource = deepmerge({
         **resource_type.template,


### PR DESCRIPTION
## Summary

This is one of a pair of pull requests that implement two possible solutions to a problem.
[The other one](https://github.com/dimagi/commcare-hq/pull/29341)

**Context:** [QA-2736](https://dimagi-dev.atlassian.net/browse/QA-2736)

**TL;DR:** If a user requests a FHIR resource via the FHIR API, and that resource has no data, either we return `{"id": <case ID>, "resourceType": <resource type>}` or a validation error will be raised if the resource type has other required properties.

The solution presented in this pull request is based on the idea that if an administrator has mapped case properties to resource properties, then they expect the resources to have data. If the resources don't, that's a problem with the mappings, and the outcome should reflect that. So an exception is the right outcome.

cc @Ben-Talbot 


## Feature Flag
"FHIR Integration"


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Automated test coverage

Tests included.


### Safety story

The FHIR API has not been released.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
