### PR TITLE
Make the case API available to flagged domains

### DIFF
--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -16,13 +16,14 @@ from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
     use_sql_backend,
 )
-from corehq.util.test_utils import privilege_enabled
+from corehq.util.test_utils import privilege_enabled, flag_enabled
 
 from ..utils import submit_case_blocks
 
 
 @use_sql_backend
 @privilege_enabled(privileges.API_ACCESS)
+@flag_enabled('CASE_API_V0_6')
 class TestCaseAPI(TestCase):
     domain = 'test-update-cases'
     maxDiff = None
@@ -32,7 +33,7 @@ class TestCaseAPI(TestCase):
         super().setUpClass()
         cls.domain_obj = create_domain(cls.domain)
         cls.web_user = WebUser.create(cls.domain, 'netflix', 'password', None, None)
-        cls.web_user.is_superuser = True  # in pre-release, this is superuser-only
+        cls.web_user.is_superuser = True
         cls.web_user.save()
         cls.case_accessor = CaseAccessors(cls.domain)
         cls.form_accessor = FormAccessors(cls.domain)

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -7,7 +7,7 @@ from casexml.apps.case.mock import CaseBlock
 
 from corehq import privileges
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.users.models import WebUser
+from corehq.apps.users.models import Permissions, UserRole, WebUser
 from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
     FormAccessors,
@@ -16,7 +16,7 @@ from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
     use_sql_backend,
 )
-from corehq.util.test_utils import privilege_enabled, flag_enabled
+from corehq.util.test_utils import flag_enabled, privilege_enabled
 
 from ..utils import submit_case_blocks
 
@@ -32,9 +32,10 @@ class TestCaseAPI(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.domain_obj = create_domain(cls.domain)
-        cls.web_user = WebUser.create(cls.domain, 'netflix', 'password', None, None)
-        cls.web_user.is_superuser = True
-        cls.web_user.save()
+        role = UserRole.get_or_create_with_permissions(
+            cls.domain, Permissions(edit_data=True), 'edit-data'
+        )
+        cls.web_user = WebUser.create(cls.domain, 'netflix', 'password', None, None, role_id=role.get_id)
         cls.case_accessor = CaseAccessors(cls.domain)
         cls.form_accessor = FormAccessors(cls.domain)
 
@@ -47,6 +48,7 @@ class TestCaseAPI(TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        cls.web_user.delete(deleted_by=None)
         cls.domain_obj.delete()
         super().tearDownClass()
 

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -11,6 +11,7 @@ from soil import DownloadBase
 
 from corehq import privileges
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
+from corehq.apps.case_importer.views import require_can_edit_data
 from corehq.apps.domain.decorators import (
     api_auth,
     require_superuser_or_contractor,
@@ -21,6 +22,7 @@ from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.utils import should_use_sql_backend
 from corehq.pillows.case_search import domain_needs_search_index
+from corehq.toggles import CASE_API_V0_6
 
 from .api.core import SubmissionError, UserError, serialize_case
 from .api.get_list import get_list
@@ -77,11 +79,11 @@ class ExplodeCasesView(BaseProjectSettingsView, TemplateView):
         return redirect('hq_soil_download', self.domain, download.download_id)
 
 
-# TODO switch to @require_can_edit_data
 @waf_allow('XSS_BODY')
 @csrf_exempt
 @api_auth
-@require_superuser_or_contractor
+@require_can_edit_data
+@CASE_API_V0_6.required_decorator()
 @requires_privilege_with_fallback(privileges.API_ACCESS)
 def case_api(request, domain, case_id=None):
     if request.method == 'GET' and case_id:

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -842,6 +842,13 @@ ECD_PREVIEW_ENTERPRISE_DOMAINS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
+CASE_API_V0_6 = StaticToggle(
+    'case_api_v0_6',
+    'Enable the v0.6 Case API',
+    TAG_SOLUTIONS_LIMITED,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
 LIVEQUERY_SYNC = StaticToggle(
     'livequery_sync',
     'Enable livequery sync algorithm',


### PR DESCRIPTION


## Summary
This will allow us to test auth using regular users
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
This adds a CASE_API_V0_6 feature flag, though the feature is still in pre-release and should only be used by the tech team.

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

This is covered by tests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Affects only an unreleased feature

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
