### PR TITLE
don't error on app sorting if no date_created is set

### DIFF
--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -1,5 +1,4 @@
-from operator import attrgetter
-
+from datetime import datetime
 from django.http import (
     HttpResponse,
     HttpResponseBadRequest,
@@ -375,7 +374,8 @@ class SingleSignOnResource(HqBaseResource, DomainSpecificResourceMixin):
 class BaseApplicationResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourceMixin):
 
     def obj_get_list(self, bundle, domain, **kwargs):
-        return sorted(get_apps_in_domain(domain, include_remote=False), key=attrgetter("date_created"))
+        return sorted(get_apps_in_domain(domain, include_remote=False),
+                      key=lambda app: getattr(app, 'date_created') or datetime.min)
 
     def obj_get(self, bundle, **kwargs):
         # support returning linked applications upon receiving an application request

--- a/corehq/apps/api/tests/app_resources.py
+++ b/corehq/apps/api/tests/app_resources.py
@@ -50,6 +50,19 @@ class TestAppResource(APIResourceTest):
             self.get_expected_structure(with_version=False),
         ])
 
+    def test_get_list_null_sorting(self):
+        another_app = self.make_app()
+        another_app.date_created = None
+        another_app.save()
+        self.addCleanup(another_app.delete)
+        response = self._assert_auth_get_resource(self.list_endpoint, allow_session_auth=True)
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content["meta"], {
+            'limit': None, 'next': None, 'offset': 0, 'previous': None,
+            'total_count': 3
+        })
+
     def test_get_single(self):
         response = self._assert_auth_get_resource(self.single_endpoint(self.apps[0]._id), allow_session_auth=True)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12064
https://sentry.io/organizations/dimagi/issues/2310732846/?project=136860

## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Some apps in the wild don't have `date_created` set, so the sorting introduced in https://github.com/dimagi/commcare-hq/pull/29411 was causing crashes.

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Fixes the app API and Zapier integrations for a subset of affected domains.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

I tested the affected code manually and the footprint is exceedingly low. Also added a test.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Added a test.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
