### PR TITLE
put multidomain user upload behind flag

### DIFF
--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -47,7 +47,7 @@ allowed_headers = set([
     'uncategorized_data', 'user_id', 'is_active', 'is_account_confirmed', 'send_confirmation_email',
     'location_code', 'role', 'user_profile',
     'User IMEIs (read only)', 'registered_on (read only)', 'last_submission (read only)',
-    'last_sync (read only)', 'web_user', 'remove_web_user', 'domain'
+    'last_sync (read only)', 'web_user', 'remove_web_user'
 ]) | required_headers
 old_headers = {
     # 'old_header_name': 'new_header_name'
@@ -55,7 +55,7 @@ old_headers = {
 }
 
 
-def check_headers(user_specs):
+def check_headers(user_specs, domain):
     messages = []
     headers = set(user_specs.fieldnames)
 
@@ -68,8 +68,11 @@ def check_headers(user_specs):
                 ))
             headers.discard(old_name)
 
+    if DOMAIN_PERMISSIONS_MIRROR.enabled(domain):
+        allowed_headers.add('domain')
+
     illegal_headers = headers - allowed_headers
-    missing_headers = required_headers - headers
+    missing_headers = required_headers - headers    
 
     for header_set, label in (missing_headers, 'required'), (illegal_headers, 'illegal'):
         if header_set:

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -73,7 +73,7 @@ def check_headers(user_specs, domain):
         allowed_headers.add('domain')
 
     illegal_headers = headers - allowed_headers
-    missing_headers = required_headers - headers    
+    missing_headers = required_headers - headers
 
     for header_set, label in (missing_headers, 'required'), (illegal_headers, 'illegal'):
         if header_set:

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -40,6 +40,7 @@ from corehq.apps.users.models import (
 )
 from corehq.apps.users.util import normalize_username, log_user_role_update
 from corehq.const import USER_CHANGE_VIA_BULK_IMPORTER
+from corehq.toggles import DOMAIN_PERMISSIONS_MIRROR
 
 required_headers = set(['username'])
 allowed_headers = set([

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1061,7 +1061,7 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
             self.group_specs = []
 
         try:
-            check_headers(self.user_specs)
+            check_headers(self.user_specs, self.domain)
         except UserUploadError as e:
             messages.error(request, _(str(e)))
             return HttpResponseRedirect(reverse(UploadCommCareUsers.urlname, args=[self.domain]))


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-658
This is the last bit of multi domain functionality that wasn't explicitly behind the mirror domain flag.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
DOMAIN_PERMISSIONS_MIRROR

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Multi domain user uploads will now only work if the DOMAIN_PERMISSIONS_MIRROR flag is enabled. Otherwise, an error will be raised saying the `domain` column is not allowed. The message does not explicitly mention the flag, since flags are non public, but is the same as any other column name not in the allowed list.

## Safety Assurance

- [ ] Risk label is set correctly
- [ ] All migrations are backwards compatible and won't block deploy
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Simple, one line change, tested locally.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
