### PR TITLE
Added related case property search support to case search admin page

### DIFF
--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -62,12 +62,16 @@ class CaseSearchView(BaseDomainView):
             search = search.owner(owner_id)
         for param in search_params:
             value = re.sub(param.get('regex', ''), '', param.get('value'))
-            search = search.case_property_query(
-                param.get('key'),
-                value,
-                clause=param.get('clause'),
-                fuzzy=param.get('fuzzy'),
-            )
+            if '/' in param.get('key'):
+                query = '{} = "{}"'.format(param.get('key'), value)
+                search = search.xpath_query(self.domain, query, fuzzy=param.get('fuzzy'))
+            else:
+                search = search.case_property_query(
+                    param.get('key'),
+                    value,
+                    clause=param.get('clause'),
+                    fuzzy=param.get('fuzzy'),
+                )
 
         if xpath:
             search = search.xpath_query(self.domain, xpath)


### PR DESCRIPTION
## Summary
Followup for https://github.com/dimagi/commcare-hq/pull/29349/ / https://github.com/dimagi/commcare-hq/pull/29508/

The "clause" dropdown won't have an effect parent properties, but I suspect that's fine.

## Feature Flag
Superusers only

## Product Description
Adds parent property support to this admin page:

![Screen Shot 2021-04-13 at 6 04 12 PM](https://user-images.githubusercontent.com/1486591/114627112-b6b61580-9c82-11eb-8c1a-70ea3951e56f.png)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

None.

### Safety story
Superuser-only page, low risk change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
