### PR TITLE
use stale query while creating repeaters

### DIFF
--- a/corehq/motech/repeaters/dbaccessors.py
+++ b/corehq/motech/repeaters/dbaccessors.py
@@ -14,6 +14,15 @@ from .const import (
 )
 
 
+def force_update_repeaters_views():
+    from .models import Repeater
+    Repeater.get_db().view(
+        'repeaters/repeaters',
+        reduce=False,
+        limit=1,
+    ).all()
+
+
 def get_pending_repeat_record_count(domain, repeater_id):
     return get_repeat_record_count(domain, repeater_id, RECORD_PENDING_STATE)
 

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -383,9 +383,9 @@ class Repeater(QuickCachedDocumentMixin, Document):
     @quickcache(['cls.__name__', 'domain', 'stale_query'], timeout=60 * 60, memoize_timeout=10)
     def by_domain(cls, domain, stale_query=False):
         key = [domain]
-        stale = False
+        stale_kwargs = {}
         if stale_query:
-            stale = stale_ok()
+            stale_kwargs['stale'] = stale_ok()
         if cls.__name__ in get_all_repeater_types():
             key.append(cls.__name__)
         elif cls.__name__ == Repeater.__name__:
@@ -404,7 +404,7 @@ class Repeater(QuickCachedDocumentMixin, Document):
             include_docs=True,
             reduce=False,
             wrap_doc=False,
-            stale=stale
+            **stale_kwargs
         )
 
         return [cls.wrap(repeater_doc['doc']) for repeater_doc in raw_docs

--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -44,7 +44,7 @@ def create_repeat_records(repeater_cls, payload):
     domain = payload.domain
 
     if domain_can_forward(domain):
-        repeaters = repeater_cls.by_domain(domain)
+        repeaters = repeater_cls.by_domain(domain, stale_query=True)
         for repeater in repeaters:
             repeater.register(payload)
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12077
While creating repeaters, use a stale query so that the read does not block on background reindexing activity.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The only effect of this is that the list of repeaters may be slightly out of date when creating new records, which means it might take a bit longer for newly created repeaters to begin receiving forwarded data.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
