### PR TITLE
Revert "use user's timezone if it's set"

### DIFF
--- a/corehq/util/timezones/tests/test_utils.py
+++ b/corehq/util/timezones/tests/test_utils.py
@@ -28,7 +28,9 @@ class GetTimezoneForUserTest(SimpleTestCase):
         domain_membership_mock.return_value = domain_membership
 
         # if not override_global_tz
-        self.assertEqual(get_timezone_for_user(couch_user, "test"), DOMAIN_TIMEZONE)
+        self.assertEqual(get_timezone_for_user(couch_user, "test"), domain_membership_timezone)
+        with override_settings(SERVER_ENVIRONMENT='icds'):
+            self.assertEqual(get_timezone_for_user(couch_user, "test"), DOMAIN_TIMEZONE)
 
         # if override_global_tz
         domain_membership.override_global_tz = True

--- a/corehq/util/timezones/utils.py
+++ b/corehq/util/timezones/utils.py
@@ -64,8 +64,12 @@ def get_timezone_for_user(couch_user_or_id, domain):
 
         if requesting_user:
             domain_membership = requesting_user.get_domain_membership(domain)
-            if domain_membership and domain_membership.override_global_tz:
-                return coerce_timezone_value(domain_membership.timezone)
+            if domain_membership:
+                if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
+                    if domain_membership.override_global_tz:
+                        return coerce_timezone_value(domain_membership.timezone)
+                else:
+                    return coerce_timezone_value(domain_membership.timezone)
 
     return get_timezone_for_domain(domain)
 


### PR DESCRIPTION
Reverts dimagi/commcare-hq#29370 which has not yet been deployed.