### PR TITLE
Revert "Revert "Sanitized mark_safe usages in hqwebapp""

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -120,7 +120,7 @@ from corehq.apps.app_manager.suite_xml.generator import (
 )
 from corehq.apps.app_manager.suite_xml.utils import get_select_chain
 from corehq.apps.app_manager.tasks import prune_auto_generated_builds
-from corehq.apps.app_manager.templatetags.xforms_extras import trans
+from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans, trans
 from corehq.apps.app_manager.util import (
     actions_use_usercase,
     expire_get_latest_app_release_by_location_cache,
@@ -1220,10 +1220,9 @@ class FormBase(DocumentSchema):
 
     def default_name(self):
         app = self.get_app()
-        return trans(
+        return clean_trans(
             self.name,
-            [app.default_language] + app.langs,
-            include_lang=False
+            [app.default_language] + app.langs
         )
 
     @property
@@ -2294,10 +2293,9 @@ class ModuleBase(IndexedSchema, ModuleMediaMixin, NavMenuItemMediaMixin, Comment
     def default_name(self, app=None):
         if not app:
             app = self.get_app()
-        return trans(
+        return clean_trans(
             self.name,
-            [app.default_language] + app.langs,
-            include_lang=False
+            [app.default_language] + app.langs
         )
 
     def rename_lang(self, old_lang, new_lang):
@@ -5811,7 +5809,7 @@ class DeleteFormRecord(DeleteRecord):
     def undo(self):
         app = Application.get(self.app_id)
         if self.module_unique_id is not None:
-            name = trans(self.form.name, app.default_language, include_lang=False)
+            name = clean_trans(self.form.name, app.default_language)
             module = app.get_module_by_unique_id(
                 self.module_unique_id,
                 error=_("Could not find form '{}'").format(name)

--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -32,19 +32,13 @@ def _create_empty_indicator(lang):
     return ''
 
 
-@register.filter
-def trans(name,
-
+def _trans(name,
         langs=None,
         include_lang=True,
         use_delim=True,
         prefix=False,
         strip_tags=False,
         generates_html=False):
-    """
-    Generates a translation in the form of 'Translation [language] '
-    Not expected to contain HTML elements
-    """
     langs = langs or ["default"]
     if include_lang:
         if use_delim:
@@ -87,12 +81,20 @@ def trans(name,
 
 
 @register.filter
+def trans(name, langs=["default"]):
+    """
+    Generates a translation in the form of 'Translation [language] '
+    """
+    return _trans(name, langs)
+
+
+@register.filter
 def html_trans(name, langs=["default"]):
     """
     Generates an HTML-friendly translation, where the language is included as markup
     i.e. 'Translation <span>language</span> '
     """
-    return trans(name, langs, use_delim=False, strip_tags=True, generates_html=True) or EMPTY_LABEL
+    return _trans(name, langs, use_delim=False, strip_tags=True, generates_html=True) or EMPTY_LABEL
 
 
 @register.filter
@@ -101,13 +103,13 @@ def html_trans_prefix(name, langs=["default"]):
     Generates an HTML-friendly translation, where the language markup is prepended
     i.e. '<span>language</span> Translation'
     """
-    return trans(name, langs, use_delim=False, prefix=True, generates_html=True) or EMPTY_LABEL
+    return _trans(name, langs, use_delim=False, prefix=True, generates_html=True) or EMPTY_LABEL
 
 
 @register.filter
 def clean_trans(name, langs=None):
     """Produces a simple translation without any language identifier"""
-    return trans(name, langs=langs, include_lang=False)
+    return _trans(name, langs=langs, include_lang=False)
 
 
 @register.filter

--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -80,7 +80,7 @@ def _trans(name,
         return pattern.format(affix=affix, name=n)
 
 
-@register.filter
+@register.filter(is_safe=True)
 def trans(name, langs=["default"]):
     """
     Generates a translation in the form of 'Translation [language] '
@@ -106,7 +106,7 @@ def html_trans_prefix(name, langs=["default"]):
     return _trans(name, langs, use_delim=False, prefix=True, generates_html=True) or EMPTY_LABEL
 
 
-@register.filter
+@register.filter(is_safe=True)
 def clean_trans(name, langs=None):
     """Produces a simple translation without any language identifier"""
     return _trans(name, langs=langs, include_lang=False)

--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -105,15 +105,6 @@ def html_trans_prefix(name, langs=["default"]):
 
 
 @register.filter
-def html_trans_prefix_delim(name, langs=["default"]):
-    """
-    Generates an HTML-friendly translation where the language is prepended without markup
-    i.e. '[language] Translation'
-    """
-    return trans(name, langs, use_delim=True, prefix=True, generates_html=True) or EMPTY_LABEL
-
-
-@register.filter
 def clean_trans(name, langs=None):
     """Produces a simple translation without any language identifier"""
     return trans(name, langs=langs, include_lang=False)

--- a/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
+++ b/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
@@ -23,11 +23,6 @@ class TestTransFilter(SimpleTestCase):
         result = trans(translation_dict)
         self.assertEqual(result, 'English Output [en] ')
 
-    def test_exclude_language_only_outputs_translation(self):
-        translation_dict = {'en': 'English Output'}
-        result = trans(translation_dict, include_lang=False)
-        self.assertEqual(result, 'English Output')
-
     def test_primary_language_excludes_indicator(self):
         translation_dict = {'en': 'English Output'}
         langs = ['en']
@@ -39,22 +34,6 @@ class TestTransFilter(SimpleTestCase):
         langs = ['por', 'en']
         result = trans(translation_dict, langs=langs)
         self.assertEqual(result, 'English Output [en] ')
-
-    def test_do_not_use_delimiter_includes_html_indicator(self):
-        translation_dict = {'en': 'English Output'}
-        result = trans(translation_dict, use_delim=False)
-        self.assertEqual(result,
-            'English Output <span class="btn btn-xs btn-info btn-langcode-preprocessed">en</span> ')
-
-    def test_prefix_puts_indicator_in_front_of_translation(self):
-        translation_dict = {'en': 'English Output'}
-        result = trans(translation_dict, prefix=True)
-        self.assertEqual(result, ' [en] English Output')
-
-    def test_strip_tags_removes_tags_from_html_indicator(self):
-        translation_dict = {'en': 'English Output'}
-        result = trans(translation_dict, use_delim=False, strip_tags=True)
-        self.assertEqual(result, 'English Output en ')
 
     def test_does_not_escape_output_by_default(self):
         translation_dict = {'en': '<b>English Output</b>'}

--- a/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
+++ b/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
@@ -1,3 +1,4 @@
+from django.utils.safestring import SafeString
 from lxml.html import fragment_fromstring
 from django.test import SimpleTestCase
 from ...templatetags.xforms_extras import (
@@ -56,6 +57,12 @@ class TestTransFilter(SimpleTestCase):
         result = trans(translation_dict, use_delim=False, strip_tags=True)
         self.assertEqual(result, 'English Output en ')
 
+    def test_does_not_escape_output_by_default(self):
+        translation_dict = {'en': '<b>English Output</b>'}
+        result = trans(translation_dict)
+        self.assertEqual(result, '<b>English Output</b> [en] ')
+        self.assertNotIsInstance(result, SafeString)
+
 
 class TestHTMLTransFilter(SimpleTestCase):
     def test_primary_language_includes_no_indicator(self):
@@ -99,6 +106,12 @@ class TestHTMLTransFilter(SimpleTestCase):
         result = html_trans(name_dict, langs)
         self.assertEqual(result, '<span class="label label-info">Empty</span>')
 
+    def test_is_safe(self):
+        name_dict = {'en': 'English Output'}
+        langs = ['en']
+        result = html_trans(name_dict, langs)
+        self.assertIsInstance(result, SafeString)
+
 
 class TestHTMLTransPrefixFilter(SimpleTestCase):
     def test_primary_language_includes_no_indicator(self):
@@ -128,6 +141,12 @@ class TestHTMLTransPrefixFilter(SimpleTestCase):
         result = html_trans_prefix(name_dict, langs)
         self.assertEqual(result, '<span class="label label-info">Empty</span>')
 
+    def test_is_safe(self):
+        name_dict = {'en': 'English Output'}
+        langs = ['en']
+        result = html_trans_prefix(name_dict, langs)
+        self.assertIsInstance(result, SafeString)
+
 
 class TestHTMLTransPrefixDelimFilter(SimpleTestCase):
     def test_primary_language_includes_no_indicator(self):
@@ -153,6 +172,12 @@ class TestHTMLTransPrefixDelimFilter(SimpleTestCase):
         result = html_trans_prefix_delim(name_dict, langs)
         self.assertEqual(result, '<span class="label label-info">Empty</span>')
 
+    def test_is_safe(self):
+        name_dict = {'en': 'English Output'}
+        langs = ['en']
+        result = html_trans_prefix_delim(name_dict, langs)
+        self.assertIsInstance(result, SafeString)
+
 
 class TestCleanTransFilter(SimpleTestCase):
     def test_primary_language_includes_no_indicator(self):
@@ -171,6 +196,12 @@ class TestCleanTransFilter(SimpleTestCase):
         name_dict = {'en': 'English Output'}
         result = clean_trans(name_dict)
         self.assertEqual(result, 'English Output')
+
+    def test_does_not_escape_output(self):
+        name_dict = {'en': '<b>English Output</b>'}
+        result = clean_trans(name_dict)
+        self.assertEqual(result, '<b>English Output</b>')
+        self.assertNotIsInstance(result, SafeString)
 
 
 class TestHTMLNameFilter(SimpleTestCase):

--- a/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
+++ b/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
@@ -4,7 +4,6 @@ from django.test import SimpleTestCase
 from ...templatetags.xforms_extras import (
     html_trans,
     html_trans_prefix,
-    html_trans_prefix_delim,
     clean_trans,
     trans,
     html_name,
@@ -145,37 +144,6 @@ class TestHTMLTransPrefixFilter(SimpleTestCase):
         name_dict = {'en': 'English Output'}
         langs = ['en']
         result = html_trans_prefix(name_dict, langs)
-        self.assertIsInstance(result, SafeString)
-
-
-class TestHTMLTransPrefixDelimFilter(SimpleTestCase):
-    def test_primary_language_includes_no_indicator(self):
-        name_dict = {'en': 'English Output'}
-        langs = ['en']
-        result = html_trans_prefix_delim(name_dict, langs)
-        self.assertEqual(result, 'English Output')
-
-    def test_non_primary_language_includes_prepended_indicator(self):
-        name_dict = {'por': 'Portuguese Output'}
-        langs = ['en', 'por']
-        result = html_trans_prefix_delim(name_dict, langs)
-        self.assertEqual(result, ' [por] Portuguese Output')
-
-    def test_default_language_includes_prepended_indicator(self):
-        name_dict = {'en': 'English Output'}
-        result = html_trans_prefix_delim(name_dict)
-        self.assertEqual(result, ' [en] English Output')
-
-    def test_empty_mapping_returns_empty_span(self):
-        name_dict = {}
-        langs = ['en', 'por']
-        result = html_trans_prefix_delim(name_dict, langs)
-        self.assertEqual(result, '<span class="label label-info">Empty</span>')
-
-    def test_is_safe(self):
-        name_dict = {'en': 'English Output'}
-        langs = ['en']
-        result = html_trans_prefix_delim(name_dict, langs)
         self.assertIsInstance(result, SafeString)
 
 

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -288,7 +288,7 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
             if xform.exists():
                 xform.set_name(name)
                 save_xform(app, form, xform.render())
-        resp['update'] = {'.variable-form_name': trans(form.name, [lang], use_delim=False)}
+        resp['update'] = {'.variable-form_name': clean_trans(form.name, [lang])}
 
     if should_edit('comment'):
         form.comment = request.POST['comment']

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -72,7 +72,7 @@ from corehq.apps.app_manager.models import (
 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import (
     get_uuids_by_instance_id,
 )
-from corehq.apps.app_manager.templatetags.xforms_extras import trans
+from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans, trans
 from corehq.apps.app_manager.util import (
     generate_xmlns,
     is_usercase_in_use,
@@ -638,7 +638,7 @@ def edit_module_attr(request, domain, app_id, module_unique_id, attr):
     if should_edit("name"):
         name = request.POST.get("name", None)
         module["name"][lang] = name
-        resp['update'] = {'.variable-module_name': trans(module.name, [lang], use_delim=False)}
+        resp['update'] = {'.variable-module_name': clean_trans(module.name, [lang])}
     if should_edit('comment'):
         module.comment = request.POST.get('comment')
     for SLUG in ('case_list', 'task_list'):

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -35,7 +35,7 @@ from dimagi.utils.couch.resource_conflict import retry_resource
 from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager.exceptions import XFormException
-from corehq.apps.app_manager.templatetags.xforms_extras import trans
+from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans
 from corehq.apps.app_manager.xform import XFormValidationError
 from corehq.apps.domain import SHARED_DOMAIN
 from corehq.apps.domain.models import LICENSE_LINKS, LICENSES
@@ -647,7 +647,7 @@ class ModuleMediaMixin(MediaMixin):
             for column in details.get_columns():
                 if column.format == 'enum-image':
                     for map_item in column.enum:
-                        icon = trans(map_item.value, [lang] + self.get_app().langs, include_lang=False)
+                        icon = clean_trans(map_item.value, [lang] + self.get_app().langs)
                         if icon:
                             media.append(ApplicationMediaReference(icon, media_class=CommCareImage,
                                                                    is_menu_media=True, **kwargs))

--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -177,6 +177,8 @@ def edited_classes(context, label_class, field_class):
 class B3MultiField(LayoutObject):
     template = 'hqwebapp/crispy/multi_field.html'
 
+    # Because fields will be passed as-is to the HTML,
+    # care should be taken to ensure they escape user input appropriately
     def __init__(self, field_label, *fields, **kwargs):
         self.fields = list(fields)
         self.label_html = field_label
@@ -199,8 +201,8 @@ class B3MultiField(LayoutObject):
         for field in self.fields:
             html += render_field(field, form, form_style, context, template_pack=template_pack)
         context.update({
-            'label_html': mark_safe(self.label_html),
-            'field_html': mark_safe(html),
+            'label_html': self.label_html,
+            'field_html': mark_safe(html),  # nosec
             'multifield': self,
             'error_list': errors,
             'help_bubble_text': self.help_bubble_text,

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -22,7 +22,10 @@ from corehq.apps.domain.forms import NoAutocompleteMixin
 from corehq.apps.users.models import CouchUser
 from corehq.util.metrics import metrics_counter
 
-LOCKOUT_MESSAGE = mark_safe(_('Sorry - you have attempted to login with an incorrect password too many times. Please <a href="/accounts/password_reset_email/">click here</a> to reset your password or contact the domain administrator.'))
+LOCKOUT_MESSAGE = mark_safe(_(  # nosec: no user input
+    'Sorry - you have attempted to login with an incorrect password too many times. '
+    'Please <a href="/accounts/password_reset_email/">click here</a> to reset your password '
+    'or contact the domain administrator.'))
 
 
 class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -40,7 +40,9 @@ def JSON(obj):
     if isinstance(obj, QueryDict):
         obj = dict(obj)
     try:
-        return mark_safe(escape_script_tags(json.dumps(obj, default=json_handler)))
+        return mark_safe(  # nosec: sanitization must be done higher up -- this can contain tags
+            escape_script_tags(json.dumps(obj, default=json_handler))
+        )
     except TypeError as e:
         msg = ("Unserializable data was sent to the `|JSON` template tag.  "
                "If DEBUG is off, Django will silently swallow this error.  "
@@ -135,9 +137,10 @@ def domains_for_user(context, request, selected_domain=None):
     context = {
         'domain_links': domain_links,
         'show_all_projects_link': show_all_projects_link,
-        'current_domain': selected_domain,
     }
-    return mark_safe(render_to_string('hqwebapp/includes/domain_list_dropdown.html', context, request))
+    return mark_safe(  # nosec: render_to_string should have already handled escaping
+        render_to_string('hqwebapp/includes/domain_list_dropdown.html', context, request)
+    )
 
 
 @register.simple_tag
@@ -400,10 +403,10 @@ def maintenance_alert(request, dismissable=True):
             '<div class="alert alert-warning alert-maintenance{}" data-id="{}">{}{}</div>',
             ' hide' if dismissable else '',
             alert.id,
-            mark_safe('''
-                <button class="close" data-dismiss="alert" aria-label="close">&times;</button>
-            ''') if dismissable else '',
-            mark_safe(alert.html),
+            mark_safe(  # nosec: no user input
+                '<button class="close" data-dismiss="alert" aria-label="close">&times;</button>'
+            ) if dismissable else '',
+            alert.html
         )
     else:
         return ''
@@ -703,8 +706,10 @@ def breadcrumbs(page, section, parents=None):
     :return:
     """
 
-    return mark_safe(render_to_string('hqwebapp/partials/breadcrumbs.html', {
-        'page': page,
-        'section': section,
-        'parents': parents or [],
-    }))
+    return mark_safe(  # nosec: render_to_string handles escaping
+        render_to_string('hqwebapp/partials/breadcrumbs.html', {
+            'page': page,
+            'section': section,
+            'parents': parents or [],
+        })
+    )

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -15,7 +15,7 @@ from django.template.base import (
 )
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils.html import escape, format_html
+from django.utils.html import conditional_escape, format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
@@ -40,9 +40,7 @@ def JSON(obj):
     if isinstance(obj, QueryDict):
         obj = dict(obj)
     try:
-        return mark_safe(  # nosec: sanitization must be done higher up -- this can contain tags
-            escape_script_tags(json.dumps(obj, default=json_handler))
-        )
+        return escape_script_tags(json.dumps(obj, default=json_handler))
     except TypeError as e:
         msg = ("Unserializable data was sent to the `|JSON` template tag.  "
                "If DEBUG is off, Django will silently swallow this error.  "
@@ -579,7 +577,7 @@ def trans_html_attr(value):
         value = value.decode('utf-8')
     if not isinstance(value, str):
         value = JSON(value)
-    return escape(_(value))
+    return conditional_escape(_(value))
 
 
 @register.simple_tag
@@ -588,7 +586,7 @@ def html_attr(value):
         value = value.decode('utf-8')
     if not isinstance(value, str):
         value = JSON(value)
-    return escape(value)
+    return conditional_escape(value)
 
 
 def _create_page_data(parser, token, node_slug):

--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -16,6 +16,7 @@ from django import template
 from django.template.defaultfilters import yesno
 from django.utils.html import conditional_escape, escape
 from django.utils.safestring import mark_safe
+from django.utils.html import format_html, format_html_join
 
 import pytz
 from jsonobject.exceptions import BadValueError
@@ -83,17 +84,21 @@ def _to_html(val, key=None, level=0, timeago=False):
             return ""
 
     if isinstance(val, dict):
-        ret = "".join(
-            ["<dl %s>" % ("class='well'" if level == 0 else '')] + 
-            ["<dt>%s</dt><dd>%s</dd>" % (_key_format(k, v), recurse(k, v))
-             for k, v in val.items()] +
-            ["</dl>"])
+        ret = format_html(
+            "<dl {}>{}</dl>",
+            mark_safe("class='well'") if level == 0 else '',  # nosec: no user input
+            format_html_join(
+                "",
+                "<dt>{}</dt><dd>{}</dd>",
+                [(_key_format(k, v), recurse(k, v)) for k, v in val.items()]
+            )
+        )
 
     elif _is_list_like(val):
-        ret = "".join(
-            ["<dl>"] +
-            ["<dt>%s</dt><dd>%s</dd>" % (key, recurse(None, v)) for v in val] +
-            ["</dl>"])
+        ret = format_html(
+            "<dl>{}</dl>",
+            format_html_join("", "<dt>{}</dt><dd>{}</dd>", [(key, recurse(None, v)) for v in val])
+        )
 
     elif isinstance(val, datetime.date):
         if isinstance(val, datetime.datetime):
@@ -102,15 +107,19 @@ def _to_html(val, key=None, level=0, timeago=False):
             fmt = USER_DATE_FORMAT
 
         iso = val.isoformat()
-        ret = mark_safe("<time %s title='%s' datetime='%s'>%s</time>" % (
-            "class='timeago'" if timeago else "", iso, iso, safe_strftime(val, fmt)))
+        ret = format_html(
+            "<time {} title='{}' datetime='{}'>{}</time>",
+            "class='timeago'" if timeago else "",
+            iso,
+            iso,
+            safe_strftime(val, fmt))
     else:
         if val is None:
             val = '---'
 
         ret = escape(val)
 
-    return mark_safe(ret)
+    return ret
 
 
 def get_display_data(data, prop_def, processors=None, timezone=pytz.utc):
@@ -150,9 +159,9 @@ def get_display_data(data, prop_def, processors=None, timezone=pytz.utc):
     try:
         val = conditional_escape(processors[process](val))
     except KeyError:
-        val = mark_safe(_to_html(val, timeago=timeago))
+        val = _to_html(val, timeago=timeago)
     if format:
-        val = mark_safe(format.format(val))
+        val = format_html(format, val)
 
     return {
         "expr": expr_name,

--- a/corehq/apps/hqwebapp/tests/test_proptable_tags.py
+++ b/corehq/apps/hqwebapp/tests/test_proptable_tags.py
@@ -1,6 +1,7 @@
+from datetime import date, datetime
 from django.test import SimpleTestCase
 
-from corehq.apps.hqwebapp.templatetags.proptable_tags import get_display_data
+from corehq.apps.hqwebapp.templatetags.proptable_tags import get_display_data, _to_html
 
 
 class CaseDisplayDataTest(SimpleTestCase):
@@ -47,3 +48,55 @@ class CaseDisplayDataTest(SimpleTestCase):
             get_display_data(data, column),
             {'expr': 'colour', 'name': 'colour', 'value': 'red', 'has_history': True}
         )
+
+
+class ToHTMLTest(SimpleTestCase):
+    def test_handles_single_value(self):
+        self.assertEqual(_to_html('value'), 'value')
+
+    def test_converts_none_to_dashes(self):
+        self.assertEqual(_to_html(None), '---')
+
+    def test_single_values_are_escaped(self):
+        self.assertEqual(_to_html('va<lue'), 'va&lt;lue')
+
+    def test_handles_list(self):
+        result = _to_html(['one', 'two', 'three'], key='test_list')
+        self.assertEqual(result,
+            "<dl>"
+            "<dt>test_list</dt><dd>one</dd>"
+            "<dt>test_list</dt><dd>two</dd>"
+            "<dt>test_list</dt><dd>three</dd>"
+            "</dl>")
+
+    def test_list_key_and_value_are_escaped(self):
+        result = _to_html(['va<lue'], key='ke>y')
+        self.assertEqual(result,
+            "<dl>"
+            "<dt>ke&gt;y</dt><dd>va&lt;lue</dd>"
+            "</dl>")
+
+    def test_handles_dict(self):
+        result = _to_html({'a': 'one', 'b': 'two'}, key='test_dict')
+        self.assertEqual(result,
+            "<dl class='well'>"
+            "<dt>a</dt><dd>one</dd>"
+            "<dt>b</dt><dd>two</dd>"
+            "</dl>")
+
+    def test_dict_key_and_values_are_escaped(self):
+        result = _to_html({'ke>y': 'va<lue'})
+        self.assertEqual(result,
+            "<dl class='well'>"
+            "<dt>ke&gt;y</dt><dd>va&lt;lue</dd>"
+            "</dl>")
+
+    def test_handles_date(self):
+        result = _to_html(date(2020, 5, 25))
+        self.assertEqual(result, "<time  title='2020-05-25' datetime='2020-05-25'>May 25, 2020</time>")
+
+    def test_handles_datetime(self):
+        result = _to_html(datetime(2020, 5, 25, 2, 12, 10, 100))
+        self.assertEqual(result,
+            "<time  title='2020-05-25T02:12:10.000100'"
+            " datetime='2020-05-25T02:12:10.000100'>May 25, 2020 02:12 </time>")

--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -2,12 +2,11 @@ import collections
 import json
 
 from django import forms
-from django.forms.fields import CharField, MultiValueField
 from django.forms.utils import flatatt
-from django.forms.widgets import CheckboxInput, Input, MultiWidget, TextInput
-from django.template.loader import render_to_string
+from django.forms.widgets import CheckboxInput, Input
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
+from django.utils.html import format_html, conditional_escape
 from django.utils.translation import ugettext_noop
 
 from dimagi.utils.dates import DateSpan
@@ -22,7 +21,7 @@ class BootstrapCheckboxInput(CheckboxInput):
         self.inline_label = inline_label
 
     def render(self, name, value, attrs=None, renderer=None):
-        extra_attrs = {'type': 'checkbox', 'name': name}
+        extra_attrs = {'type': 'checkbox', 'name': conditional_escape(name)}
         extra_attrs.update(self.attrs)
         final_attrs = self.build_attrs(attrs, extra_attrs=extra_attrs)
         try:
@@ -34,8 +33,10 @@ class BootstrapCheckboxInput(CheckboxInput):
         if value not in ('', True, False, None):
             # Only add the 'value' attribute if a value is non-empty.
             final_attrs['value'] = force_text(value)
-        return mark_safe('<label class="checkbox"><input%s /> %s</label>' %
-                         (flatatt(final_attrs), self.inline_label))
+        return format_html(
+            '<label class="checkbox"><input{} /> {}</label>',
+            mark_safe(flatatt(final_attrs)),  # nosec: trusting the user to sanitize attributes
+            self.inline_label)
 
 
 class _Select2AjaxMixin():
@@ -79,7 +80,7 @@ class Select2Ajax(_Select2AjaxMixin, forms.Select):
             'data-multiple': '1' if self.multiple else '0',
         })
         output = super(Select2Ajax, self).render(name, value, attrs, renderer=renderer)
-        return mark_safe(output)
+        return mark_safe(output)  # nosec: the output IS HTML, so needs to be marked safe
 
 
 class DateRangePickerWidget(Input):
@@ -126,15 +127,14 @@ class DateRangePickerWidget(Input):
             'data-start-date': startdate,
             'data-end-date': enddate,
         })
-        final_attrs = self.build_attrs(attrs)
 
         output = super(DateRangePickerWidget, self).render(name, value, attrs, renderer)
-        return mark_safe("""
-            <div class="input-group hqwebapp-datespan">
-                <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
-                {}
-            </div>
-        """.format(output))
+        return format_html(
+            '<div class="input-group hqwebapp-datespan">'
+            '   <span class="input-group-addon"><i class="fa fa-calendar"></i></span>'
+            '   {}'
+            '</div>',
+            mark_safe(output))  # nosec: must support the input tag
 
 
 class SelectToggle(forms.Select):
@@ -170,6 +170,6 @@ class GeoCoderInput(Input):
         if isinstance(value, dict):
             value = json.dumps(value)
         output = super(GeoCoderInput, self).render(name, value, attrs, renderer)
-        return mark_safe("""
-            <div class="geocoder-proximity">{}</div>
-        """.format(output))
+        return format_html(
+            '<div class="geocoder-proximity">{}</div>',
+            mark_safe(output))  # nosec: must support the input tag


### PR DESCRIPTION
Corrects encoding errors encountered in dimagi/commcare-hq#29405.  In addition, refactored to try to prevent these type of errors in the future. The issue was caused because I moved all `mark_safe` behavior into the `trans` method, when this method wasn't always used for HTML output, and would cause issues if it unnecessarily escaped that output. This change tries to prevent future regressions by:
- Moving all complicated translation/formatting logic into the `_trans` helper method. This should make it easier to understand when each top-level filter produces HTML output, and thus needs to be escaped or not.
- Documenting the expected output for each filter. Again, this should make it easier to understand when each filter produces HTML output.
- No longer escaping the `trans` or `clean_trans` filters. These were the filters used outside of an HTML context, and escaping caused issues. Their output still needs to be escaped in an HTML-context, but because it is no longer marked as safe, Django's templates will escape it (assuming auto-escaping is on).

Additionally, conditional escapes are used to prevent double-escaping when the output is already safe.

Probably easiest to review commit-by-commit.