### PR TITLE
Custom requirements in local.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ bad/
 startover.sh
 celery.db
 tmp.sh
+/requirements/local.in
 /requirements/local.txt
 /resource_versions.yaml
 /loadtest/results/

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ bad/
 startover.sh
 celery.db
 tmp.sh
+/requirements/local.txt
 /resource_versions.yaml
 /loadtest/results/
 /loadtest/localsettings.py

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -138,6 +138,12 @@ Next, install the appropriate requirements (only one is necessary).
 
       $ pip install -r requirements/dev-requirements.txt
 
+* Recommended for developers or others with custom requirements
+
+      $ cp requirements/local.txt.sample requirements/local.txt
+      # customize requirements/local.txt as desired
+      $ pip install -r requirements/local.txt
+
 * For production environments
 
       $ pip install -r requirements/prod-requirements.txt

--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -1,16 +1,13 @@
 -r test-requirements.in
 
-django-debug-toolbar
 fixture==1.5.11
 sniffer==0.4.1
 psutil>5.1.3  # for memory profiling
 django-extensions
 ipython==7.16.1
-ipdb==0.11
 wheel==0.36.2
 transifex-client==0.12.4
 modernize
-pdbpp
 gnureadline==8.0.0
 git-build-branch
 

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -129,8 +129,6 @@ django-crispy-forms==1.10.0
     # via -r base-requirements.in
 django-cte==1.1.4
     # via -r base-requirements.in
-django-debug-toolbar==3.1
-    # via -r dev-requirements.in
 django-extensions==3.1.1
     # via -r dev-requirements.in
 django-formtools==2.1
@@ -182,7 +180,6 @@ django==2.2.19
     #   django-appconf
     #   django-braces
     #   django-bulk-update
-    #   django-debug-toolbar
     #   django-formtools
     #   django-logentry-admin
     #   django-oauth-toolkit
@@ -228,8 +225,6 @@ fakecouch==0.0.15
     # via -r test-requirements.in
 faker==5.0.2
     # via -r base-requirements.in
-fancycompleter==0.9.1
-    # via pdbpp
 fixture==1.5.11
     # via -r dev-requirements.in
 flake8==3.8.4
@@ -279,14 +274,10 @@ importlib-metadata==2.0.0
     #   jsonschema
 intervaltree==3.1.0
     # via ddtrace
-ipdb==0.11
-    # via -r dev-requirements.in
 ipython-genutils==0.2.0
     # via traitlets
 ipython==7.16.1
-    # via
-    #   -r dev-requirements.in
-    #   ipdb
+    # via -r dev-requirements.in
 iso8601==0.1.13
     # via -r base-requirements.in
 isodate==0.6.0
@@ -373,8 +364,6 @@ parso==0.7.1
     # via jedi
 pbr==5.5.0
     # via mock
-pdbpp==0.10.2
-    # via -r dev-requirements.in
 pexpect==4.8.0
     # via ipython
 phonenumberslite==8.12.10
@@ -429,7 +418,6 @@ pygments==2.7.1
     # via
     #   -r base-requirements.in
     #   ipython
-    #   pdbpp
     #   pycco
     #   sphinx
 pygooglechart==0.4.0
@@ -444,8 +432,6 @@ pyparsing==2.4.7
     # via packaging
 pyphen==0.9.5
     # via weasyprint
-pyrepl==0.9.0
-    # via fancycompleter
 pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
@@ -622,9 +608,7 @@ sqlalchemy==1.3.19
     #   sqlagg
     #   sqlalchemy-postgres-copy
 sqlparse==0.3.1
-    # via
-    #   django
-    #   django-debug-toolbar
+    # via django
 stripe==2.54.0
     # via -r base-requirements.in
 suds-jurko==0.6
@@ -687,8 +671,6 @@ werkzeug==1.0.1
     # via -r base-requirements.in
 wheel==0.36.2
     # via -r dev-requirements.in
-wmctrl==0.3
-    # via pdbpp
 wrapt==1.12.1
     # via deprecated
 xlrd==1.0.0
@@ -711,7 +693,6 @@ setuptools==50.3.0
     #   cssselect2
     #   django-websocket-redis
     #   gunicorn
-    #   ipdb
     #   ipython
     #   jsonschema
     #   protobuf

--- a/requirements/local.txt.sample
+++ b/requirements/local.txt.sample
@@ -1,0 +1,16 @@
+# This file is meant to be customized for personal development environments.
+# Feel free make a copy without the .sample extension to use locally.
+#
+# requirements/local.txt is in .gitignore so you will not be prompted to (nor
+# should you) commit your custom version of that file.
+#
+# After adding your custom requirements you can run one simple command to keep
+# your virtualenv up to date:
+#
+#   pip-sync requirements/local.txt [--dry-run]
+
+-r dev-requirements.txt
+
+django-debug-toolbar
+ipdb==0.11
+pdbpp


### PR DESCRIPTION
Add support for custom local development requirements.

Feel free to suggest better wording for the change to [DEV_SETUP.md](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP.md)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] This PR can be reverted after deploy with no further considerations 
