### PR TITLE
casedb add_assignment_cases script modification

### DIFF
--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -69,7 +69,7 @@ class Command(CaseUpdateCommand):
                 else:
                     if case.get_case_property('is_assigned_primary') == 'yes':
                         case_blocks.append(self.case_block(case, new_owner_id, 'primary'))
-                    elif case.get_case_property('is_assigned_temp') == 'yes':
+                    if case.get_case_property('is_assigned_temp') == 'yes':
                         case_blocks.append(self.case_block(case, new_owner_id, 'temp'))
         print(f"{len(case_blocks)} to update in {domain}, {skip_count} cases have skipped because they're closed"
               f" or in an inactive location")

--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -20,13 +20,12 @@ def needs_update(case):
         case.get_case_property('is_assigned_temp') == 'yes'
 
 
-def find_owner_id(case, accessor):
+def find_owner_id(case, accessor, case_property):
     try:
-        checkin_case = accessor.get_case(case.get_case_property('assigned_to_primary_checkin_case_id'))
+        checkin_case = accessor.get_case(case.get_case_property(case_property))
         return checkin_case.get_case_property('hq_user_id')
     except CaseNotFound:
-        print("CaseNotFound: case:{} no matching case for this case's "
-              "assigned_to_primary_checkin_case_id".format(case.case_id))
+        print("CaseNotFound: case:{} no matching case for this case's {}".format(case.case_id, case_property))
         return None
 
 
@@ -60,17 +59,22 @@ class Command(CaseUpdateCommand):
             if case.get_case_property('current_status') == 'closed':
                 skip_count += 1
             elif needs_update(case):
-                new_owner_id = find_owner_id(case, accessor)
-                if new_owner_id is None:
-                    invalid_id = case.get_case_property('assigned_to_primary_checkin_case_id')
+                new_primary_owner_id = find_owner_id(case, accessor, 'assigned_to_primary_checkin_case_id')
+                new_temp_owner_id = find_owner_id(case, accessor, 'assigned_to_temp_checkin_case_id')
+                case_created = False
+                if case.get_case_property('is_assigned_primary') == 'yes' and new_primary_owner_id:
+                    case_blocks.append(self.case_block(case, new_primary_owner_id, 'primary'))
+                    case_created = True
+                if case.get_case_property('is_assigned_temp') == 'yes' and new_temp_owner_id:
+                    case_blocks.append(self.case_block(case, new_temp_owner_id, 'temp'))
+                    case_created = True
+                if not case_created:
+                    invalid_primary_id = case.get_case_property('assigned_to_primary_checkin_case_id')
+                    invalid_temp_id = case.get_case_property('assigned_to_temp_checkin_case_id')
                     errors.append("CaseNotFound: case:{} no matching case for this case's "
-                                  "assigned_to_primary_checkin_case_id:{}".format(case.case_id, invalid_id))
+                                  "assigned_to_primary_checkin_case_id:{} or assigned_to_temp_checkin_case_id:"
+                                  "{}".format(case.case_id, invalid_primary_id, invalid_temp_id))
                     skip_count += 1
-                else:
-                    if case.get_case_property('is_assigned_primary') == 'yes':
-                        case_blocks.append(self.case_block(case, new_owner_id, 'primary'))
-                    if case.get_case_property('is_assigned_temp') == 'yes':
-                        case_blocks.append(self.case_block(case, new_owner_id, 'temp'))
         print(f"{len(case_blocks)} to update in {domain}, {skip_count} cases have skipped because they're closed"
               f" or in an inactive location")
 

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -313,5 +313,5 @@ class CaseCommandsTest(TestCase):
 
         assignment_cases = self.case_accessor.get_case_ids_in_domain("assignment")
 
-        self.assertEqual(len(assignment_cases), 3)
+        self.assertEqual(len(assignment_cases), 4)
         self.assertEqual(self.case_accessor.get_case(assignment_cases[0]).indices[0].relationship, 'extension')


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-796 

## Product Description
After the last casedb script migration, we realized that the script was not working as expected. Kim and I discovered that there was a discrepancy in the spec and for cases where `is_assigned_temp` = yes, we should find the new owner_id by looking up the checkin case using the `assigned_to_temp_checkin_case_id` property (not the `assigned_to_primary_checkin_case_id`. Also, a case should be created for both temp and primary is `is_assigned_primary` = yes and is_assigned_temp` = yes

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Modified tests in `test_mamangment_commands.py`

### QA Plan
Not requesting QA

### Safety story
This will be run on test domains prior to the next big casedb run

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
