### PR TITLE
Delete repeat records associated with deleted repeater

### DIFF
--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -141,18 +141,16 @@ def process_repeat_record(repeat_record):
         return
 
     try:
-        if repeater.paused:
-            # postpone repeat record by 1 day so that these don't get picked in each cycle and
-            # thus clogging the queue with repeat records with paused repeater
-            repeat_record.postpone_by(MAX_RETRY_WAIT)
-            return
-
         if repeater.doc_type.endswith(DELETED_SUFFIX):
             if not repeat_record.doc_type.endswith(DELETED_SUFFIX):
                 repeat_record.doc_type += DELETED_SUFFIX
                 repeat_record.save()
+        elif repeater.paused:
+            # postpone repeat record by MAX_RETRY_WAIT so that these don't get picked in each cycle and
+            # thus clogging the queue with repeat records with paused repeater
+            repeat_record.postpone_by(MAX_RETRY_WAIT)
         elif repeat_record.state == RECORD_PENDING_STATE or repeat_record.state == RECORD_FAILURE_STATE:
-                repeat_record.fire()
+            repeat_record.fire()
     except Exception:
         logging.exception('Failed to process repeat record: {}'.format(repeat_record._id))
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The logic appeared out of order here which resulted in repeat records that should have been deleted instead being put back in the queue. Noticed in [this domain](https://www.commcarehq.org/a/kizazi-kipya/settings/project/repeat_record_report/) that there were no active repeaters, but repeat records were still being attempted (not actually fired though).
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This change keeps behavior the same (minus checking for deleted repeaters first). 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
