### PR TITLE
Revert "Revert "record timing data for slow form submissions""

### DIFF
--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -311,7 +311,7 @@ class BaseMigrationTestCase(TestCase, TestFileMixin):
             return get_result(self_, sql_form, couch_form)
 
         @staticmethod
-        def maybe_process_xforms_for_cases(xforms, casedb):
+        def maybe_process_xforms_for_cases(xforms, casedb, timing_context=None):
             if any(f.form_id == form_id for f in xforms):
                 assert len(xforms) == 1, xforms
                 stock = StockProcessingResult(xforms[0])

--- a/corehq/apps/locations/middleware.py
+++ b/corehq/apps/locations/middleware.py
@@ -4,7 +4,6 @@ from django.utils.translation import ugettext_lazy
 from corehq.apps.hqwebapp.views import no_permissions
 from corehq.apps.users.models import AnonymousCouchUser
 from corehq.toggles import PUBLISH_CUSTOM_REPORTS
-
 from .permissions import is_location_safe, location_restricted_response
 
 RESTRICTED_USER_UNASSIGNED_MSG = ugettext_lazy("""

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -115,6 +115,7 @@ from corehq.apps.domain.decorators import (
 )
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import CouchUser
+from corehq.middleware import get_view_func
 
 from .models import SQLLocation
 
@@ -123,6 +124,8 @@ from .models import SQLLocation
 # evaluate it against the current language.
 # https://docs.djangoproject.com/en/dev/topics/i18n/translation/#other-uses-of-lazy-in-delayed-translations
 # has details on how to create a delayed format_html/mark_safe
+
+
 LOCATION_ACCESS_DENIED = format_html(ugettext_lazy(
     "This project has restricted data access rules. Please contact your "
     "project administrator to be assigned access to data in this project. "
@@ -249,15 +252,8 @@ def is_location_safe(view_fn, request, view_args, view_kwargs):
     if 'resource_name' in view_kwargs:
         return view_kwargs['resource_name'] in LOCATION_SAFE_TASTYPIE_RESOURCES
 
-    if getattr(view_fn, 'is_hq_report', False):  # HQ report
-        dispatcher = view_fn.view_class
-        report_class = dispatcher.get_report(view_kwargs['domain'], view_kwargs['report_slug'])
-        return _view_obj_is_safe(report_class, request, *view_args, **view_kwargs)
-
-    if hasattr(view_fn, "view_class"):  # Django view
-        return _view_obj_is_safe(view_fn.view_class, request, *view_args, **view_kwargs)
-
-    return _view_obj_is_safe(view_fn, request, *view_args, **view_kwargs)
+    view_func = get_view_func(view_fn, view_kwargs)
+    return _view_obj_is_safe(view_func, request, *view_args, **view_kwargs)
 
 
 def report_class_is_location_safe(report_class):

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -54,7 +54,7 @@ from corehq.form_processor.utils import (
     should_use_sql_backend,
 )
 from corehq.util.metrics import metrics_counter, metrics_histogram
-from corehq.util.timer import TimingContext
+from corehq.util.timer import TimingContext, set_request_duration_reporting_threshold
 from couchdbkit import ResourceNotFound
 from tastypie.http import HttpTooManyRequests
 
@@ -134,6 +134,7 @@ def _process_form(request, domain, app_id, user_id, authenticated,
             last_sync_token=couchforms.get_last_sync_token(request),
             openrosa_headers=couchforms.get_openrosa_headers(request),
             force_logs=request.GET.get('force_logs', 'false') == 'true',
+            timing_context=timer
         )
 
         try:
@@ -150,6 +151,8 @@ def _process_form(request, domain, app_id, user_id, authenticated,
             )
 
     response = result.response
+    response.request_timer = timer  # logged as Sentry breadcrumbs in LogLongRequestMiddleware
+
     _record_metrics(metric_tags, result.submission_type, result.response, timer, result.xform)
 
     return response
@@ -210,6 +213,7 @@ def _record_metrics(tags, submission_type, response, timer=None, xform=None):
 @csrf_exempt
 @require_POST
 @check_domain_migration
+@set_request_duration_reporting_threshold(60)
 def post(request, domain, app_id=None):
     try:
         if domain_requires_auth(domain):
@@ -300,6 +304,7 @@ def _noauth_post(request, domain, app_id=None):
 
 @login_or_digest_ex(allow_cc_users=True)
 @two_factor_exempt
+@set_request_duration_reporting_threshold(60)
 def _secure_post_digest(request, domain, app_id=None):
     """only ever called from secure post"""
     return _process_form(
@@ -314,6 +319,7 @@ def _secure_post_digest(request, domain, app_id=None):
 @handle_401_response
 @login_or_basic_ex(allow_cc_users=True)
 @two_factor_exempt
+@set_request_duration_reporting_threshold(60)
 def _secure_post_basic(request, domain, app_id=None):
     """only ever called from secure post"""
     return _process_form(
@@ -328,6 +334,7 @@ def _secure_post_basic(request, domain, app_id=None):
 @login_or_api_key_ex()
 @require_permission(Permissions.edit_data)
 @require_permission(Permissions.access_api)
+@set_request_duration_reporting_threshold(60)
 def _secure_post_api_key(request, domain, app_id=None):
     """only ever called from secure post"""
     return _process_form(
@@ -344,6 +351,7 @@ def _secure_post_api_key(request, domain, app_id=None):
 @csrf_exempt
 @require_POST
 @check_domain_migration
+@set_request_duration_reporting_threshold(60)
 def secure_post(request, domain, app_id=None):
     authtype_map = {
         DIGEST: _secure_post_digest,

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -113,9 +113,10 @@ class ReportDispatcher(View):
                 if report.slug == report_slug:
                     return report
 
+    @classmethod
     @quickcache(['domain', 'report_slug'], timeout=300)
-    def get_report_class_name(self, domain, report_slug):
-        report_cls = self.get_report(domain, report_slug)
+    def get_report_class_name(cls, domain, report_slug):
+        report_cls = cls.get_report(domain, report_slug)
         return report_cls.__module__ + '.' + report_cls.__name__ if report_cls else ''
 
     def _redirect_slug(self, slug):

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -20,6 +20,7 @@ from corehq.apps.domain.utils import legacy_domain_re
 from corehq.const import OPENROSA_DEFAULT_VERSION
 from corehq.util.timer import DURATION_REPORTING_THRESHOLD
 from dimagi.utils.logging import notify_exception
+from dimagi.utils.modules import to_function
 
 from dimagi.utils.parsing import json_format_datetime, string_to_utc_datetime
 
@@ -324,9 +325,10 @@ def get_view_func(view_fn, view_kwargs):
         domain = view_kwargs.get("domain", None)
         slug = view_kwargs.get("report_slug", None)
         try:
-            return dispatcher.get_report(domain, slug)
-        except TypeError:
-            # custom report dispatchers may take different args for get_report
+            class_name = dispatcher.get_report_class_name(domain, slug)
+            return to_function(class_name) if class_name else None
+        except:
+            # custom report dispatchers may do things differently
             return
 
     if hasattr(view_fn, "view_class"):  # Django view

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -4,6 +4,8 @@ import mimetypes
 import os
 import datetime
 import re
+from datetime import timedelta
+
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.exceptions import MiddlewareNotUsed
@@ -11,10 +13,12 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.contrib.auth.views import LogoutView
 from django.utils.deprecation import MiddlewareMixin
+from sentry_sdk import add_breadcrumb
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import legacy_domain_re
 from corehq.const import OPENROSA_DEFAULT_VERSION
+from corehq.util.timer import DURATION_REPORTING_THRESHOLD
 from dimagi.utils.logging import notify_exception
 
 from dimagi.utils.parsing import json_format_datetime, string_to_utc_datetime
@@ -97,16 +101,39 @@ class TimingMiddleware(object):
 
 
 class LogLongRequestMiddleware(MiddlewareMixin):
+    """Report requests that violate the timing threshold configured for the view.
+
+    Use `corehq.util.timer.set_request_duration_reporting_threshold` to override the
+    default threshold for specific views.
+    """
+    DEFAULT_THRESHOLD = timedelta(minutes=10).total_seconds()  # 10 minutes
 
     def process_request(self, request):
         request._profile_starttime = datetime.datetime.utcnow()
 
+    def process_view(self, request, view_fn, view_args, view_kwargs):
+        view_func = get_view_func(view_fn, view_kwargs)
+        reporting_threshold = getattr(view_func, DURATION_REPORTING_THRESHOLD, self.DEFAULT_THRESHOLD)
+        setattr(request, DURATION_REPORTING_THRESHOLD, reporting_threshold)
+
     def process_response(self, request, response):
+        request_timer = getattr(response, 'request_timer', None)
+        if request_timer:
+            for sub in request_timer.to_list(exclude_root=True):
+                add_breadcrumb(
+                    category="timing",
+                    message=f"{sub.name}: {sub.duration:0.3f}",
+                    level="info",
+                )
+
         if hasattr(request, '_profile_starttime'):
             duration = datetime.datetime.utcnow() - request._profile_starttime
-            if duration > datetime.timedelta(minutes=10):
-                notify_exception(request, "Request took a very long time.", details={
+            threshold = getattr(request, DURATION_REPORTING_THRESHOLD, self.DEFAULT_THRESHOLD)
+            if duration.total_seconds() > threshold:
+                notify_exception(request, "Request timing above threshold", details={
+                    'threshold': threshold,
                     'duration': duration.total_seconds(),
+                    'status_code': response.status_code
                 })
         return response
 
@@ -284,3 +311,17 @@ class SelectiveSessionMiddleware(SessionMiddleware):
         if self._bypass_sessions(request):
             request.session.save = lambda *x: None
             request._bypass_sessions = True
+
+
+def get_view_func(view_fn, view_kwargs):
+    """Given a view_fn from the `process_view` middleware function return the actual
+    function or class that represents the view.
+    """
+    if getattr(view_fn, 'is_hq_report', False):  # HQ report
+        dispatcher = view_fn.view_class
+        return dispatcher.get_report(view_kwargs['domain'], view_kwargs['report_slug'])
+
+    if hasattr(view_fn, "view_class"):  # Django view
+        return view_fn.view_class
+
+    return view_fn

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -316,10 +316,18 @@ class SelectiveSessionMiddleware(SessionMiddleware):
 def get_view_func(view_fn, view_kwargs):
     """Given a view_fn from the `process_view` middleware function return the actual
     function or class that represents the view.
+
+    :returns: the view function or class or None if not able to determine the view class
     """
     if getattr(view_fn, 'is_hq_report', False):  # HQ report
         dispatcher = view_fn.view_class
-        return dispatcher.get_report(view_kwargs['domain'], view_kwargs['report_slug'])
+        domain = view_kwargs.get("domain", None)
+        slug = view_kwargs.get("report_slug", None)
+        try:
+            return dispatcher.get_report(domain, slug)
+        except TypeError:
+            # custom report dispatchers may take different args for get_report
+            return
 
     if hasattr(view_fn, "view_class"):  # Django view
         return view_fn.view_class

--- a/corehq/tests/test_middleware.py
+++ b/corehq/tests/test_middleware.py
@@ -2,11 +2,15 @@ import time
 
 import mock
 from django.http import HttpResponse
-from django.test import override_settings, SimpleTestCase
-from django.urls import path
+from django.test import override_settings, SimpleTestCase, TestCase
+from django.urls import path, include
 from django.views import View
 from testil import Regex
 
+from corehq.apps.domain.models import Domain
+from corehq.apps.reports.dispatcher import ReportDispatcher
+from corehq.apps.reports.generic import GenericReportView
+from corehq.apps.users.models import WebUser
 from corehq.util.timer import set_request_duration_reporting_threshold, TimingContext
 
 
@@ -27,27 +31,100 @@ def slow_function_view(request):
     return response
 
 
+class TestReportDispatcher(ReportDispatcher):
+    map_name = "REPORTS"
+    prefix = "test"
+
+    @classmethod
+    def get_reports(cls, domain):
+        return [('All Reports', [
+            SlowReport,
+            FastReport,
+        ])]
+
+
+class TestNoDomainReportDispatcher(ReportDispatcher):
+    map_name = "REPORTS"
+    prefix = "test_no_domain"
+
+    @classmethod
+    def get_reports(cls, domain):
+        return [('All Reports', [
+            NoDomainReport,
+        ])]
+
+
+class TestCustomReportDispatcher(TestNoDomainReportDispatcher):
+    map_name = "REPORTS"
+    prefix = "test_custom"
+
+    def get_report(self, domain, slug, config_id):
+        """Intentionally different method signature to the parent class"""
+        return CustomReport
+
+    def get_report_class_name(self, domain, report_slug):
+        return CustomReport.__module__ + '.' + CustomReport.__name__
+
+
+class BaseReport(GenericReportView):
+    name = "Test report"
+    section_name = "test"
+
+    @property
+    def view_response(self):
+        return HttpResponse(200)
+
+
+@set_request_duration_reporting_threshold(0.1)
+class SlowReport(BaseReport):
+    dispatcher = TestReportDispatcher
+    slug = 'slow_report'
+
+    @property
+    def view_response(self):
+        time.sleep(0.2)
+        return HttpResponse(200)
+
+
+@set_request_duration_reporting_threshold(0.1)
+class FastReport(BaseReport):
+    dispatcher = TestReportDispatcher
+    slug = 'fast_report'
+
+
+class CustomReport(BaseReport):
+    dispatcher = TestCustomReportDispatcher
+    slug = 'custom_report'
+
+
+class NoDomainReport(BaseReport):
+    dispatcher = TestNoDomainReportDispatcher
+    slug = 'admin_report'
+
+
 urlpatterns = [
     path('slow_class', SlowClassView.as_view()),
     path('slow_function', slow_function_view),
+    TestNoDomainReportDispatcher.url_pattern(),
+    path('<domain>/', include([TestReportDispatcher.url_pattern()])),
+    path('<domain>/custom/', include([TestCustomReportDispatcher.url_pattern()])),
 ]
 
 
-@override_settings(ROOT_URLCONF='corehq.tests.test_middleware')
+@override_settings(
+    ROOT_URLCONF='corehq.tests.test_middleware',
+    MIDDLEWARE=('corehq.middleware.LogLongRequestMiddleware',)
+)
+@mock.patch('corehq.middleware.add_breadcrumb')
+@mock.patch('corehq.middleware.notify_exception')
 class TestLogLongRequestMiddleware(SimpleTestCase):
 
-    @override_settings(MIDDLEWARE=('corehq.middleware.LogLongRequestMiddleware',))
-    @mock.patch('corehq.middleware.add_breadcrumb')
-    @mock.patch('corehq.middleware.notify_exception')
     def test_middleware_reports_slow_class_view(self, notify_exception, add_breadcrumb):
         res = self.client.get('/slow_class')
         self.assertEqual(res.status_code, 200)
         notify_exception.assert_called_once()
         add_breadcrumb.assert_not_called()
 
-    @override_settings(MIDDLEWARE=('corehq.middleware.LogLongRequestMiddleware',))
-    @mock.patch('corehq.middleware.add_breadcrumb')
-    @mock.patch('corehq.middleware.notify_exception')
     def test_middleware_reports_slow_function_view_with_timer(self, notify_exception, add_breadcrumb):
         res = self.client.get('/slow_function')
         self.assertEqual(res.status_code, 200)
@@ -55,3 +132,51 @@ class TestLogLongRequestMiddleware(SimpleTestCase):
         add_breadcrumb.assert_has_calls([
             mock.call(category="timing", message=Regex(r"^sleep: 0.\d+"), level="info")
         ])
+
+
+@override_settings(
+    ROOT_URLCONF='corehq.tests.test_middleware',
+    DOMAIN_MODULE_MAP={"test_middleware": "corehq.tests.test_middleware"}
+)
+@mock.patch('corehq.middleware.notify_exception')
+class TestLogLongRequestMiddlewareReports(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = Domain(name="long_request", is_active=True)
+        cls.domain.save()
+
+        cls.username = 'fingile'
+        cls.password = '*******'
+        cls.user = WebUser.create(cls.domain.name, cls.username, cls.password, None, None)
+        cls.user.set_role(cls.domain.name, 'admin')
+        cls.user.save()
+
+    def setUp(self):
+        self.client.login(username=self.username, password=self.password)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete(deleted_by=None)
+        cls.domain.delete()
+        super().tearDownClass()
+
+    def test_slow_domain_report(self, notify_exception):
+        res = self.client.get('/domain1/slow_report/')
+        self.assertEqual(res.status_code, 200)
+        notify_exception.assert_called_once()
+
+    def test_fast_domain_report(self, notify_exception):
+        res = self.client.get('/domain1/fast_report/')
+        self.assertEqual(res.status_code, 200)
+        notify_exception.assert_not_called()
+
+    def test_no_domain_report(self, notify_exception):
+        res = self.client.get('/admin_report/')
+        self.assertEqual(res.status_code, 200)
+        notify_exception.assert_not_called()
+
+    def test_custom_report(self, notify_exception):
+        res = self.client.get('/domain2/custom/custom_report/')
+        self.assertEqual(res.status_code, 200)
+        notify_exception.assert_not_called()

--- a/corehq/tests/test_middleware.py
+++ b/corehq/tests/test_middleware.py
@@ -86,7 +86,7 @@ class SlowReport(BaseReport):
         return HttpResponse(200)
 
 
-@set_request_duration_reporting_threshold(0.1)
+@set_request_duration_reporting_threshold(1)
 class FastReport(BaseReport):
     dispatcher = TestReportDispatcher
     slug = 'fast_report'

--- a/corehq/tests/test_middleware.py
+++ b/corehq/tests/test_middleware.py
@@ -1,0 +1,57 @@
+import time
+
+import mock
+from django.http import HttpResponse
+from django.test import override_settings, SimpleTestCase
+from django.urls import path
+from django.views import View
+from testil import Regex
+
+from corehq.util.timer import set_request_duration_reporting_threshold, TimingContext
+
+
+@set_request_duration_reporting_threshold(0.1)
+class SlowClassView(View):
+    def get(self, request):
+        time.sleep(0.2)
+        return HttpResponse()
+
+
+@set_request_duration_reporting_threshold(0.1)
+def slow_function_view(request):
+    timer = TimingContext()
+    with timer("sleep"):
+        time.sleep(0.2)
+    response = HttpResponse()
+    response.request_timer = timer
+    return response
+
+
+urlpatterns = [
+    path('slow_class', SlowClassView.as_view()),
+    path('slow_function', slow_function_view),
+]
+
+
+@override_settings(ROOT_URLCONF='corehq.tests.test_middleware')
+class TestLogLongRequestMiddleware(SimpleTestCase):
+
+    @override_settings(MIDDLEWARE=('corehq.middleware.LogLongRequestMiddleware',))
+    @mock.patch('corehq.middleware.add_breadcrumb')
+    @mock.patch('corehq.middleware.notify_exception')
+    def test_middleware_reports_slow_class_view(self, notify_exception, add_breadcrumb):
+        res = self.client.get('/slow_class')
+        self.assertEqual(res.status_code, 200)
+        notify_exception.assert_called_once()
+        add_breadcrumb.assert_not_called()
+
+    @override_settings(MIDDLEWARE=('corehq.middleware.LogLongRequestMiddleware',))
+    @mock.patch('corehq.middleware.add_breadcrumb')
+    @mock.patch('corehq.middleware.notify_exception')
+    def test_middleware_reports_slow_function_view_with_timer(self, notify_exception, add_breadcrumb):
+        res = self.client.get('/slow_function')
+        self.assertEqual(res.status_code, 200)
+        notify_exception.assert_called_once()
+        add_breadcrumb.assert_has_calls([
+            mock.call(category="timing", message=Regex(r"^sleep: 0.\d+"), level="info")
+        ])

--- a/corehq/tests/test_middleware.py
+++ b/corehq/tests/test_middleware.py
@@ -58,12 +58,12 @@ class TestCustomReportDispatcher(TestNoDomainReportDispatcher):
     map_name = "REPORTS"
     prefix = "test_custom"
 
-    def get_report(self, domain, slug, config_id):
-        """Intentionally different method signature to the parent class"""
-        return CustomReport
+    def dispatch(self, request, *args, **kwargs):
+        return CustomReport(request).view_response
 
-    def get_report_class_name(self, domain, report_slug):
-        return CustomReport.__module__ + '.' + CustomReport.__name__
+    @classmethod
+    def get_report_class_name(cls, domain, report_slug):
+        raise Exception("Custom dispatcher's don't like this method")
 
 
 class BaseReport(GenericReportView):

--- a/corehq/util/timer.py
+++ b/corehq/util/timer.py
@@ -224,3 +224,23 @@ def time_method():
                 return fn(self, *args, **kwargs)
         return _inner
     return decorator
+
+
+DURATION_REPORTING_THRESHOLD = "_duration_reporting_threshold"
+
+
+def set_request_duration_reporting_threshold(seconds):
+    """Decorator to override the default reporting threshold for a view.
+
+    If requests to the view take longer than the threshold a Sentry event
+    will get created.
+
+    :param seconds: Requests that take longer than this many seconds to process
+        will be reported to Sentry. See ``corehq.middleware.LogLongRequestMiddleware``
+        for where the duration check takes place.
+    """
+    def decorator(view):
+        setattr(view, DURATION_REPORTING_THRESHOLD, seconds)
+        return view
+
+    return decorator


### PR DESCRIPTION
Reverts dimagi/commcare-hq#29439 which reverted #29395

Copied description from original PR:

## Summary
https://dimagi-dev.atlassian.net/browse/USH-836

The help diagnose performance issues during form submission processing this PR adds more granular timing data which get's reported to Sentry as breadcrumbs. In addition, if requests take longer than 60s an event is created in Sentry.

This extends the existing `LogLongRequestMiddleware` to allow configuring the timing threshold on a per view basis.

Can be reviewed by commit.

Note: this changes the sentry message:

```diff
- Request took a very long time.
+ Request timing above threshold
``` 


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added tests

### QA Plan
Automated tests have been added that cover the changes to the functionality as well as the existing functionality.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
