### PR TITLE
Added fuzzy matching support for case search related case queries

### DIFF
--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -14,6 +14,7 @@ from corehq.apps.es.case_search import (
     CaseSearchES,
     case_property_missing,
     case_property_range_query,
+    case_property_text_query,
     exact_case_property_text_query,
     reverse_index_case_query,
 )
@@ -73,8 +74,10 @@ NEQ = "!="
 ALL_OPERATORS = [EQ, NEQ] + list(OPERATOR_MAPPING.keys()) + list(COMPARISON_MAPPING.keys())
 
 
-def build_filter_from_ast(domain, node):
+def build_filter_from_ast(domain, node, fuzzy=False):
     """Builds an ES filter from an AST provided by eulxml.xpath.parse
+
+    If fuzzy is true, all equality operations will be treated as fuzzy.
     """
 
     def _walk_related_cases(node):
@@ -122,7 +125,7 @@ def build_filter_from_ast(domain, node):
             _raise_step_RHS(node)
         new_query = '{} {} "{}"'.format(serialize(node.left.right), node.op, node.right)
 
-        es_query = CaseSearchES().domain(domain).xpath_query(domain, new_query)
+        es_query = CaseSearchES().domain(domain).xpath_query(domain, new_query, fuzzy=fuzzy)
         if es_query.count() > MAX_RELATED_CASES:
             raise TooManyRelatedCasesError(
                 _("The related case lookup you are trying to perform would return too many cases"),
@@ -184,6 +187,8 @@ def build_filter_from_ast(domain, node):
 
             if value == '':
                 q = case_property_missing(case_property_name)
+            elif fuzzy:
+                q = case_property_text_query(case_property_name, value, fuzziness='AUTO')
             else:
                 q = exact_case_property_text_query(case_property_name, value)
 
@@ -248,14 +253,14 @@ def build_filter_from_ast(domain, node):
     return visit(node)
 
 
-def build_filter_from_xpath(domain, xpath):
+def build_filter_from_xpath(domain, xpath, fuzzy=False):
     error_message = _(
         "We didn't understand what you were trying to do with {}. "
         "Please try reformatting your query. "
         "The operators we accept are: {}"
     )
     try:
-        return build_filter_from_ast(domain, parse_xpath(xpath))
+        return build_filter_from_ast(domain, parse_xpath(xpath), fuzzy=fuzzy)
     except TypeError as e:
         text_error = re.search(r"Unknown text '(.+)'", str(e))
         if text_error:

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -116,6 +116,6 @@ class CaseSearchCriteria(object):
 
             if '/' in key:
                 query = '{} = "{}"'.format(key, value)
-                self.search_es = self.search_es.xpath_query(self.domain, query)
+                self.search_es = self.search_es.xpath_query(self.domain, query, fuzzy=(key in fuzzies))
             else:
                 self.search_es = self.search_es.case_property_query(key, value, fuzzy=(key in fuzzies))

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -94,7 +94,7 @@ class CaseSearchES(CaseES):
         """
         return self.add_query(case_property_range_query(case_property_name, gt, gte, lt, lte), clause)
 
-    def xpath_query(self, domain, xpath):
+    def xpath_query(self, domain, xpath, fuzzy=False):
         """Search for cases using an XPath predicate expression.
 
         Enter an arbitrary XPath predicate in the context of the case. Also supports related case lookups.
@@ -104,9 +104,11 @@ class CaseSearchES(CaseES):
         - date ranges: "first_came_online >= '2017-08-12' or died <= '2020-11-15"
         - numeric ranges: "age >= 100 and height < 1.25"
         - related cases: "mother/first_name = 'maeve' or parent/parent/host/age = 13"
+
+        If fuzzy is true, all equality checks will be treated as fuzzy.
         """
         from corehq.apps.case_search.filter_dsl import build_filter_from_xpath
-        return self.filter(build_filter_from_xpath(domain, xpath))
+        return self.filter(build_filter_from_xpath(domain, xpath, fuzzy=fuzzy))
 
     def get_child_cases(self, case_ids, identifier):
         """Returns all cases that reference cases with ids: `case_ids`


### PR DESCRIPTION
## Summary

https://dimagi-dev.atlassian.net/browse/USH-834

Follows up on https://github.com/dimagi/commcare-hq/pull/29349

## Feature Flag
Case search & claim

## Product Description
Allows projects to configure related case properties as fuzzy. Fuzzy properties get configured on the case type being searched on, not the type they belong to:

<img width="563" alt="Screen Shot 2021-04-09 at 8 24 52 PM" src="https://user-images.githubusercontent.com/1486591/114252125-c0cdd080-9971-11eb-8cd8-8dfe81551cd7.png">

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

There's decent test coverage of case search.

### QA Plan

Tested locally, not requesting QA.

### Safety story
This is a pretty minor addition, code-wise, to existing case search functionality.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
