### PR TITLE
Sanitized mark_safe usages in accounting

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -2,7 +2,7 @@ import datetime
 
 from django.db import transaction
 from django.urls import reverse
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext
 
@@ -478,10 +478,13 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
             ) % {
                 'num_apps': num_apps,
             },
-            [mark_safe('<a href="%(url)s">%(title)s</a>') % {
-                'title': app['name'],
-                'url': reverse('view_app', args=[domain.name, app['_id']])
-            } for app in cloudcare_enabled_apps],
+            [
+                format_html(
+                    '<a href="{}">{}</a>',
+                    reverse('view_app', args=[domain.name, app['_id']]),
+                    app['name']
+                ) for app in cloudcare_enabled_apps
+            ],
         )
 
     @staticmethod
@@ -784,8 +787,11 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
             ) % {
                 'num_apps': len(apps),
             },
-            [mark_safe('<a href="%(url)s">%(title)s</a>') % {
-                'title': app['name'],
-                'url': reverse('view_app', args=[project.name, app['_id']])
-            } for app in apps],
+            [
+                format_html(
+                    '<a href="{}">{}</a>',
+                    reverse('view_app', args=[project.name, app['_id']]),
+                    app['name']
+                ) for app in apps
+            ],
         )

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -16,7 +16,7 @@ from django.http import (
 )
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop
 from django.views.generic import View
@@ -1326,10 +1326,12 @@ class TriggerAutopaymentsView(BaseTriggerAccountingTestView):
             statements_url = reverse(DomainBillingStatementsView.urlname, args=[domain])
             messages.success(
                 request,
-                mark_safe(
-                    f'Successfully triggered autopayments for "{domain}",'
-                    f' please check <a href="{statements_url}">billing statements</a>'
-                    f' to confirm.'
+                format_html(
+                    'Successfully triggered autopayments for "{}",'
+                    ' please check <a href="{}">billing statements</a>'
+                    ' to confirm.',
+                    domain,
+                    statements_url
                 )
             )
             return HttpResponseRedirect(reverse(self.urlname))


### PR DESCRIPTION
## Summary
Part of the XSS work in [SAAS-11853](https://dimagi-dev.atlassian.net/browse/SAAS-11853).


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No changes in behavior; no new tests. The existing accounting tests all pass.

### QA Plan

This will need a general run-through of accounting features by QA.

### Safety story
I used local testing to verify several of these changes, although some were hard enough to reproduce that I just eyeballed the replacements. My understanding is that this is an admin-only feature, so while I don't believe I introduced any defects, I'm less concerned if a message is displayed incorrectly.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
