### PR TITLE
sanitized mark_safe references in smaller applications

### DIFF
--- a/corehq/ex-submodules/phonelog/reports.py
+++ b/corehq/ex-submodules/phonelog/reports.py
@@ -25,7 +25,7 @@ from corehq.apps.reports.datatables import (
 )
 from corehq.util.timezones.conversions import ServerTime
 from memoized import memoized
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy
 from .models import DeviceReportEntry
 from .utils import device_users_by_xform
@@ -153,20 +153,18 @@ class BaseDeviceLogReport(GetParamsMixin, DatespanMixin, PaginatedReportMixin):
     def rendered_report_title(self):
         new_title = self.name
         if self.errors_only:
-            new_title = (
-                "Errors &amp; Warnings Log <small>for %s</small>" % (
-                    ", ".join(self.device_log_users)
-                )
-                if self.device_log_users
-                else "Errors &amp; Warnings Log"
-            )
+            new_title = format_html(
+                "Errors &amp; Warnings Log <small>for {}</small>",
+                ", ".join(self.device_log_users)
+            ) if self.device_log_users else "Errors & Warnings Log"
         elif self.goto_key:
             log = self.goto_log
-            new_title = "Last %s Logs <small>before %s</small>" % (
+            new_title = format_html(
+                "Last {} Logs <small>before {}</small>",
                 self.limit,
                 ServerTime(log.date).user_time(self.timezone).ui_string()
             )
-        return mark_safe(new_title)
+        return new_title
 
     @property
     def rows(self):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -10,6 +10,7 @@ from django.contrib import messages
 from django.http import Http404
 from django.urls import reverse
 from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 
 from attr import attrib, attrs
 from couchdbkit import ResourceNotFound
@@ -87,7 +88,7 @@ TAG_SOLUTIONS_CONDITIONAL = Tag(
 TAG_SOLUTIONS_LIMITED = Tag(
     name='Solutions - Limited Use',
     css_class='info',
-    description=mark_safe(
+    description=mark_safe(  # nosec: no user input
         'These features are only available for our services projects. This '
         'may affect support and pricing when the project is transitioned to a '
         'subscription. Limited Use Solutions Feature Flags cannot be enabled '
@@ -213,10 +214,11 @@ class StaticToggle(object):
                     toggle_url = reverse(ToggleEditView.urlname, args=[self.slug])
                     messages.warning(
                         request,
-                        mark_safe((
+                        format_html(
                             'This <a href="{}">feature flag</a> should be enabled '
-                            'to access this URL'
-                        ).format(toggle_url)),
+                            'to access this URL',
+                            toggle_url
+                        ),
                         fail_silently=True,  # workaround for tests: https://code.djangoproject.com/ticket/17971
                     )
                 raise Http404()

--- a/corehq/util/markup.py
+++ b/corehq/util/markup.py
@@ -12,27 +12,29 @@ url_re = re.compile(
 )
 
 
+def _wrap_url(url):
+    return format_html('<a href="{url}">{url}</a>', url=url)
+
+
+def _get_url_segments(text):
+    for chunk in url_re.split(text):
+        # The match pattern contains multiple capture groups;
+        # Because only one will be populated, we need to ignore the Nones
+        if not chunk:
+            continue
+        elif url_re.match(chunk):
+            yield _wrap_url(chunk)
+        else:
+            yield escape(chunk)
+
+
 def mark_up_urls(text):
     """
-    >>> mark_up_urls("Please see http://google.com for more info.")
-    u'Please see <a href="http://google.com">http://google.com</a> for more info.'
-    >>> mark_up_urls("http://commcarehq.org redirects to https://commcarehq.org.")
-    u'<a href="http://commcarehq.org">http://commcarehq.org</a> redirects to <a href="https://commcarehq.org">https://commcarehq.org</a>.'
-
+    Add HTML markup to any links within the text.
+    I.e. 'Go to http://www.google.com'
+    becomes 'Go to <a href="http://www.google.com">http://www.google.com</a>'.
     """
-    def wrap_url(url):
-        return format_html('<a href="{url}">{url}</a>', url=url)
-
-    def parts():
-        for chunk in url_re.split(text):
-            if not chunk:
-                continue
-            elif url_re.match(chunk):
-                yield wrap_url(chunk)
-            else:
-                yield escape(chunk)
-
-    return mark_safe(''.join(parts()))
+    return mark_safe(''.join(_get_url_segments(text)))  # nosec: all segments are sanitized
 
 
 def _shell_color_template(color_code):

--- a/corehq/util/tests/test_markup.py
+++ b/corehq/util/tests/test_markup.py
@@ -1,5 +1,31 @@
+from django.test import SimpleTestCase
+from django.utils.safestring import SafeString
 from corehq.util.markup import mark_up_urls
 
 __test__ = {
     'mark_up_urls': mark_up_urls
 }
+
+
+class TestMarkUpURLs(SimpleTestCase):
+    def test_handles_empty_string(self):
+        result = mark_up_urls('')
+        self.assertEqual(result, '')
+
+    def test_string_without_urls_returns_string(self):
+        result = mark_up_urls('This has no urls')
+        self.assertEqual(result, 'This has no urls')
+
+    def test_creates_markup(self):
+        result = mark_up_urls('Please see http://google.com for more info.')
+        self.assertEqual(result, 'Please see <a href="http://google.com">http://google.com</a> for more info.')
+
+    def test_marksup_multiple_urls(self):
+        result = mark_up_urls("http://commcarehq.org redirects to https://commcarehq.org.")
+        self.assertEqual(result,
+            '<a href="http://commcarehq.org">http://commcarehq.org</a>'
+            ' redirects to <a href="https://commcarehq.org">https://commcarehq.org</a>.')
+
+    def test_output_with_urls_is_safe(self):
+        result = mark_up_urls('this points to http://google.com')
+        self.assertIsInstance(result, SafeString)

--- a/custom/_legacy/pact/reports/chw.py
+++ b/custom/_legacy/pact/reports/chw.py
@@ -4,7 +4,7 @@ from corehq.apps.api.es import ReportCaseESView, ReportFormESView
 from corehq.apps.es import filters
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
 from corehq.apps.users.models import CommCareUser
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from memoized import memoized
 from pact.enums import PACT_CASE_TYPE, PACT_DOMAIN
 from . import chw_schedule
@@ -144,8 +144,10 @@ class PactCHWProfileReport(PactDrilldownReportMixin, PactElasticTabularReportMix
         """
         if self.get_user() is not None:
             def _format_row(row_field_dict):
-                yield mark_safe("<a class='ajax_dialog' href='%s'>View</a>" % (
-                reverse('render_form_data', args=[self.domain, row_field_dict['_id']])))
+                yield format_html(
+                    "<a class='ajax_dialog' href='{}'>View</a>",
+                    reverse('render_form_data', args=[self.domain, row_field_dict['_id']])
+                )
                 yield row_field_dict['script_pact_id']
                 yield self.format_date(row_field_dict["received_on"].replace('_', ' ').title())
                 yield self.format_date(row_field_dict['script_encounter_date'])

--- a/custom/_legacy/pact/reports/chw_list.py
+++ b/custom/_legacy/pact/reports/chw_list.py
@@ -2,7 +2,7 @@ from django.urls import NoReverseMatch
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
 from corehq.apps.reports.generic import GenericTabularReport
 from corehq.apps.reports.standard import CustomProjectReport, ProjectReportParametersMixin
-from django.utils import html
+from django.utils.html import format_html
 from corehq.apps.reports.util import make_form_couch_key
 from corehq.util.dates import iso_string_to_datetime
 
@@ -29,10 +29,11 @@ class PactCHWDashboard(GenericTabularReport, ProjectReportParametersMixin, Custo
 
     def _chw_profile_link(self, user_id):
         try:
-            return html.mark_safe("<a class='ajax_dialog' href='%s'>%s</a>" % (
-                html.escape(PactCHWProfileReport.get_url(*[self.domain]) + "?chw_id=%s" % user_id),
+            return format_html(
+                "<a class='ajax_dialog' href='{}'>{}</a>",
+                PactCHWProfileReport.get_url(self.domain) + "?chw_id=%s" % user_id,
                 "View Profile",
-                ))
+            )
         except NoReverseMatch:
             return "Unknown User ID"
 

--- a/custom/_legacy/pact/reports/patient.py
+++ b/custom/_legacy/pact/reports/patient.py
@@ -2,7 +2,7 @@ import logging
 from django.urls import reverse
 from django.http import Http404
 import json
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from corehq.apps.api.es import ReportFormESView
 from corehq.apps.hqwebapp.decorators import use_timeago
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
@@ -140,11 +140,13 @@ class PactPatientInfoReport(PactDrilldownReportMixin, PactElasticTabularReportMi
     def rows(self):
         if self.patient_id:
             def _format_row(row_field_dict):
-                yield mark_safe("<a class='ajax_dialog' href='%s'>View</a>" % (
-                reverse('render_form_data', args=[self.domain, row_field_dict['_id']])))
+                yield format_html(
+                    "<a class='ajax_dialog' href='{}'>View</a>",
+                    reverse('render_form_data', args=[self.domain, row_field_dict['_id']])
+                )
                 yield self.format_date(row_field_dict["received_on"].replace('_', ' '))
                 yield self.format_date(row_field_dict.get("form.meta.timeStart", ""))
-                if row_field_dict["script_encounter_date"] != None:
+                if row_field_dict["script_encounter_date"] is not None:
                     yield row_field_dict["script_encounter_date"]
                 else:
                     yield "---"

--- a/custom/_legacy/pact/reports/patient_list.py
+++ b/custom/_legacy/pact/reports/patient_list.py
@@ -1,5 +1,5 @@
 from django.urls import NoReverseMatch
-from django.utils import html
+from django.utils.html import format_html
 
 from corehq.apps.api.es import ReportCaseESView, ReportFormESView
 from corehq.apps.es import filters
@@ -195,11 +195,11 @@ class PatientListDashboardReport(PactElasticTabularReportMixin):
 
     def pact_case_link(self, case_id, name):
         try:
-            return html.mark_safe("<a class='ajax_dialog' href='%s'>%s</a>" % (
-                html.escape(
-                    PactPatientInfoReport.get_url(*[self.domain]) + "?patient_id=%s" % case_id),
-                html.escape(name),
-                ))
+            return format_html(
+                "<a class='ajax_dialog' href='{}'>{}</a>",
+                PactPatientInfoReport.get_url(self.domain) + "?patient_id=%s" % case_id,
+                name
+            )
         except NoReverseMatch:
             return "%s (bad ID format)" % name
 
@@ -219,10 +219,10 @@ class PatientListDashboardReport(PactElasticTabularReportMixin):
             return ''
 
         try:
-            return html.mark_safe("<span class='label label-info'>%s</span> <a class='ajax_dialog' href='%s'>Report</a>" % (
-                html.escape(status),
-                html.escape(
-                    PactDOTReport.get_url(*[self.domain]) + "?dot_patient=%s" % case_id),
-                ))
+            return format_html(
+                "<span class='label label-info'>{}</span> <a class='ajax_dialog' href='{}'>Report</a>",
+                status,
+                PactDOTReport.get_url(self.domain) + "?dot_patient=%s" % case_id
+            )
         except NoReverseMatch:
             return "%s (bad ID format)" % status

--- a/custom/icds_core/view_utils.py
+++ b/custom/icds_core/view_utils.py
@@ -9,7 +9,7 @@ from custom.icds_core.const import ICDS_DOMAIN, IS_ICDS_ENVIRONMENT
 from corehq.apps.users.models import DomainMembershipError
 from django.http import HttpResponse
 
-DATA_INTERFACE_ACCESS_DENIED = mark_safe(ugettext_lazy(
+DATA_INTERFACE_ACCESS_DENIED = mark_safe(ugettext_lazy(  # nosec: no user input
     "This project has blocked access to interfaces that edit data for forms and cases"
 ))
 


### PR DESCRIPTION
## Summary
Several small sanitization changes for `mark_safe` as part of [SAAS-11853](https://dimagi-dev.atlassian.net/browse/SAAS-11853)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Tests introduced for `mark_up_urls` to handle refactoring.

### QA Plan

No QA required

### Safety story

Many of the changes were verified locally. The smaller legacy changes, replacing `mark_safe` with `format_html`, were only verified by eye.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
