### PR TITLE
Fix adding query parameters twice for configurable reports 

### DIFF
--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -738,9 +738,6 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
                         mock_request.bypass_two_factor = True
 
                         mock_query_string_parts = [report_config.query_string, 'filterSet=true']
-                        if report_config.is_configurable_report:
-                            mock_query_string_parts.append(urlencode(report_config.filters, True))
-                            mock_query_string_parts.append(urlencode(report_config.get_date_range(), True))
                         mock_request.GET = QueryDict('&'.join(mock_query_string_parts))
                         request_data = vars(mock_request)
                         request_data['couch_user'] = mock_request.couch_user.userID


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Support Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11772)

I didn't think to look for other instances of this bug in [my last PR](https://github.com/dimagi/commcare-hq/pull/29305). This is the same change since `query_string` already adds `filters` and `date_range` as parameters.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests here. It would need a pretty high level test for the `_get_and_send_report` which could be worth it. I'll look into it.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This only applies to scheduled reports that are too large and need to be sent with an excel attachment (I think). I will try to think of how to test this on staging.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
