### PR TITLE
Allow colons in WhatsApp template variables

### DIFF
--- a/corehq/messaging/smsbackends/turn/tests/test_template_messages.py
+++ b/corehq/messaging/smsbackends/turn/tests/test_template_messages.py
@@ -36,3 +36,11 @@ class TurnWhatsAppTemplateTest(SimpleTestCase):
         self.assertEqual(parts.template_name, "template_name")
         self.assertEqual(parts.lang_code, "en-US")
         self.assertEqual(parts.params, [])
+
+        # Colons in parameters
+        parts = get_template_hsm_parts(
+            "cc_wa_template:template_name:en-US:{name of person: Snoopy},{address: 123 street}"
+        )
+        self.assertEqual(parts.template_name, "template_name")
+        self.assertEqual(parts.lang_code, "en-US")
+        self.assertEqual(parts.params, ["name of person: Snoopy", "address: 123 street"])

--- a/corehq/messaging/whatsapputil.py
+++ b/corehq/messaging/whatsapputil.py
@@ -45,7 +45,7 @@ def get_template_hsm_parts(message_text):
     """The magic string users enter looks like: cc_wa_template:template_name:lang_code:{var1}{var2}{var3}
     """
     HsmParts = namedtuple("hsm_parts", "template_name lang_code params")
-    parts = message_text.split(":")
+    parts = message_text.split(":", maxsplit=3)
 
     try:
         params = re.findall("{(.+?)}+", parts[3])


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SC-1393
Adding colons inside template variables was breaking the template discovery

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Well tested function.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
