### PR TITLE
Application API performance tweak

### DIFF
--- a/corehq/apps/api/resources/pagination.py
+++ b/corehq/apps/api/resources/pagination.py
@@ -39,3 +39,24 @@ class DoesNothingPaginator(Paginator):
             self.collection_name: self.objects,
             "meta": {'total_count': self.get_count()}
         }
+
+
+class DoesNothingPaginatorCompat(Paginator):
+    """Similar to DoesNothingPaginator this paginator
+    does not do any pagination but it preserves the
+    pagination fields for backwards compatibility.
+    """
+    def page(self):
+        count = self.get_count()
+        meta = {
+            'offset': 0,
+            'limit': None,
+            'total_count': count,
+            'previous': None,
+            'next': None,
+        }
+
+        return {
+            self.collection_name: self.objects,
+            'meta': meta,
+        }

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -1,3 +1,5 @@
+from operator import attrgetter
+
 from django.http import (
     HttpResponse,
     HttpResponseBadRequest,
@@ -372,7 +374,7 @@ class SingleSignOnResource(HqBaseResource, DomainSpecificResourceMixin):
 class BaseApplicationResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourceMixin):
 
     def obj_get_list(self, bundle, domain, **kwargs):
-        return get_apps_in_domain(domain, include_remote=False)
+        return sorted(get_apps_in_domain(domain, include_remote=False), key=attrgetter("date_created"))
 
     def obj_get(self, bundle, **kwargs):
         # support returning linked applications upon receiving an application request

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -15,6 +15,7 @@ from tastypie.exceptions import BadRequest
 
 from casexml.apps.case.xform import get_case_updates
 from corehq.apps.api.query_adapters import GroupQuerySetAdapter
+from corehq.apps.api.resources.pagination import DoesNothingPaginator
 from couchforms.models import doc_types
 
 from corehq.apps.api.es import ElasticAPIQuerySet, FormESView, es_query_from_get_params
@@ -387,6 +388,7 @@ class BaseApplicationResource(CouchResourceMixin, HqBaseResource, DomainSpecific
         list_allowed_methods = ['get']
         detail_allowed_methods = ['get']
         resource_name = 'application'
+        paginator_class = DoesNothingPaginator
 
 
 class ApplicationResource(BaseApplicationResource):

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -15,7 +15,7 @@ from tastypie.exceptions import BadRequest
 
 from casexml.apps.case.xform import get_case_updates
 from corehq.apps.api.query_adapters import GroupQuerySetAdapter
-from corehq.apps.api.resources.pagination import DoesNothingPaginator
+from corehq.apps.api.resources.pagination import DoesNothingPaginatorCompat
 from couchforms.models import doc_types
 
 from corehq.apps.api.es import ElasticAPIQuerySet, FormESView, es_query_from_get_params
@@ -388,7 +388,7 @@ class BaseApplicationResource(CouchResourceMixin, HqBaseResource, DomainSpecific
         list_allowed_methods = ['get']
         detail_allowed_methods = ['get']
         resource_name = 'application'
-        paginator_class = DoesNothingPaginator
+        paginator_class = DoesNothingPaginatorCompat
 
 
 class ApplicationResource(BaseApplicationResource):

--- a/corehq/apps/api/tests/app_resources.py
+++ b/corehq/apps/api/tests/app_resources.py
@@ -1,5 +1,6 @@
 import json
 
+from mock.mock import patch
 from testil import Regex
 
 from corehq.apps.api.resources import v0_4
@@ -16,7 +17,9 @@ class TestAppResource(APIResourceTest):
     def setUpClass(cls):
         super(TestAppResource, cls).setUpClass()
         cls.apps = [cls.make_app(), cls.make_app()]
-        cls.apps[0].make_build().save()
+
+        with patch('corehq.apps.app_manager.models.validate_xform', return_value=None):
+            cls.apps[0].make_build().save()
 
     @classmethod
     def make_app(cls):

--- a/corehq/apps/api/tests/app_resources.py
+++ b/corehq/apps/api/tests/app_resources.py
@@ -40,7 +40,10 @@ class TestAppResource(APIResourceTest):
         response = self._assert_auth_get_resource(self.list_endpoint, allow_session_auth=True)
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
-        self.assertEqual(content["meta"], {"total_count": 2})
+        self.assertEqual(content["meta"], {
+            'limit': None, 'next': None, 'offset': 0, 'previous': None,
+            'total_count': 2
+        })
         self.assertEqual(content["objects"], [
             self.get_expected_structure(with_version=True),
             self.get_expected_structure(with_version=False),

--- a/corehq/apps/api/tests/app_resources.py
+++ b/corehq/apps/api/tests/app_resources.py
@@ -1,0 +1,94 @@
+import json
+
+from testil import Regex
+
+from corehq.apps.accounting.models import Subscription
+from corehq.apps.api.resources import v0_4
+from corehq.apps.app_manager.tests.app_factory import AppFactory
+from corehq.apps.app_manager.xform_builder import XFormBuilder
+from corehq.apps.domain.models import Domain
+from .utils import APIResourceTest
+
+
+class TestAppResource(APIResourceTest):
+
+    resource = v0_4.ApplicationResource
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestAppResource, cls).setUpClass()
+        cls.apps = [cls.make_app(), cls.make_app()]
+        cls.apps[0].make_build().save()
+
+    @classmethod
+    def make_app(cls):
+        factory = AppFactory(domain=cls.domain.name, name="API App", build_version='2.11.0')
+        module1, form1 = factory.new_basic_module('open_case', 'house')
+        form1.source = XFormBuilder().new_question("name", "name").form.tostring()
+        factory.form_opens_case(form1)
+
+        module2, form2 = factory.new_basic_module('update_case', 'person')
+        form2.source = XFormBuilder().new_question("name", "name").form.tostring()
+        factory.form_requires_case(form2, case_type='house')
+        factory.form_opens_case(form2, case_type="person", is_subcase=True)
+
+        app = factory.app
+        app.save()
+        return app
+
+    def test_get_list(self):
+        response = self._assert_auth_get_resource(self.list_endpoint, allow_session_auth=True)
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content["meta"], {"total_count": 2})
+        self.assertEqual(content["objects"], [
+            self.get_expected_structure(with_version=True),
+            self.get_expected_structure(with_version=False),
+        ])
+
+    def test_get_single(self):
+        response = self._assert_auth_get_resource(self.single_endpoint(self.apps[0]._id), allow_session_auth=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), self.get_expected_structure(with_version=True))
+
+    def get_expected_structure(self, with_version=False):
+        xmlns = Regex(r"http://openrosa.org/formdesigner/[a-fA-F0-9\-]{36}")
+        unique_id = Regex(r"[a-f0-9]{32}")
+        questions = [
+            {"comment": None, "constraint": None, "group": None, "hashtagValue": "#form/name", "is_group": False,
+             "label": "name", "label_ref": "name-label", "relevant": None, "repeat": None, "required": False,
+             "setvalue": None, "tag": "input", "translations": {"en": "name"}, "type": "Text",
+             "value": "/data/name"}
+        ]
+        if with_version:
+            versions = [{
+                "id": unique_id, "build_comment": None,
+                "built_on": Regex(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z"),
+                "is_released": False, "version": 1
+            }]
+        else:
+            versions = []
+        return {
+            "name": "API App", "resource_uri": "", "version": 1,
+            "build_comment": None, "built_from_app_id": None, "built_on": None, "id": unique_id,
+            "versions": versions,
+            "is_released": False, "modules": [
+                {
+                    "unique_id": "open_case_module",
+                    "case_type": "house",
+                    "case_properties": ["name"],
+                    "forms": [{
+                        "unique_id": "open_case_form_0", "name": {"en": "open_case form 0"},
+                        "questions": questions, "xmlns": xmlns
+                    }],
+                },
+                {
+                    "unique_id": "update_case_module",
+                    "case_type": "person",
+                    "case_properties": ["name"], "forms": [{
+                    "unique_id": "update_case_form_0", "name": {"en": "update_case form 0"},
+                    "questions": questions, "xmlns": xmlns
+                }],
+                }
+            ],
+        }

--- a/corehq/apps/api/tests/app_resources.py
+++ b/corehq/apps/api/tests/app_resources.py
@@ -89,9 +89,9 @@ class TestAppResource(APIResourceTest):
                     "unique_id": "update_case_module",
                     "case_type": "person",
                     "case_properties": ["name"], "forms": [{
-                    "unique_id": "update_case_form_0", "name": {"en": "update_case form 0"},
-                    "questions": questions, "xmlns": xmlns
-                }],
+                        "unique_id": "update_case_form_0", "name": {"en": "update_case form 0"},
+                        "questions": questions, "xmlns": xmlns
+                    }],
                 }
             ],
         }

--- a/corehq/apps/api/tests/app_resources.py
+++ b/corehq/apps/api/tests/app_resources.py
@@ -2,11 +2,9 @@ import json
 
 from testil import Regex
 
-from corehq.apps.accounting.models import Subscription
 from corehq.apps.api.resources import v0_4
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.xform_builder import XFormBuilder
-from corehq.apps.domain.models import Domain
 from .utils import APIResourceTest
 
 

--- a/corehq/apps/api/tests/utils.py
+++ b/corehq/apps/api/tests/utils.py
@@ -136,7 +136,7 @@ class APIResourceTest(TestCase, metaclass=PatchMeta):
             api_url = "%s?%s" % (url, api_params)
         return api_url
 
-    def _assert_auth_get_resource(self, url, username=None, password=None, failure_code=401, headers=None):
+    def _assert_auth_get_resource(self, url, username=None, password=None, allow_session_auth=False, headers=None):
         """
         This tests that the given URL fails when accessed via sessions and returns the response
         obtained via using API auth. It's callers' responsibility to test resource specific logic
@@ -149,10 +149,10 @@ class APIResourceTest(TestCase, metaclass=PatchMeta):
         password = password or self.password
         headers = headers or {}
 
-        # session based auth should fail
-        self.client.login(username=username, password=password)
-        response = self.client.get(url, **headers)
-        self.assertEqual(response.status_code, failure_code)
+        if not allow_session_auth:
+            self.client.login(username=username, password=password)
+            response = self.client.get(url, **headers)
+            self.assertEqual(response.status_code, 401)
 
         # api_key auth should succeed, caller can check for expected code
         api_url = self._api_url(url, username)

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -482,9 +482,11 @@ def get_case_properties(app, case_types, defaults=(), include_parent_properties=
     return builder.get_case_property_map(case_types)
 
 
-@quickcache(vary_on=['app.get_id'])
-def get_all_case_properties(app):
-    return get_case_properties(app, app.get_case_types(), defaults=('name',), exclude_invalid_properties=True)
+@quickcache(vary_on=['app.get_id', 'exclude_invalid_properties'])
+def get_all_case_properties(app, exclude_invalid_properties=True):
+    return get_case_properties(
+        app, app.get_case_types(), defaults=('name',), exclude_invalid_properties=exclude_invalid_properties
+    )
 
 
 def get_all_case_properties_for_case_type(domain, case_type):

--- a/corehq/apps/app_manager/xform_builder.py
+++ b/corehq/apps/app_manager/xform_builder.py
@@ -429,6 +429,10 @@ class Question(object):
         self.xform = xform
         self.groups = groups
 
+    @property
+    def form(self) -> "XFormBuilder":
+        return self.xform
+
 
 class QuestionGroup(object):
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-832

## Summary
The main goal of this PR is to improve performance of the application API.

The crux of the PR is 9664b840461:
> For each case type a call to `get_case_properties` was made and for each of those calls the entire set of properties for all case types is generated resulting in a lot of duplicate work for apps with lots of case types and lots of modules. Each call to 
 get_case_properties` could take a few seconds.

Other changes:
* sort results so that the API returns results in a creation order (instead of the App ID ordering)
* remove pagination
  * The API fetches all apps in the domain on each request so there's no point in paginating. Also the number of apps (excluding builds) should be fairly low.
  * To avoid changing the content of the `meta` field in the API output this adds a new paginator that does not do any pagination but preserves the pagination fields in the output. This should ensure that any clients expecting those fields to exist don't break (assuming they are using the fields correctly).
* add tests

## Product Description
* Performance improvement to Application API
* Remove pagination from Application API while preserving pagination fields.
* Sort Application API results according to date created.

## Safety Assurance
- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added tests.

### QA Plan
I'm not recommending any QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
