### PR TITLE
Add feature flag to specifically skip fixtures on restores based on project

### DIFF
--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -221,7 +221,7 @@ class AdminRestoreView(TemplateView):
     def _get_restore_response(self):
         return get_restore_response(
             self.user.domain, self.user, app_id=self.app_id,
-            **get_restore_params(self.request)
+            **get_restore_params(self.request, self.user.domain)
         )
 
     @staticmethod

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -167,6 +167,12 @@ def get_restore_params(request, domain):
     if isinstance(openrosa_version, bytes):
         openrosa_version = openrosa_version.decode('utf-8')
 
+    skip_fixtures = (
+        toggles.SKIP_FIXTURES_ON_RESTORE.enabled(
+            domain, namespace=toggles.NAMESPACE_DOMAIN
+        ) or request.GET.get('skip_fixtures') == 'true'
+    )
+
     return {
         'since': request.GET.get('since'),
         'version': request.GET.get('version', "2.0"),
@@ -178,7 +184,7 @@ def get_restore_params(request, domain):
         'device_id': request.GET.get('device_id'),
         'user_id': request.GET.get('user_id'),
         'case_sync': request.GET.get('case_sync'),
-        'skip_fixtures': request.GET.get('skip_fixtures') == 'true',
+        'skip_fixtures': skip_fixtures,
         'auth_type': getattr(request, 'auth_type', None),
     }
 

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -84,7 +84,7 @@ def restore(request, domain, app_id=None):
         return HttpTooManyRequests()
 
     response, timing_context = get_restore_response(
-        domain, request.couch_user, app_id, **get_restore_params(request))
+        domain, request.couch_user, app_id, **get_restore_params(request, domain))
     return response
 
 
@@ -154,7 +154,7 @@ def claim(request, domain):
     return HttpResponse(status=200)
 
 
-def get_restore_params(request):
+def get_restore_params(request, domain):
     """
     Given a request, get the relevant restore parameters out with sensible defaults
     """

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1824,6 +1824,16 @@ BLOCK_RESTORES = StaticToggle(
     """
 )
 
+SKIP_FIXTURES_ON_RESTORE = StaticToggle(
+    'skip_fixtures_on_restore',
+    'Skip Fixture Syncs on Restores',
+    TAG_INTERNAL,
+    [NAMESPACE_DOMAIN],
+    description="""
+    Use this flag to skip fixtures on restores for certain project spaces.
+    """
+)
+
 SKIP_UPDATING_USER_REPORTING_METADATA = StaticToggle(
     'skip_updating_user_reporting_metadata',
     'ICDS: Skip updates to user reporting metadata to avoid expected load on couch',


### PR DESCRIPTION
## Summary
This is a smaller hammer in addition to https://github.com/dimagi/commcare-hq/pull/29403 that would allow us to block fixture syncs for a specific project space on all of their restores rather than blocking the whole restore in its entirety.

see https://dimagi-dev.atlassian.net/browse/SAAS-12012

## Feature Flag
`SKIP_FIXTURES_ON_RESTORE`

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
i believe so

### QA Plan
no QA needed

### Safety story
carefully adds a new feature flag to skip fixtures on restores

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
