### PR TITLE
Bump django from 2.2.16 to 2.2.19

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -39,7 +39,7 @@ django-transfer==0.4
 django-two-factor-auth~=1.12
 django-user-agents==0.4.0
 django-websocket-redis==0.6.0
-django~=2.2.16
+django~=2.2.19
 djangorestframework~=3.12.2
 dnspython==1.15.0
 dropbox==9.3.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -175,7 +175,7 @@ django-user-agents==0.4.0
     # via -r base-requirements.in
 django-websocket-redis==0.6.0
     # via -r base-requirements.in
-django==2.2.16
+django==2.2.19
     # via
     #   -r base-requirements.in
     #   django-angular

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -151,7 +151,7 @@ django-user-agents==0.4.0
     # via -r base-requirements.in
 django-websocket-redis==0.6.0
     # via -r base-requirements.in
-django==2.2.16
+django==2.2.19
     # via
     #   -r base-requirements.in
     #   django-angular

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -157,7 +157,7 @@ django-user-agents==0.4.0
     # via -r base-requirements.in
 django-websocket-redis==0.6.0
     # via -r base-requirements.in
-django==2.2.16
+django==2.2.19
     # via
     #   -r base-requirements.in
     #   django-angular

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -147,7 +147,7 @@ django-user-agents==0.4.0
     # via -r base-requirements.in
 django-websocket-redis==0.6.0
     # via -r base-requirements.in
-django==2.2.16
+django==2.2.19
     # via
     #   -r base-requirements.in
     #   django-angular

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -155,7 +155,7 @@ django-user-agents==0.4.0
     # via -r base-requirements.in
 django-websocket-redis==0.6.0
     # via -r base-requirements.in
-django==2.2.16
+django==2.2.19
     # via
     #   -r base-requirements.in
     #   django-angular


### PR DESCRIPTION
## Summary

Bump django to latest patch release.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan

No QA.

### Safety story

Reviewed Django [release notes](https://docs.djangoproject.com/en/3.1/releases/), which detail minor patches, no major changes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
