### PR TITLE
Revert "Bump tornado from 4.5.3 to 6.1 in /requirements"

### DIFF
--- a/requirements/prod-requirements.in
+++ b/requirements/prod-requirements.in
@@ -3,7 +3,7 @@
 pip>=10.0.0
 
 flower==0.9.2
-tornado<7.0
+tornado<5.0
 setproctitle==1.2.2
 uWSGI==2.0.19.1
 ipython==7.16.1

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -517,7 +517,7 @@ tinycss2==1.0.2
     #   weasyprint
 tinys3==0.1.12
     # via -r base-requirements.in
-tornado==6.1
+tornado==4.5.3
     # via
     #   -r prod-requirements.in
     #   flower


### PR DESCRIPTION
Reverts dimagi/commcare-hq#29434

was causing issues with flower after a staging deploy.

```
  File "/home/cchq/www/staging/releases/2021-03-30_22.11/python_env-3.6/lib/python3.6/site-packages/flower/command.py", line 18, in <module>
    from .app import Flower
  File "/home/cchq/www/staging/releases/2021-03-30_22.11/python_env-3.6/lib/python3.6/site-packages/flower/app.py", line 15, in <module>
    from .urls import handlers
  File "/home/cchq/www/staging/releases/2021-03-30_22.11/python_env-3.6/lib/python3.6/site-packages/flower/urls.py", line 9, in <module>
    from .api import tasks
  File "/home/cchq/www/staging/releases/2021-03-30_22.11/python_env-3.6/lib/python3.6/site-packages/flower/api/tasks.py", line 81, in <module>
    class TaskApply(BaseTaskHandler):
  File "/home/cchq/www/staging/releases/2021-03-30_22.11/python_env-3.6/lib/python3.6/site-packages/flower/api/tasks.py", line 83, in TaskApply
    @web.asynchronous
AttributeError: module 'tornado.web' has no attribute 'asynchronous'
```