### PR TITLE
sanitize mark_safe references in domain

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -27,7 +27,7 @@ from django.forms.widgets import Select
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.encoding import force_bytes, smart_str
-from django.utils.functional import cached_property
+from django.utils.functional import cached_property, lazy
 from django.utils.http import urlsafe_base64_encode
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
@@ -114,6 +114,10 @@ from corehq.toggles import HIPAA_COMPLIANCE_CHECKBOX, MOBILE_UCR, \
     SECURE_SESSION_TIMEOUT, MONITOR_2FA_CHANGES
 from corehq.util.timezones.fields import TimeZoneField
 from corehq.util.timezones.forms import TimeZoneChoiceField
+
+
+mark_safe_lazy = lazy(mark_safe, str)  # TODO: Use library method
+
 
 # used to resize uploaded custom logos, aspect ratio is preserved
 LOGO_SIZE = (211, 32)
@@ -581,7 +585,7 @@ class PrivacySecurityForm(forms.Form):
     secure_submissions = BooleanField(
         label=ugettext_lazy("Secure submissions"),
         required=False,
-        help_text=ugettext_lazy(mark_safe(
+        help_text=mark_safe_lazy(ugettext_lazy(  # nosec: no user input
             "Secure Submissions prevents others from impersonating your mobile workers."
             "This setting requires all deployed applications to be using secure "
             "submissions as well. "
@@ -1286,12 +1290,11 @@ class ConfidentialPasswordResetForm(HQPasswordResetForm):
 
 
 class HQSetPasswordForm(SetPasswordForm):
-    new_password1 = forms.CharField(label=ugettext_lazy("New password"),
-                                    widget=forms.PasswordInput(
-                                        attrs={'data-bind': "value: password, valueUpdate: 'input'"}),
-                                    help_text=mark_safe("""
-                                    <span data-bind="text: passwordHelp, css: color">
-                                    """))
+    new_password1 = forms.CharField(
+        label=ugettext_lazy("New password"),
+        widget=forms.PasswordInput(attrs={'data-bind': "value: password, valueUpdate: 'input'"}),
+        help_text=mark_safe('<span data-bind="text: passwordHelp, css: color">')  # nosec: no user input
+    )
 
     def save(self, commit=True):
         user = super(HQSetPasswordForm, self).save(commit)

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -13,7 +13,7 @@ from django.db.models import Sum
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from django.views.decorators.http import require_POST
@@ -877,14 +877,13 @@ class InternalSubscriptionManagementView(BaseAdminProjectSettingsView):
                 form.process_subscription_management()
                 return HttpResponseRedirect(reverse(DomainSubscriptionView.urlname, args=[self.domain]))
             except (NewSubscriptionError, SubscriptionAdjustmentError) as e:
-                messages.error(self.request, mark_safe(
+                messages.error(self.request, format_html(
                     'This request will require Ops assistance. '
-                    'Please explain to <a href="mailto:%(ops_email)s">%(ops_email)s</a>'
-                    ' what you\'re trying to do and report the following error: <strong>"%(error)s"</strong>' % {
-                        'error': str(e),
-                        'ops_email': settings.ACCOUNTS_EMAIL,
-                    }
-                ))
+                    'Please explain to <a href="mailto:{ops_email}">{ops_email}</a>'
+                    ' what you\'re trying to do and report the following error: <strong>"{error}"</strong>',
+                    error=str(e),
+                    ops_email=settings.ACCOUNTS_EMAIL)
+                )
         return self.get(request, *args, **kwargs)
 
     @property

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -7,7 +7,7 @@ from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from django.views.decorators.http import require_GET
@@ -66,7 +66,7 @@ class BaseInternalDomainSettingsView(BaseProjectSettingsView):
 
     @property
     def page_name(self):
-        return mark_safe("%s <small>Internal</small>" % self.page_title)
+        return format_html("{} <small>Internal</small>", self.page_title)
 
 
 class EditInternalDomainInfoView(BaseInternalDomainSettingsView):


### PR DESCRIPTION
## Summary
Small changes to the domain app, as part of sanitizing all `mark_safe` references ([SAAS-11853](https://dimagi-dev.atlassian.net/browse/SAAS-11853)). One quirk was that I left `mark_safe` on the _helper_ attributes, despite currently doing nothing -- _crispy_ passes the text through raw. This seems error prone, so I have a TODO to investigate _crispy_ to see if it can behave like Django.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

These changes were either marking `mark_safe` usages with a comment, or replacing them with `format_html`. No functionality was changed, so no tests were added.

### QA Plan

No QA required.

### Safety story

Locally tested the areas where `format_html` was used.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
