### PR TITLE
Update venv and Docker setup instructions.

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -176,26 +176,38 @@ following should cover the needs of most developers.
 
 1. Install docker packages.
 
+    **Mac**: see [Install Docker Desktop on
+    Mac](https://docs.docker.com/docker-for-mac/install/) for docker
+    installation and setup.
+
+    **Linux**:
+
     ```sh
+    # install docker
     $ sudo apt install docker.io
-    $ pip install docker-compose
+
+    # ensure docker is running
+    $ systemctl is-active docker || sudo systemctl start docker
+    # add your user to the `docker` group
     $ sudo adduser $USER docker
-    ```
-
-1. Log in as yourself again to activate membership of the "docker" group and
-   re-activate your virtualenv.
-
-    ```sh
+    # login as yourself again to activate membership of the "docker" group
     $ su - $USER
+
+    # re-activate your virtualenv (with your venv tool of choice)
+    # (virtualenvwrapper)
     $ workon cchq
+
+    # or (pyenv)
+    $ pyenv activate cchq
+
+    # or (virtualenv)
+    $ source $WORKON_HOME/cchq/bin/activate
     ```
 
-1. Ensure the Docker service is running.
+1. Install the `docker-compose` python library.
 
     ```sh
-    $ sudo systemctl status docker
-    # if service is not running, execute:
-    $ sudo systemctl start docker
+    $ pip install docker-compose
     ```
 
 1. Ensure the elasticsearch config files are world-readable (their containers
@@ -205,12 +217,14 @@ following should cover the needs of most developers.
     chmod 0644 ./docker/files/elasticsearch*.yml
     ```
 
-1. Bring up the Docker containers.
+1. Bring up the docker containers.
 
     ```sh
-    $ ./scripts/docker up
-    # Or, use '-d' option to detach and run in the background:
     $ ./scripts/docker up -d
+    # Or, omit the '-d' option to keep the containers attached in the foreground
+    $ ./scripts/docker up
+    # Optionally, bring up only specific containers (add '-d' to detach)
+    $ ./scripts/docker up postgres couch redis elasticsearch zookeeper kafka minio
     ```
 
 1. If you are planning on running Formplayer from source, stop the formplayer

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -117,6 +117,10 @@ please see [`xmlsec`'s install notes](https://pypi.org/project/xmlsec/).
 
        $ workon cchq
 
+1. Ensure your vitualenv `pip` is up-to-date:
+
+       $ python3 -m pip install --upgrade pip
+
 
 #### Clone repo and install requirements
 
@@ -167,28 +171,54 @@ Create the shared directory.  If you have not modified `SHARED_DRIVE_ROOT`, then
 Once you have completed the above steps, you can use Docker to build
 and run all of the service containers. There are detailed instructions
 for setting up Docker in the [docker folder](docker/README.md). But the
-following should cover the needs of most developers:
+following should cover the needs of most developers.
 
+
+1. Install docker packages.
+
+    ```sh
     $ sudo apt install docker.io
     $ pip install docker-compose
     $ sudo adduser $USER docker
+    ```
 
-Log in as yourself again, to activate membership of the "docker" group:
+1. Log in as yourself again to activate membership of the "docker" group and
+   re-activate your virtualenv.
 
+    ```sh
     $ su - $USER
+    $ workon cchq
+    ```
 
-Ensure the Docker service is running:
+1. Ensure the Docker service is running.
 
-    $ sudo service docker status
+    ```sh
+    $ sudo systemctl status docker
+    # if service is not running, execute:
+    $ sudo systemctl start docker
+    ```
 
-Bring up the Docker containers for the services you probably need:
+1. Ensure the elasticsearch config files are world-readable (their containers
+   will fail to start otherwise).
 
-    $ scripts/docker up postgres couch redis elasticsearch zookeeper kafka minio
+    ```sh
+    chmod 0644 ./docker/files/elasticsearch*.yml
+    ```
 
-or, to detach and run in the background, use the `-d` option:
+1. Bring up the Docker containers.
 
-    $ scripts/docker up -d postgres couch redis elasticsearch zookeeper kafka minio
+    ```sh
+    $ ./scripts/docker up
+    # Or, use '-d' option to detach and run in the background:
+    $ ./scripts/docker up -d
+    ```
 
+1. If you are planning on running Formplayer from source, stop the formplayer
+   container.
+
+    ```sh
+    $ ./scripts/docker stop formplayer
+    ```
 
 ### (Optional) Copying data from an existing HQ install
 


### PR DESCRIPTION
- Add step to upgrade pip after venv creation.
- Convert Docker instructions to ordered list with shell code blocks.
- Add step for ensuring ES configs are world-readable.
- Simplify `./scripts/docker up` command.
- Add step to stop formplayer if running it from source.

## Summary
Documentation updates in [`DEV_SETUP.md`](./DEV_SETUP.md) which was prompted by my onboarding process and gotchas encountered.

## Feature Flag

## Product Description

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

### QA Plan

### Safety story

Documentation only.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
