### PR TITLE
don't return None

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -170,12 +170,10 @@ class LocationType(models.Model):
             self._populate_stock_levels(config)
 
         is_not_first_save = self.pk is not None
-        saved = super(LocationType, self).save(*args, **kwargs)
+        super(LocationType, self).save(*args, **kwargs)
 
         if is_not_first_save:
             self.sync_administrative_status()
-
-        return saved
 
     def sync_administrative_status(self, sync_supply_points=True):
         from .tasks import sync_administrative_status


### PR DESCRIPTION
## Summary
Django model `save` does not return (returns None). Having this code here makes it look like the model is returned.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Functionally this is identical to what's happening now (return None vs no return statement). 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
