### PR TITLE
upgrade js-xpath to 0.0.4

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/xpathValidator.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/xpathValidator.html
@@ -3,9 +3,9 @@
 {% load i18n %}
 {% compress js %}
   <script src="{% static 'biginteger/biginteger.js' %}"></script>
-  <script src="{% static 'xpath/lib/schemeNumber.js' %}"></script>
-  <script src="{% static 'xpath/xpath.js' %}"></script>
-  <script src="{% static 'xpath/parser.js' %}"></script>
+  <script src="{% static 'xpath/src/lib/schemeNumber.js' %}"></script>
+  <script src="{% static 'xpath/dist/js-xpath.js' %}"></script>
+  <script src="{% static 'xpath/src/parser.js' %}"></script>
   <script src="{% static 'app_manager/js/xpathConfig.js' %}"></script>
   <script src="{% static 'app_manager/js/xpathValidator.js' %}"></script>
 {% endcompress %}

--- a/corehq/apps/app_manager/xpath_validator/nodejs/xpathConfig.js
+++ b/corehq/apps/app_manager/xpath_validator/nodejs/xpathConfig.js
@@ -1,6 +1,6 @@
 if (typeof require !== 'undefined' && typeof exports !== 'undefined') {
-    var parser = require('xpath/parser');
-    var xpath = require('xpath/xpath');
+    var parser = require('xpath/src/parser');
+    var xpath = require('xpath/dist/js-xpath');
 }
 
 var XPATH_CONFIG = (function () {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "ui-select": "npm:ui-select#0.13.2",
         "underscore": "1.8.3",
         "url-polyfill": "1.1.10",
-        "xpath": "dimagi/js-xpath#v0.0.3",
+        "xpath": "dimagi/js-xpath#v0.0.4",
         "zxcvbn": "4.4.2"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6466,9 +6466,9 @@ xdg-basedir@^3.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
   integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
 
-xpath@dimagi/js-xpath#v0.0.3:
-  version "0.0.3"
-  resolved "https://codeload.github.com/dimagi/js-xpath/tar.gz/f9a249581249c2fda914cc2483291dac1f815d87"
+xpath@dimagi/js-xpath#v0.0.4:
+  version "0.0.4"
+  resolved "https://codeload.github.com/dimagi/js-xpath/tar.gz/3a152a7bc5cd1f88a5d1da0055cb9d32e389003d"
   dependencies:
     biginteger "^1.0.3"
 


### PR DESCRIPTION
## Summary
We recently upgraded most of the dev dependencies for dimagi/js-xpath due to security vulnerabilities. This bumps the version referenced in vellum to the newest release/tag in our repo

relevant Vellum PR https://github.com/dimagi/Vellum/pull/1001

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Tests in `dimagi/js-xpath` and `vellum` should cover any issues that would arise.

### QA Plan
I think QA isn't necessary for this since there's really good test coverage. I might stick this on staging for a week, along with the vellum changes, and see if it causes any issues.

### Safety story
Great test coverage.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
