### PR TITLE
Escape DataTables JSON output

### DIFF
--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -15,6 +15,7 @@ from django.template.context import RequestContext
 from django.template.loader import render_to_string
 from django.urls import NoReverseMatch
 from django.utils.translation import ugettext
+from django.utils.html import conditional_escape
 
 from celery.utils.log import get_task_logger
 from memoized import memoized
@@ -45,6 +46,14 @@ from corehq.util.view_utils import absolute_reverse, request_as_dict, reverse
 from corehq import toggles
 
 CHART_SPAN_MAP = {1: '10', 2: '6', 3: '4', 4: '3', 5: '2', 6: '2'}
+
+
+def _sanitize_rows(rows):
+    return [_sanitize_row(row) for row in rows]
+
+
+def _sanitize_row(row):
+    return [conditional_escape(col) for col in row]
 
 
 class GenericReportView(object):
@@ -897,7 +906,7 @@ class GenericTabularReport(GenericReportView):
             self.pagination.start (skip)
             self.pagination.count (limit)
         """
-        rows = list(self.rows)
+        rows = _sanitize_rows(self.rows)
         total_records = self.total_records
         if not isinstance(total_records, int):
             raise ValueError("Property 'total_records' should return an int.")


### PR DESCRIPTION
## Summary

Currently, because DataTables gets populated by a JSON API call, all row and column data bypasses Django autoescaping behavior. Because of this, marking HTML fragments with `mark_safe` or `format_html` will have no effect, while data that is expected to contain plain text will allow potential XSS exploits if that plain text includes HTML tags.  Given this code, this is how you would correctly handle rows:
```
rows = [
  html_data
  escape(plain_data1),
  escape(plain_data2)
]
```

This is the exact opposite of how we are used to Django templates performing, and is error-prone. This change modifies how rows are handled so all rows will be escaped unless they are marked as safe, i.e.:
```
rows = [
  mark_safe(html_data),
  plain_data1,
  plain_data2
]
```

This makes DataTables behave in line with Django's templating behavior, and is far less error-prone, because using it incorrectly will just escape HTML output, which will display incorrectly.


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Added a small test suite.

### QA Plan

This will need some QA to ensure that raw HTML fragments we rely on have not been accidentally escaped -- basically all Report tables should be checked.

### Safety story

The largest risk here is the existing HTML fragments, which can only really be handled by looking through the code and QA testing. I expect changes will be required to update some of that code, so this will likely need additional commits.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
