### PR TITLE
Remove unused download_fixture_file

### DIFF
--- a/corehq/apps/fixtures/urls.py
+++ b/corehq/apps/fixtures/urls.py
@@ -5,7 +5,6 @@ from corehq.apps.fixtures.dispatcher import FixtureInterfaceDispatcher
 from corehq.apps.fixtures.views import (
     FixtureUploadStatusView,
     UploadItemLists,
-    download_file,
     download_item_lists,
     fixture_api_upload_status,
     fixture_metadata,
@@ -24,7 +23,6 @@ urlpatterns = [
     FixtureInterfaceDispatcher.url_pattern(),
     url(r'^edit_lookup_tables/download/$', download_item_lists, name="download_fixtures"),
     url(r'^edit_lookup_tables/upload/$', waf_allow('XSS_BODY')(UploadItemLists.as_view()), name='upload_fixtures'),
-    url(r'^edit_lookup_tables/file/$', download_file, name="download_fixture_file"),
     url(r'^edit_lookup_tables/update-tables/(?P<data_type_id>[\w-]+)?$', update_tables,
         name='update_lookup_tables'),
 

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -289,21 +289,6 @@ def download_item_lists(request, domain):
     return download.get_start_response()
 
 
-@require_can_edit_fixtures
-def download_file(request, domain):
-    download_id = request.GET.get("download_id")
-    try:
-        dw = CachedDownload.get(download_id)
-        if dw:
-            return dw.toHttpResponse()
-        else:
-            raise IOError
-    except IOError:
-        notify_exception(request)
-        messages.error(request, _("Sorry, Something went wrong with your download! Please try again. If you see this repeatedly please report an issue "))
-        return HttpResponseRedirect(reverse("fixture_interface_dispatcher", args=[], kwargs={'domain': domain, 'report_slug': 'edit_lookup_tables'}))
-
-
 def fixtures_home(domain):
     return reverse("fixture_interface_dispatcher", args=[],
                    kwargs={'domain': domain, 'report_slug': 'edit_lookup_tables'})


### PR DESCRIPTION
## Summary

https://dimagi-dev.atlassian.net/browse/SAAS-11745
This was long ago replaced with a more standard approach.

## Feature Flag
None

## Product Description
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None needed.

### QA Plan

Checked locally that a fixture download still works.

### Safety story
This is just removing completely unused code and an unused url that points to it.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
