### PR TITLE
Handle an empty project space filter

### DIFF
--- a/corehq/apps/accounting/async_handlers.py
+++ b/corehq/apps/accounting/async_handlers.py
@@ -515,15 +515,18 @@ class DomainFilterAsyncHandler(BaseSingleOptionFilterAsyncHandler):
     @property
     def query(self):
         db = Domain.get_db()
-        startkey = self.search_string
-        endkey = "{}Z".format(self.search_string) if startkey else ''
-        query = db.view(
-            'domain/domains',
-            reduce=False,
-            startkey=startkey,
-            endkey=endkey,
-            limit=20,
-        )
+
+        search_params = {
+            'reduce': False,
+            'limit': 20
+        }
+
+        if self.search_string:
+            # Search by string range: https://docs.couchdb.org/en/latest/ddocs/views/collation.html#string-ranges
+            search_params['startkey'] = self.search_string
+            search_params['endkey'] = "{}\ufff0".format(self.search_string)
+
+        query = db.view('domain/domains', **search_params)
         return query
 
     @property


### PR DESCRIPTION
## Summary
In testing another accounting change, I noticed that the 'Project Space' dropdown for _Subscription Adustments_ and _Invoices_ did not work. This allows that drop down to be populated with no filter, while retaining the ability to filter by a prefix.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests for this. The testable behavior is almost entirely just testing how CouchDB handles the provided arguments, and the difficulty of creating CouchDB domain data that would clean up after itself didn't seem worth it here. I could have created a mock that verified the arguments it received, but that also didn't seem to have much value.

### QA Plan

No QA required

### Safety story

Local testing was performed to verify that the handler works. The blast radius is lessened, as this filter is only used by accounting, which is admin functionality.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
