### PR TITLE
Fixes for auditcare issues

### DIFF
--- a/corehq/apps/auditcare/models.py
+++ b/corehq/apps/auditcare/models.py
@@ -92,7 +92,7 @@ class AuditEvent(models.Model):
     def create_audit(cls, request, user):
         audit = cls()
         audit.domain = get_domain(request)
-        audit.path = request.path
+        audit.path = request.path[:255]
         audit.ip_address = get_ip(request)
         audit.session_key = request.session.session_key
         audit.user_agent = request.META.get('HTTP_USER_AGENT')
@@ -134,7 +134,7 @@ class NavigationEventAudit(AuditEvent):
         try:
             audit = cls.create_audit(request, user)
             if request.GET:
-                audit.params = request.META.get("QUERY_STRING", "")
+                audit.params = request.META.get("QUERY_STRING", "")[:512]
             audit.view = "%s.%s" % (view_func.__module__, view_func.__name__)
             for k in STANDARD_HEADER_KEYS:
                 header_item = request.META.get(k, None)

--- a/corehq/util/models.py
+++ b/corehq/util/models.py
@@ -296,7 +296,11 @@ class ForeignValue:
     @cached_property
     def get_related(self):
         def get_related(value):
-            return manager.get_or_create(value=value)[0]
+            try:
+                return manager.get_or_create(value=value)[0]
+            except model.MultipleObjectsReturned:
+                return manager.filter(value=value).order_by("id").first()
+        model = self.fk.related_model
         manager = self.fk.related_model.objects
         if self.cache_size:
             get_related = lru_cache(self.cache_size)(get_related)

--- a/corehq/util/tests/test_models.py
+++ b/corehq/util/tests/test_models.py
@@ -90,3 +90,13 @@ class TestForeignValue(TestCase):
         info = UserAccessLog.user_agent.get_related.cache_info()
         self.assertEqual(info.misses, 1)
         self.assertEqual(info.hits, 1)
+
+    def test_foreign_value_duplicate(self):
+        ua1 = UserAgent(value="Mozilla")
+        ua2 = UserAgent(value="Mozilla")
+        ua1.save()
+        ua2.save()
+        self.assertNotEqual(ua1.id, ua2.id)
+        self.log.user_agent = "Mozilla"
+        self.log.save()
+        self.assertEqual(self.log.user_agent_fk.id, ua1.id)


### PR DESCRIPTION
Fix too long value and duplicate foreign value

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Test added for issues.

### QA Plan

No QA.

### Safety story

Paired with Simon to write these fixes. Ran all relevant tests locally to verify that they pass.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
