### PR TITLE
PyYAML 5.4.1

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -92,7 +92,7 @@ python-imap==1.0.0
 python-Levenshtein
 python-magic~=0.4.22
 pytz>=2017.2
-PyYAML~=5.1
+PyYAML~=5.4.1
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache~=0.5

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -484,7 +484,7 @@ pytz==2020.1
     #   django
     #   jenkinsapi
     #   twilio
-pyyaml==5.3.1
+pyyaml==5.4.1
     # via
     #   -r base-requirements.in
     #   git-build-branch

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -374,7 +374,7 @@ pytz==2020.1
     #   celery
     #   django
     #   twilio
-pyyaml==5.3.1
+pyyaml==5.4.1
     # via -r base-requirements.in
 pyzxcvbn==0.8.0
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -403,7 +403,7 @@ pytz==2020.1
     #   django
     #   flower
     #   twilio
-pyyaml==5.3.1
+pyyaml==5.4.1
     # via -r base-requirements.in
 pyzxcvbn==0.8.0
     # via -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -363,7 +363,7 @@ pytz==2020.1
     #   celery
     #   django
     #   twilio
-pyyaml==5.3.1
+pyyaml==5.4.1
     # via -r base-requirements.in
 pyzxcvbn==0.8.0
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -391,7 +391,7 @@ pytz==2020.1
     #   celery
     #   django
     #   twilio
-pyyaml==5.3.1
+pyyaml==5.4.1
     # via -r base-requirements.in
 pyzxcvbn==0.8.0
     # via -r base-requirements.in


### PR DESCRIPTION
## Summary

Bump PyYAML to latest patch release.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan

No QA.

### Safety story

Reviewed the [change log](https://github.com/yaml/pyyaml/blob/master/CHANGES), and [github](https://github.com/yaml/pyyaml)  issues and PRs for PyYAML. Changes appear to be minor or do not affect us (Python 3.5 support was dropped).

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
