### PR TITLE
Escape html in hqwebapp

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
@@ -21,7 +21,7 @@
  *      onLoad: Typically needed with slug, in order to avoid a race condition between the cookie and the default
  *          value of perPage. Typically will call goToPage(1). Not needed when your pages wait on some other
  *          logic before loading, e.g., they aren't loaded until an ajax request brings back their content.
- *      itemsTextTemplate: Optional. A string that contains <%= firstItem %>, <%= lastItem %>, <%= maxItems %>
+ *      itemsTextTemplate: Optional. A string that contains <%- firstItem %>, <%- lastItem %>, <%- maxItems %>
  *          which shows up next to the left of the limit dropdown.
  *      resetFlag: Optional. An observable. If provided, this widget will subscribe to changes on this observable
  *          and, on change, will go back to the first page.
@@ -65,7 +65,7 @@ hqDefine('hqwebapp/js/components/pagination', [
             }
 
             self.perPageOptionsText = function (num) {
-                return _.template(gettext('<%= num %> per page'))({ num: num });
+                return _.template(gettext('<%- num %> per page'))({ num: num });
             };
 
             self.numPages = ko.computed(function () {
@@ -94,7 +94,7 @@ hqDefine('hqwebapp/js/components/pagination', [
             self.itemsText = ko.computed(function () {
                 var lastItem = Math.min(self.currentPage() * self.perPage(), self.totalItems());
                 return _.template(
-                    params.itemsTextTemplate || gettext('Showing <%= firstItem %> to <%= lastItem %> of <%= maxItems %> entries')
+                    params.itemsTextTemplate || gettext('Showing <%- firstItem %> to <%- lastItem %> of <%- maxItems %> entries')
                 )({
                     firstItem: ((self.currentPage() - 1) * self.perPage()) + 1,
                     lastItem: isNaN(lastItem) ? 1 : lastItem,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -123,7 +123,7 @@ hqDefine('hqwebapp/js/inactivity', [
                         src += "?next=" + initialPageData.reverse('iframe_domain_login_new_window');
                         src += "&username=" + initialPageData.get('secure_timeout_username');
                         $modal.on('shown.bs.modal', function () {
-                            var content = _.template('<iframe src="<%= src %>" height="<%= height %>" width="<%= width %>" style="border: none;"></iframe>')({
+                            var content = _.template('<iframe src="<%- src %>" height="<%- height %>" width="<%- width %>" style="border: none;"></iframe>')({
                                 src: src,
                                 width: $body.width(),
                                 height: $body.height() - 10,
@@ -152,7 +152,7 @@ hqDefine('hqwebapp/js/inactivity', [
                     var error = "";
                     if (data.success) {
                         if (data.username !== initialPageData.get('secure_timeout_username')) {
-                            error = gettext(_.template("Please log in as <%= username %>"))({
+                            error = gettext(_.template("Please log in as <%- username %>"))({
                                 username: initialPageData.get('secure_timeout_username'),
                             });
                         }

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -12,18 +12,20 @@ hqDefine('hqwebapp/js/multiselect_utils', [
     var multiselect_utils = {};
 
     var _renderHeader = function (title, action, search) {
-        var header = _.template('<div class="ms-header"><%= headerTitle %><%= actionButton %></div><%= searchInput %>');
-        return header({
-            headerTitle: title,
-            actionButton: action || '',
-            searchInput: search || '',
-        });
+        if (!action){
+            action = '';
+        }
+        if (!search){
+            search = '';
+        }
+        var templateStr = '<div class="ms-header">' + title + action + '</div>' + search;
+        return  _.template(templateStr);
     };
 
     var _renderAction = function (buttonId, buttonClass, buttonIcon, text) {
         var action = _.template(
-            '<button class="btn <%=actionButtonClass %> btn-xs pull-right" id="<%= actionButtonId %>">' +
-                '<i class="<%= actionButtonIcon %>"></i> <%= actionButtonText %>' +
+            '<button class="btn <%-actionButtonClass %> btn-xs pull-right" id="<%- actionButtonId %>">' +
+                '<i class="<%- actionButtonIcon %>"></i> <%- actionButtonText %>' +
             '</button>'
         );
         return action({
@@ -40,7 +42,7 @@ hqDefine('hqwebapp/js/multiselect_utils', [
                 '<span class="input-group-addon">' +
                     '<i class="fa fa-search"></i>' +
                 '</span>' +
-                '<input type="search" class="form-control search-input" id="<%= searchInputId %>" autocomplete="off" placeholder="<%= searchInputPlaceholder %>" />' +
+                '<input type="search" class="form-control search-input" id="<%- searchInputId %>" autocomplete="off" placeholder="<%- searchInputPlaceholder %>" />' +
             '</div>'
         );
         return input({

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -12,15 +12,15 @@ hqDefine('hqwebapp/js/multiselect_utils', [
     var multiselect_utils = {};
 
     var _renderHeader = function (title, action, search) {
-        if (!action){
-            action = '';
-        }
-        if (!search){
-            search = '';
-        }
-        var templateStr = '<div class="ms-header">' + title + action + '</div>' + search;
-        return  _.template(templateStr);
-    };
+        // Since action and search are created from _renderAction() and _renderSearch()
+        // and the variables the functions are esacaped so it would be safe to use them with <%=
+        var header = _.template('<div class="ms-header"><%- headerTitle %><%= actionButton %></div><%= searchInput %>');
+        return header({
+            headerTitle: title,
+            actionButton: action || '',
+            searchInput: search || '',
+        });
+    }
 
     var _renderAction = function (buttonId, buttonClass, buttonIcon, text) {
         var action = _.template(

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -20,7 +20,7 @@ hqDefine('hqwebapp/js/multiselect_utils', [
             actionButton: action || '',
             searchInput: search || '',
         });
-    }
+    };
 
     var _renderAction = function (buttonId, buttonClass, buttonIcon, text) {
         var action = _.template(

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-mapping.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-mapping.js
@@ -300,7 +300,7 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-mapping', function () {
             });
             $modalDiv.koApplyBindings({
                 modalTitle: ko.computed(function () {
-                    return _.template(gettext('Edit mapping for <%= property %>'))({
+                    return _.template(gettext('Edit mapping for <%- property %>'))({
                         property: m.getPropertyName(),
                     });
                 }),


### PR DESCRIPTION

## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-11428

This is one of the PRs from the series of PRs that will be replacing `<%=` to `<%-`.

This PR specifically covers changes in HQ WebApps.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA plan is described here https://dimagi-dev.atlassian.net/browse/QA-2854?focusedCommentId=133830 
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The local testing and notes have been updated in the doc https://docs.google.com/spreadsheets/d/1oBLABIn41A7LbslViK997GmaQsQ5kRUJNDyn9WzFpGc/edit#gid=0
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 