### PR TITLE
record detailed timing for syncs > 5s

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -285,6 +285,7 @@ class AbstractSyncLog(SafeSaveDocument):
 
     previous_log_id = StringProperty()  # previous sync log, forming a chain
     duration = IntegerProperty()  # in seconds
+    timing_detail = DictProperty()  # value from TimingContext.to_dict
     log_format = StringProperty()
 
     # owner_ids_on_phone stores the ids the phone thinks it's the owner of.

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -453,7 +453,7 @@ class RestoreState(object):
     def finish_sync(self, timing_context):
         self.duration = datetime.utcnow() - self.start_time
         self.current_sync_log.duration = self.duration.seconds
-        if self.duration.seconds > 1:
+        if self.duration.seconds > 5:
             self.current_sync_log.timing_detail = timing_context.to_dict(minimal=True)["subs"]
         self.current_sync_log.save()
 

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -450,9 +450,11 @@ class RestoreState(object):
         self.start_time = datetime.utcnow()
         self.current_sync_log = self._new_sync_log()
 
-    def finish_sync(self):
+    def finish_sync(self, timing_context):
         self.duration = datetime.utcnow() - self.start_time
         self.current_sync_log.duration = self.duration.seconds
+        if self.duration.seconds > 1:
+            self.current_sync_log.timing_detail = timing_context.to_dict()
         self.current_sync_log.save()
 
     def _new_sync_log(self):
@@ -627,7 +629,7 @@ class RestoreConfig(object):
         self.restore_state.start_sync()
         fileobj = self._generate_restore_response(async_task=async_task)
         try:
-            self.restore_state.finish_sync()
+            self.restore_state.finish_sync(self.timing_context)
             cached_response = self.set_cached_payload_if_necessary(
                 fileobj, self.restore_state.duration, async_task)
             if async_task:

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -454,7 +454,7 @@ class RestoreState(object):
         self.duration = datetime.utcnow() - self.start_time
         self.current_sync_log.duration = self.duration.seconds
         if self.duration.seconds > 1:
-            self.current_sync_log.timing_detail = timing_context.to_dict()
+            self.current_sync_log.timing_detail = timing_context.to_dict(minimal=True)["subs"]
         self.current_sync_log.save()
 
     def _new_sync_log(self):

--- a/corehq/util/timer.py
+++ b/corehq/util/timer.py
@@ -59,10 +59,8 @@ class NestableTimer(object):
     def to_dict(self, minimal=False):
         timer_dict = {
             'name': self.name,
-            'duration': self.duration,
-            'percent_total': self.percent_of_total,
-            'percent_parent': self.percent_of_parent,
-            'subs': [sub.to_dict() for sub in self.subs]
+            'duration': None if self.duration is None else round(self.duration, 4),
+            'subs': [sub.to_dict(minimal) for sub in self.subs]
         }
         if not minimal:
             timer_dict['percent_total'] = self.percent_of_total,

--- a/corehq/util/timer.py
+++ b/corehq/util/timer.py
@@ -56,7 +56,7 @@ class NestableTimer(object):
         else:
             return None
 
-    def to_dict(self):
+    def to_dict(self, minimal=False):
         timer_dict = {
             'name': self.name,
             'duration': self.duration,
@@ -64,6 +64,10 @@ class NestableTimer(object):
             'percent_parent': self.percent_of_parent,
             'subs': [sub.to_dict() for sub in self.subs]
         }
+        if not minimal:
+            timer_dict['percent_total'] = self.percent_of_total,
+            timer_dict['percent_parent'] = self.percent_of_parent
+
         if not self.duration:
             timer_dict.update({
                 'beginning': self.beginning,
@@ -170,7 +174,7 @@ class TimingContext(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop(self.peek().name)
 
-    def to_dict(self):
+    def to_dict(self, minimal=False):
         """Get timing data as a recursive dictionary of the format:
         {
             "name": "demo_timing",
@@ -187,8 +191,11 @@ class TimingContext(object):
                 }
             ]
         }
+
+        :param minimal: If set to True the ``percent_*`` fields will be excluded
+            from the result.
         """
-        return self.root.to_dict()
+        return self.root.to_dict(minimal=minimal)
 
     @property
     def duration(self):


### PR DESCRIPTION
## Summary
Putting this up as a potential means of getting more detailed data about sync timing. This saves the full timing context for syncs > ~1s~ 5s.

This will add more data to the synclog DB but most syncs are below ~1s~ 5s so it should not be overwhelming.

Analysis would require exporting synclog data for a time period and analysing the timing data.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Covered by existing tests

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
