### PR TITLE
Increase timeout for Repeater.by_domain to 1h

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -374,7 +374,7 @@ class Repeater(QuickCachedDocumentMixin, Document):
         Repeater.by_domain.clear(Repeater, self.domain)
 
     @classmethod
-    @quickcache(['cls.__name__', 'domain'], timeout=5 * 60, memoize_timeout=10)
+    @quickcache(['cls.__name__', 'domain'], timeout=60 * 60, memoize_timeout=10)
     def by_domain(cls, domain):
         key = [domain]
         if cls.__name__ in get_all_repeater_types():


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12079

There is good cache invalidation for this function, so we could probably safely go hire.
However I am choosing 1h in case there is a crack in the cache invalidation,
so that the result can never possibly be more than an hour old.
This change is motivated by wanting to further decouple form submissions and case changes
from couch. This should reduce to a tenth the proportion of submissions that need to
make a request to this couch view.

## Feature Flag
None

## Product Description
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

This code path in general is definitely covered by tests, though no tests cover the timeout.

### QA Plan

None needed.

### Safety story
This doesn't qualitatively change anything that the code doing, but just modifies a cache timeout value. The cache invalidation mechanism is common and works well throughout the codebase, so I believe the cache invalidation works and there will be no stale responses (except for maybe within the normal race condition window). Still I chose 1h rather than 24h or something as a second layer of safety.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
