### PR TITLE
Escaped user-submitted field names on forms

### DIFF
--- a/corehq/apps/commtrack/forms.py
+++ b/corehq/apps/commtrack/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
+from django.utils.html import format_html
 
 from crispy_forms.bootstrap import PrependedText
 from crispy_forms.helper import FormHelper
@@ -120,7 +121,7 @@ class ConsumptionForm(forms.Form):
         products = SQLProduct.active_objects.filter(domain=domain)
         for product in products:
             field_name = 'default_%s' % product.product_id
-            display = _('Default %(product_name)s') % {'product_name': product.name}
+            display = format_html(_('Default {product_name}'), product_name=product.name)
             layout.append(field_name)
             self.fields[field_name] = forms.DecimalField(
                 label=display,

--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -7,6 +7,7 @@ from django.core.validators import RegexValidator
 from django.forms.widgets import Select
 from django.urls import reverse
 from django.utils.translation import ugettext as _
+from django.utils.html import escape
 from corehq.apps.accounting.utils import domain_has_privilege
 
 from crispy_forms.layout import HTML, Div, Field, Fieldset, Layout
@@ -101,9 +102,10 @@ class CustomDataEditor(object):
         return dict(system_data, **cleaned_data)    # cleaned_data may overwrite existing system data
 
     def _make_field(self, field):
+        safe_label = escape(field.label)
         if field.regex:
             validator = RegexValidator(field.regex, field.regex_msg)
-            return forms.CharField(label=field.label, required=field.is_required,
+            return forms.CharField(label=safe_label, required=field.is_required,
                                    validators=[validator])
         elif field.choices:
             # If form uses knockout, knockout must have control over the select2.
@@ -120,13 +122,13 @@ class CustomDataEditor(object):
                 placeholder_choices = [('', _('Select one'))]
 
             return forms.ChoiceField(
-                label=field.label,
+                label=safe_label,
                 required=field.is_required,
                 choices=placeholder_choices + [(c, c) for c in field.choices],
                 widget=forms.Select(attrs=attrs)
             )
         else:
-            return forms.CharField(label=field.label, required=field.is_required)
+            return forms.CharField(label=safe_label, required=field.is_required)
 
     @property
     @memoized


### PR DESCRIPTION
## Summary
This is a fix for [QA-2867](https://dimagi-dev.atlassian.net/browse/QA-2867) and [QA-2869](https://dimagi-dev.atlassian.net/browse/QA-2869), and any other places where custom data fields are used. The label for the field is user-supplied data, and currently undergoes no modifications before being presented to the user, which allows an XSS attack. This fix simply escapes the label before it is presented.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

I would like to add tests to this area, but currently do not have time. I will circle back later: [SAAS-12060](https://dimagi-dev.atlassian.net/browse/SAAS-12060)

### QA Plan

No QA required.

### Safety story

Local testing was done to verify that the changes were safe and fix the associated issues. As far as I can tell, the `label` property is only used as a display property -- it does not affect how the data is saved or loaded. In theory, errors would be limited to display only.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
