### PR TITLE
Optionally dump only specified models

### DIFF
--- a/corehq/apps/dump_reload/couch/dump.py
+++ b/corehq/apps/dump_reload/couch/dump.py
@@ -89,8 +89,7 @@ class ToggleDumper(DataDumper):
 
     def dump(self, output_stream):
         count = 0
-        usernames = get_all_usernames_by_domain(self.domain)
-        for toggle in _get_toggles_to_migrate(self.domain, usernames):
+        for toggle in _get_toggles_to_migrate(self.domain):
             count += 1
             output_stream.write(json.dumps(toggle))
             output_stream.write('\n')
@@ -99,12 +98,13 @@ class ToggleDumper(DataDumper):
         return Counter({'Toggle': count})
 
 
-def _get_toggles_to_migrate(domain, usernames):
+def _get_toggles_to_migrate(domain):
     from corehq.toggles import all_toggles, NAMESPACE_DOMAIN
     from toggle.models import Toggle
     from toggle.shortcuts import namespaced_item
 
     domain_item = namespaced_item(domain, NAMESPACE_DOMAIN)
+    usernames = set(get_all_usernames_by_domain(domain))
 
     for toggle in all_toggles() + all_previews():
         try:

--- a/corehq/apps/dump_reload/couch/dump.py
+++ b/corehq/apps/dump_reload/couch/dump.py
@@ -56,7 +56,7 @@ class CouchDataDumper(DataDumper):
 
     def dump(self, output_stream):
         stats = Counter()
-        for doc_class, doc_ids in get_doc_ids_to_dump(self.domain, self.excludes):
+        for doc_class, doc_ids in get_doc_ids_to_dump(self.domain, self.excludes, self.includes):
             stats += self._dump_docs(doc_class, doc_ids, output_stream)
         return stats
 
@@ -72,11 +72,13 @@ class CouchDataDumper(DataDumper):
         return Counter({model_label: count})
 
 
-def get_doc_ids_to_dump(domain, exclude_doc_types=None):
+def get_doc_ids_to_dump(domain, exclude_doc_types=None, include_doc_types=None):
     """
     :return: A generator of (doc_class, list(doc_ids))
     """
     for id_provider in DOC_PROVIDERS:
+        if include_doc_types and id_provider.doc_type not in include_doc_types:
+            continue
         if exclude_doc_types and id_provider.doc_type in exclude_doc_types:
             continue
 

--- a/corehq/apps/dump_reload/interface.py
+++ b/corehq/apps/dump_reload/interface.py
@@ -12,15 +12,17 @@ class DataDumper(metaclass=ABCMeta):
     """
     :param domain: Name of domain to dump data for
     :param excludes: List of app labels ("app_label.model_name" or "app_label") to exclude
+    :param includes: List of app labels ("app_label.model_name" or "app_label") to include
     """
 
     @abstractproperty
     def slug(self):
         raise NotImplementedError
 
-    def __init__(self, domain, excludes, stdout=None, stderr=None):
+    def __init__(self, domain, excludes, includes, stdout=None, stderr=None):
         self.domain = domain
         self.excludes = excludes
+        self.includes = includes
         self.stdout = stdout or sys.stdout
         self.stderr = stderr or sys.stderr
 

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -24,6 +24,11 @@ class Command(BaseCommand):
                  '(use multiple --exclude to exclude multiple apps/models).'
         )
         parser.add_argument(
+            '-i', '--include', dest='include', action='append', default=[],
+            help='An app_label, app_label.ModelName or CouchDB doc_type to include '
+                 '(use multiple --include to include multiple apps/models).'
+        )
+        parser.add_argument(
             '--console', action='store_true', default=False, dest='console',
             help='Write output to the console instead of to file.'
         )
@@ -32,6 +37,7 @@ class Command(BaseCommand):
 
     def handle(self, domain_name, **options):
         excludes = options.get('exclude')
+        includes = options.get('include')
         console = options.get('console')
         show_traceback = options.get('traceback')
         requested_dumpers = options.get('dumpers')
@@ -49,7 +55,7 @@ class Command(BaseCommand):
             filename = _get_dump_stream_filename(dumper.slug, domain_name, self.utcnow)
             stream = self.stdout if console else gzip.open(filename, 'wt')
             try:
-                meta[dumper.slug] = dumper(domain_name, excludes).dump(stream)
+                meta[dumper.slug] = dumper(domain_name, excludes, includes).dump(stream)
             except Exception as e:
                 if show_traceback:
                     raise

--- a/corehq/apps/dump_reload/management/commands/print_domain_stats.py
+++ b/corehq/apps/dump_reload/management/commands/print_domain_stats.py
@@ -101,7 +101,7 @@ def _get_couchdb_counts(domain):
 
 def _get_sql_counts(domain):
     counter = Counter()
-    for model_class, builder in get_model_iterator_builders_to_dump(domain, []):
+    for model_class, builder in get_model_iterator_builders_to_dump(domain, [], []):
         if model_class in (User, XFormInstanceSQL, CommCareCaseSQL):
             continue  # User is very slow, others we want to break out
         for queryset in builder.querysets():

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -24,14 +24,17 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('locations.LocationType', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('locations.SQLLocation', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('blobs.BlobMeta', SimpleFilter('domain')),
+
     FilteredModelIteratorBuilder('form_processor.XFormInstanceSQL', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.XFormOperationSQL', SimpleFilter('form__domain')),
+
     FilteredModelIteratorBuilder('form_processor.CommCareCaseSQL', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.CommCareCaseIndexSQL', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.CaseAttachmentSQL', SimpleFilter('case__domain')),
     FilteredModelIteratorBuilder('form_processor.CaseTransaction', SimpleFilter('case__domain')),
     FilteredModelIteratorBuilder('form_processor.LedgerValue', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.LedgerTransaction', SimpleFilter('case__domain')),
+
     FilteredModelIteratorBuilder('case_search.CaseSearchConfig', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('case_search.FuzzyProperties', SimpleFilter('domain')),
     UniqueFilteredModelIteratorBuilder('scheduling.SMSContent', SimpleFilter('alertevent__schedule__domain')),
@@ -160,7 +163,7 @@ class SqlDataDumper(DataDumper):
 
     def dump(self, output_stream):
         stats = Counter()
-        objects = get_objects_to_dump(self.domain, self.excludes, stats_counter=stats, stdout=self.stdout)
+        objects = get_objects_to_dump(self.domain, self.excludes, self.includes, stats_counter=stats, stdout=self.stdout)
         JsonLinesSerializer().serialize(
             objects,
             use_natural_foreign_keys=False,
@@ -170,14 +173,14 @@ class SqlDataDumper(DataDumper):
         return stats
 
 
-def get_objects_to_dump(domain, excludes, stats_counter=None, stdout=None):
+def get_objects_to_dump(domain, excludes, includes, stats_counter=None, stdout=None):
     """
     :param domain: domain name to filter with
     :param app_list: List of (app_config, model_class) tuples to dump
     :param excluded_models: List of model_class classes to exclude
     :return: generator yielding models objects
     """
-    builders = get_model_iterator_builders_to_dump(domain, excludes)
+    builders = get_model_iterator_builders_to_dump(domain, excludes, includes)
     yield from get_objects_to_dump_from_builders(builders, stats_counter, stdout)
 
 
@@ -194,18 +197,21 @@ def get_objects_to_dump_from_builders(builders, stats_counter=None, stdout=None)
             stdout.write('Dumped {} {}\n'.format(stats_counter[model_label], model_label))
 
 
-def get_model_iterator_builders_to_dump(domain, excludes, limit_to_db=None):
+def get_model_iterator_builders_to_dump(domain, excludes, includes, limit_to_db=None):
     """
     :param domain: domain name to filter with
     :param app_list: List of (app_config, model_class) tuples to dump
     :param excluded_models: List of model_class classes to exclude
     :return: generator yielding query sets
     """
-    excluded_apps, excluded_models = get_excluded_apps_and_models(excludes)
-    app_config_models = _get_app_list(excluded_apps)
+    excluded_apps, excluded_models = get_apps_and_models(excludes)
+    included_apps, included_models = get_apps_and_models(includes)
+    app_config_models = _get_app_list(excluded_apps, included_apps)
 
     # Collate the objects to be serialized.
     for model_class in serializers.sort_dependencies(list(app_config_models.items())):
+        if included_models and model_class not in included_models:
+            continue
         if model_class in excluded_models:
             continue
 
@@ -240,42 +246,44 @@ def get_all_model_iterators_builders_for_domain(model_class, domain, builders, l
             yield model_class, builder.build(domain, model_class, db_alias)
 
 
-def get_excluded_apps_and_models(excludes):
+def get_apps_and_models(app_or_model_label):
     """
-    :param excludes: list of app labels ("app_label.model_name" or "app_label") to exclude
-    :return: Tuple containing two sets: Set of AppConfigs to exclude, Set of model classes to excluded.
+    :param app_or_model_label: list of app labels ("app_label.model_name" or "app_label")
+    :return: Tuple containing two sets: Set of AppConfigs, Set of model classes
     """
-    excluded_apps = set()
-    excluded_models = set()
-    for exclude in excludes:
-        if '.' in exclude:
+    specified_apps = set()
+    specified_models = set()
+    for label in app_or_model_label:
+        if '.' in label:
             try:
-                model = apps.get_model(exclude)
+                model = apps.get_model(label)
             except LookupError:
-                raise DomainDumpError('Unknown model in excludes: %s' % exclude)
-            excluded_models.add(model)
+                raise DomainDumpError('Unknown model: %s' % label)
+            specified_models.add(model)
         else:
             try:
-                app_config = apps.get_app_config(exclude)
+                app_config = apps.get_app_config(label)
             except LookupError:
                 from corehq.util.couch import get_document_class_by_doc_type
                 from corehq.util.exceptions import DocumentClassNotFound
                 # ignore this if it's a couch doc type
                 try:
-                    get_document_class_by_doc_type(exclude)
+                    get_document_class_by_doc_type(label)
                 except DocumentClassNotFound:
-                    raise DomainDumpError('Unknown app in excludes: %s' % exclude)
-            excluded_apps.add(app_config)
-    return excluded_apps, excluded_models
+                    raise DomainDumpError('Unknown app in excludes: %s' % label)
+            specified_apps.add(app_config)
+    return specified_apps, specified_models
 
 
-def _get_app_list(excluded_apps):
+def _get_app_list(excluded_apps, included_apps):
     """
     :return: OrderedDict(app_config, model), ...)
     """
     app_list = OrderedDict()
     for label in APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP:
         app_config, model = get_model_class(label)
+        if included_apps and app_config not in included_apps:
+            continue
         if app_config in excluded_apps:
             continue
 

--- a/corehq/apps/dump_reload/tests/test_couch_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_couch_dump_load.py
@@ -54,7 +54,7 @@ class CouchDumpLoadTest(TestCase):
 
     def _dump_and_load(self, expected_objects, not_expected_objects=None, doc_to_doc_class=None):
         output_stream = StringIO()
-        CouchDataDumper(self.domain_name, []).dump(output_stream)
+        CouchDataDumper(self.domain_name, [], []).dump(output_stream)
 
         self._delete_couch_data()
 
@@ -220,7 +220,7 @@ class TestDumpLoadToggles(SimpleTestCase):
         super(TestDumpLoadToggles, self).tearDown()
 
     def test_dump_toggles(self):
-        dumper = ToggleDumper(self.domain_name, [])
+        dumper = ToggleDumper(self.domain_name, [], [])
         users = iter(['user1', 'user2', 'user3'])
 
         output_stream = StringIO()

--- a/corehq/apps/dump_reload/tests/test_couch_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_couch_dump_load.py
@@ -221,7 +221,7 @@ class TestDumpLoadToggles(SimpleTestCase):
 
     def test_dump_toggles(self):
         dumper = ToggleDumper(self.domain_name, [])
-        users = {'user1', 'user2', 'user3'}
+        users = iter(['user1', 'user2', 'user3'])
 
         output_stream = StringIO()
 

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -97,12 +97,12 @@ class BaseDumpLoadTest(TestCase):
         if dumper_fn:
             dumper_fn(output_stream)
         else:
-            SqlDataDumper(self.domain_name, []).dump(output_stream)
+            SqlDataDumper(self.domain_name, [], []).dump(output_stream)
 
         self.delete_sql_data()
 
         # make sure that there's no data left in the DB
-        objects_remaining = list(get_objects_to_dump(self.domain_name, []))
+        objects_remaining = list(get_objects_to_dump(self.domain_name, [], []))
         object_classes = [obj.__class__.__name__ for obj in objects_remaining]
         counts = Counter(object_classes)
         self.assertEqual([], objects_remaining, 'Not all data deleted: {}'.format(counts))
@@ -149,7 +149,7 @@ class BaseDumpLoadTest(TestCase):
 
 @nottest
 def delete_domain_sql_data_for_dump_load_test(domain_name):
-    for model_class, builder in get_model_iterator_builders_to_dump(domain_name, []):
+    for model_class, builder in get_model_iterator_builders_to_dump(domain_name, [], []):
         for iterator in builder.querysets():
             with transaction.atomic(using=iterator.db), \
                  constraint_checks_deferred(iterator.db):
@@ -157,7 +157,7 @@ def delete_domain_sql_data_for_dump_load_test(domain_name):
                 collector.collect(iterator)
                 collector.delete()
 
-    assert [] == list(get_objects_to_dump(domain_name, [])), "Not all SQL objects deleted"
+    assert [] == list(get_objects_to_dump(domain_name, [], [])), "Not all SQL objects deleted"
 
 
 @use_sql_backend
@@ -693,7 +693,7 @@ class TestSqlLoadWithError(BaseDumpLoadTest):
 
     def _load_with_errors(self, chunk_size):
         output_stream = StringIO()
-        SqlDataDumper(self.domain_name, []).dump(output_stream)
+        SqlDataDumper(self.domain_name, [], []).dump(output_stream)
         self.delete_sql_data()
         # resave the product to force an error
         self.products[0].save()


### PR DESCRIPTION
## Summary
There are a lot of models, and it's currently hard to focus the dump on one problematic area.  This should help with that.  The behavior around specifying `--include` AND `--exclude` in the same command is a little weird, but I think that's tolerable with code like this.

First commit is a bugfix

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Only affects a management command

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
