### PR TITLE
Removed MONITOR_2FA_CHANGES

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -111,7 +111,7 @@ from corehq.apps.sms.phonenumbers_helper import parse_phone_number
 from corehq.apps.users.models import CouchUser, WebUser
 from corehq.apps.users.permissions import can_manage_releases
 from corehq.toggles import HIPAA_COMPLIANCE_CHECKBOX, MOBILE_UCR, \
-    SECURE_SESSION_TIMEOUT, MONITOR_2FA_CHANGES
+    SECURE_SESSION_TIMEOUT
 from corehq.util.timezones.fields import TimeZoneField
 from corehq.util.timezones.forms import TimeZoneChoiceField
 
@@ -666,13 +666,7 @@ class PrivacySecurityForm(forms.Form):
         domain.allow_domain_requests = self.cleaned_data.get('allow_domain_requests', False)
         domain.secure_sessions = self.cleaned_data.get('secure_sessions', False)
         domain.secure_sessions_timeout = self.cleaned_data.get('secure_sessions_timeout', None)
-
-        new_two_factor_auth_setting = self.cleaned_data.get('two_factor_auth', False)
-        if domain.two_factor_auth != new_two_factor_auth_setting and MONITOR_2FA_CHANGES.enabled(domain.name):
-            from corehq.apps.hqwebapp.utils import monitor_2fa_soft_assert
-            status = "ON" if new_two_factor_auth_setting else "OFF"
-            monitor_2fa_soft_assert(False, f'{domain.name} turned 2FA {status}')
-        domain.two_factor_auth = new_two_factor_auth_setting
+        domain.two_factor_auth = self.cleaned_data.get('two_factor_auth', False)
 
         domain.strong_mobile_passwords = self.cleaned_data.get('strong_mobile_passwords', False)
         secure_submissions = self.cleaned_data.get(

--- a/corehq/apps/hqwebapp/utils.py
+++ b/corehq/apps/hqwebapp/utils.py
@@ -11,9 +11,6 @@ from Crypto.PublicKey import RSA
 from Crypto.Signature import PKCS1_PSS
 from memoized import memoized
 
-from corehq.util.soft_assert import soft_assert
-from dimagi.utils.logging import notify_exception
-
 from corehq.apps.hqwebapp.forms import BulkUploadForm
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.users.models import WebUser
@@ -21,11 +18,6 @@ from corehq.util.view_utils import get_request
 from custom.nic_compliance.utils import get_raw_password
 
 logger = logging.getLogger(__name__)
-
-monitor_2fa_soft_assert = soft_assert(
-    to=['{}@{}'.format('biyeun', 'dimagi.com')],
-    send_to_ops=False
-)
 
 
 @memoized

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -52,7 +52,6 @@ from memoized import memoized
 from sentry_sdk import last_event_id
 from two_factor.views import LoginView
 
-from corehq.toggles import MONITOR_2FA_CHANGES
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.sms.event_handlers import handle_email_messaging_subevent
 from corehq.apps.users.event_handlers import handle_email_invite_message
@@ -207,11 +206,6 @@ def redirect_to_default(req, domain=None):
         else:
             url = reverse('login')
     elif domain and _two_factor_needed(domain, req):
-        if MONITOR_2FA_CHANGES.enabled(domain):
-            from corehq.apps.hqwebapp.utils import monitor_2fa_soft_assert
-            monitor_2fa_soft_assert(False, f'2FA required page shown to user '
-                                           f'{req.user.username} on {domain} after '
-                                           f'login')
         return TemplateResponse(
             request=req,
             template='two_factor/core/otp_required.html',
@@ -389,8 +383,6 @@ def _login(req, domain_name, custom_login_page, extra_context=None):
         with mutable_querydict(req.POST):
             req.POST['auth-username'] = format_username(req.POST['auth-username'], domain_name)
 
-    context = {}
-
     if 'auth-username' in req.POST:
         couch_user = CouchUser.get_by_username(req.POST['auth-username'].lower())
         if couch_user:
@@ -398,13 +390,9 @@ def _login(req, domain_name, custom_login_page, extra_context=None):
             old_lang = req.session.get(LANGUAGE_SESSION_KEY)
             update_session_language(req, old_lang, new_lang)
 
-            # context needed for MONITOR_2FA_CHANGES toggle in HQLoginView
-            context.update({
-                'is_commcare_user': couch_user.is_commcare_user(),
-            })
-
     req.base_template = settings.BASE_TEMPLATE
 
+    context = {}
     template_name = custom_login_page if custom_login_page else 'login_and_password/login.html'
     if not custom_login_page and domain_name:
         domain_obj = Domain.get_by_name(domain_name)
@@ -494,19 +482,6 @@ class HQLoginView(LoginView):
     def get_context_data(self, **kwargs):
         context = super(HQLoginView, self).get_context_data(**kwargs)
         context.update(self.extra_context)
-
-        steps = context.get('wizard', {}).get('steps')
-        domain = context.get('domain')
-        is_commcare_user = context.get('is_commcare_user', False)
-        if (steps and steps.current == 'token'
-                and is_commcare_user and MONITOR_2FA_CHANGES.enabled(domain)):
-            username = self.request.POST['auth-username'].lower()
-            from corehq.apps.hqwebapp.utils import monitor_2fa_soft_assert
-            monitor_2fa_soft_assert(
-                False,
-                f'2FA TOKEN required upon login for mobile worker {username} from {domain}'
-            )
-
         return context
 
 

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -28,7 +28,6 @@ from two_factor.views import (
 )
 
 from corehq.apps.domain.extension_points import has_custom_clean_password
-from corehq.toggles import MONITOR_2FA_CHANGES
 from dimagi.utils.web import json_response
 
 import langcodes
@@ -339,15 +338,7 @@ class TwoFactorSetupCompleteView(BaseMyAccountView, SetupCompleteView):
 
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
-        # todo this bit of code should be replaced with a better event logging system
-        if (request.couch_user.is_commcare_user()
-                and MONITOR_2FA_CHANGES.enabled(request.couch_user.domain)):
-            from corehq.apps.hqwebapp.utils import monitor_2fa_soft_assert
-            monitor_2fa_soft_assert(
-                False,
-                f'2FA was ENABLED for mobile worker {request.couch_user.username} '
-                f'from {request.couch_user.domain}'
-            )
+        # this is only here to add the login_required decorator
         return super(TwoFactorSetupCompleteView, self).dispatch(request, *args, **kwargs)
 
     @property

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -650,14 +650,6 @@ VISIT_SCHEDULER = StaticToggle(
 )
 
 
-MONITOR_2FA_CHANGES = StaticToggle(
-    'monitor_2fa_changes',
-    'Monitor 2FA activity for SAAS-11210 ticket',
-    TAG_CUSTOM,
-    namespaces=[NAMESPACE_DOMAIN]
-)
-
-
 USER_CONFIGURABLE_REPORTS = StaticToggle(
     'user_reports',
     'User configurable reports UI',


### PR DESCRIPTION
## Summary
Reverts https://github.com/dimagi/commcare-hq/pull/28431/ which is no longer needed.

For some reason the previous PR didn't revert cleanly, but the code changes should be exactly opposite, plus removing an unrelated unused import or two that got flagged when I committed.

## Feature Flag
Removes flag 'Monitor 2FA activity for SAAS-11210 ticket'

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

Not requesting QA.

### Safety story
This is a fairly small revert.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
