### PR TITLE
[SSO] Cleanup admin forms, certificate uploads and downloads

### DIFF
--- a/corehq/apps/sso/certificates.py
+++ b/corehq/apps/sso/certificates.py
@@ -7,7 +7,7 @@ from dateutil.parser import parse
 from django.conf import settings
 from django.http import HttpResponse
 
-DEFAULT_EXPIRATION = 365 * 24 * 60 * 60 # one year in seconds
+DEFAULT_EXPIRATION = 3 * 365 * 24 * 60 * 60  # two years in seconds
 
 
 def create_key_pair():
@@ -16,18 +16,18 @@ def create_key_pair():
     return k
 
 
-def create_self_signed_cert(key_pair, expiration_in_seconds=None):
+def create_self_signed_cert(key_pair, expiration_in_seconds=DEFAULT_EXPIRATION):
     cert = crypto.X509()
-    cert.get_subject().C = "US"
-    cert.get_subject().ST = "MA"
-    cert.get_subject().L = "Cambridge"
-    cert.get_subject().O = "Dimagi Inc."
-    cert.get_subject().OU = "CommCareHQ"
-    cert.get_subject().CN = "CommCare"
+    cert.get_subject().C = "US"  # country
+    cert.get_subject().ST = "MA"  # state
+    cert.get_subject().L = "Cambridge"  # location
+    cert.get_subject().O = "Dimagi Inc."  # organization
+    cert.get_subject().OU = "CommCareHQ"  # organizational unit name
+    cert.get_subject().CN = "CommCare"  # common name
     cert.get_subject().emailAddress = settings.ACCOUNTS_EMAIL
     cert.set_serial_number(uuid.uuid4().int)
     cert.gmtime_adj_notBefore(0)
-    cert.gmtime_adj_notAfter(expiration_in_seconds or DEFAULT_EXPIRATION)
+    cert.gmtime_adj_notAfter(expiration_in_seconds)
     cert.set_issuer(cert.get_subject())
     cert.set_pubkey(key_pair)
     cert.sign(key_pair, "sha256")

--- a/corehq/apps/sso/certificates.py
+++ b/corehq/apps/sso/certificates.py
@@ -46,6 +46,10 @@ def get_private_key(key_pair):
     return crypto.dump_privatekey(crypto.FILETYPE_PEM, key_pair).decode("utf-8")
 
 
+def get_certificate_from_file(file):
+    return crypto.load_certificate(crypto.FILETYPE_PEM, file.read())
+
+
 def get_certificate_response(cert_string, filename):
     response = HttpResponse(
         BytesIO(cert_string.encode("utf-8")),

--- a/corehq/apps/sso/certificates.py
+++ b/corehq/apps/sso/certificates.py
@@ -7,7 +7,7 @@ from dateutil.parser import parse
 from django.conf import settings
 from django.http import HttpResponse
 
-DEFAULT_EXPIRATION = 3 * 365 * 24 * 60 * 60  # two years in seconds
+DEFAULT_EXPIRATION = 3 * 365 * 24 * 60 * 60  # three years in seconds
 
 
 def create_key_pair():

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -126,11 +126,11 @@ class ServiceProviderDetailsForm(forms.Form):
     required service provider information that's needed to link with an
     identity provider."""
     sp_entity_id = forms.CharField(
-        label=ugettext_lazy("Entity ID"),
+        label=ugettext_lazy("Identifier (Entity ID)"),
         required=False,
     )
     sp_acs_url = forms.CharField(
-        label=ugettext_lazy("Assertion Consumer Service"),
+        label=ugettext_lazy("Reply URL (Assertion Consumer Service)"),
         required=False,
     )
     sp_sign_on_url = forms.CharField(
@@ -425,7 +425,7 @@ class SSOEnterpriseSettingsForm(forms.Form):
         required=False,
     )
     entity_id = forms.CharField(
-        label=ugettext_lazy("Issuer/Entity ID"),
+        label=ugettext_lazy("Azure AD Identifier"),
         required=False,
     )
     login_url = forms.CharField(
@@ -498,7 +498,7 @@ class SSOEnterpriseSettingsForm(forms.Form):
             crispy.Div(
                 crispy.Div(
                     crispy.Fieldset(
-                        _('Service Provider Details for Azure AD'),
+                        _('Basic SAML Configuration for Azure AD'),
                         *sp_details_form.service_provider_fields
                     ),
                     css_class="panel-body"

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -565,21 +565,25 @@ class SSOEnterpriseSettingsForm(forms.Form):
         return is_active
 
     def clean_entity_id(self):
+        is_active = bool(self.data.get('is_active'))
         entity_id = self.cleaned_data['entity_id']
-        _check_required_when_active(self.cleaned_data['is_active'], entity_id)
+        _check_required_when_active(is_active, entity_id)
         return entity_id
 
     def clean_login_url(self):
+        is_active = bool(self.data.get('is_active'))
         login_url = self.cleaned_data['login_url']
-        _check_required_when_active(self.cleaned_data['is_active'], login_url)
+        _check_required_when_active(is_active, login_url)
         return login_url
 
     def clean_logout_url(self):
+        is_active = bool(self.data.get('is_active'))
         logout_url = self.cleaned_data['logout_url']
-        _check_required_when_active(self.cleaned_data['is_active'], logout_url)
+        _check_required_when_active(is_active, logout_url)
         return logout_url
 
     def clean_idp_cert_public(self):
+        is_active = bool(self.data.get('is_active'))
         idp_cert_file = self.cleaned_data['idp_cert_public']
         if idp_cert_file:
             try:
@@ -599,7 +603,7 @@ class SSOEnterpriseSettingsForm(forms.Form):
             public_key = self.idp.idp_cert_public
             date_expiration = self.idp.date_idp_cert_expiration
 
-        _check_required_when_active(self.cleaned_data['is_active'], public_key)
+        _check_required_when_active(is_active, public_key)
         return public_key, date_expiration
 
     def update_identity_provider(self, admin_user):

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -133,8 +133,8 @@ class ServiceProviderDetailsForm(forms.Form):
         label=ugettext_lazy("Assertion Consumer Service"),
         required=False,
     )
-    sp_logout_url = forms.CharField(
-        label=ugettext_lazy("Logout URL"),
+    sp_sign_on_url = forms.CharField(
+        label=ugettext_lazy("Sign on URL"),
         required=False,
     )
     sp_public_cert = forms.CharField(
@@ -197,8 +197,8 @@ class ServiceProviderDetailsForm(forms.Form):
                 url_helpers.get_saml_acs_url(self.idp),
             ),
             hqcrispy.B3TextField(
-                'sp_logout_url',
-                url_helpers.get_saml_sls_url(self.idp),
+                'sp_sign_on_url',
+                url_helpers.get_saml_login_url(self.idp),
             ),
         ])
         return shown_fields

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 
 from django import forms
 from django.db import transaction
@@ -18,6 +19,8 @@ from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput
 from corehq.apps.sso import certificates
 from corehq.apps.sso.models import IdentityProvider
 from corehq.apps.sso.utils import url_helpers
+
+log = logging.getLogger(__name__)
 
 TIME_FORMAT = "%Y/%m/%d %I:%M %p"
 
@@ -591,6 +594,7 @@ class SSOEnterpriseSettingsForm(forms.Form):
                 public_key = certificates.get_public_key(cert)
                 date_expiration = certificates.get_expiration_date(cert)
             except certificates.crypto.Error:
+                log.exception("Error uploading certificate: bad cert file.")
                 raise forms.ValidationError(
                     _("File type not accepted. Please ensure you have "
                       "uploaded a Base64 x509 certificate.")

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -174,9 +174,9 @@ class ServiceProviderDetailsForm(forms.Form):
     @property
     def token_encryption_help_block(self):
         help_text = _(
-            'SAML Token Encryption for Azure AD is a high security feature '
-            'that ensures Assertions are fully encrypted. This feature '
-            'requires a Premium Azure AD subscription. '
+            'This is a high security feature  that ensures Assertions are '
+            'fully encrypted. This feature requires a Premium Azure AD '
+            'subscription. '
         )
         return crispy.HTML(
             format_html('<p class="help-block">{}</p>', help_text)
@@ -522,7 +522,7 @@ class SSOEnterpriseSettingsForm(forms.Form):
             crispy.Div(
                 crispy.Div(
                     crispy.Fieldset(
-                        _('SAML Token Encryption Settings'),
+                        _('SAML Token Encryption'),
                         sp_details_form.token_encryption_help_block,
                         twbscrispy.PrependedText('require_encrypted_assertions', ''),
                         crispy.Div(*sp_details_form.token_encryption_fields),

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -527,8 +527,8 @@ class SSOEnterpriseSettingsForm(forms.Form):
                 crispy.Div(
                     crispy.Fieldset(
                         _('Connection Details from Azure AD'),
-                        'entity_id',
                         'login_url',
+                        'entity_id',
                         'logout_url',
                         crispy.Div(*certificate_details),
                         'idp_cert_public',

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -508,24 +508,6 @@ class SSOEnterpriseSettingsForm(forms.Form):
             crispy.Div(
                 crispy.Div(
                     crispy.Fieldset(
-                        _('Single Sign-On Settings'),
-                        hqcrispy.B3TextField(
-                            'name',
-                            identity_provider.name,
-                        ),
-                        hqcrispy.B3TextField(
-                            'linked_email_domains',
-                            ", ".join(identity_provider.get_email_domains()),
-                        ),
-                        twbscrispy.PrependedText('is_active', ''),
-                    ),
-                    css_class="panel-body"
-                ),
-                css_class="panel panel-modern-gray panel-form-only"
-            ),
-            crispy.Div(
-                crispy.Div(
-                    crispy.Fieldset(
                         _('Connection Details from Azure AD'),
                         'login_url',
                         'entity_id',
@@ -544,6 +526,24 @@ class SSOEnterpriseSettingsForm(forms.Form):
                         sp_details_form.token_encryption_help_block,
                         twbscrispy.PrependedText('require_encrypted_assertions', ''),
                         crispy.Div(*sp_details_form.token_encryption_fields),
+                    ),
+                    css_class="panel-body"
+                ),
+                css_class="panel panel-modern-gray panel-form-only"
+            ),
+            crispy.Div(
+                crispy.Div(
+                    crispy.Fieldset(
+                        _('Single Sign-On Settings'),
+                        hqcrispy.B3TextField(
+                            'name',
+                            identity_provider.name,
+                        ),
+                        hqcrispy.B3TextField(
+                            'linked_email_domains',
+                            ", ".join(identity_provider.get_email_domains()),
+                        ),
+                        twbscrispy.PrependedText('is_active', ''),
                     ),
                     css_class="panel-body"
                 ),

--- a/corehq/apps/sso/static/sso/js/enterprise_edit_identity_provider.js
+++ b/corehq/apps/sso/static/sso/js/enterprise_edit_identity_provider.js
@@ -5,7 +5,6 @@ hqDefine('sso/js/enterprise_edit_identity_provider', [
     'hqwebapp/js/utils/email',
     "hqwebapp/js/initial_page_data",
     'sso/js/models',
-    'eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min',
 ], function (
     $,
     ko,
@@ -24,11 +23,5 @@ hqDefine('sso/js/enterprise_edit_identity_provider', [
         });
         $('#sso-exempt-user-manager').koApplyBindings(ssoExemptUserManager);
         ssoExemptUserManager.init();
-
-        var $expDate = $("#id_date_idp_cert_expiration"),
-            initialDate = $expDate.val();
-        $expDate.datetimepicker({
-            date: initialDate,
-        });
     });
 });

--- a/corehq/apps/sso/templates/sso/enterprise_admin/edit_identity_provider.html
+++ b/corehq/apps/sso/templates/sso/enterprise_admin/edit_identity_provider.html
@@ -14,7 +14,7 @@
   </ul>
   <div class="tab-content tab-padded">
     <div class="tab-pane" id="idp">
-      <form class="form form-horizontal" method="post">
+      <form class="form form-horizontal" method="post" enctype="multipart/form-data">
         {% crispy edit_idp_form %}
       </form>
     </div>

--- a/corehq/apps/sso/tests/generator.py
+++ b/corehq/apps/sso/tests/generator.py
@@ -1,3 +1,4 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django_prbac.models import Role
 
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -74,3 +75,30 @@ def create_request_session(request, use_sso=False):
     request.session.save()
     if use_sso:
         request.session['samlSessionIndex'] = '_7c84c96e-8774-4e64-893c-06f91d285100'
+
+
+@unit_testing_only
+def get_public_cert_file(expiration_in_seconds=certificates.DEFAULT_EXPIRATION):
+    key_pair = certificates.create_key_pair()
+    cert = certificates.create_self_signed_cert(
+        key_pair,
+        expiration_in_seconds
+    )
+    cert_bytes = certificates.crypto.dump_certificate(
+        certificates.crypto.FILETYPE_PEM,
+        cert
+    )
+    return SimpleUploadedFile(
+        "certificate.cer",
+        cert_bytes,
+        content_type="application/x-x509-ca-cert",
+    )
+
+
+@unit_testing_only
+def get_bad_cert_file(bad_cert_data):
+    return SimpleUploadedFile(
+        "certificate.cer",
+        bad_cert_data,
+        content_type="application/x-x509-ca-cert",
+    )

--- a/corehq/apps/sso/tests/test_forms.py
+++ b/corehq/apps/sso/tests/test_forms.py
@@ -9,7 +9,6 @@ from corehq.apps.sso.forms import (
     CreateIdentityProviderForm,
     EditIdentityProviderAdminForm,
     SSOEnterpriseSettingsForm,
-    TIME_FORMAT,
 )
 from corehq.apps.sso.models import (
     IdentityProvider,
@@ -303,21 +302,24 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
 
     @staticmethod
     def _get_post_data(no_entity_id=False, no_login_url=False, no_logout_url=False,
-                       no_certificate=False, no_certificate_date=False, is_active=False,
-                       require_encrypted_assertions=False):
-        expiration_date = datetime.utcnow() + timedelta(days=30)
+                       is_active=False, require_encrypted_assertions=False,
+                       certificate=None):
         return {
             'is_active': is_active,
             'entity_id': '' if no_entity_id else 'https://test.org/metadata',
             'login_url': '' if no_login_url else 'https://test.org/sls',
             'logout_url': '' if no_logout_url else 'https://test.org/slo',
-            'idp_cert_public': '' if no_certificate else 'TEST CERTIFICATE',
-            'date_idp_cert_expiration': ('' if no_certificate_date
-                                         else expiration_date.strftime(TIME_FORMAT)),
             'require_encrypted_assertions': require_encrypted_assertions,
+            'idp_cert_public': certificate,
         }
 
-    def test_is_active_triggers_required_fields_and_updates(self):
+    @staticmethod
+    def _get_request_files(cert_file):
+        return {
+            'idp_cert_public': cert_file,
+        }
+
+    def test_is_active_triggers_form_validation_errors(self):
         """
         Test that if `is_active` is set to true, then related required fields
         raise ValidationErrors if left blank. Once the requirements are met and
@@ -326,8 +328,10 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
         the IdentityProvider as expected.
         """
         post_data = self._get_post_data(
-            is_active=True, no_entity_id=True, no_login_url=True,
-            no_logout_url=True, no_certificate=True, no_certificate_date=True
+            is_active=True,
+            no_entity_id=True,
+            no_login_url=True,
+            no_logout_url=True,
         )
         edit_sso_idp_form = SSOEnterpriseSettingsForm(self.idp, post_data)
         edit_sso_idp_form.cleaned_data = post_data
@@ -357,26 +361,46 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
             edit_sso_idp_form.clean_logout_url()
         with self.assertRaises(forms.ValidationError):
             edit_sso_idp_form.clean_idp_cert_public()
-        with self.assertRaises(forms.ValidationError):
-            edit_sso_idp_form.clean_date_idp_cert_expiration()
         self.assertFalse(edit_sso_idp_form.is_valid())
 
-        corrected_post_data = self._get_post_data(is_active=True)
-        corrected_edit_sso_idp_form = SSOEnterpriseSettingsForm(self.idp, corrected_post_data)
-        self.assertTrue(corrected_edit_sso_idp_form.is_valid())
-        corrected_edit_sso_idp_form.update_identity_provider(self.accounting_admin)
+    def test_that_is_active_updates_successfully_when_requirements_are_met(self):
+        """
+        Ensure that update_identity_provider() updates the `is_active` field on
+        the IdentityProvider as expected when requirements are met.
+        """
+        email_domain = AuthenticatedEmailDomain.objects.create(
+            identity_provider=self.idp,
+            email_domain='vaultwax.com',
+        )
+        UserExemptFromSingleSignOn.objects.create(
+            username='b@vaultwax.com',
+            email_domain=email_domain,
+        )
+
+        certificate_file = generator.get_public_cert_file()
+        post_data = self._get_post_data(
+            is_active=True,
+            certificate=certificate_file,
+        )
+
+        self.assertFalse(self.idp.is_active)
+        edit_sso_idp_form = SSOEnterpriseSettingsForm(
+            self.idp, post_data, self._get_request_files(certificate_file)
+        )
+        edit_sso_idp_form.cleaned_data = post_data
+        self.assertTrue(edit_sso_idp_form.is_valid())
+
+        edit_sso_idp_form.update_identity_provider(self.accounting_admin)
 
         idp = IdentityProvider.objects.get(id=self.idp.id)
         self.assertTrue(idp.is_editable)
         self.assertTrue(idp.is_active)
-        self.assertEqual(idp.entity_id, corrected_post_data['entity_id'])
-        self.assertEqual(idp.login_url, corrected_post_data['login_url'])
-        self.assertEqual(idp.logout_url, corrected_post_data['logout_url'])
-        self.assertEqual(idp.idp_cert_public, corrected_post_data['idp_cert_public'])
-        self.assertEqual(
-            idp.date_idp_cert_expiration.strftime(TIME_FORMAT),
-            corrected_post_data['date_idp_cert_expiration']
-        )
+        self.assertEqual(idp.entity_id, post_data['entity_id'])
+        self.assertEqual(idp.login_url, post_data['login_url'])
+        self.assertEqual(idp.logout_url, post_data['logout_url'])
+        certificate_file.seek(0)
+        self.assertEqual(idp.idp_cert_public, certificate_file.read().decode('utf-8'))
+        self.assertIsNotNone(idp.date_idp_cert_expiration)
 
     def test_last_modified_by_and_fields_update_when_not_active(self):
         """
@@ -405,24 +429,8 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
         self.assertEqual(idp.entity_id, post_data['entity_id'])
         self.assertEqual(idp.login_url, post_data['login_url'])
         self.assertEqual(idp.logout_url, post_data['logout_url'])
-        self.assertEqual(idp.idp_cert_public, post_data['idp_cert_public'])
-        self.assertEqual(
-            idp.date_idp_cert_expiration.strftime(TIME_FORMAT),
-            post_data['date_idp_cert_expiration']
-        )
-
-    def test_date_idp_cert_expiration_with_bad_value(self):
-        """
-        Ensure that SSOEnterpriseSettingsForm raises a ValidationError if
-        `date_idp_cert_expiration` is provided with a incorrectly formatted date
-        string.
-        """
-        post_data = self._get_post_data()
-        post_data['date_idp_cert_expiration'] = 'purposefully bad date string'
-        edit_sso_idp_form = SSOEnterpriseSettingsForm(self.idp, post_data)
-        edit_sso_idp_form.cleaned_data = post_data
-        with self.assertRaises(forms.ValidationError):
-            edit_sso_idp_form.clean_date_idp_cert_expiration()
+        self.assertIsNone(idp.idp_cert_public)
+        self.assertIsNone(idp.date_idp_cert_expiration)
 
     def test_require_encrypted_assertions_is_saved(self):
         """
@@ -434,7 +442,6 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
         )
         self.assertFalse(self.idp.require_encrypted_assertions)
         edit_sso_idp_form = SSOEnterpriseSettingsForm(self.idp, post_data)
-        edit_sso_idp_form.cleaned_data = post_data
         self.assertTrue(edit_sso_idp_form.is_valid())
         edit_sso_idp_form.update_identity_provider(self.accounting_admin)
         self.idp.refresh_from_db()

--- a/corehq/apps/sso/utils/url_helpers.py
+++ b/corehq/apps/sso/utils/url_helpers.py
@@ -11,6 +11,10 @@ def get_saml_acs_url(identity_provider):
     return _get_full_sso_url("sso_saml_acs", identity_provider)
 
 
+def get_saml_login_url(identity_provider):
+    return _get_full_sso_url("sso_saml_login", identity_provider)
+
+
 def get_saml_sls_url(identity_provider):
     return _get_full_sso_url("sso_saml_sls", identity_provider)
 

--- a/corehq/apps/sso/views/accounting_admin.py
+++ b/corehq/apps/sso/views/accounting_admin.py
@@ -189,12 +189,12 @@ class EditIdentityProviderAdminView(BaseIdentityProviderAdminView, AsyncHandlerM
         if 'sp_cert_public' in request.GET:
             return get_certificate_response(
                 self.identity_provider.sp_cert_public,
-                f"{self.identity_provider.slug}_sp_public.cert"
+                f"{self.identity_provider.slug}_sp_public.cer"
             )
         if 'sp_rollover_cert_public' in request.GET:
             return get_certificate_response(
                 self.identity_provider.sp_rollover_cert_public,
-                f"{self.identity_provider.slug}_sp_rollover_public.cert"
+                f"{self.identity_provider.slug}_sp_rollover_public.cer"
             )
         return super().get(request, args, kwargs)
 

--- a/corehq/apps/sso/views/enterprise_admin.py
+++ b/corehq/apps/sso/views/enterprise_admin.py
@@ -112,4 +112,9 @@ class EditIdentityProviderEnterpriseView(BaseEnterpriseAdminView, AsyncHandlerMi
             # we redirect here to force the memoized identity_provider property
             # to re-fetch its data.
             return HttpResponseRedirect(self.page_url)
+        else:
+            messages.error(
+                request,
+                _("Please check form for errors.")
+            )
         return self.get(request, *args, **kwargs)

--- a/corehq/apps/sso/views/enterprise_admin.py
+++ b/corehq/apps/sso/views/enterprise_admin.py
@@ -80,12 +80,12 @@ class EditIdentityProviderEnterpriseView(BaseEnterpriseAdminView, AsyncHandlerMi
         if 'sp_cert_public' in request.GET:
             return get_certificate_response(
                 self.identity_provider.sp_cert_public,
-                f"{self.identity_provider.slug}_sp_public.cert"
+                f"{self.identity_provider.slug}_sp_public.cer"
             )
         if 'sp_rollover_cert_public' in request.GET:
             return get_certificate_response(
                 self.identity_provider.sp_rollover_cert_public,
-                f"{self.identity_provider.slug}_sp_rollover_public.cert"
+                f"{self.identity_provider.slug}_sp_rollover_public.cer"
             )
         return super().get(request, args, kwargs)
 

--- a/corehq/apps/sso/views/enterprise_admin.py
+++ b/corehq/apps/sso/views/enterprise_admin.py
@@ -82,6 +82,11 @@ class EditIdentityProviderEnterpriseView(BaseEnterpriseAdminView, AsyncHandlerMi
                 self.identity_provider.sp_cert_public,
                 f"{self.identity_provider.slug}_sp_public.cer"
             )
+        if 'idp_cert_public' in request.GET:
+            return get_certificate_response(
+                self.identity_provider.idp_cert_public,
+                f"{self.identity_provider.slug}_idp_public.cer"
+            )
         if 'sp_rollover_cert_public' in request.GET:
             return get_certificate_response(
                 self.identity_provider.sp_rollover_cert_public,

--- a/corehq/apps/sso/views/enterprise_admin.py
+++ b/corehq/apps/sso/views/enterprise_admin.py
@@ -93,7 +93,9 @@ class EditIdentityProviderEnterpriseView(BaseEnterpriseAdminView, AsyncHandlerMi
     @memoized
     def edit_enterprise_idp_form(self):
         if self.request.method == 'POST':
-            return SSOEnterpriseSettingsForm(self.identity_provider, self.request.POST)
+            return SSOEnterpriseSettingsForm(
+                self.identity_provider, self.request.POST, self.request.FILES
+            )
         return SSOEnterpriseSettingsForm(self.identity_provider)
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
## Summary
Now that SSO is working between Azure AD and CommCare HQ, I revisited the workflow/UI for a full end-to-end setup between Azure and HQ. In the process, I noticed a few inconsistencies and made some changes...

- updated wording of field labels and the order of fields needed to match Azure AD a bit better
- Azure expected `.cer` files for token encryption, rather than `.cert` files, so I changed our certificate downloads to reflect this.
- there was no easy/intuitive way to copy/paste the certificate data from Azure to HQ, so I implemented file upload for x509 certificates. In doing this, I realized we should just fetch the expiration date straight from the certificate data, rather than requiring the user to fill in the date themselves.
- updated tests (was quite a chore with the file upload!)

No ticket for this one since this is an improvement upon earlier work.

## Feature Flag
`ENTERPRISE_SSO`

## Product Description
Some screenshots of the Enterprise Admin form
![Screen Shot 2021-04-08 at 4 10 29 PM](https://user-images.githubusercontent.com/716573/114090113-9d752980-987c-11eb-9a20-061e1d196b67.png)
<img width="1390" alt="Screen Shot 2021-04-08 at 4 00 51 PM" src="https://user-images.githubusercontent.com/716573/114090134-a5cd6480-987c-11eb-8ede-794e1287aff1.png">

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Lots of test coverage

### QA Plan
None needed yet

### Safety story
This is actively in development and not in use on production

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
