### PR TITLE
Emit histogram of number of lookup table items sent in each restore

### DIFF
--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -60,7 +60,9 @@ class ItemListsProvider(FixtureProvider):
                 global_types[data_type._id] = data_type
             else:
                 user_types[data_type._id] = data_type
-        items = global_items = user_items = []
+        items = []
+        global_items = []
+        user_items = []
         if global_types:
             global_items = self.get_global_items(global_types, restore_state)
             items.extend(global_items)

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -8,12 +8,11 @@ from casexml.apps.phone.utils import (
     GLOBAL_USER_ID,
     get_or_cache_global_fixture,
 )
-
 from corehq.apps.fixtures.dbaccessors import iter_fixture_items_for_data_type
 from corehq.apps.fixtures.models import FIXTURE_BUCKET, FixtureDataType
 from corehq.apps.products.fixtures import product_fixture_generator_json
 from corehq.apps.programs.fixtures import program_fixture_generator_json
-
+from corehq.util.metrics import metrics_histogram
 from .utils import get_index_schema_node
 
 
@@ -61,11 +60,29 @@ class ItemListsProvider(FixtureProvider):
                 global_types[data_type._id] = data_type
             else:
                 user_types[data_type._id] = data_type
-        items = []
+        items = global_items = user_items = []
         if global_types:
-            items.extend(self.get_global_items(global_types, restore_state))
+            global_items = self.get_global_items(global_types, restore_state)
+            items.extend(global_items)
         if user_types:
-            items.extend(self.get_user_items(user_types, restore_user))
+            user_items = self.get_user_items(user_types, restore_user)
+            items.extend(user_items)
+
+        for metric_name, items_count in [
+            ('commcare.fixtures.item_lists.global', len(global_items)),
+            ('commcare.fixtures.item_lists.user', len(user_items)),
+            ('commcare.fixtures.item_lists.all', len(items)),
+        ]:
+            metrics_histogram(
+                metric_name,
+                items_count,
+                bucket_tag='items',
+                buckets=[1, 100, 1000, 10000, 30000, 100000, 300000, 1000000],
+                bucket_unit='',
+                tags={
+                    'domain': restore_user.domain
+                }
+            )
         return items
 
     def get_global_items(self, global_types, restore_state):


### PR DESCRIPTION
both total and split out by global vs user

## Summary
A beginning step in https://dimagi-dev.atlassian.net/browse/SAAS-12010. Will be particularly helpful in picking the details of how we want to limit lookup table sizes (Items per lookup table? Total number of items? Total number of global items and user items separately?)

## Feature Flag
None

## Product Description
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

https://github.com/dimagi/commcare-hq/blob/38102e873be50289efa9b7e991ef972df538d33a/corehq/apps/fixtures/tests/test_fixture_data.py#L34 covers this code over a number of code paths.

### QA Plan

Check the metric being generated on staging (and also thus that the code path doesn't break in some way surprisingly not covered by the test). (No need to involve QA team.)

### Safety story
This is a pretty small change (ostensibly just adding metrics), fairly well covered by tests, and I'm going to do a sanity check on staging before rolling it out. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
