### PR TITLE
Use FHIR version name in URL

### DIFF
--- a/corehq/motech/fhir/tests/test_utils.py
+++ b/corehq/motech/fhir/tests/test_utils.py
@@ -1,8 +1,13 @@
 from django.test import TestCase
 
+from nose.tools import assert_equal
+
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
 from corehq.motech.fhir.models import FHIRResourceProperty, FHIRResourceType
-from corehq.motech.fhir.utils import update_fhir_resource_property
+from corehq.motech.fhir.utils import (
+    resource_url,
+    update_fhir_resource_property,
+)
 
 DOMAIN = "test-domain"
 
@@ -133,3 +138,9 @@ class TestUpdateFHIRResourceProperty(TestCase):
                 jsonpath=new_fhir_resource_prop_path
             ).count(),
             1)
+
+
+def test_resource_url():
+    url = resource_url(DOMAIN, 'R4', 'Patient', 'abc123')
+    drop_hostname = url.split('/', maxsplit=3)[3]
+    assert_equal(drop_hostname, f'a/{DOMAIN}/fhir/R4/Patient/abc123/')

--- a/corehq/motech/fhir/utils.py
+++ b/corehq/motech/fhir/utils.py
@@ -5,9 +5,9 @@ from corehq.util.view_utils import absolute_reverse
 from .const import CAPABILITY_STATEMENT_PUBLISHED_DATE
 
 
-def resource_url(domain, resource_type, case_id):
+def resource_url(domain, fhir_version_name, resource_type, case_id):
     from corehq.motech.fhir.views import get_view
-    return absolute_reverse(get_view, args=(domain, resource_type, case_id))
+    return absolute_reverse(get_view, args=(domain, fhir_version_name, resource_type, case_id))
 
 
 def load_fhir_resource_mappings(domain):

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -106,7 +106,7 @@ def search_view(request, domain, fhir_version_name, resource_type):
     }
     for case in cases:
         response["entry"].append({
-            "fullUrl": resource_url(domain, resource_type, case.case_id),
+            "fullUrl": resource_url(domain, fhir_version_name, resource_type, case.case_id),
             "search": {
                 "mode": "match"
             }


### PR DESCRIPTION
## Summary

A PR for [@proteusvacuum 's commit](https://github.com/dimagi/commcare-hq/commit/779fd88c3ee6e4193e4b5e50db3670c2a6989235).


## Feature Flag

"FHIR Integration"


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Automated test coverage


### Safety story

Small. Fixes a bug. 


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
