### PR TITLE
add temporary script to catch disappearing form

### DIFF
--- a/scripts/tmp-disappearing-form-poller.py
+++ b/scripts/tmp-disappearing-form-poller.py
@@ -1,0 +1,58 @@
+import logging
+from datetime import datetime
+import time
+
+from corehq.blobs import get_blob_db
+from corehq.apps.app_manager.dbaccessors import get_app
+
+'''
+Temporary script used to periodically poll the internal state of an application
+form to catch changes. Refer to https://dimagi-dev.atlassian.net/browse/SAAS-11820
+TODO: Remove when case closed.
+'''
+
+
+def form_blob(app_id, form_key):
+    db = get_blob_db()
+    meta = db.metadb.get(parent_id=app_id, key=form_key)
+    with meta.open() as fn:
+        source = fn.read()
+        return source
+
+
+def app_details(domain, app_id, form_key):
+    app = get_app(domain, app_id)
+    return {
+        'form_key': app.external_blobs[form_key + '.xml'].key
+    }
+
+
+def run(domain, app_id, form_key, dir="form_blobs", interval_in_seconds=600, log_name=None):
+    logger = logging.getLogger('scripts.tmp-disappearing-form-poller')
+    if log_name:
+        fh = logging.FileHandler('tmp.log')
+        formatter = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
+        fh.setFormatter(formatter)
+        logger.addHandler(fh)
+
+    last_form_blob = None
+    while True:
+        # get app details and blob
+        app_deets = app_details(domain, app_id, form_key)
+        app_form_key = app_deets['form_key']
+        cur_form_blob = form_blob(app_id, app_form_key)
+
+        # Compare blob against old
+        changed = last_form_blob != cur_form_blob
+
+        logger.info(f'form key: {app_form_key}. Blob {"changed" if changed and last_form_blob else "unchanged"}.')
+
+        # Print to file if blob changed
+        if changed:
+            date_str = datetime.now().isoformat()
+            file_name = f'{dir}/{date_str}-{app_form_key}-{"CHANGED" if last_form_blob else ""}.xml'
+            with open(file_name, 'wb') as fn:
+                fn.write(cur_form_blob)
+
+        last_form_blob = cur_form_blob
+        time.sleep(int(interval_in_seconds))


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-11642

User is reporting that forms disappear from an app.
Script to be run to monitor state changes on an application internal representation. This periodically polls and checks for changes in the app form reference and the actual form blob. It logs if the reference is changed and prints out the blob.

Usage example (tested locally on local data): `./manage.py runscript tmp-disappearing-form-poller  --script-args test-project 5e7616d2e9d948e2adc3af0da7f84744 ffc364fa16b740ad82006001a59fdc1c form_blobs 4 tmp.log` 

Output is log lines like
```
2021-03-16 20:08:46,255 INFO form key: 0664e2db933a404bb9f9a7da51da1628. Blob unchanged.
2021-03-16 20:08:50,283 INFO form key: 0664e2db933a404bb9f9a7da51da1628. Blob unchanged.
2021-03-16 20:08:54,305 INFO form key: 0664e2db933a404bb9f9a7da51da1628. Blob unchanged.
2021-03-16 20:08:58,323 INFO form key: 0664e2db933a404bb9f9a7da51da1628. Blob unchanged.
```

and files written to a directory with the form blob xml when it changes.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

N/A
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Invisible change


## Safety Assurance

- [x ] Risk label is set correctly
- [ x] All migrations are backwards compatible and won't block deploy
- [ x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x ] If QA is part of the safety story, the "Awaiting QA" label is used
- [ x] I have confidence that this PR will not introduce a regression for the reasons below
Is a script run outside webworkers.


### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Not needed

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not needed

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This is a script run on another machine (django manage?). It periodically (5 min?) makes simple queries to the db.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ x] This PR can be reverted after deploy with no further considerations 
