### PR TITLE
Escape html in Cloudcare

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -14,7 +14,7 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         if (isWebApps) {
             var url = hqImport("hqwebapp/js/initial_page_data").reverse('login_new_window');
             return _.template(gettext("Looks like you got logged out because of inactivity, but your work is safe. " +
-                                      "<a href='<%= url %>' target='_blank'>Click here to log back in.</a>"))({url: url});
+                                      "<a href='<%- url %>' target='_blank'>Click here to log back in.</a>"))({url: url});
         } else {
             // target=_blank doesn't work properly within an iframe
             return gettext("You have been logged out because of inactivity.");

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -389,7 +389,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 columnVisible: function (index) {
                     return !(this.widthHints && this.widthHints[index] === 0);
                 },
-                pageNumLabel: _.template(gettext("Page <%=num%>")),
+                pageNumLabel: _.template(gettext("Page <%-num%>")),
             };
         },
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
@@ -114,7 +114,7 @@ hqDefine("cloudcare/js/formplayer/users/views", function () {
                 endPage: paginationOptions.endPage,
                 pageCount: paginationOptions.pageCount,
                 currentPage: this.model.get('page') - 1,
-                pageNumLabel: _.template(gettext("Page <%= num %>")),
+                pageNumLabel: _.template(gettext("Page <%- num %>")),
             };
         },
         navigate: function () {

--- a/corehq/apps/cloudcare/templates/formplayer/case_detail.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_detail.html
@@ -9,9 +9,9 @@
 <script type="text/template" id="detail-view-item-template">
   <th><%- header %></th>
   <% if (style.displayFormat === 'Graph') { %>
-  <td><iframe srcdoc="<%= data %>" height="300" width="300"></iframe></td>
+  <td><iframe srcdoc="<%- data %>" height="300" width="300"></iframe></td>
   <% } else if (style.displayFormat === 'Image') { %>
-  <td class="module-caselist-column"><img class="module-icon" src="<%= resolveUri(data) %>"/></td>
+  <td class="module-caselist-column"><img class="module-icon" src="<%- resolveUri(data) %>"/></td>
   <% } else if (style.displayFormat === 'Phone') { %>
   <td><a href="tel:<%- data %>"><%- data %></a></td>
   <% } else { %>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -28,9 +28,9 @@
           <% _.each(headers, function(header, index) { %>
           <% if (columnVisible(index)) { %>
           <% if (columnSortable(index)) { %>
-          <th class="module-caselist-header header-clickable formplayer-request" data-id="<%= index %>"> <%= header %></th>
+          <th class="module-caselist-header header-clickable formplayer-request" data-id="<%- index %>"> <%- header %></th>
           <% } else { %>
-          <th class="module-caselist-header" data-id="<%= index %>"> <%= header %></th>
+          <th class="module-caselist-header" data-id="<%- index %>"> <%- header %></th>
           <% } %>
           <% } %>
           <% }); %>
@@ -40,7 +40,7 @@
         <% if (hasNoItems) { %>
         <tbody>
         <tr>
-          <td class="module-caselist-column module-caselist-column-empty" colspan="<%=headers.length%>">
+          <td class="module-caselist-column module-caselist-column-empty" colspan="<%-headers.length%>">
             <div class="alert alert-info">{% trans "List is empty." %}</div>
           </td>
         </tr>
@@ -56,7 +56,7 @@
     <div class="caselist-actions">
       <% _.each(actions, function(action, index) { %>
       <div class="caselist-action-button btn-group formplayer-request">
-        <button type="button" class="btn btn-success btn-lg" data-index="<%= index %>"><%= action.text %></button>
+        <button type="button" class="btn btn-success btn-lg" data-index="<%- index %>"><%- action.text %></button>
       </div>
       <% }) %>
     </div>
@@ -74,28 +74,28 @@
   <% _.each(data, function(datum, index) { %>
   <% if (!(styles[index].widthHint === 0)) { %>
   <% if (styles[index].displayFormat === 'Image') { %>
-  <td class="module-caselist-column"><img class="module-icon" src="<%= resolveUri(datum) %>"/></td>
+  <td class="module-caselist-column"><img class="module-icon" src="<%- resolveUri(datum) %>"/></td>
   <% } else if (styles[index].displayFormat === 'Graph') { %>
-  <td class="module-caselist-column"><iframe srcdoc="<%= datum %>" height="300" width="300"></iframe></td>
+  <td class="module-caselist-column"><iframe srcdoc="<%- datum %>" height="300" width="300"></iframe></td>
   <% } else { %>
-  <td class="module-caselist-column"><%= datum %></td>
+  <td class="module-caselist-column"><%- datum %></td>
   <% } %>
   <% } %>
   <% }); %>
 </script>
 
 <script type="text/template" id="case-tile-view-item-template">
-  <div class="<%= prefix %>-cell-grid-style">
+  <div class="<%- prefix %>-cell-grid-style">
     <% _.each(data, function(datum, index) { %>
-    <div class="<%= prefix %>-grid-style-<%= index %> box">
+    <div class="<%- prefix %>-grid-style-<%- index %> box">
       <% if (styles[index].displayFormat === 'Image') {
       if(resolveUri(datum)) { %>
-      <img class="module-icon" style="max-width:100%; max-height:100%;" src="<%= resolveUri(datum) %>"/>
+      <img class="module-icon" style="max-width:100%; max-height:100%;" src="<%- resolveUri(datum) %>"/>
       <% } %>
       <% } else if(styles[index].widthHint === 0) { %>
-      <div style="display:none;"><%= datum %></div>
+      <div style="display:none;"><%- datum %></div>
       <% } else { %>
-      <div><%= datum %></div>
+      <div><%- datum %></div>
       <% } %>
     </div>
     <% }); %>
@@ -104,18 +104,18 @@
 
 <script type="text/template" id="cell-layout-style-template">
   <% _.each(models, function(model){ %>
-  .<%= model.id %> {
-  grid-area: <%= model.gridStyle %>;
-  font-size: <%= model.fontStyle %>;
+  .<%- model.id %> {
+  grid-area: <%- model.gridStyle %>;
+  font-size: <%- model.fontStyle %>;
   }
   <% }); %>
 </script>
 
 <script type="text/template" id="cell-container-style-template">
   .list-cell-container-style {
-  width: <%= model.widthPercentage %>%;
+  width: <%- model.widthPercentage %>%;
   height: 0;
-  padding-bottom: <%= model.heightPercentage %>%;
+  padding-bottom: <%- model.heightPercentage %>%;
   display: inline-block;
   border: 1px solid white;
   border-collapse: collapse;
@@ -126,10 +126,10 @@
 </script>
 
 <script type="text/template" id="cell-grid-style-template">
-  .<%= model.prefix %>-cell-grid-style {
+  .<%- model.prefix %>-cell-grid-style {
   display: grid;
-  grid-template-columns: repeat(<%= model.numColumns %>, <%= model.widthPixels %>px) min-content 5px;
-  grid-template-rows: repeat(<%= model.numRows %>, <%= model.heightPixels %>px) min-content 5px;
+  grid-template-columns: repeat(<%- model.numColumns %>, <%- model.widthPixels %>px) min-content 5px;
+  grid-template-rows: repeat(<%- model.numRows %>, <%- model.heightPixels %>px) min-content 5px;
   background-color: transparent;
   color: #685c53;
   justify-items: left;
@@ -147,7 +147,7 @@
         <tr>
           <% _.each(headers, function(header, index) { %>
           <% if (!(styles[index].widthHint === 0)) { %>
-          <th class="module-caselist-header"> <%= header %></th>
+          <th class="module-caselist-header"> <%- header %></th>
           <% } %>
           <% }); %>
         </tr>
@@ -155,7 +155,7 @@
         <% if (hasNoItems) { %>
         <tbody>
         <tr>
-          <td class="module-caselist-column module-caselist-column-empty" colspan="<%=headers.length%>">
+          <td class="module-caselist-column module-caselist-column-empty" colspan="<%-headers.length%>">
             <div class="alert alert-info">{% trans "List is empty." %}</div>
           </td>
         </tr>

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -52,7 +52,7 @@
 
 <script id="single-app-template" type="text/template">
   <ol class="breadcrumb">
-    <li class="breadcrumb-text"><%= appName %></li>
+    <li class="breadcrumb-text"><%- appName %></li>
   </ol>
   <div class="container container-appicons">
     <div class="row">
@@ -115,10 +115,10 @@
         <% if (!imageUrl) { %>
           <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
         <% } else { %>
-          <i class="fcc appicon-custom appicon-icon" style="background-image: url('<%= imageUrl %>');" aria-hidden="true"></i>
+          <i class="fcc appicon-custom appicon-icon" style="background-image: url('<%- imageUrl %>');" aria-hidden="true"></i>
         <% } %>
         <div class="appicon-title">
-          <h3><%= appName %></h3>
+          <h3><%- appName %></h3>
         </div>
       </div>
     </div>
@@ -131,7 +131,7 @@
     <% if (!imageUrl) { %>
       <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
     <% } else { %>
-      <i class="fcc appicon-custom appicon-icon" style="background-image: url('<%= imageUrl %>');" aria-hidden="true"></i>
+      <i class="fcc appicon-custom appicon-icon" style="background-image: url('<%- imageUrl %>');" aria-hidden="true"></i>
     <% } %>
     <div class="appicon-title">
       <h3><%- name %></h3>

--- a/corehq/apps/cloudcare/templates/formplayer/menu_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/menu_list.html
@@ -30,12 +30,12 @@
   <td class="module-column module-column-icon">
     <% if (imageUrl) { %>
     <div class="module-icon-image badge-container" style="background-image: url('<%- imageUrl %>');">
-      <%= _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
+      <%- _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
     </div>
     <% } else { %>
     <div class="module-icon-container badge-container">
       <i class="fa fa-pencil module-icon" aria-hidden="true"></i>
-      <%= _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
+      <%- _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
     </div>
     <% } %>
   </td>
@@ -55,7 +55,7 @@
   <td class="module-column module-column-icon">
     <% if (imageUrl) { %>
     <div class="module-icon-image badge-container" style="background-image: url('<%- imageUrl %>');">
-      <%= _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
+      <%- _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
     </div>
     <% } else { %>
     <div class="module-icon-container badge-container">
@@ -64,7 +64,7 @@
       <% } else { %>
       <i class="fa fa-folder module-icon" aria-hidden="true"></i>
       <% } %>
-      <%= _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
+      <%- _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
     </div>
     <% } %>
   </td>
@@ -77,7 +77,7 @@
   <div class="col-xs-6 col-sm-4 col-md-3">
     <% if (imageUrl) { %>
     <div class="gridicon badge-container" style="background-image: url('<%- imageUrl %>');">
-      <%= _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
+      <%- _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
     </div>
     <% } else { %>
     <div class="gridicon gridicon-circle badge-container">
@@ -86,7 +86,7 @@
       <% } else { %>
       <i class="fa fa-folder gridicon-icon" aria-hidden="true"></i>
       <% } %>
-      <%= _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
+      <%- _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
     </div>
     <% } %>
     <div class="module-column-name text-center">
@@ -116,7 +116,7 @@
 </script>
 
 <script type="text/template" id="breadcrumb-item-template">
-  <%= data %>
+  <%- data %>
 </script>
 
 <script type="text/template" id="breadcrumb-list-template">
@@ -135,5 +135,5 @@
 </script>
 
 <script type="text/template" id="language-option-template">
-  <a class="lang" id="<%= lang %>"><%= lang %></a>
+  <a class="lang" id="<%- lang %>"><%- lang %></a>
 </script>

--- a/corehq/apps/cloudcare/templates/formplayer/pagination.html
+++ b/corehq/apps/cloudcare/templates/formplayer/pagination.html
@@ -11,9 +11,9 @@
           <select class="form-control per-page-limit">
             <% for(var i = 0; i < rowRange.length; i++) { %>
               <% if (rowRange[i] === limit) { %>
-                <option value="<%= rowRange[i] %>" selected>{% trans "<%= rowRange[i] %> per page" %}</option>
+                <option value="<%- rowRange[i] %>" selected>{% trans "<%- rowRange[i] %> per page" %}</option>
               <% } else { %>
-                <option value="<%= rowRange[i] %>">{% trans "<%= rowRange[i] %> per page" %}</option>
+                <option value="<%- rowRange[i] %>">{% trans "<%- rowRange[i] %> per page" %}</option>
               <% } %>
             <% } %>
           </select>
@@ -29,7 +29,7 @@
                   <a class="js-page" aria-label='{% trans_html_attr "First Page" %}' tabindex="0" data-id="0">
                   <span><i class="fa fa-fast-backward"></i></span>
                 </a>
-                <a class="js-page" aria-label='{% trans_html_attr "Previous" %}' tabindex="0" data-id="<%= currentPage - 1 %>">
+                <a class="js-page" aria-label='{% trans_html_attr "Previous" %}' tabindex="0" data-id="<%- currentPage - 1 %>">
                   <span><i class="fa fa-caret-left"></i></span>
                 </a>
                 </li>
@@ -38,7 +38,7 @@
                 <a class="js-page" data-id="0">
                   <span><i class="fa fa-fast-backward"></i></span>
                 </a>
-                <a class="js-page" data-id="<%= currentPage - 1 %>">
+                <a class="js-page" data-id="<%- currentPage - 1 %>">
                   <span><i class="fa fa-caret-left"></i></span>
                 </a>
                 </li>
@@ -46,45 +46,45 @@
               <!-- Render page buttons -->
               <% if (pageCount <= 5) { %>
                   <% for (i = startPage-1; i < endPage; i++) { %>
-                    <li class="js-page<% if (i === currentPage) { %> active<% } %>" data-id="<%= i %>"><a aria-label="<%= pageNumLabel({num: i + 1}) %>" <% if (i === currentPage ) { %> aria-current ='page'<% } %> tabindex="0"><%= i + 1 %></a></li>
+                    <li class="js-page<% if (i === currentPage) { %> active<% } %>" data-id="<%- i %>"><a aria-label="<%- pageNumLabel({num: i + 1}) %>" <% if (i === currentPage ) { %> aria-current ='page'<% } %> tabindex="0"><%- i + 1 %></a></li>
                   <% } %>
               <% } else { %>
                 <% if (startPage <= 3) { %>
                   <% for (i = 0; i < startPage; i++) { %>
-                    <li class="js-page<% if (i === currentPage) { %> active<% } %>" data-id="<%= i %>"><a aria-label="<%= pageNumLabel({num: i + 1}) %>" <% if (i === currentPage ) { %> aria-current='page'<% } %> tabindex="0"><%= i + 1 %></a></li>
+                    <li class="js-page<% if (i === currentPage) { %> active<% } %>" data-id="<%- i %>"><a aria-label="<%- pageNumLabel({num: i + 1}) %>" <% if (i === currentPage ) { %> aria-current='page'<% } %> tabindex="0"><%- i + 1 %></a></li>
                   <% } %>
                 <% } else { %>
-                    <li class="js-page" data-id="0"><a aria-label="<%= pageNumLabel({num: 1}) %>" tabindex="0">{% trans "1" %}</a></li>
+                    <li class="js-page" data-id="0"><a aria-label="<%- pageNumLabel({num: 1}) %>" tabindex="0">{% trans "1" %}</a></li>
                     <li class="js-page"><a class="paginate-disabled">{% trans "..." %}</a></li>
                 <% } %>
                 <% for (i = startPage; i < endPage; i++) { %>
-                  <li class="js-page<% if (i === currentPage) { %> active<% } %>" data-id="<%= i %>"><a aria-label="<%= pageNumLabel({num: i + 1}) %>" <% if (i === currentPage ) { %> aria-current='page'<% } %> tabindex="0"><%= i + 1 %></a></li>
+                  <li class="js-page<% if (i === currentPage) { %> active<% } %>" data-id="<%- i %>"><a aria-label="<%- pageNumLabel({num: i + 1}) %>" <% if (i === currentPage ) { %> aria-current='page'<% } %> tabindex="0"><%- i + 1 %></a></li>
                 <% } %>
                 <% if (endPage >= pageCount - 2) { %>
                   <% for (i = endPage+1; i <= pageCount; i++) { %>
-                    <li class="js-page<% if (i === currentPage) { %> active<% } %>" data-id="<%= i - 1 %>"><a aria-label="<%= pageNumLabel({num: i + 1}) %>" <% if (i === currentPage ) { %> aria-current='page'<% } %> tabindex="0"><%= i %></a></li>
+                    <li class="js-page<% if (i === currentPage) { %> active<% } %>" data-id="<%- i - 1 %>"><a aria-label="<%- pageNumLabel({num: i + 1}) %>" <% if (i === currentPage ) { %> aria-current='page'<% } %> tabindex="0"><%- i %></a></li>
                   <% } %>
                 <% } else { %>
                   <li class="js-page"><a class="paginate-disabled">{% trans "..." %}</a></li>
-                  <li class="js-page" data-id="<%= pageCount - 1 %>"><a aria-label="<%= pageNumLabel({num: pageCount}) %>" tabindex="0"><%= pageCount %></a></li>
+                  <li class="js-page" data-id="<%- pageCount - 1 %>"><a aria-label="<%- pageNumLabel({num: pageCount}) %>" tabindex="0"><%- pageCount %></a></li>
                 <% } %>
               <% } %>
               <!-- Render Next buttons -->
               <% if (currentPage >= pageCount - 1) { %>
                 <li class="paginate-disabled">
-                  <a class="js-page" data-id="<%= currentPage + 1 %>">
+                  <a class="js-page" data-id="<%- currentPage + 1 %>">
                   <span><i class="fa fa-caret-right"></i></span>
                 </a>
-                <a class="js-page" data-id="<%= pageCount - 1 %>">
+                <a class="js-page" data-id="<%- pageCount - 1 %>">
                   <span><i class="fa fa-fast-forward"></i></span>
                 </a>
                 </li>
               <% } else { %>
                 <li>
-                <a class="js-page" aria-label='{% trans_html_attr "Next" %}' tabindex="0" data-id="<%= currentPage + 1 %>">
+                <a class="js-page" aria-label='{% trans_html_attr "Next" %}' tabindex="0" data-id="<%- currentPage + 1 %>">
                   <span><i class="fa fa-caret-right"></i></span>
                 </a>
-                <a class="js-page" aria-label='{% trans_html_attr "Last Page" %}' tabindex="0" data-id="<%= pageCount - 1 %>">
+                <a class="js-page" aria-label='{% trans_html_attr "Last Page" %}' tabindex="0" data-id="<%- pageCount - 1 %>">
                   <span><i class="fa fa-fast-forward"></i></span>
                 </a>
                 </li>

--- a/corehq/apps/cloudcare/templates/formplayer/progress.html
+++ b/corehq/apps/cloudcare/templates/formplayer/progress.html
@@ -2,7 +2,7 @@
   <div id="formplayer-progress">
     <div class="progress-container">
       <div class="progress-title">
-        <h1><%= progressMessage %></h1>
+        <h1><%- progressMessage %></h1>
         <h2 class="subtext text-left js-subtext"><small></small></h2>
       </div>
       <div class="progress">

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -38,7 +38,7 @@
       <select class="query-field form-control"  data-receive="<%- receive %>">
         <option value=""></option>
         <% for (var i = 0; i < itemsetChoices.length; i++) { %>
-          <option value="<%= i %>" <% if (value === i) { %>selected<% } %>>
+          <option value="<%- i %>" <% if (value === i) { %>selected<% } %>>
             <%- itemsetChoices[i] %>
           </option>
         <% } %>

--- a/corehq/apps/cloudcare/templates/formplayer/settings_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/settings_view.html
@@ -27,7 +27,7 @@
     <select class="form-control js-lang">
       <% _.each(langs, function(lang) { %>
       <option <% if (lang === currentLang) { %>selected<% } %>>
-      <%= lang %>
+      <%- lang %>
       </option>
       <% }) %>
     </select>

--- a/corehq/apps/cloudcare/templates/formplayer/users.html
+++ b/corehq/apps/cloudcare/templates/formplayer/users.html
@@ -11,7 +11,7 @@
         <input
           type="text"
           class="js-user-query form-control"
-          value="<%= query %>"
+          value="<%- query %>"
           placeholder="Filter workers" />
         <div class="input-group-btn">
           <button class="btn btn-default" type="submit">
@@ -40,9 +40,9 @@
   </td>
   <td class="module-column module-column-name">
     <h3>
-      <b><%= username %></b>
+      <b><%- username %></b>
       <span><%- first_name + ' ' + last_name %></span>
-      <i><small><%= location ? location.name + ' (' + location.location_type + ')' : '' %></small></i>
+      <i><small><%- location ? location.name + ' (' + location.location_type + ')' : '' %></small></i>
     </h3>
   </td>
 </script>
@@ -57,22 +57,22 @@
     <% if (user.location) { %>
     <tr>
       <th>{% trans "Organization" %}</th>
-      <td><%= user.location.name %></td>
+      <td><%- user.location.name %></td>
     </tr>
     <tr>
       <th>{% trans "Organization Type" %}</th>
-      <td><%= user.location.location_type %></td>
+      <td><%- user.location.location_type %></td>
     </tr>
     <% } %>
     <tr>
       <th>{% trans "Date Registered" %}</th>
-      <td><%= user.dateRegistered %></td>
+      <td><%- user.dateRegistered %></td>
     </tr>
     <% _.each(user.customFields, function(value, key) { %>
     <% if (!key.startsWith('commcare_') && !key.startsWith('commtrack') && value) { %>
     <tr>
-      <th><%= key %></th>
-      <td><%= value %></td>
+      <th><%- key %></th>
+      <td><%- value %></td>
     </tr>
     <% } %>
     <% }) %>
@@ -86,8 +86,8 @@
     <div class="restore-as-banner module-banner">
       {% blocktrans %}
         <span>
-                Working as <b><%= restoreAs %></b>.
-                <a class="js-clear-user">Use <%= username %>.</a>
+                Working as <b><%- restoreAs %></b>.
+                <a class="js-clear-user">Use <%- username %>.</a>
             </span>
       {% endblocktrans %}
     </div>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-11428

This is one of the PRs from the series of PRs that will be replacing `<%=` to `<%-`.

This PR specifically covers the changes in Cloudcare.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA plan is described here https://dimagi-dev.atlassian.net/browse/QA-2854?focusedCommentId=133830 
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The local testing and notes have been updated in the doc https://docs.google.com/spreadsheets/d/1oBLABIn41A7LbslViK997GmaQsQ5kRUJNDyn9WzFpGc/edit#gid=0
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
