### PR TITLE
sanitized mark_safe usages in tabs

### DIFF
--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1,8 +1,7 @@
 from django.conf import settings
 from django.http import Http404
 from django.urls import reverse
-from django.utils.html import escape, strip_tags
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html, strip_tags
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
@@ -907,10 +906,11 @@ class ApplicationsTab(UITab):
 
     @classmethod
     def make_app_title(cls, app):
-        return mark_safe("%s%s" % (
-            escape(strip_tags(app.name)) or '(Untitled)',
+        return format_html(
+            '{}{}',
+            strip_tags(app.name) or '(Untitled)',
             ' (Remote)' if is_remote_app(app) else '',
-        ))
+        )
 
     @property
     def dropdown_items(self):
@@ -1303,8 +1303,8 @@ class ProjectUsersTab(UITab):
                         couch_user.is_commcare_user()):
                     username = couch_user.username_in_report
                     if couch_user.is_deleted():
-                        username += " (%s)" % _("Deleted")
-                    return mark_safe(username)
+                        username = format_html('{} ({})', username, _("Deleted"))
+                    return username
                 else:
                     return None
 
@@ -1380,8 +1380,8 @@ class ProjectUsersTab(UITab):
                         not couch_user.is_commcare_user()):
                     username = couch_user.human_friendly_name
                     if couch_user.is_deleted():
-                        username += " (%s)" % _("Deleted")
-                    return mark_safe(username)
+                        username = format_html('{} ({})', username, _('Deleted'))
+                    return username
                 else:
                     return None
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -908,7 +908,7 @@ class ApplicationsTab(UITab):
     def make_app_title(cls, app):
         return format_html(
             '{}{}',
-            strip_tags(app.name) or '(Untitled)',
+            strip_tags(app.name) or _('(Untitled)'),
             ' (Remote)' if is_remote_app(app) else '',
         )
 

--- a/corehq/tabs/templatetags/menu_tags.py
+++ b/corehq/tabs/templatetags/menu_tags.py
@@ -1,7 +1,6 @@
 from corehq.apps.users.models import DomainMembershipError
 from django import template
 from django.template.loader import render_to_string
-from django.utils.safestring import mark_safe
 
 from corehq.tabs.config import MENU_TABS
 from corehq.tabs.exceptions import TabClassError, TabClassErrorSummary
@@ -104,7 +103,7 @@ class MainMenuNode(template.Node):
             'tabs': visible_tabs,
             'role_rev': role_rev
         })
-        return mark_safe(render_to_string('tabs/menu_main.html', flat))
+        return render_to_string('tabs/menu_main.html', flat)
 
 
 @register.tag(name="format_main_menu")
@@ -143,7 +142,7 @@ def format_sidebar(context):
                             nav['subpage'] = subpage
                             break
 
-    return mark_safe(render_to_string(
+    return render_to_string(
         'hqwebapp/partials/navigation_left_sidebar.html',
         {'sections': sections}
-    ))
+    )


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Part of the XSS work in [SAAS-11853](https://dimagi-dev.atlassian.net/browse/SAAS-11853). One change in this one is that I removed `mark_safe` from the `render_to_string` calls, as I realized those calls already return safe strings.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No change in functionality, no tests.

### QA Plan

No QA needed.

### Safety story

Tested locally, using the debugger to create edge cases.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
