### PR TITLE
Only report user fixture counts, but get them right

### DIFF
--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -61,30 +61,24 @@ class ItemListsProvider(FixtureProvider):
             else:
                 user_types[data_type._id] = data_type
         items = []
-        global_items = []
-        user_items = []
+        user_items_count = 0
         if global_types:
             global_items = self.get_global_items(global_types, restore_state)
             items.extend(global_items)
         if user_types:
-            user_items = self.get_user_items(user_types, restore_user)
+            user_items, user_items_count = self.get_user_items_and_count(user_types, restore_user)
             items.extend(user_items)
 
-        for metric_name, items_count in [
-            ('commcare.fixtures.item_lists.global', len(global_items)),
-            ('commcare.fixtures.item_lists.user', len(user_items)),
-            ('commcare.fixtures.item_lists.all', len(items)),
-        ]:
-            metrics_histogram(
-                metric_name,
-                items_count,
-                bucket_tag='items',
-                buckets=[1, 100, 1000, 10000, 30000, 100000, 300000, 1000000],
-                bucket_unit='',
-                tags={
-                    'domain': restore_user.domain
-                }
-            )
+        metrics_histogram(
+            'commcare.fixtures.item_lists.user',
+            user_items_count,
+            bucket_tag='items',
+            buckets=[1, 100, 1000, 10000, 30000, 100000, 300000, 1000000],
+            bucket_unit='',
+            tags={
+                'domain': restore_user.domain
+            }
+        )
         return items
 
     def get_global_items(self, global_types, restore_state):
@@ -100,19 +94,21 @@ class ItemListsProvider(FixtureProvider):
 
         return self._get_fixtures(global_types, get_items_by_type, GLOBAL_USER_ID)
 
-    def get_user_items(self, user_types, restore_user):
+    def get_user_items_and_count(self, user_types, restore_user):
+        user_items_count = 0
         items_by_type = defaultdict(list)
         for item in restore_user.get_fixture_data_items():
             data_type = user_types.get(item.data_type_id)
             if data_type:
                 self._set_cached_type(item, data_type)
                 items_by_type[data_type].append(item)
+                user_items_count += 1
 
         def get_items_by_type(data_type):
             return sorted(items_by_type.get(data_type, []),
                           key=attrgetter('sort_key'))
 
-        return self._get_fixtures(user_types, get_items_by_type, restore_user.user_id)
+        return self._get_fixtures(user_types, get_items_by_type, restore_user.user_id), user_items_count
 
     def _set_cached_type(self, item, data_type):
         # set the cached version used by the object so that it doesn't


### PR DESCRIPTION
## Summary
Followup to https://github.com/dimagi/commcare-hq/pull/29430. Realized that that was in effect reporting the number of lookup tables, no the number of lookup table _items_. Getting the number of global items is going to take a bit more acrobatics just based on the way the code is written, so I've opted to remove the metrics that rely on that and focus instead on getting the one for user lookup table items right.

## Feature Flag
None

## Product Description
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

Will
- [x] smoke test on staging
- [x] see that the metric gets collected

### Safety story
This area of the code is has pretty good test coverage. That plus a sanity test on staging to show that it's also emitting something sensical should be enough to validate this small change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
