### PR TITLE
Replace default_export_settings ff with privilege

### DIFF
--- a/corehq/apps/enterprise/forms.py
+++ b/corehq/apps/enterprise/forms.py
@@ -8,10 +8,11 @@ from crispy_forms import layout as crispy
 from crispy_forms.bootstrap import PrependedText, StrictButton
 from crispy_forms.helper import FormHelper
 
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput
-from corehq.toggles import DEFAULT_EXPORT_SETTINGS
 from corehq.apps.export.models.export_settings import ExportFileType
+from corehq.privileges import DEFAULT_EXPORT_SETTINGS
 
 
 class EnterpriseSettingsForm(forms.Form):
@@ -118,7 +119,7 @@ class EnterpriseSettingsForm(forms.Form):
             "restrict_signup_message": self.account.restrict_signup_message,
         }
 
-        if self.export_settings and DEFAULT_EXPORT_SETTINGS.enabled(self.username):
+        if self.export_settings and domain_has_privilege(self.domain, DEFAULT_EXPORT_SETTINGS):
             kwargs['initial'].update(self.export_settings.as_dict())
 
         super(EnterpriseSettingsForm, self).__init__(*args, **kwargs)
@@ -142,7 +143,7 @@ class EnterpriseSettingsForm(forms.Form):
             )
         )
 
-        if DEFAULT_EXPORT_SETTINGS.enabled(self.username):
+        if domain_has_privilege(self.domain, DEFAULT_EXPORT_SETTINGS):
             self.helper.layout.append(
                 crispy.Div(
                     crispy.Fieldset(
@@ -190,7 +191,7 @@ class EnterpriseSettingsForm(forms.Form):
         account.restrict_signup_message = self.cleaned_data.get('restrict_signup_message', '')
         account.save()
 
-        if self.export_settings and DEFAULT_EXPORT_SETTINGS.enabled(self.username):
+        if self.export_settings and domain_has_privilege(self.domain, DEFAULT_EXPORT_SETTINGS):
             # forms
             self.export_settings.forms_filetype = self.cleaned_data.get(
                 'forms_filetype',

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -44,7 +44,7 @@ from corehq.apps.domain.decorators import (
 )
 
 from corehq.apps.accounting.utils.subscription import get_account_or_404
-from corehq.apps.export.utils import get_default_export_settings_for_user
+from corehq.apps.export.utils import get_default_export_settings_if_available
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.const import USER_DATE_FORMAT
 
@@ -115,7 +115,7 @@ def enterprise_dashboard_email(request, domain, slug):
 @login_and_domain_required
 def enterprise_settings(request, domain):
     account = get_account_or_404(request, domain)
-    export_settings = get_default_export_settings_for_user(request.user.username, domain)
+    export_settings = get_default_export_settings_if_available(domain)
 
     if request.method == 'POST':
         form = EnterpriseSettingsForm(request.POST, domain=domain, account=account,
@@ -142,7 +142,7 @@ def enterprise_settings(request, domain):
 @require_POST
 def edit_enterprise_settings(request, domain):
     account = get_account_or_404(request, domain)
-    export_settings = get_default_export_settings_for_user(request.user.username, domain)
+    export_settings = get_default_export_settings_if_available(domain)
     form = EnterpriseSettingsForm(request.POST, username=request.user.username, domain=domain,
                                   account=account, export_settings=export_settings)
 

--- a/corehq/apps/export/tests/test_export_utils.py
+++ b/corehq/apps/export/tests/test_export_utils.py
@@ -4,19 +4,16 @@ from django.test import TestCase
 
 from corehq.apps.accounting.models import SoftwarePlanEdition, Subscription, DefaultProductPlan, BillingAccount, \
     SubscriptionAdjustment
-from corehq.apps.domain.models import Domain
-from corehq.apps.export.utils import get_default_export_settings_for_user
-from corehq.apps.users.models import WebUser
-from corehq.util.test_utils import flag_enabled
+from corehq.apps.export.utils import get_default_export_settings_if_available
+from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
+from corehq.apps.accounting.tests import generator
 
 
-class TestExportUtils(TestCase):
+class TestExportUtils(TestCase, DomainSubscriptionMixin):
 
     def setUp(self):
         super(TestExportUtils, self).setUp()
-        self.domain = Domain.get_or_create_with_name('test-export-utils', is_active=True)
-        self.user = WebUser.create(self.domain.name, "export-settings-user", "*******",
-                                   None, None, is_admin=True)
+        self.domain = generator.arbitrary_domain()
         self.account, _ = BillingAccount.get_or_create_account_by_domain(
             self.domain.name,
             created_by='webuser@test.com'
@@ -24,7 +21,7 @@ class TestExportUtils(TestCase):
         self.account.save()
         subscription = Subscription.new_domain_subscription(
             self.account, self.domain.name,
-            DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.ENTERPRISE),
+            DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.COMMUNITY),
             date_start=date.today() - timedelta(days=3)
         )
         subscription.is_active = True
@@ -42,75 +39,59 @@ class TestExportUtils(TestCase):
         if current_subscription.plan_version.plan.edition != plan:
             current_subscription.change_plan(DefaultProductPlan.get_default_plan_version(plan))
 
-    def test_default_export_settings_no_ff_enabled(self):
-        """
-        Default export settings are only available if the feature flag is enabled
-        NOTE: no decorator to enable DEFAULT_EXPORT_SETTINGS feature flag
-        """
-        self.update_subscription(SoftwarePlanEdition.ENTERPRISE)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
-        self.assertIsNone(settings)
-
-    @flag_enabled('DEFAULT_EXPORT_SETTINGS')
-    def test_default_export_settings_community_domain(self):
+    def test_default_export_settings_community_domain_returns_none(self):
         """
         Verify COMMUNITY software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.COMMUNITY)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
+        settings = get_default_export_settings_if_available(self.domain)
         self.assertIsNone(settings)
 
-    @flag_enabled('DEFAULT_EXPORT_SETTINGS')
-    def test_default_export_settings_standard_domain(self):
+    def test_default_export_settings_standard_domain_returns_none(self):
         """
         Verify STANDARD software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.STANDARD)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
+        settings = get_default_export_settings_if_available(self.domain)
         self.assertIsNone(settings)
 
-    @flag_enabled('DEFAULT_EXPORT_SETTINGS')
-    def test_default_export_settings_pro_domain(self):
+    def test_default_export_settings_pro_domain_returns_none(self):
         """
         Verify PRO software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.PRO)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
+        settings = get_default_export_settings_if_available(self.domain)
         self.assertIsNone(settings)
 
-    @flag_enabled('DEFAULT_EXPORT_SETTINGS')
-    def test_default_export_settings_advanced_domain(self):
+    def test_default_export_settings_advanced_domain_returns_none(self):
         """
         Verify ADVANCED software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.ADVANCED)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
+        settings = get_default_export_settings_if_available(self.domain)
         self.assertIsNone(settings)
 
-    @flag_enabled('DEFAULT_EXPORT_SETTINGS')
-    def test_default_export_settings_reseller_domain(self):
+    def test_default_export_settings_reseller_domain_returns_none(self):
         """
         Verify RESELLER software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.RESELLER)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
+        settings = get_default_export_settings_if_available(self.domain)
         self.assertIsNone(settings)
 
-    @flag_enabled('DEFAULT_EXPORT_SETTINGS')
-    def test_default_export_settings_managed_hosting_domain(self):
+    def test_default_export_settings_managed_hosting_domain_returns_none(self):
         """
         Verify MANAGED_HOSTING software plans do not have access to default export settings
         """
         self.update_subscription(SoftwarePlanEdition.MANAGED_HOSTING)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
+        settings = get_default_export_settings_if_available(self.domain)
         self.assertIsNone(settings)
 
-    @flag_enabled('DEFAULT_EXPORT_SETTINGS')
-    def test_default_export_settings_enterprise_domain(self):
+    def test_default_export_settings_enterprise_domain_returns_not_none(self):
         """
-        Verify software plan editions that do have access to default export settings
+        Verify software plan editions that have access to default export settings
         are able to create a DefaultExportSettings instance
         """
         self.update_subscription(SoftwarePlanEdition.ENTERPRISE)
-        settings = get_default_export_settings_for_user(self.user.username, self.domain)
+        settings = get_default_export_settings_if_available(self.domain)
         self.assertIsNotNone(settings)

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -2,10 +2,9 @@ from django.http import Http404
 
 from couchdbkit import ResourceNotFound
 
-from corehq import toggles
-from corehq.apps.accounting.models import Subscription, SoftwarePlanEdition
+from corehq.apps.accounting.models import Subscription
 from corehq.apps.accounting.utils import domain_has_privilege
-from corehq.privileges import DAILY_SAVED_EXPORT, EXCEL_DASHBOARD
+from corehq.privileges import DAILY_SAVED_EXPORT, DEFAULT_EXPORT_SETTINGS, EXCEL_DASHBOARD
 from corehq.toggles import MESSAGE_LOG_METADATA
 
 
@@ -54,19 +53,13 @@ def get_export(export_type, domain, export_id=None, username=None):
     raise Exception("Unexpected export type received %s" % export_type)
 
 
-def get_default_export_settings_for_user(username, domain):
+def get_default_export_settings_if_available(domain):
     """
-    Only creates settings if the the subscription level supports it
-    Currently only available to Enterprise accounts with the DEFAULT_EXPORT_SETTINGS FF enabled
+    Only creates settings if the domain has the DEFAULT_EXPORT_SETTINGS privilege
     """
-    if not toggles.DEFAULT_EXPORT_SETTINGS.enabled(username):
-        return None
-
     settings = None
     current_subscription = Subscription.get_active_subscription_by_domain(domain)
-    # currently only available for enterprise customers
-    supported_editions = [SoftwarePlanEdition.ENTERPRISE]
-    if current_subscription.plan_version.plan.edition in supported_editions:
+    if current_subscription and domain_has_privilege(domain, DEFAULT_EXPORT_SETTINGS):
         from corehq.apps.export.models import DefaultExportSettings
         settings = DefaultExportSettings.objects.get_or_create(account=current_subscription.account)[0]
 

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -41,7 +41,7 @@ from corehq.apps.export.models import (
     FormExportDataSchema,
     FormExportInstance,
 )
-from corehq.apps.export.utils import get_default_export_settings_for_user
+from corehq.apps.export.utils import get_default_export_settings_if_available
 from corehq.apps.export.views.utils import (
     DailySavedExportMixin,
     DashboardFeedMixin,
@@ -260,7 +260,7 @@ class CreateNewCustomFormExportView(BaseExportView):
         app_id = request.GET.get('app_id')
         xmlns = request.GET.get('export_tag').strip('"')
 
-        export_settings = get_default_export_settings_for_user(request.user.username, self.domain)
+        export_settings = get_default_export_settings_if_available(self.domain)
         schema = self.get_export_schema(self.domain, app_id, xmlns)
         self.export_instance = self.create_new_export_instance(schema, export_settings=export_settings)
 
@@ -285,7 +285,7 @@ class CreateNewCustomCaseExportView(BaseExportView):
     def get(self, request, *args, **kwargs):
         case_type = request.GET.get('export_tag').strip('"')
 
-        export_settings = get_default_export_settings_for_user(request.user.username, self.domain)
+        export_settings = get_default_export_settings_if_available(self.domain)
         schema = self.get_export_schema(self.domain, None, case_type)
         self.export_instance = self.create_new_export_instance(schema, export_settings=export_settings)
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1978,16 +1978,6 @@ APP_ANALYTICS = StaticToggle(
     help_link="https://confluence.dimagi.com/display/ccinternal/App+Analytics",
 )
 
-DEFAULT_EXPORT_SETTINGS = StaticToggle(
-    'default_export_settings',
-    'Allow enterprise admin to set default export settings',
-    TAG_PRODUCT,
-    namespaces=[NAMESPACE_USER],
-    description="""
-    Allows an enterprise admin to set default export settings for all domains under the enterprise account.
-    """
-)
-
 ENTERPRISE_SSO = StaticToggle(
     'enterprise_sso',
     'Enable Enterprise SSO options for the users specified in this list.',


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11474)

Making the default export settings feature generally available to enterprise customers.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Removes DEFAULT_EXPORT_SETTINGS
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Unit tests check that only enterprise software plans have access to this feature (not from a UI perspective though).
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
[QA Smoke Test](https://dimagi-dev.atlassian.net/browse/QA-2728)
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
A separate PR handles the migration for the new DEFAULT_EXPORT_SETTINGS privilege [here](https://github.com/dimagi/commcare-hq/pull/29339), so this is safe to revert.
- [x] This PR can be reverted after deploy with no further considerations 
