### PR TITLE
add management command for getting repeaters stats

### DIFF
--- a/corehq/motech/repeaters/management/commands/generate_repeaters_summary.py
+++ b/corehq/motech/repeaters/management/commands/generate_repeaters_summary.py
@@ -1,0 +1,36 @@
+from django.core.management.base import BaseCommand
+from corehq.motech.repeaters.models import RepeatRecord, Repeater
+
+
+class Command(BaseCommand):
+    help = """
+    Shows the number of Repeaters and RepeatRecords per domain.
+    """
+
+    def handle(self, *args, **options):
+        self.stdout.write("\n")
+        self.stdout.write('fetching repeater data...')
+        repeater_summary = Repeater.get_db().view(
+            'repeaters/repeaters',
+            group_level=1,
+            reduce=True
+        ).all()
+        repeaters_by_domain = {info['key'][0]: info['value'] for info in repeater_summary}
+
+        self.stdout.write("\n")
+        self.stdout.write('fetching repeat record data...')
+        repeat_records_summary = RepeatRecord.get_db().view(
+            'repeaters/repeat_records',
+            group_level=1,
+            reduce=True
+        ).all()
+
+        self.stdout.write("\n\n\n")
+        self.stdout.write("Domain\tRepeaters\tRepeatRecords")
+        for info in repeat_records_summary:
+            domain = info['key'][0]
+            num_repeaters = repeaters_by_domain.get(domain, 0)
+            num_repeat_records = info['value']
+            self.stdout.write(f'{domain}\t{num_repeaters}\t{num_repeat_records}')
+        self.stdout.write('*' * 230)
+        self.stdout.write('done...')


### PR DESCRIPTION
## Summary
just a simple management command for generating statistics for number of repeaters and repeat records per domain.

I think this might be a useful utility for future debugging

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
management command only

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
