### PR TITLE
Change description for New High Performing Users on Project Performance Report

### DIFF
--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -202,7 +202,8 @@ class MonthlyPerformanceSummary(jsonobject.JsonObject):
         but are not this month (though are still active).
         """
         if self._previous_summary:
-            unhealthy_users = [stub for stub in self._get_all_user_stubs_with_extra_data() if stub.is_active and not stub.is_performing]
+            unhealthy_users = [stub for stub in self._get_all_user_stubs_with_extra_data()
+                               if stub.is_active and not stub.is_performing]
             return sorted(unhealthy_users, key=lambda stub: stub.delta_forms)
 
     def get_dropouts(self):
@@ -220,8 +221,9 @@ class MonthlyPerformanceSummary(jsonobject.JsonObject):
         after not performing last month.
         """
         if self._previous_summary:
-            dropouts = [stub for stub in self._get_all_user_stubs_with_extra_data() if stub.is_newly_performing]
-            return sorted(dropouts, key=lambda stub: -stub.delta_forms)
+            new_performers = [stub for stub in self._get_all_user_stubs_with_extra_data()
+                              if stub.is_newly_performing]
+            return sorted(new_performers, key=lambda stub: -stub.delta_forms)
 
 
 def build_worksheet(title, headers, rows):

--- a/corehq/apps/reports/templates/reports/project_health/partials/users_tables.html
+++ b/corehq/apps/reports/templates/reports/project_health/partials/users_tables.html
@@ -24,7 +24,7 @@
   <h2>{% trans "New High Performing Users" %}</h2>
   <p class="lead">
     {% blocktrans %}
-      These are workers who submitted {{ threshold }} forms this month and didn't last month.
+      These are workers who submitted {{ threshold }} forms last month and didn't the previous month.
     {% endblocktrans %}
   </p>
   {% with last_month.get_newly_performing as user_list %}


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The wording for the description of New High Performing Users implies the users in the table are new high performers users _this month_, which is not the case. See [this ticket](https://github.com/dimagi/commcare-hq/pull/29369) for more details.

This is a slight change to clearly state these are new high performing users _last month_. Open to suggestions if this does not seem clear enough.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Just a text change.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Just a text change.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Just a text change.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
