### PR TITLE
Don't bundle if there is only one

### DIFF
--- a/corehq/motech/fhir/repeater_helpers.py
+++ b/corehq/motech/fhir/repeater_helpers.py
@@ -69,6 +69,51 @@ def send_resources(
     requests: Requests,
     info_resources_list: List[tuple],
     fhir_version: str,
+    repeater_id: str,
+) -> Response:
+    if not info_resources_list:
+        # Either the payload had no data to be forwarded, or resources
+        # were all patients to be registered: Nothing left to send.
+        return True
+
+    if len(info_resources_list) == 1:
+        info, resource = info_resources_list[0]
+        return send_resource(requests, info, resource, repeater_id)
+
+    return send_bundle(requests, info_resources_list, fhir_version)
+
+
+def send_resource(
+    requests: Requests,
+    info: CaseTriggerInfo,
+    resource: dict,
+    repeater_id: str,
+    *,
+    raise_on_ext_id: bool = False,
+) -> Response:
+    external_id = info.extra_fields['external_id']
+    if external_id:
+        endpoint = f"{resource['resourceType']}/{external_id}"
+        response = requests.put(endpoint, json=resource, raise_for_status=True)
+        return response
+
+    endpoint = f"{resource['resourceType']}/"
+    response = requests.post(endpoint, json=resource, raise_for_status=True)
+    try:
+        _set_external_id(info, response.json()['id'], repeater_id)
+    except (ValueError, KeyError) as err:
+        # The remote service returned a 2xx response, but did not
+        # return JSON, or the JSON does not include an ID.
+        if raise_on_ext_id:
+            msg = 'Unable to parse response from remote FHIR service'
+            raise HTTPError(msg, response=response) from err
+    return response
+
+
+def send_bundle(
+    requests: Requests,
+    info_resources_list: List[tuple],
+    fhir_version: str,
 ) -> Response:
     entries = get_bundle_entries(info_resources_list, fhir_version)
     bundle = create_bundle(entries, bundle_type='transaction')

--- a/corehq/motech/fhir/repeater_helpers.py
+++ b/corehq/motech/fhir/repeater_helpers.py
@@ -30,20 +30,10 @@ def register_patients(
             # Patient is already registered
             info_resource_list_to_send.append((info, resource))
             continue
-        response = requests.post(
-            'Patient/',
-            json=resource,
-            raise_for_status=True,
-        )
-        try:
-            _set_external_id(info, response.json()['id'], repeater_id)
-            # Don't append `resource` to `info_resource_list_to_send`
-            # because the remote service has all its data now.
-        except (ValueError, KeyError) as err:
-            # The remote service returned a 2xx response, but did not
-            # return JSON, or the JSON does not include an ID.
-            msg = 'Unable to parse response from remote FHIR service'
-            raise HTTPError(msg, response=response) from err
+        send_resource(requests, info, resource, repeater_id,
+                      raise_on_ext_id=True)
+        # Don't append `resource` to `info_resource_list_to_send`
+        # because the remote service has all its data now.
     return info_resource_list_to_send
 
 

--- a/corehq/motech/fhir/repeaters.py
+++ b/corehq/motech/fhir/repeaters.py
@@ -85,9 +85,6 @@ class FHIRRepeater(CaseRepeater):
         )
         try:
             resources = get_info_resource_list(infos, resource_types)
-            if not resources:
-                # Nothing to send
-                return True
             resources = register_patients(requests, resources, self._id)
             response = send_resources(requests, resources, self.fhir_version, self._id)
         except Exception as err:

--- a/corehq/motech/fhir/repeaters.py
+++ b/corehq/motech/fhir/repeaters.py
@@ -89,7 +89,7 @@ class FHIRRepeater(CaseRepeater):
                 # Nothing to send
                 return True
             resources = register_patients(requests, resources, self._id)
-            response = send_resources(requests, resources, self.fhir_version)
+            response = send_resources(requests, resources, self.fhir_version, self._id)
         except Exception as err:
             requests.notify_exception(str(err))
             return RepeaterResponse(400, 'Bad Request', pformat_json(str(err)))


### PR DESCRIPTION
## Summary

This affects data forwarding to a FHIR service: If we are only forwarding a single FHIR resource, don't bother wrapping it in a bundle.

This is a small change for the EmptyBoxes project (a PoC). By sending a single resource instead of a bundle, we can avoid unnecessary complexity for an OpenHIM mediator. (Also, it just makes sense.)

:fish: :blowfish: :tropical_fish: 

## Feature Flag
"FHIR Integration"

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story

This feature is behind a feature flag, and not used in any production domains.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
