### PR TITLE
copy advanced and multimedia settings

### DIFF
--- a/corehq/apps/app_manager/tests/test_handle_shadow_child_modules.py
+++ b/corehq/apps/app_manager/tests/test_handle_shadow_child_modules.py
@@ -2,11 +2,12 @@ from django.test import TestCase
 
 import jsonobject
 
-from corehq.apps.app_manager.models import Application, Module, ShadowModule
+from corehq.apps.app_manager.models import Application, Module, ShadowModule, ModuleBase, NavMenuItemMediaMixin
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import delete_all_apps
 from corehq.apps.app_manager.views.utils import (
     SHADOW_MODULE_PROPERTIES_TO_COPY,
+    MODULE_BASE_PROPERTIES_TO_COPY,
     handle_shadow_child_modules,
 )
 
@@ -136,6 +137,37 @@ class HandleShadowChildModulesTest(TestCase):
             and prop not in ignored_properties
         }
         copied_properties = {prop for prop, _ in SHADOW_MODULE_PROPERTIES_TO_COPY}
+
+        self.assertItemsEqual(
+            required_properties - copied_properties,
+            [],
+            (f"Please handle the new property you just added '{required_properties - copied_properties}' "
+             "to ShadowModule in app_manager.views.utils.handle_child_shadow_modules, or add it "
+             "to the ignored_propertieslist in this test."),
+        )
+
+    def test_all_base_module_properties_set(self):
+        ignored_properties = [
+            "doc_type",
+            "root_module_id",
+            "name",
+            "case_type",
+            "unique_id"
+        ]
+        required_properties = {
+            prop
+            for prop in vars(ModuleBase)
+            if isinstance(vars(ModuleBase)[prop], jsonobject.base_properties.JsonProperty)
+            and prop not in ignored_properties
+        }
+        required_properties |= {
+            prop
+            for prop in vars(NavMenuItemMediaMixin)
+            if isinstance(vars(NavMenuItemMediaMixin)[prop], jsonobject.base_properties.JsonProperty)
+            and prop not in ignored_properties
+        }
+        
+        copied_properties = {prop for prop, _ in MODULE_BASE_PROPERTIES_TO_COPY}
 
         self.assertItemsEqual(
             required_properties - copied_properties,

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -438,14 +438,42 @@ def get_multimedia_sizes_for_build(domain, build_id, build_profile_id=None):
     return total_size
 
 
+def _copy_as_dict(attribute):
+    return deepcopy(dict(attribute))
+
+
+def _copy_list_of_dict(attribute):
+    dict_list = [dict(schema) for schema in attribute]
+    return deepcopy(dict_list)
+
+
 SHADOW_MODULE_PROPERTIES_TO_COPY = [
-    ('case_details', True),
-    ('ref_details', True),
-    ('case_list', True),
-    ('referral_list', True),
-    ('task_list', True),
-    ('parent_select', False),
-    ('search_config', False),
+    ('case_details', deepcopy),
+    ('ref_details', deepcopy),
+    ('case_list', deepcopy),
+    ('referral_list', deepcopy),
+    ('task_list', deepcopy),
+    ('parent_select', None),
+    ('search_config', None),
+]
+
+
+MODULE_BASE_PROPERTIES_TO_COPY = [
+    ('module_filter', None),
+    ('put_in_root', None),
+
+    ('fixture_select', deepcopy),
+    ('report_context_tile', None),
+    ('auto_select_case', None),
+    ('is_training_module', None),
+    ('case_list_form', deepcopy),
+
+    # deepcopy cannot handle DictProperty, so convert to normal python dict first
+    ('media_image', _copy_as_dict),
+    ('media_audio', _copy_as_dict),
+    ('custom_icons', _copy_list_of_dict),
+    ('use_default_image_for_all', None),
+    ('use_default_audio_for_all', None),
 ]
 
 
@@ -504,28 +532,17 @@ def handle_shadow_child_modules(app, shadow_parent):
         changes = True
         new_shadow = ShadowModule.new_module(source_child.default_name(app=app), app.default_language)
         new_shadow.source_module_id = source_child.unique_id
-
-        # ModuleBase properties
-        new_shadow.module_filter = source_child.module_filter
-        new_shadow.put_in_root = source_child.put_in_root
         new_shadow.root_module_id = shadow_parent.unique_id
-        new_shadow.fixture_select = deepcopy(source_child.fixture_select)
-        new_shadow.report_context_tile = source_child.report_context_tile
-        new_shadow.auto_select_case = source_child.auto_select_case
-        new_shadow.is_training_module = source_child.is_training_module
-        new_shadow.case_list_form = deepcopy(source_child.case_list_form)
-        # Multimedia Properties
-        # deepcopy cannot handle DictProperty, so convert to normal python dict first
-        new_shadow.media_image = deepcopy(dict(source_child.media_image))
-        new_shadow.media_audio = deepcopy(dict(source_child.media_audio))
-        new_shadow.custom_icons = deepcopy(source_child.custom_icons.to_json())
-        new_shadow.use_default_image_for_all = source_child.use_default_image_for_all
-        new_shadow.use_default_audio_for_all = source_child.use_default_audio_for_all
+
+        # BaseModule properties
+        for prop, transform in MODULE_BASE_PROPERTIES_TO_COPY:
+            new_value = getattr(source_child, prop)
+            setattr(new_shadow, prop, transform(new_value) if transform is not None else new_value)
 
         # ShadowModule properties
-        for prop, to_deepcopy in SHADOW_MODULE_PROPERTIES_TO_COPY:
+        for prop, transform in SHADOW_MODULE_PROPERTIES_TO_COPY:
             new_value = getattr(source_child, prop)
-            setattr(new_shadow, prop, deepcopy(new_value) if to_deepcopy else new_value)
+            setattr(new_shadow, prop, transform(new_value) if transform is not None else new_value)
 
         # move excluded form ids
         source_child_form_ids = set(

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -515,9 +515,10 @@ def handle_shadow_child_modules(app, shadow_parent):
         new_shadow.is_training_module = source_child.is_training_module
         new_shadow.case_list_form = deepcopy(source_child.case_list_form)
         # Multimedia Properties
-        new_shadow.media_image = deepcopy(source_child.media_image)
-        new_shadow.media_audio = deepcopy(source_child.media_audio)
-        new_shadow.custom_icons = deepcopy(source_child.custom_icons)
+        # deepcopy cannot handle DictProperty, so convert to normal python dict first
+        new_shadow.media_image = deepcopy(dict(source_child.media_image))
+        new_shadow.media_audio = deepcopy(dict(source_child.media_audio))
+        new_shadow.custom_icons = deepcopy(source_child.custom_icons.to_json())
         new_shadow.use_default_image_for_all = source_child.use_default_image_for_all
         new_shadow.use_default_audio_for_all = source_child.use_default_audio_for_all
 

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -513,6 +513,13 @@ def handle_shadow_child_modules(app, shadow_parent):
         new_shadow.report_context_tile = source_child.report_context_tile
         new_shadow.auto_select_case = source_child.auto_select_case
         new_shadow.is_training_module = source_child.is_training_module
+        new_shadow.case_list_form = deepcopy(source_child.case_list_form)
+        # Multimedia Properties
+        new_shadow.media_image = deepcopy(source_child.media_image)
+        new_shadow.media_audio = deepcopy(source_child.media_audio)
+        new_shadow.custom_icons = deepcopy(source_child.custom_icons)
+        new_shadow.use_default_image_for_all = source_child.use_default_image_for_all
+        new_shadow.use_default_audio_for_all = source_child.use_default_audio_for_all
 
         # ShadowModule properties
         for prop, to_deepcopy in SHADOW_MODULE_PROPERTIES_TO_COPY:


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-685

When copying a child module to a shadow module, it was missing some of the settings. This adds the missing ones (multimedia and registration from case list).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[Shadow Modules](https://www.commcarehq.org/hq/flags/edit/shadow-app-builder/)

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When a child module is copied to a new shadow module, the multimedia and advanced settings will be copied.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This copies two additional module attributes using the same method that copies all others.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
