### PR TITLE
use user's timezone if it's set

### DIFF
--- a/corehq/util/timezones/tests/test_utils.py
+++ b/corehq/util/timezones/tests/test_utils.py
@@ -28,9 +28,7 @@ class GetTimezoneForUserTest(SimpleTestCase):
         domain_membership_mock.return_value = domain_membership
 
         # if not override_global_tz
-        self.assertEqual(get_timezone_for_user(couch_user, "test"), domain_membership_timezone)
-        with override_settings(SERVER_ENVIRONMENT='icds'):
-            self.assertEqual(get_timezone_for_user(couch_user, "test"), DOMAIN_TIMEZONE)
+        self.assertEqual(get_timezone_for_user(couch_user, "test"), DOMAIN_TIMEZONE)
 
         # if override_global_tz
         domain_membership.override_global_tz = True

--- a/corehq/util/timezones/utils.py
+++ b/corehq/util/timezones/utils.py
@@ -64,12 +64,8 @@ def get_timezone_for_user(couch_user_or_id, domain):
 
         if requesting_user:
             domain_membership = requesting_user.get_domain_membership(domain)
-            if domain_membership:
-                if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
-                    if domain_membership.override_global_tz:
-                        return coerce_timezone_value(domain_membership.timezone)
-                else:
-                    return coerce_timezone_value(domain_membership.timezone)
+            if domain_membership and domain_membership.override_global_tz:
+                return coerce_timezone_value(domain_membership.timezone)
 
     return get_timezone_for_domain(domain)
 


### PR DESCRIPTION


## Summary
Originally done for ICDS only: https://github.com/dimagi/commcare-hq/pull/27860

This should fix the timezone of dates being displayed in reports. Currently it always uses the value from the user's domain membership which is by default UTC and mostly not changed.

After this change it will only use that value if the user has requested to use it, otherwise it will use the domains timezone.

## Product Description
See above.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
