### PR TITLE
Stop passing sessionid cookie in to media uploader

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/case_detail_print.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_detail_print.js
@@ -7,7 +7,7 @@ hqDefine("app_manager/js/details/case_detail_print", function () {
         printTemplateUploader = new HQMediaFileUploadController(
             print_uploader.slug,
             print_uploader.media_type,
-            print_uploader.options,
+            print_uploader.options
         );
         printTemplateUploader.init();
         printRef = hqImport('hqmedia/js/media_reference_models').BaseMediaReference(initial_page_data('print_ref'));

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_detail_print.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_detail_print.js
@@ -7,10 +7,8 @@ hqDefine("app_manager/js/details/case_detail_print", function () {
         printTemplateUploader = new HQMediaFileUploadController(
             print_uploader.slug,
             print_uploader.media_type,
-            _.extend({}, print_uploader.options, {
-                swfURL: initial_page_data('swfURL'),
-                sessionid: initial_page_data('sessionid'),
-            }));
+            print_uploader.options,
+        );
         printTemplateUploader.init();
         printRef = hqImport('hqmedia/js/media_reference_models').BaseMediaReference(initial_page_data('print_ref'));
         printRef.upload_controller = printTemplateUploader;

--- a/corehq/apps/app_manager/static/app_manager/js/nav_menu_media_common.js
+++ b/corehq/apps/app_manager/static/app_manager/js/nav_menu_media_common.js
@@ -7,10 +7,7 @@ hqDefine("app_manager/js/nav_menu_media_common", function () {
         uploaders[type] = new HQMediaFileUploadController(
             uploader.slug,
             uploader.media_type,
-            _.extend({}, uploader.options, {
-                sessionid: initial_page_data("sessionid"),
-                swfURL: initial_page_data("swfURL"),
-            })
+            uploader.options,
         );
         uploaders[type].init();
     });

--- a/corehq/apps/app_manager/static/app_manager/js/nav_menu_media_common.js
+++ b/corehq/apps/app_manager/static/app_manager/js/nav_menu_media_common.js
@@ -7,7 +7,7 @@ hqDefine("app_manager/js/nav_menu_media_common", function () {
         uploaders[type] = new HQMediaFileUploadController(
             uploader.slug,
             uploader.media_type,
-            uploader.options,
+            uploader.options
         );
         uploaders[type].init();
     });

--- a/corehq/apps/app_manager/templates/app_manager/app_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view_settings.html
@@ -39,8 +39,6 @@
   {% initial_page_data 'linked_whitelist' app.linked_whitelist %}
   {% initial_page_data 'media_refs' refs %}
   {% initial_page_data 'media_info' media_info %}
-  {% initial_page_data 'sessionid' request.COOKIES.sessionid %}
-  {% initial_page_data 'swfURL' 'hqmedia/MediaUploader/flashuploader.swf'|static %}
   {% initial_page_data 'uploaders' uploaders_js %}
   {% registerurl 'app_multimedia_ajax' domain app.get_id %}
   {% registerurl "hqmedia_remove_logo" domain app.id %}

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -144,12 +144,10 @@
   {% initial_page_data 'nav_menu_media_specifics' nav_menu_media_specifics %}
   {% initial_page_data 'root_requires_same_case' root_requires_same_case %}
   {% initial_page_data 'put_in_root' module.put_in_root %}
-  {% initial_page_data 'sessionid' request.COOKIES.sessionid %}
   {% initial_page_data 'shadow_parent_form_id' form.shadow_parent_form_id %}
   {% initial_page_data 'is_release_notes_form' form.is_release_notes_form %}
   {% initial_page_data 'is_allowed_to_be_release_notes_form' is_allowed_to_be_release_notes_form %}
   {% initial_page_data 'is_training_module' is_training_module %}
-  {% initial_page_data 'swfURL' 'hqmedia/MediaUploader/flashuploader.swf'|static %}
   {% if allow_form_copy and request|toggle_enabled:"COPY_FORM_TO_APP" %}
     {% initial_page_data 'apps_modules' apps_modules %}
   {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -74,8 +74,6 @@
   {% initial_page_data 'print_ref' print_ref %}
   {% initial_page_data 'print_uploader_js' print_uploader_js %}
   {% initial_page_data 'shadow_module_options' shadow_module_options %}
-  {% initial_page_data 'swfURL' 'hqmedia/MediaUploader/flashuploader.swf'|static %}
-  {% initial_page_data 'sessionid' request.COOKIES.sessionid %}
   {% initial_page_data 'default_language' app.default_language %}
   {% initial_page_data 'current_language' lang %}
   {% registerurl "view_form" domain app.id '---' %}

--- a/corehq/apps/app_manager/templates/app_manager/module_view_report.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view_report.html
@@ -27,8 +27,6 @@
   {% initial_page_data 'multimedia_object_map' multimedia.object_map %}
   {% initial_page_data 'multimedia_upload_managers' multimedia.upload_managers_js %}
   {% initial_page_data 'nav_menu_media_specifics' nav_menu_media_specifics %}
-  {% initial_page_data 'sessionid' request.COOKIES.sessionid %}
-  {% initial_page_data 'swfURL' 'hqmedia/MediaUploader/flashuploader.swf'|static %}
   {% initial_page_data 'report_module_options' report_module_options %}
   {% initial_page_data 'static_data_options' static_data_options %}
   {% initial_page_data 'uuids_by_instance_id' uuids_by_instance_id %}

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -236,7 +236,6 @@ def _get_base_vellum_options(request, domain, form, displayLang):
                 'text': reverse("hqmedia_uploader_text", args=[domain, app.id]),
             },
             'objectMap': app.get_object_map(multimedia_map=form.get_relevant_multimedia_map(app)),
-            'sessionid': request.COOKIES.get('sessionid'),
         },
     }
 
@@ -273,7 +272,6 @@ def _get_vellum_core_context(request, domain, app, module, form, lang):
             "meta/location",
         ] + _get_core_context_scheduler_data_nodes(module, form),
         'activityUrl': reverse('ping'),
-        'sessionid': request.COOKIES.get('sessionid'),
         'externalLinks': {
             'changeSubscription': reverse("domain_subscription_view",
                                           kwargs={'domain': domain}),

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -279,7 +279,6 @@ def view_generic(request, domain, app_id, module_id=None, form_id=None,
             for slug in uploader_slugs
         ]
         context.update({
-            "sessionid": request.COOKIES.get('sessionid'),
             "uploaders": uploaders,
             "uploaders_js": [u.js_options for u in uploaders],
             "refs": {

--- a/corehq/apps/hqmedia/static/hqmedia/js/hqmediauploaders.js
+++ b/corehq/apps/hqmedia/static/hqmedia/js/hqmediauploaders.js
@@ -6,10 +6,8 @@ hqDefine("hqmedia/js/hqmediauploaders", function () {
         HQMediaUploaders[uploader.slug] = new HQMediaUploaderTypes[uploader.uploader_type](
             uploader.slug,
             uploader.media_type,
-            _.extend({
-                sessionid: initial_page_data("sessionid"),
-                swfURL: initial_page_data("swfURL"),
-            }, uploader.options));
+            uploader.options,
+        );
         HQMediaUploaders[uploader.slug].init();
     });
 

--- a/corehq/apps/hqmedia/static/hqmedia/js/hqmediauploaders.js
+++ b/corehq/apps/hqmedia/static/hqmedia/js/hqmediauploaders.js
@@ -6,7 +6,7 @@ hqDefine("hqmedia/js/hqmediauploaders", function () {
         HQMediaUploaders[uploader.slug] = new HQMediaUploaderTypes[uploader.uploader_type](
             uploader.slug,
             uploader.media_type,
-            uploader.options,
+            uploader.options
         );
         HQMediaUploaders[uploader.slug].init();
     });

--- a/corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html
@@ -14,8 +14,6 @@
 {% endblock %}
 
 {% block page_content %}
-  {% initial_page_data 'sessionid' request.COOKIES.sessionid %}
-  {% initial_page_data 'swfURL' 'hqmedia/MediaUploader/flashuploader.swf'|static %}
   {% initial_page_data 'uploaders' uploaders_js %}
 
   <p class="lead">{{ current_page.page_name }}</p>

--- a/corehq/apps/hqmedia/templates/hqmedia/references.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/references.html
@@ -18,8 +18,6 @@
 {% endblock %}
 
 {% block page_content %}
-  {% initial_page_data 'sessionid' request.COOKIES.sessionid %}
-  {% initial_page_data 'swfURL' 'hqmedia/MediaUploader/flashuploader.swf'|static %}
   {% initial_page_data 'uploaders' uploaders_js %}
   {% registerurl 'hqmedia_references' app.domain app.id %}
   {% registerurl 'view_module' app.domain app.id '---' %}

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -149,7 +149,6 @@ class BaseMultimediaUploaderView(BaseMultimediaTemplateView):
         context.update({
             'uploaders': self.upload_controllers,
             'uploaders_js': [u.js_options for u in self.upload_controllers],
-            "sessionid": self.request.COOKIES.get('sessionid'),
         })
         return context
 
@@ -172,7 +171,6 @@ class MultimediaReferencesView(BaseMultimediaUploaderView):
         if self.app is None:
             raise Http404(self)
         context.update({
-            "sessionid": self.request.COOKIES.get('sessionid'),
             "multimedia_state": self.app.check_media_state(),
         })
         return context


### PR DESCRIPTION
it has not served a purpose in years and is a poor practice.
Also remove references to swfURL, which was removed 5 years ago.

## Summary
https://dimagi-dev.atlassian.net/browse/SAAS-11746

Corresponding PRs https://github.com/dimagi/MediaUploader/pull/29 and https://github.com/dimagi/Vellum/pull/1004 are part of the same cleanup, but I believe each can actually be merged separately without causing errors from mismatched versions. (That's how little used the values are.)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

Not planning QA

### Safety story

I tested (1) bulk media upload (2) case list media upload in app builder (3) question media upload in form builder, both locally and on staging. On staging this was tested _without_ the other two related branches to make sure it's safe to deploy on its own, allowing us to later deploy the others as no-op cleanups rather than wondering whether they need to be perfectly timed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
