### PR TITLE
Fix typo in DatadogMetrics._histogram example in docstring

### DIFF
--- a/corehq/util/metrics/datadog.py
+++ b/corehq/util/metrics/datadog.py
@@ -77,7 +77,7 @@ class DatadogMetrics(HqMetrics):
 
             h = metrics_histogram(
                 'commcare.request.duration', 1.4,
-                bucket_tag='duration', buckets=[1,2,3], bucket_units='ms',
+                bucket_tag='duration', buckets=[1, 2, 3], bucket_unit='ms',
                 tags=tags
             )
 


### PR DESCRIPTION
## Summary
The docstring had a code example that had a typo in it.

## Feature Flag
None

## Product Description
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

N/A

### QA Plan
None

### Safety story
The only thing changing is a docstring.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
