### PR TITLE
Removed icds-ucr from testsettings

### DIFF
--- a/testsettings.py
+++ b/testsettings.py
@@ -125,14 +125,6 @@ LOGGING = {
     'loggers': {},
 }
 
-# Default custom databases to use the same configuration as the default
-# This is so that all devs don't have to run citus locally
-if 'icds-ucr' not in DATABASES:
-    DATABASES['icds-ucr'] = deepcopy(DATABASES['default'])
-    # use a different name otherwise migrations don't get run
-    DATABASES['icds-ucr']['NAME'] = 'commcarehq_icds_ucr'
-    del DATABASES['icds-ucr']['TEST']['NAME']  # gets set by `helper.assign_test_db_names`
-
 helper.assign_test_db_names(DATABASES)
 
 # See comment under settings.SMS_QUEUE_ENABLED


### PR DESCRIPTION
I think this is the right way to stop doing citus setup locally when using `reusedb=reset`.