### PR TITLE
Index auditcare views separately from the rest of them

### DIFF
--- a/corehq/ex-submodules/dimagi/utils/couch/sync_docs.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/sync_docs.py
@@ -30,7 +30,7 @@ def sync_design_docs(db, design_dir, design_name, temp=None):
         index_design_docs(db, docid, design_name_)
 
 
-def index_design_docs(db, docid, design_name, wait=True):
+def index_design_docs(db, docid, design_name, wait=True, abort_on_timeout=False):
     # found in the innards of couchdbkit
     view_names = list(db[docid].get('views', {}))
     if view_names:
@@ -45,6 +45,8 @@ def index_design_docs(db, docid, design_name, wait=True):
             except HTTPError as e:
                 if 'timeout' not in six.text_type(e) and e.response.status_code != 504:
                     raise
+                elif abort_on_timeout:
+                    break
             else:
                 break
 

--- a/corehq/preindex/accessors.py
+++ b/corehq/preindex/accessors.py
@@ -62,12 +62,13 @@ def sync_design_doc(design, temp=None):
     )
 
 
-def index_design_doc(design, wait=True):
+def index_design_doc(design, wait=True, abort_on_timeout=False):
     design_name = design.app_label
     docid = "_design/%s" % design_name
     sync_docs.index_design_docs(
         db=design.db,
         docid=docid,
         design_name=design_name,
-        wait=wait
+        wait=wait,
+        abort_on_timeout=abort_on_timeout,
     )


### PR DESCRIPTION
And don't retry after timeout for auditcare

## Summary
The repeat couch issue https://dimagi-dev.atlassian.net/browse/SAAS-11998

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
I will test this on staging and just make sure the basics are working. Overall it's a very small code change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
