### PR TITLE
Update Ivory Coast MTN Gateway Params

### DIFF
--- a/corehq/messaging/smsbackends/ivory_coast_mtn/models.py
+++ b/corehq/messaging/smsbackends/ivory_coast_mtn/models.py
@@ -47,13 +47,13 @@ class IvoryCoastMTNBackend(SQLSMSBackend):
 
         return {
             'customerID': config.customer_id,
-            'userName': config.username,
+            'username': config.username,
             'userPassword': config.password,
             'originator': config.sender_id,
             # This is for a custom project and they only send messages in French
             'messageType': 'Latin',
             # This must be set to the date and time to send the message; it's a required field
-            'defDate': self.get_ivory_coast_timestamp().strftime('%Y%m%d%H%M%S'),
+            'defdate': self.get_ivory_coast_timestamp().strftime('%Y%m%d%H%M%S'),
             'blink': 'false',
             'flash': 'false',
             'private': 'false',
@@ -74,7 +74,7 @@ class IvoryCoastMTNBackend(SQLSMSBackend):
             return
 
         response = requests.get(
-            'http://smspro.mtn.ci/smspro/soap/messenger.asmx/HTTP_SendSms',
+            'https://smspro.mtn.ci/smspro/Soap/Messenger.asmx/HTTP_SendSms',
             params=self.get_params(msg_obj),
             timeout=settings.SMS_GATEWAY_TIMEOUT,
         )


### PR DESCRIPTION

## Summary
https://dimagi-dev.atlassian.net/browse/SC-1324
Updating some of the params to be more like the example request we were given:
`https://smspro.mtn.ci/bms/Soap/Messenger.asmx/HTTP_SendSms?customerID=[customerID]&username=[username]&userPassword=[password]&originator=[originator]&smsText=[MESSAGE]&recipientPhone=[555555555]&messageType=Latin&defdate=&blink=false&private=false&flash=false`

<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This hasn't worked in a couple years

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
