### PR TITLE
Fix KeyError bug when emailing large reports

### DIFF
--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -678,7 +678,6 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
 
     def _get_and_send_report(self, language, emails):
         from corehq.apps.reports.views import get_scheduled_report_response, render_full_report_notification
-        from corehq.apps.reports.standard.deployments import ApplicationStatusReport
         with localize(language):
             title = (
                 _(DEFAULT_REPORT_NOTIF_SUBJECT)
@@ -741,9 +740,9 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
                         mock_request.GET = QueryDict('&'.join(mock_query_string_parts))
                         request_data = vars(mock_request)
                         request_data['couch_user'] = mock_request.couch_user.userID
-                        if report_config.report_slug != ApplicationStatusReport.slug:
-                            # ApplicationStatusReport doesn't have date filter
-                            date_range = report_config.get_date_range()
+
+                        date_range = report_config.get_date_range()
+                        if 'startdate' in date_range and 'enddate' in date_range:
                             start_date = datetime.strptime(date_range['startdate'], '%Y-%m-%d')
                             end_date = datetime.strptime(date_range['enddate'], '%Y-%m-%d')
                             datespan = DateSpan(start_date, end_date)

--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -734,7 +734,10 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
                             'context': {},
                             'request_params': json_request(request_data['GET'])}
 
-            export_all_rows_task(report_config.report, full_request, emails, title)
+            from corehq.apps.userreports.reports.view import ConfigurableReportView
+            report_class = ConfigurableReportView if report_config.is_configurable_report else report_config.report
+
+            export_all_rows_task(report_class, full_request, emails, title)
 
     def remove_recipient(self, email):
         try:

--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.db import models
-from django.http import Http404, HttpRequest, QueryDict
+from django.http import Http404
 from django.utils.translation import ugettext as _
 
 from couchdbkit.ext.django.schema import (
@@ -52,6 +52,7 @@ from corehq.apps.saved_reports.exceptions import (
     UnsupportedSavedReportError,
     UnsupportedScheduledReportError,
 )
+from corehq.apps.saved_reports.util import create_mock_request
 from corehq.apps.userreports.util import \
     default_language as ucr_default_language
 from corehq.apps.userreports.util import localize as ucr_localize
@@ -358,17 +359,7 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
                 None,
             )
 
-        mock_request = HttpRequest()
-        mock_request.couch_user = self.owner
-        mock_request.user = self.owner.get_django_user()
-        mock_request.domain = self.domain
-        mock_request.couch_user.current_domain = self.domain
-        mock_request.couch_user.language = lang
-        mock_request.method = 'GET'
-        mock_request.bypass_two_factor = True
-
-        mock_query_string_parts = [self.query_string, 'filterSet=true']
-        mock_request.GET = QueryDict('&'.join(mock_query_string_parts))
+        mock_request = create_mock_request(self.owner, self.domain, lang, self.query_string)
 
         # Make sure the request gets processed by PRBAC Middleware
         CCHQPRBACMiddleware.apply_prbac(mock_request)
@@ -723,37 +714,27 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
                                           smtp_exception_skip_list=LARGE_FILE_SIZE_ERROR_CODES)
 
                 elif getattr(er, 'smtp_code', None) in LARGE_FILE_SIZE_ERROR_CODES or type(er) == ESError:
-                    # If the email doesn't work because it is too large to fit in the HTML body,
-                    # send it as an excel attachment, by creating a mock request with the right data.
+                    self._send_email_as_downloadable_export(emails, title)
 
-                    for report_config in self.configs:
-                        mock_request = HttpRequest()
-                        mock_request.couch_user = self.owner
-                        mock_request.user = self.owner.get_django_user()
-                        mock_request.domain = self.domain
-                        mock_request.couch_user.current_domain = self.domain
-                        mock_request.couch_user.language = self.language
-                        mock_request.method = 'GET'
-                        mock_request.bypass_two_factor = True
+    def _send_email_as_downloadable_export(self, emails, title):
+        for report_config in self.configs:
+            mock_request = create_mock_request(self.owner, self.domain, self.language, report_config.query_string)
+            request_data = vars(mock_request)
+            request_data['couch_user'] = mock_request.couch_user.userID
 
-                        mock_query_string_parts = [report_config.query_string, 'filterSet=true']
-                        mock_request.GET = QueryDict('&'.join(mock_query_string_parts))
-                        request_data = vars(mock_request)
-                        request_data['couch_user'] = mock_request.couch_user.userID
+            date_range = report_config.get_date_range()
+            if 'startdate' in date_range and 'enddate' in date_range:
+                start_date = datetime.strptime(date_range['startdate'], '%Y-%m-%d')
+                end_date = datetime.strptime(date_range['enddate'], '%Y-%m-%d')
+                datespan = DateSpan(start_date, end_date)
+                request_data['datespan'] = datespan
 
-                        date_range = report_config.get_date_range()
-                        if 'startdate' in date_range and 'enddate' in date_range:
-                            start_date = datetime.strptime(date_range['startdate'], '%Y-%m-%d')
-                            end_date = datetime.strptime(date_range['enddate'], '%Y-%m-%d')
-                            datespan = DateSpan(start_date, end_date)
-                            request_data['datespan'] = datespan
+            full_request = {'request': request_data,
+                            'domain': request_data['domain'],
+                            'context': {},
+                            'request_params': json_request(request_data['GET'])}
 
-                        full_request = {'request': request_data,
-                                        'domain': request_data['domain'],
-                                        'context': {},
-                                        'request_params': json_request(request_data['GET'])}
-
-                        export_all_rows_task(report_config.report, full_request, emails, title)
+            export_all_rows_task(report_config.report, full_request, emails, title)
 
     def remove_recipient(self, email):
         try:

--- a/corehq/apps/saved_reports/util.py
+++ b/corehq/apps/saved_reports/util.py
@@ -1,0 +1,17 @@
+from django.http import HttpRequest, QueryDict
+
+
+def create_mock_request(couch_user, domain, language, query_string, method='GET', bypass_two_factor=True):
+    mock_request = HttpRequest()
+    mock_request.couch_user = couch_user
+    mock_request.user = couch_user.get_django_user()
+    mock_request.domain = domain
+    mock_request.couch_user.current_domain = domain
+    mock_request.couch_user.language = language
+    mock_request.method = method
+    mock_request.bypass_two_factor = bypass_two_factor
+
+    mock_query_string_parts = [query_string, 'filterSet=true']
+    mock_request.GET = QueryDict('&'.join(mock_query_string_parts))
+
+    return mock_request


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
When testing the changes from [this PR](https://github.com/dimagi/commcare-hq/pull/29493), I ran into this [KeyError](https://sentry.io/organizations/dimagi/issues/2161486167/?environment=staging&project=136860&query=is%3Aunresolved+send_report&statsPeriod=14d). In this case, the report is a UCR that has an empty `date_range` property so `datespan` should not apply. 

**Easiest to review commit by commit**. First is the change referenced above, second is just a refactor that also applies the same change as [this PR](https://github.com/dimagi/commcare-hq/pull/29493), third is removing icds code. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [ ] Risk label is set correctly
- [ ] All migrations are backwards compatible and won't block deploy
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Going to request QA.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This flow is already broken for Going to test on staging.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
