### PR TITLE
record timing data for slow form submissions

### DIFF
--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -311,7 +311,7 @@ class BaseMigrationTestCase(TestCase, TestFileMixin):
             return get_result(self_, sql_form, couch_form)
 
         @staticmethod
-        def maybe_process_xforms_for_cases(xforms, casedb):
+        def maybe_process_xforms_for_cases(xforms, casedb, timing_context=None):
             if any(f.form_id == form_id for f in xforms):
                 assert len(xforms) == 1, xforms
                 stock = StockProcessingResult(xforms[0])

--- a/corehq/apps/locations/middleware.py
+++ b/corehq/apps/locations/middleware.py
@@ -3,8 +3,8 @@ from django.utils.translation import ugettext_lazy
 
 from corehq.apps.hqwebapp.views import no_permissions
 from corehq.apps.users.models import AnonymousCouchUser
+from corehq.middleware import get_view_func
 from corehq.toggles import PUBLISH_CUSTOM_REPORTS
-
 from .permissions import is_location_safe, location_restricted_response
 
 RESTRICTED_USER_UNASSIGNED_MSG = ugettext_lazy("""
@@ -35,7 +35,8 @@ class LocationAccessMiddleware(MiddlewareMixin):
         self.apply_location_access(request)
 
         if not request.can_access_all_locations:
-            if not is_location_safe(view_fn, request, view_args, view_kwargs):
+            view_func = get_view_func(view_fn, view_kwargs)
+            if not is_location_safe(view_func, request, view_args, view_kwargs):
                 return location_restricted_response(request)
             elif not user.get_sql_location(domain):
                 return no_permissions(request, message=RESTRICTED_USER_UNASSIGNED_MSG)

--- a/corehq/apps/locations/middleware.py
+++ b/corehq/apps/locations/middleware.py
@@ -3,7 +3,6 @@ from django.utils.translation import ugettext_lazy
 
 from corehq.apps.hqwebapp.views import no_permissions
 from corehq.apps.users.models import AnonymousCouchUser
-from corehq.middleware import get_view_func
 from corehq.toggles import PUBLISH_CUSTOM_REPORTS
 from .permissions import is_location_safe, location_restricted_response
 
@@ -35,8 +34,7 @@ class LocationAccessMiddleware(MiddlewareMixin):
         self.apply_location_access(request)
 
         if not request.can_access_all_locations:
-            view_func = get_view_func(view_fn, view_kwargs)
-            if not is_location_safe(view_func, request, view_args, view_kwargs):
+            if not is_location_safe(view_fn, request, view_args, view_kwargs):
                 return location_restricted_response(request)
             elif not user.get_sql_location(domain):
                 return no_permissions(request, message=RESTRICTED_USER_UNASSIGNED_MSG)

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -249,14 +249,6 @@ def is_location_safe(view_fn, request, view_args, view_kwargs):
     if 'resource_name' in view_kwargs:
         return view_kwargs['resource_name'] in LOCATION_SAFE_TASTYPIE_RESOURCES
 
-    if getattr(view_fn, 'is_hq_report', False):  # HQ report
-        dispatcher = view_fn.view_class
-        report_class = dispatcher.get_report(view_kwargs['domain'], view_kwargs['report_slug'])
-        return _view_obj_is_safe(report_class, request, *view_args, **view_kwargs)
-
-    if hasattr(view_fn, "view_class"):  # Django view
-        return _view_obj_is_safe(view_fn.view_class, request, *view_args, **view_kwargs)
-
     return _view_obj_is_safe(view_fn, request, *view_args, **view_kwargs)
 
 

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -115,6 +115,7 @@ from corehq.apps.domain.decorators import (
 )
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import CouchUser
+from corehq.middleware import get_view_func
 
 from .models import SQLLocation
 
@@ -123,6 +124,8 @@ from .models import SQLLocation
 # evaluate it against the current language.
 # https://docs.djangoproject.com/en/dev/topics/i18n/translation/#other-uses-of-lazy-in-delayed-translations
 # has details on how to create a delayed format_html/mark_safe
+
+
 LOCATION_ACCESS_DENIED = format_html(ugettext_lazy(
     "This project has restricted data access rules. Please contact your "
     "project administrator to be assigned access to data in this project. "
@@ -249,7 +252,8 @@ def is_location_safe(view_fn, request, view_args, view_kwargs):
     if 'resource_name' in view_kwargs:
         return view_kwargs['resource_name'] in LOCATION_SAFE_TASTYPIE_RESOURCES
 
-    return _view_obj_is_safe(view_fn, request, *view_args, **view_kwargs)
+    view_func = get_view_func(view_fn, view_kwargs)
+    return _view_obj_is_safe(view_func, request, *view_args, **view_kwargs)
 
 
 def report_class_is_location_safe(report_class):

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -134,6 +134,7 @@ def _process_form(request, domain, app_id, user_id, authenticated,
             last_sync_token=couchforms.get_last_sync_token(request),
             openrosa_headers=couchforms.get_openrosa_headers(request),
             force_logs=request.GET.get('force_logs', 'false') == 'true',
+            timing_context=timer
         )
 
         try:

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -63,9 +63,11 @@ class FormProcessingResult(namedtuple('FormProcessingResult', 'response xform ca
 
 class SubmissionPost(object):
 
-    def __init__(self, instance=None, attachments=None, auth_context=None, domain=None, app_id=None, build_id=None,
-                 path=None, location=None, submit_ip=None, openrosa_headers=None, last_sync_token=None,
-                 received_on=None, date_header=None, partial_submission=False, case_db=None, force_logs=False,
+    def __init__(self, instance=None, attachments=None, auth_context=None,
+                 domain=None, app_id=None, build_id=None, path=None,
+                 location=None, submit_ip=None, openrosa_headers=None,
+                 last_sync_token=None, received_on=None, date_header=None,
+                 partial_submission=False, case_db=None, force_logs=False,
                  timing_context=None):
         assert domain, "'domain' is required"
         assert instance, instance

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -36,6 +36,7 @@ from corehq.form_processor.utils.metadata import scrub_meta
 from corehq.form_processor.submission_process_tracker import unfinished_submission
 from corehq.util.metrics.load_counters import form_load_counter
 from corehq.util.global_request import get_request
+from corehq.util.timer import TimingContext
 from couchforms import openrosa_response
 from couchforms.const import DEVICE_LOG_XMLNS
 from couchforms.models import DefaultAuthContext, UnfinishedSubmissionStub
@@ -62,11 +63,10 @@ class FormProcessingResult(namedtuple('FormProcessingResult', 'response xform ca
 
 class SubmissionPost(object):
 
-    def __init__(self, instance=None, attachments=None, auth_context=None,
-                 domain=None, app_id=None, build_id=None, path=None,
-                 location=None, submit_ip=None, openrosa_headers=None,
-                 last_sync_token=None, received_on=None, date_header=None,
-                 partial_submission=False, case_db=None, force_logs=False):
+    def __init__(self, instance=None, attachments=None, auth_context=None, domain=None, app_id=None, build_id=None,
+                 path=None, location=None, submit_ip=None, openrosa_headers=None, last_sync_token=None,
+                 received_on=None, date_header=None, partial_submission=False, case_db=None, force_logs=False,
+                 timing_context=None):
         assert domain, "'domain' is required"
         assert instance, instance
         assert not isinstance(instance, HttpRequest), instance
@@ -96,6 +96,7 @@ class SubmissionPost(object):
 
         self.is_openrosa_version3 = self.openrosa_headers.get(OPENROSA_VERSION_HEADER, '') == OPENROSA_VERSION_3
         self.track_load = form_load_counter("form_submission", domain)
+        self.timing_context = timing_context or TimingContext()
 
     def _set_submission_properties(self, xform):
         # attaches shared properties of the request to the document.
@@ -212,45 +213,48 @@ class SubmissionPost(object):
 
     def run(self):
         self.track_load()
-        report_submission_usage(self.domain)
-        failure_response = self._handle_basic_failure_modes()
-        if failure_response:
-            return FormProcessingResult(failure_response, None, [], [], 'known_failures')
+        with self.timing_context("process_xml"):
+            report_submission_usage(self.domain)
+            failure_response = self._handle_basic_failure_modes()
+            if failure_response:
+                return FormProcessingResult(failure_response, None, [], [], 'known_failures')
 
-        result = process_xform_xml(self.domain, self.instance, self.attachments, self.auth_context.to_json())
-        submitted_form = result.submitted_form
+            result = process_xform_xml(self.domain, self.instance, self.attachments, self.auth_context.to_json())
+            submitted_form = result.submitted_form
 
-        self._post_process_form(submitted_form)
-        self._invalidate_caches(submitted_form)
+            self._post_process_form(submitted_form)
+            self._invalidate_caches(submitted_form)
 
-        if submitted_form.is_submission_error_log:
-            logging.info('Processing form %s as a submission error', submitted_form.form_id)
-            self.formdb.save_new_form(submitted_form)
+            if submitted_form.is_submission_error_log:
+                logging.info('Processing form %s as a submission error', submitted_form.form_id)
+                self.formdb.save_new_form(submitted_form)
 
-            response = None
-            try:
-                xml = self.instance.decode()
-            except UnicodeDecodeError:
-                pass
-            else:
-                if 'log_subreport' in xml:
+                response = None
+                try:
+                    xml = self.instance.decode()
+                except UnicodeDecodeError:
+                    pass
+                else:
+                    if 'log_subreport' in xml:
+                        response = self.get_exception_response_and_log(
+                            'Badly formed device log', submitted_form, self.path
+                        )
+
+                if not response:
                     response = self.get_exception_response_and_log(
-                        'Badly formed device log', submitted_form, self.path
+                        'Problem receiving submission', submitted_form, self.path
                     )
-
-            if not response:
-                response = self.get_exception_response_and_log(
-                    'Problem receiving submission', submitted_form, self.path
-                )
-            return FormProcessingResult(response, None, [], [], 'submission_error_log')
+                return FormProcessingResult(response, None, [], [], 'submission_error_log')
 
         if submitted_form.xmlns == SYSTEM_ACTION_XMLNS:
             logging.info('Processing form %s as a system action', submitted_form.form_id)
-            return self.handle_system_action(submitted_form)
+            with self.timing_context("process_system_action"):
+                return self.handle_system_action(submitted_form)
 
         if submitted_form.xmlns == DEVICE_LOG_XMLNS:
             logging.info('Processing form %s as a device log', submitted_form.form_id)
-            return self.process_device_log(submitted_form)
+            with self.timing_context("process_device_log"):
+                return self.process_device_log(submitted_form)
 
         # Begin Normal Form Processing
         self._log_form_details(submitted_form)
@@ -275,7 +279,7 @@ class SubmissionPost(object):
                 instance = xforms[0]
 
                 if instance.is_duplicate:
-                    with tracer.trace('submission.process_duplicate'):
+                    with self.timing_context("process_duplicate"), tracer.trace('submission.process_duplicate'):
                         submission_type = 'duplicate'
                         existing_form = xforms[1]
                         stub = UnfinishedSubmissionStub.objects.filter(
@@ -302,7 +306,7 @@ class SubmissionPost(object):
                 elif not instance.is_error:
                     submission_type = 'normal'
                     try:
-                        case_stock_result = self.process_xforms_for_cases(xforms, case_db)
+                        case_stock_result = self.process_xforms_for_cases(xforms, case_db, self.timing_context)
                     except (IllegalCaseId, UsesReferrals, MissingProductId,
                             PhoneDateValueError, InvalidCaseIndex, CaseValueError) as e:
                         self._handle_known_error(e, instance, xforms)
@@ -396,7 +400,7 @@ class SubmissionPost(object):
     def save_processed_models(self, case_db, xforms, case_stock_result):
         instance = xforms[0]
         try:
-            with unfinished_submission(instance) as unfinished_submission_stub:
+            with self.timing_context("save_models"), unfinished_submission(instance) as unfinished_submission_stub:
                 try:
                     self.interface.save_processed_models(
                         xforms,
@@ -411,7 +415,8 @@ class SubmissionPost(object):
                 else:
                     unfinished_submission_stub.submission_saved()
 
-                self.do_post_save_actions(case_db, xforms, case_stock_result)
+                with self.timing_context("post_save_actions"):
+                    self.do_post_save_actions(case_db, xforms, case_stock_result)
         except PostSaveError:
             return "Error performing post save operations"
 
@@ -442,20 +447,26 @@ class SubmissionPost(object):
 
     @staticmethod
     @tracer.wrap(name='submission.process_cases_and_stock')
-    def process_xforms_for_cases(xforms, case_db):
+    def process_xforms_for_cases(xforms, case_db, timing_context=None):
         from casexml.apps.case.xform import process_cases_with_casedb
         from corehq.apps.commtrack.processing import process_stock
 
+        timing_context = timing_context or TimingContext()
+
         instance = xforms[0]
 
-        case_result = process_cases_with_casedb(xforms, case_db)
-        stock_result = process_stock(xforms, case_db)
+        with timing_context("process_cases"):
+            case_result = process_cases_with_casedb(xforms, case_db)
+        with timing_context("process_ledgers"):
+            stock_result = process_stock(xforms, case_db)
+            stock_result.populate_models()
 
         modified_on_date = instance.received_on
         if getattr(instance, 'edited_on', None) and instance.edited_on > instance.received_on:
             modified_on_date = instance.edited_on
-        cases = case_db.get_cases_for_saving(modified_on_date)
-        stock_result.populate_models()
+
+        with timing_context("check_cases_before_save"):
+            cases = case_db.get_cases_for_saving(modified_on_date)
 
         return CaseStockProcessingResult(
             case_result=case_result,

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -112,6 +112,11 @@ class LogLongRequestMiddleware(MiddlewareMixin):
     def process_request(self, request):
         request._profile_starttime = datetime.datetime.utcnow()
 
+    def process_view(self, request, view_fn, view_args, view_kwargs):
+        view_func = get_view_func(view_fn, view_kwargs)
+        reporting_threshold = getattr(view_func, DURATION_REPORTING_THRESHOLD, self.DEFAULT_THRESHOLD.total_seconds())
+        setattr(request, DURATION_REPORTING_THRESHOLD, reporting_threshold)
+
     def process_response(self, request, response):
         request_timer = getattr(response, 'request_timer', None)
         if request_timer:
@@ -132,11 +137,6 @@ class LogLongRequestMiddleware(MiddlewareMixin):
                     'status_code': response.status_code
                 })
         return response
-
-    def process_view(self, request, view_fn, view_args, view_kwargs):
-        view_func = get_view_func(view_fn, view_kwargs)
-        reporting_threshold = getattr(view_func, DURATION_REPORTING_THRESHOLD, self.DEFAULT_THRESHOLD.total_seconds())
-        setattr(request, DURATION_REPORTING_THRESHOLD, reporting_threshold)
 
 
 class TimeoutMiddleware(MiddlewareMixin):

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -4,6 +4,8 @@ import mimetypes
 import os
 import datetime
 import re
+from datetime import timedelta
+
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.exceptions import MiddlewareNotUsed
@@ -104,7 +106,7 @@ class LogLongRequestMiddleware(MiddlewareMixin):
     Use `corehq.util.timer.set_request_duration_reporting_threshold` to override the
     default threshold for specific views.
     """
-    DEFAULT_THRESHOLD = 10 * 3600  # 10 minutes
+    DEFAULT_THRESHOLD = timedelta(minutes=10)  # 10 minutes
     DURATION_FORMAT = "0.3f"  # millisecond granularity
 
     def process_request(self, request):
@@ -122,7 +124,7 @@ class LogLongRequestMiddleware(MiddlewareMixin):
 
         if hasattr(request, '_profile_starttime'):
             duration = datetime.datetime.utcnow() - request._profile_starttime
-            threshold = getattr(request, DURATION_REPORTING_THRESHOLD, self.DEFAULT_THRESHOLD)
+            threshold = getattr(request, DURATION_REPORTING_THRESHOLD, self.DEFAULT_THRESHOLD.total_seconds())
             if duration.total_seconds() > threshold:
                 notify_exception(request, "Request timing above threshold", details={
                     'threshold': threshold,
@@ -133,7 +135,7 @@ class LogLongRequestMiddleware(MiddlewareMixin):
 
     def process_view(self, request, view_fn, view_args, view_kwargs):
         view_func = get_view_func(view_fn, view_kwargs)
-        reporting_threshold = getattr(view_func, DURATION_REPORTING_THRESHOLD, self.DEFAULT_THRESHOLD)
+        reporting_threshold = getattr(view_func, DURATION_REPORTING_THRESHOLD, self.DEFAULT_THRESHOLD.total_seconds())
         setattr(request, DURATION_REPORTING_THRESHOLD, reporting_threshold)
 
 

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -105,6 +105,7 @@ class LogLongRequestMiddleware(MiddlewareMixin):
     default threshold for specific views.
     """
     DEFAULT_THRESHOLD = 10 * 3600  # 10 minutes
+    DURATION_FORMAT = "0.3f"  # millisecond granularity
 
     def process_request(self, request):
         request._profile_starttime = datetime.datetime.utcnow()
@@ -115,7 +116,7 @@ class LogLongRequestMiddleware(MiddlewareMixin):
             for sub in request_timer.to_list(exclude_root=True):
                 add_breadcrumb(
                     category="timing",
-                    message=f"{sub.name}: {sub.duration}",
+                    message=f"{sub.name}: {sub.duration:{LogLongRequestMiddleware.DURATION_FORMAT}}",
                     level="info",
                 )
 
@@ -134,7 +135,6 @@ class LogLongRequestMiddleware(MiddlewareMixin):
         view_func = get_view_func(view_fn, view_kwargs)
         reporting_threshold = getattr(view_func, DURATION_REPORTING_THRESHOLD, self.DEFAULT_THRESHOLD)
         setattr(request, DURATION_REPORTING_THRESHOLD, reporting_threshold)
-
 
 
 class TimeoutMiddleware(MiddlewareMixin):

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -107,7 +107,6 @@ class LogLongRequestMiddleware(MiddlewareMixin):
     default threshold for specific views.
     """
     DEFAULT_THRESHOLD = timedelta(minutes=10)  # 10 minutes
-    DURATION_FORMAT = "0.3f"  # millisecond granularity
 
     def process_request(self, request):
         request._profile_starttime = datetime.datetime.utcnow()
@@ -123,7 +122,7 @@ class LogLongRequestMiddleware(MiddlewareMixin):
             for sub in request_timer.to_list(exclude_root=True):
                 add_breadcrumb(
                     category="timing",
-                    message=f"{sub.name}: {sub.duration:{LogLongRequestMiddleware.DURATION_FORMAT}}",
+                    message=f"{sub.name}: {sub.duration:0.3f}",
                     level="info",
                 )
 

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -106,14 +106,14 @@ class LogLongRequestMiddleware(MiddlewareMixin):
     Use `corehq.util.timer.set_request_duration_reporting_threshold` to override the
     default threshold for specific views.
     """
-    DEFAULT_THRESHOLD = timedelta(minutes=10)  # 10 minutes
+    DEFAULT_THRESHOLD = timedelta(minutes=10).total_seconds()  # 10 minutes
 
     def process_request(self, request):
         request._profile_starttime = datetime.datetime.utcnow()
 
     def process_view(self, request, view_fn, view_args, view_kwargs):
         view_func = get_view_func(view_fn, view_kwargs)
-        reporting_threshold = getattr(view_func, DURATION_REPORTING_THRESHOLD, self.DEFAULT_THRESHOLD.total_seconds())
+        reporting_threshold = getattr(view_func, DURATION_REPORTING_THRESHOLD, self.DEFAULT_THRESHOLD)
         setattr(request, DURATION_REPORTING_THRESHOLD, reporting_threshold)
 
     def process_response(self, request, response):
@@ -128,7 +128,7 @@ class LogLongRequestMiddleware(MiddlewareMixin):
 
         if hasattr(request, '_profile_starttime'):
             duration = datetime.datetime.utcnow() - request._profile_starttime
-            threshold = getattr(request, DURATION_REPORTING_THRESHOLD, self.DEFAULT_THRESHOLD.total_seconds())
+            threshold = getattr(request, DURATION_REPORTING_THRESHOLD, self.DEFAULT_THRESHOLD)
             if duration.total_seconds() > threshold:
                 notify_exception(request, "Request timing above threshold", details={
                     'threshold': threshold,

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -11,10 +11,12 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.contrib.auth.views import LogoutView
 from django.utils.deprecation import MiddlewareMixin
+from sentry_sdk import add_breadcrumb
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import legacy_domain_re
 from corehq.const import OPENROSA_DEFAULT_VERSION
+from corehq.util.timer import DURATION_REPORTING_THRESHOLD
 from dimagi.utils.logging import notify_exception
 
 from dimagi.utils.parsing import json_format_datetime, string_to_utc_datetime
@@ -97,18 +99,42 @@ class TimingMiddleware(object):
 
 
 class LogLongRequestMiddleware(MiddlewareMixin):
+    """Report requests that violate the timing threshold configured for the view.
+
+    Use `corehq.util.timer.set_request_duration_reporting_threshold` to override the
+    default threshold for specific views.
+    """
+    DEFAULT_THRESHOLD = 10 * 3600  # 10 minutes
 
     def process_request(self, request):
         request._profile_starttime = datetime.datetime.utcnow()
 
     def process_response(self, request, response):
+        request_timer = getattr(response, 'request_timer', None)
+        if request_timer:
+            for sub in request_timer.to_list(exclude_root=True):
+                add_breadcrumb(
+                    category="timing",
+                    message=f"{sub.name}: {sub.duration}",
+                    level="info",
+                )
+
         if hasattr(request, '_profile_starttime'):
             duration = datetime.datetime.utcnow() - request._profile_starttime
-            if duration > datetime.timedelta(minutes=10):
-                notify_exception(request, "Request took a very long time.", details={
+            threshold = getattr(request, DURATION_REPORTING_THRESHOLD, self.DEFAULT_THRESHOLD)
+            if duration.total_seconds() > threshold:
+                notify_exception(request, "Request timing above threshold", details={
+                    'threshold': threshold,
                     'duration': duration.total_seconds(),
+                    'status_code': response.status_code
                 })
         return response
+
+    def process_view(self, request, view_fn, view_args, view_kwargs):
+        view_func = get_view_func(view_fn, view_kwargs)
+        reporting_threshold = getattr(view_func, DURATION_REPORTING_THRESHOLD, self.DEFAULT_THRESHOLD)
+        setattr(request, DURATION_REPORTING_THRESHOLD, reporting_threshold)
+
 
 
 class TimeoutMiddleware(MiddlewareMixin):
@@ -284,3 +310,17 @@ class SelectiveSessionMiddleware(SessionMiddleware):
         if self._bypass_sessions(request):
             request.session.save = lambda *x: None
             request._bypass_sessions = True
+
+
+def get_view_func(view_fn, view_kwargs):
+    """Given a view_fn from the `process_view` middleware function return the actual
+    function or class that represents the view.
+    """
+    if getattr(view_fn, 'is_hq_report', False):  # HQ report
+        dispatcher = view_fn.view_class
+        return dispatcher.get_report(view_kwargs['domain'], view_kwargs['report_slug'])
+
+    if hasattr(view_fn, "view_class"):  # Django view
+        return view_fn.view_class
+
+    return view_fn

--- a/corehq/tests/test_middleware.py
+++ b/corehq/tests/test_middleware.py
@@ -5,8 +5,8 @@ from django.http import HttpResponse
 from django.test import override_settings, SimpleTestCase
 from django.urls import path
 from django.views import View
+from testil import Regex
 
-from corehq.middleware import LogLongRequestMiddleware
 from corehq.util.timer import set_request_duration_reporting_threshold, TimingContext
 
 
@@ -49,10 +49,9 @@ class TestLogLongRequestMiddleware(SimpleTestCase):
     @mock.patch('corehq.middleware.add_breadcrumb')
     @mock.patch('corehq.middleware.notify_exception')
     def test_middleware_reports_slow_function_view_with_timer(self, notify_exception, add_breadcrumb):
-        with mock.patch.object(LogLongRequestMiddleware, "DURATION_FORMAT", "0.1f"):
-            res = self.client.get('/slow_function')
+        res = self.client.get('/slow_function')
         self.assertEqual(res.status_code, 200)
         notify_exception.assert_called_once()
         add_breadcrumb.assert_has_calls([
-            mock.call(category="timing", message="sleep: 0.2", level="info")
+            mock.call(category="timing", message=Regex(r"^sleep: 0.\d+"), level="info")
         ])

--- a/corehq/tests/test_middleware.py
+++ b/corehq/tests/test_middleware.py
@@ -1,0 +1,58 @@
+import time
+
+import mock
+from django.http import HttpResponse
+from django.test import override_settings, SimpleTestCase
+from django.urls import path
+from django.views import View
+
+from corehq.middleware import LogLongRequestMiddleware
+from corehq.util.timer import set_request_duration_reporting_threshold, TimingContext
+
+
+@set_request_duration_reporting_threshold(0.1)
+class SlowClassView(View):
+    def get(self, request):
+        time.sleep(0.2)
+        return HttpResponse()
+
+
+@set_request_duration_reporting_threshold(0.1)
+def slow_function_view(request):
+    timer = TimingContext()
+    with timer("sleep"):
+        time.sleep(0.2)
+    response = HttpResponse()
+    response.request_timer = timer
+    return response
+
+
+urlpatterns = [
+    path('slow_class', SlowClassView.as_view()),
+    path('slow_function', slow_function_view),
+]
+
+
+@override_settings(ROOT_URLCONF='corehq.tests.test_middleware')
+class TestLogLongRequestMiddleware(SimpleTestCase):
+
+    @override_settings(MIDDLEWARE=('corehq.middleware.LogLongRequestMiddleware',))
+    @mock.patch('corehq.middleware.add_breadcrumb')
+    @mock.patch('corehq.middleware.notify_exception')
+    def test_middleware_reports_slow_class_view(self, notify_exception, add_breadcrumb):
+        res = self.client.get('/slow_class')
+        self.assertEqual(res.status_code, 200)
+        notify_exception.assert_called_once()
+        add_breadcrumb.assert_not_called()
+
+    @override_settings(MIDDLEWARE=('corehq.middleware.LogLongRequestMiddleware',))
+    @mock.patch('corehq.middleware.add_breadcrumb')
+    @mock.patch('corehq.middleware.notify_exception')
+    def test_middleware_reports_slow_function_view_with_timer(self, notify_exception, add_breadcrumb):
+        with mock.patch.object(LogLongRequestMiddleware, "DURATION_FORMAT", "0.1f"):
+            res = self.client.get('/slow_function')
+        self.assertEqual(res.status_code, 200)
+        notify_exception.assert_called_once()
+        add_breadcrumb.assert_has_calls([
+            mock.call(category="timing", message="sleep: 0.2", level="info")
+        ])

--- a/corehq/util/timer.py
+++ b/corehq/util/timer.py
@@ -229,17 +229,18 @@ def time_method():
 DURATION_REPORTING_THRESHOLD = "_duration_reporting_threshold"
 
 
-def set_request_duration_reporting_threshold(threshold):
+def set_request_duration_reporting_threshold(seconds):
     """Decorator to override the default reporting threshold for a view.
 
     If requests to the view take longer than the threshold a Sentry event
     will get created.
 
-    See `corehq.middleware.LogLongRequestMiddleware` for where the duration is compared
-    to the threshold.
+    :param seconds: Requests that take longer than this many seconds to process
+        will be reported to Sentry. See ``corehq.middleware.LogLongRequestMiddleware``
+        for where the duration check takes place.
     """
     def decorator(view):
-        setattr(view, DURATION_REPORTING_THRESHOLD, threshold)
+        setattr(view, DURATION_REPORTING_THRESHOLD, seconds)
         return view
 
     return decorator

--- a/corehq/util/timer.py
+++ b/corehq/util/timer.py
@@ -224,3 +224,22 @@ def time_method():
                 return fn(self, *args, **kwargs)
         return _inner
     return decorator
+
+
+DURATION_REPORTING_THRESHOLD = "_duration_reporting_threshold"
+
+
+def set_request_duration_reporting_threshold(threshold):
+    """Decorator to override the default reporting threshold for a view.
+
+    If requests to the view take longer than the threshold a Sentry event
+    will get created.
+
+    See `corehq.middleware.LogLongRequestMiddleware` for where the duration is compared
+    to the threshold.
+    """
+    def decorator(view):
+        setattr(view, DURATION_REPORTING_THRESHOLD, threshold)
+        return view
+
+    return decorator


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-836

The help diagnose performance issues during form submission processing this PR adds more granular timing data which get's reported to Sentry as breadcrumbs. In addition, if requests take longer than 60s an event is created in Sentry.

This extends the existing `LogLongRequestMiddleware` to allow configuring the timing threshold on a per view basis.

Can be reviewed by commit.

Note: this changes the sentry message:

```diff
- Request took a very long time.
+ Request timing above threshold
``` 


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added tests

### QA Plan
Automated tests have been added that cover the changes to the functionality as well as the existing functionality.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
