### PR TITLE
Use this month instead of previous month for project performance report

### DIFF
--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -38,16 +38,15 @@ class UserActivityStub(namedtuple('UserStub', ['user_id', 'username', 'num_forms
 
     @property
     def delta_forms(self):
-        previous_forms = 0 if self.previous_stub is None else self.previous_stub.num_forms_submitted
-        return self.num_forms_submitted - previous_forms
+        return self.num_forms_submitted - self.num_forms_submitted_previous_month
 
     @property
-    def num_forms_submitted_next_month(self):
-        return self.next_stub.num_forms_submitted if self.next_stub else 0
+    def num_forms_submitted_previous_month(self):
+        return self.previous_stub.num_forms_submitted if self.previous_stub else 0
 
     @property
-    def delta_forms_next_month(self):
-        return self.num_forms_submitted_next_month - self.num_forms_submitted
+    def delta_forms_previous_month(self):
+        return self.previous_stub.delta_forms if self.previous_stub else 0
 
 
 class MonthlyPerformanceSummary(jsonobject.JsonObject):
@@ -220,8 +219,9 @@ class MonthlyPerformanceSummary(jsonobject.JsonObject):
         after not performing last month.
         """
         if self._previous_summary:
-            dropouts = [stub for stub in self._get_all_user_stubs_with_extra_data() if stub.is_newly_performing]
-            return sorted(dropouts, key=lambda stub: -stub.delta_forms)
+            new_performers = [stub for stub in self._get_all_user_stubs_with_extra_data()
+                              if stub.is_newly_performing]
+            return sorted(new_performers, key=lambda stub: -stub.delta_forms)
 
 
 def build_worksheet(title, headers, rows):
@@ -352,24 +352,24 @@ class ProjectHealthDashboard(ProjectReport):
     @property
     def export_table(self):
         previous_months_reports = self.previous_months_summary(self.get_number_of_months())
-        last_month = previous_months_reports[-2]
+        this_month = previous_months_reports[-1]
 
         header = ['user_id', 'username', 'last_month_forms', 'delta_last_month',
                   'this_month_forms', 'delta_this_month', 'is_performing']
 
         def extract_user_stat(user_list):
-            return [[user.user_id, user.username, user.num_forms_submitted, user.delta_forms,
-                    user.num_forms_submitted_next_month, user.delta_forms_next_month,
+            return [[user.user_id, user.username, user.num_forms_submitted_previous_month,
+                    user.delta_forms_previous_month, user.num_forms_submitted, user.delta_forms,
                     user.is_performing] for user in user_list]
 
         return [
             self.export_summary(previous_months_reports),
             build_worksheet(title="Inactive Users", headers=header,
-                            rows=extract_user_stat(last_month.get_dropouts())),
+                            rows=extract_user_stat(this_month.get_dropouts())),
             build_worksheet(title=_("Low Performing Users"), headers=header,
-                            rows=extract_user_stat(last_month.get_unhealthy_users())),
+                            rows=extract_user_stat(this_month.get_unhealthy_users())),
             build_worksheet(title=_("New Performing Users"), headers=header,
-                            rows=extract_user_stat(last_month.get_newly_performing())),
+                            rows=extract_user_stat(this_month.get_newly_performing())),
         ]
 
     @property

--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -46,7 +46,7 @@ class UserActivityStub(namedtuple('UserStub', ['user_id', 'username', 'num_forms
 
     @property
     def delta_forms_previous_month(self):
-        return self.previous_stub.delta_forms if self.previous_stub else 0
+        return self.num_forms_submitted - self.num_forms_submitted_previous_month
 
 
 class MonthlyPerformanceSummary(jsonobject.JsonObject):

--- a/corehq/apps/reports/templates/reports/project_health/partials/user_list.html
+++ b/corehq/apps/reports/templates/reports/project_health/partials/user_list.html
@@ -22,15 +22,15 @@
       </a>
       </td>
       <td title="{% trans 'Change in Forms Submitted Since Two Months Ago' %}">
-        {% chevron user.delta_forms %} {{ user.delta_forms }} &nbsp;&nbsp;
+        {% chevron user.delta_forms_previous_month %} {{ user.delta_forms_previous_month }} &nbsp;&nbsp;
         <small class="text-muted" title="{% trans 'Number of Forms Submitted Last Month' %}">
-          {{ user.num_forms_submitted }}
+          {{ user.num_forms_submitted_previous_month }}
         </small>
       </td>
       <td title="{% trans 'Change in Forms Submitted Since Last Month' %}">
-        {% chevron user.delta_forms_next_month %} {{ user.delta_forms_next_month }} &nbsp;&nbsp;
+        {% chevron user.delta_forms %} {{ user.delta_forms }} &nbsp;&nbsp;
         <small class="text-muted" title="{% trans 'Number of Forms Submitted This Month' %}">
-          {{ user.num_forms_submitted_next_month }}
+          {{ user.num_forms_submitted }}
         </small>
       </td>
     </tr>

--- a/corehq/apps/reports/templates/reports/project_health/partials/users_tables.html
+++ b/corehq/apps/reports/templates/reports/project_health/partials/users_tables.html
@@ -7,7 +7,7 @@
       These are people who used CommCare last month but didn't submit {{ threshold }} forms.
     {% endblocktrans %}
   </p>
-  {% with last_month.get_unhealthy_users as user_list %}
+  {% with this_month.get_unhealthy_users as user_list %}
     {% include "reports/project_health/partials/user_list.html" %}
   {% endwith %}
 </div>
@@ -16,7 +16,7 @@
   <p class="lead">
     {% trans "These are workers who stopped using CommCare last month." %}
   </p>
-  {% with last_month.get_dropouts as user_list %}
+  {% with this_month.get_dropouts as user_list %}
     {% include "reports/project_health/partials/user_list.html" %}
   {% endwith %}
 </div>
@@ -27,7 +27,7 @@
       These are workers who submitted {{ threshold }} forms this month and didn't last month.
     {% endblocktrans %}
   </p>
-  {% with last_month.get_newly_performing as user_list %}
+  {% with this_month.get_newly_performing as user_list %}
     {% include "reports/project_health/partials/user_list.html" %}
   {% endwith %}
 </div>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
For more context see the [JIRA ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11855).

This support issue pointed to a data mismatch in the project performance report between the two graph types (bar vs tables). I believe the issue is due to using the previous month as the summary to compare against rather than the current month. 

The following is a bit confusing to word, so bear with me. The wording throughout the project performance report implies we are comparing the current month (e.g., March) to the two previous months (e.g., January and February), but in reality we are comparing the previous month (e.g., February) to its previous and next month (e.g., January and March). While this sounds the same and does share _some_ of the same data (e.g., form submission counts and deltas), this causes 2 issues. 

1) Users are not classified appropriately (e.g., new performing vs low performing vs inactive). For example, say a user named "tester" submitted 10 forms in January, 20 in February, and 10 in March. When viewing the project performance page in March, the current behavior classifies "tester" as a new high performing user since this is based on the February summary, when in reality, "tester" should now be classified as a low performing user for March. 

2) Users created in the current month do not appear in the tables at all, because the previous month does not know about these users.

This change is currently on staging and so far behaves as expected.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
I am working on some tests now.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Undecided on if this should go through QA.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested on staging. This change only impacts the project performance report.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
