### PR TITLE
Bump lxml from 4.6.2 to 4.6.3

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -71,7 +71,7 @@ kafka-python==1.4.7
 kombu==4.2.2.post1
 billiard!=3.5.0.5  # Should be resolved in celery 4.3: https://github.com/celery/billiard/issues/260
 laboratory==0.2.0
-lxml~=4.6.2
+lxml~=4.6.3
 markdown==2.2.1
 mock==2.0.0
 openpyxl~=3.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -332,7 +332,7 @@ laboratory==0.2.0
     # via -r base-requirements.in
 linecache2==1.0.0
     # via traceback2
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   -r base-requirements.in
     #   eulxml

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -269,7 +269,7 @@ kombu==4.2.2.post1
     #   celery
 laboratory==0.2.0
     # via -r base-requirements.in
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   -r base-requirements.in
     #   eulxml

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -277,7 +277,7 @@ kombu==4.2.2.post1
     #   celery
 laboratory==0.2.0
     # via -r base-requirements.in
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   -r base-requirements.in
     #   eulxml

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -258,7 +258,7 @@ kombu==4.2.2.post1
     #   celery
 laboratory==0.2.0
     # via -r base-requirements.in
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   -r base-requirements.in
     #   eulxml

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -274,7 +274,7 @@ laboratory==0.2.0
     # via -r base-requirements.in
 linecache2==1.0.0
     # via traceback2
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   -r base-requirements.in
     #   eulxml


### PR DESCRIPTION
Bumping to latest patch release. The HTML cleaner now removes the HTML5 ``formaction`` attribute.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan

No QA.

### Safety story

Review [change log](https://github.com/lxml/lxml/blob/master/CHANGES.txt) and [commits](https://github.com/lxml/lxml/commits/lxml-4.6.3). Looks like a very minor change.

From what I could tell we have no references in our codebase to the `formaction` attribute, although we do have a Python class and Couch doc type named `FormAction`, which I believe is unrelated.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
