### PR TITLE
add allow_cors decorator and allow CORS for new case API

### DIFF
--- a/corehq/apps/api/cors.py
+++ b/corehq/apps/api/cors.py
@@ -1,0 +1,5 @@
+
+
+ACCESS_CONTROL_ALLOW = 'Allow'
+ACCESS_CONTROL_ALLOW_HEADERS = 'Access-Control-Allow-Headers'
+ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin'

--- a/corehq/apps/api/cors.py
+++ b/corehq/apps/api/cors.py
@@ -3,3 +3,9 @@
 ACCESS_CONTROL_ALLOW = 'Allow'
 ACCESS_CONTROL_ALLOW_HEADERS = 'Access-Control-Allow-Headers'
 ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin'
+
+
+def add_cors_headers_to_response(response):
+    response[ACCESS_CONTROL_ALLOW_ORIGIN] = '*'
+    response[ACCESS_CONTROL_ALLOW_HEADERS] = 'Content-Type, Authorization'
+    return response

--- a/corehq/apps/api/decorators.py
+++ b/corehq/apps/api/decorators.py
@@ -3,7 +3,7 @@ from functools import wraps
 
 from django.http import HttpResponse
 
-from corehq.apps.api.cors import ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW
+from corehq.apps.api.cors import ACCESS_CONTROL_ALLOW, add_cors_headers_to_response
 from corehq.apps.api.models import ApiUser
 
 
@@ -35,14 +35,11 @@ def allow_cors(allowed_methods):
         def wrapped_view(request, *args, **kwargs):
             if request.method == "OPTIONS":
                 response = HttpResponse()
-                response[ACCESS_CONTROL_ALLOW_ORIGIN] = '*'
-                response[ACCESS_CONTROL_ALLOW_HEADERS] = 'Content-Type, Authorization'
                 response[ACCESS_CONTROL_ALLOW] = ', '.join(allowed_methods)
-                return response
+                return add_cors_headers_to_response(response)
             response = view_func(request, *args, **kwargs)
             if request.method in allowed_methods:
-                response[ACCESS_CONTROL_ALLOW_ORIGIN] = '*'
-                response[ACCESS_CONTROL_ALLOW_HEADERS] = 'Content-Type, Authorization'
+                add_cors_headers_to_response(response)
             return response
         return wrapped_view
     return decorator

--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -10,6 +10,7 @@ from tastypie.resources import Resource
 from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_workflow
+from corehq.apps.api.cors import add_cors_headers_to_response
 from corehq.apps.api.util import get_obj
 
 
@@ -64,10 +65,7 @@ class CorsResourceMixin(object):
 
     def create_response(self, *args, **kwargs):
         response = super(CorsResourceMixin, self).create_response(*args, **kwargs)
-        response['Access-Control-Allow-Origin'] = '*'
-        response['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
-
-        return response
+        return add_cors_headers_to_response(response)
 
     def method_check(self, request, allowed=None):
         if allowed is None:
@@ -78,8 +76,7 @@ class CorsResourceMixin(object):
 
         if request_method == 'options':
             response = HttpResponse(allows)
-            response['Access-Control-Allow-Origin'] = '*'
-            response['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
+            add_cors_headers_to_response(response)
             response['Allow'] = allows
             raise ImmediateHttpResponse(response=response)
 

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -692,31 +692,3 @@ def track_domain_request(calculated_prop):
         return _wrapped
 
     return _dec
-
-
-ACCESS_CONTROL_ALLOW = 'Allow'
-ACCESS_CONTROL_ALLOW_HEADERS = 'Access-Control-Allow-Headers'
-ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin'
-
-
-def allow_cors(allowed_methods):
-    allowed_methods = allowed_methods or []
-    # always allow options
-    allowed_methods = allowed_methods + ['OPTIONS']
-
-    def decorator(view_func):
-        @wraps(view_func)
-        def wrapped_view(request, *args, **kwargs):
-            if request.method == "OPTIONS":
-                response = HttpResponse()
-                response[ACCESS_CONTROL_ALLOW_ORIGIN] = '*'
-                response[ACCESS_CONTROL_ALLOW_HEADERS] = 'Content-Type, Authorization'
-                response[ACCESS_CONTROL_ALLOW] = ', '.join(allowed_methods)
-                return response
-            response = view_func(request, *args, **kwargs)
-            if request.method in allowed_methods:
-                response[ACCESS_CONTROL_ALLOW_ORIGIN] = '*'
-                response[ACCESS_CONTROL_ALLOW_HEADERS] = 'Content-Type, Authorization'
-            return response
-        return wrapped_view
-    return decorator

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -710,8 +710,9 @@ def allow_cors(allowed_methods):
                 response[ACCESS_CONTROL_ALLOW] = allowed_methods
                 return response
             response = view_func(request, *args, **kwargs)
-            response[ACCESS_CONTROL_ALLOW_ORIGIN] = '*'
-            response[ACCESS_CONTROL_ALLOW_HEADERS] = 'Content-Type, Authorization'
+            if request.method in allowed_methods:
+                response[ACCESS_CONTROL_ALLOW_ORIGIN] = '*'
+                response[ACCESS_CONTROL_ALLOW_HEADERS] = 'Content-Type, Authorization'
             return response
         return wrapped_view
     return decorator

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -700,14 +700,18 @@ ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin'
 
 
 def allow_cors(allowed_methods):
+    allowed_methods = allowed_methods or []
+    # always allow options
+    allowed_methods = allowed_methods + ['OPTIONS']
+
     def decorator(view_func):
         @wraps(view_func)
         def wrapped_view(request, *args, **kwargs):
             if request.method == "OPTIONS":
-                response = HttpResponse(allowed_methods)
+                response = HttpResponse()
                 response[ACCESS_CONTROL_ALLOW_ORIGIN] = '*'
                 response[ACCESS_CONTROL_ALLOW_HEADERS] = 'Content-Type, Authorization'
-                response[ACCESS_CONTROL_ALLOW] = allowed_methods
+                response[ACCESS_CONTROL_ALLOW] = ', '.join(allowed_methods)
                 return response
             response = view_func(request, *args, **kwargs)
             if request.method in allowed_methods:

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -692,3 +692,21 @@ def track_domain_request(calculated_prop):
         return _wrapped
 
     return _dec
+
+
+def allow_cors(allowed_methods):
+    def decorator(view_func):
+        @wraps(view_func)
+        def wrapped_view(request, *args, **kwargs):
+            if request.method == "OPTIONS":
+                response = HttpResponse(allowed_methods)
+                response['Access-Control-Allow-Origin'] = '*'
+                response['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
+                response['Allow'] = allowed_methods
+                return response
+            response = view_func(request, *args, **kwargs)
+            response['Access-Control-Allow-Origin'] = '*'
+            response['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
+            return response
+        return wrapped_view
+    return decorator

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -694,19 +694,24 @@ def track_domain_request(calculated_prop):
     return _dec
 
 
+ACCESS_CONTROL_ALLOW = 'Allow'
+ACCESS_CONTROL_ALLOW_HEADERS = 'Access-Control-Allow-Headers'
+ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin'
+
+
 def allow_cors(allowed_methods):
     def decorator(view_func):
         @wraps(view_func)
         def wrapped_view(request, *args, **kwargs):
             if request.method == "OPTIONS":
                 response = HttpResponse(allowed_methods)
-                response['Access-Control-Allow-Origin'] = '*'
-                response['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
-                response['Allow'] = allowed_methods
+                response[ACCESS_CONTROL_ALLOW_ORIGIN] = '*'
+                response[ACCESS_CONTROL_ALLOW_HEADERS] = 'Content-Type, Authorization'
+                response[ACCESS_CONTROL_ALLOW] = allowed_methods
                 return response
             response = view_func(request, *args, **kwargs)
-            response['Access-Control-Allow-Origin'] = '*'
-            response['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
+            response[ACCESS_CONTROL_ALLOW_ORIGIN] = '*'
+            response[ACCESS_CONTROL_ALLOW_HEADERS] = 'Content-Type, Authorization'
             return response
         return wrapped_view
     return decorator

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -5,8 +5,9 @@ from django.http import HttpResponseForbidden, HttpResponse
 from django.test import SimpleTestCase, TestCase, RequestFactory
 from mock import mock
 
-from corehq.apps.domain.decorators import _login_or_challenge, api_auth, allow_cors, ACCESS_CONTROL_ALLOW_ORIGIN, \
-    ACCESS_CONTROL_ALLOW
+from corehq.apps.api.cors import ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_ALLOW
+from corehq.apps.api.decorators import allow_cors
+from corehq.apps.domain.decorators import _login_or_challenge, api_auth
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser, CommCareUser
 

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -5,7 +5,8 @@ from django.http import HttpResponseForbidden, HttpResponse
 from django.test import SimpleTestCase, TestCase, RequestFactory
 from mock import mock
 
-from corehq.apps.domain.decorators import _login_or_challenge, api_auth, allow_cors, ACCESS_CONTROL_ALLOW_ORIGIN
+from corehq.apps.domain.decorators import _login_or_challenge, api_auth, allow_cors, ACCESS_CONTROL_ALLOW_ORIGIN, \
+    ACCESS_CONTROL_ALLOW
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser, CommCareUser
 
@@ -259,3 +260,12 @@ class AllowCORSDecoratorTest(TestCase):
     def test_method_exclusions(self):
         response = allow_cors(['POST'])(sample_view_with_response)(_get_request())
         self._assert_no_cors(response)
+
+    def test_options_no_decorator(self):
+        response = sample_view_with_response(RequestFactory().options('/foobar/'))
+        self._assert_no_cors(response)
+
+    def test_options(self):
+        response = allow_cors(['POST'])(sample_view_with_response)(RequestFactory().options('/foobar/'))
+        self._assert_cors(response)
+        self.assertEqual(response[ACCESS_CONTROL_ALLOW], 'POST, OPTIONS')

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -1,11 +1,11 @@
 from functools import wraps
 
 from django.contrib.auth.models import AnonymousUser
-from django.http import HttpResponseForbidden
+from django.http import HttpResponseForbidden, HttpResponse
 from django.test import SimpleTestCase, TestCase, RequestFactory
 from mock import mock
 
-from corehq.apps.domain.decorators import _login_or_challenge, api_auth
+from corehq.apps.domain.decorators import _login_or_challenge, api_auth, allow_cors, ACCESS_CONTROL_ALLOW_ORIGIN
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser, CommCareUser
 
@@ -234,3 +234,28 @@ class ApiAuthTest(SimpleTestCase, AuthTestMixin):
             self.assertForbidden(decorated_view(request, self.domain_name))
         with mock.patch(decorator_to_mock, mock_failed_auth):
             self.assertForbidden(decorated_view(request, self.domain_name))
+
+
+def sample_view_with_response(request, *args, **kwargs):
+    return HttpResponse(SUCCESS)
+
+
+class AllowCORSDecoratorTest(TestCase):
+    domain_name = 'allow-cors-test'
+
+    def _assert_no_cors(self, response):
+        self.assertFalse(response.has_header(ACCESS_CONTROL_ALLOW_ORIGIN))
+
+    def _assert_cors(self, response):
+        self.assertEqual(response[ACCESS_CONTROL_ALLOW_ORIGIN], '*')
+
+    def test_no_decorator_no_cors_headers(self):
+        self._assert_no_cors(sample_view_with_response(_get_request()))
+
+    def test_decorator_has_headers(self):
+        response = allow_cors(['GET'])(sample_view_with_response)(_get_request())
+        self._assert_cors(response)
+
+    def test_method_exclusions(self):
+        response = allow_cors(['POST'])(sample_view_with_response)(_get_request())
+        self._assert_no_cors(response)

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -5,7 +5,7 @@ from django.http import HttpResponseForbidden, HttpResponse
 from django.test import SimpleTestCase, TestCase, RequestFactory
 from mock import mock
 
-from corehq.apps.api.cors import ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_ALLOW
+from corehq.apps.api.cors import ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_ALLOW, ACCESS_CONTROL_ALLOW_HEADERS
 from corehq.apps.api.decorators import allow_cors
 from corehq.apps.domain.decorators import _login_or_challenge, api_auth
 from corehq.apps.domain.shortcuts import create_domain
@@ -250,6 +250,7 @@ class AllowCORSDecoratorTest(TestCase):
 
     def _assert_cors(self, response):
         self.assertEqual(response[ACCESS_CONTROL_ALLOW_ORIGIN], '*')
+        self.assertEqual(response[ACCESS_CONTROL_ALLOW_HEADERS], 'Content-Type, Authorization')
 
     def test_no_decorator_no_cors_headers(self):
         self._assert_no_cors(sample_view_with_response(_get_request()))

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -15,7 +15,7 @@ from corehq.apps.case_importer.views import require_can_edit_data
 from corehq.apps.domain.decorators import (
     api_auth,
     require_superuser_or_contractor,
-)
+    allow_cors)
 from corehq.apps.domain.views.settings import BaseProjectSettingsView
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.form_processor.exceptions import CaseNotFound
@@ -81,6 +81,7 @@ class ExplodeCasesView(BaseProjectSettingsView, TemplateView):
 
 @waf_allow('XSS_BODY')
 @csrf_exempt
+@allow_cors(['OPTIONS', 'GET', 'POST', 'PUT'])
 @api_auth
 @require_can_edit_data
 @CASE_API_V0_6.required_decorator()

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -7,6 +7,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
 
+from corehq.apps.api.decorators import allow_cors
 from soil import DownloadBase
 
 from corehq import privileges
@@ -15,7 +16,7 @@ from corehq.apps.case_importer.views import require_can_edit_data
 from corehq.apps.domain.decorators import (
     api_auth,
     require_superuser_or_contractor,
-    allow_cors)
+)
 from corehq.apps.domain.views.settings import BaseProjectSettingsView
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.form_processor.exceptions import CaseNotFound


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

This enables CORS headers on the new case API via a new decorator function.

The standard answer to Django + CORS seems to be [django-cors-headers](https://pypi.org/project/django-cors-headers/) but it seems a rather blunt instrument that isn't designed to make things configurable at the view level, more at the project level. So I went with a much simpler approach inspired by [our current TastyPie implementation](https://github.com/dimagi/commcare-hq/pull/4564)

Very open to feedback on this approach though - this isn't an area of expertise of mine.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

Currently only affects the v0.6 case API

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

External applications can integrate with the v0.6 case API.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

New code is well tested and touches to old code were very rote refactor/cleanups.

### Automated test coverage

Added tests for new functionality. Existing APIs also have tests.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
