### PR TITLE
Add location fields to web user download

### DIFF
--- a/corehq/apps/users/bulk_download.py
+++ b/corehq/apps/users/bulk_download.py
@@ -147,14 +147,19 @@ def make_web_user_dict(user, location_cache, domain):
     }
 
 
-def make_invited_web_user_dict(invite):
+def make_invited_web_user_dict(invite, location_cache):
+    location_codes = []
+    try:
+        location_codes.append(location_cache.get(invite.supply_point))
+    except SQLLocation.DoesNotExist:
+        pass
     return {
         'username': invite.email,
         'first_name': 'N/A',
         'last_name': 'N/A',
         'email': invite.email,
         'role': invite.get_role_name(),
-        'location_code': '',
+        'location_code': location_codes,
         'status': ugettext('Invited'),
         'last_access_date (read only)': 'N/A',
         'last_login (read only)': 'N/A',
@@ -241,7 +246,7 @@ def parse_web_users(domain, task=None, total_count=None):
         if task:
             DownloadBase.set_progress(task, n, total_count)
     for m, invite in enumerate(Invitation.by_domain(domain)):
-        user_dict = make_invited_web_user_dict(invite)
+        user_dict = make_invited_web_user_dict(invite, location_cache)
         user_dicts.append(user_dict)
         if task:
             DownloadBase.set_progress(task, n + m, total_count)

--- a/corehq/apps/users/bulk_download.py
+++ b/corehq/apps/users/bulk_download.py
@@ -56,15 +56,15 @@ def get_devices(user):
     )])
 
 
-def get_location_codes(user, location_cache):
+def get_location_codes(location_cache, loc_id, assigned_loc_ids):
     location_codes = []
     try:
-        location_codes.append(location_cache.get(user.location_id))
+        location_codes.append(location_cache.get(loc_id))
     except SQLLocation.DoesNotExist:
         pass
-    for location_id in user.assigned_location_ids:
+    for location_id in assigned_loc_ids:
         # skip if primary location_id, as it is already added to the start of list above
-        if location_id != user.location_id:
+        if location_id != loc_id:
             try:
                 location_codes.append(location_cache.get(location_id))
             except SQLLocation.DoesNotExist:
@@ -87,7 +87,7 @@ def make_mobile_user_dict(user, group_names, location_cache, domain, fields_defi
             profile = None
     activity = user.reporting_metadata
 
-    location_codes = get_location_codes(user, location_cache)
+    location_codes = get_location_codes(location_cache, user.location_id, user.assigned_location_ids)
 
     def _format_date(date):
         return date.strftime('%Y-%m-%d %H:%M:%S') if date else ''
@@ -132,7 +132,8 @@ def make_web_user_dict(user, location_cache, domain):
     user = CouchUser.wrap_correctly(user['doc'])
     domain_membership = user.get_domain_membership(domain)
     role_name = get_user_role_name(domain_membership)
-    location_codes = get_location_codes(user, location_cache)
+    location_codes = get_location_codes(location_cache, domain_membership.location_id,
+                                        domain_membership.assigned_location_ids)
     return {
         'username': user.username,
         'first_name': user.first_name,


### PR DESCRIPTION
## Summary
Desire to add location fields to web user upload and download were requesting in the web user upload QA: https://dimagi-dev.atlassian.net/browse/QA-2633. This is the PR to modify the download.

## Product Description
This adds the location column in the same way as with mobile workers. It also adds the location saved to the `supply_point` part of the web user invite if the invite was created during the mobile worker upload.

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
There is test coverage of a web_user download

### QA Plan
I'll have QA look at it as part of the ticket above

### Safety story
`location_codes` is empty to start so hopefully this won't break any existing functionality, but rather just add on

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
