### PR TITLE
stick with default escaping for multi select2

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select_2_ajax_widget.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select_2_ajax_widget.js
@@ -10,7 +10,6 @@ hqDefine("hqwebapp/js/select_2_ajax_widget", [
 
             $select.select2({
                 multiple: htmlData.multiple,
-                escapeMarkup: function (m) { return m; },
                 width: '100%',
                 ajax: {
                     url: htmlData.endpoint,

--- a/corehq/apps/reports/static/reports/js/filters/select2s.js
+++ b/corehq/apps/reports/static/reports/js/filters/select2s.js
@@ -71,7 +71,6 @@ hqDefine("reports/js/filters/select2s", [
         if (!data.endpoint) {
             $filter.select2({
                 width: '100%',
-                escapeMarkup: function (m) { return m; },
             });
             return;
         }
@@ -120,7 +119,6 @@ hqDefine("reports/js/filters/select2s", [
                 },
             },
             multiple: true,
-            escapeMarkup: function (m) { return m; },
             width: '100%',
         });
 


### PR DESCRIPTION
## Summary
This was prompted by scenario 3 in [this comment](https://dimagi-dev.atlassian.net/browse/QA-2866?focusedCommentId=134253). Basically, some of our select2 filters are allowing through formatted text. The example pointed out via the comment was the Users filter for Submit History. Worker Activity->Group suffered from the same problem. This was caused by us explicitly overriding the default [escaping behavior](https://select2.org/dropdown#built-in-escaping) of select2.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No test cases

### QA Plan

This will need a QA pass-thru to ensure that the fixes here don't break other fields.

### Safety story

Local testing was done to verify this fix for the affected areas. However, it does look like we were deliberately not escaping one of these paths before, which makes me worried that we rely on this behavior elsewhere. Relying on QA to find if this is the case.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
