### PR TITLE
Sanitize mark_safe usages for reports

### DIFF
--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -316,7 +316,11 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
 
     def _format_date(self, date):
         if date:
-            return f'<div>{naturaltime(date)}</div><div>{date.strftime(SERVER_DATETIME_FORMAT)}</div>'
+            return format_html(
+                '<div>{}</div><div>{}</div>',
+                naturaltime(date),
+                date.strftime(SERVER_DATETIME_FORMAT)
+            )
         return "---"
 
     def _hyperlink_diff_url(self, diff_url):

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -320,9 +320,13 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
         return "---"
 
     def _hyperlink_diff_url(self, diff_url):
-        return f'<a href="{diff_url}">Diff with previous</a>'
+        return format_html('<a href="{}">Diff with previous</a>', diff_url)
 
     def _shorten_and_hyperlink_commit(self, commit_sha):
         if commit_sha:
-            return f'<a href="https://github.com/dimagi/commcare-hq/commit/{commit_sha}">{commit_sha[:7]}</a>'
+            return format_html(
+                '<a href="https://github.com/dimagi/commcare-hq/commit/{full_sha}">{abbrev_sha}</a>',
+                full_sha=commit_sha,
+                abbrev_sha=commit_sha[:7]
+            )
         return None

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -1,5 +1,6 @@
 from django.urls import reverse
 from django.utils.functional import cached_property
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 from django.contrib.humanize.templatetags.humanize import naturaltime
@@ -254,7 +255,11 @@ class UserListReport(GetParamsMixin, AdminReport):
         return self._users_query().count()
 
     def _user_link(self, username):
-        return f'<a href="{self._user_lookup_url}?q={username}">{username}</a>'
+        return format_html(
+            '<a href="{url}?q={username}">{username}</a>',
+            url=self._user_lookup_url,
+            username=username
+        )
 
     @cached_property
     def _user_lookup_url(self):

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -46,10 +46,10 @@ class DeviceLogSoftAssertReport(BaseDeviceLogReport, AdminReport):
     emailable = False
     default_rows = 10
 
-    _username_fmt = "%(username)s"
-    _device_users_fmt = "%(username)s"
-    _device_id_fmt = "%(device)s"
-    _log_tag_fmt = "<label class='%(classes)s'>%(text)s</label>"
+    _username_fmt = "{username}"
+    _device_users_fmt = "{username}"
+    _device_id_fmt = "{device}"
+    _log_tag_fmt = "<label class='{classes}'>{text}</label>"
 
     @property
     def selected_domain(self):

--- a/corehq/apps/reports/display.py
+++ b/corehq/apps/reports/display.py
@@ -1,4 +1,5 @@
 from django.utils.translation import ugettext as _
+from django.utils.html import format_html
 
 from couchdbkit.exceptions import ResourceNotFound
 
@@ -30,10 +31,11 @@ class FormDisplay(object):
 
     @property
     def form_data_link(self):
-        return "<a class='ajax_dialog' target='_new' href='%(url)s'>%(text)s</a>" % {
-            "url": absolute_reverse('render_form_data', args=[self.report.domain, self.form['_id']]),
-            "text": _("View Form")
-        }
+        return format_html(
+            "<a class='ajax_dialog' target='_new' href='{url}'>{text}</a>",
+            url=absolute_reverse('render_form_data', args=[self.report.domain, self.form['_id']]),
+            text=_("View Form")
+        )
 
     @property
     def username(self):

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
+from django.utils.functional import lazy
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
@@ -25,6 +26,9 @@ from .base import (
     BaseReportFilter,
     BaseSingleOptionFilter,
 )
+
+#TODO: replace with common code
+mark_safe_lazy = lazy(mark_safe, str)
 
 
 class UserOrGroupFilter(BaseSingleOptionFilter):
@@ -210,8 +214,7 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         user_types = emwf.selected_user_types(mobile_user_and_group_slugs)
         group_ids = emwf.selected_group_ids(mobile_user_and_group_slugs)
     """
-    location_search_help = ugettext_lazy(mark_safe(
-        '<i class="fa fa-info-circle"></i> '
+    location_search_help = mark_safe_lazy(ugettext_lazy(  # nosec: no user input
         '<a href="https://confluence.dimagi.com/display/commcarepublic/Search+for+Locations"'
         'target="_blank">Advanced Search:</a> '
         'Put your location name in quotes to show only exact matches. To more '
@@ -225,11 +228,10 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
     placeholder = ugettext_lazy("Add users and groups to filter this report.")
     is_cacheable = False
     options_url = 'emwf_options_all_users'
-    filter_help_inline = ugettext_lazy(mark_safe("""
-        <i class="fa fa-info-circle"></i> See
-        <a href="https://confluence.dimagi.com/display/commcarepublic/Report+and+Export+Filters"'
-        ' target="_blank"> Filter Definitions</a>.
-    """))
+    filter_help_inline = mark_safe_lazy(ugettext_lazy(  # nosec: no user input
+        '<i class="fa fa-info-circle"></i> See '
+        '<a href="https://confluence.dimagi.com/display/commcarepublic/Report+and+Export+Filters"'
+        ' target="_blank"> Filter Definitions</a>.'))
 
     @property
     @memoized

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -161,7 +161,7 @@ def absolute_path_from_context(path, path_context):
 def _html_interpolate_output_refs(itext_value, context):
     if hasattr(itext_value, 'with_refs'):
         underline_template = '<u>&nbsp;&nbsp;%s&nbsp;&nbsp;</u>'
-        return mark_safe(
+        return mark_safe(  # nosec: output is escaped
             itext_value.with_refs(
                 context,
                 processor=lambda x: underline_template % (

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -15,6 +15,7 @@ from django.template.context import RequestContext
 from django.template.loader import render_to_string
 from django.urls import NoReverseMatch
 from django.utils.translation import ugettext
+from django.utils.html import conditional_escape
 
 from celery.utils.log import get_task_logger
 from memoized import memoized
@@ -45,6 +46,14 @@ from corehq.util.view_utils import absolute_reverse, request_as_dict, reverse
 from corehq import toggles
 
 CHART_SPAN_MAP = {1: '10', 2: '6', 3: '4', 4: '3', 5: '2', 6: '2'}
+
+
+def _sanitize_rows(rows):
+    return [_sanitize_row(row) for row in rows]
+
+
+def _sanitize_row(row):
+    return [conditional_escape(col) for col in row]
 
 
 class GenericReportView(object):
@@ -897,7 +906,7 @@ class GenericTabularReport(GenericReportView):
             self.pagination.start (skip)
             self.pagination.count (limit)
         """
-        rows = list(self.rows)
+        rows = _sanitize_rows(self.rows)
         total_records = self.total_records
         if not isinstance(total_records, int):
             raise ValueError("Property 'total_records' should return an int.")

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -11,9 +11,9 @@ from django.http import (
     JsonResponse,
 )
 from django.shortcuts import render
-from django.template.context import RequestContext
 from django.template.loader import render_to_string
 from django.urls import NoReverseMatch
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext
 from django.utils.html import conditional_escape
 
@@ -1104,10 +1104,11 @@ class GenericTabularReport(GenericReportView):
         return context
 
     def table_cell(self, value, html=None, zerostyle=False):
-        styled_value = '<span class="text-muted">0</span>' if zerostyle and value == 0 else value
+        empty_indicator = mark_safe('<span class="text-muted">0</span>')  # nosec: no user input
+        styled_value = empty_indicator if zerostyle and value == 0 else value
         return dict(
             sort_key=value,
-            html="%s" % styled_value if html is None else html
+            html=styled_value if html is None else html
         )
 
 

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -53,7 +53,16 @@ def _sanitize_rows(rows):
 
 
 def _sanitize_row(row):
-    return [conditional_escape(col) for col in row]
+    return [_sanitize_col(col) for col in row]
+
+
+def _sanitize_col(col):
+    if isinstance(col, str):
+        return conditional_escape(col)
+
+    # HACK: dictionaries make it here. The dictionaries I've seen have an 'html' key
+    # which I expect to be sanitized already, but there is no guaranteee
+    return col
 
 
 class GenericReportView(object):

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -3,8 +3,7 @@ from datetime import datetime
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils import html
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop
 
@@ -110,7 +109,6 @@ class TempCommCareUser(CommCareUser):
             _id=uuid,
             date_joined=datetime.utcnow(),
             is_active=False,
-            metadata={},
             first_name='',
             last_name='',
             filter_flag=filter_flag
@@ -126,11 +124,11 @@ class TempCommCareUser(CommCareUser):
     @property
     def username_in_report(self):
         if self.filter_flag == HQUserType.UNKNOWN:
-            final = mark_safe('%s <strong>[unregistered]</strong>' % html.escape(self.username))
+            final = format_html('{} <strong>[unregistered]</strong>', self.username)
         elif self.filter_flag == HQUserType.DEMO_USER:
-            final = mark_safe('<strong>%s</strong>' % html.escape(self.username))
+            final = format_html('<strong>{}</strong>', self.username)
         else:
-            final = mark_safe('<strong>%s</strong> (%s)' % tuple(map(html.escape, [self.username, self.user_id])))
+            final = format_html('<strong>{}</strong> ({})', self.username, self.user_id)
         return final
 
     @property

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.contrib import messages
-from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 
@@ -154,7 +153,7 @@ class CaseListReport(CaseListMixin, ProjectInspectionReport, ReportDataSource):
     def get_subpages(cls):
         def _get_case_name(request=None, **context):
             if 'case' in context and context['case'].name:
-                return mark_safe(context['case'].name)
+                return context['case'].name
             else:
                 return _('View Case')
 

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -2,10 +2,9 @@ import datetime
 import json
 
 import pytz
-from django.core import cache
 from django.template.defaultfilters import yesno
 from django.urls import NoReverseMatch
-from django.utils import html
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 
 import dateutil
@@ -170,8 +169,10 @@ class CaseDisplay:
     def case_link(self):
         url = self.case_detail_url
         if url:
-            return html.mark_safe("<a class='ajax_dialog' href='%s' target='_blank'>%s</a>" % (
-                self.case_detail_url, html.escape(self.case_name_display)))
+            return format_html(
+                "<a class='ajax_dialog' href='{}' target='_blank'>{}</a>",
+                self.case_detail_url,
+                self.case_name_display)
         else:
             return "%s (bad ID format)" % self.case_name
 
@@ -269,6 +270,7 @@ class SafeCaseDisplay(object):
             link = absolute_reverse('case_data', args=[self.case.get("domain"), self.case.get('_id')])
         except NoReverseMatch:
             return _("No link found")
-        return html.mark_safe(
-            "<a class='ajax_dialog' href='{}' target='_blank'>{}</a>".format(link, _("View Case"))
-        )
+        return format_html(
+            "<a class='ajax_dialog' href='{}' target='_blank'>{}</a>",
+            link,
+            _("View Case"))

--- a/corehq/apps/reports/standard/cases/filters.py
+++ b/corehq/apps/reports/standard/cases/filters.py
@@ -3,6 +3,7 @@ from collections import Counter
 
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy
+from django.utils.functional import lazy
 
 from corehq.apps.app_manager.app_schemas.case_properties import (
     all_case_properties_by_domain,
@@ -13,11 +14,14 @@ from corehq.apps.case_search.const import (
 )
 from corehq.apps.reports.filters.base import BaseSimpleFilter
 
+# TODO: Replace with library method
+mark_safe_lazy = lazy(mark_safe, str)
+
 
 class CaseSearchFilter(BaseSimpleFilter):
     slug = 'search_query'
     label = ugettext_lazy("Search")
-    help_inline = mark_safe(ugettext_lazy(
+    help_inline = mark_safe_lazy(ugettext_lazy(  # nosec: no user input
         'Search any text, or use a targeted query. For more info see the '
         '<a href="https://wiki.commcarehq.org/display/commcarepublic/'
         'Advanced+Case+Search" target="_blank">Case Search</a> help page'

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -5,6 +5,7 @@ from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.db.models import Q
 from django.urls import reverse
 from django.utils.functional import cached_property
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 
@@ -508,11 +509,12 @@ def _fmt_date(date, include_sort_key=True):
         return _bootstrap_class(delta, timedelta(days=7), timedelta(days=3))
 
     if not date:
-        text = '<span class="label label-default">{0}</span>'.format(_("Never"))
+        text = format_html('<span class="label label-default">{}</span>', _("Never"))
     else:
-        text = '<span class="{cls}">{text}</span>'.format(
-                cls=_timedelta_class(datetime.utcnow() - date),
-                text=_(_naturaltime_with_hover(date)),
+        text = format_html(
+            '<span class="{cls}">{text}</span>',
+            cls=_timedelta_class(datetime.utcnow() - date),
+            text=_(_naturaltime_with_hover(date)),
         )
     if include_sort_key:
         return format_datatables_data(text, _get_sort_key(date))
@@ -521,7 +523,7 @@ def _fmt_date(date, include_sort_key=True):
 
 
 def _naturaltime_with_hover(date):
-    return '<span title="{}">{}</span>'.format(date, naturaltime(date) or '---')
+    return format_html('<span title="{}">{}</span>', date, naturaltime(date) or '---')
 
 
 def _bootstrap_class(obj, severe, warn):

--- a/corehq/apps/reports/standard/forms/reports.py
+++ b/corehq/apps/reports/standard/forms/reports.py
@@ -1,4 +1,5 @@
 from django.urls import NoReverseMatch, reverse
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop
 from django.views import View
@@ -124,10 +125,11 @@ class SubmissionErrorReport(DeploymentsReport):
                 else:
                     view_name = 'download_form'
                 try:
-                    return "<a class='ajax_dialog' href='%(url)s'>%(text)s</a>" % {
-                        "url": reverse(view_name, args=[self.domain, doc_id]),
-                        "text": _("View Form")
-                    }
+                    return format_html(
+                        "<a class='ajax_dialog' href='{url}'>{text}</a>",
+                        url=reverse(view_name, args=[self.domain, doc_id]),
+                        text=_("View Form")
+                    )
                 except NoReverseMatch:
                     return 'unable to view form'
 

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -1,4 +1,3 @@
-from django.utils.safestring import mark_safe
 from django.utils.translation import get_language
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop
@@ -164,7 +163,7 @@ class SubmitHistory(SubmitHistoryMixin, ProjectReport):
         def _get_form_name(request=None, **context):
             if 'instance' in context:
                 try:
-                    return mark_safe(context['instance'].form_data['@name'])
+                    return context['instance'].form_data['@name']
                 except KeyError:
                     pass
             return _('View Form')

--- a/corehq/apps/reports/standard/message_event_display.py
+++ b/corehq/apps/reports/standard/message_event_display.py
@@ -2,6 +2,7 @@ import cgi
 from collections import namedtuple
 
 from django.urls import reverse
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 
 from corehq.apps.data_interfaces.models import AutomaticUpdateRule
@@ -114,7 +115,7 @@ def _get_keyword_display(keyword_id, content_cache):
     else:
         urlname = (EditStructuredKeywordView.urlname if keyword.is_structured_sms()
                    else EditNormalKeywordView.urlname)
-        display = '<a target="_blank" href="%s">%s</a>' % (
+        display = format_html('<a target="_blank" href="{}">{}</a>',
             reverse(urlname, args=[keyword.domain, keyword_id]),
             keyword.description,
         )
@@ -156,7 +157,7 @@ def _get_scheduled_broadcast_display(domain, broadcast_id, content_cache):
         if broadcast.deleted:
             result = _("(Deleted Broadcast)")
         else:
-            result = '<a target="_blank" href="%s">%s</a>' % (
+            result = format_html('<a target="_blank" href="{}">{}</a>',
                 reverse(EditScheduleView.urlname,
                         args=[domain, EditScheduleView.SCHEDULED_BROADCAST, broadcast_id]),
                 broadcast.name,
@@ -179,7 +180,7 @@ def _get_immediate_broadcast_display(domain, broadcast_id, content_cache):
         if broadcast.deleted:
             result = _("(Deleted Broadcast)")
         else:
-            result = '<a target="_blank" href="%s">%s</a>' % (
+            result = format_html('<a target="_blank" href="{}">{}</a>',
                 reverse(EditScheduleView.urlname,
                         args=[domain, EditScheduleView.IMMEDIATE_BROADCAST, broadcast_id]),
                 broadcast.name,
@@ -202,7 +203,7 @@ def _get_case_rule_display(domain, rule_id, content_cache):
         if rule.deleted:
             result = _("(Deleted Conditional Alert)")
         else:
-            result = '<a target="_blank" href="%s">%s</a>' % (
+            result = format_html('<a target="_blank" href="{}">{}</a>',
                 reverse(EditConditionalAlertView.urlname,
                         args=[domain, rule_id]),
                 rule.name,

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -143,13 +143,10 @@ class WorkerMonitoringFormReportTableBase(WorkerMonitoringReportTableBase):
 
         from corehq.apps.reports.standard.inspect import SubmitHistory
 
-        user_link_template = '<a href="%(link)s">%(username)s</a>'
+        user_link_template = '<a href="{link}">{username}</a>'
         base_link = SubmitHistory.get_url(domain=self.domain)
         link = "{baselink}?{params}".format(baselink=base_link, params=urlencode(params))
-        return user_link_template % {
-            'link': link,
-            'username': user.username_in_report,
-        }
+        return format_html(user_link_template, link=link, username=user.username_in_report)
 
 
 class MultiFormDrilldownMixin(object):
@@ -1244,8 +1241,8 @@ class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase
             return ", ".join(status)
 
     def _view_form_link(self, instance_id):
-        return '<a class="btn btn-default" href="%s">View Form</a>' % absolute_reverse(
-            'render_form_data', args=[self.domain, instance_id])
+        return format_html('<a class="btn btn-default" href="{}">View Form</a>', absolute_reverse(
+            'render_form_data', args=[self.domain, instance_id]))
 
 
 class WorkerMonitoringChartBase(ProjectReport, ProjectReportParametersMixin):

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1131,7 +1131,7 @@ class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase
         try:
             return self._get_rows()
         except TooMuchDataError as e:
-            return [['<span class="label label-danger">{}</span>'.format(e)] + ['--'] * 5]
+            return [[format_html('<span class="label label-danger">{}</span>', e)] + ['--'] * 5]
 
     def _get_rows(self):
         rows = []
@@ -1209,7 +1209,7 @@ class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase
 
     def _format_td_status(self, td, use_label=True):
         status = list()
-        template = '<span class="label %(klass)s">%(status)s</span>'
+        template = '<span class="label {klass}">{status}</span>'
         klass = "label-default"
         if isinstance(td, int):
             td = datetime.timedelta(seconds=td)
@@ -1236,7 +1236,7 @@ class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase
                     status = [_("same")]
 
         if use_label:
-            return template % dict(status=", ".join(status), klass=klass)
+            return format_html(template, status=", ".join(status), klass=klass)
         else:
             return ", ".join(status)
 
@@ -1564,7 +1564,7 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
 
     @staticmethod
     def _html_anchor_tag(href, value):
-        return '<a href="{}" target="_blank">{}</a>'.format(href, value)
+        return format_html('<a href="{}" target="_blank">{}</a>', href, value)
 
     @staticmethod
     def _make_url(base_url, params):

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -733,9 +733,9 @@ class SubmissionsByFormReport(WorkerMonitoringFormReportTableBase,
                     ])
                 row_sum = sum(row)
                 row = (
-                    [self.get_user_link(simplified_user)] +
-                    [self.table_cell(row_data, zerostyle=True) for row_data in row] +
-                    [self.table_cell(row_sum, "<strong>%s</strong>" % row_sum)]
+                    [self.get_user_link(simplified_user)]
+                    + [self.table_cell(row_data, zerostyle=True) for row_data in row]
+                    + [self.table_cell(row_sum, format_html("<strong>{}</strong>", row_sum))]
                 )
                 totals = [totals[i] + col.get('sort_key')
                           for i, col in enumerate(row[1:])]

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -7,7 +7,7 @@ from django.db.models import Count, F, Q
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.functional import cached_property
-from django.utils.html import escape, format_html
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
@@ -1431,7 +1431,7 @@ class ScheduleInstanceReport(ProjectReport, ProjectReportParametersMixin, Generi
         return ServerTime(timestamp).user_time(self.timezone).done().strftime('%Y-%m-%d %H:%M:%S')
 
     def get_link_display(self, href, text):
-        return '<a target="_blank" href="%s">%s</a>' % (href, escape(text))
+        return format_html('<a target="_blank" href="{}">{}</a>', href, text)
 
     def get_case_display(self, case):
         from corehq.apps.reports.views import CaseDataView

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -7,7 +7,7 @@ from django.db.models import Count, F, Q
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.functional import cached_property
-from django.utils.html import escape
+from django.utils.html import escape, format_html
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
@@ -128,12 +128,13 @@ class MessagesReport(ProjectReport, ProjectReportParametersMixin, GenericTabular
         )
 
     def get_user_link(self, user):
-        user_link_template = '<a href="%(link)s">%(username)s</a>'
-        user_link = user_link_template % {
-            "link": absolute_reverse(EditCommCareUserView.urlname,
-                                     args=[self.domain, user._id]),
-            "username": user.username_in_report
-        }
+        user_link_template = '<a href="{link}">{username}</a>'
+        user_link = format_html(
+            user_link_template,
+            link=absolute_reverse(EditCommCareUserView.urlname,
+                args=[self.domain, user._id]),
+            username=user.username_in_report
+        )
         return self.table_cell(user.raw_username, user_link)
 
     @property
@@ -221,7 +222,7 @@ class BaseCommConnectLogReport(ProjectReport, ProjectReportParametersMixin, Gene
         username = username or "-"
         contact_type = contact_type or _("Unknown")
         if url:
-            ret = self.table_cell(username, '<a target="_blank" href="%s">%s</a>' % (url, username))
+            ret = self.table_cell(username, format_html('<a target="_blank" href="{}">{}</a>', url, username))
         else:
             ret = self.table_cell(username, username)
         ret['raw'] = "|||".join([username, contact_type,
@@ -600,7 +601,8 @@ class BaseMessagingEventReport(BaseCommConnectLogReport):
 
     def get_event_detail_link(self, event):
         display_text = _('View Details')
-        display = '<a target="_blank" href="/a/%s/reports/message_event_detail/?id=%s">%s</a>' % (
+        display = format_html(
+            '<a target="_blank" href="/a/{}/reports/message_event_detail/?id={}">{}</a>',
             self.domain,
             event.pk,
             display_text,
@@ -615,7 +617,8 @@ class BaseMessagingEventReport(BaseCommConnectLogReport):
         if not subevent.xforms_session_id:
             return self._fmt(form_name)
         else:
-            display = '<a target="_blank" href="%s">%s</a>' % (
+            display = format_html(
+                '<a target="_blank" href="{}">{}</a>',
                 self.get_survey_detail_url(subevent),
                 form_name,
             )

--- a/corehq/apps/reports/templates/reports/async/partials/tabular_cell.html
+++ b/corehq/apps/reports/templates/reports/async/partials/tabular_cell.html
@@ -1,4 +1,4 @@
 {% if not col.unwrap %}<td{% if not col or col.html != None and not col.html %} class="null-entry"{% endif %}>{% endif %}
   <span title="{% if col.sort_key != "" %}{{ col.sort_key }}{% else %}{{ col }}{% endif %}"></span>
-  {% if col.html != None %}{{ col.html|safe }}{% else %}{{ col }}{% endif %}
+  {% if col.html != None %}{{ col.html }}{% else %}{{ col }}{% endif %}
 {% if not col.unwrap %}</td>{% endif %}

--- a/corehq/apps/reports/templates/reports/async/partials/tabular_cell.html
+++ b/corehq/apps/reports/templates/reports/async/partials/tabular_cell.html
@@ -1,4 +1,4 @@
 {% if not col.unwrap %}<td{% if not col or col.html != None and not col.html %} class="null-entry"{% endif %}>{% endif %}
   <span title="{% if col.sort_key != "" %}{{ col.sort_key }}{% else %}{{ col }}{% endif %}"></span>
-  {% if col.html != None %}{{ col.html|safe }}{% else %}{{ col|safe }}{% endif %}
+  {% if col.html != None %}{{ col.html|safe }}{% else %}{{ col }}{% endif %}
 {% if not col.unwrap %}</td>{% endif %}

--- a/corehq/apps/reports/tests/test_models.py
+++ b/corehq/apps/reports/tests/test_models.py
@@ -1,0 +1,32 @@
+from django.test import SimpleTestCase
+from django.utils.safestring import SafeText
+from unittest import skip
+
+from ..models import TempCommCareUser
+
+
+# NOTE: I do not think this class is used, as the constructor throws an exception
+@skip("constructor doesnt work")
+class TestTempUser_UsernameInReport(SimpleTestCase):
+    def test_unknown_user_generates_correct_template(self):
+        user = TempCommCareUser('test_domain', 'unknown_user', 'id')
+        html = user.username_in_report
+        self.assertEqual(html, 'unknown_user <strong>[unregistered]</strong>')
+        self.assertIsInstance(html, SafeText)
+
+    def test_escapes_unknown_username(self):
+        user = TempCommCareUser('test_domain', 'unknown&user', 'id')
+        html = user.username_in_report
+        self.assertEqual(html, 'unknown&amp;user <strong>[unregistered]</strong>')
+
+    def test_demo_user_generates_correct_template(self):
+        user = TempCommCareUser('test_domain', 'demo_user', 'id')
+        html = user.username_in_report
+        self.assertEqual(html, '<strong>demo_user</strong>')
+        self.assertIsInstance(html, SafeText)
+
+    def test_admin_user_generates_correct_template(self):
+        user = TempCommCareUser('test_domain', 'admin', 'id')
+        html = user.username_in_report
+        self.assertEqual(html, '<strong>admin</strong> (id)')
+        self.assertIsInstance(html, SafeText)

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -257,7 +257,7 @@ def get_simplified_users(user_es_query):
 def format_datatables_data(text, sort_key, raw=None):
     # todo: this is redundant with report.table_cell()
     # should remove/refactor one of them away
-    data = {"html": html.conditional_escape(text), "sort_key": sort_key}
+    data = {"html": text, "sort_key": sort_key}
     if raw is not None:
         data['raw'] = raw
     return data

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -7,9 +7,6 @@ from importlib import import_module
 
 from django.conf import settings
 from django.http import Http404
-from django.utils import html
-from django.utils.html import format_html
-from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
 import pytz

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -219,7 +219,7 @@ def _report_user_dict(user):
                         else username)
         first = user.get('first_name', '')
         last = user.get('last_name', '')
-        username_in_report = _get_username_html_fragment(raw_username, first, last)
+        username_in_report = _get_username_fragment(raw_username, first, last)
         info = SimplifiedUserInfo(
             user_id=user.get('_id', ''),
             username_in_report=username_in_report,
@@ -234,12 +234,12 @@ def _report_user_dict(user):
 
 
 # TODO: This is very similar code to what exists in apps/users/util/user_display_string
-def _get_username_html_fragment(username, first='', last=''):
+def _get_username_fragment(username, first='', last=''):
     full_name = ("%s %s" % (first, last)).strip()
 
-    result = mark_safe(html.escape(username))  # nosec: escaped
+    result = username
     if full_name:
-        result = format_html('{} "{}"', result, full_name)
+        result = '{} "{}"'.format(result, full_name)
 
     return result
 

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -7,7 +7,9 @@ from importlib import import_module
 
 from django.conf import settings
 from django.http import Http404
-from django.utils import html, safestring
+from django.utils import html
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
 import pytz
@@ -231,14 +233,15 @@ def _report_user_dict(user):
         return info
 
 
+# TODO: This is very similar code to what exists in apps/users/util/user_display_string
 def _get_username_html_fragment(username, first='', last=''):
     full_name = ("%s %s" % (first, last)).strip()
 
-    def parts():
-        yield '%s' % html.escape(username)
-        if full_name:
-            yield ' "%s"' % html.escape(full_name)
-    return safestring.mark_safe(''.join(parts()))
+    result = mark_safe(html.escape(username))  # nosec: escaped
+    if full_name:
+        result = format_html('{} "{}"', result, full_name)
+
+    return result
 
 
 def get_simplified_users(user_es_query):

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -257,7 +257,7 @@ def get_simplified_users(user_es_query):
 def format_datatables_data(text, sort_key, raw=None):
     # todo: this is redundant with report.table_cell()
     # should remove/refactor one of them away
-    data = {"html": text, "sort_key": sort_key}
+    data = {"html": html.conditional_escape(text), "sort_key": sort_key}
     if raw is not None:
         data['raw'] = raw
     return data

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -217,13 +217,7 @@ def _report_user_dict(user):
                         else username)
         first = user.get('first_name', '')
         last = user.get('last_name', '')
-        full_name = ("%s %s" % (first, last)).strip()
-
-        def parts():
-            yield '%s' % html.escape(raw_username)
-            if full_name:
-                yield ' "%s"' % html.escape(full_name)
-        username_in_report = safestring.mark_safe(''.join(parts()))
+        username_in_report = _get_username_html_fragment(raw_username, first, last)
         info = SimplifiedUserInfo(
             user_id=user.get('_id', ''),
             username_in_report=username_in_report,
@@ -235,6 +229,16 @@ def _report_user_dict(user):
             group_ids = user['__group_ids']
             info.__group_ids = group_ids if isinstance(group_ids, list) else [group_ids]
         return info
+
+
+def _get_username_html_fragment(username, first='', last=''):
+    full_name = ("%s %s" % (first, last)).strip()
+
+    def parts():
+        yield '%s' % html.escape(username)
+        if full_name:
+            yield ' "%s"' % html.escape(full_name)
+    return safestring.mark_safe(''.join(parts()))
 
 
 def get_simplified_users(user_es_query):

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -22,7 +22,8 @@ from django.http import (
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
-from django.utils.safestring import mark_safe
+# from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import get_language
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
@@ -1090,7 +1091,9 @@ class CaseDataView(BaseProjectReportSectionView):
             "dynamic_properties": dynamic_data,
             "dynamic_properties_as_table": dynamic_properties,
             "show_properties_edit": show_properties_edit,
-            "case_actions": mark_safe(json.dumps(wrapped_case.actions())),
+            #TODO: Figure out if this is safe to just remove -- it doesn't appear to be referenced
+            #  within reports/reportdata/case_data.html
+            # "case_actions": mark_safe(json.dumps(wrapped_case.actions())),
             "timezone": timezone,
             "tz_abbrev": tz_abbrev,
             "ledgers": ledger_map,
@@ -1324,14 +1327,15 @@ def close_case_view(request, domain, case_id):
     else:
         device_id = __name__ + ".close_case_view"
         form_id = close_case(case_id, domain, request.couch_user, device_id)
-        msg = _('''Case {name} has been closed.
+        msg = format_html(
+            _('''Case {name} has been closed.
             <a href="{url}" class="post-link">Undo</a>.
             You can also reopen the case in the future by archiving the last form in the case history.
-        '''.format(
+        '''),
             name=case.name,
             url=reverse('undo_close_case', args=[domain, case_id, form_id]),
-        ))
-        messages.success(request, mark_safe(msg), extra_tags='html')
+        )
+        messages.success(request, msg, extra_tags='html')
     return HttpResponseRedirect(reverse('case_data', args=[domain, case_id]))
 
 
@@ -1788,7 +1792,7 @@ class EditFormInstance(View):
         instance_id = self.kwargs.get('instance_id', None)
 
         def _error(msg):
-            messages.error(request, mark_safe(msg))
+            messages.error(request, msg)
             url = reverse('render_form_data', args=[domain, instance_id])
             return HttpResponseRedirect(url)
 
@@ -1845,20 +1849,20 @@ class EditFormInstance(View):
                 edit_session_data['case_id'] = non_parents[0].caseblock.get(const.CASE_ATTR_ID)
                 case = CaseAccessors(domain).get_case(edit_session_data['case_id'])
                 if case.closed:
-                    return _error(_(
+                    message = format_html(_(
                         'Case <a href="{case_url}">{case_name}</a> is closed. Please reopen the '
-                        'case before editing the form'
-                    ).format(
+                        'case before editing the form'),
                         case_url=reverse('case_data', args=[domain, case.case_id]),
                         case_name=case.name,
-                    ))
-                elif case.is_deleted:
-                    return _error(
-                        _('Case <a href="{case_url}">{case_name}</a> is deleted. Cannot edit this form.').format(
-                            case_url=reverse('case_data', args=[domain, case.case_id]),
-                            case_name=case.name,
-                        )
                     )
+                    return _error(message)
+                elif case.is_deleted:
+                    message = format_html(_(
+                        'Case <a href="{case_url}">{case_name}</a> is deleted. Cannot edit this form.'),
+                        case_url=reverse('case_data', args=[domain, case.case_id]),
+                        case_name=case.name,
+                    )
+                    return _error(message)
 
         edit_session_data['is_editing'] = True
         edit_session_data['function_context'] = {
@@ -1934,8 +1938,8 @@ def archive_form(request, domain, instance_id):
     }
 
     msg_template = "{notif} <a href='{url}' class='post-link'>{undo}</a>" if instance.is_archived else '{notif}'
-    msg = msg_template.format(**params)
-    messages.add_message(request, notify_level, mark_safe(msg), extra_tags='html')
+    msg = format_html(msg_template, **params)
+    messages.add_message(request, notify_level, msg, extra_tags='html')
 
     return HttpResponseRedirect(redirect)
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -22,7 +22,6 @@ from django.http import (
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
-# from django.utils.safestring import mark_safe
 from django.utils.html import format_html
 from django.utils.translation import get_language
 from django.utils.translation import ugettext as _
@@ -1091,9 +1090,6 @@ class CaseDataView(BaseProjectReportSectionView):
             "dynamic_properties": dynamic_data,
             "dynamic_properties_as_table": dynamic_properties,
             "show_properties_edit": show_properties_edit,
-            #TODO: Figure out if this is safe to just remove -- it doesn't appear to be referenced
-            #  within reports/reportdata/case_data.html
-            # "case_actions": mark_safe(json.dumps(wrapped_case.actions())),
             "timezone": timezone,
             "tz_abbrev": tz_abbrev,
             "ledgers": ledger_map,

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -15,6 +15,7 @@ from django.http.response import HttpResponseServerError
 from django.shortcuts import redirect, render
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop
+from django.utils.html import escape
 
 from braces.views import JSONResponseMixin
 from memoized import memoized
@@ -407,6 +408,14 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     def headers(self):
         return DataTablesHeader(*[col.data_tables_column for col in self.data_source.inner_columns])
 
+    @classmethod
+    def sanitize_page(cls, page):
+        result = []
+        for row in page:
+            result.append({k: escape(v) for (k, v) in row.items()})
+
+        return result
+
     def get_ajax(self, params):
         sort_column = params.get('iSortCol_0')
         sort_order = params.get('sSortDir_0', 'ASC')
@@ -425,6 +434,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
                 )
 
             page = list(data_source.get_data(start=datatables_params.start, limit=datatables_params.count))
+            page = self.sanitize_page(page)
             total_records = data_source.get_total_records()
             total_row = data_source.get_total_row() if data_source.has_total_row else None
         except UserReportsError as e:
@@ -552,6 +562,14 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
         return redirect(DownloadUCRStatusView.urlname, self.domain, download.download_id, self.report_config_id)
 
     @classmethod
+    def sanitize_export_table(cls, table):
+        result = []
+        for row in table:
+            result.append([escape(x) for x in row])
+
+        return result
+
+    @classmethod
     def report_preview_data(cls, domain, temp_report):
 
         with tmp_report_config(temp_report) as report_config:
@@ -571,7 +589,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
                 return None
             else:
                 return {
-                    "table": export_table[0][1],
+                    "table": cls.sanitize_export_table(export_table[0][1]),
                     "map_config": view.spec.map_config,
                     "chart_configs": view.spec.charts,
                     "aaData": datatables_data['aaData'],

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -67,27 +67,27 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
     ]
 
     def _make_cancel_payload_button(self, record_id):
-        return '''
+        return format_html('''
                 <a
                     class="btn btn-default cancel-record-payload"
                     role="button"
                     data-record-id={}>
                     Cancel Payload
                 </a>
-                '''.format(record_id)
+                ''', record_id)
 
     def _make_requeue_payload_button(self, record_id):
-        return '''
+        return format_html('''
                 <a
                     class="btn btn-default requeue-record-payload"
                     role="button"
                     data-record-id={}>
                     Requeue Payload
                 </a>
-                '''.format(record_id)
+                ''', record_id)
 
     def _make_view_payload_button(self, record_id):
-        return '''
+        return format_html('''
         <a
             class="btn btn-default"
             role="button"
@@ -96,16 +96,16 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
             data-target="#view-record-payload-modal">
             View Payload
         </a>
-        '''.format(record_id)
+        ''', record_id)
 
     def _make_resend_payload_button(self, record_id):
-        return '''
+        return format_html('''
         <button
             class="btn btn-default resend-record-payload"
             data-record-id={}>
             Resend Payload
         </button>
-        '''.format(record_id)
+        ''', record_id)
 
     def _get_state(self, record):
         if record.state == RECORD_SUCCESS_STATE:
@@ -127,11 +127,7 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
         return (label_cls, label_text)
 
     def _make_state_label(self, record):
-        return '''
-        <span class="label label-{}">
-            {}
-        </span>
-        '''.format(*self._get_state(record))
+        return format_html('<span class="label label-{}">{}</span>', *self.get_state(record))
 
     @property
     def total_records(self):
@@ -188,11 +184,10 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
         return rows
 
     def _payload_id_and_search_link(self, payload_id):
-        return (
+        return format_html(
             '<a href="{url}?q={payload_id}">'
             '<img src="{flower}" title="Search in HQ" width="14px" height="14px" />'
-            '</a> {payload_id}'
-        ).format(
+            '</a> {payload_id}',
             url=reverse('global_quick_find'),
             flower=static('hqwebapp/images/commcare-flower.png'),
             payload_id=payload_id,

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -127,7 +127,7 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
         return (label_cls, label_text)
 
     def _make_state_label(self, record):
-        return format_html('<span class="label label-{}">{}</span>', *self.get_state(record))
+        return format_html('<span class="label label-{}">{}</span>', *self._get_state(record))
 
     @property
     def total_records(self):


### PR DESCRIPTION
## Summary
Another XSS ticket as part of [SAAS-11853](https://dimagi-dev.atlassian.net/browse/SAAS-11853)

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Small test suite in test_models.py

### QA Plan

This will need to be QA'd in conjunction with the data tables change to verify that the reports are still displaying correctly (no incorrectly-encoded HTML characters like ', ", &, <, and >)

### Safety story
Some areas were local tested where possible. The biggest concern is how this integrates with the data tables change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
