### PR TITLE
Escape HTML in underscore templates for other apps

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -94,11 +94,10 @@ hqDefine('accounting/js/pricing_table', [
             self.form = $(e.currentTarget).closest("form");
 
             var invoicingContact = _.escape(self.invoicingContact);
-            var mailtoHtml = "<a href='mailto:" + invoicingContact + "'>" + invoicingContact + "</a>";
             if (self.isDowngrade() && self.subscriptionBelowMinimum) {
                 var oldPlan = utils.capitalize(self.oCurrentPlan());
                 var newPlan = utils.capitalize(self.oSelectedPlan());
-                var newStartDateHtml = "<strong>" + self.oStartDateAfterMinimumSubscription() + "</strong>";
+                var newStartDate = self.oStartDateAfterMinimumSubscription();
 
                 var message = "",
                     title = gettext("Downgrading?");
@@ -107,61 +106,61 @@ hqDefine('accounting/js/pricing_table', [
                     message = _.template(gettext(
                         "<p>All CommCare subscriptions require a 30 day minimum commitment.</p>" +
                         "<p>Continuing ahead will allow you to schedule your current <%- oldPlan %> " +
-                        "Edition Plan subscription to be paused on <%= dateHtml %>.</p>" +
+                        "Edition Plan subscription to be paused on <strong> <%- date %> </strong></p>" +
                         "<p>If you have questions or if you would like to speak to us about your subscription, " +
-                        "please reach out to <%= emailHtml %>.</p>"
+                        "please reach out to <a href='mailto: <%- invoicingContact %>'><%- invoicingContact %></a>.</p>"
                     ))({
-                        dateHtml: newStartDateHtml,
+                        date: newStartDate,
                         newPlan: newPlan,
                         oldPlan: oldPlan,
-                        emailHtml: mailtoHtml,
+                        invoicingContact: invoicingContact,
                     });
                 } else if (self.oIsNextPlanPaused()) {
                     message = _.template(gettext(
                         "<p>All CommCare subscriptions require a 30 day minimum commitment.</p>" +
                         "<p>Your current <%- oldPlan %> Edition Plan subscription is scheduled to be paused " +
-                        "on <%= dateHtml %>.</p>" +
+                        "on <strong> <%- date %> </strong></p>" +
                         "<p>Continuing ahead will allow you to schedule your current <%- oldPlan %> Edition " +
                         "Plan subscription to be downgraded to the <%- newPlan %> Edition Plan " +
-                        "on <%= dateHtml %>.</p>" +
+                        "on <strong> <%- date %> </strong></p>" +
                         "<p>If you have questions or if you would like to speak to us about your subscription, " +
-                        "please reach out to <%= emailHtml %>.</p>"
+                        "please reach out to <a href='mailto: <%- invoicingContact %>'><%- invoicingContact %></a>.</p>"
                     ))({
                         oldPlan: oldPlan,
-                        dateHtml: newStartDateHtml,
+                        date: newStartDate,
                         newPlan: newPlan,
-                        emailHtml: mailtoHtml,
+                        invoicingContact: invoicingContact,
                     });
                 } else if (self.oIsNextPlanDowngrade()) {
                     message = _.template(gettext(
                         "<p>All CommCare subscriptions require a 30 day minimum commitment.</p>" +
                         "<p>Your current <%- oldPlan %> Edition Plan subscription is scheduled to be downgraded " +
-                        "to the <%- nextSubscription %> Edition Plan on <%= dateHtml %>.</p>" +
+                        "to the <%- nextSubscription %> Edition Plan on <strong> <%- date %> </strong></p>" +
                         "<p>Continuing ahead will allow you to schedule your current <%- oldPlan %> Edition " +
                         "Plan subscription to be downgraded to the <%- newPlan %> Edition Plan " +
-                        "on <%= dateHtml %>.</p>" +
+                        "on <strong> <%- date %> </strong></p>" +
                         "<p>If you have questions or if you would like to speak to us about your subscription, " +
-                        "please reach out to <%= emailHtml %>.</p>"
+                        "please reach out to <a href='mailto: <%- invoicingContact %>'><%- invoicingContact %></a>.</p>"
                     ))({
                         oldPlan: oldPlan,
                         nextSubscription: self.oNextSubscription(),
-                        dateHtml: newStartDateHtml,
+                        date: newStartDate,
                         newPlan: newPlan,
-                        emailHtml: mailtoHtml,
+                        invoicingContact: invoicingContact,
                     });
                 } else {
                     message = _.template(gettext(
                         "<p>All CommCare subscriptions require a 30 day minimum commitment.</p>" +
                         "<p>Continuing ahead will allow you to schedule your current <%- oldPlan %> Edition " +
                         "Plan subscription to be downgraded to the <%- newPlan %> Edition Plan " +
-                        "on <%= dateHtml %>.</p>" +
+                        "on <strong> <%- date %> </strong></p>" +
                         "If you have questions or if you would like to speak to us about your subscription, " +
-                        "please reach out to <%= emailHtml %>."
+                        "please reach out to <a href='mailto: <%- invoicingContact %>'><%- invoicingContact %></a>."
                     ))({
                         oldPlan: oldPlan,
-                        dateHtml: newStartDateHtml,
+                        date: newStartDate,
                         newPlan: newPlan,
-                        emailHtml: mailtoHtml,
+                        invoicingContact: invoicingContact,
                     });
                 }
                 var $modal = $("#modal-minimum-subscription");

--- a/corehq/apps/enterprise/static/enterprise/js/enterprise_settings.js
+++ b/corehq/apps/enterprise/static/enterprise/js/enterprise_settings.js
@@ -25,8 +25,8 @@ hqDefine("enterprise/js/enterprise_settings", [
         self.restrictSignupHelp = _.template(gettext("Do not allow new users to sign up on commcarehq.org. " +
             "This may take up to an hour to take effect. " +
             "<br>This will affect users with email addresses from the following domains: " +
-            "<strong><%= domains %></strong>" +
-            "<br>Contact <a href='mailto:<%= email %>'><%= email %></a> to change the list of domains."))(context);
+            "<strong><%- domains %></strong>" +
+            "<br>Contact <a href='mailto:<%- email %>'><%- email %></a> to change the list of domains."))(context);
 
         return self;
     };

--- a/corehq/apps/export/static/export/js/create_export.js
+++ b/corehq/apps/export/static/export/js/create_export.js
@@ -97,9 +97,9 @@ hqDefine("export/js/create_export", [
             var text = '';
             if (self.modelType() === 'form') {
                 if (newValue.submissions === 1) {
-                    text = gettext('<%= count %> form submission available.');
+                    text = gettext('<%- count %> form submission available.');
                 } else {
-                    text = gettext('<%= count %> form submissions available.');
+                    text = gettext('<%- count %> form submissions available.');
                 }
                 text = _.template(text)({ count: newValue.submissions });
             }

--- a/corehq/apps/locations/static/locations/js/location.js
+++ b/corehq/apps/locations/static/locations/js/location.js
@@ -28,7 +28,7 @@ hqDefine("locations/js/location", [
         $select.select2("data", currentUsers);
     };
     var TEMPLATE_STRINGS = {
-        new_user_success: _.template(gettext("User <%= name %> added successfully. " +
+        new_user_success: _.template(gettext("User <%- name %> added successfully. " +
                                              "A validation message has been sent to the phone number provided.")),
     };
 

--- a/corehq/apps/locations/static/locations/js/location_tree.js
+++ b/corehq/apps/locations/static/locations/js/location_tree.js
@@ -291,10 +291,10 @@ hqDefine('locations/js/location_tree', [
             $(button).closest('.loc_section').remove();
         };
 
-        self.archive_success_message = _.template(gettext("You have successfully archived the location <%=name%>"));
+        self.archive_success_message = _.template(gettext("You have successfully archived the location <%-name%>"));
 
         self.delete_success_message = _.template(gettext(
-            "You have successfully deleted the location <%=name%> and all of its child locations"
+            "You have successfully deleted the location <%-name%> and all of its child locations"
         ));
 
         self.delete_error_message = _.template(gettext("An error occurred while deleting your location. If the problem persists, please report an issue"));

--- a/corehq/apps/reports/templates/reports/partials/base_maps.html
+++ b/corehq/apps/reports/templates/reports/partials/base_maps.html
@@ -15,14 +15,14 @@
     <div class="hq-graphic-report">
       <script type="text/template" id="default_detail_popup">
         <div class="default-popup">
-          <h3><%= name %></h3>
+          <h3><%- name %></h3>
           <hr>
           <table>
             <% _.each(info, function(field) { %>
-            <tr class="data data-<%= field.slug %>">
-              <td><%= field.label %></td>
+            <tr class="data data-<%- field.slug %>">
+              <td><%- field.label %></td>
               <td class="detail_data">
-                <%= field.value %>
+                <%- field.value %>
               </td>
             </tr>
             <% }); %>
@@ -31,21 +31,21 @@
       </script>
 
       <script type="text/template" id="info_popup">
-        <% if (name) { %><h4><%= name %></h4><% } %>
+        <% if (name) { %><h4><%- name %></h4><% } %>
         <% _.each(info, function(field) { %>
-        <div><%= field.label %></div>
-        <div class="detail_data"><%= field.value %></div>
+        <div><%- field.label %></div>
+        <div class="detail_data"><%- field.value %></div>
         <% }); %>
       </script>
 
       <script type="text/template" id="legend_size">
         <table class="sizelegend">
           <% _.each(entries, function(e, i) { %>
-          <tr id="sizerow-<%= i %>">
+          <tr id="sizerow-<%- i %>">
             <td class="circle-container">
               <div class="circle"></div>
             </td>
-            <td class="vallabel"><%= e.valfmt %></td>
+            <td class="vallabel"><%- e.valfmt %></td>
           </tr>
           <% }); %>
         </table>
@@ -54,7 +54,7 @@
       <script type="text/template" id="legend_enum">
         <table class="enumlegend">
           <% _.each(enums, function(e, i) { %>
-          <tr id="enumrow-<%= i %>"><td class="enum"></td><td class="vallabel"><%= e.label %></td></tr>
+          <tr id="enumrow-<%- i %>"><td class="enum"></td><td class="vallabel"><%- e.label %></td></tr>
           <% }); %>
         </table>
       </script>
@@ -66,9 +66,9 @@
             <td class="tickmarks">
               <div class="tickmarks-inner">
                 <% _.each(ticks, function(e) { %>
-                <div class="width-spacer"><%= e.label %></div>
-                <div class="ticklabel" style="top: <%= e.coord %>px;">
-                  <div class="ticklabel-inner"><%= e.label %></div>
+                <div class="width-spacer"><%- e.label %></div>
+                <div class="ticklabel" style="top: <%- e.coord %>px;">
+                  <div class="ticklabel-inner"><%- e.label %></div>
                 </div>
                 <% }); %>
               </div>

--- a/corehq/apps/reports_core/static/reports_core/js/maps.js
+++ b/corehq/apps/reports_core/static/reports_core/js/maps.js
@@ -64,8 +64,8 @@ hqDefine('reports_core/js/maps', function () {
                 "       <td><%- row[col.column_id] %></td>",
                 "     </tr>",
                 "   <% }) %>",
-                "</table>"
-            ].join('\n'))
+                "</table>",
+            ].join('\n'));
         }
     };
 

--- a/corehq/apps/reports_core/static/reports_core/js/maps.js
+++ b/corehq/apps/reports_core/static/reports_core/js/maps.js
@@ -57,11 +57,11 @@ hqDefine('reports_core/js/maps', function () {
         if (!privates.template || !_.isEqual(config.columns, privates.columns)) {
             privates.columns = config.columns;
             var rows = _.map(privates.columns, function (col) {
-                var tr = _.template("<tr><td><%= label %></td>")(col);
-                tr += "<td><%= " + col.column_id + "%></td></tr>";
+                var tr = _.template("<tr><td><%- label %></td>")(col);
+                tr += "<td><%- " + col.column_id + "%></td></tr>";
                 return tr;
             });
-            var table = '<table class="table table-bordered"><%= rows %></table>';
+            var table = '<table class="table table-bordered"><%- rows %></table>';
             var template = _.template(table)({rows: rows.join('')});
             privates.template = _.template(template);
         }

--- a/corehq/apps/reports_core/static/reports_core/js/maps.js
+++ b/corehq/apps/reports_core/static/reports_core/js/maps.js
@@ -56,14 +56,16 @@ hqDefine('reports_core/js/maps', function () {
     var initPopupTemplate = function (config) {
         if (!privates.template || !_.isEqual(config.columns, privates.columns)) {
             privates.columns = config.columns;
-            var rows = _.map(privates.columns, function (col) {
-                var tr = _.template("<tr><td><%- label %></td>")(col);
-                tr += "<td><%- " + col.column_id + "%></td></tr>";
-                return tr;
-            });
-            var table = '<table class="table table-bordered"><%- rows %></table>';
-            var template = _.template(table)({rows: rows.join('')});
-            privates.template = _.template(template);
+            privates.template = _.template([
+                "<table class='table table-bordered'>",
+                "   <% _.map(columns, function (col) { %>",
+                "     <tr>",
+                "       <td><%- col.label %></td>",
+                "       <td><%- row[col.column_id] %></td>",
+                "     </tr>",
+                "   <% }) %>",
+                "</table>"
+            ].join('\n'))
         }
     };
 
@@ -76,7 +78,7 @@ hqDefine('reports_core/js/maps', function () {
             var val = row[config.location_column_id];
             if (val !== null && !bad_re.test(val)) {
                 var latlon = val.split(" ").slice(0, 2);
-                return L.marker(latlon).bindPopup(privates.template(row));
+                return L.marker(latlon).bindPopup(privates.template({row: row, columns: privates.columns}));
             }
         }));
         if (points.length > 0) {

--- a/corehq/apps/sms/static/sms/js/chat_contacts.js
+++ b/corehq/apps/sms/static/sms/js/chat_contacts.js
@@ -36,10 +36,10 @@ hqDefine('sms/js/chat_contacts', [
                     "aTargets": [0],
                     "render": function (data, type, row) {
                         return _.template(
-                            '<a target="_blank" href="<%= href %>"><%= content %></a>' +
+                            '<a target="_blank" href="<%- href %>"><%- content %></a>' +
                             '<span class="btn btn-primary pull-right" ' +
-                                  'onClick="window.open(\'<%= url %>\', \'_blank\', \'location=no,menubar=no,scrollbars=no,status=no,toolbar=no,height=400,width=400\');">' +
-                            '<%= chat %> <i class="fa fa-share"></i></span>'
+                                  'onClick="window.open(\'<%- url %>\', \'_blank\', \'location=no,menubar=no,scrollbars=no,status=no,toolbar=no,height=400,width=400\');">' +
+                            '<%- chat %> <i class="fa fa-share"></i></span>'
                         )({
                             href: row[4],
                             content: row[0],

--- a/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
+++ b/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
@@ -22,7 +22,8 @@ hqDefine("userreports/js/configurable_reports_home", [
                 return text;
             }
             var options = $(item.element).data();
-            return _.template("<%- static_label %> <%- deactivated_label %> <i class='<%- icon %>'></i> <%- text %> <script>alert('stuff')</script>")({
+            // static_label and deactivated_label are sanitized from backend
+            return _.template("<%= static_label %> <%= deactivated_label %> <i class='<%- icon %>'></i> <%- text %>")({
                 icon: options.label === "report" ? "fcc fcc-reports" : "fa fa-database",
                 static_label: options.isStatic ? "<span class='label label-default'>" + gettext("static") + "</span>" : "",
                 deactivated_label: options.isDeactivated ? "<span class='label label-default'>" + gettext("deactivated") + "</span>" : "",

--- a/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
+++ b/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
@@ -22,7 +22,7 @@ hqDefine("userreports/js/configurable_reports_home", [
                 return text;
             }
             var options = $(item.element).data();
-            return _.template("<%= static_label %> <%= deactivated_label %> <i class='<%= icon %>'></i> <%= text %> <script>alert('stuff')</script>")({
+            return _.template("<%- static_label %> <%- deactivated_label %> <i class='<%- icon %>'></i> <%- text %> <script>alert('stuff')</script>")({
                 icon: options.label === "report" ? "fcc fcc-reports" : "fa fa-database",
                 static_label: options.isStatic ? "<span class='label label-default'>" + gettext("static") + "</span>" : "",
                 deactivated_label: options.isDeactivated ? "<span class='label label-default'>" + gettext("deactivated") + "</span>" : "",


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-11428

This is one of the PRs from the series of PRs that will be replacing `<%=` to `<%-`.

This PR specifically covers the applications which only had one or two occurrences of `<%=`

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA plan is described here https://dimagi-dev.atlassian.net/browse/QA-2854?focusedCommentId=133830 
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The local testing and notes have been updated in the doc https://docs.google.com/spreadsheets/d/1oBLABIn41A7LbslViK997GmaQsQ5kRUJNDyn9WzFpGc/edit#gid=0
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
