### PR TITLE
Upgrade to select2 4.1.0 release candidate

### DIFF
--- a/corehq/apps/locations/static/locations/js/search.js
+++ b/corehq/apps/locations/static/locations/js/search.js
@@ -39,7 +39,7 @@ hqDefine('locations/js/search', [
     };
 
     var reloadLocationSearchSelect = function () {
-        $('#location_search_select').val(null);
+        $('#location_search_select').val(null).trigger('change');
         enableLocationSearchSelect();
     };
 

--- a/corehq/apps/locations/static/locations/js/search.js
+++ b/corehq/apps/locations/static/locations/js/search.js
@@ -39,7 +39,7 @@ hqDefine('locations/js/search', [
     };
 
     var reloadLocationSearchSelect = function () {
-        $('#location_search_select').select2('val', null);
+        $('#location_search_select').val(null);
         enableLocationSearchSelect();
     };
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         "perfect-scrollbar": "1.5.0",
         "quicksearch": "DeuxHuitHuit/quicksearch#2.2.1",
         "requirejs": "2.3.6",
-        "select2": "4.0.0",
+        "select2": "4.1.0-rc.0",
         "topojson": "3.0.2",
         "uglify-js": "2.8.29",
         "ui-select": "npm:ui-select#0.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5317,10 +5317,10 @@ samsam@1.x, samsam@^1.1.3:
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
   integrity sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==
 
-select2@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/select2/-/select2-4.0.0.tgz#81b461456c77148e7e422eb63bd71ca0b254fce7"
-  integrity sha1-gbRhRWx3FI5+Qi62O9ccoLJU/Oc=
+select2@4.1.0-rc.0:
+  version "4.1.0-rc.0"
+  resolved "https://registry.yarnpkg.com/select2/-/select2-4.1.0-rc.0.tgz#ba3cd3901dda0155e1c0219ab41b74ba51ea22d8"
+  integrity sha512-Hr9TdhyHCZUtwznEH2CBf7967mEM0idtJ5nMtjvk3Up5tPukOLXbHUNmh10oRfeNIhj+3GD3niu+g6sVK+gK0A==
 
 select@^1.0.6:
   version "1.1.2"


### PR DESCRIPTION
## Summary
Upgrade the select2 package from 4.0.0 to [4.1.0 release candidate](https://github.com/select2/select2/releases/tag/4.1.0-rc.0). The main reason to upgrade now is to make Web Apps comboboxes more accessible (i.e. screen readers will read them).

## Product Description
Users of screen readers should now hear the options in a dropdown menu.

Multiple lines of text can be pasted when searching. Otherwise, behavior is expected to be the same as the previous version.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan

[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-2745)


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
