### PR TITLE
Show properties from related cases in case search results

### DIFF
--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -594,7 +594,7 @@ class PropertyXpathGenerator(BaseXpathGenerator):
             case = CaseXPath(UserCaseXPath().case())
         else:
             for index in indexes:
-                case = case.index_id(index).case()
+                case = case.index_id(index).case(instance_name=self.detail.instance_name)
 
         if property == '#owner_name':
             return self.owner_name(case.property('@owner_id'))

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1977,6 +1977,8 @@ class Detail(IndexedSchema, CaseListLookupMixin):
     sort_nodeset_columns = BooleanProperty()
     filter = StringProperty()
 
+    instance_name = StringProperty(default='casedb')
+
     # If True, a small tile will display the case name after selection.
     persist_case_context = BooleanProperty()
     persistent_case_context_xml = StringProperty(default='case_name')
@@ -2413,7 +2415,9 @@ class ModuleDetailsMixin(object):
 
     @property
     def search_detail(self):
-        return deepcopy(self.case_details.short)
+        detail = deepcopy(self.case_details.short)
+        detail.instance_name = "results"
+        return detail
 
     def rename_lang(self, old_lang, new_lang):
         super(Module, self).rename_lang(old_lang, new_lang)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2413,9 +2413,8 @@ class ModuleDetailsMixin(object):
         except Exception:
             return []
 
-    @property
-    def search_detail(self):
-        detail = deepcopy(self.case_details.short)
+    def search_detail(self, short_or_long):
+        detail = deepcopy(getattr(self.case_details, short_or_long))
         detail.instance_name = "results"
         return detail
 
@@ -2432,7 +2431,8 @@ class ModuleDetailsMixin(object):
             ('ref_long', self.ref_details.long, False),
         ]
         if module_offers_search(self) and not self.case_details.short.custom_xml:
-            details.append(('search_short', self.search_detail, True))
+            details.append(('search_short', self.search_detail("short"), True))
+            details.append(('search_long', self.search_detail("long"), True))
         return tuple(details)
 
 
@@ -3124,9 +3124,10 @@ class AdvancedModule(ModuleBase):
     def all_forms_require_a_case(self):
         return all(form.requires_case() for form in self.get_forms())
 
-    @property
-    def search_detail(self):
-        return deepcopy(self.case_details.short)
+    def search_detail(self, short_or_long):
+        detail = deepcopy(getattr(self.case_details, short_or_long))
+        detail.instance_name = "results"
+        return detail
 
     def get_details(self):
         details = [
@@ -3136,7 +3137,8 @@ class AdvancedModule(ModuleBase):
             ('product_long', self.product_details.long, False),
         ]
         if module_offers_search(self) and not self.case_details.short.custom_xml:
-            details.append(('search_short', self.search_detail, True))
+            details.append(('search_short', self.search_detail("short"), True))
+            details.append(('search_long', self.search_detail("long"), True))
         return details
 
     @property

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -118,6 +118,7 @@ from corehq.apps.app_manager.suite_xml.generator import (
     MediaSuiteGenerator,
     SuiteGenerator,
 )
+from corehq.apps.app_manager.suite_xml.sections.remote_requests import RESULTS_INSTANCE
 from corehq.apps.app_manager.suite_xml.utils import get_select_chain
 from corehq.apps.app_manager.tasks import prune_auto_generated_builds
 from corehq.apps.app_manager.templatetags.xforms_extras import trans
@@ -2415,7 +2416,7 @@ class ModuleDetailsMixin(object):
 
     def search_detail(self, short_or_long):
         detail = deepcopy(getattr(self.case_details, short_or_long))
-        detail.instance_name = "results"
+        detail.instance_name = RESULTS_INSTANCE
         return detail
 
     def rename_lang(self, old_lang, new_lang):
@@ -3126,7 +3127,7 @@ class AdvancedModule(ModuleBase):
 
     def search_detail(self, short_or_long):
         detail = deepcopy(getattr(self.case_details, short_or_long))
-        detail.instance_name = "results"
+        detail.instance_name = RESULTS_INSTANCE
         return detail
 
     def get_details(self):

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -124,8 +124,10 @@ class RemoteRequestFactory(object):
         details_helper = DetailsHelper(self.app)
         if self.module.case_details.short.custom_xml:
             short_detail_id = 'case_short'
+            long_detail_id = 'case_long'
         else:
             short_detail_id = 'search_short'
+            long_detail_id = 'search_long'
 
         nodeset = CaseTypeXpath(self.module.case_type).case(instance_name=RESULTS_INSTANCE)
         if self.module.search_config.search_filter:
@@ -136,7 +138,7 @@ class RemoteRequestFactory(object):
             nodeset=nodeset,
             value='./@case_id',
             detail_select=details_helper.get_detail_id_safe(self.module, short_detail_id),
-            detail_confirm=details_helper.get_detail_id_safe(self.module, 'case_long'),
+            detail_confirm=details_helper.get_detail_id_safe(self.module, long_detail_id),
         )]
 
     def _get_remote_request_query_datums(self):

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -111,7 +111,7 @@ class RemoteRequestFactory(object):
     def _build_remote_request_queries(self):
         return [
             RemoteRequestQuery(
-                url=absolute_reverse('remote_search', args=[self.app.domain]),
+                url=absolute_reverse('app_aware_remote_search', args=[self.app.domain, self.app._id]),
                 storage_instance=RESULTS_INSTANCE,
                 template='case',
                 data=self._get_remote_request_query_datums(),

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -20,7 +20,7 @@
     <instance id="locations" src="jr://fixture/locations"/>
     <instance id="reports" src="jr://fixture/commcare:reports"/>
     <session>
-      <query url="https://www.example.com/a/test_domain/phone/search/"
+      <query url="https://www.example.com/a/test_domain/phone/search/123/"
              default_search="false"
              storage-instance="results"
              template="case">

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -45,7 +45,7 @@
       <datum id="search_case_id"
              nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name]"
              value="./@case_id"
-             detail-confirm="{module_id}_case_long"
+             detail-confirm="{module_id}_search_long"
              detail-select="{module_id}_search_short"/>
     </session>
     <stack>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
@@ -18,7 +18,7 @@
     <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
     <instance id="locations" src="jr://fixture/locations"/>
     <session>
-      <query url="https://www.example.com/a/test_domain/phone/search/"
+      <query url="https://www.example.com/a/test_domain/phone/search/123/"
              default_search="false"
              storage-instance="results"
              template="case">

--- a/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
@@ -49,6 +49,18 @@
         </text>
       </template>
     </field>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.case_short.case_parent/whatever_4.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="instance('casedb')/casedb/case[@case_id=current()/index/parent]/whatever"/>
+         </text>
+       </template>
+     </field>
     <action auto_launch="false" redo_last="false">
       <display>
         <text>
@@ -145,6 +157,18 @@
               <xpath function="instance('item-list:moons')/moons_list/moons[favorite='yes']/name"/>
             </variable>
           </xpath>
+        </text>
+      </template>
+    </field>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.search_short.case_parent/whatever_4.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="instance('results')/results/case[@case_id=current()/index/parent]/whatever"/>
         </text>
       </template>
     </field>

--- a/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
@@ -162,6 +162,41 @@
       </stack>
     </action>
   </detail>
+  <detail id="m0_search_long">
+    <title>
+      <text>
+        <locale id="cchq.case"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.search_long.case_name_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+    </field>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.search_long.case_calculated_property_2.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="$calculated_property">
+            <variable name="calculated_property">
+              <xpath function="instance('ledgerdb')/ledgers/name/name"/>
+            </variable>
+          </xpath>
+        </text>
+      </template>
+    </field>
+  </detail>
   <detail id="m1_case_short">
     <title>
       <text>
@@ -244,6 +279,25 @@
         </push>
       </stack>
     </action>
+  </detail>
+  <detail id="m1_search_long">
+    <title>
+      <text>
+        <locale id="cchq.case"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m1.search_long.case_name_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+    </field>
   </detail>
   <detail id="m2_case_short"/>
   <detail id="m2_case_long">

--- a/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
@@ -34,7 +34,7 @@
       <datum id="search_case_id"
              nodeset="instance('results')/results/case[@case_type='case']"
              value="./@case_id"
-             detail-confirm="m0_case_long"
+             detail-confirm="m0_search_long"
              detail-select="m0_search_short"/>
     </session>
     <stack>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
@@ -17,7 +17,7 @@
     <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
     <instance id="reports" src="jr://fixture/commcare:reports"/>
     <session>
-      <query url="https://www.example.com/a/test_domain/phone/search/"
+      <query url="https://www.example.com/a/test_domain/phone/search/123/"
              default_search="false"
              storage-instance="results"
              template="case">

--- a/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
@@ -18,7 +18,7 @@
     <instance id="locations" src="jr://fixture/locations"/>
     <instance id="reports" src="jr://fixture/commcare:reports"/>
     <session>
-      <query url="https://www.example.com/a/test_domain/phone/search/"
+      <query url="https://www.example.com/a/test_domain/phone/search/123/"
              default_search="false"
              storage-instance="results"
              template="case">

--- a/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
@@ -29,7 +29,7 @@
       <datum id="search_case_id"
              nodeset="instance('results')/results/case[@case_type='case']"
              value="./@case_id"
-             detail-confirm="m0_case_long"
+             detail-confirm="m0_search_long"
              detail-select="m0_search_short"/>
     </session>
     <stack>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -56,6 +56,14 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 calc_xpath="instance('item-list:moons')/moons_list/moons[favorite='yes']/name",
             ))
         )
+        self.module.case_details.short.columns.append(
+            DetailColumn.wrap(dict(
+                header={"en": "Parent's Whatever"},
+                model="case",
+                format="plain",
+                field="parent/whatever",
+            ))
+        )
         self.module.case_details.long.columns.append(
             DetailColumn.wrap(dict(
                 header={"en": "ledger_name"},

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -31,6 +31,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
 
     def setUp(self):
         self.app = Application.new_app(DOMAIN, "Untitled Application")
+        self.app._id = '123'
         self.app.build_spec = BuildSpec(version='2.35.0', build_number=1)
         self.module = self.app.add_module(Module.new_module("Untitled Module", None))
         self.app.new_form(0, "Untitled Form", None)

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -136,6 +136,8 @@ def get_related_cases(cases, app_id):
 
     app = get_app_cached(cases[0].domain, app_id)
     paths = get_related_case_relationships(app, cases[0].type)
+    if not paths:
+        return []
     return get_related_case_results(cases, paths)
 
 

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -145,7 +145,6 @@ def get_related_case_relationships(app, case_type):
     """
     Get unique case relationships used by search details in any modules that
     match the given case type and are configured for case search.
-    It will miss related cases that are referenced only by calculated properties
 
     Returns a set of paths, e.g. {"parent", "host", "parent/parent"}
     """

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -150,7 +150,7 @@ def get_related_case_relationships(app, case_type):
     paths = set()
     for module in app.get_modules():
         if module.case_type == case_type and module_offers_search(module):
-            for column in module.search_detail.columns:
+            for column in module.search_detail("short").columns + module.search_detail("long").columns:
                 if not column.useXpathExpression:
                     parts = column.field.split("/")
                     if len(parts) > 1:

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -174,9 +174,6 @@ def get_related_case_results(domain, cases, paths):
         parts = path.split("/")
         for index, identifier in enumerate(parts):
             fragment = "/".join(parts[:index + 1])
-            if not fragment:
-                continue
-
             if fragment in results_cache:
                 current_cases = results_cache[fragment]
             else:

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -124,7 +124,7 @@ class CaseSearchCriteria(object):
                 self.search_es = self.search_es.case_property_query(key, value, fuzzy=(key in fuzzies))
 
 
-def get_related_cases(cases, app_id):
+def get_related_cases(domain, app_id, case_type, cases):
     """
     Fetch related cases that are necessary to display any related-case
     properties in the app requesting this case search.
@@ -134,11 +134,11 @@ def get_related_cases(cases, app_id):
     if not cases:
         return []
 
-    app = get_app_cached(cases[0].domain, app_id)
-    paths = get_related_case_relationships(app, cases[0].type)
+    app = get_app_cached(domain, app_id)
+    paths = get_related_case_relationships(app, case_type)
     if not paths:
         return []
-    return get_related_case_results(cases, paths)
+    return get_related_case_results(domain, cases, paths)
 
 
 def get_related_case_relationships(app, case_type):
@@ -161,7 +161,7 @@ def get_related_case_relationships(app, case_type):
     return paths
 
 
-def get_related_case_results(cases, paths):
+def get_related_case_results(domain, cases, paths):
     """
     Given a set of cases and a set of case property paths,
     fetches ES documents for all cases referenced by those paths.
@@ -169,7 +169,6 @@ def get_related_case_results(cases, paths):
     if not cases:
         return []
 
-    domain = cases[0].domain
     results_cache = {}
     for path in paths:
         current_cases = cases

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -134,15 +134,14 @@ def get_related_cases(cases, app_id):
     if not cases:
         return []
 
-    domain = cases[0].domain
-    case_type = cases[0].type
-    paths = get_related_case_relationships(domain, app_id, case_type)
+    app = get_app_cached(cases[0].domain, app_id)
+    paths = get_related_case_relationships(app, cases[0].type)
     results = get_related_case_results(cases, paths)
 
     return [CommCareCase.wrap(flatten_result(result)) for result in results]
 
 
-def get_related_case_relationships(domain, app_id, case_type):
+def get_related_case_relationships(app, case_type):
     """
     Get unique case relationships used by search details in any modules that
     match the given case type and are configured for case search.
@@ -151,7 +150,6 @@ def get_related_case_relationships(domain, app_id, case_type):
     Returns a set of paths, e.g. {"parent", "host", "parent/parent"}
     """
     paths = set()
-    app = get_app_cached(domain, app_id)
     for module in app.get_modules():
         if module.case_type == case_type and module_offers_search(module):
             for column in module.search_detail.columns:

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -35,7 +35,6 @@ class CaseSearchES(CaseES):
     @property
     def builtin_filters(self):
         return [
-            case_ids,
             case_property_filter,
             blacklist_owner_id,
             external_id,
@@ -138,10 +137,6 @@ class CaseSearchES(CaseES):
             desc,
             reset_sort=False
         )
-
-
-def case_ids(case_ids):
-    return filters.term('_id', case_ids)
 
 
 def case_property_filter(case_property_name, value):

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -35,6 +35,7 @@ class CaseSearchES(CaseES):
     @property
     def builtin_filters(self):
         return [
+            case_ids,
             case_property_filter,
             blacklist_owner_id,
             external_id,
@@ -137,6 +138,10 @@ class CaseSearchES(CaseES):
             desc,
             reset_sort=False
         )
+
+
+def case_ids(case_ids):
+    return filters.term('_id', case_ids)
 
 
 def case_property_filter(case_property_name, value):

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -5,6 +5,7 @@ from django.test.testcases import SimpleTestCase
 from django.test import TestCase
 from mock import MagicMock, patch
 
+from casexml.apps.case.models import CommCareCase
 from corehq.apps.app_manager.models import (
     Application,
     CaseSearchProperty,
@@ -16,6 +17,7 @@ from corehq.apps.case_search.models import CaseSearchConfig
 from corehq.apps.case_search.utils import (
     CaseSearchCriteria,
     get_related_case_relationships,
+    get_related_case_results,
 )
 from corehq.apps.es.tests.utils import ElasticTestMixin, es_test
 from corehq.apps.es.case_search import (
@@ -263,26 +265,29 @@ class TestCaseSearchLookups(TestCase):
         ensure_index_deleted(CASE_SEARCH_INDEX)
         super(TestCaseSearchLookups, self).tearDown()
 
-    def _make_case(self, domain, case_properties):
+    def _make_case(self, domain, case_properties, index=None):
         # make a case
         case_properties = case_properties or {}
         case_id = case_properties.pop('_id')
+        case_type = case_properties.pop('case_type', self.case_type)
         case_name = 'case-name-{}'.format(uuid.uuid4().hex)
         owner_id = case_properties.pop('owner_id', None)
         case = create_and_save_a_case(
-            domain, case_id, case_name, case_properties, owner_id=owner_id, case_type=self.case_type)
+            domain, case_id, case_name, case_properties, owner_id=owner_id, case_type=case_type, index=index
+        )
         return case
 
-    def _bootstrap_cases_in_es_for_domain(self, domain):
+    def _bootstrap_cases_in_es_for_domain(self, domain, input_cases):
+        for case in input_cases:
+            index = case.pop('index', None)
+            self._make_case(domain, case, index=index)
         with patch('corehq.pillows.case_search.domains_needing_search_index',
                    MagicMock(return_value=[domain])):
             CaseSearchReindexerFactory(domain=domain).build().reindex()
+        self.elasticsearch.indices.refresh(CASE_SEARCH_INDEX)
 
     def _assert_query_runs_correctly(self, domain, input_cases, query, xpath_query, output):
-        for case in input_cases:
-            self._make_case(domain, case)
-        self._bootstrap_cases_in_es_for_domain(domain)
-        self.elasticsearch.indices.refresh(CASE_SEARCH_INDEX)
+        self._bootstrap_cases_in_es_for_domain(domain, input_cases)
         self.assertItemsEqual(
             query.get_ids(),
             output
@@ -467,3 +472,39 @@ class TestCaseSearchLookups(TestCase):
 
         self.assertEqual(get_related_case_relationships(app, self.case_type), {"parent/parent", "host"})
         self.assertEqual(get_related_case_relationships(app, "monster"), set())
+
+    def test_get_related_case_results(self):
+        # Note that cases must be defined before other cases can reference them
+        cases = [
+            {'_id': 'c1', 'case_type': 'monster', 'description': 'grandparent of first person'},
+            {'_id': 'c2', 'case_type': 'monster', 'description': 'parent of first person', 'index': {
+                'parent': ('monster', 'c1')
+            }},
+            {'_id': 'c3', 'case_type': 'monster', 'description': 'parent of host'},
+            {'_id': 'c4', 'case_type': 'monster', 'description': 'host of second person', 'index': {
+                'parent': ('monster', 'c3')
+            }},
+            {'_id': 'c5', 'description': 'first person', 'index': {
+                'parent': ('monster', 'c2')
+            }},
+            {'_id': 'c6', 'description': 'second person', 'index': {
+                'host': ('monster', 'c4')
+            }},
+        ]
+        self._bootstrap_cases_in_es_for_domain(self.domain, cases)
+
+        hits = CaseSearchES().domain(self.domain).case_type(self.case_type).run().hits
+        cases = [CommCareCase.wrap(flatten_result(result)) for result in hits]
+        self.assertEqual({case.case_id for case in cases}, {'c5', 'c6'})
+
+        self._assert_related_case_ids(cases, set(), set())
+        self._assert_related_case_ids(cases, {"parent"}, {"c2"})
+        self._assert_related_case_ids(cases, {"host"}, {"c4"})
+        self._assert_related_case_ids(cases, {"parent/parent"}, {"c1"})
+        self._assert_related_case_ids(cases, {"host/parent"}, {"c3"})
+        self._assert_related_case_ids(cases, {"host", "parent"}, {"c2", "c4"})
+        self._assert_related_case_ids(cases, {"host", "parent/parent"}, {"c4", "c1"})
+
+    def _assert_related_case_ids(self, cases, paths, ids):
+        results = get_related_case_results(cases, paths)
+        self.assertEqual(ids, {result['_id'] for result in results})

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -506,5 +506,5 @@ class TestCaseSearchLookups(TestCase):
         self._assert_related_case_ids(cases, {"host", "parent/parent"}, {"c4", "c1"})
 
     def _assert_related_case_ids(self, cases, paths, ids):
-        results = get_related_case_results(cases, paths)
+        results = get_related_case_results(self.domain, cases, paths)
         self.assertEqual(ids, {result['_id'] for result in results})

--- a/corehq/apps/ota/urls.py
+++ b/corehq/apps/ota/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 
 from corehq.apps.hqadmin.views.users import DomainAdminRestoreView
 from corehq.apps.ota.views import (
+    app_aware_search,
     claim,
     get_next_id,
     heartbeat,
@@ -16,6 +17,7 @@ urlpatterns = [
     url(r'^admin_restore/(?P<app_id>[\w-]+)/$', DomainAdminRestoreView.as_view()),
     url(r'^restore/(?P<app_id>[\w-]+)/$', restore, name='app_aware_restore'),
     url(r'^search/$', search, name='remote_search'),
+    url(r'^search/(?P<app_id>[\w-]+)/$', app_aware_search, name='app_aware_remote_search'),
     url(r'^claim-case/$', claim, name='claim_case'),
     url(r'^heartbeat/(?P<app_build_id>[\w-]+)/$', heartbeat, name='phone_heartbeat'),
     url(r'^get_next_id/$', get_next_id, name='get_next_id'),

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -92,6 +92,13 @@ def restore(request, domain, app_id=None):
 @mobile_auth
 @check_domain_migration
 def search(request, domain):
+    return app_aware_search(request, domain, None)
+
+
+@location_safe
+@mobile_auth
+@check_domain_migration
+def app_aware_search(request, domain, app_id):
     """
     Accepts search criteria as GET params, e.g. "https://www.commcarehq.org/a/domain/phone/search/?a=b&c=d"
     Returns results as a fixture with the same structure as a casedb instance.

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -126,7 +126,7 @@ def app_aware_search(request, domain, app_id):
     # Even if it's a SQL domain, we just need to render the hits as cases, so CommCareCase.wrap will be fine
     cases = [CommCareCase.wrap(flatten_result(result, include_score=True)) for result in hits]
     if app_id:
-        cases.extend(get_related_cases(cases, app_id))
+        cases.extend(get_related_cases(domain, app_id, case_type, cases))
 
     fixtures = CaseDBFixture(cases).fixture
     return HttpResponse(fixtures, content_type="text/xml; charset=utf-8")

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -46,6 +46,7 @@ from corehq.apps.domain.decorators import (
     mobile_auth_or_formplayer,
 )
 from corehq.apps.domain.models import Domain
+from corehq.apps.es.cases import CaseES
 from corehq.apps.es.case_search import flatten_result
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.ota.decorators import require_mobile_access
@@ -134,14 +135,36 @@ def app_aware_search(request, domain, app_id):
 
 
 def _get_related_cases(cases, app_id):
+    """
+    Fetch related cases that are necessary to display any related-case
+    properties in the app requesting this case search.
+
+    Returns list of CommCareCase objects for adding to CaseDBFixture.
+    """
     if not cases:
         return []
 
     domain = cases[0].domain
     case_type = cases[0].type
+    paths = _get_related_case_relationship_paths(domain, app_id, case_type)
+    results = _get_related_case_results(cases, paths)
 
-    # Get unique case relationships used by search details in possible modules
-    # This will miss related cases that are referenced only by calculated properties
+    # Handle incompatibility between sql cases and CommCareCase
+    # See https://github.com/dimagi/commcare-hq/commit/f7eca23eaffb9168d04c06a06a8c5d497202f6bf
+    for result in results:
+        result.pop('modified_by')
+
+    return [CommCareCase.wrap(result) for result in results]
+
+
+def _get_related_case_relationship_paths(domain, app_id, case_type):
+    """
+    Get unique case relationships used by search details in any modules that
+    match the given case type and are configured for case search.
+    It will miss related cases that are referenced only by calculated properties
+
+    Returns a set of paths, e.g. {"parent", "host", "parent/parent"}
+    """
     paths = set()
     app = get_app_cached(domain, app_id)
     for module in app.get_modules():
@@ -150,22 +173,41 @@ def _get_related_cases(cases, app_id):
                 if not column.useXpathExpression:
                     parts = column.field.split("/")
                     if len(parts) > 1:
-                        parts[-1] = "name"
+                        parts.pop()     # keep only the relationship: "parent", "parent/parent", etc.
                         paths.add("/".join(parts))
+    return paths
 
-    # TODO: get only relevant cases
-    parent_indices = [case.get_index('parent') for case in cases]
-    parent_ids = {i.referenced_id for i in parent_indices if i}
 
-    from corehq.apps.es.cases import CaseES
-    results = CaseES().domain(domain).case_ids(parent_ids).run().hits
+def _get_related_case_results(cases, paths):
+    """
+    Given a set of cases and a set of case property paths,
+    fetches ES documents for all cases referenced by those paths.
+    """
+    if not cases:
+        return []
 
-    # Handle incompatibility between sql cases and CommCareCase
-    # See https://github.com/dimagi/commcare-hq/commit/f7eca23eaffb9168d04c06a06a8c5d497202f6bf
-    for result in results:
-        result.pop('modified_by')
+    domain = cases[0].domain
+    results_cache = {}
+    for path in paths:
+        parts = path.split("/")
+        for index, identifier in enumerate(parts):
+            fragment = "/".join(parts[:index + 1])
+            if not fragment:
+                continue
 
-    return [CommCareCase.wrap(result) for result in results]
+            if fragment in results_cache:
+                cases = results_cache[fragment]
+            else:
+                indices = [case.get_index(identifier) for case in cases]
+                related_case_ids = {i.referenced_id for i in indices if i}
+                results = CaseES().domain(domain).case_ids(related_case_ids).run().hits
+                results_cache[fragment] = results
+
+    results = []
+    for path in paths:
+        results.extend(results_cache[path])
+
+    return results
 
 
 @location_safe

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -571,7 +571,7 @@ def _create_case(domain, **kwargs):
 
 
 def create_and_save_a_case(domain, case_id, case_name, case_properties=None, case_type=None,
-        drop_signals=True, owner_id=None, user_id=None):
+        drop_signals=True, owner_id=None, user_id=None, index=None):
     from casexml.apps.case.signals import case_post_save
     from corehq.form_processor.signals import sql_case_post_save
 
@@ -580,6 +580,7 @@ def create_and_save_a_case(domain, case_id, case_name, case_properties=None, cas
         'case_id': case_id,
         'case_name': case_name,
         'update': case_properties,
+        'index': index,
     }
 
     if case_type:


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-803

Review by commit. There are two main changes:
1. Related case properties are stored in the suite as absolute xpath expressions that reference the casedb. This PR adds an `instance_name` property to `Detail` objects so that details used to display search results instead reference the `results` instance.
2. Determine which related cases to include in the search results. The naive approach would be to include all related cases. The optimal approach would be to include only those cases needed by the detail that will display the search results. I'm doing a compromise approach: look up all of the fields used for details in the relevant app that are the appropriate case type and have case search enabled. One extra ES query is done for each relationship, though they should be relatively fast queries since they're querying on case id and will return at most 500 results.

## Feature Flag
Case search & claim

## Product Description
Previously, any related case properties referenced on the case detail used for case search results would show up as blank unless that related case already happened to be in the user's casedb. Now, the appropriate related cases will be included in search results, so their properties can be displayed in results.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

This PR includes test coverage.

### QA Plan

[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-2895)

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
