### PR TITLE
Escape templates in datainterfaces

### DIFF
--- a/corehq/apps/data_interfaces/static/data_interfaces/js/find_by_id.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/find_by_id.js
@@ -22,7 +22,7 @@ hqDefine("data_interfaces/js/find_by_id", [
 
         self.linkMessage = ko.computed(function () {
             if (self.link()) {
-                var redirectTemplate = _.template(gettext("<a href='<%= link %>' target='_blank'>View <i class='fa fa-external-link'></i></a>"));
+                var redirectTemplate = _.template(gettext("<a href='<%- link %>' target='_blank'>View <i class='fa fa-external-link'></i></a>"));
                 return self.successMessage + " " + redirectTemplate({link: self.link()});
             }
             return '';
@@ -63,7 +63,7 @@ hqDefine("data_interfaces/js/find_by_id", [
 
         $("#find-case").koApplyBindings(findModel({
             header: gettext('Find Case'),
-            help: _.template(gettext('IDs can be found in a <a href="<%= url %>">case data export</a>'))({
+            help: _.template(gettext('IDs can be found in a <a href="<%- url %>">case data export</a>'))({
                 url: initialPageData.reverse('list_case_exports'),
             }),
             placeholder: gettext('Case ID'),
@@ -74,7 +74,7 @@ hqDefine("data_interfaces/js/find_by_id", [
 
         $("#find-form").koApplyBindings(findModel({
             header: gettext('Find Form Submission'),
-            help: _.template(gettext('IDs can be found in a <a href="<%= url %>">form data export</a>'))({
+            help: _.template(gettext('IDs can be found in a <a href="<%- url %>">form data export</a>'))({
                 url: initialPageData.reverse('list_form_exports'),
             }),
             errorMessage: gettext('Could not find form submission'),

--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -244,7 +244,7 @@
                 params="goToPage: $root.data.goToPage,
                         slug: 'datagrid',
                         perPage: $root.data.limit,
-                        itemsTextTemplate: '{% trans_html_attr 'Showing <%= firstItem %> to <%= lastItem %> of <%= maxItems %> cases' %}',
+                        itemsTextTemplate: '{% trans_html_attr 'Showing <%- firstItem %> to <%- lastItem %> of <%- maxItems %> cases' %}',
                         totalItems: $root.data.totalRecords"></pagination>
 
     <div class="modal fade"

--- a/corehq/apps/data_interfaces/templates/data_interfaces/manage_case_groups.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/manage_case_groups.html
@@ -19,7 +19,7 @@
 
     <script type="text/html" id="template-upload-progress">
       <p>
-        <%=current%> / <%=total%> {% trans 'cases processed. Please do not refresh or close this page.' %}
+        <%-current%> / <%-total%> {% trans 'cases processed. Please do not refresh or close this page.' %}
       </p>
     </script>
 
@@ -29,7 +29,7 @@
         <h4>{% trans 'Cases were successfully added:' %}</h4>
         <ul>
           <% _.each(success, function (s) { %>
-          <li><%=s%></li>
+          <li><%-s%></li>
           <% }); %>
         </ul>
       </div>
@@ -40,7 +40,7 @@
         <h4>{% trans 'Issues encountered during bulk upload:' %}</h4>
         <ul>
           <% _.each(errors, function (error) { %>
-          <li><%=error%></li>
+          <li><%-error%></li>
           <% }); %>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-11428

This is one of the PRs from the series of PRs that will be replacing `<%=` to `<%-`.

This PR specifically covers changes in Data Interfaces

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA plan is described here https://dimagi-dev.atlassian.net/browse/QA-2854?focusedCommentId=133830 
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The local testing and notes have been updated in the doc https://docs.google.com/spreadsheets/d/1oBLABIn41A7LbslViK997GmaQsQ5kRUJNDyn9WzFpGc/edit#gid=0
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
