### PR TITLE
Escape html templates in app manager

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/actions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/actions.js
@@ -100,20 +100,20 @@ hqDefine('app_manager/js/forms/advanced/actions', function () {
             }
         },
         header: function (action) {
-            var nameSnip = "<i class=\"fa fa-tag\"></i> <%= action.case_tag() %> (<%= action.case_type() %>)";
+            var nameSnip = "<i class=\"fa fa-tag\"></i> <%- action.case_tag() %> (<%- action.case_type() %>)";
             var closeSnip = "<% if (action.close_case()) { %> : close<% }%>";
             var spanSnip = '<span class="text-muted" style="font-weight: normal;">';
             if (action.actionType === 'open') {
                 return _.template(
                     nameSnip + spanSnip +
                     '<% if (action.parent_tags()) { %> : ' +
-                    gettext('subcase of') + '<span style="font-weight: bold;"><%= action.parent_tags() %></span>' +
+                    gettext('subcase of') + '<span style="font-weight: bold;"><%- action.parent_tags() %></span>' +
                     '<% } %>' + closeSnip + "</span>")({
                     action: action,
                 });
             } else {
                 if (action.auto_select) {
-                    nameSnip = "<i class=\"fa fa-tag\"></i> <%= action.case_tag() %> (" + gettext("autoselect mode: ") + "<%= action.auto_select.mode() %>)";
+                    nameSnip = "<i class=\"fa fa-tag\"></i> <%- action.case_tag() %> (" + gettext("autoselect mode: ") + "<%- action.auto_select.mode() %>)";
                 }
                 if (action.load_case_from_fixture) {
                     nameSnip += gettext(" (from fixture)");

--- a/corehq/apps/app_manager/static/app_manager/js/section_changer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/section_changer.js
@@ -37,7 +37,7 @@ hqDefine("app_manager/js/section_changer", function () {
     // page is something like "module-view"
     // section is something like "logic"
     var getKey = function (page, section) {
-        return _.template("app-manager-collapse-<%= page %>-<%= section %>")({
+        return _.template("app-manager-collapse-<%- page %>-<%- section %>")({
             page: page,
             section: section,
         });

--- a/corehq/apps/app_manager/static/app_manager/js/summary/models.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/models.js
@@ -298,8 +298,8 @@ hqDefine('app_manager/js/summary/models',[
         self.moduleFormReference = function (formId) {
             var formData = self.formNameMap[formId];
             var template = self.readOnly
-                ? "<%= moduleName %> &rarr; <%= formName %>"
-                : "<a href='<%= moduleUrl %>'><%= moduleName %></a> &rarr; <a href='<%= formUrl %>'><%= formName %></a>"
+                ? "<%- moduleName %> &rarr; <%- formName %>"
+                : "<a href='<%- moduleUrl %>'><%- moduleName %></a> &rarr; <a href='<%- formUrl %>'><%- formName %></a>"
             ;
             return _.template(template)({
                 moduleName: self.translate(formData.module_name),
@@ -311,8 +311,8 @@ hqDefine('app_manager/js/summary/models',[
         self.moduleReference = function (moduleId) {
             var moduleData = self.formNameMap[moduleId];
             var template = self.readOnly
-                ? "<%= moduleName %>"
-                : "<a href='<%= moduleUrl %>'><%= moduleName %></a>"
+                ? "<%- moduleName %>"
+                : "<a href='<%- moduleUrl %>'><%- moduleName %></a>"
             ;
             return _.template(template)({
                 moduleName: self.translate(moduleData.module_name),

--- a/corehq/apps/app_manager/static/app_manager/js/supported_languages.js
+++ b/corehq/apps/app_manager/static/app_manager/js/supported_languages.js
@@ -36,7 +36,7 @@ hqDefine('app_manager/js/supported_languages',[
                 return '';
             }
 
-            return "(" + _.template("originally <%= originalLanguage %>")({
+            return "(" + _.template("originally <%- originalLanguage %>")({
                 originalLanguage: self.originalLangcode(),
             }) + ")";
         });

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -164,7 +164,7 @@
   </script>
 
   <script type="text/html" class="js-popover-template-add-item-content" data-slug="form">
-    <div data-module-unique-id="<%= moduleUniqueId %>">
+    <div data-module-unique-id="<%- moduleUniqueId %>">
       <% if (showSurvey) { %>
       <div class="pull-left">
         <button type="button" class="popover-additem-option js-new-form appnav-responsive"
@@ -211,7 +211,7 @@
         </button>
       </div>
       <% } %>
-      <form method="post" class="hide" action="<%= newFormUrl %>">
+      <form method="post" class="hide" action="<%- newFormUrl %>">
         {% csrf_token %}
         <input type="hidden" name="case_action" />
         <input type="hidden" name="form_type" />

--- a/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
@@ -32,9 +32,9 @@
   <script type="text/html">
     <li class="checkbox">
       <label>
-        <input type="checkbox" data-slug="<%= slug %>" />
-        <span class='label label-<%= tag_css_class %>'><%= tag_name %></span>
-        <%= label %>
+        <input type="checkbox" data-slug="<%- slug %>" />
+        <span class='label label-<%- tag_css_class %>'><%- tag_name %></span>
+        <%- label %>
       </label>
     </li>
   </script>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-11428

This is one of the PRs from the series of PRs that will be replacing `<%=` to `<%-`.

This PR specifically covers the changes of App Manager.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA plan is described here https://dimagi-dev.atlassian.net/browse/QA-2854?focusedCommentId=133830 
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The local testing and notes have been updated in the doc https://docs.google.com/spreadsheets/d/1oBLABIn41A7LbslViK997GmaQsQ5kRUJNDyn9WzFpGc/edit#gid=0
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
