### PR TITLE
consolidate doc lookup

### DIFF
--- a/corehq/apps/hqadmin/views/__init__.py
+++ b/corehq/apps/hqadmin/views/__init__.py
@@ -1,6 +1,5 @@
 from corehq.apps.hqadmin.views.data import (
     doc_in_es,
-    get_db_from_db_name,
     raw_doc,
 )
 from corehq.apps.hqadmin.views.operations import (

--- a/corehq/apps/hqadmin/views/data.py
+++ b/corehq/apps/hqadmin/views/data.py
@@ -82,7 +82,7 @@ def raw_doc_lookup(doc_id, db_name=None):
             response["raw_data"] = raw_data
         result_dict = result.asdict()
         result_dict["doc"] = json.dumps(
-            result.get_serialized_doc(), indent=4, sort_keys=True, cls=CommCareJSONEncoder
+            serialized_doc, indent=4, sort_keys=True, cls=CommCareJSONEncoder
         )
         response.update(result_dict)
     if db_name:

--- a/corehq/apps/hqadmin/views/data.py
+++ b/corehq/apps/hqadmin/views/data.py
@@ -1,157 +1,15 @@
 import json
-from collections import OrderedDict, defaultdict, namedtuple
 
-from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
 
-from couchdbkit import ResourceNotFound
-from memoized import memoized
-
 from corehq.apps.domain.decorators import require_superuser
-from corehq.apps.locations.models import SQLLocation
 from corehq.apps.es.es_query import ESQuery
+from corehq.apps.hqwebapp.doc_lookup import lookup_id_in_databases, get_databases, get_db_from_db_name
 from corehq.elastic import ES_META
-from corehq.form_processor.exceptions import CaseNotFound, XFormNotFound
-from corehq.form_processor.models import CommCareCaseSQL, XFormInstanceSQL
-from corehq.form_processor.serializers import (
-    CommCareCaseSQLRawDocSerializer,
-    XFormInstanceSQLRawDocSerializer,
-)
-from corehq.util.couchdb_management import couch_config
+from corehq.form_processor.models import XFormInstanceSQL
 from corehq.util.json import CommCareJSONEncoder
-
-
-class _DbWrapper(object):
-    def __init__(self, dbname, doc_type):
-        self.dbname = dbname
-        self.doc_type = doc_type
-
-    def get(self, record_id):
-        raise NotImplementedError
-
-    def get_context(self, record_id):
-        doc = self.get(record_id)
-        return self._context_for_doc(doc)
-
-    def _context_for_doc(self, doc):
-        return {
-            "doc": json.dumps(doc, indent=4, sort_keys=True, cls=CommCareJSONEncoder),
-            "doc_type": doc.get('doc_type', self.doc_type),
-            "domain": doc.get('domain', 'Unknown'),
-            "dbname": self.dbname,
-            "errors": []
-        }
-
-
-class _CouchDb(_DbWrapper):
-    """
-    Light wrapper for providing interface like Couchdbkit's Database objects.
-    """
-
-    def __init__(self, db):
-        self.db = db
-        super(_CouchDb, self).__init__(db.dbname, getattr(db, 'doc_type', 'Unknown'))
-
-    def get(self, record_id):
-        return self.db.get(record_id)
-
-
-class _SQLDb(_DbWrapper):
-    def __init__(self, dbname, getter, doc_type):
-        self._getter = getter
-        super(_SQLDb, self).__init__(dbname, doc_type)
-
-    def get(self, record_id):
-        try:
-            return self._getter(record_id)
-        except (XFormNotFound, CaseNotFound, ObjectDoesNotExist):
-            raise ResourceNotFound("missing")
-
-
-class _SQLFormDb(_SQLDb):
-    def get_context(self, record_id):
-        form = self.get(record_id)
-        doc = XFormInstanceSQLRawDocSerializer(form).data
-        context = self._context_for_doc(doc)
-        if 'form' not in doc:
-            context['errors'].append(_('Missing Form XML'))
-        elif not doc['form']:
-            context['errors'].append(_('Form XML not valid. See "Raw Data" section below.'))
-            raw_data = form.get_xml()
-            if isinstance(raw_data, str):
-                context['raw_data'] = raw_data
-            else:
-                try:
-                    context['raw_data'] = raw_data.decode()
-                except (UnicodeDecodeError, AttributeError):
-                    context['raw_data'] = repr(raw_data)
-        return context
-
-
-@memoized
-def get_databases():
-    sql_dbs = [
-        _SQLFormDb(
-            XFormInstanceSQL._meta.db_table,
-            lambda id_: XFormInstanceSQL.get_obj_by_id(id_),
-            XFormInstanceSQL.__name__
-        ),
-        _SQLDb(
-            CommCareCaseSQL._meta.db_table,
-            lambda id_: CommCareCaseSQLRawDocSerializer(CommCareCaseSQL.get_obj_by_id(id_)).data,
-            CommCareCaseSQL.__name__
-        ),
-        _SQLDb(
-            SQLLocation._meta.db_table,
-            lambda id_: SQLLocation.objects.get(location_id=id_).to_json(),
-            SQLLocation.__name__
-        ),
-    ]
-
-    all_dbs = OrderedDict()
-    couchdbs_by_name = couch_config.all_dbs_by_db_name
-    for dbname in sorted(couchdbs_by_name):
-        all_dbs[dbname] = _CouchDb(couchdbs_by_name[dbname])
-    for db in sql_dbs:
-        all_dbs[db.dbname] = db
-    return all_dbs
-
-
-def get_db_from_db_name(db_name):
-    all_dbs = get_databases()
-    if db_name in all_dbs:
-        return all_dbs[db_name]
-    else:
-        return _CouchDb(couch_config.get_db(db_name))
-
-
-def _lookup_id_in_database(doc_id, db_name=None):
-    db_result = namedtuple('db_result', 'dbname result status')
-    STATUSES = defaultdict(lambda: 'warning', {
-        'missing': 'default',
-        'deleted': 'danger',
-    })
-
-    response = {"doc_id": doc_id}
-    if db_name:
-        dbs = [get_db_from_db_name(db_name)]
-        response['selected_db'] = db_name
-    else:
-        dbs = list(get_databases().values())
-
-    db_results = []
-    for db in dbs:
-        try:
-            response.update(db.get_context(doc_id))
-        except ResourceNotFound as e:
-            db_results.append(db_result(db.dbname, str(e), STATUSES[str(e)]))
-        else:
-            db_results.append(db_result(db.dbname, 'found', 'success'))
-
-    response['db_results'] = db_results
-    return response
 
 
 @require_superuser
@@ -178,7 +36,7 @@ def doc_in_es(request):
             "doc_type": es_doc_type,
             "found_indices": found_indices,
         },
-        "couch_info": _lookup_id_in_database(doc_id),
+        "couch_info": raw_doc_lookup(doc_id),
     }
     return render(request, "hqadmin/doc_in_es.html", context)
 
@@ -195,7 +53,7 @@ def raw_doc(request):
     db_name = request.GET.get("db_name", None)
     if db_name and "__" in db_name:
         db_name = db_name.split("__")[-1]
-    context = _lookup_id_in_database(doc_id, db_name) if doc_id else {}
+    context = raw_doc_lookup(doc_id, db_name) if doc_id else {}
 
     if request.GET.get("raw", False):
         if 'doc' in context:
@@ -206,3 +64,44 @@ def raw_doc(request):
 
     context['all_databases'] = [db for db in get_databases()]
     return render(request, "hqadmin/raw_doc.html", context)
+
+
+def raw_doc_lookup(doc_id, db_name=None):
+    if db_name:
+        dbs = [get_db_from_db_name(db_name)]
+    else:
+        dbs = list(get_databases().values())
+
+    result, db_results = lookup_id_in_databases(doc_id, dbs, find_first=False)
+    response = {"db_results": db_results}
+    if result:
+        serialized_doc = result.get_serialized_doc()
+        if isinstance(result.doc, XFormInstanceSQL):
+            errors, raw_data = check_form_for_errors(result.doc, serialized_doc)
+            response["errors"] = errors
+            response["raw_data"] = raw_data
+        result_dict = result.asdict()
+        result_dict["doc"] = json.dumps(
+            result.get_serialized_doc(), indent=4, sort_keys=True, cls=CommCareJSONEncoder
+        )
+        response.update(result_dict)
+    if db_name:
+        response['selected_db'] = db_name
+    return response
+
+
+def check_form_for_errors(form, form_doc):
+    errors = []
+    raw_data = None
+    if 'form' not in form_doc:
+        errors.append(_('Missing Form XML'))
+    elif not form_doc['form']:
+        errors.append(_('Form XML not valid. See "Raw Data" section below.'))
+        raw_data = form.get_xml()
+        if not isinstance(raw_data, str):
+            try:
+                raw_data = raw_data.decode()
+            except (UnicodeDecodeError, AttributeError):
+                raw_data = repr(raw_data)
+
+    return errors, raw_data

--- a/corehq/apps/hqwebapp/doc_info.py
+++ b/corehq/apps/hqwebapp/doc_info.py
@@ -185,6 +185,8 @@ def get_doc_info_couch(doc, domain_hint=None, cache=None):
 
 def form_docinfo(domain, doc_id, is_deleted):
     doc_info = DocInfo(
+        id=doc_id,
+        type="XFormInstance",
         type_display=_('Form'),
         link=reverse(
             'render_form_data',
@@ -197,6 +199,8 @@ def form_docinfo(domain, doc_id, is_deleted):
 
 def case_docinfo(domain, doc_id, name, is_deleted):
     return DocInfo(
+        id=doc_id,
+        type="CommCareCase",
         display=name,
         type_display=_('Case'),
         link=get_case_url(domain, doc_id),
@@ -240,6 +244,8 @@ def get_doc_info_sql(obj, cache=None):
     if isinstance(obj, SQLLocation):
         from corehq.apps.locations.views import EditLocationView
         doc_info = DocInfo(
+            id=obj.location_id,
+            type="Location",
             type_display=_('Location'),
             display=obj.name,
             link=reverse(
@@ -259,7 +265,7 @@ def get_doc_info_sql(obj, cache=None):
 
     doc_info.id = doc_info.id or str(obj.pk)
     doc_info.domain = obj.domain if hasattr(obj, 'domain') else None
-    doc_info.type = class_name
+    doc_info.type = doc_info.type or class_name
 
     if cache:
         cache[cache_key] = doc_info

--- a/corehq/apps/hqwebapp/doc_info.py
+++ b/corehq/apps/hqwebapp/doc_info.py
@@ -52,12 +52,8 @@ def get_doc_info(doc, domain_hint=None, cache=None):
     else:
         doc_info = get_doc_info_sql(doc, cache=cache)
 
-    if (
-        domain_hint and
-        not (
-            doc_info.domain == domain_hint or
-            domain_hint in domains
-        )
+    if domain_hint and not (
+        doc_info.domain == domain_hint or domain_hint in domains
     ):
         raise DomainMismatchException("Doc '%s' does not match the domain_hint '%s'" % (doc_info.id, domain_hint))
 

--- a/corehq/apps/hqwebapp/doc_info.py
+++ b/corehq/apps/hqwebapp/doc_info.py
@@ -1,15 +1,11 @@
-from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
-from couchdbkit import ResourceNotFound
-
+from corehq.apps.hqwebapp.doc_lookup import lookup_doc_id
+from corehq.apps.users.util import raw_username
 from couchforms import models as couchforms_models
 from dimagi.ext.jsonobject import *
-from dimagi.utils.couch.database import get_db
 from dimagi.utils.couch.undo import DELETED_SUFFIX
-
-from corehq.apps.users.util import raw_username
 
 
 class DomainMismatchException(Exception):
@@ -32,20 +28,15 @@ def get_doc_info_by_id(domain, id):
     if not id:
         return not_found_value
 
-    for db_name in [None] + settings.COUCH_SETTINGS_HELPER.extra_db_names:
-        try:
-            doc = get_db(db_name).get(id)
-        except ResourceNotFound:
-            pass
-        else:
-            break
-    else:
+    result = lookup_doc_id(id)
+    if not result:
         return not_found_value
 
-    if doc.get('domain') != domain and domain not in doc.get('domains', ()):
+    doc = result.doc
+    try:
+        return get_doc_info(doc, domain_hint=domain)
+    except DomainMismatchException:
         return not_found_value
-
-    return get_doc_info(doc, domain_hint=domain)
 
 
 def get_doc_info(doc, domain_hint=None, cache=None):
@@ -53,6 +44,28 @@ def get_doc_info(doc, domain_hint=None, cache=None):
     cache is just a dictionary that you can keep passing in to speed up info
     retrieval.
     """
+    domains = ()
+    if isinstance(doc, dict):
+        domains = doc.get('domains', ())
+        domain_hint = domain_hint or (domains[0] if domains else None)
+        doc_info = get_doc_info_couch(doc, domain_hint, cache=cache)
+    else:
+        doc_info = get_doc_info_sql(doc, cache=cache)
+
+    if (
+        domain_hint and
+        not (
+            doc_info.domain == domain_hint or
+            domain_hint in domains
+        )
+    ):
+        raise DomainMismatchException("Doc '%s' does not match the domain_hint '%s'" % (doc_info.id, domain_hint))
+
+    return doc_info
+
+
+def get_doc_info_couch(doc, domain_hint=None, cache=None):
+    """Return DocInfo objects for Couch doc dicts"""
     domain = doc.get('domain') or domain_hint
     doc_type = doc.get('doc_type')
     doc_id = doc.get('_id')
@@ -61,15 +74,6 @@ def get_doc_info(doc, domain_hint=None, cache=None):
     def has_doc_type(doc_type, expected_doc_type):
         return (doc_type == expected_doc_type or
             doc_type == ('%s%s' % (expected_doc_type, DELETED_SUFFIX)))
-
-    if (
-        domain_hint and
-        not (
-            doc.get('domain') == domain_hint or
-            domain_hint in doc.get('domains', ())
-        )
-    ):
-        raise DomainMismatchException("Doc '%s' does not match the domain_hint '%s'" % (doc_id, domain_hint))
 
     if cache and doc_id in cache:
         return cache[doc_id]
@@ -221,11 +225,9 @@ def get_webuser_url(domain, user_id):
     )
 
 
-def get_object_info(obj, cache=None):
+def get_doc_info_sql(obj, cache=None):
     """
-    This function is intended to behave just like get_doc_info, only
-    you call it with objects other than Couch docs (such as objects
-    that use the Django ORM).
+    Return DocInfo objects for SQL models
     """
     class_name = obj.__class__.__name__
     cache_key = '%s-%s' % (class_name, obj.pk)

--- a/corehq/apps/hqwebapp/doc_lookup.py
+++ b/corehq/apps/hqwebapp/doc_lookup.py
@@ -1,0 +1,177 @@
+from collections import OrderedDict, defaultdict, namedtuple
+
+import attr
+from couchdbkit import ResourceNotFound
+from django.core.exceptions import ObjectDoesNotExist
+from memoized import memoized
+
+from corehq.apps.locations.models import SQLLocation
+from corehq.form_processor.exceptions import CaseNotFound, XFormNotFound
+from corehq.form_processor.models import CommCareCaseSQL, XFormInstanceSQL
+from corehq.form_processor.serializers import (
+    CommCareCaseSQLRawDocSerializer,
+    XFormInstanceSQLRawDocSerializer,
+)
+from corehq.util.couchdb_management import couch_config
+
+DbResult = namedtuple('DbResult', 'dbname result status')
+
+@attr.s
+class LookupResult:
+    doc_id = attr.ib()
+    doc = attr.ib()
+    doc_type = attr.ib()
+    domain = attr.ib()
+    dbname = attr.ib()
+    data_serializer = attr.ib()
+
+    def asdict(self):
+        res = attr.asdict(self)
+        res.pop("data_serializer")
+        return res
+
+    def get_serialized_doc(self):
+        if not self.data_serializer:
+            return self.doc
+        return self.data_serializer(self.doc)
+
+
+def lookup_doc_id(doc_id):
+    """Look up a document ID
+
+    :param doc_id: ID of document to look for
+    :returns: LookupResult or None
+    """
+    result, _ = lookup_id_in_databases(doc_id, get_databases().values())
+    return result
+
+
+def lookup_id_in_databases(doc_id, dbs, find_first=True):
+    """Look up a document ID
+
+    :param doc_id: ID of document to look for
+    :param dbs: list of databases to look in
+    :param find_first: Set to False to look in all databases even after a match is found.
+    :returns: Tuple of (LookupResult or None, list of DbResult objects for each DB searched)
+    """
+    STATUSES = defaultdict(lambda: 'warning', {
+        'missing': 'default',
+        'deleted': 'danger',
+    })
+
+    db_results = []
+    response = None
+    for db in dbs:
+        try:
+            db_response = db.get_context(doc_id)
+            if not response:
+                response = db_response
+        except ResourceNotFound as e:
+            db_results.append(DbResult(db.dbname, str(e), STATUSES[str(e)]))
+        else:
+            db_results.append(DbResult(db.dbname, 'found', 'success'))
+            if find_first:
+                break
+
+    return response, db_results
+
+
+@memoized
+def get_databases():
+    """Return an ordered dict of (dbname: database). The order is
+    according to search preference, the first DB to contain a document
+    should be assumed to be the authoritative one."""
+    sql_dbs = [
+        _SQLDb(
+            XFormInstanceSQL._meta.db_table,
+            lambda id_: XFormInstanceSQL.get_obj_by_id(id_),
+            "XFormInstance",
+            lambda doc: XFormInstanceSQLRawDocSerializer(doc).data,
+        ),
+        _SQLDb(
+            CommCareCaseSQL._meta.db_table,
+            lambda id_: CommCareCaseSQL.get_obj_by_id(id_),
+            "CommCareCase",
+            lambda doc: CommCareCaseSQLRawDocSerializer(doc).data,
+        ),
+        _SQLDb(
+            SQLLocation._meta.db_table,
+            lambda id_: SQLLocation.objects.get(location_id=id_),
+            'Location',
+            lambda doc: doc.to_json()
+        ),
+    ]
+
+    all_dbs = OrderedDict()
+    for db in sql_dbs:
+        all_dbs[db.dbname] = db
+    couchdbs_by_name = couch_config.all_dbs_by_db_name
+    for dbname in sorted(couchdbs_by_name):
+        all_dbs[dbname] = _CouchDb(couchdbs_by_name[dbname])
+    return all_dbs
+
+
+def get_db_from_db_name(db_name):
+    all_dbs = get_databases()
+    if db_name in all_dbs:
+        return all_dbs[db_name]
+    else:
+        return _CouchDb(couch_config.get_db(db_name))
+
+
+class _DbWrapper(object):
+    def __init__(self, dbname, doc_type, serializer):
+        self.dbname = dbname
+        self.doc_type = doc_type
+        self.serializer = serializer
+
+    def get(self, record_id):
+        raise NotImplementedError
+
+    def get_context(self, record_id):
+        doc = self.get(record_id)
+        return self._context_for_doc(record_id, doc)
+
+    def _context_for_doc(self, doc_id, doc):
+
+        if isinstance(doc, dict):
+            doc_type = doc.get('doc_type', self.doc_type)
+            domain = doc.get('domain', 'Unknown')
+        else:
+            doc_type = self.doc_type
+            domain = getattr(doc, 'domain', 'Unknown')
+
+        return LookupResult(
+            doc_id=doc_id,
+            doc=doc,
+            doc_type=doc_type,
+            domain=domain,
+            dbname=self.dbname,
+            data_serializer=self.serializer
+        )
+
+
+class _CouchDb(_DbWrapper):
+    """
+    Light wrapper for providing interface like Couchdbkit's Database objects.
+    """
+
+    def __init__(self, db):
+        self.db = db
+        doc_type = getattr(db, 'doc_type', 'Unknown')
+        super(_CouchDb, self).__init__(db.dbname, doc_type, None)
+
+    def get(self, record_id):
+        return self.db.get(record_id)
+
+
+class _SQLDb(_DbWrapper):
+    def __init__(self, dbname, getter, doc_type, serializer):
+        self._getter = getter
+        super(_SQLDb, self).__init__(dbname, doc_type, serializer)
+
+    def get(self, record_id):
+        try:
+            return self._getter(record_id)
+        except (XFormNotFound, CaseNotFound, ObjectDoesNotExist):
+            raise ResourceNotFound("missing")

--- a/corehq/apps/hqwebapp/doc_lookup.py
+++ b/corehq/apps/hqwebapp/doc_lookup.py
@@ -16,6 +16,7 @@ from corehq.util.couchdb_management import couch_config
 
 DbResult = namedtuple('DbResult', 'dbname result status')
 
+
 @attr.s
 class LookupResult:
     doc_id = attr.ib()

--- a/corehq/apps/hqwebapp/tests/test_doc_info.py
+++ b/corehq/apps/hqwebapp/tests/test_doc_info.py
@@ -1,0 +1,103 @@
+import uuid
+
+from django.test import TestCase
+
+from casexml.apps.case.mock import CaseBlock
+from casexml.apps.case.models import CommCareCase
+from corehq.apps.casegroups.models import CommCareCaseGroup
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.groups.models import Group
+from corehq.apps.hqcase.utils import submit_case_blocks
+from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id
+from corehq.apps.locations.models import make_location, LocationType
+from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.apps.users.util import format_username
+from couchforms.models import XFormInstance
+
+
+class TestDocInfo(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = uuid.uuid4().hex
+        cls.domain_obj = create_domain(cls.domain)
+
+    def test_couch_user(self):
+        user = CommCareUser.create(self.domain, format_username("lilly", self.domain), "123", None, None)
+        self.addCleanup(lambda: user.delete(None))
+        self._test_doc(user.user_id, "CommCareUser")
+
+    def test_web_user(self):
+        user = WebUser.create(self.domain, "marias@email.com", "123", None, None)
+        self.addCleanup(lambda: user.delete(None))
+        self._test_doc(user.user_id, "WebUser")
+
+    def test_location(self):
+        loc_type = LocationType(domain=self.domain, name='type')
+        loc_type.save()
+        self.addCleanup(loc_type.delete)
+        location = make_location(
+            domain=self.domain,
+            site_code='doc_info_test',
+            name='doc_info_test',
+            location_type='type'
+        )
+        location.save()
+        self.addCleanup(location.delete)
+        self._test_doc(location.location_id, "Location")
+
+    def test_group(self):
+        group = Group(domain=self.domain, name='doc_info_test')
+        group.save()
+        self.addCleanup(group.delete)
+        self._test_doc(group.get_id, "Group")
+
+    def test_case_group(self):
+        group = CommCareCaseGroup(name='A', domain=self.domain, cases=['A', 'B'])
+        group.save()
+        self.addCleanup(group.delete)
+        self._test_doc(group.get_id, "CommCareCaseGroup")
+
+    def test_couch_case(self):
+        case = CommCareCase(domain=self.domain)
+        case.save()
+        self.addCleanup(case.delete)
+        self._test_doc(case.get_id, "CommCareCase")
+
+    def test_sql_case(self):
+        case, xform = self._make_form_and_case()
+        self._test_doc(case.case_id, "CommCareCase")
+
+    def test_couch_form(self):
+        form = XFormInstance(
+            xmlns='doc_info_test',
+            domain=self.domain,
+        )
+        form.save()
+        self.addCleanup(form.delete)
+        self._test_doc(form.form_id, "XFormInstance")
+
+    def test_sql_form(self):
+        case, xform = self._make_form_and_case()
+        self._test_doc(xform.form_id, "XFormInstance")
+
+    def _make_form_and_case(self):
+        xform, cases = submit_case_blocks([CaseBlock(
+            case_id=str(uuid.uuid4()),
+            case_type='doc_info_test',
+            case_name='doc_info_test',
+            owner_id='doc_info_test',
+            create=True,
+        ).as_text()], domain=self.domain)
+        case = cases[0]
+        self.addCleanup(case.delete)
+        self.addCleanup(xform.delete)
+        return case, xform
+
+    def _test_doc(self, doc_id, doc_type):
+        info = get_doc_info_by_id(self.domain, doc_id)
+        self.assertEqual(info.id, doc_id)
+        self.assertEqual(info.domain, self.domain)
+        self.assertEqual(info.type, doc_type)
+        self.assertFalse(info.is_deleted)
+        return info

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -1176,7 +1176,7 @@ def quick_find(request):
     elif redirect and request.couch_user.is_superuser:
         return HttpResponseRedirect('{}?id={}'.format(reverse('raw_doc'), result.doc_id))
     else:
-        return JsonResponse(doc_info)
+        return JsonResponse(doc_info.to_json())
 
 
 def osdd(request, template='osdd.xml'):

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -1,4 +1,3 @@
-import functools
 import json
 import logging
 import os
@@ -9,6 +8,8 @@ import uuid
 from datetime import datetime
 from urllib.parse import urlparse
 
+import httpagentparser
+import requests
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -38,38 +39,20 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import LANGUAGE_SESSION_KEY
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.http import require_GET, require_POST
-from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.generic import TemplateView
 from django.views.generic.base import View
-
-import httpagentparser
-import requests
-from couchdbkit import ResourceNotFound
 from memoized import memoized
 from sentry_sdk import last_event_id
 from two_factor.views import LoginView
 
-from corehq.apps.hqwebapp.decorators import waf_allow
-from corehq.apps.sms.event_handlers import handle_email_messaging_subevent
-from corehq.apps.users.event_handlers import handle_email_invite_message
-from corehq.util.email_event_utils import handle_email_sns_event
-from corehq.util.metrics import create_metrics_event, metrics_counter, metrics_gauge
-from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
-from dimagi.utils.couch.database import get_db
-from dimagi.utils.django.email import COMMCARE_MESSAGE_ID_HEADER
-from dimagi.utils.django.request import mutable_querydict
-from dimagi.utils.logging import notify_exception, notify_error
-from dimagi.utils.web import get_site_domain, get_url_base, json_response
-from soil import DownloadBase
-from soil import views as soil_views
-
-from corehq.apps.accounting.models import Subscription
 from corehq.apps.accounting.decorators import (
     always_allow_project_access,
 )
+from corehq.apps.accounting.models import Subscription
 from corehq.apps.analytics import ab_tests
 from corehq.apps.domain.decorators import (
     login_and_domain_required,
@@ -90,7 +73,9 @@ from corehq.apps.hqadmin.management.commands.deploy_in_progress import (
     DEPLOY_IN_PROGRESS_FLAG,
 )
 from corehq.apps.hqadmin.service_checks import CHECKS, run_checks
-from corehq.apps.hqwebapp.doc_info import get_doc_info, get_object_info
+from corehq.apps.hqwebapp.decorators import waf_allow
+from corehq.apps.hqwebapp.doc_info import get_doc_info
+from corehq.apps.hqwebapp.doc_lookup import lookup_doc_id
 from corehq.apps.hqwebapp.encoders import LazyEncoder
 from corehq.apps.hqwebapp.forms import (
     CloudCareAuthenticationForm,
@@ -103,25 +88,30 @@ from corehq.apps.hqwebapp.utils import (
     get_environment_friendly_name,
     update_session_language,
 )
-from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.permissions import location_safe
+from corehq.apps.sms.event_handlers import handle_email_messaging_subevent
+from corehq.apps.users.event_handlers import handle_email_invite_message
 from corehq.apps.users.landing_pages import (
     get_cloudcare_urlname,
     get_redirect_url,
 )
 from corehq.apps.users.models import CouchUser, Invitation
 from corehq.apps.users.util import format_username
-from corehq.form_processor.backends.sql.dbaccessors import (
-    CaseAccessorSQL,
-    FormAccessorSQL,
-)
-from corehq.form_processor.exceptions import CaseNotFound, XFormNotFound
 from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.util.context_processors import commcare_hq_names
+from corehq.util.email_event_utils import handle_email_sns_event
+from corehq.util.metrics import create_metrics_event, metrics_counter, metrics_gauge
 from corehq.util.metrics.const import TAG_UNKNOWN, MPM_MAX
 from corehq.util.metrics.utils import sanitize_url
 from corehq.util.view_utils import reverse
+from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
+from dimagi.utils.django.email import COMMCARE_MESSAGE_ID_HEADER
+from dimagi.utils.django.request import mutable_querydict
+from dimagi.utils.logging import notify_exception, notify_error
+from dimagi.utils.web import get_site_domain, get_url_base
 from no_exceptions.exceptions import Http403
+from soil import DownloadBase
+from soil import views as soil_views
 
 
 def is_deploy_in_progress():
@@ -1171,55 +1161,22 @@ def quick_find(request):
     if not query:
         return HttpResponseBadRequest('GET param "q" must be provided')
 
-    def deal_with_doc(doc, domain, doc_info_fn):
-        is_member = domain and request.couch_user.is_member_of(domain, allow_mirroring=True)
-        if is_member or request.couch_user.is_superuser:
-            doc_info = doc_info_fn(doc)
-        else:
-            raise Http404()
-        if redirect and doc_info.link:
-            messages.info(request, _("We've redirected you to the %s matching your query") % doc_info.type_display)
-            return HttpResponseRedirect(doc_info.link)
-        elif redirect and request.couch_user.is_superuser:
-            return HttpResponseRedirect('{}?id={}'.format(reverse('raw_doc'), doc.get('_id')))
-        else:
-            return json_response(doc_info)
+    result = lookup_doc_id(query)
+    if not result:
+        raise Http404()
 
-    couch_dbs = [None] + settings.COUCH_SETTINGS_HELPER.extra_db_names
-    for db_name in couch_dbs:
-        try:
-            doc = get_db(db_name).get(query)
-        except ResourceNotFound:
-            pass
-        else:
-            domain = doc.get('domain') or doc.get('domains', [None])[0]
-            doc_info_fn = functools.partial(get_doc_info, domain_hint=domain)
-            return deal_with_doc(doc, domain, doc_info_fn)
-
-    for accessor in (FormAccessorSQL.get_form, CaseAccessorSQL.get_case):
-        try:
-            doc = accessor(query)
-        except (XFormNotFound, CaseNotFound):
-            pass
-        else:
-            domain = doc.domain
-            return deal_with_doc(doc, domain, get_object_info)
-
-    for django_model in (SQLLocation,):
-        try:
-            if hasattr(django_model, 'by_id') and callable(django_model.by_id):
-                doc = django_model.by_id(query)
-            else:
-                doc = django_model.objects.get(pk=query)
-        except django_model.DoesNotExist:
-            continue
-        else:
-            if doc is None:
-                continue
-            domain = doc.domain
-            return deal_with_doc(doc, domain, get_object_info)
-
-    raise Http404()
+    is_member = result.domain and request.couch_user.is_member_of(result.domain, allow_mirroring=True)
+    if is_member or request.couch_user.is_superuser:
+        doc_info = get_doc_info(result.doc)
+    else:
+        raise Http404()
+    if redirect and doc_info.link:
+        messages.info(request, _("We've redirected you to the %s matching your query") % doc_info.type_display)
+        return HttpResponseRedirect(doc_info.link)
+    elif redirect and request.couch_user.is_superuser:
+        return HttpResponseRedirect('{}?id={}'.format(reverse('raw_doc'), result.doc_id))
+    else:
+        return JsonResponse(doc_info)
 
 
 def osdd(request, template='osdd.xml'):

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -26,7 +26,6 @@ from corehq.apps.hqwebapp.doc_info import (
     DomainMismatchException,
     get_doc_info,
     get_doc_info_by_id,
-    get_object_info,
 )
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.views import EditLocationView
@@ -258,19 +257,21 @@ class BaseCommConnectLogReport(ProjectReport, ProjectReportParametersMixin, Gene
             except (ResourceNotFound, CaseNotFound, ObjectDoesNotExist):
                 pass
 
-        doc_info = None
+        doc, doc_info = None, None
         if couch_object:
+            doc = couch_object.to_json()
+        elif sql_object:
+            doc = sql_object
+
+        if doc:
             try:
-                doc_info = get_doc_info(couch_object.to_json(), domain)
+                doc_info = get_doc_info(doc, domain)
             except DomainMismatchException:
                 # This can happen, for example, if a WebUser was sent an SMS
                 # and then they unsubscribed from the domain. If that's the
                 # case, we'll just leave doc_info as None and no contact link
                 # will be displayed.
                 pass
-
-        if sql_object:
-            doc_info = get_object_info(sql_object)
 
         contact_cache[recipient_id] = doc_info
 

--- a/corehq/blobs/management/commands/blob_storage_report.py
+++ b/corehq/blobs/management/commands/blob_storage_report.py
@@ -12,7 +12,7 @@ from six.moves.urllib.parse import unquote
 from couchdbkit.exceptions import ResourceNotFound
 from django.core.management import BaseCommand
 
-from corehq.apps.hqadmin.views.data import get_db_from_db_name
+from corehq.apps.hqwebapp.doc_lookup import get_db_from_db_name
 from corehq.blobs import get_blob_db
 from corehq.blobs.exceptions import NotFound
 from corehq.util.decorators import change_log_level


### PR DESCRIPTION
## Summary
I noticed that we don't properly render Locations on the case data view. In the image below 'Owner' is a location and should be rendered as in a similar way to how the user is rendered:

![image](https://user-images.githubusercontent.com/249606/112967153-3d2f0b00-914b-11eb-988e-85d228f9fbbf.png)

With the changes in this PR the rendering is fixed:

![image](https://user-images.githubusercontent.com/249606/112967292-6b144f80-914b-11eb-9baf-c1cf72ed3208.png)

When I started looking into this I found that we have separate code paths for getting DocInfo for couch and SQL models and 3 places in code that 'search' for docs in all the DBs (doc_info, search view and raw docs view). The main `get_doc_info` function was only looking in Couch and hence not able to find Locations now that they are in SQL.

This PR consolidates that code and creates a generic `lookup_doc_id` function which will return a metadata object with the doc if it exists in any DB. The `get_doc_info`, `search` view and `raw_docs` view are all updates to use this lookup function. Finally the `get_doc_info` function has lifted up so that it delegates to the couch / sql version as necessary.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added some happy path tests.

### QA Plan
QA on staging

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
