### PR TITLE
Removed NEW_MULTIMEDIA_UPLOADER toggle

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/new_multimedia_uploader.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/new_multimedia_uploader.html
@@ -1,6 +1,0 @@
-{% load i18n %}
-{% load hq_shared_tags %}
-
-{% if request|toggle_enabled:'NEW_MULTIMEDIA_UPLOADER' %}
-  <p>This is only a test.</p>
-{% endif %}

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -637,13 +637,6 @@ MM_CASE_PROPERTIES = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-NEW_MULTIMEDIA_UPLOADER = StaticToggle(
-    'new_multimedia_uploader',
-    'Display new multimedia uploader',
-    TAG_INTERNAL,
-    [NAMESPACE_DOMAIN]
-)
-
 VISIT_SCHEDULER = StaticToggle(
     'app_builder_visit_scheduler',
     'ICDS: Visit Scheduler',


### PR DESCRIPTION
## Summary
Small bit of cleanup related to https://dimagi-dev.atlassian.net/browse/SAAS-11746

Removes an old POC that isn't being used in prod.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
This is basically a bit of dead code.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
