### PR TITLE
Escape html in multimedia

### DIFF
--- a/corehq/apps/hqmedia/templates/hqmedia/uploader/details_multi.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/uploader/details_multi.html
@@ -1,13 +1,13 @@
 {% load i18n %}
 <% if (unknowns.length > 0) { %>
 <div class="well well-small">
-  <h4>{% trans 'No Matches' %} <span class="badge badge-important"><%= unknowns.length %></span></h4>
+  <h4>{% trans 'No Matches' %} <span class="badge badge-important"><%- unknowns.length %></span></h4>
   <ul>
     <% for (var u=0; u < unknowns.length; u++) {
     var unknown = unknowns[u]; %>
     <li><p>
-      <%= unknown.reason %>
-      <code class="hqm-path"><span><%= unknown.path %></span></code>
+      <%- unknown.reason %>
+      <code class="hqm-path"><span><%- unknown.path %></span></code>
     </p></li>
     <% } %>
   </ul>
@@ -16,23 +16,23 @@
 <% var m = 0; %>
 <% if (images.length > 0) { %>
 <div class="well well-small">
-  <h4>{% trans 'Matched Images' %} <span class="badge badge-success"><%= images.length %></span></h4>
+  <h4>{% trans 'Matched Images' %} <span class="badge badge-success"><%- images.length %></span></h4>
   <ul>
     <% for (var i=0; i < images.length; i++) {
     var image = images[i]; %>
     <li>
       <p>
-        <img src="<%= image.url %>?thumb=50" style="height: 50px;" alt="<%= image.path %>" />
-        <a href="<%= image.url %>"
+        <img src="<%- image.url %>?thumb=50" style="height: 50px;" alt="<%- image.path %>" />
+        <a href="<%- image.url %>"
            target="_blank"
            class="btn btn-primary match-info"
-           data-content="<img src='<%= image.url %>?thumb=220' width='220' alt='<%= image.path %>' />">
-          <i class="<%= image.icon_class %>"></i> {% trans 'View Full Image' %}</a>
+           data-content="<img src='<%- image.url %>?thumb=220' width='220' alt='<%- image.path %>' />">
+          <i class="<%- image.icon_class %>"></i> {% trans 'View Full Image' %}</a>
         <% if (image.updated) { %>
         <span class="label label-info">{% trans 'Updated' %}</span>
         <% } %>
       </p>
-      <p><code class="hqm-path"><span><%= image.path %></span></code></p>
+      <p><code class="hqm-path"><span><%- image.path %></span></code></p>
     </li>
     <% } %>
   </ul>
@@ -40,22 +40,22 @@
 <% } %>
 <% if (audio.length > 0) { %>
 <div class="well well-small">
-  <h4>{% trans 'Matched Audio' %} <span class="badge badge-success"><%= audio.length %></span></h4>
+  <h4>{% trans 'Matched Audio' %} <span class="badge badge-success"><%- audio.length %></span></h4>
   <ul>
     <% for (var a=0; a < audio.length; a++) {
     var sound = audio[a]; %>
     <li>
-      <p><a href="<%= sound.url %>"
+      <p><a href="<%- sound.url %>"
             target="_blank"
             class="btn btn-primary match-info"
             data-content="{% trans 'Playing audio directly on this page is currently not supported.' %}">
-        <i class="<%= sound.icon_class %>"></i> {% trans 'Listen to Audio' %}</a>
+        <i class="<%- sound.icon_class %>"></i> {% trans 'Listen to Audio' %}</a>
         <% if (sound.updated) { %>
         <span class="label label-info">{% trans 'Updated' %}</span>
         <% } %>
       </p>
       <p>
-        <code class="hqm-path"><span><%= sound.path %></span></code>
+        <code class="hqm-path"><span><%- sound.path %></span></code>
       </p>
     </li>
     <% } %>
@@ -64,22 +64,22 @@
 <% } %>
 <% if (video.length > 0) { %>
 <div class="well well-small">
-  <h4>{% trans 'Matched Videos' %} <span class="badge badge-success"><%= video.length %></span></h4>
+  <h4>{% trans 'Matched Videos' %} <span class="badge badge-success"><%- video.length %></span></h4>
   <ul>
     <% for (var v=0; v < video.length; v++) {
     var vid = video[v]; %>
     <li>
-      <p><a href="<%= vid.url %>"
+      <p><a href="<%- vid.url %>"
             target="_blank"
             class="btn btn-primary match-info"
             data-content="{% trans 'Watching video directly on this page is not supported. Opens a new tab.' %}">
-        <i class="<%= vid.icon_class %>"></i> {% trans 'Watch Video' %}</a>
+        <i class="<%- vid.icon_class %>"></i> {% trans 'Watch Video' %}</a>
         <% if (vid.updated) { %>
         <span class="label label-info">{% trans 'Updated' %}</span>
         <% } %>
       </p>
       <p>
-        <code class="hqm-path"><span><%= vid.path %></span></code>
+        <code class="hqm-path"><span><%- vid.path %></span></code>
       </p>
     </li>
     <% } %>

--- a/corehq/apps/hqmedia/templates/hqmedia/uploader/errors.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/uploader/errors.html
@@ -4,7 +4,7 @@
   <h5>{% trans 'Errors found' %}</h5>
   <% for (var e = 0; e < errors.length; e++) {
   var error = errors[e]; %>
-  <p><%= error %></p>
+  <p><%- error %></p>
   <% } %>
 </div>
 <% } %>

--- a/corehq/apps/hqmedia/templates/hqmedia/uploader/preview_audio_single.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/uploader/preview_audio_single.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <p>
-  <a href="<%= url %>"
+  <a href="<%- url %>"
      class="btn btn-default existing-media"
      target="_blank"
      data-toggle="tooltip" data-title="Opens file in new tab.">{% trans 'Listen to Audio' %}</a>

--- a/corehq/apps/hqmedia/templates/hqmedia/uploader/preview_html_single.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/uploader/preview_html_single.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <p>
   <a class="btn btn-default existing-media"
-     href="<%= url %>"
+     href="<%- url %>"
      target="_blank"
      data-toggle="tooltip"
      data-title="{% trans "Opens file in new tab." %}">{% trans "Open HTML" %}</a>

--- a/corehq/apps/hqmedia/templates/hqmedia/uploader/preview_image_single.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/uploader/preview_image_single.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <p>
-  <img src="<%=url %>?thumb=100" alt="uploaded image" />
-  <a href="<%= url %>"
+  <img src="<%-url %>?thumb=100" alt="uploaded image" />
+  <a href="<%- url %>"
      class="btn btn-default existing-media"
      target="_blank"
      data-toggle="tooltip" data-title="Opens image in new tab.">{% trans 'View Full Size' %}</a>

--- a/corehq/apps/hqmedia/templates/hqmedia/uploader/preview_video_single.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/uploader/preview_video_single.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <p>
-  <a href="<%= url %>"
+  <a href="<%- url %>"
      class="btn btn-default existing-media"
      target="_blank"
      data-toggle="tooltip" data-title="Opens file in new tab.">{% trans 'Watch Video' %}</a>

--- a/corehq/apps/hqmedia/templates/hqmedia/uploader/queue_multi.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/uploader/queue_multi.html
@@ -1,7 +1,7 @@
 {% load i18n %}
-<tr id="<%= unique_id %>">
-  <td><%= file_name %></td>
-  <td><%= file_size %> MB</td>
+<tr id="<%- unique_id %>">
+  <td><%- file_name %></td>
+  <td><%- file_size %> MB</td>
   <td class="hqm-progress">
     <div class="progress" style="margin-bottom: 5px;">
       <div class="progress-bar progress-bar-striped active" style="width: 0%;"></div>

--- a/corehq/apps/hqmedia/templates/hqmedia/uploader/queue_single.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/uploader/queue_single.html
@@ -1,7 +1,7 @@
 {% load i18n %}
-<div id="<%= unique_id %>" class="clearfix">
+<div id="<%- unique_id %>" class="clearfix">
   <div class="alert alert-success" style="margin-bottom: 2px; margin-top: 10px;">
-    <i class="fa fa-check"></i> <%= file_name %> <strong>[<%= file_size %> MB]</strong>
+    <i class="fa fa-check"></i> <%- file_name %> <strong>[<%- file_size %> MB]</strong>
   </div>
   <div class="hqm-progress">
     <div class="progress" style="margin-bottom: 5px;">

--- a/corehq/apps/hqmedia/templates/hqmedia/uploader/status_multi.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/uploader/status_multi.html
@@ -6,7 +6,7 @@
         <% if (num == 1) { %>
             {% trans '1 Match Found' %}
         <% } else { %>
-            {% trans '<%= num %> Matches Found' %}
+            {% trans '<%- num %> Matches Found' %}
         <% } %>
     </span>
   <% } else { %>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-11428

This is one of the PRs from the series of PRs that will be replacing `<%=` to `<%-`.

This PR specifically covers changes in HQ Media

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA plan is described here https://dimagi-dev.atlassian.net/browse/QA-2854?focusedCommentId=133830 
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The local testing and notes have been updated in the doc https://docs.google.com/spreadsheets/d/1oBLABIn41A7LbslViK997GmaQsQ5kRUJNDyn9WzFpGc/edit#gid=0
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
