### PR TITLE
Include couch data in auditcare reports

### DIFF
--- a/corehq/apps/auditcare/management/commands/gdpr_scrub_user_auditcare.py
+++ b/corehq/apps/auditcare/management/commands/gdpr_scrub_user_auditcare.py
@@ -2,7 +2,7 @@ import logging
 
 from django.core.management.base import BaseCommand
 
-from ...utils.export import navigation_events_by_user
+from ...models import AccessAudit, NavigationEventAudit
 
 logger = logging.getLogger(__name__)
 
@@ -15,8 +15,12 @@ class Command(BaseCommand):
         parser.add_argument('username', help="Username to scrub")
 
     def handle(self, username, **options):
-        events = navigation_events_by_user(username)
-        events.query.update(user=self.new_username)
+        def update_events(model):
+            user_events = model.objects.filter(user=username)
+            user_events.update(user=self.new_username)
+
+        update_events(AccessAudit)
+        update_events(NavigationEventAudit)
         self.scrub_legacy_couch_events(username)
 
     def scrub_legacy_couch_events(self, username):

--- a/corehq/apps/auditcare/tests/test_export.py
+++ b/corehq/apps/auditcare/tests/test_export.py
@@ -1,7 +1,11 @@
+import os.path
 from contextlib import contextmanager
+from csv import DictReader
 from datetime import datetime
 from itertools import chain
 from unittest.mock import patch
+
+from testil import tempdir
 
 from corehq.apps.auditcare.models import AccessAudit, NavigationEventAudit
 
@@ -10,45 +14,100 @@ from ..utils.export import (
     ForeignKeyAccessError,
     get_all_log_events,
     get_foreign_names,
+    get_sql_start_date,
     navigation_events_by_user,
+    write_export_from_all_log_events,
 )
-from .testutils import AuditcareTest
+from .testutils import AuditcareTest, save_couch_doc, delete_couch_docs
 
 
 class TestNavigationEventsQueries(AuditcareTest):
 
+    maxDiff = None
     username = "test@test.com"
 
     @classmethod
-    def setUpTestData(cls):
-        def iter_events(model, username):
+    def setUpClass(cls):
+        super().setUpClass()
+        username = "couch@test.com"
+        event_date = datetime(2021, 2, 1, 2).strftime("%Y-%m-%dT%H:%M:%SZ")
+        cls.couch_ids = [
+            # field structure based on real auditcare docs in Couch
+            save_couch_doc(
+                "NavigationEventAudit",
+                username,
+                event_date=event_date,
+                description='User Name',
+                extra={},
+                headers={
+                    'REQUEST_METHOD': 'GET',
+                    'QUERY_STRING': 'version=2.0&since=...',
+                    'HTTP_CONNECTION': 'close',
+                    'HTTP_COOKIE': 'sessionid=abc123',
+                    'SERVER_NAME': '0.0.0.0',
+                    'SERVER_PORT': '9010',
+                    'HTTP_ACCEPT': 'application/json, application/*+json, */*',
+                    'REMOTE_ADDR': '10.2.10.60',
+                    'HTTP_ACCEPT_ENCODING': 'gzip'
+                },
+                ip_address='10.1.2.3',
+                request_path='/a/delmar/phone/restore/?version=2.0&since=...',
+                session_key='abc123',
+                status_code=200,
+                user_agent='okhttp/4.4.1',
+                view_kwargs={'domain': 'delmar'},
+                view='corehq.apps.ota.views.restore',
+            ),
+            save_couch_doc(
+                "AccessAudit",
+                username,
+                event_date=event_date,
+                access_type='login',
+                description='Login Success',
+                failures_since_start=None,
+                get_data=[],
+                http_accept='text/html',
+                ip_address='10.1.3.2',
+                path_info='/a/delmar/login/',
+                post_data=[],
+                session_key='abc123',
+                user_agent='Mozilla/5.0',
+            ),
+        ]
+
+        def iter_events(model, username, **kw):
             for event_date in cls.event_dates:
-                yield model(user=username, event_date=event_date)
+                yield model(user=username, event_date=event_date, **kw)
 
         cls.event_dates = [datetime(2021, 2, d, 3) for d in range(1, 29)]
+        headers = {"REQUEST_METHOD": "GET"}
         NavigationEventAudit.objects.bulk_create(chain(
-            iter_events(NavigationEventAudit, cls.username),
-            iter_events(NavigationEventAudit, "other@test.com")
+            iter_events(NavigationEventAudit, cls.username, headers=headers),
+            iter_events(NavigationEventAudit, "other@test.com", headers=headers)
         ))
         AccessAudit.objects.bulk_create(chain(
-            iter_events(AccessAudit, cls.username),
-            iter_events(AccessAudit, "other@test.com")
+            iter_events(AccessAudit, cls.username, access_type="o"),
+            iter_events(AccessAudit, "other@test.com", access_type="i")
         ))
 
+    @classmethod
+    def tearDownClass(cls):
+        delete_couch_docs(cls.couch_ids)
+        super().tearDownClass()
+
     def test_navigation_events_query(self):
-        events = navigation_events_by_user(self.username)
-        self.assertEqual(events.count(), 28)
+        events = list(navigation_events_by_user(self.username))
         self.assertEqual({e.user for e in events}, {self.username})
         self.assertEqual([e.event_date for e in events], self.event_dates)
+        self.assertEqual(len(events), 28)
 
     def test_navigation_events_date_range_query(self):
         start = datetime(2021, 2, 5)
         end = datetime(2021, 2, 15)
-        events = navigation_events_by_user(self.username, start, end)
-        self.assertEqual(events.count(), 11)
-        events = list(events)
+        events = list(navigation_events_by_user(self.username, start, end))
         self.assertEqual({e.user for e in events}, {self.username})
         self.assertEqual({e.event_date for e in events}, set(self.event_dates[4:15]))
+        self.assertEqual(len(events), 11)
 
     def test_recent_all_log_events_query(self):
         start = datetime(2021, 2, 4)
@@ -67,6 +126,68 @@ class TestNavigationEventsQueries(AuditcareTest):
         self.assertEqual({e.event_date for e in events}, set(self.event_dates[4:15]))
         self.assertEqual(len(events), 44)
 
+    def test_all_log_events_query_returns_events_from_couch(self):
+        start = datetime(2021, 2, 1)
+        end = datetime(2021, 2, 1)
+        events = list(get_all_log_events(start, end))
+        self.assertEqual({e.user for e in events}, {self.username, "other@test.com", "couch@test.com"})
+        self.assertEqual({e.doc_type for e in events}, {"AccessAudit", "NavigationEventAudit"})
+        self.assertEqual({e.event_date for e in events}, {datetime(2021, 2, 1, 2), datetime(2021, 2, 1, 3)})
+        self.assertEqual(len(events), 6)
+
+    def test_write_export_from_all_log_events(self):
+        def unpack(row):
+            return {k: row[k] for k in ["Date", "Type", "User", "Description"]}
+        start = datetime(2021, 2, 1)
+        end = datetime(2021, 2, 1)
+        with tempdir() as tmp:
+            filename = os.path.join(tmp, "events.csv")
+            with open(filename, 'w', encoding="utf-8") as csvfile:
+                write_export_from_all_log_events(csvfile, start=start, end=end)
+            with open(filename, encoding="utf-8") as fh:
+                def key(row):
+                    return row["Date"], row["Type"]
+                rows = DictReader(fh)
+                items = sorted([unpack(r) for r in rows], key=key)
+                self.assertEqual(items, [
+                    {
+                        'Date': '2021-02-01 02:00:00',
+                        'Type': 'AccessAudit',
+                        'User': 'couch@test.com',
+                        'Description': 'Login Success',
+                    },
+                    {
+                        'Date': '2021-02-01 02:00:00',
+                        'Type': 'NavigationEventAudit',
+                        'User': 'couch@test.com',
+                        'Description': 'User Name',
+                    },
+                    {
+                        'Date': '2021-02-01 03:00:00',
+                        'Type': 'AccessAudit',
+                        'User': 'other@test.com',
+                        'Description': 'Login: other@test.com',
+                    },
+                    {
+                        'Date': '2021-02-01 03:00:00',
+                        'Type': 'AccessAudit',
+                        'User': 'test@test.com',
+                        'Description': 'Logout: test@test.com',
+                    },
+                    {
+                        'Date': '2021-02-01 03:00:00',
+                        'Type': 'NavigationEventAudit',
+                        'User': 'other@test.com',
+                        'Description': 'other@test.com',
+                    },
+                    {
+                        'Date': '2021-02-01 03:00:00',
+                        'Type': 'NavigationEventAudit',
+                        'User': 'test@test.com',
+                        'Description': 'test@test.com',
+                    },
+                ])
+
     def test_query_window_size(self):
         # NOTE small window size ensures multiple queries per event date
         with patch_window_size(1):
@@ -82,10 +203,13 @@ class TestNavigationEventsQueries(AuditcareTest):
             with self.assertRaises(ForeignKeyAccessError):
                 getattr(event, key)
 
+    def test_get_sql_start_date(self):
+        self.assertEqual(get_sql_start_date(), datetime(2021, 2, 1, 3))
+
 
 @contextmanager
 def patch_window_size(size):
     with patch.object(AuditWindowQuery.__init__, "__defaults__", (size,)):
-        qry = AuditWindowQuery("ignored", {})
+        qry = AuditWindowQuery("ignored")
         assert qry.window_size == size, f"patch failed ({qry.window_size})"
         yield

--- a/corehq/apps/auditcare/tests/test_gdpr_scrub_user_auditcare.py
+++ b/corehq/apps/auditcare/tests/test_gdpr_scrub_user_auditcare.py
@@ -1,12 +1,9 @@
-from uuid import uuid4
-
 from django.core import management
 
 from couchdbkit.ext.django.loading import get_db
 
-from ..models import NavigationEventAudit
-from ..utils.export import navigation_events_by_user
-from .testutils import AuditcareTest
+from ..models import AccessAudit, NavigationEventAudit
+from .testutils import AuditcareTest, save_couch_doc, delete_couch_docs
 
 USERNAME = "gdpr_user1"
 
@@ -17,28 +14,40 @@ class TestGDPRScrubUserAuditcare(AuditcareTest):
         NavigationEventAudit(user=USERNAME, path="/fake/path/0").save()
         NavigationEventAudit(user=USERNAME, path="/fake/path/1").save()
         NavigationEventAudit(user=USERNAME, path="/fake/path/2").save()
+        AccessAudit(user=USERNAME, path="/fake/login").save()
+        AccessAudit(user=USERNAME, path="/fake/logout").save()
         self.couch_ids = [
             save_couch_doc("NavigationEventAudit", USERNAME, path="/fake/path/3"),
             save_couch_doc("AccessAudit", USERNAME, ip_address="123.45.67.89"),
         ]
 
     def tearDown(self):
-        db = get_db("auditcare")
-        for doc_id in self.couch_ids:
-            db.delete_doc(doc_id)
+        delete_couch_docs(self.couch_ids)
 
     def test_update_username_no_returned_docs(self):
         management.call_command("gdpr_scrub_user_auditcare", "nonexistent_user")
-        self.assertEqual(navigation_events_by_user("Redacted User (GDPR)").count(), 0)
-        self.assertEqual(navigation_events_by_user(USERNAME).count(), 5)
+        self.assertEqual(count_events("Redacted User (GDPR)"), 0)
+        self.assertEqual(count_events(USERNAME), 7)
 
     def test_update_username_returned_docs(self):
         management.call_command("gdpr_scrub_user_auditcare", USERNAME)
-        self.assertEqual(navigation_events_by_user("Redacted User (GDPR)").count(), 5)
-        self.assertEqual(navigation_events_by_user(USERNAME).count(), 0)
+        self.assertEqual(count_events("Redacted User (GDPR)"), 7)
+        self.assertEqual(count_events(USERNAME), 0)
 
 
-def save_couch_doc(doc_type, user, **doc):
-    db = get_db("auditcare")
-    doc.update(doc_type=doc_type, user=user, _id=uuid4().hex, base_type="AuditEvent")
-    return db.save_doc(doc)["id"]
+def count_events(username):
+    return sum([
+        AccessAudit.objects.filter(user=username).count(),
+        NavigationEventAudit.objects.filter(user=username).count(),
+        couch_count(username),
+    ])
+
+
+def couch_count(username):
+    return get_db("auditcare").view(
+        "auditcare/urlpath_by_user_date",
+        startkey=[username],
+        endkey=[username, {}],
+        reduce=False,
+        include_docs=False,
+    ).count()

--- a/corehq/apps/auditcare/tests/testutils.py
+++ b/corehq/apps/auditcare/tests/testutils.py
@@ -1,6 +1,10 @@
+from uuid import uuid4
+
 from django.db import router
 from django.test import TestCase
 from django.utils.decorators import classproperty
+
+from couchdbkit.ext.django.loading import get_db
 
 from ..models import AuditEvent
 
@@ -10,3 +14,15 @@ class AuditcareTest(TestCase):
     @classproperty
     def databases(self):
         return {"default", router.db_for_read(AuditEvent)}
+
+
+def save_couch_doc(doc_type, user, **doc):
+    db = get_db("auditcare")
+    doc.update(doc_type=doc_type, user=user, _id=uuid4().hex, base_type="AuditEvent")
+    return db.save_doc(doc)["id"]
+
+
+def delete_couch_docs(couch_ids):
+    db = get_db("auditcare")
+    for doc_id in couch_ids:
+        db.delete_doc(doc_id)


### PR DESCRIPTION
Since auditcare switched to a SQL backend its reports included only SQL data. This PR makes auditcare reports return both SQL and Couch data. Couch is not queried if the start date of the query is after the first SQL record was written.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Tests have been added and some were modified to verify that Couch data is returned in addition to SQL data.

### QA Plan

No QA.

### Safety story

This PR modifies audicare report code and makes a small change to the GDPR scrubber management command. All of the things modified by this PR are rarely used.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
