### PR TITLE
Upgrade Pillow from 7.1.0 to 8.1.2

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -76,7 +76,7 @@ markdown==2.2.1
 mock==2.0.0
 openpyxl~=3.0
 phonenumberslite~=8.12
-Pillow>=7.1.0
+Pillow>=8.1.2
 polib==1.1.0
 prometheus-client==0.7.1
 psycogreen~=1.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -383,7 +383,7 @@ phonenumberslite==8.12.10
     # via -r base-requirements.in
 pickleshare==0.7.5
     # via ipython
-pillow==7.2.0
+pillow==8.1.2
     # via
     #   -r base-requirements.in
     #   cairosvg

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -299,7 +299,7 @@ pbr==5.5.0
     # via mock
 phonenumberslite==8.12.10
     # via -r base-requirements.in
-pillow==7.2.0
+pillow==8.1.2
     # via
     #   -r base-requirements.in
     #   cairosvg

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -314,7 +314,7 @@ phonenumberslite==8.12.10
     # via -r base-requirements.in
 pickleshare==0.7.5
     # via ipython
-pillow==7.2.0
+pillow==8.1.2
     # via
     #   -r base-requirements.in
     #   cairosvg

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -287,7 +287,7 @@ pbr==5.5.0
     # via mock
 phonenumberslite==8.12.10
     # via -r base-requirements.in
-pillow==7.2.0
+pillow==8.1.2
     # via
     #   -r base-requirements.in
     #   cairosvg

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -310,7 +310,7 @@ pbr==5.5.0
     # via mock
 phonenumberslite==8.12.10
     # via -r base-requirements.in
-pillow==7.2.0
+pillow==8.1.2
     # via
     #   -r base-requirements.in
     #   cairosvg


### PR DESCRIPTION
## Summary

Upgrade Pillow to latest patch release (`8.1.2`).

- Jira [SAAS-12023](https://dimagi-dev.atlassian.net/browse/SAAS-12023)

## Feature Flag

## Product Description

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

### QA Plan

Test image uploading functionality to ensure no regressions result from this upgrade.

- I reviewed the affected functions/methods noted in the release notes and compared to what we use -- no compatibility issues found.
- [QA-2810](https://dimagi-dev.atlassian.net/browse/QA-2810)

### Safety story

Pillow [changelog](https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst) includes mostly minor changes. Notable changes include dropped support for Python 3.5, which is a non-issue.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
