### PR TITLE
Removed ICDS-specific code from context_processors

### DIFF
--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -42,23 +42,16 @@ def get_per_domain_context(project, request=None):
             and domain_has_privilege(project.name, privileges.CUSTOM_BRANDING)):
         custom_logo_url = reverse('logo', args=[project.name])
 
-    def allow_report_issue(user, domain):
-        if toggles.ICDS.enabled(domain) and user.is_commcare_user():
-            domain_membership = user.get_domain_membership(
-                domain, allow_mirroring=True)
-            if domain_membership and not domain_membership.role:
-                return False
-        return user.has_permission(domain, 'report_an_issue')
-
     if getattr(request, 'couch_user', None) and project:
-        allow_report_an_issue = allow_report_issue(request.couch_user, project.name)
+        allow_report_an_issue = request.couch_user.has_permission(project.name, 'report_an_issue')
     elif settings.ENTERPRISE_MODE:
         if not getattr(request, 'couch_user', None):
             allow_report_an_issue = False
         elif request.couch_user.is_web_user():
             allow_report_an_issue = True
         else:
-            allow_report_an_issue = allow_report_issue(request.couch_user, request.couch_user.domain)
+            user = request.couch_user
+            allow_report_an_issue = user.has_permission(user.domain, 'report_an_issue')
     else:
         allow_report_an_issue = True
 


### PR DESCRIPTION
## Summary
Noticed while working on something else. Marking invisible because no one is using the ICDS flag.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Unlikely.

### QA Plan

Not requesting QA.

### Safety story
Pretty straightforward removal of unused code. Smoke tested both code branches locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
