### PR TITLE
Removed AgeInMonthsBucketsColumn

### DIFF
--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -1411,18 +1411,14 @@ Keep in mind that the only variables available for formatting are
 | "%b (%y)" | "Sep (08)"        |
 +-----------+-------------------+
 
-IntegerBucketsColumn and AgeInMonthsBucketsColumn
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+IntegerBucketsColumn
+~~~~~~~~~~~~~~~~~~~~
 
 Bucket columns allow you to define a series of ranges with corresponding names,
 then group together rows where a specific field's value falls within those ranges.
 These ranges are inclusive, since they are implemented using the ``between`` operator.
 It is the user's responsibility to make sure the ranges do not overlap; if a value
 falls into multiple ranges, it is undefined behavior which bucket it will be assigned to.
-
-There are two types: ``integer_buckets`` for integer values, and
-``age_in_months_buckets``, where the given field must be a date
-and the buckets are based on the number of months since that date.
 
 Here's an example that groups children based on their age at the time of
 registration:
@@ -1444,24 +1440,6 @@ registration:
 
 The ``"ranges"`` attribute maps conditional expressions to labels. If the field's value
 does not fall into any of these ranges, the row will receive the ``"else_"`` value, if provided.
-
-Here's an example using ``age_in_months_buckets``:
-
-.. code:: json
-
-   {
-       "display": "Age Group",
-       "column_id": "age_group",
-       "type": "age_in_months_buckets",
-       "field": "dob",
-       "ranges": {
-            "0_to_5": [0, 5],
-            "6_to_11": [6, 11],
-            "12_to_35": [12, 35],
-            "36_to_59": [36, 59],
-            "60_to_71": [60, 71],
-       }
-   }
 
 SumWhenColumn and SumWhenTemplateColumn
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -10,7 +10,6 @@ from corehq.apps.userreports.const import (
 )
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.reports.specs import (
-    AgeInMonthsBucketsColumn,
     AggregateDateColumn,
     ArrayAggLastValueReportColumn,
     ExpandedColumn,
@@ -86,7 +85,6 @@ from custom.nutrition_project.ucr.sum_when_templates import (
 
 class ReportColumnFactory(object):
     class_map = {
-        'age_in_months_buckets': AgeInMonthsBucketsColumn,
         'aggregate_date': AggregateDateColumn,
         'expanded': ExpandedColumn,
         'expression': ExpressionColumn,

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -359,16 +359,6 @@ class IntegerBucketsColumn(_CaseExpressionColumn):
         return "{} between {} and {}".format(self.field, bounds[0], bounds[1])
 
 
-class AgeInMonthsBucketsColumn(IntegerBucketsColumn):
-    type = TypeProperty('age_in_months_buckets')
-
-    def _base_expression(self, bounds):
-        current_date = date.today().isoformat()
-        return "extract(year from age(date('{}'), {}))*12 + \
-            extract(month from age(date('{}'), {})) BETWEEN {} and {}".format(
-            current_date, self.field, current_date, self.field, bounds[0], bounds[1])
-
-
 class SumWhenColumn(_CaseExpressionColumn):
     type = TypeProperty("sum_when")
     else_ = IntegerProperty(default=0)

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -1013,51 +1013,6 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportAggregationTestMixin, 
         with self.assertRaises(BadSpecError):
             view.export_table
 
-    def test_age_in_months_buckets(self):
-        report_config = self._create_report(
-            aggregation_columns=[
-                'indicator_col_id_state',
-                'months_ago',
-            ],
-            columns=[
-                {
-                    'type': 'field',
-                    'display': 'state',
-                    'field': 'indicator_col_id_state',
-                    'column_id': 'state',
-                    'aggregation': 'simple'
-                },
-                {
-                    'type': 'age_in_months_buckets',
-                    'display': 'months_ago',
-                    'column_id': 'months_ago',
-                    'field': 'date',
-                    'ranges': {
-                        '0-12': [0, 12],
-                        '12-24': [12, 24],
-                    },
-                    'else_': '24+'
-                },
-                {
-                    'type': 'field',
-                    'display': 'report_column_display_number',
-                    'field': 'indicator_col_id_number',
-                    'column_id': 'report_column_col_id_number',
-                    'aggregation': 'sum'
-                }
-            ],
-            filters=None,
-        )
-        view = self._create_view(report_config)
-        table = view.export_table[0][1]
-        self.assertEqual(len(table), 3)
-        for table_row in [
-            ['state', 'months_ago', 'report_column_display_number'],
-            ['MA', '12-24', 9],
-            ['TN', '24+', 1],
-        ]:
-            self.assertIn(table_row, table)
-
     def test_sum_when(self):
         report_config = self._create_report(
             aggregation_columns=[


### PR DESCRIPTION
## Summary
This is an ICDS-only feature, and the test for it is abominably flaky.

To be paranoid, I checked that no one is using this on prod or india:
```
docs = []
for doc in get_all_docs_with_doc_types(db, ['ReportConfiguration']):
    if any(c.get("type", None) == "age_in_months_buckets" for c in doc.get("columns", [])):
        docs.append(doc)
```

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Code removal. Removes tests.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
