### PR TITLE
Ce/multidropdown webapps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -56,7 +56,6 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
 
         self.rawAnswer.subscribe(self.onPreProcess.bind(self));
         self.previousAnswer = self.answer();
-
     }
     EntryArrayAnswer.prototype = Object.create(Entry.prototype);
     EntryArrayAnswer.prototype.constructor = Entry;

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -1163,7 +1163,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         InfoEntry: InfoEntry,
         IntEntry: IntEntry,
         MultiSelectEntry: MultiSelectEntry,
-        MultDropdownEntry: MultiDropdownEntry,
+        MultiDropdownEntry: MultiDropdownEntry,
         PhoneEntry: PhoneEntry,
         SingleSelectEntry: SingleSelectEntry,
         TimeEntry: TimeEntry,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -422,30 +422,17 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
             });
         });
 
-        self.renderSelect2 = function () {
-            var $input = $('#' + self.entryId);
-            $input.select2(_.extend({
-                allowClear: true,
-                placeholder: self.placeholderText,
-                multiple: true,
-                escapeMarkup: function (m) { return DOMPurify.sanitize(m); },
-            }));
+        self.additionalSelect2Options = function () {
+            return {};
         };
 
         self.afterRender = function () {
-            self.renderSelect2();
+            select2ify(self);
         };
     }
     MultiDropdownEntry.prototype = Object.create(MultiSelectEntry.prototype);
     MultiDropdownEntry.prototype.constructor = MultiSelectEntry;
-    MultiDropdownEntry.prototype.onAnswerChange = function (newValue) {
-        var self = this;
-        MultiSelectEntry.prototype.onAnswerChange.call(self, newValue);
-        _.delay(function () {
-            $("#" + self.entryId).trigger("change.select2");
-        });
-    };
-
+    MultiDropdownEntry.prototype.onAnswerChange = select2AnswerChange(MultiSelectEntry);
 
     /**
      * Represents multiple radio button entries
@@ -560,28 +547,14 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         self.additionalSelect2Options = function () {
             return {};
         };
-        self.renderSelect2 = function () {
-            var $input = $('#' + self.entryId);
-            $input.select2(_.extend({
-                allowClear: true,
-                placeholder: self.placeholderText,
-                escapeMarkup: function (m) { return DOMPurify.sanitize(m); },
-            }, self.additionalSelect2Options()));
-        };
 
         self.afterRender = function () {
-            self.renderSelect2();
+            select2ify(self);
         };
     }
     DropdownEntry.prototype = Object.create(EntrySingleAnswer.prototype);
     DropdownEntry.prototype.constructor = EntrySingleAnswer;
-    DropdownEntry.prototype.onAnswerChange = function (newValue) {
-        var self = this;
-        EntrySingleAnswer.prototype.onAnswerChange.call(self, newValue);
-        _.delay(function () {
-            $("#" + self.entryId).trigger("change.select2");
-        });
-    };
+    DropdownEntry.prototype.onAnswerChange = select2AnswerChange(EntrySingleAnswer);
     DropdownEntry.prototype.onPreProcess = function (newValue) {
         // When newValue is undefined it means we've unset the select question.
         if (newValue === Const.NO_ANSWER || newValue === undefined) {
@@ -1148,6 +1121,32 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         }
 
         return form.displayOptions || {};
+    }
+
+    /**
+     * Utility to render question as select2
+     */
+    function select2ify(entry) {
+        var $input = $('#' + entry.entryId);
+        $input.select2(_.extend({
+            allowClear: true,
+            placeholder: entry.placeholderText,
+            escapeMarkup: function (m) { return DOMPurify.sanitize(m); },
+        }, entry.additionalSelect2Options()));
+
+    }
+
+    /**
+     * Function to handle answer changes for entries using selct2
+     */
+    function select2AnswerChange(parentClass) {
+        return function(newValue) {
+            var self = this;
+            parentClass.prototype.onAnswerChange.call(self, newValue);
+            _.delay(function () {
+                $("#" + self.entryId).trigger("change.select2");
+            });
+        };
     }
 
     return {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -422,12 +422,8 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
             });
         });
 
-        self.additionalSelect2Options = function () {
-            return {};
-        };
-
         self.afterRender = function () {
-            select2ify(self);
+            select2ify(self, {});
         };
     }
     MultiDropdownEntry.prototype = Object.create(MultiSelectEntry.prototype);
@@ -549,7 +545,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         };
 
         self.afterRender = function () {
-            select2ify(self);
+            select2ify(self, self.additionalSelect2Options());
         };
     }
     DropdownEntry.prototype = Object.create(EntrySingleAnswer.prototype);
@@ -1125,14 +1121,15 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
 
     /**
      * Utility to render question as select2
+     * additionalOptions is passed as object to select2 constructor
      */
-    function select2ify(entry) {
+    function select2ify(entry, additionalOptions) {
         var $input = $('#' + entry.entryId);
         $input.select2(_.extend({
             allowClear: true,
             placeholder: entry.placeholderText,
             escapeMarkup: function (m) { return DOMPurify.sanitize(m); },
-        }, entry.additionalSelect2Options()));
+        }, additionalOptions));
 
     }
 

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -383,7 +383,7 @@
     "></span>
 </script>
 <script type="text/html" id="multidropdown-entry-ko-template">
-  <select class="form-control" data-bind="
+  <select multiple class="form-control" data-bind="
         foreach: options,
         selectedOptions: rawAnswer,
         attr: {

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -382,6 +382,23 @@
         visible: helpText(),
     "></span>
 </script>
+<script type="text/html" id="multidropdown-entry-ko-template">
+  <select class="form-control" data-bind="
+        foreach: options,
+        selectedOptions: rawAnswer,
+        attr: {
+            id: entryId,
+            'aria-required': $parent.required() ? 'true' : 'false',
+        },
+        valueAllowUnset: true,
+        ">
+    <option data-bind="value: id, text: text"></option>
+  </select>
+  <span class="help-block type" data-bind="
+        text: helpText(),
+        visible: helpText(),
+    "></span>
+</script>
 <script type="text/html" id="choice-label-entry-ko-template">
   <div class="row">
     <!-- ko foreach: choices -->


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-517

This allows setting multiselect questions to use a select2 with the `minimal` appearance attribute. 

Most of the code is adapted from the same use case with single selects, which we already support. One difference between the two is the lack of explicitly clearing answers when the choices change. However, that still occurs, it just does not appear to need explicit code. This does mark a change from checkbox questions which attempt to preserve your answers if the values change, but that is known to be a bit [buggy](https://dimagi-dev.atlassian.net/browse/USH-517), so aligning this with the other select2 implementation seems preferable.

With selections:
![Screenshot from 2021-04-07 16-55-55](https://user-images.githubusercontent.com/6844721/113933215-4ad73700-97c2-11eb-94c9-9d593f2d4bfc.png)

Empty
![Screenshot from 2021-04-07 16-56-15](https://user-images.githubusercontent.com/6844721/113933219-4ad73700-97c2-11eb-99b1-026ddbdca1f7.png)
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Users will be able to use the `minimal` attribute to have multiselects render as a dropdown rather than a set of checkboxes.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This is tested locally and is very similar to previous code doing similar work. It also does not change any active applications. Users have to choose to use this feature.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
