### PR TITLE
Sanitize mark_safe usages in exports

### DIFF
--- a/corehq/apps/export/views/incremental.py
+++ b/corehq/apps/export/views/incremental.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.http import HttpResponseNotFound, StreamingHttpResponse, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 
 from corehq.apps.data_interfaces.dispatcher import require_can_edit_data
@@ -177,27 +177,29 @@ class IncrementalExportLogView(GenericTabularReport, DatespanMixin):
 
         for checkpoint in self._get_paged_checkpoints():
             if checkpoint.status == 1:
-                status = f'<span class="label label-success">{_("Success")}</span>'
+                status = format_html('<span class="label label-success">{}</span>', _("Success"))
             else:
-                status = f'<span class="label label-danger">{_("Failure")}</span>'
+                status = format_html('<span class="label label-danger">{}</span>', _("Failure"))
 
             log_url = reverse(MotechLogDetailView.urlname, args=[self.domain, checkpoint.request_log_id])
             file_url = reverse("incremental_export_checkpoint_file", args=[self.domain, checkpoint.id])
             reset_url = reverse("incremental_export_reset_checkpoint", args=[self.domain, checkpoint.id])
             if checkpoint.blob_exists():
-                download = f'<a href="{file_url}"><i class="fa fa-download"></i></a>'
+                download = format_html('<a href="{}"><i class="fa fa-download"></i></a>', file_url)
             else:
                 download = _("File Expired")
             rows.append(
                 [
-                    mark_safe(status),
+                    status,
                     checkpoint.incremental_export.name,
                     checkpoint.date_created.strftime("%Y-%m-%d %H:%M:%S"),
                     checkpoint.doc_count,
-                    mark_safe(download),
-                    mark_safe(f'<a href="{log_url}">{_("Request Details")}</a>'),
-                    mark_safe(
-                        f'<a href="{reset_url}">{_("Resend all cases after this checkpoint")}</a>'
+                    download,
+                    format_html('<a href="{}">{}</a>', log_url, _("Request Details")),
+                    format_html(
+                        '<a href="{}">{}</a>',
+                        reset_url,
+                        _("Resend all cases after this checkpoint")
                     ),
                 ]
             )

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -8,6 +8,7 @@ from django.template.defaultfilters import filesizeformat
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.functional import lazy
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
@@ -1012,7 +1013,7 @@ class ODataFeedListView(BaseExportListView, ODataFeedListHelper):
 
     @property
     def lead_text(self):
-        return _("""
+        return _(format_html("""
         Use OData feeds to integrate your CommCare data with Power BI or Tableau.
         <a href="https://confluence.dimagi.com/pages/viewpage.action?pageId=63013347"
            id="js-odata-track-learn-more"
@@ -1021,10 +1022,9 @@ class ODataFeedListView(BaseExportListView, ODataFeedListHelper):
         </a><br />
         This feature allows {odata_feed_limit} feed configurations. Need more?
         Please write to us at <a href="mailto:{sales_email}">{sales_email}</a>.
-        """).format(
+        """,
             odata_feed_limit=self.odata_feed_limit,
-            sales_email=settings.SALES_EMAIL,
-        )
+            sales_email=settings.SALES_EMAIL,))
 
     @property
     def page_context(self):

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -1013,7 +1013,7 @@ class ODataFeedListView(BaseExportListView, ODataFeedListHelper):
 
     @property
     def lead_text(self):
-        return _(format_html("""
+        return format_html(_("""
         Use OData feeds to integrate your CommCare data with Power BI or Tableau.
         <a href="https://confluence.dimagi.com/pages/viewpage.action?pageId=63013347"
            id="js-odata-track-learn-more"
@@ -1022,9 +1022,9 @@ class ODataFeedListView(BaseExportListView, ODataFeedListHelper):
         </a><br />
         This feature allows {odata_feed_limit} feed configurations. Need more?
         Please write to us at <a href="mailto:{sales_email}">{sales_email}</a>.
-        """,
+        """),
             odata_feed_limit=self.odata_feed_limit,
-            sales_email=settings.SALES_EMAIL,))
+            sales_email=settings.SALES_EMAIL,)
 
     @property
     def page_context(self):

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -7,6 +7,7 @@ from django.http import Http404, HttpResponseRedirect, JsonResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from django.views.generic import View
@@ -90,7 +91,8 @@ class BaseExportView(BaseProjectDataView):
     def terminology(self):
         return {
             'page_header': _("Export Settings"),
-            'help_text': mark_safe(_("""
+            'help_text': mark_safe(  # nosec: no user input
+                _("""
                 Learn more about exports on our <a
                 href="https://help.commcarehq.org/display/commcarepublic/Data+Export+Overview"
                 target="_blank">Help Site</a>.
@@ -192,11 +194,7 @@ class BaseExportView(BaseProjectDataView):
         export.save()
         messages.success(
             request,
-            mark_safe(
-                _("Export <strong>{}</strong> saved.").format(
-                    export.name
-                )
-            )
+            format_html(_("Export <strong>{}</strong> saved."), export.name)
         )
         return export._id
 
@@ -369,11 +367,7 @@ class DeleteNewCustomExportView(BaseExportView):
         export.delete()
         messages.success(
             request,
-            mark_safe(
-                _("Export <strong>{}</strong> was deleted.").format(
-                    export.name
-                )
-            )
+            format_html(_("Export <strong>{}</strong> was deleted."), export.name)
         )
         return export._id
 
@@ -425,11 +419,7 @@ class CopyExportView(View):
             new_export.save()
             messages.success(
                 request,
-                mark_safe(
-                    _("Export <strong>{}</strong> created.").format(
-                        new_export.name
-                    )
-                )
+                format_html(_("Export <strong>{}</strong> created."), new_export.name)
             )
         redirect = request.GET.get('next', reverse('data_interfaces_default', args=[domain]))
         return HttpResponseRedirect(redirect)


### PR DESCRIPTION
## Summary
Part of the XSS work for [SAAS-11853](https://dimagi-dev.atlassian.net/browse/SAAS-11853).

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests. 

### QA Plan

QA verified exports continued to work

### Safety story
Local testing was done to ensure that these changes are invisible.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
