### PR TITLE
Disable auditcare foreign value LRU caches

### DIFF
--- a/corehq/apps/auditcare/models.py
+++ b/corehq/apps/auditcare/models.py
@@ -68,7 +68,7 @@ class AuditEvent(models.Model):
     session_key = models.CharField(max_length=255, blank=True, null=True)
     user_agent_fk = models.ForeignKey(
         UserAgent, null=True, db_index=False, on_delete=models.PROTECT)
-    user_agent = ForeignValue(user_agent_fk, truncate=True)
+    user_agent = ForeignValue(user_agent_fk, truncate=True, cache_size=0)
 
     @property
     def doc_type(self):
@@ -116,7 +116,7 @@ class NavigationEventAudit(AuditEvent):
     params = models.CharField(max_length=512, blank=True, default='')
     view_fk = models.ForeignKey(
         ViewName, null=True, db_index=False, on_delete=models.PROTECT)
-    view = ForeignValue(view_fk, truncate=True)
+    view = ForeignValue(view_fk, truncate=True, cache_size=0)
     view_kwargs = NullJsonField(default=dict)
     headers = NullJsonField(default=dict)
     status_code = models.SmallIntegerField(default=0)
@@ -165,7 +165,7 @@ class AccessAudit(AuditEvent):
     access_type = models.CharField(max_length=1, choices=ACCESS_CHOICES.items())
     http_accept_fk = models.ForeignKey(
         HttpAccept, null=True, db_index=False, on_delete=models.PROTECT)
-    http_accept = ForeignValue(http_accept_fk, truncate=True)
+    http_accept = ForeignValue(http_accept_fk, truncate=True, cache_size=0)
     trace_id = models.CharField(max_length=127, null=True, blank=True)
 
     # Optional (django-ified) settings.AUDIT_TRACE_ID_HEADER set by AuditcareConfig


### PR DESCRIPTION
This PR is not intended to be merged (ever). I will cherry-pick the test off of it in a later PR.

## Summary

Temporarily disable LRU caches to make it safer to [add unique constraints](https://github.com/dimagi/commcare-hq/pull/29393) on the foreign value tables. The theory is that the race condition still exists in `ForeignValue`, so it is possible for new duplicates to be created until the unique constraints have been added. While the LRU caches are enabled a webworker could reference a duplicate (one that does not have the lowest primary key value) foreign value in its cache (if it won a race), and would create new audit records referencing those values concurrently while the duplicates are being deleted by the mirgation.

This branch is meant to be deployed to production temporarily before/while [the migration](https://github.com/dimagi/commcare-hq/pull/29393) is run. Once that is done master can be deployed to production.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Test added for ForeignValue with LRU cache disabled. Notably, that commit should not be reverted once the migration is complete.

### QA Plan

No QA.

### Safety story

### Rollback instructions

This PR can be reverted if [the migration](https://github.com/dimagi/commcare-hq/pull/29393) is not running. If the migration is running it should not be reverted until after that has finished.
