### PR TITLE
enable Oauth in api_auth decorated functions

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -3,6 +3,7 @@ import logging
 import re
 from functools import wraps
 
+import binascii
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.models import User
 from django.db.models import Q
@@ -129,7 +130,10 @@ def get_username_and_password_from_request(request):
         except UnicodeDecodeError:
             pass
     elif auth[0].lower() == BASIC:
-        username, password = _decode(base64.b64decode(auth[1])).split(':', 1)
+        try:
+            username, password = _decode(base64.b64decode(auth[1])).split(':', 1)
+        except binascii.Error:
+            return None, None
         username = username.lower()
         # decode password submitted from mobile app login
         password = decode_password(password)

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -433,6 +433,7 @@ def get_auth_decorator_map(allow_cc_users=False, require_domain=True, allow_sess
         BASIC: login_or_basic_ex(**decorator_function_kwargs),
         API_KEY: login_or_api_key_ex(**decorator_function_kwargs),
         OAUTH2: login_or_oauth2_ex(**decorator_function_kwargs),
+        FORMPLAYER: login_or_formplayer_ex(**decorator_function_kwargs),
     }
 
 

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -427,13 +427,18 @@ api_key_auth = login_or_api_key_ex(allow_sessions=False)
 basic_auth_or_try_api_key_auth = login_or_basic_or_api_key_ex(allow_sessions=False)
 
 
-def get_auth_decorator_map(require_domain=True, allow_sessions=True):
+def get_auth_decorator_map(allow_cc_users=False, require_domain=True, allow_sessions=True):
     # get a mapped set of decorators for different auth types with the specified parameters
+    decorator_function_kwargs = {
+        'allow_cc_users': allow_cc_users,
+        'require_domain': require_domain,
+        'allow_sessions': allow_sessions,
+    }
     return {
-        DIGEST: login_or_digest_ex(require_domain=require_domain, allow_sessions=allow_sessions),
-        BASIC: login_or_basic_ex(require_domain=require_domain, allow_sessions=allow_sessions),
-        API_KEY: login_or_api_key_ex(require_domain=require_domain, allow_sessions=allow_sessions),
-        OAUTH2: login_or_oauth2_ex(require_domain=require_domain, allow_sessions=allow_sessions),
+        DIGEST: login_or_digest_ex(**decorator_function_kwargs),
+        BASIC: login_or_basic_ex(**decorator_function_kwargs),
+        API_KEY: login_or_api_key_ex(**decorator_function_kwargs),
+        OAUTH2: login_or_oauth2_ex(**decorator_function_kwargs),
     }
 
 

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -40,6 +40,7 @@ from corehq.apps.domain.auth import (
     BASIC,
     DIGEST,
     FORMPLAYER,
+    OAUTH2,
     basic_or_api_key,
     basicauth,
     determine_authtype_from_request,
@@ -379,6 +380,7 @@ def _get_multi_auth_decorator(default, allow_formplayer=False):
                 DIGEST: login_or_digest_ex(allow_cc_users=True),
                 API_KEY: login_or_api_key_ex(allow_cc_users=True),
                 FORMPLAYER: login_or_formplayer_ex(allow_cc_users=True),
+                OAUTH2: login_or_oauth2_ex(allow_cc_users=True),
             }[authtype]
             return function_wrapper(fn)(request, *args, **kwargs)
         return _inner

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -375,13 +375,7 @@ def _get_multi_auth_decorator(default, allow_formplayer=False):
                 )
                 return HttpResponseForbidden()
             request.auth_type = authtype  # store auth type on request for access in views
-            function_wrapper = {
-                BASIC: login_or_basic_ex(allow_cc_users=True),
-                DIGEST: login_or_digest_ex(allow_cc_users=True),
-                API_KEY: login_or_api_key_ex(allow_cc_users=True),
-                FORMPLAYER: login_or_formplayer_ex(allow_cc_users=True),
-                OAUTH2: login_or_oauth2_ex(allow_cc_users=True),
-            }[authtype]
+            function_wrapper = get_auth_decorator_map(allow_cc_users=True)[authtype]
             return function_wrapper(fn)(request, *args, **kwargs)
         return _inner
     return decorator

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -428,10 +428,10 @@ basic_auth_or_try_api_key_auth = login_or_basic_or_api_key_ex(allow_sessions=Fal
 def get_auth_decorator_map(require_domain=True, allow_sessions=True):
     # get a mapped set of decorators for different auth types with the specified parameters
     return {
-        'digest': login_or_digest_ex(require_domain=require_domain, allow_sessions=allow_sessions),
-        'basic': login_or_basic_ex(require_domain=require_domain, allow_sessions=allow_sessions),
-        'api_key': login_or_api_key_ex(require_domain=require_domain, allow_sessions=allow_sessions),
-        'oauth2': login_or_oauth2_ex(require_domain=require_domain, allow_sessions=allow_sessions),
+        DIGEST: login_or_digest_ex(require_domain=require_domain, allow_sessions=allow_sessions),
+        BASIC: login_or_basic_ex(require_domain=require_domain, allow_sessions=allow_sessions),
+        API_KEY: login_or_api_key_ex(require_domain=require_domain, allow_sessions=allow_sessions),
+        OAUTH2: login_or_oauth2_ex(require_domain=require_domain, allow_sessions=allow_sessions),
     }
 
 

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -22,7 +22,6 @@ from django_otp import match_token
 from django_prbac.utils import has_privilege
 from oauth2_provider.oauth2_backends import get_oauthlib_core
 
-from corehq.apps.domain.auth import HQApiKeyAuthentication
 from tastypie.http import HttpUnauthorized
 
 from corehq.apps.sso.utils.request_helpers import (
@@ -45,8 +44,8 @@ from corehq.apps.domain.auth import (
     basicauth,
     determine_authtype_from_request,
     formplayer_as_user_auth,
-    formplayer_auth,
     get_username_and_password_from_request,
+    HQApiKeyAuthentication,
 )
 from corehq.apps.domain.models import Domain, DomainAuditRecordEntry
 from corehq.apps.domain.utils import normalize_domain_name

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -327,10 +327,12 @@ def login_or_digest_ex(allow_cc_users=False, allow_sessions=True, require_domain
     )
 
 
-def login_or_formplayer_ex(allow_cc_users=False, allow_sessions=True):
+def login_or_formplayer_ex(allow_cc_users=False, allow_sessions=True, require_domain=True):
     return _login_or_challenge(
         formplayer_as_user_auth,
-        allow_cc_users=allow_cc_users, allow_sessions=allow_sessions
+        allow_cc_users=allow_cc_users,
+        allow_sessions=allow_sessions,
+        require_domain=require_domain,
     )
 
 

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import AnonymousUser
 from django.test import SimpleTestCase, TestCase, RequestFactory
 
-from corehq.apps.domain.decorators import _login_or_challenge
+from corehq.apps.domain.decorators import _login_or_challenge, api_auth
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser, CommCareUser
 
@@ -166,3 +166,13 @@ class LoginOrChallengeDBTest(TestCase, AuthTestMixin):
 
         request = _get_request(self.commcare_django_user)
         self.assertEqual(SUCCESS, test(request))
+
+
+class ApiAuthTest(SimpleTestCase, AuthTestMixin):
+    domain_name = 'api-auth-test'
+
+    def test_api_auth_no_auth(self):
+        decorated_view = api_auth(sample_view)
+        request = _get_request()
+        # result = decorated_view(request, self.domain_name)
+        self.assertForbidden(decorated_view(request, self.domain_name))

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -227,7 +227,7 @@ class ApiAuthTest(SimpleTestCase, AuthTestMixin):
         decorated_view = api_auth(sample_view)
         request = _get_request()
         request.META['HTTP_X_MAC_DIGEST'] = 'fomplayerAuth'
-        with mock.patch(decorator_to_mock, mock_successful_auth) as mock_success:
+        with mock.patch(decorator_to_mock, mock_successful_auth):
             # even if formplayer returns successful auth, api_auth rejects it because
             # allow_formplayer is set to false
             self.assertForbidden(decorated_view(request, self.domain_name))

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -1,4 +1,3 @@
-import base64
 from functools import wraps
 
 from django.contrib.auth.models import AnonymousUser

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -198,3 +198,7 @@ class ApiAuthTest(SimpleTestCase, AuthTestMixin):
         # fake oauth header
         request.META['HTTP_AUTHORIZATION'] = 'bearer myToken'
         self.assertEqual(SUCCESS, decorated_view(request, self.domain_name))
+
+        # also confirm other auth fails (because not mocked)
+        request.META['HTTP_AUTHORIZATION'] = f'basic user:12345'
+        self.assertForbidden(decorated_view(request, self.domain_name))

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -61,7 +61,13 @@ def _get_request(user=AnonymousUser()):
     return request
 
 
-class LoginOrChallengeDBTest(TestCase):
+class AuthTestMixin:
+
+    def assertForbidden(self, result):
+        self.assertNotEqual(SUCCESS, result)
+
+
+class LoginOrChallengeDBTest(TestCase, AuthTestMixin):
     domain_name = 'auth-challenge-test'
 
     @classmethod
@@ -92,9 +98,6 @@ class LoginOrChallengeDBTest(TestCase):
                                            allow_sessions=allow_sessions,
                                            require_domain=require_domain)
         return cc_decorator(sample_view)
-
-    def assertForbidden(self, result):
-        self.assertNotEqual(SUCCESS, result)
 
     def test_no_user_set(self):
         # no matter what, no user = no success

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -228,8 +228,9 @@ class ApiAuthTest(SimpleTestCase, AuthTestMixin):
         request = _get_request()
         request.META['HTTP_X_MAC_DIGEST'] = 'fomplayerAuth'
         with mock.patch(decorator_to_mock, mock_successful_auth):
-            # even if formplayer returns successful auth, api_auth rejects it because
-            # allow_formplayer is set to false
+            # even if formplayer returns successful auth, the api_auth decorator rejects it because
+            # it calls _get_multi_auth_decorator with allow_formplayer=False, short-circuiting
+            # any additional auth checkng.
             self.assertForbidden(decorated_view(request, self.domain_name))
         with mock.patch(decorator_to_mock, mock_failed_auth):
             self.assertForbidden(decorated_view(request, self.domain_name))


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

This allows any function decorated with `api_auth` to use Oauth2 as a form of authentication.

@esoergel I completely forgot that [you already suggested this](https://github.com/dimagi/commcare-hq/pull/28189/files#r459721474) and I even promised to do it. Better late than never?

Review by commit. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Technically this makes certain APIs available under Oauth2, but since no one is using Oauth2 yet except [the API explorer](https://commcare-api-explorer.dimagi.com/) and we haven't announced it publicly this is basically invisible. 

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

Oauth was already released on all tastypie APIs with no side-effects, so I don't anticipate any additional consequences here.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
