### PR TITLE
Added link to feature flag docs & updated roles UI

### DIFF
--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -323,28 +323,19 @@
             {% if request|toggle_enabled:"RESTRICT_MOBILE_ACCESS" %}
             {# BEGIN MOBILE permission #}
             <div class="form-group">
-              <div class="col-sm-2 controls">
+              <label class="col-sm-4 control-label">
+                {% trans "Mobile App Access" %}
+              </label>
+              <div class="col-sm-8 controls">
                 <div class="form-check">
                   <input type="checkbox"
-                           id="edit-mobile-checkbox"
-                           data-bind="checked: permissions.access_mobile_endpoints,
-                                      disable: !$root.allowEdit" />
+                         id="edit-mobile-checkbox"
+                         data-bind="checked: permissions.access_mobile_endpoints,
+                                    disable: !$root.allowEdit" />
                   <label for="edit-mobile-checkbox">
-                    <span class="sr-only">
-                      {% trans "Access to Offline Mobile Apps" %}
-                    </span>
+                    {% trans "Allow mobile users access to offline mobile application" %}
                   </label>
                 </div>
-              </div>
-              <div class="col-sm-2 controls">
-                <div class="form-check-placeholder">
-                  <label></label>
-               </div>
-              </div>
-              <div class="col-sm-8 control-label">
-               {% blocktrans %}
-               <strong>Mobile App Access</strong> &mdash; Allows mobile users access to offline mobile application
-               {% endblocktrans %}
               </div>
             </div>
             {# END MOBILE permission #}

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1820,9 +1820,10 @@ SKIP_UPDATING_USER_REPORTING_METADATA = StaticToggle(
 
 RESTRICT_MOBILE_ACCESS = StaticToggle(
     'restrict_mobile_endpoints',
-    'Require explicit permissions to access mobile app endpoints',
+    'COVID: Require explicit permissions to access mobile app endpoints',
     TAG_CUSTOM,
     [NAMESPACE_DOMAIN],
+    help_link="https://confluence.dimagi.com/display/ccinternal/COVID%3A+Require+explicit+permissions+to+access+mobile+app+endpoints",
 )
 
 DOMAIN_PERMISSIONS_MIRROR = StaticToggle(


### PR DESCRIPTION
Added docs link and fixed UI for the "Mobile App Access" checkbox controlled by the feature flag "COVID: Require explicit permissions to access mobile app endpoints".

Before
![Screen Shot 2021-03-16 at 9 46 38 AM](https://user-images.githubusercontent.com/1486591/111319940-e4388080-863c-11eb-91c2-2b209f41e0b1.png)

After
![Screen Shot 2021-03-16 at 9 46 44 AM](https://user-images.githubusercontent.com/1486591/111319994-ee5a7f00-863c-11eb-8a0f-0e9a64c6a2dd.png)

Not requesting QA.