### PR TITLE
properly generate parent ID reference in DET schemas for single-parent case types

### DIFF
--- a/corehq/apps/export/det/schema_generator.py
+++ b/corehq/apps/export/det/schema_generator.py
@@ -67,8 +67,7 @@ class CaseDETSchemaHelper(DefaultDETSchemaHelper):
 
         # todo: this could be made smarter in the future for multi-parentage use cases
         def _is_index_reference(path):
-            path_as_array = path.split('.')
-            return len(path_as_array) == 2 and path_as_array[0] == 'indices'
+            return path.startswith("indices.") and path.count(".") == 1
 
         if _is_index_reference(input_path):
             return PARENT_INDEX_PATH  # as could this

--- a/corehq/apps/export/det/schema_generator.py
+++ b/corehq/apps/export/det/schema_generator.py
@@ -41,6 +41,9 @@ class DefaultDETSchemaHelper(object):
     """
     Helper to do datatype transformations, etc. during schema generation
     """
+    def get_path(self, input_column):
+        return self.transform_path(input_column.item.readable_path)
+
     @staticmethod
     def transform_path(input_path):
         return input_path
@@ -221,7 +224,7 @@ def _add_rows_for_table(input_table, output_table, helper=None):
 
 def _get_det_row_for_export_column(column, helper):
     return DETRow(
-        source_field=helper.transform_path(column.item.readable_path),
+        source_field=helper.get_path(column),
         field=column.label,
         map_via=helper.get_map_via(column.item)
     )

--- a/corehq/apps/export/det/schema_generator.py
+++ b/corehq/apps/export/det/schema_generator.py
@@ -27,7 +27,6 @@ CASE_API_PATH_MAP = {
     'type': 'properties.case_type',
     'user_id': 'user_id',
 }
-PARENT_INDEX_PATH = 'indices.parent.case_id'
 
 FORM_API_PATH_MAP = {
     'xmlns': 'form.@xmlns',
@@ -67,7 +66,11 @@ class CaseDETSchemaHelper(DefaultDETSchemaHelper):
 
     def get_path(self, input_column):
         if isinstance(input_column, CaseIndexExportColumn):
-            return PARENT_INDEX_PATH  # as could this
+            # this is an obscure but correct reference to the index reference ID
+            # typically "parent", occasionally "host", rarely miscellaneous other things...
+            # https://github.com/dimagi/commcare-hq/pull/29530/files#r613936070
+            index_ref_id = input_column.item.label.split('.')[0]
+            return f'indices.{index_ref_id}.case_id'
 
         input_path = input_column.item.readable_path
         return CASE_API_PATH_MAP.get(input_path, f'{PROPERTIES_PREFIX}{input_path}')

--- a/corehq/apps/export/det/schema_generator.py
+++ b/corehq/apps/export/det/schema_generator.py
@@ -27,7 +27,7 @@ CASE_API_PATH_MAP = {
     'type': 'properties.case_type',
     'user_id': 'user_id',
 }
-
+PARENT_INDEX_PATH = 'indices.parent.case_id'
 
 FORM_API_PATH_MAP = {
     'xmlns': 'form.@xmlns',
@@ -64,7 +64,15 @@ class CaseDETSchemaHelper(DefaultDETSchemaHelper):
 
     @staticmethod
     def transform_path(input_path):
-        # either return hard-coded lookup or add prefix
+
+        # todo: this could be made smarter in the future for multi-parentage use cases
+        def _is_index_reference(path):
+            path_as_array = path.split('.')
+            return len(path_as_array) == 2 and path_as_array[0] == 'indices'
+
+        if _is_index_reference(input_path):
+            return PARENT_INDEX_PATH  # as could this
+
         return CASE_API_PATH_MAP.get(input_path, f'{PROPERTIES_PREFIX}{input_path}')
 
     def get_map_via(self, export_item):

--- a/corehq/apps/export/det/schema_generator.py
+++ b/corehq/apps/export/det/schema_generator.py
@@ -3,7 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 from corehq.apps.data_dictionary.models import CaseProperty
 from corehq.apps.export.det.base import DETRow, DETTable, DETConfig
 from corehq.apps.export.det.exceptions import DETConfigError
-from corehq.apps.export.models import FormExportInstance, CaseExportInstance
+from corehq.apps.export.models import FormExportInstance, CaseExportInstance, CaseIndexExportColumn
 from corehq.apps.userreports import datatypes
 
 PROPERTIES_PREFIX = 'properties.'
@@ -65,16 +65,11 @@ class CaseDETSchemaHelper(DefaultDETSchemaHelper):
     def __init__(self, dd_property_types):
         self.dd_property_types = dd_property_types
 
-    @staticmethod
-    def transform_path(input_path):
-
-        # todo: this could be made smarter in the future for multi-parentage use cases
-        def _is_index_reference(path):
-            return path.startswith("indices.") and path.count(".") == 1
-
-        if _is_index_reference(input_path):
+    def get_path(self, input_column):
+        if isinstance(input_column, CaseIndexExportColumn):
             return PARENT_INDEX_PATH  # as could this
 
+        input_path = input_column.item.readable_path
         return CASE_API_PATH_MAP.get(input_path, f'{PROPERTIES_PREFIX}{input_path}')
 
     def get_map_via(self, export_item):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -2613,7 +2613,7 @@ class CaseIndexExportColumn(ExportColumn):
         case_type = self.item.case_type
 
         indices = NestedDictGetter(path)(doc) or []
-        case_ids = [index.get('referenced_id') for index in [index for index in indices if index.get('referenced_type') == case_type]]
+        case_ids = [index.get('referenced_id') for index in indices if index.get('referenced_type') == case_type]
         return ' '.join(case_ids)
 
 

--- a/corehq/apps/export/tests/data/det/case_export_instance.json
+++ b/corehq/apps/export/tests/data/det/case_export_instance.json
@@ -306,6 +306,42 @@
                 },
                 {
                     "deid_transform": null,
+                    "doc_type": "CaseIndexExportColumn",
+                    "help_text": "The ID of the associated foo case type",
+                    "is_advanced": false,
+                    "is_deleted": false,
+                    "item": {
+                        "datatype": null,
+                        "doc_type": "CaseIndexItem",
+                        "inferred": false,
+                        "inferred_from": [],
+                        "label": "sibling.foo",
+                        "last_occurrences": {
+                            "1c92b29059c9f7b217e4751a73ad159c": 82
+                        },
+                        "path": [
+                            {
+                                "doc_type": "PathNode",
+                                "is_repeat": false,
+                                "name": "indices"
+                            },
+                            {
+                                "doc_type": "PathNode",
+                                "is_repeat": false,
+                                "name": "foo"
+                            }
+                        ],
+                        "tag": "case",
+                        "transform": null
+                    },
+                    "label": "indices.foo",
+                    "selected": true,
+                    "tags": [
+                        "case"
+                    ]
+                },
+                {
+                    "deid_transform": null,
                     "doc_type": "ExportColumn",
                     "help_text": "True if the case is closed, otherwise False",
                     "is_advanced": false,

--- a/corehq/apps/export/tests/test_det_schema_generation.py
+++ b/corehq/apps/export/tests/test_det_schema_generation.py
@@ -1,4 +1,3 @@
-import json
 import os
 import tempfile
 from io import BytesIO
@@ -11,7 +10,6 @@ from corehq.apps.export.det.exceptions import DETConfigError
 from corehq.apps.export.det.schema_generator import (
     generate_from_form_export_instance,
     generate_from_case_export_instance,
-    CaseDETSchemaHelper,
     FormDETSchemaHelper)
 from corehq.apps.export.models import FormExportInstance, CaseExportInstance
 from corehq.util.test_utils import TestFileMixin

--- a/corehq/apps/export/tests/test_det_schema_generation.py
+++ b/corehq/apps/export/tests/test_det_schema_generation.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 from io import BytesIO
@@ -50,9 +51,29 @@ class TestDETFCaseInstance(SimpleTestCase, TestFileMixin):
             self.assertEqual('domain', domain_row['Field'])
             main_table = self.export_instance.selected_tables[0]
             self.assertEqual(len(main_table.selected_columns), len(data_by_headings))
+
+            expected_paths = {
+                "_id": "id",
+                "activity_name": "properties.activity_name",
+                "closed": "closed",
+                "closed_by": "properties.closed_by",
+                "closed_on": "date_closed",
+                "event_date": "properties.event_date",
+                "event_duration": "properties.event_duration",
+                "event_score": "properties.event_score",
+                "indices.activity": "properties.indices.activity",
+                "location": "properties.location",
+                "modified_on": "properties.modified_on",
+                "name": "properties.case_name",
+                "number": "properties.number",
+                "opened_by": "opened_by",
+                "opened_on": "properties.date_opened",
+                "owner_id": "properties.owner_id",
+                "user_id": "user_id"
+            }
             for i, input_column in enumerate(main_table.selected_columns):
                 self.assertEqual(input_column.label, data_by_headings[i]['Field'])
-                self.assertEqual(CaseDETSchemaHelper.transform_path(input_column.item.readable_path),
+                self.assertEqual(expected_paths[input_column.item.readable_path],
                                  data_by_headings[i]['Source Field'])
 
             # test individual fields / types

--- a/corehq/apps/export/tests/test_det_schema_generation.py
+++ b/corehq/apps/export/tests/test_det_schema_generation.py
@@ -61,7 +61,7 @@ class TestDETFCaseInstance(SimpleTestCase, TestFileMixin):
                 "event_date": "properties.event_date",
                 "event_duration": "properties.event_duration",
                 "event_score": "properties.event_score",
-                "indices.activity": "properties.indices.activity",
+                "indices.activity": "indices.parent.case_id",
                 "location": "properties.location",
                 "modified_on": "properties.modified_on",
                 "name": "properties.case_name",

--- a/corehq/apps/export/tests/test_det_schema_generation.py
+++ b/corehq/apps/export/tests/test_det_schema_generation.py
@@ -60,6 +60,7 @@ class TestDETFCaseInstance(SimpleTestCase, TestFileMixin):
                 "event_duration": "properties.event_duration",
                 "event_score": "properties.event_score",
                 "indices.activity": "indices.parent.case_id",
+                "indices.foo": "indices.sibling.case_id",
                 "location": "properties.location",
                 "modified_on": "properties.modified_on",
                 "name": "properties.case_name",


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Related to https://docs.google.com/document/d/1HecsnOT7n4YxuJKeBEzeo9xibz_iFeF8N8tHktAV0zY/edit

Review by commit (first is a tiny refactor because I realized that the tests were "broken" if they didn't require changing as a result of this change)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

DET Schema generation

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

References to the parent case ID now properly resolve.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

Added tests and is behind a flag.

### Automated test coverage

Added / updated

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
