### PR TITLE
Combine CaseInfo and CaseDisplay

### DIFF
--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -83,7 +83,7 @@ class CaseReassignmentInterface(CaseListMixin, DataInterface):
 
         for row in self.es_results['hits'].get('hits', []):
             case = self.get_case(row)
-            display = CaseDisplay(self, case)
+            display = CaseDisplay(case, self.timezone, self.individual)
             yield [
                 format_html(
                     checkbox_format,

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -296,7 +296,7 @@ def user_can_access_case(domain, user, case):
     if user.has_permission(domain, 'access_all_locations'):
         return True
 
-    info = CaseDisplay(None, case.to_json())
+    info = CaseDisplay(case.to_json())
     if info.owner_type == 'location':
         return user_can_access_location_id(domain, user, info.owner_id)
     elif info.owner_type == 'user':

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -292,11 +292,11 @@ def user_can_access_other_user(domain, user, other_user):
 
 
 def user_can_access_case(domain, user, case):
-    from corehq.apps.reports.standard.cases.data_sources import CaseInfo
+    from corehq.apps.reports.standard.cases.data_sources import CaseDisplay
     if user.has_permission(domain, 'access_all_locations'):
         return True
 
-    info = CaseInfo(None, case.to_json())
+    info = CaseDisplay(None, case.to_json())
     if info.owner_type == 'location':
         return user_can_access_location_id(domain, user, info.owner_id)
     elif info.owner_type == 'user':

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -229,7 +229,7 @@ class CaseListReport(CaseListMixin, ProjectInspectionReport, ReportDataSource):
     @property
     def rows(self):
         for row in self.es_results['hits'].get('hits', []):
-            display = CaseDisplay(self, self.get_case(row))
+            display = CaseDisplay(self.get_case(row), self.timezone, self.individual)
 
             yield [
                 display.case_type,
@@ -240,10 +240,3 @@ class CaseListReport(CaseListMixin, ProjectInspectionReport, ReportDataSource):
                 display.modified_on,
                 display.closed_display
             ]
-
-    def date_to_json(self, date):
-        if date:
-            return (PhoneTime(date, self.timezone).user_time(self.timezone)
-                    .ui_string(USER_DATETIME_FORMAT_WITH_SEC))
-        else:
-            return ''

--- a/corehq/apps/reports/standard/cases/case_list_explorer.py
+++ b/corehq/apps/reports/standard/cases/case_list_explorer.py
@@ -171,7 +171,7 @@ class CaseListExplorer(CaseListReport):
         )
         with timer:
             for case in data:
-                case_display = SafeCaseDisplay(self, case)
+                case_display = SafeCaseDisplay(case, self.timezone, self.individual)
                 yield [
                     case_display.get(column.prop_name)
                     for column in self.columns

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 
+import pytz
 from django.core import cache
 from django.template.defaultfilters import yesno
 from django.urls import NoReverseMatch
@@ -32,12 +33,15 @@ class CaseDisplay:
     to certain properties as well as formatting for properties for use in
     the UI"""
 
-    def __init__(self, report, case):
+    date_format = USER_DATETIME_FORMAT_WITH_SEC
+
+    def __init__(self, case, timezone=pytz.UTC, override_user_id=None):
         """
         case is a dict object of the case doc
         """
         self.case = case
-        self.report = report
+        self.timezone = timezone
+        self.override_user_id = override_user_id
 
     @property
     def case_type(self):
@@ -63,7 +67,7 @@ class CaseDisplay:
     @property
     def case_detail_url(self):
         try:
-            return absolute_reverse('case_data', args=[self.report.domain, self.case_id])
+            return absolute_reverse('case_data', args=[self.case['domain'], self.case_id])
         except NoReverseMatch:
             return None
 
@@ -113,7 +117,7 @@ class CaseDisplay:
 
     @property
     def user_id(self):
-        return self.report and self.report.individual or self.owner_id
+        return self.override_user_id or self.owner_id
 
     @property
     def owner_id(self):
@@ -172,7 +176,12 @@ class CaseDisplay:
             return "%s (bad ID format)" % self.case_name
 
     def _dateprop(self, prop):
-        return self.report.date_to_json(self.parse_date(self.case[prop]))
+        date = self.parse_date(self.case[prop])
+        if date:
+            user_time = PhoneTime(date, self.timezone).user_time(self.timezone)
+            return user_time.ui_string(self.date_format)
+        else:
+            return ''
 
     @property
     def opened_on(self):
@@ -237,9 +246,10 @@ class CaseDisplay:
 class SafeCaseDisplay(object):
     """Show formatted properties if they are used in XML, otherwise show the property directly from the case
     """
-    def __init__(self, report, case):
+    def __init__(self, case, timezone, override_user_id=None):
         self.case = case
-        self.report = report
+        self.timezone = timezone
+        self.override_user_id = override_user_id
 
     def get(self, name):
         if name == '_link':
@@ -249,14 +259,14 @@ class SafeCaseDisplay(object):
             return json.dumps(self.case.get('indices', []))
 
         if name in (SPECIAL_CASE_PROPERTIES + CASE_COMPUTED_METADATA):
-            return getattr(CaseDisplay(self.report, self.case), name.replace('@', ''))
+            return getattr(CaseDisplay(self.case, self.timezone, self.override_user_id), name.replace('@', ''))
 
         return self.case.get(name)
 
     @property
     def _link(self):
         try:
-            link = absolute_reverse('case_data', args=[self.report.domain, self.case.get('_id')])
+            link = absolute_reverse('case_data', args=[self.case.get("domain"), self.case.get('_id')])
         except NoReverseMatch:
             return _("No link found")
         return html.mark_safe(

--- a/custom/apps/crs_reports/reports.py
+++ b/custom/apps/crs_reports/reports.py
@@ -48,13 +48,18 @@ def visit_completion_counter(case):
 
 
 class HNBCReportDisplay(CaseDisplay):
+    date_format = "'%d-%m-%Y'"
+
+    def __init__(self, report, case):
+        super().__init__(case, report.timezone, report.individual)
+        self.report = report
 
     @property
     def dob(self):
         if 'date_birth' not in self.case:
             return '---'
         else:
-            return self.report.date_to_json(self.case['date_birth'])
+            return self._dateprop('date_birth')
 
     @property
     def visit_completion(self):
@@ -78,7 +83,7 @@ class HNBCReportDisplay(CaseDisplay):
         try:
             return format_html(
                 "<a class='ajax_dialog' href='{}'>{}</a>",
-                reverse('crs_details_report', args=[self.report.domain, case_id, self.report.slug]),
+                reverse('crs_details_report', args=[self.case["domain"], case_id, self.report.slug]),
                 case_name,
             )
         except NoReverseMatch:
@@ -173,17 +178,6 @@ class BaseHNBCReport(CustomProjectReport, CaseListReport):
         if individual:
             filters.append({'term': {'owner_id': individual}})
         return filters
-
-    def date_to_json(self, date):
-        if date:
-            try:
-                date = force_to_datetime(date)
-                return (PhoneTime(date, self.timezone).user_time(self.timezone)
-                        .ui_string('%d-%m-%Y'))
-            except ValueError:
-                return ''
-        else:
-            return ''
 
 
 class HBNCMotherReport(BaseHNBCReport):


### PR DESCRIPTION
## Summary
Follow on refactor from https://github.com/dimagi/commcare-hq/pull/29380 to combine the CaseInfo and CaseDisplay instead of having a hierarchy.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Fairly straightforward refactor.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
