### PR TITLE
[SSO] Allow SSO-logged in users to view 2FA domain (if Trust was established)

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -475,6 +475,13 @@ def two_factor_check(view_func, api_key):
 
 
 def _two_factor_required(view_func, domain, couch_user, request):
+    if (ENTERPRISE_SSO.enabled_for_request(request)
+            and is_request_using_sso(request)):
+        # SSO authenticated users manage two-factor auth on the Identity Provider
+        # level, so CommCare HQ does not attempt 2FA with them. This is one of
+        # the reasons we require that domains establish TrustedIdentityProvider
+        # relationships.
+        return False
     exempt = getattr(view_func, 'two_factor_exempt', False)
     if exempt:
         return False

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -485,7 +485,7 @@ def _two_factor_required(view_func, domain_obj, request):
     exempt = getattr(view_func, 'two_factor_exempt', False)
     if exempt:
         return False
-    if not getattr(request, 'couch_user'):
+    if not request.couch_user:
         return False
     if (ENTERPRISE_SSO.enabled_for_request(request)
             and is_request_using_sso(request)):

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -482,17 +482,17 @@ def _two_factor_required(view_func, domain_obj, request):
     :param request: Request
     :return: Boolean (True if 2FA is required)
     """
+    exempt = getattr(view_func, 'two_factor_exempt', False)
+    if exempt:
+        return False
+    if not getattr(request, 'couch_user'):
+        return False
     if (ENTERPRISE_SSO.enabled_for_request(request)
             and is_request_using_sso(request)):
         # SSO authenticated users manage two-factor auth on the Identity Provider
         # level, so CommCare HQ does not attempt 2FA with them. This is one of
         # the reasons we require that domains establish TrustedIdentityProvider
         # relationships.
-        return False
-    exempt = getattr(view_func, 'two_factor_exempt', False)
-    if exempt:
-        return False
-    if not getattr(request, 'couch_user'):
         return False
     return (
         # If a user is a superuser, then there is no two_factor_disabled loophole allowed.

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -444,7 +444,7 @@ def two_factor_check(view_func, api_key):
         @wraps(fn)
         def _inner(request, domain, *args, **kwargs):
             domain_obj = Domain.get_by_name(domain)
-            couch_user = _ensure_request_couch_user(request)
+            _ensure_request_couch_user(request)
             if (
                 not api_key and
                 not getattr(request, 'skip_two_factor_check', False) and

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -155,7 +155,7 @@ def _inactive_domain_response(request, domain_name):
 
 
 def _is_missing_two_factor(view_fn, request):
-    return (_two_factor_required(view_fn, request.project, request.couch_user)
+    return (_two_factor_required(view_fn, request.project, request.couch_user, request)
             and not getattr(request, 'bypass_two_factor', False)
             and not request.user.is_verified())
 
@@ -449,7 +449,7 @@ def two_factor_check(view_func, api_key):
                 not api_key and
                 not getattr(request, 'skip_two_factor_check', False) and
                 domain_obj and
-                _two_factor_required(view_func, domain_obj, couch_user)
+                _two_factor_required(view_func, domain_obj, couch_user, request)
             ):
                 token = request.META.get('HTTP_X_COMMCAREHQ_OTP')
                 if not token and 'otp' in request.GET:
@@ -474,7 +474,7 @@ def two_factor_check(view_func, api_key):
     return _outer
 
 
-def _two_factor_required(view_func, domain, couch_user):
+def _two_factor_required(view_func, domain, couch_user, request):
     exempt = getattr(view_func, 'two_factor_exempt', False)
     if exempt:
         return False

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -474,7 +474,7 @@ def two_factor_check(view_func, api_key):
     return _outer
 
 
-def _two_factor_required(view_func, domain, couch_user, request):
+def _two_factor_required(view_func, domain_obj, couch_user, request):
     if (ENTERPRISE_SSO.enabled_for_request(request)
             and is_request_using_sso(request)):
         # SSO authenticated users manage two-factor auth on the Identity Provider
@@ -496,7 +496,7 @@ def _two_factor_required(view_func, domain, couch_user, request):
         # For other policies requiring two factor auth,
         # allow the two_factor_disabled loophole for people who have lost their phones
         # and need time to set up two factor auth again.
-        (domain.two_factor_auth or TWO_FACTOR_SUPERUSER_ROLLOUT.enabled(couch_user.username))
+        (domain_obj.two_factor_auth or TWO_FACTOR_SUPERUSER_ROLLOUT.enabled(couch_user.username))
         and not couch_user.two_factor_disabled
     )
 

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -475,6 +475,13 @@ def two_factor_check(view_func, api_key):
 
 
 def _two_factor_required(view_func, domain_obj, request):
+    """
+    Check if Two Factor Authentication is required.
+    :param view_func: the view function being accessed
+    :param domain_obj: Domain instance associated with the view
+    :param request: Request
+    :return: Boolean (True if 2FA is required)
+    """
     if (ENTERPRISE_SSO.enabled_for_request(request)
             and is_request_using_sso(request)):
         # SSO authenticated users manage two-factor auth on the Identity Provider

--- a/corehq/apps/domain/tests/test_two_factor_check.py
+++ b/corehq/apps/domain/tests/test_two_factor_check.py
@@ -37,14 +37,23 @@ class TestTwoFactorCheck(TestCase):
     def test_two_factor_required_with_feature_flag(self):
         view_func = 'dummy_view_func'
         request = self.request
-        two_factor_required_bool = _two_factor_required(view_func, self.domain, request.couch_user)
+        two_factor_required_bool = _two_factor_required(
+            view_func,
+            self.domain,
+            request.couch_user,
+            request
+        )
         self.assertTrue(two_factor_required_bool)
 
     def test_two_factor_required_without_feature_flag(self):
         view_func = 'dummy_view_func'
         request = self.request
-        two_factor_required_bool = _two_factor_required(view_func, self.domain,
-                                                        request.couch_user)
+        two_factor_required_bool = _two_factor_required(
+            view_func,
+            self.domain,
+            request.couch_user,
+            request
+        )
         self.assertFalse(two_factor_required_bool)
 
     @flag_enabled('TWO_FACTOR_SUPERUSER_ROLLOUT')

--- a/corehq/apps/domain/tests/test_two_factor_check.py
+++ b/corehq/apps/domain/tests/test_two_factor_check.py
@@ -41,7 +41,6 @@ class TestTwoFactorCheck(TestCase):
         two_factor_required_bool = _two_factor_required(
             view_func,
             self.domain,
-            request.couch_user,
             request
         )
         self.assertTrue(two_factor_required_bool)
@@ -54,7 +53,6 @@ class TestTwoFactorCheck(TestCase):
         two_factor_required_bool = _two_factor_required(
             view_func,
             self.domain,
-            request.couch_user,
             request
         )
         self.assertFalse(two_factor_required_bool)
@@ -65,7 +63,6 @@ class TestTwoFactorCheck(TestCase):
         two_factor_required_bool = _two_factor_required(
             view_func,
             self.domain,
-            request.couch_user,
             request
         )
         self.assertFalse(two_factor_required_bool)

--- a/corehq/apps/domain/tests/test_two_factor_check.py
+++ b/corehq/apps/domain/tests/test_two_factor_check.py
@@ -11,6 +11,7 @@ from corehq.apps.domain.decorators import (
 )
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.sso.tests.generator import create_request_session
 from corehq.apps.users.models import CouchUser
 from corehq.util.test_utils import flag_enabled
 
@@ -44,6 +45,19 @@ class TestTwoFactorCheck(TestCase):
             request
         )
         self.assertTrue(two_factor_required_bool)
+
+    @flag_enabled('ENTERPRISE_SSO')
+    def test_two_factor_check_with_sso_request(self):
+        view_func = 'dummy_view_func'
+        request = self.request
+        create_request_session(request, use_sso=True)
+        two_factor_required_bool = _two_factor_required(
+            view_func,
+            self.domain,
+            request.couch_user,
+            request
+        )
+        self.assertFalse(two_factor_required_bool)
 
     def test_two_factor_required_without_feature_flag(self):
         view_func = 'dummy_view_func'


### PR DESCRIPTION
## Summary
With SSO, the 2FA happens on the Identity Provider side, so CommCare HQ cannot meaningfully use the Two-Factor option when if one is present.

This PR adds a check to `_two_factor_required` that if the request is using SSO, then it should not require 2FA.

See https://dimagi-dev.atlassian.net/browse/SAAS-11970

NOTE: this PR is marked as High Risk because the `domain/decorators.py` file was edited. This change is carefully feature flagged and well-tested.

## Feature Flag
`ENTERPRISE_SSO`

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Area is well tested

### QA Plan
not needed

### Safety story
Tests + feature flagged code make this feel like a very safe change

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
