### PR TITLE
Add vectorlink-sierra-leone

### DIFF
--- a/custom/abt/reports/data_sources/late_pmt.json
+++ b/custom/abt/reports/data_sources/late_pmt.json
@@ -24,6 +24,7 @@
     "vectorlink-mozambique",
     "vectorlink-rwanda",
     "vectorlink-senegal",
+    "vectorlink-sierra-leone",
     "vectorlink-tanzania",
     "vectorlink-uganda",
     "vectorlink-zambia",

--- a/custom/abt/reports/data_sources/sms_case.json
+++ b/custom/abt/reports/data_sources/sms_case.json
@@ -24,6 +24,7 @@
     "vectorlink-mozambique",
     "vectorlink-rwanda",
     "vectorlink-senegal",
+    "vectorlink-sierra-leone",
     "vectorlink-tanzania",
     "vectorlink-uganda",
     "vectorlink-zambia",

--- a/custom/abt/reports/data_sources/supervisory_v2.json
+++ b/custom/abt/reports/data_sources/supervisory_v2.json
@@ -23,6 +23,7 @@
         "vectorlink-mali",
         "vectorlink-mozambique",
         "vectorlink-rwanda",
+        "vectorlink-sierra-leone",
         "vectorlink-tanzania",
         "vectorlink-uganda",
         "vectorlink-zambia",

--- a/custom/abt/reports/data_sources/supervisory_v2019.json
+++ b/custom/abt/reports/data_sources/supervisory_v2019.json
@@ -25,6 +25,7 @@
         "vectorlink-mozambique",
         "vectorlink-rwanda",
         "vectorlink-senegal",
+        "vectorlink-sierra-leone",
         "vectorlink-tanzania",
         "vectorlink-uganda",
         "vectorlink-zambia",

--- a/custom/abt/reports/data_sources/supervisory_v2020.json
+++ b/custom/abt/reports/data_sources/supervisory_v2020.json
@@ -25,6 +25,7 @@
         "vectorlink-mozambique",
         "vectorlink-rwanda",
         "vectorlink-senegal",
+        "vectorlink-sierra-leone",
         "vectorlink-tanzania",
         "vectorlink-uganda",
         "vectorlink-zambia",

--- a/custom/abt/reports/sms_indicator_report.json
+++ b/custom/abt/reports/sms_indicator_report.json
@@ -24,6 +24,7 @@
         "vectorlink-mozambique",
         "vectorlink-rwanda",
         "vectorlink-senegal",
+        "vectorlink-sierra-leone",
         "vectorlink-tanzania",
         "vectorlink-uganda",
         "vectorlink-zambia",

--- a/custom/abt/reports/spray_progress_country.json
+++ b/custom/abt/reports/spray_progress_country.json
@@ -24,6 +24,7 @@
         "vectorlink-mozambique",
         "vectorlink-rwanda",
         "vectorlink-senegal",
+        "vectorlink-sierra-leone",
         "vectorlink-tanzania",
         "vectorlink-uganda",
         "vectorlink-zambia",

--- a/custom/abt/reports/spray_progress_level_1.json
+++ b/custom/abt/reports/spray_progress_level_1.json
@@ -24,6 +24,7 @@
         "vectorlink-mozambique",
         "vectorlink-rwanda",
         "vectorlink-senegal",
+        "vectorlink-sierra-leone",
         "vectorlink-tanzania",
         "vectorlink-uganda",
         "vectorlink-zambia",

--- a/custom/abt/reports/spray_progress_level_2.json
+++ b/custom/abt/reports/spray_progress_level_2.json
@@ -24,6 +24,7 @@
         "vectorlink-mozambique",
         "vectorlink-rwanda",
         "vectorlink-senegal",
+        "vectorlink-sierra-leone",
         "vectorlink-tanzania",
         "vectorlink-uganda",
         "vectorlink-zambia",

--- a/custom/abt/reports/spray_progress_level_3.json
+++ b/custom/abt/reports/spray_progress_level_3.json
@@ -23,6 +23,7 @@
         "vectorlink-mozambique",
         "vectorlink-rwanda",
         "vectorlink-senegal",
+        "vectorlink-sierra-leone",
         "vectorlink-tanzania",
         "vectorlink-uganda",
         "vectorlink-zambia",

--- a/custom/abt/reports/spray_progress_level_4.json
+++ b/custom/abt/reports/spray_progress_level_4.json
@@ -23,6 +23,7 @@
         "vectorlink-mozambique",
         "vectorlink-rwanda",
         "vectorlink-senegal",
+        "vectorlink-sierra-leone",
         "vectorlink-tanzania",
         "vectorlink-uganda",
         "vectorlink-zambia",

--- a/custom/abt/reports/supervisory_report_v2.json
+++ b/custom/abt/reports/supervisory_report_v2.json
@@ -23,6 +23,7 @@
         "vectorlink-mali",
         "vectorlink-mozambique",
         "vectorlink-rwanda",
+        "vectorlink-sierra-leone",
         "vectorlink-tanzania",
         "vectorlink-uganda",
         "vectorlink-zambia",

--- a/custom/abt/reports/supervisory_report_v2019.json
+++ b/custom/abt/reports/supervisory_report_v2019.json
@@ -25,6 +25,7 @@
         "vectorlink-mozambique",
         "vectorlink-rwanda",
         "vectorlink-senegal",
+        "vectorlink-sierra-leone",
         "vectorlink-tanzania",
         "vectorlink-uganda",
         "vectorlink-zambia",

--- a/custom/abt/reports/supervisory_report_v2020.json
+++ b/custom/abt/reports/supervisory_report_v2020.json
@@ -25,6 +25,7 @@
         "vectorlink-mozambique",
         "vectorlink-rwanda",
         "vectorlink-senegal",
+        "vectorlink-sierra-leone",
         "vectorlink-tanzania",
         "vectorlink-uganda",
         "vectorlink-zambia",

--- a/settings.py
+++ b/settings.py
@@ -1987,6 +1987,7 @@ DOMAIN_MODULE_MAP = {
     'vectorlink-mozambique': 'custom.abt',
     'vectorlink-rwanda': 'custom.abt',
     'vectorlink-senegal': 'custom.abt',
+    'vectorlink-sierra-leone': 'custom.abt',
     'vectorlink-tanzania': 'custom.abt',
     'vectorlink-uganda': 'custom.abt',
     'vectorlink-zambia': 'custom.abt',


### PR DESCRIPTION

## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Enable static UCRs for vectorlink-sierra-leone
https://dimagi-dev.atlassian.net/browse/SC-1350

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
Enable static UCRs for vectorlink-sierra-leone

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This is a pretty routine change

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
