### PR TITLE
Escape html in users

### DIFF
--- a/corehq/apps/users/static/users/js/filtered_download.js
+++ b/corehq/apps/users/static/users/js/filtered_download.js
@@ -26,7 +26,7 @@ hqDefine('users/js/filtered_download', [
             data: currentFilters,
             success: function (data) {
                 var count = data.count;
-                var template = count === 1 ? gettext("Download <%= count %> user") : gettext("Download <%= count %> users");
+                var template = count === 1 ? gettext("Download <%- count %> user") : gettext("Download <%- count %> users");
                 $('.submit_button').text(_.template(template)({count: count}));
             },
             error: function () {

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -367,7 +367,7 @@ hqDefine('users/js/roles',[
                 var title = gettext("Delete Role: ") + role.name();
                 var context = {role: role.name()};
                 var modalConfirmation = _.template(gettext(
-                    "Are you sure you want to delete the role <%= role %>?"
+                    "Are you sure you want to delete the role <%- role %>?"
                 ))(context);
                 var roleCopy = UserRole.wrap(UserRole.unwrap(role));
 

--- a/corehq/apps/users/static/users/js/web_users.js
+++ b/corehq/apps/users/static/users/js/web_users.js
@@ -94,7 +94,7 @@ hqDefine("users/js/web_users",[
             return self.daysRemaining() < 0;
         });
         self.daysRemainingText = ko.computed(function () {
-            return _.template(gettext("<%= days %> days remaining"))({
+            return _.template(gettext("<%- days %> days remaining"))({
                 days: Math.floor(self.daysRemaining()),
             });
         });


### PR DESCRIPTION

## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-11428

This is one of the PRs from the series of PRs that will be replacing `<%=` to `<%-`.

This PR specifically covers changes in Users

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA plan is described here https://dimagi-dev.atlassian.net/browse/QA-2854?focusedCommentId=133830 
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The local testing and notes have been updated in the doc https://docs.google.com/spreadsheets/d/1oBLABIn41A7LbslViK997GmaQsQ5kRUJNDyn9WzFpGc/edit#gid=0
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 