### PR TITLE
Added accessibility documentation in style guide

### DIFF
--- a/corehq/apps/styleguide/templates/styleguide/_includes/atoms/accessibility.html
+++ b/corehq/apps/styleguide/templates/styleguide/_includes/atoms/accessibility.html
@@ -98,6 +98,34 @@
     <li><a href="https://a11yproject.com/">https://a11yproject.com/</a></li>
     <li><a href="http://www.carbondesignsystem.com/guidelines/accessibility">http://www.carbondesignsystem.com/guidelines/accessibility</a></li>
     <li><a href="https://www.w3.org/WAI/tutorials">https://www.w3.org/WAI/tutorials</a></li>
+    <li><a href="https://www.youtube.com/playlist?list=PLNYkxOF6rcICWx0C9LVWWVqvHlYJyqw7g">A11ycast videos</a></li>
+  </ul>
+  </p>
+    <p>
+    In 2020, USH began a web accessibility improvement effort, specifically surrounding screen readers.
+    <a href="https://developers.google.com/web/tools/chrome-devtools/accessibility/reference">This document</a> details
+    an overview of the effort, deficiencies found by an outside agency of CommCare, recommendations, and resources.
+  </p>
+
+  <p>
+    Quick ways to test for web accessibility*
+  <ul>
+    <li>
+      Keyboard Navigation: Testing if modified code is navigable by keyboard is an effective way to
+      test for accessibility. Many users rely on keyboard navigation that are otherwise unable to use a mouse and it’s
+      also a good indicator if it will be visible to a screen reader. Read more about potential barriers to effective
+      keyboard navigation and keyboard testing <a href="https://webaim.org/techniques/keyboard/">here</a>.
+    </li>
+    <li>
+      Explore the accessibility tree: An accessibility tree is a part of your website's DOM. All
+      accessible objects are created in the accessibility tree for each DOM element that needs to be exposed to
+      assistive technologies. From it, you can see how the page elements are included and organized. To view the
+      accessibility tree of a page under development, we can use
+      <a href="https://developers.google.com/web/tools/chrome-devtools/accessibility/reference">Chrome DevTools' accessibility feature</a>.
+    </li>
+    <li>
+      <em>*this is by no means a complete list and covers only a portion of what makes a site accessible to all users</em>
+    </li>
   </ul>
   </p>
 </section>

--- a/corehq/apps/styleguide/templates/styleguide/_includes/atoms/accessibility.html
+++ b/corehq/apps/styleguide/templates/styleguide/_includes/atoms/accessibility.html
@@ -103,7 +103,7 @@
   </p>
     <p>
     In 2020, USH began a web accessibility improvement effort, specifically surrounding screen readers.
-    <a href="https://developers.google.com/web/tools/chrome-devtools/accessibility/reference">This document</a> details
+    <a href="https://docs.google.com/document/d/1fHNaVlaFl1xrbtPbMqj0YpByss1e0_hzCRlAUbVLboM/edit?usp=sharing">This document</a> details
     an overview of the effort, deficiencies found by an outside agency of CommCare, recommendations, and resources.
   </p>
 

--- a/corehq/apps/styleguide/templates/styleguide/_includes/atoms/accessibility.html
+++ b/corehq/apps/styleguide/templates/styleguide/_includes/atoms/accessibility.html
@@ -9,7 +9,7 @@
   <p>
     This guide will help ensure that our experiences meet the standards for
     accessibility required by law (WCAG AA, Section 508, European Standards). Patterns should be perceivable, operable,
-    and understable to users, even when using assistive technology.
+    and understandable to users, even when using assistive technology.
   </p>
 
   <p>
@@ -17,7 +17,7 @@
     context. Disabilities can be situational (an end user with typical vision may struggle to view their screen in a
     bright or sunny environment), temporary (a person with a broken wrist may not be able to type in HQ but will regain
     ability when healed), and long-lasting (barriers from birth, an illness, disease, accident, or developed over age;
-    some may not condsider themselves to have disabilities even if they experience functional limitations). We design
+    some may not consider themselves to have disabilities even if they experience functional limitations). We design
     and build products for everyone.
   </p>
 
@@ -63,11 +63,11 @@
       Deaf and Hard-of-Hearing (may rely on captioning and alternative representations of audio
     </li>
     <li>
-      Physical Disabilities (may rely on keyboards, trackballs, voice recognition or assitive tech, may lack mouse access
+      Physical Disabilities (may rely on keyboards, trackballs, voice recognition or assistive tech, may lack mouse access
     </li>
     <li>
-      Congitive Disabilities (may have limited working memory, problem solving, attention, reading/linguistic/visual comprehension,
-      sensitivity to flashing content; try to design linearly and focus on heuristics that have to do with congitive load and memory)
+      Cognitive Disabilities (may have limited working memory, problem solving, attention, reading/linguistic/visual comprehension,
+      sensitivity to flashing content; try to design linearly and focus on heuristics that have to do with cognitive load and memory)
     </li>
   </ul>
   </p>


### PR DESCRIPTION
## Summary
Adding to the docs of some new resources we gathered with the web accessibility improvement effort. Also linked the doc Charlie created that has a ton of resources and CommCare-specific accessibility changes.


## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below


### QA Plan
no qa

### Safety story
minor-- just affects the styleguide

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
