### PR TITLE
Get last value instead of grouping for changing case props

### DIFF
--- a/custom/nutrition_project/ucr/reports/hcm_3years_6years_v1.json
+++ b/custom/nutrition_project/ucr/reports/hcm_3years_6years_v1.json
@@ -17,11 +17,7 @@
       "supervisor_id",
       "flw_id",
       "month",
-      "member_residential_status",
-      "member_gender",
-      "disability",
-      "family_unit_caste",
-      "family_unit_religion"
+      "member_gender"
     ],
     "filters": [
       {
@@ -81,9 +77,9 @@
       {
         "display": "Residential Status",
         "column_id": "member_residential_status",
-        "type": "field",
-        "field": "member_residential_status",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "member_residential_status"
       },
       {
         "display": "Gender",
@@ -95,23 +91,23 @@
       {
         "display": "Disability",
         "column_id": "disability",
-        "type": "field",
-        "field": "disability",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "disability"
       },
       {
         "display": "Caste",
         "column_id": "family_unit_caste",
-        "type": "field",
-        "field": "family_unit_caste",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "family_unit_caste"
       },
       {
         "display": "Religion",
         "column_id": "family_unit_religion",
-        "type": "field",
-        "field": "family_unit_religion",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "family_unit_religion"
       },
       {
         "display": "child_case_id",

--- a/custom/nutrition_project/ucr/reports/thr_6months_3years_v1.json
+++ b/custom/nutrition_project/ucr/reports/thr_6months_3years_v1.json
@@ -17,11 +17,7 @@
       "supervisor_id",
       "flw_id",
       "month",
-      "member_residential_status",
-      "member_gender",
-      "disability",
-      "family_unit_caste",
-      "family_unit_religion"
+      "member_gender"
     ],
     "filters": [
       {
@@ -81,9 +77,9 @@
       {
         "display": "Residential Status",
         "column_id": "member_residential_status",
-        "type": "field",
-        "field": "member_residential_status",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "member_residential_status"
       },
       {
         "display": "Gender",
@@ -95,23 +91,23 @@
       {
         "display": "Disability",
         "column_id": "disability",
-        "type": "field",
-        "field": "disability",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "disability"
       },
       {
         "display": "Caste",
         "column_id": "family_unit_caste",
-        "type": "field",
-        "field": "family_unit_caste",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "family_unit_caste"
       },
       {
         "display": "Religion",
         "column_id": "family_unit_religion",
-        "type": "field",
-        "field": "family_unit_religion",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "family_unit_religion"
       },
       {
         "display": "child_case_id",

--- a/custom/nutrition_project/ucr/reports/thr_lw_v1.json
+++ b/custom/nutrition_project/ucr/reports/thr_lw_v1.json
@@ -16,11 +16,7 @@
       "woman_case_id",
       "supervisor_id",
       "flw_id",
-      "month",
-      "member_residential_status",
-      "disability",
-      "family_unit_caste",
-      "family_unit_religion"
+      "month"
     ],
     "filters": [
       {
@@ -88,30 +84,30 @@
       {
         "display": "Residential Status",
         "column_id": "member_residential_status",
-        "type": "field",
-        "field": "member_residential_status",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "member_residential_status"
       },
       {
         "display": "Disability",
         "column_id": "disability",
-        "type": "field",
-        "field": "disability",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "disability"
       },
       {
         "display": "Caste",
         "column_id": "family_unit_caste",
-        "type": "field",
-        "field": "family_unit_caste",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "family_unit_caste"
       },
       {
         "display": "Religion",
         "column_id": "family_unit_religion",
-        "type": "field",
-        "field": "family_unit_religion",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "family_unit_religion"
       },
       {
         "display": "woman_case_id",

--- a/custom/nutrition_project/ucr/reports/thr_pw_v1.json
+++ b/custom/nutrition_project/ucr/reports/thr_pw_v1.json
@@ -16,11 +16,7 @@
       "woman_case_id",
       "supervisor_id",
       "flw_id",
-      "month",
-      "member_residential_status",
-      "disability",
-      "family_unit_caste",
-      "family_unit_religion"
+      "month"
     ],
     "filters": [
       {
@@ -95,30 +91,30 @@
       {
         "display": "Residential Status",
         "column_id": "member_residential_status",
-        "type": "field",
-        "field": "member_residential_status",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "member_residential_status"
       },
       {
         "display": "Disability",
         "column_id": "disability",
-        "type": "field",
-        "field": "disability",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "disability"
       },
       {
         "display": "Caste",
         "column_id": "family_unit_caste",
-        "type": "field",
-        "field": "family_unit_caste",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "family_unit_caste"
       },
       {
         "display": "Religion",
         "column_id": "family_unit_religion",
-        "type": "field",
-        "field": "family_unit_religion",
-        "aggregation": "simple"
+        "type": "array_agg_last_value",
+        "order_by_col": "completed_time",
+        "field": "family_unit_religion"
       },
       {
         "display": "woman_case_id",


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Some reports, built on form based data sources, which had one row per case, per form,
were grouping on the case properties (status, disability, caste and religion) that would change, which lead to multiple rows per case for the month in the report as debugged in https://dimagi-dev.atlassian.net/browse/QA-2578?focusedCommentId=127361

This PR updates to find the last value for such case properties instead of grouping by them.

Corresponding dynamic reports were updated for testing the change

PW: https://india.commcarehq.org/a/india-nutrition-project/configurable_reports/reports/edit/f4b6a69cc568f7f15a48404fa3aa94cf/
LW: https://india.commcarehq.org/a/india-nutrition-project/configurable_reports/reports/edit/212f4bee7d91067592e884e5f93926d6/
HCM 6mo-3y: https://india.commcarehq.org/a/india-nutrition-project/configurable_reports/reports/edit/dffe10f123504f21e64908688f47b0e7/
HCM 3y-6y: https://india.commcarehq.org/a/india-nutrition-project/configurable_reports/reports/edit/e64ea1071922519142fa6240387e0fc5/

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Only specific to static reports of a particular project on India env.
Edits were tested in corresponding dynamic reports.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
