### PR TITLE
add feature flag that immediately blocks all restores for a specific domain

### DIFF
--- a/corehq/apps/ota/rate_limiter.py
+++ b/corehq/apps/ota/rate_limiter.py
@@ -6,7 +6,7 @@ from corehq.project_limits.rate_limiter import (
     RateLimiter,
 )
 from corehq.project_limits.shortcuts import get_standard_ratio_rate_definition
-from corehq.toggles import RATE_LIMIT_RESTORES, NAMESPACE_DOMAIN
+from corehq.toggles import RATE_LIMIT_RESTORES, NAMESPACE_DOMAIN, BLOCK_RESTORES
 from corehq.util.decorators import run_only_when, silence_and_report_error
 from corehq.util.metrics import metrics_counter
 
@@ -37,6 +37,8 @@ SHOULD_RATE_LIMIT_RESTORES = not settings.ENTERPRISE_MODE and not settings.UNIT_
 def rate_limit_restore(domain):
     if RATE_LIMIT_RESTORES.enabled(domain, namespace=NAMESPACE_DOMAIN):
         return _rate_limit_restore(domain)
+    elif BLOCK_RESTORES.enabled(domain, namespace=NAMESPACE_DOMAIN):
+        return True
     else:
         _rate_limit_restore_test(domain)
         return False

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1813,6 +1813,17 @@ RATE_LIMIT_RESTORES = DynamicallyPredictablyRandomToggle(
     """
 )
 
+BLOCK_RESTORES = StaticToggle(
+    'block_restores',
+    'Block Restores Immediately with a 429 TOO MANY REQUESTS response',
+    TAG_INTERNAL,
+    [NAMESPACE_DOMAIN],
+    description="""
+    Use this flag for EMERGENCY PURPOSES ONLY if a project's restore is causing
+    system-wide issues that aren't caught by rate limiting or other mechanisms.
+    """
+)
+
 SKIP_UPDATING_USER_REPORTING_METADATA = StaticToggle(
     'skip_updating_user_reporting_metadata',
     'ICDS: Skip updates to user reporting metadata to avoid expected load on couch',


### PR DESCRIPTION
## Summary
We are having some trouble with a partner's project causing site-wide load issues during restores for their app. To buy us some time to figure out the root cause, we need a feature flag to temporarily block their project from making restores during peak times in a way that does not limit their access to other project functionality.

## Feature Flag
`BLOCK_RESTORES`

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
area is tested

### QA Plan
none needed

### Safety story
just adding a feature flag

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
