### PR TITLE
Revert 29375 revert 29370 sk/timezone override

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -228,7 +228,7 @@ def get_tables_as_columns(*args, **kwargs):
     return sections
 
 
-def get_default_definition(keys, num_columns=1, name=None, assume_phonetimes=True):
+def get_default_definition(keys, num_columns=1, name=None, assume_phonetimes=True, parse_dates=False):
     """
     Get a default single table layout definition for `keys` split across
     `num_columns` columns.
@@ -242,7 +242,7 @@ def get_default_definition(keys, num_columns=1, name=None, assume_phonetimes=Tru
     # but doesn't hurt either, and is easier than trying to detect.
     # I believe no caller uses this on non-phone-time datetimes
     # but if something does, we'll have to do this in a more targetted way
-    layout = chunked([{"expr": prop, "is_phone_time": assume_phonetimes, "has_history": True}
+    layout = chunked([{"expr": prop, "is_phone_time": assume_phonetimes, "has_history": True, "parse_date": parse_dates}
                       for prop in keys], num_columns)
 
     return [

--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -140,11 +140,7 @@ def get_display_data(data, prop_def, processors=None, timezone=pytz.utc):
 
     if prop_def.pop('parse_date', None):
         val = _parse_date_or_datetime(val)
-    # is_utc is deprecated in favor of is_phone_time
-    # but preserving here for backwards compatibility
-    # is_utc = False is just reinterpreted as is_phone_time = True
-    is_phone_time = prop_def.pop('is_phone_time',
-                                 not prop_def.pop('is_utc', True))
+    is_phone_time = prop_def.pop('is_phone_time', False)
     if isinstance(val, datetime.datetime):
         if not is_phone_time:
             val = ServerTime(val).user_time(timezone).done()

--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -43,12 +43,12 @@ def _parse_date_or_datetime(val):
             return None
 
         # datetime is a subclass of date
-        if isinstance(val, datetime.date):
+        if isinstance(val, datetime.date) or not isinstance(val, str):
             return val
 
         try:
             dt = iso_string_to_datetime(val)
-        except BadValueError:
+        except ValueError:
             try:
                 return DateProperty().wrap(val)
             except BadValueError:

--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -224,7 +224,7 @@ def get_tables_as_columns(*args, **kwargs):
     return sections
 
 
-def get_default_definition(keys, num_columns=1, name=None, assume_phonetimes=True, parse_dates=False):
+def get_default_definition(keys, num_columns=1, name=None, phonetime_fields=None, parse_dates=False):
     """
     Get a default single table layout definition for `keys` split across
     `num_columns` columns.
@@ -233,17 +233,18 @@ def get_default_definition(keys, num_columns=1, name=None, assume_phonetimes=Tru
     (See corehq.util.timezones.conversions.PhoneTime for more context.)
 
     """
-
-    # is_phone_time isn't necessary on non-datetime columns,
-    # but doesn't hurt either, and is easier than trying to detect.
-    # I believe no caller uses this on non-phone-time datetimes
-    # but if something does, we'll have to do this in a more targetted way
-    layout = chunked([{"expr": prop, "is_phone_time": assume_phonetimes, "has_history": True, "parse_date": parse_dates}
-                      for prop in keys], num_columns)
+    phonetime_fields = phonetime_fields or set()
+    layout = chunked(
+        [
+            {"expr": prop, "is_phone_time": prop in phonetime_fields, "has_history": True, "parse_date": parse_dates}
+            for prop in keys
+        ],
+        num_columns
+    )
 
     return [
         {
             "name": name,
-            "layout": layout
+            "layout": list(layout)
         }
     ]

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -25,12 +25,12 @@ from corehq.apps.reports.standard.cases.utils import (
     query_location_restricted_cases,
 )
 from corehq.apps.reports.standard.inspect import ProjectInspectionReport
-from corehq.const import SERVER_DATETIME_FORMAT
+from corehq.const import USER_DATETIME_FORMAT_WITH_SEC
 from corehq.elastic import ESError
 from corehq.toggles import CASE_LIST_EXPLORER
 from corehq.util.timezones.conversions import PhoneTime
 
-from .data_sources import CaseDisplay, CaseInfo
+from .data_sources import CaseDisplay
 
 
 class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin):
@@ -271,6 +271,6 @@ class CaseListReport(CaseListMixin, ProjectInspectionReport, ReportDataSource):
     def date_to_json(self, date):
         if date:
             return (PhoneTime(date, self.timezone).user_time(self.timezone)
-                    .ui_string(SERVER_DATETIME_FORMAT))
+                    .ui_string(USER_DATETIME_FORMAT_WITH_SEC))
         else:
             return ''

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -74,15 +74,15 @@ class CaseInfo(object):
 
     @property
     def opened_on(self):
-        return self._dateprop('opened_on')
+        return self.case['opened_on']
 
     @property
     def modified_on(self):
-        return self._dateprop('modified_on')
+        return self.case['modified_on']
 
     @property
     def closed_on(self):
-        return self._dateprop('closed_on')
+        return self.case['closed_on']
 
     @property
     def creating_user(self):
@@ -196,6 +196,10 @@ class CaseDisplay(CaseInfo):
     def modified_on(self):
         return self._dateprop('modified_on', False)
     last_modified = modified_on
+
+    @property
+    def closed_on(self):
+        return self._dateprop('closed_on', False)
 
     @property
     def server_last_modified_date(self):

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -26,6 +26,8 @@ from corehq.util.view_utils import absolute_reverse
 
 
 class CaseInfo(object):
+    """This class wraps a raw case from ES to provide simpler access
+    to certain properties."""
 
     def __init__(self, report, case):
         """
@@ -65,12 +67,6 @@ class CaseInfo(object):
     @property
     def is_closed(self):
         return self.case['closed']
-
-    def _dateprop(self, prop, iso=True):
-        val = self.report.date_to_json(self.parse_date(self.case[prop]))
-        if iso:
-            val = 'T'.join(val.split(' ')) if val else None
-        return val
 
     @property
     def opened_on(self):
@@ -172,6 +168,9 @@ class CaseInfo(object):
 
 
 class CaseDisplay(CaseInfo):
+    """This class wraps a raw case from ES to provide simpler access
+    to certain properties as well as formatting for properties for use in
+    the UI"""
 
     @property
     def closed_display(self):
@@ -187,23 +186,26 @@ class CaseDisplay(CaseInfo):
         else:
             return "%s (bad ID format)" % self.case_name
 
+    def _dateprop(self, prop):
+        return self.report.date_to_json(self.parse_date(self.case[prop]))
+
     @property
     def opened_on(self):
-        return self._dateprop('opened_on', False)
+        return self._dateprop('opened_on')
     date_opened = opened_on
 
     @property
     def modified_on(self):
-        return self._dateprop('modified_on', False)
+        return self._dateprop('modified_on')
     last_modified = modified_on
 
     @property
     def closed_on(self):
-        return self._dateprop('closed_on', False)
+        return self._dateprop('closed_on')
 
     @property
     def server_last_modified_date(self):
-        return self._dateprop('server_modified_on', False)
+        return self._dateprop('server_modified_on')
 
     @property
     def owner_display(self):

--- a/corehq/apps/reports/v2/formatters/cases.py
+++ b/corehq/apps/reports/v2/formatters/cases.py
@@ -41,12 +41,12 @@ class CaseDataFormatter(BaseDataFormatter):
     @property
     def date_opened(self):
         """Special Case Property date_opened"""
-        return self._fmt_dateprop('opened_on', False)
+        return self._fmt_dateprop('opened_on')
 
     @property
     def last_modified(self):
         """Special Case Property last_modified"""
-        return self._fmt_dateprop('modified_on', False)
+        return self._fmt_dateprop('modified_on')
 
     @property
     def closed_by_username(self):
@@ -90,7 +90,7 @@ class CaseDataFormatter(BaseDataFormatter):
     @property
     def server_last_modified_date(self):
         """Computed metadata"""
-        return self._fmt_dateprop('server_modified_on', False)
+        return self._fmt_dateprop('server_modified_on')
 
     def get_context(self):
         context = {}
@@ -128,15 +128,12 @@ class CaseDataFormatter(BaseDataFormatter):
         return (SPECIAL_CASE_PROPERTIES_MAP[prop]
             .value_getter(self.raw_data))
 
-    def _fmt_dateprop(self, prop, iso=True):
+    def _fmt_dateprop(self, prop):
         val = report_date_to_json(
             self.request,
             self.domain,
             parse_date(self.raw_data[prop])
         )
-        if iso:
-            val = 'T'.join(val.split(' ')) if val else None
-        return val
 
     @property
     @quickcache(['self.owner_id'])

--- a/corehq/apps/reports/v2/formatters/cases.py
+++ b/corehq/apps/reports/v2/formatters/cases.py
@@ -90,7 +90,7 @@ class CaseDataFormatter(BaseDataFormatter):
     @property
     def server_last_modified_date(self):
         """Computed metadata"""
-        return self._fmt_dateprop('server_modified_on')
+        return self._fmt_dateprop('server_modified_on', False)
 
     def get_context(self):
         context = {}
@@ -128,11 +128,12 @@ class CaseDataFormatter(BaseDataFormatter):
         return (SPECIAL_CASE_PROPERTIES_MAP[prop]
             .value_getter(self.raw_data))
 
-    def _fmt_dateprop(self, prop):
-        val = report_date_to_json(
+    def _fmt_dateprop(self, prop, is_phonetime=True):
+        return report_date_to_json(
             self.request,
             self.domain,
-            parse_date(self.raw_data[prop])
+            parse_date(self.raw_data[prop]),
+            is_phonetime=is_phonetime
         )
 
     @property

--- a/corehq/apps/reports/v2/utils.py
+++ b/corehq/apps/reports/v2/utils.py
@@ -1,12 +1,15 @@
 from corehq.const import SERVER_DATETIME_FORMAT
-from corehq.util.timezones.conversions import PhoneTime
+from corehq.util.timezones.conversions import PhoneTime, ServerTime
 from corehq.util.timezones.utils import get_timezone
 
 
-def report_date_to_json(request, domain, date):
+def report_date_to_json(request, domain, date, is_phonetime=True):
     timezone = get_timezone(request, domain)
     if date:
-        return (PhoneTime(date, timezone).user_time(timezone)
-                .ui_string(SERVER_DATETIME_FORMAT))
+        if is_phonetime:
+            user_time = PhoneTime(date, timezone).user_time(timezone)
+        else:
+            user_time = ServerTime(date).user_time(timezone)
+        user_time.ui_string(SERVER_DATETIME_FORMAT)
     else:
         return ''

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1529,6 +1529,9 @@ def _get_form_metadata_context(domain, form, timezone, support_enabled=False):
 
     from corehq.apps.hqwebapp.templatetags.proptable_tags import get_default_definition, get_tables_as_columns
     definition = get_default_definition(_sorted_form_metadata_keys(list(meta)), parse_dates=True)
+    definition['received_on']['is_phone_time'] = False
+    definition['server_modified_on']['is_phone_time'] = False
+    definition['last_sync_token']['is_phone_time'] = False
     form_meta_data = get_tables_as_columns(meta, definition, timezone=timezone)
     if getattr(form, 'auth_context', None):
         auth_context = AuthContext(form.auth_context)

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1528,7 +1528,7 @@ def _get_form_metadata_context(domain, form, timezone, support_enabled=False):
         meta['last_sync_token'] = form.last_sync_token
 
     from corehq.apps.hqwebapp.templatetags.proptable_tags import get_default_definition, get_tables_as_columns
-    definition = get_default_definition(_sorted_form_metadata_keys(list(meta)))
+    definition = get_default_definition(_sorted_form_metadata_keys(list(meta)), parse_dates=True)
     form_meta_data = get_tables_as_columns(meta, definition, timezone=timezone)
     if getattr(form, 'auth_context', None):
         auth_context = AuthContext(form.auth_context)

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1573,6 +1573,7 @@ def _top_level_tags(form):
         Returns a OrderedDict of the top level tags found in the xml, in the
         order they are found.
 
+        The actual values are taken from the form JSON data and not from the XML
         """
         to_return = OrderedDict()
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1019,6 +1019,7 @@ class CaseDataView(BaseProjectReportSectionView):
         from corehq.apps.hqwebapp.templatetags.proptable_tags import get_tables_as_rows, get_default_definition
         wrapped_case = get_wrapped_case(self.case_instance)
         timezone = get_timezone_for_user(self.request.couch_user, self.domain)
+        # Get correct timezone for the current date: https://github.com/dimagi/commcare-hq/pull/5324
         timezone = timezone.localize(datetime.utcnow()).tzinfo
         _get_tables_as_rows = partial(get_tables_as_rows, timezone=timezone)
         display = self.request.project.get_case_display(self.case_instance) or wrapped_case.get_display_config()

--- a/corehq/util/timezones/conversions.py
+++ b/corehq/util/timezones/conversions.py
@@ -62,6 +62,11 @@ class UserTime(_HQTZTime):
 
 
 class PhoneTime(_HQTZTime):
+    """Utility for dealing with datetime fields that were originally in the phone TZ
+    such as form.meta.timeEnd.
+
+    This utility transparently handles the timezone migration for legacy couch domains.
+    """
 
     def server_time(self):
         return ServerTime(_adjust_phone_datetime_to_utc(

--- a/corehq/util/timezones/tests/test_utils.py
+++ b/corehq/util/timezones/tests/test_utils.py
@@ -28,9 +28,7 @@ class GetTimezoneForUserTest(SimpleTestCase):
         domain_membership_mock.return_value = domain_membership
 
         # if not override_global_tz
-        self.assertEqual(get_timezone_for_user(couch_user, "test"), domain_membership_timezone)
-        with override_settings(SERVER_ENVIRONMENT='icds'):
-            self.assertEqual(get_timezone_for_user(couch_user, "test"), DOMAIN_TIMEZONE)
+        self.assertEqual(get_timezone_for_user(couch_user, "test"), DOMAIN_TIMEZONE)
 
         # if override_global_tz
         domain_membership.override_global_tz = True

--- a/corehq/util/timezones/utils.py
+++ b/corehq/util/timezones/utils.py
@@ -64,12 +64,8 @@ def get_timezone_for_user(couch_user_or_id, domain):
 
         if requesting_user:
             domain_membership = requesting_user.get_domain_membership(domain)
-            if domain_membership:
-                if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
-                    if domain_membership.override_global_tz:
-                        return coerce_timezone_value(domain_membership.timezone)
-                else:
-                    return coerce_timezone_value(domain_membership.timezone)
+            if domain_membership and domain_membership.override_global_tz:
+                return coerce_timezone_value(domain_membership.timezone)
 
     return get_timezone_for_domain(domain)
 


### PR DESCRIPTION
## Summary
Reverts dimagi/commcare-hq#29375 and adds a number of new commits to fix places in reports that have broken /inconsistent timezone handling.

Labelled as medium risk since this change what dates users see in reports.

The PR also includes some comments / cleanup.

Best reviewed per commit.

## Product Description
When displaying data to users in HQ we generally try to convert dates (with times) to the timezone for the user. This timezone is configured in 2 places:

 1. Domain
 2. User's domain membership

If (2) is set then it will override (1) - at least that's what's meant to happen. The original PR (dimagi/commcare-hq#29375) fixes a bug where (2) is always used even if the user has not set it and the default value it UTC.

When investigating the impact of this change I found 3 other places still in reports that do not handle the time conversion correctly / consistently:

1. case list reports

    The date columns in this report were formatted differntly to those in the Submit History.
    This PR changes the format to match the Submit History report:

    2021-02-01 12:11:20 -> Feb 01, 2021 12:11:20 SAST

2. Form metadata view 

    ![image](https://user-images.githubusercontent.com/249606/111779485-dd20a500-88be-11eb-8ce4-709aacf68c4d.png)
    ![image](https://user-images.githubusercontent.com/249606/111779523-ea3d9400-88be-11eb-9b55-32ef167d5511.png)

    to
    
    ![image](https://user-images.githubusercontent.com/249606/111779331-ae0a3380-88be-11eb-8836-0708b52593de.png)
    ![image](https://user-images.githubusercontent.com/249606/111779386-bc584f80-88be-11eb-906b-ed72dbc2902c.png)

3. `server_last_modified_date` in case list explorer formatted as a phone time

    I think this would only impact old couch domains that haven't had the timezone migration run.

### Does this impact exports, APIs, repeaters
No. This only impacts the display of datetime values on the UI. It also does not get applied to dynamic user data (data in forms / cases that is not metadata).

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None

### QA Plan
Not clear on the level of QA required for this. If we want QA it should cover:

* anywhere a datetime is displayed on the UI including
  * report / export filters
  * report columns
  * case / form view
* domains on couch backend that have had the TZ migration done
* domains on couch backend that have not had the TZ migration done
* domains on SQL backend

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
