### PR TITLE
Add missing encoding parameter

### DIFF
--- a/corehq/apps/app_manager/tests/test_app_strings.py
+++ b/corehq/apps/app_manager/tests/test_app_strings.py
@@ -61,7 +61,7 @@ class AppManagerTranslationsTest(TestCase, SuiteMixin):
             ('abc < def > abc', '<value>abc &lt; def &gt; abc</value>'),
             ("bee's knees", "<value>bee's knees</value>"),
             ('unfortunate <xml expression', '<value>unfortunate &lt;xml expression</value>'),
-            ('क्लिक', '<value>&#2325;&#2381;&#2354;&#2367;&#2325;</value>'),
+            ('क्लिक', '<value>क्लिक</value>'),
             ('&#39', '<value>&amp;#39</value>'),
             ('question1 is <output value="/data/question1" vellum:value="#form/question1"/> !',
              '<value>question1 is &lt;output value="/data/question1" vellum:value="#form/question1"/&gt; !</value>'),
@@ -71,7 +71,7 @@ class AppManagerTranslationsTest(TestCase, SuiteMixin):
         ]
         for input, expected_output in test_cases:
             escaped_input = BulkAppTranslationFormUpdater.escape_output_value(input)
-            self.assertEqual(expected_output, etree.tostring(escaped_input).decode('utf-8'))
+            self.assertEqual(expected_output, etree.tostring(escaped_input, encoding='utf-8').decode('utf-8'))
 
     def test_language_names(self):
         factory = AppFactory(build_version='2.40.0')

--- a/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
+++ b/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
@@ -151,9 +151,8 @@ class ReportFixturesProviderTests(SimpleTestCase, TestXmlMixin):
         last_sync_time_patch.return_value = datetime(2017, 9, 11, 6, 35, 20).isoformat()
         restore_user = Mock(domain='mock-domain', user_id='mock-user-id')
         report_index_fixture = _get_report_index_fixture(restore_user)
-        print(etree.tostring(report_index_fixture, pretty_print=True).decode('utf-8'))
         self.assertXMLEqual(
-            etree.tostring(report_index_fixture, pretty_print=True).decode('utf-8'),
+            etree.tostring(report_index_fixture, pretty_print=True, encoding='utf-8').decode('utf-8'),
             """
             <fixture id="commcare-reports:index" user_id="mock-user-id">
               <report_index>

--- a/corehq/apps/translations/app_translations/upload_form.py
+++ b/corehq/apps/translations/app_translations/upload_form.py
@@ -98,7 +98,7 @@ class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
                 except BulkAppTranslationsException as e:
                     self.msgs.append((messages.warning, str(e)))
 
-        save_xform(self.app, self.form, etree.tostring(self.xform.xml))
+        save_xform(self.app, self.form, etree.tostring(self.xform.xml, encoding='utf-8'))
 
         return [(t, _('Error in {sheet}: {msg}').format(sheet=self.sheet_name, msg=m)) for (t, m) in self.msgs]
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-11944
lxml requires you to pass the encoding parameter while calling `tostring` from the newer versions. We were not doing it while we were saving the form after updating bulk translations because of which we were getting malformed XML in some cases.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The changes have been tested on local.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
