### PR TITLE
markdown in help modal

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -569,6 +569,11 @@ hqDefine("cloudcare/js/form_entry/fullform-ui", function () {
                     return options.data ? md.render(options.data) : null;
                 },
             },
+            help: {
+                update: function (options) {
+                    return options.data ? md.render(options.data) : null;
+                },
+            },
         };
 
         ko.mapping.fromJS(json, mapping, self);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -571,7 +571,7 @@ hqDefine("cloudcare/js/form_entry/fullform-ui", function () {
             },
             help: {
                 update: function (options) {
-                    return options.data ? md.render(options.data) : null;
+                    return options.data ? md.render(DOMPurify.sanitize(options.data)) : null;
                 },
             },
         };

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -150,7 +150,7 @@
           <div class="modal-dialog">
             <div class="modal-content">
               <div class="modal-body">
-                <p align="left" data-bind="text: help"></p>
+                <p class="webapp-markdown-output" align="left" data-bind="html: help"></p>
               </div>
               <div class="modal-footer">
                 <button class="btn btn-default help-modal-close" data-dismiss="modal">{% trans "Close" %}</button>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-11887

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
N/A

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Makes the help modal conform to markdown formatting.


## Safety Assurance

- [ x] Risk label is set correctly
- [ x] All migrations are backwards compatible and won't block deploy
- [x ] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x ] If QA is part of the safety story, the "Awaiting QA" label is used
- [x ] I have confidence that this PR will not introduce a regression for the reasons below

It is a front end change that can be easily reverted.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tested manually.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Small change that uses methods that we have in the past for markdown formatting, so light testing on staging should be sufficient. See it live on staging https://staging.commcarehq.org/a/test-42/apps/view/951ed40d7142426fc86137c7b367e079/module/8131f3d6147a491da983f15c4ad490cd/

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

tested locally and currently on staging

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x ] This PR can be reverted after deploy with no further considerations 
