### PR TITLE
Updated help text on case search config

### DIFF
--- a/corehq/apps/domain/templates/domain/admin/case_search.html
+++ b/corehq/apps/domain/templates/domain/admin/case_search.html
@@ -49,6 +49,11 @@
             {% blocktrans %}
               Add a list of all fuzzy search properties by case type below. These are
               properties that might be spelled inexactly by a user, e.g. "name".
+              <br><br>
+              When working with related case properties, add them to the case type that
+              you willbe searching on, not the related case type. For example, if fuzzy matching
+              on the parent's case name, add <strong>parent/name</strong> here as a property of
+              the child case type.
             {% endblocktrans %}
           </p>
 


### PR DESCRIPTION
Trivial followup for https://github.com/dimagi/commcare-hq/pull/29508 - adds a bit of help text on the admin page:

![Screen Shot 2021-04-14 at 9 26 48 AM](https://user-images.githubusercontent.com/1486591/114718812-5f588980-9d04-11eb-82ab-4cdfdb30a97d.png)

Feature flag: case search & claim