### PR TITLE
Change Hubspot/Kissmetrics failure email recipient

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -721,13 +721,11 @@ def submit_data_to_hub_and_kiss(submit_json):
         try:
             dispatcher(submit_json)
         except requests.exceptions.HTTPError as e:
-            soft_assert(to=[settings.SUPPORT_EMAIL,
-                            '{}@{}'.format('miemma', 'dimagi.com'),
-                            '{}@{}'.format('aphilippot', 'dimagi.com'),
-                            '{}@{}'.format('colaughlin', 'dimagi.com')],
-                        send_to_ops=False)(False,
-                                           'Error submitting periodic analytics data to Hubspot or Kissmetrics',
-                                           {'response': e.response.content.decode('utf-8')})
+            soft_assert(to=settings.SAAS_OPS_EMAIL, send_to_ops=False)(
+                False,
+                'Error submitting periodic analytics data to Hubspot or Kissmetrics',
+                {'response': e.response.content.decode('utf-8')}
+            )
         except Exception as e:
             notify_exception(None, "{msg}: {exc}".format(msg=error_message, exc=e))
 

--- a/corehq/util/email_event_utils.py
+++ b/corehq/util/email_event_utils.py
@@ -164,6 +164,7 @@ def get_emails_to_never_bounce():
         settings.FEEDBACK_EMAIL,
         settings.SOFT_ASSERT_EMAIL,
         settings.DAILY_DEPLOY_EMAIL,
+        settings.SAAS_OPS_EMAIL,
         settings.SAAS_REPORTING_EMAIL,
     ]
     system_emails.extend(settings.BOOKKEEPER_CONTACT_EMAILS)

--- a/settings.py
+++ b/settings.py
@@ -460,6 +460,7 @@ EMAIL_USE_TLS = True
 SERVER_EMAIL = 'commcarehq-noreply@example.com'
 DEFAULT_FROM_EMAIL = 'commcarehq-noreply@example.com'
 SUPPORT_EMAIL = "support@example.com"
+SAAS_OPS_EMAIL = "saas-ops@example.com"
 PROBONO_SUPPORT_EMAIL = 'pro-bono@example.com'
 ACCOUNTS_EMAIL = 'accounts@example.com'
 DATA_EMAIL = 'datatree@example.com'


### PR DESCRIPTION
- Send to `SAAS_OPS_EMAIL` setting instead of `SUPPORT_EMAIL`
- Do not send to individual (personal) emails.
- See also: dimagi/commcare-cloud#4628

## Summary

The Support email group, as well as a few individual support analysts were getting analytics submission failure emails. These emails were not best suited to go to those people, so a new recipient email group was added to receive the messages instead.

[SAAS-11884](https://dimagi-dev.atlassian.net/browse/SAAS-11884)

## Feature Flag

## Product Description

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

### QA Plan

No QA required.

### Safety story

The change does not affect any user-facing code, and is confined to a very specific "backend error condition" scenario where an analytics submission request fails and the details should be sent in the form of an email.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
