### PR TITLE
Removed copy_multimedia view

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/multimedia_ajax.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/multimedia_ajax.html
@@ -50,45 +50,6 @@
     </div>
   {% endif %}
 
-  {% if request|toggle_enabled:"MULTI_MASTER_LINKED_DOMAINS" %}
-    <div class="panel panel-appmanager">
-      <div class="panel-heading">
-        <h4 class="panel-title panel-title-nolink">{% trans 'Copy Multimedia from Another Application' %}</h4>
-      </div>
-      <div class="panel-body">
-        {% if import_apps %}
-          <form action="{% url "copy_multimedia" domain app.id %}" method="POST">
-            <p class="help-block">
-              Select an app to copy over any media that is present in the selected app but missing in this app.
-            </p>
-            <p>
-              {% csrf_token %}
-              <select name="app_id" class="form-control hqwebapp-select2"
-                      data-placeholder="{% trans_html_attr "Select an app" %}">
-                <option value=""></option>
-                {% for app in import_apps %}
-                  {# Poor readability because any whitespace within the option will also appear in the title attribute and therefore on hover #}
-                  <option value="{{ app.id }}">{{ app.name }} ({% for id, count in import_app_counts.items %}{% if id == app.id %}{% blocktrans with c=count %}{{ c }} item(s) to import{% endblocktrans %}{% endif %}{% endfor %})</option>
-                {% endfor %}
-              </select>
-            </p>
-            <p>
-              <button type="submit" class="btn btn-primary">
-                <i class="fa fa-copy"></i>
-                {% trans "Copy Multimedia" %}
-              </button>
-            </p>
-          </form>
-        {% else %}
-          <p>
-            <div class="alert alert-info">
-              There is no multimedia in this app that can be copied from other apps.
-            </div>
-          </p>
-        {% endif %}
-      </div>
-    </div>
-  {% endif %}
 {% else %}
   <div class="alert alert-info">{% blocktrans %}This application currently does not contain any multimedia references.{% endblocktrans %}</div>
 {% endif %}

--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -90,7 +90,6 @@ from corehq.apps.app_manager.views import (
 )
 from corehq.apps.app_manager.views.apps import move_child_modules_after_parents
 from corehq.apps.app_manager.views.modules import ExistingCaseTypesView
-from corehq.apps.hqmedia.views import copy_multimedia
 from corehq.apps.hqmedia.urls import application_urls as hqmedia_urls
 from corehq.apps.hqmedia.urls import download_urls as media_download_urls
 from corehq.apps.linked_domain.views import pull_missing_multimedia
@@ -215,7 +214,6 @@ urlpatterns = [
 
     # multimedia stuff
     url(r'^(?P<app_id>[\w-]+)/multimedia/', include(hqmedia_urls)),
-    url(r'^copy_multimedia/(?P<app_id>[\w-]+)/$', copy_multimedia, name='copy_multimedia'),
     url(r'^edit_module_detail_screens/(?P<app_id>[\w-]+)/(?P<module_unique_id>[\w-]+)/$',
         edit_module_detail_screens, name='edit_module_detail_screens'),
     url(r'^edit_module_attr/(?P<app_id>[\w-]+)/(?P<module_unique_id>[\w-]+)/(?P<attr>[\w-]+)/$',

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -383,27 +383,6 @@ def download_multimedia_paths(request, domain, app_id):
     return export_response(temp, Format.XLS_2007, filename)
 
 
-@toggles.MULTI_MASTER_LINKED_DOMAINS.required_decorator()
-@require_can_edit_apps
-@require_POST
-def copy_multimedia(request, domain, app_id):
-    app = get_app(domain, app_id)
-    other_app_id = request.POST.get("app_id")
-    other_app = get_app(domain, other_app_id)
-
-    paths = app.all_media_paths()
-    count = 0
-    for path in paths:
-        if path not in app.multimedia_map:
-            app.multimedia_map[path] = other_app.multimedia_map[path]
-            count += 1
-    if count:
-        app.save()
-
-    messages.success(request, "Copied {} multimedia items.".format(count))
-    return redirect("app_settings", domain=domain, app_id=app_id)
-
-
 @method_decorator(toggles.BULK_UPDATE_MULTIMEDIA_PATHS.required_decorator(), name='dispatch')
 @method_decorator(require_can_edit_apps, name='dispatch')
 class MultimediaTranslationsCoverageView(BaseMultimediaTemplateView):


### PR DESCRIPTION
## Summary
This is part of the multi master flag, which was ICDS-only.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Dead code removal. Tested locally that app manager still loads.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
