### PR TITLE
Match expected API base url and param names

### DIFF
--- a/corehq/messaging/smsbackends/ivory_coast_mtn/models.py
+++ b/corehq/messaging/smsbackends/ivory_coast_mtn/models.py
@@ -47,16 +47,16 @@ class IvoryCoastMTNBackend(SQLSMSBackend):
 
         return {
             'customerID': config.customer_id,
-            'username': config.username,
+            'userName': config.username,
             'userPassword': config.password,
             'originator': config.sender_id,
             # This is for a custom project and they only send messages in French
             'messageType': 'Latin',
             # This must be set to the date and time to send the message; it's a required field
-            'defdate': self.get_ivory_coast_timestamp().strftime('%Y%m%d%H%M%S'),
+            'defDate': self.get_ivory_coast_timestamp().strftime('%Y%m%d%H%M%S'),
             'blink': 'false',
             'flash': 'false',
-            'private': 'false',
+            'Private': 'false',
             'smsText': msg_obj.text.encode('utf-8'),
             'recipientPhone': msg_obj.phone_number,
         }
@@ -74,7 +74,7 @@ class IvoryCoastMTNBackend(SQLSMSBackend):
             return
 
         response = requests.get(
-            'https://smspro.mtn.ci/smspro/Soap/Messenger.asmx/HTTP_SendSms',
+            'https://smspro.mtn.ci/bms/Soap/Messenger.asmx/HTTP_SendSms',
             params=self.get_params(msg_obj),
             timeout=settings.SMS_GATEWAY_TIMEOUT,
         )


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Support Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11999)

A customer's custom sms gateway is unable to successfully send sms over the API. The service we are using is `HTTP_SendSms`, and based on the documentation for it [here](https://smspro.mtn.ci/bms/Soap/Messenger.asmx?page=op&tab=msg&op=HTTP_SendSms&bnd=MessengerSoap), we have a mismatch in the base url, as well as some case sensitivity mismatches in the parameters but not sure if that is an issue. 

Using smspro's test API interface, I tested a request with values I would expect commcare to send and it succeeded, so the issue is most likely on our end. 

I'm not sold this will fix the issue since it seems like navigating to https://smspro.mtn.ci/smspro/Soap/Messenger.asmx autoresolves to https://smspro.mtn.ci/bms/Soap/Messenger.asmx, but maybe the API behaves differently.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This is isolated to the one domain that relies on this custom backend, which is already broken.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
