### PR TITLE
Sk/deviceid not date

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -224,7 +224,7 @@ def get_tables_as_columns(*args, **kwargs):
     return sections
 
 
-def get_default_definition(keys, num_columns=1, name=None, phonetime_fields=None, parse_dates=False):
+def get_default_definition(keys, num_columns=1, name=None, phonetime_fields=None, date_fields=None):
     """
     Get a default single table layout definition for `keys` split across
     `num_columns` columns.
@@ -234,9 +234,15 @@ def get_default_definition(keys, num_columns=1, name=None, phonetime_fields=None
 
     """
     phonetime_fields = phonetime_fields or set()
+    date_fields = date_fields or set()
     layout = chunked(
         [
-            {"expr": prop, "is_phone_time": prop in phonetime_fields, "has_history": True, "parse_date": parse_dates}
+            {
+                "expr": prop,
+                "is_phone_time": prop in phonetime_fields,
+                "has_history": True,
+                "parse_date": prop in date_fields
+            }
             for prop in keys
         ],
         num_columns

--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -139,7 +139,11 @@ def get_display_data(data, prop_def, processors=None, timezone=pytz.utc):
     val = eval_expr(expr, data)
 
     if prop_def.pop('parse_date', None):
-        val = _parse_date_or_datetime(val)
+        try:
+            val = _parse_date_or_datetime(val)
+        except Exception:
+            # ignore exceptions from date parsing
+            pass
     is_phone_time = prop_def.pop('is_phone_time', False)
     if isinstance(val, datetime.datetime):
         if not is_phone_time:

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1526,15 +1526,16 @@ def _get_form_metadata_context(domain, form, timezone, support_enabled=False):
     from corehq.apps.hqwebapp.templatetags.proptable_tags import get_default_definition, get_tables_as_columns
 
     meta = _top_level_tags(form).get('meta', None) or {}
-    phonetime_keys = list(meta)
 
     meta['received_on'] = json_format_datetime(form.received_on)
     meta['server_modified_on'] = json_format_datetime(form.server_modified_on) if form.server_modified_on else ''
     if support_enabled:
         meta['last_sync_token'] = form.last_sync_token
 
+    phonetime_fields = ['timeStart', 'timeEnd']
+    date_fields = ['received_on', 'server_modified_on'] + phonetime_fields
     definition = get_default_definition(
-        _sorted_form_metadata_keys(list(meta)), phonetime_fields=phonetime_keys, parse_dates=True
+        _sorted_form_metadata_keys(list(meta)), phonetime_fields=phonetime_fields, date_fields=date_fields
     )
     form_meta_data = get_tables_as_columns(meta, definition, timezone=timezone)
     if getattr(form, 'auth_context', None):


### PR DESCRIPTION
## Summary
[COMMCAREHQ-4NF5](https://sentry.io/organizations/dimagi/issues/2310596754)

Fix for date parsing bug in form display that was introduced in https://github.com/dimagi/commcare-hq/pull/29379

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
