### PR TITLE
FHIR Data dictionary code followup

### DIFF
--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -112,12 +112,14 @@
             <!-- ko if: deprecated() -->
             <button data-bind="click: restoreProperty" class="btn btn-default btn-sm">{% trans "Restore Property" %}</button>
             <!-- /ko -->
+            {% if fhir_integration_enabled %}
             <!-- ko if: fhirResourcePropPath() && !removeFHIRResourcePropertyPath() -->
             <button data-bind="click: removePath" class="btn btn-danger btn-sm">{% trans "Remove Path" %}</button>
             <!-- /ko -->
             <!-- ko if: removeFHIRResourcePropertyPath() -->
             <button data-bind="click: restorePath" class="btn btn-default btn-sm">{% trans "Restore Path" %}</button>
             <!-- /ko -->
+            {% endif %}
           </td>
         </tr>
         <!-- /ko -->

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -115,10 +115,10 @@ def data_dictionary_json(request, domain, case_type_name=None):
 @login_and_domain_required
 @toggles.DATA_DICTIONARY.required_decorator()
 def update_case_property(request, domain):
-    property_list = json.loads(request.POST.get('properties'))
     fhir_resource_type_obj = None
     errors = []
     update_fhir_resources = toggles.FHIR_INTEGRATION.enabled(domain)
+    property_list = json.loads(request.POST.get('properties'))
 
     if update_fhir_resources:
         errors, fhir_resource_type_obj = _update_fhir_resource_type(request, domain)

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -364,21 +364,18 @@ def _process_bulk_upload(bulk_file, domain):
                 if len(row) < expected_columns_in_prop_sheet:
                     error = _('Not enough columns')
                 else:
+                    error, fhir_resource_prop_path, remove_path = None, None, None
+                    name, group, data_type, description, deprecated = [cell.value for cell in row[:5]]
                     if import_fhir_data:
-                        name, group, data_type, description, deprecated, fhir_resource_prop_path, remove_path = [
-                            cell.value for cell in row[:7]]
+                        fhir_resource_prop_path, remove_path = row[5:]
                         remove_path = remove_path == 'Y' if remove_path else False
                         fhir_resource_type = fhir_resource_type_by_case_type.get(case_type)
                         if fhir_resource_prop_path and not fhir_resource_type:
                             error = _('Could not find resource type for {}').format(case_type)
-                        else:
-                            error = save_case_property(name, case_type, domain, data_type, description, group,
-                                                       deprecated, fhir_resource_prop_path, fhir_resource_type,
-                                                       remove_path)
-                    else:
-                        name, group, data_type, description, deprecated = [cell.value for cell in row[:5]]
+                    if not error:
                         error = save_case_property(name, case_type, domain, data_type, description, group,
-                                                   deprecated)
+                                                   deprecated, fhir_resource_prop_path, fhir_resource_type,
+                                                   remove_path)
                 if error:
                     errors.append(_('Error in case type {}, row {}: {}').format(case_type, i, error))
     return errors


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Good to review by commit.

Just some follow up to points noted down in https://github.com/dimagi/commcare-hq/pull/29210.
1. https://github.com/dimagi/commcare-hq/pull/29210#discussion_r606164491 (commit 1)
2. https://github.com/dimagi/commcare-hq/pull/29210#discussion_r606162551 (commit 2 & 3)
3. https://github.com/dimagi/commcare-hq/pull/29210#discussion_r606160392 (commit 4)

Just code improvements and stronger checks for feature flag being enabled but no change to workflow or user experience/ UI.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`DATA_DICTIONARY` & `FHIR_INTEGRATION`(New)

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
