### PR TITLE
add location fixtures to case restore

### DIFF
--- a/corehq/apps/case_migrations/tests/test_restore.py
+++ b/corehq/apps/case_migrations/tests/test_restore.py
@@ -73,7 +73,7 @@ class TestRelatedCases(TestCase):
         )
 
     @flag_enabled('ADD_LIMITED_FIXTURES_TO_CASE_RESTORE')
-    def test_restore(self):
+    def test_locations_in_restore(self):
         case_id = self.dad.case_id
 
         domain_obj = create_domain(self.domain)

--- a/corehq/apps/case_migrations/tests/test_restore.py
+++ b/corehq/apps/case_migrations/tests/test_restore.py
@@ -11,6 +11,7 @@ from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.fixtures import FlatLocationSerializer
 from corehq.apps.locations.models import LocationType, SQLLocation
+from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.users.models import WebUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.util.hmac_request import get_hmac_digest
@@ -75,8 +76,11 @@ class TestRelatedCases(TestCase):
     def test_restore(self):
         case_id = self.dad.case_id
 
-        create_domain(self.domain)
+        domain_obj = create_domain(self.domain)
         user = WebUser.create(self.domain, 'test-user', 'passmein', created_by=None, created_via=None)
+
+        self.addCleanup(delete_all_users)
+        self.addCleanup(domain_obj.delete)
 
         location_type = LocationType.objects.create(domain=self.domain, name="Top", code="top")
         SQLLocation.objects.create(domain=self.domain, name="Top Location", location_type=location_type)

--- a/corehq/apps/case_migrations/tests/test_restore.py
+++ b/corehq/apps/case_migrations/tests/test_restore.py
@@ -1,11 +1,20 @@
 import uuid
+from xml.etree import cElementTree as ElementTree
 
+from django.conf import settings
 from django.test import TestCase
+from django.urls import reverse
 
 from casexml.apps.case.const import CASE_INDEX_CHILD
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.locations.fixtures import FlatLocationSerializer
+from corehq.apps.locations.models import LocationType, SQLLocation
+from corehq.apps.users.models import WebUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.util.hmac_request import get_hmac_digest
+from corehq.util.test_utils import flag_enabled
 
 from ..views import get_case_hierarchy_for_restore
 
@@ -61,3 +70,29 @@ class TestRelatedCases(TestCase):
             [self.dad.case_id, self.kid.case_id, self.kid2.case_id,
              self.grandkid.case_id]
         )
+
+    @flag_enabled('ADD_LIMITED_FIXTURES_TO_CASE_RESTORE')
+    def test_restore(self):
+        case_id = self.dad.case_id
+
+        create_domain(self.domain)
+        user = WebUser.create(self.domain, 'test-user', 'passmein', created_by=None, created_via=None)
+
+        location_type = LocationType.objects.create(domain=self.domain, name="Top", code="top")
+        SQLLocation.objects.create(domain=self.domain, name="Top Location", location_type=location_type)
+
+        response = self._generate_restore(case_id, user)
+        self.assertEqual(response.status_code, 200)
+
+        response_content = next(response.streaming_content)
+        locations_content = b""
+        for xml_node in FlatLocationSerializer().get_xml_nodes('locations', self.domain, case_id,
+                                                               SQLLocation.active_objects):
+            locations_content += ElementTree.tostring(xml_node, encoding='utf-8')
+        self.assertIn(locations_content, response_content)
+
+    def _generate_restore(self, case_id, user):
+        self.client.login(username=user.username, password=user.password)
+        url = reverse("migration_restore", args=[self.domain, case_id])
+        hmac_header_value = get_hmac_digest(settings.FORMPLAYER_INTERNAL_AUTH_KEY, url)
+        return self.client.get(url, HTTP_X_MAC_DIGEST=hmac_header_value)

--- a/corehq/apps/case_migrations/views.py
+++ b/corehq/apps/case_migrations/views.py
@@ -24,7 +24,7 @@ from corehq.apps.locations.fixtures import (
 from corehq.apps.locations.models import SQLLocation
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.toggles import WEBAPPS_CASE_MIGRATION, ADD_LIMITED_FIXTURES_TO_SMS_WORKFLOW
+from corehq.toggles import WEBAPPS_CASE_MIGRATION, ADD_LIMITED_FIXTURES_TO_CASE_RESTORE
 from corehq.util import reverse
 
 from .forms import MigrationForm
@@ -91,7 +91,7 @@ def migration_restore(request, domain, case_id):
             # Formplayer will be creating these cases for the first time, so
             # include create blocks
             content.append(get_case_element(case, ('create', 'update'), V2))
-        if ADD_LIMITED_FIXTURES_TO_SMS_WORKFLOW.enabled(domain):
+        if ADD_LIMITED_FIXTURES_TO_CASE_RESTORE.enabled(domain):
             _add_limited_fixtures(domain, case_id, content)
         payload = content.get_fileobj()
 

--- a/corehq/apps/case_migrations/views.py
+++ b/corehq/apps/case_migrations/views.py
@@ -92,14 +92,13 @@ def migration_restore(request, domain, case_id):
             # include create blocks
             content.append(get_case_element(case, ('create', 'update'), V2))
         if ADD_LIMITED_FIXTURES_TO_CASE_RESTORE.enabled(domain):
-            _add_limited_fixtures(domain, case_id, content)
+            _add_limited_fixtures(case_id, content)
         payload = content.get_fileobj()
 
     return RestoreResponse(payload).get_http_response()
 
 
-def _add_limited_fixtures(domain, case_id, content):
+def _add_limited_fixtures(case_id, content):
     serializer = FlatLocationSerializer()
-    data_fields = get_location_data_fields(domain)
     restore_user = MockCaseAsRestoreUser(user_id=case_id)
-    content.extend(serializer.get_xml_nodes('locations', restore_user, SQLLocation.active_objects, data_fields))
+    content.extend(serializer.get_xml_nodes('locations', restore_user, SQLLocation.active_objects))

--- a/corehq/apps/case_migrations/views.py
+++ b/corehq/apps/case_migrations/views.py
@@ -31,9 +31,6 @@ from .forms import MigrationForm
 from .migration import perform_migration
 
 
-MockCaseAsRestoreUser = namedtuple("MockCaseAsRestoreUser", "user_id")
-
-
 @method_decorator(domain_admin_required, name='dispatch')
 @method_decorator(WEBAPPS_CASE_MIGRATION.required_decorator(), name='dispatch')
 class BaseMigrationView(BaseDomainView):
@@ -92,13 +89,12 @@ def migration_restore(request, domain, case_id):
             # include create blocks
             content.append(get_case_element(case, ('create', 'update'), V2))
         if ADD_LIMITED_FIXTURES_TO_CASE_RESTORE.enabled(domain):
-            _add_limited_fixtures(case_id, content)
+            _add_limited_fixtures(domain, case_id, content)
         payload = content.get_fileobj()
 
     return RestoreResponse(payload).get_http_response()
 
 
-def _add_limited_fixtures(case_id, content):
+def _add_limited_fixtures(domain, case_id, content):
     serializer = FlatLocationSerializer()
-    restore_user = MockCaseAsRestoreUser(user_id=case_id)
-    content.extend(serializer.get_xml_nodes('locations', restore_user, SQLLocation.active_objects))
+    content.extend(serializer.get_xml_nodes('locations', domain, case_id, SQLLocation.active_objects))

--- a/corehq/apps/case_migrations/views.py
+++ b/corehq/apps/case_migrations/views.py
@@ -1,5 +1,3 @@
-from collections import namedtuple
-
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.http.response import Http404
@@ -18,8 +16,7 @@ from corehq.apps.domain.auth import formplayer_auth
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.locations.fixtures import (
-    FlatLocationSerializer,
-    get_location_data_fields,
+    FlatLocationSerializer
 )
 from corehq.apps.locations.models import SQLLocation
 from corehq.form_processor.exceptions import CaseNotFound

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -113,7 +113,8 @@ class LocationFixtureProvider(FixtureProvider):
         if not should_sync_locations(restore_state.last_sync_log, locations_queryset, restore_state):
             return []
 
-        return self.serializer.get_xml_nodes(self.id, restore_user, locations_queryset)
+        return self.serializer.get_xml_nodes(self.id, restore_user.domain, restore_user.user_id,
+                                             locations_queryset)
 
 
 class HierarchicalLocationSerializer(object):
@@ -121,14 +122,14 @@ class HierarchicalLocationSerializer(object):
     def should_sync(self, restore_user, app):
         return should_sync_hierarchical_fixture(restore_user.project, app)
 
-    def get_xml_nodes(self, fixture_id, restore_user, locations_queryset):
+    def get_xml_nodes(self, fixture_id, domain, user_id, locations_queryset):
         locations_db = LocationSet(locations_queryset)
 
-        root_node = Element('fixture', {'id': fixture_id, 'user_id': restore_user.user_id})
+        root_node = Element('fixture', {'id': fixture_id, 'user_id': user_id})
         root_locations = locations_db.root_locations
 
         if root_locations:
-            data_fields = get_location_data_fields(restore_user.domain)
+            data_fields = get_location_data_fields(domain)
             _append_children(root_node, locations_db, root_locations, data_fields)
         else:
             # There is a bug on mobile versions prior to 2.27 where
@@ -145,9 +146,9 @@ class FlatLocationSerializer(object):
     def should_sync(self, restore_user, app):
         return should_sync_flat_fixture(restore_user.project, app)
 
-    def get_xml_nodes(self, fixture_id, restore_user, locations_queryset):
-        data_fields = get_location_data_fields(restore_user.domain)
-        all_types = LocationType.objects.filter(domain=restore_user.domain).values_list(
+    def get_xml_nodes(self, fixture_id, domain, user_id, locations_queryset):
+        data_fields = get_location_data_fields(domain)
+        all_types = LocationType.objects.filter(domain=domain).values_list(
             'code', flat=True
         )
         location_type_attrs = ['{}_id'.format(t) for t in all_types if t is not None]
@@ -155,13 +156,13 @@ class FlatLocationSerializer(object):
         attrs_to_index.extend(['@id', '@type', 'name'])
 
         return [get_index_schema_node(fixture_id, attrs_to_index),
-                self._get_fixture_node(fixture_id, restore_user, locations_queryset,
+                self._get_fixture_node(fixture_id, user_id, locations_queryset,
                                        location_type_attrs, data_fields)]
 
-    def _get_fixture_node(self, fixture_id, restore_user, locations_queryset,
+    def _get_fixture_node(self, fixture_id, user_id, locations_queryset,
                           location_type_attrs, data_fields):
         root_node = Element('fixture', {'id': fixture_id,
-                                        'user_id': restore_user.user_id,
+                                        'user_id': user_id,
                                         'indexed': 'true'})
         outer_node = Element('locations')
         root_node.append(outer_node)
@@ -191,7 +192,7 @@ class FlatLocationSerializer(object):
                     ).format(
                         domain=current_location.domain,
                         location_id=current_location.location_id,
-                        user_id=restore_user.user_id,
+                        user_id=user_id,
                     )
                     _soft_assert(False, msg=message)
 

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -113,8 +113,7 @@ class LocationFixtureProvider(FixtureProvider):
         if not should_sync_locations(restore_state.last_sync_log, locations_queryset, restore_state):
             return []
 
-        data_fields = get_location_data_fields(restore_user.domain)
-        return self.serializer.get_xml_nodes(self.id, restore_user, locations_queryset, data_fields)
+        return self.serializer.get_xml_nodes(self.id, restore_user, locations_queryset)
 
 
 class HierarchicalLocationSerializer(object):
@@ -122,13 +121,14 @@ class HierarchicalLocationSerializer(object):
     def should_sync(self, restore_user, app):
         return should_sync_hierarchical_fixture(restore_user.project, app)
 
-    def get_xml_nodes(self, fixture_id, restore_user, locations_queryset, data_fields):
+    def get_xml_nodes(self, fixture_id, restore_user, locations_queryset):
         locations_db = LocationSet(locations_queryset)
 
         root_node = Element('fixture', {'id': fixture_id, 'user_id': restore_user.user_id})
         root_locations = locations_db.root_locations
 
         if root_locations:
+            data_fields = get_location_data_fields(restore_user.domain)
             _append_children(root_node, locations_db, root_locations, data_fields)
         else:
             # There is a bug on mobile versions prior to 2.27 where
@@ -145,8 +145,8 @@ class FlatLocationSerializer(object):
     def should_sync(self, restore_user, app):
         return should_sync_flat_fixture(restore_user.project, app)
 
-    def get_xml_nodes(self, fixture_id, restore_user, locations_queryset, data_fields):
-
+    def get_xml_nodes(self, fixture_id, restore_user, locations_queryset):
+        data_fields = get_location_data_fields(restore_user.domain)
         all_types = LocationType.objects.filter(domain=restore_user.domain).values_list(
             'code', flat=True
         )

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -113,7 +113,7 @@ class LocationFixtureProvider(FixtureProvider):
         if not should_sync_locations(restore_state.last_sync_log, locations_queryset, restore_state):
             return []
 
-        data_fields = _get_location_data_fields(restore_user.domain)
+        data_fields = get_location_data_fields(restore_user.domain)
         return self.serializer.get_xml_nodes(self.id, restore_user, locations_queryset, data_fields)
 
 
@@ -331,7 +331,7 @@ def _fill_in_location_element(xml_root, location, data_fields):
     xml_root.append(_get_metadata_node(location, data_fields))
 
 
-def _get_location_data_fields(domain):
+def get_location_data_fields(domain):
     from corehq.apps.locations.views import LocationFieldsView
     fields_definition = CustomDataFieldsDefinition.get(domain, LocationFieldsView.field_type)
     if fields_definition:

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -113,7 +113,7 @@ class LocationFixtureProvider(FixtureProvider):
         if not should_sync_locations(restore_state.last_sync_log, locations_queryset, restore_state):
             return []
 
-        return self.serializer.get_xml_nodes(self.id, restore_user.domain, restore_user.user_id,
+        return self.serializer.get_xml_nodes(restore_user.domain, self.id, restore_user.user_id,
                                              locations_queryset)
 
 
@@ -122,7 +122,7 @@ class HierarchicalLocationSerializer(object):
     def should_sync(self, restore_user, app):
         return should_sync_hierarchical_fixture(restore_user.project, app)
 
-    def get_xml_nodes(self, fixture_id, domain, user_id, locations_queryset):
+    def get_xml_nodes(self, domain, fixture_id, user_id, locations_queryset):
         locations_db = LocationSet(locations_queryset)
 
         root_node = Element('fixture', {'id': fixture_id, 'user_id': user_id})
@@ -146,7 +146,7 @@ class FlatLocationSerializer(object):
     def should_sync(self, restore_user, app):
         return should_sync_flat_fixture(restore_user.project, app)
 
-    def get_xml_nodes(self, fixture_id, domain, user_id, locations_queryset):
+    def get_xml_nodes(self, domain, fixture_id, user_id, locations_queryset):
         data_fields = get_location_data_fields(domain)
         all_types = LocationType.objects.filter(domain=domain).values_list(
             'code', flat=True

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -33,8 +33,8 @@ from corehq.util.test_utils import flag_enabled, generate_cases
 
 from ..fixtures import (
     LocationSet,
-    _get_location_data_fields,
     _location_to_fixture,
+    get_location_data_fields,
     flat_location_fixture_generator,
     get_location_fixture_queryset,
     location_fixture_generator,
@@ -450,10 +450,10 @@ class LocationFixturesDataTest(LocationHierarchyTestCase, FixtureHasLocationsMix
         super(LocationFixturesDataTest, cls).tearDownClass()
 
     def test_utility_method(self):
-        self.assertItemsEqual(self.field_slugs, [f.slug for f in _get_location_data_fields(self.domain)])
+        self.assertItemsEqual(self.field_slugs, [f.slug for f in get_location_data_fields(self.domain)])
 
     def test_utility_method_empty(self):
-        self.assertEqual([], [f.slug for f in _get_location_data_fields('no-fields-defined')])
+        self.assertEqual([], [f.slug for f in get_location_data_fields('no-fields-defined')])
 
     def test_metadata_added_to_all_nodes(self):
         mass = self.locations['Massachusetts']

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -2050,9 +2050,9 @@ FHIR_INTEGRATION = StaticToggle(
 )
 
 
-ADD_LIMITED_FIXTURES_TO_SMS_WORKFLOW = StaticToggle(
-    'fixtures_in_sms_workflow',
-    'Allow limited fixtures to be available in SMS workflows',
+ADD_LIMITED_FIXTURES_TO_CASE_RESTORE = StaticToggle(
+    'fixtures_in_case_restore',
+    'Allow limited fixtures to be available in case restore for SMS workflows',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN]
 )

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -2048,3 +2048,11 @@ FHIR_INTEGRATION = StaticToggle(
     TAG_SOLUTIONS_LIMITED,
     namespaces=[NAMESPACE_DOMAIN]
 )
+
+
+ADD_LIMITED_FIXTURES_TO_SMS_WORKFLOW = StaticToggle(
+    'fixtures_in_sms_workflow',
+    'Allow limited fixtures to be available in SMS workflows',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN]
+)

--- a/testsettings.py
+++ b/testsettings.py
@@ -163,3 +163,5 @@ if os.path.exists("extensions/icds/custom/icds"):
     if "custom.icds.commcare_extensions" not in COMMCARE_EXTENSIONS:
         COMMCARE_EXTENSIONS.append("custom.icds.commcare_extensions")
         CUSTOM_DB_ROUTING["icds_reports"] = "icds-ucr-citus"
+
+FORMPLAYER_INTERNAL_AUTH_KEY = "abc123"


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Best to view once by commit before reviewing as a whole.
(Good to review but added "do not merge" till we are sure this would solve the underlying requirement of getting new cases to a desired location)

https://dimagi-dev.atlassian.net/browse/INDIV-9?focusedCommentId=132616
Add locations to a [case restore](https://github.com/dimagi/commcare-hq/blob/cc95ca552269ee6b9b5f85562d554439ef4a6658/corehq/apps/case_migrations/views.py#L67), that is used by formplayer to respond to SMS registration/followup workflows.
Being open to possibility of add more fixtures (not sure what others we have apart from locations), to support more workflows with sms, hence using the term "limited fixtures".

This is experimental right now, and would be used only for a single project as of now to test things out, hence `TAG_CUSTOM`


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`ADD_LIMITED_FIXTURES_TO_CASE_RESTORE`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
No functional changes to code other than the part behind the feature flag.
Relying on tests that are present for the code improvements done.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
