### PR TITLE
Conditional alert warning modal

### DIFF
--- a/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_main.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_main.js
@@ -33,6 +33,20 @@ hqDefine("scheduling/js/conditional_alert_main", [
         var basicInformation = basicInformationTab(name);
         // setup tab
         basicInformation.setRuleTabVisibility();
+
         $("#conditional-alert-basic-info-panel").koApplyBindings(basicInformation);
+
+        $("#conditional-alert-form-save").click(function () {
+            var $form = $("#conditional-alert-form"),
+                $modal = $("#conditional-alert-warning-modal");
+            if ($modal.length) {
+                $modal.find(".btn-primary").off("click").on("click", function () {
+                    $form.submit();
+                });
+                $modal.modal('show');
+                return;
+            }
+            $form.submit();
+        });
     });
 });

--- a/corehq/messaging/scheduling/templates/scheduling/partials/conditional_alert_save.html
+++ b/corehq/messaging/scheduling/templates/scheduling/partials/conditional_alert_save.html
@@ -1,7 +1,32 @@
 {% load i18n %}
+{% load hq_shared_tags %}
+{% load humanize %}
+
 <div class="form-actions">
   <div class="col-xs-12 col-sm-8 col-md-8 col-lg-6 col-sm-offset-4 col-md-offset-4 col-lg-offset-2 controls">
-    <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
-    <a href="{% url 'conditional_alert_list' domain %}" class="btn btn-default">Cancel</a>
+    <button type="button" class="btn btn-primary" id="conditional-alert-form-save">{% trans "Save" %}</button>
+    <a href="{% url 'conditional_alert_list' domain %}" class="btn btn-default">{% trans "Cancel" %}</a>
   </div>
 </div>
+
+{% if case_count %}
+  <div class="modal fade" id="conditional-alert-warning-modal" role="dialog">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal">&times;</button>
+            <h4 class="modal-title">{% trans "Warning" %}</h4>
+          </div>
+          <div class="modal-body">
+            {% blocktrans with case_count=case_count|intcomma %}
+              This update may alert {{ case_count }} cases. Are you sure you want to proceed?
+            {% endblocktrans %}
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary">{% trans "Yes" %}</button>
+            <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "No" %}</button>
+          </div>
+        </div>
+      </div>
+  </div>
+{% endif %}

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -56,6 +56,8 @@ from corehq.messaging.scheduling.view_helpers import (
     UntranslatedConditionalAlertUploader,
     upload_conditional_alert_workbook,
 )
+
+from corehq.apps.es.cases import CaseES
 from corehq.const import SERVER_DATETIME_FORMAT
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_user
@@ -776,8 +778,12 @@ class CreateConditionalAlertView(BaseMessagingSectionView, AsyncHandlerMixin):
     @property
     def page_context(self):
         context = super().page_context
+        case_count = 0
+        if self.rule and self.rule.case_type:
+            case_count = CaseES().domain(self.domain).case_type(self.rule.case_type).count()
         context.update({
             'basic_info_form': self.basic_info_form,
+            'case_count': case_count,
             'criteria_form': self.criteria_form,
             'help_text': self.help_text,
             'schedule_form': self.schedule_form,

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -778,7 +778,7 @@ class CreateConditionalAlertView(BaseMessagingSectionView, AsyncHandlerMixin):
     @property
     def page_context(self):
         context = super().page_context
-        case_count = 0
+        case_count = None
         if self.rule and self.rule.case_type:
             case_count = CaseES().domain(self.domain).case_type(self.rule.case_type).count()
         context.update({


### PR DESCRIPTION
## Summary
Wrapping up https://github.com/dimagi/commcare-hq/pull/29020/

@mkangia I just added one commit, but it's good-sized. It might be easier to review the whole PR as one.

## Product Description
Adds a popup when editing a conditional alert to signal that you're going to alert cases, possibly a lot of cases:
![Screen Shot 2021-03-18 at 1 52 33 PM](https://user-images.githubusercontent.com/1486591/111673328-3d491580-87f1-11eb-9466-168e91163f5c.png)


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

QA was kicked off for https://github.com/dimagi/commcare-hq/pull/29020/, ticket is [here](https://dimagi-dev.atlassian.net/browse/QA-2630).

### Safety story
Pretty limited, low-risk UI change. This was previously a more involved change that changed the logic of when rules trigger, but now it just always shows the popup.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
