### PR TITLE
fix broken 2FA link

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/disable_two_factor.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/disable_two_factor.html
@@ -8,7 +8,7 @@
     compromises their account security, are you sure?{% endblocktrans %}</p>
   <div class="alert alert-warning">
     <p>When temporarily disabling and resetting Two-Factor Auth it is important to verify that the request was made by the owner of the account (and not faked by someone else).</p>
-    <p>Please follow the <a href=\"https://confluence.dimagi.com/pages/viewpage.action?pageId=27362739"#Two-StepAuthentication(2FA)-StepsforsupporttoresetCommCareHQaccount\">guidelines on the wiki</a>.</p>
+    <p>Please follow the <a href="https://confluence.dimagi.com/pages/viewpage.action?pageId=27362739"#Two-StepAuthentication(2FA)-StepsforsupporttoresetCommCareHQaccount\">guidelines on the wiki</a>.</p>
   </div>
   {% crispy form %}
 {% endblock %}


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

2FA wiki link was broken on /disable_two_factor/ page. 
Example: https://www.commcarehq.org/hq/admin/disable_two_factor/?q=csmith%40dimagi.com
Removed a backslash which caused the issue.
Link to ticket: https://dimagi-dev.atlassian.net/browse/SAAS-11430

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Tested on local server. WIll test on staging.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
