### PR TITLE
Sanitized mark_safe usages in hqwebapp

### DIFF
--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -177,6 +177,8 @@ def edited_classes(context, label_class, field_class):
 class B3MultiField(LayoutObject):
     template = 'hqwebapp/crispy/multi_field.html'
 
+    # Because fields will be passed as-is to the HTML,
+    # care should be taken to ensure they escape user input appropriately
     def __init__(self, field_label, *fields, **kwargs):
         self.fields = list(fields)
         self.label_html = field_label
@@ -199,8 +201,8 @@ class B3MultiField(LayoutObject):
         for field in self.fields:
             html += render_field(field, form, form_style, context, template_pack=template_pack)
         context.update({
-            'label_html': mark_safe(self.label_html),
-            'field_html': mark_safe(html),
+            'label_html': self.label_html,
+            'field_html': mark_safe(html),  # nosec
             'multifield': self,
             'error_list': errors,
             'help_bubble_text': self.help_bubble_text,

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -22,7 +22,10 @@ from corehq.apps.domain.forms import NoAutocompleteMixin
 from corehq.apps.users.models import CouchUser
 from corehq.util.metrics import metrics_counter
 
-LOCKOUT_MESSAGE = mark_safe(_('Sorry - you have attempted to login with an incorrect password too many times. Please <a href="/accounts/password_reset_email/">click here</a> to reset your password or contact the domain administrator.'))
+LOCKOUT_MESSAGE = mark_safe(_(  # nosec: no user input
+    'Sorry - you have attempted to login with an incorrect password too many times. '
+    'Please <a href="/accounts/password_reset_email/">click here</a> to reset your password '
+    'or contact the domain administrator.'))
 
 
 class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -40,7 +40,9 @@ def JSON(obj):
     if isinstance(obj, QueryDict):
         obj = dict(obj)
     try:
-        return mark_safe(escape_script_tags(json.dumps(obj, default=json_handler)))
+        return mark_safe(  # nosec: sanitization must be done higher up -- this can contain tags
+            escape_script_tags(json.dumps(obj, default=json_handler))
+        )
     except TypeError as e:
         msg = ("Unserializable data was sent to the `|JSON` template tag.  "
                "If DEBUG is off, Django will silently swallow this error.  "
@@ -135,9 +137,10 @@ def domains_for_user(context, request, selected_domain=None):
     context = {
         'domain_links': domain_links,
         'show_all_projects_link': show_all_projects_link,
-        'current_domain': selected_domain,
     }
-    return mark_safe(render_to_string('hqwebapp/includes/domain_list_dropdown.html', context, request))
+    return mark_safe(  # nosec: render_to_string should have already handled escaping
+        render_to_string('hqwebapp/includes/domain_list_dropdown.html', context, request)
+    )
 
 
 @register.simple_tag
@@ -400,10 +403,10 @@ def maintenance_alert(request, dismissable=True):
             '<div class="alert alert-warning alert-maintenance{}" data-id="{}">{}{}</div>',
             ' hide' if dismissable else '',
             alert.id,
-            mark_safe('''
-                <button class="close" data-dismiss="alert" aria-label="close">&times;</button>
-            ''') if dismissable else '',
-            mark_safe(alert.html),
+            mark_safe(  # nosec: no user input
+                '<button class="close" data-dismiss="alert" aria-label="close">&times;</button>'
+            ) if dismissable else '',
+            alert.html
         )
     else:
         return ''
@@ -703,8 +706,10 @@ def breadcrumbs(page, section, parents=None):
     :return:
     """
 
-    return mark_safe(render_to_string('hqwebapp/partials/breadcrumbs.html', {
-        'page': page,
-        'section': section,
-        'parents': parents or [],
-    }))
+    return mark_safe(  # nosec: render_to_string handles escaping
+        render_to_string('hqwebapp/partials/breadcrumbs.html', {
+            'page': page,
+            'section': section,
+            'parents': parents or [],
+        })
+    )

--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -163,9 +163,9 @@ def get_display_data(data, prop_def, processors=None, timezone=pytz.utc):
     try:
         val = conditional_escape(processors[process](val))
     except KeyError:
-        val = mark_safe(_to_html(val, timeago=timeago))
+        val = _to_html(val, timeago=timeago)
     if format:
-        val = mark_safe(format.format(val))
+        val = format_html(format, val)
 
     return {
         "expr": expr_name,

--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -16,6 +16,7 @@ from django import template
 from django.template.defaultfilters import yesno
 from django.utils.html import conditional_escape, escape
 from django.utils.safestring import mark_safe
+from django.utils.html import format_html, format_html_join
 
 import pytz
 from jsonobject.exceptions import BadValueError
@@ -83,17 +84,21 @@ def _to_html(val, key=None, level=0, timeago=False):
             return ""
 
     if isinstance(val, dict):
-        ret = "".join(
-            ["<dl %s>" % ("class='well'" if level == 0 else '')]
-            + ["<dt>%s</dt><dd>%s</dd>" % (escape(_key_format(k, v)), recurse(k, v))
-             for k, v in val.items()]
-            + ["</dl>"])
+        ret = format_html(
+            "<dl {}>{}</dl>",
+            mark_safe("class='well'") if level == 0 else '',  # nosec: no user input
+            format_html_join(
+                "",
+                "<dt>{}</dt><dd>{}</dd>",
+                [(_key_format(k, v), recurse(k, v)) for k, v in val.items()]
+            )
+        )
 
     elif _is_list_like(val):
-        ret = "".join(
-            ["<dl>"]
-            + ["<dt>%s</dt><dd>%s</dd>" % (escape(key), recurse(None, v)) for v in val]
-            + ["</dl>"])
+        ret = format_html(
+            "<dl>{}</dl>",
+            format_html_join("", "<dt>{}</dt><dd>{}</dd>", [(key, recurse(None, v)) for v in val])
+        )
 
     elif isinstance(val, datetime.date):
         if isinstance(val, datetime.datetime):
@@ -102,15 +107,19 @@ def _to_html(val, key=None, level=0, timeago=False):
             fmt = USER_DATE_FORMAT
 
         iso = val.isoformat()
-        ret = mark_safe("<time %s title='%s' datetime='%s'>%s</time>" % (
-            "class='timeago'" if timeago else "", iso, iso, safe_strftime(val, fmt)))
+        ret = format_html(
+            "<time {} title='{}' datetime='{}'>{}</time>",
+            "class='timeago'" if timeago else "",
+            iso,
+            iso,
+            safe_strftime(val, fmt))
     else:
         if val is None:
             val = '---'
 
         ret = escape(val)
 
-    return mark_safe(ret)
+    return ret
 
 
 def get_display_data(data, prop_def, processors=None, timezone=pytz.utc):

--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -84,16 +84,16 @@ def _to_html(val, key=None, level=0, timeago=False):
 
     if isinstance(val, dict):
         ret = "".join(
-            ["<dl %s>" % ("class='well'" if level == 0 else '')] + 
-            ["<dt>%s</dt><dd>%s</dd>" % (_key_format(k, v), recurse(k, v))
-             for k, v in val.items()] +
-            ["</dl>"])
+            ["<dl %s>" % ("class='well'" if level == 0 else '')]
+            + ["<dt>%s</dt><dd>%s</dd>" % (escape(_key_format(k, v)), recurse(k, v))
+             for k, v in val.items()]
+            + ["</dl>"])
 
     elif _is_list_like(val):
         ret = "".join(
-            ["<dl>"] +
-            ["<dt>%s</dt><dd>%s</dd>" % (key, recurse(None, v)) for v in val] +
-            ["</dl>"])
+            ["<dl>"]
+            + ["<dt>%s</dt><dd>%s</dd>" % (escape(key), recurse(None, v)) for v in val]
+            + ["</dl>"])
 
     elif isinstance(val, datetime.date):
         if isinstance(val, datetime.datetime):

--- a/corehq/apps/hqwebapp/tests/test_proptable_tags.py
+++ b/corehq/apps/hqwebapp/tests/test_proptable_tags.py
@@ -1,6 +1,7 @@
+from datetime import date, datetime
 from django.test import SimpleTestCase
 
-from corehq.apps.hqwebapp.templatetags.proptable_tags import get_display_data
+from corehq.apps.hqwebapp.templatetags.proptable_tags import get_display_data, _to_html
 
 
 class CaseDisplayDataTest(SimpleTestCase):
@@ -47,3 +48,55 @@ class CaseDisplayDataTest(SimpleTestCase):
             get_display_data(data, column),
             {'expr': 'colour', 'name': 'colour', 'value': 'red', 'has_history': True}
         )
+
+
+class ToHTMLTest(SimpleTestCase):
+    def test_handles_single_value(self):
+        self.assertEqual(_to_html('value'), 'value')
+
+    def test_converts_none_to_dashes(self):
+        self.assertEqual(_to_html(None), '---')
+
+    def test_single_values_are_escaped(self):
+        self.assertEqual(_to_html('va<lue'), 'va&lt;lue')
+
+    def test_handles_list(self):
+        result = _to_html(['one', 'two', 'three'], key='test_list')
+        self.assertEqual(result,
+            "<dl>"
+            "<dt>test_list</dt><dd>one</dd>"
+            "<dt>test_list</dt><dd>two</dd>"
+            "<dt>test_list</dt><dd>three</dd>"
+            "</dl>")
+
+    def test_list_key_and_value_are_escaped(self):
+        result = _to_html(['va<lue'], key='ke>y')
+        self.assertEqual(result,
+            "<dl>"
+            "<dt>ke&gt;y</dt><dd>va&lt;lue</dd>"
+            "</dl>")
+
+    def test_handles_dict(self):
+        result = _to_html({'a': 'one', 'b': 'two'}, key='test_dict')
+        self.assertEqual(result,
+            "<dl class='well'>"
+            "<dt>a</dt><dd>one</dd>"
+            "<dt>b</dt><dd>two</dd>"
+            "</dl>")
+
+    def test_dict_key_and_values_are_escaped(self):
+        result = _to_html({'ke>y': 'va<lue'})
+        self.assertEqual(result,
+            "<dl class='well'>"
+            "<dt>ke&gt;y</dt><dd>va&lt;lue</dd>"
+            "</dl>")
+
+    def test_handles_date(self):
+        result = _to_html(date(2020, 5, 25))
+        self.assertEqual(result, "<time  title='2020-05-25' datetime='2020-05-25'>May 25, 2020</time>")
+
+    def test_handles_datetime(self):
+        result = _to_html(datetime(2020, 5, 25, 2, 12, 10, 100))
+        self.assertEqual(result,
+            "<time  title='2020-05-25T02:12:10.000100'"
+            " datetime='2020-05-25T02:12:10.000100'>May 25, 2020 02:12 </time>")

--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -2,12 +2,11 @@ import collections
 import json
 
 from django import forms
-from django.forms.fields import CharField, MultiValueField
 from django.forms.utils import flatatt
-from django.forms.widgets import CheckboxInput, Input, MultiWidget, TextInput
-from django.template.loader import render_to_string
+from django.forms.widgets import CheckboxInput, Input
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
+from django.utils.html import format_html, conditional_escape
 from django.utils.translation import ugettext_noop
 
 from dimagi.utils.dates import DateSpan
@@ -22,7 +21,7 @@ class BootstrapCheckboxInput(CheckboxInput):
         self.inline_label = inline_label
 
     def render(self, name, value, attrs=None, renderer=None):
-        extra_attrs = {'type': 'checkbox', 'name': name}
+        extra_attrs = {'type': 'checkbox', 'name': conditional_escape(name)}
         extra_attrs.update(self.attrs)
         final_attrs = self.build_attrs(attrs, extra_attrs=extra_attrs)
         try:
@@ -34,8 +33,10 @@ class BootstrapCheckboxInput(CheckboxInput):
         if value not in ('', True, False, None):
             # Only add the 'value' attribute if a value is non-empty.
             final_attrs['value'] = force_text(value)
-        return mark_safe('<label class="checkbox"><input%s /> %s</label>' %
-                         (flatatt(final_attrs), self.inline_label))
+        return format_html(
+            '<label class="checkbox"><input{} /> {}</label>',
+            mark_safe(flatatt(final_attrs)),  # nosec: trusting the user to sanitize attributes
+            self.inline_label)
 
 
 class _Select2AjaxMixin():
@@ -79,7 +80,7 @@ class Select2Ajax(_Select2AjaxMixin, forms.Select):
             'data-multiple': '1' if self.multiple else '0',
         })
         output = super(Select2Ajax, self).render(name, value, attrs, renderer=renderer)
-        return mark_safe(output)
+        return mark_safe(output)  # nosec: the output IS HTML, so needs to be marked safe
 
 
 class DateRangePickerWidget(Input):
@@ -126,15 +127,14 @@ class DateRangePickerWidget(Input):
             'data-start-date': startdate,
             'data-end-date': enddate,
         })
-        final_attrs = self.build_attrs(attrs)
 
         output = super(DateRangePickerWidget, self).render(name, value, attrs, renderer)
-        return mark_safe("""
-            <div class="input-group hqwebapp-datespan">
-                <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
-                {}
-            </div>
-        """.format(output))
+        return format_html(
+            '<div class="input-group hqwebapp-datespan">'
+            '   <span class="input-group-addon"><i class="fa fa-calendar"></i></span>'
+            '   {}'
+            '</div>',
+            mark_safe(output))  # nosec: must support the input tag
 
 
 class SelectToggle(forms.Select):
@@ -170,6 +170,6 @@ class GeoCoderInput(Input):
         if isinstance(value, dict):
             value = json.dumps(value)
         output = super(GeoCoderInput, self).render(name, value, attrs, renderer)
-        return mark_safe("""
-            <div class="geocoder-proximity">{}</div>
-        """.format(output))
+        return format_html(
+            '<div class="geocoder-proximity">{}</div>',
+            mark_safe(output))  # nosec: must support the input tag


### PR DESCRIPTION
## Summary
Another XSS ticket focusing on _hqwebapp_.  Part of [SAAS-11853](https://dimagi-dev.atlassian.net/browse/SAAS-11853)

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

The changes/refactoring done within _proptable_tags/_to_html_ are supported by tests

### QA Plan

Looking for a QA smoke test, focusing on cases and forms. Will be combined with another change like this.

### Safety story
The bulk of these changes are just labelling existing `mark_safe` usages as safe. The significant change to `_to_html` has a test suite and was tested locally.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
