### PR TITLE
Index deletion

### DIFF
--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -137,6 +137,9 @@ load_ignore_rules = memoized(lambda: add_duplicate_rules({
         Ignore('missing', ('indices', '[*]', 'doc_type'), old='CommCareCaseIndex', new=MISSING),
         Ignore('missing', ('indices', '[*]', 'relationship'), old=MISSING, new='child'),  # defaulted on SQL
 
+        # Deleted indices are no longer removed from the model
+        Ignore('missing', ('indices', '[*]'), old=MISSING, check=deleted_index),
+
         Ignore(path=('actions', '[*]')),
 
         Ignore('diff', 'name', check=is_truncated_255),
@@ -524,3 +527,7 @@ def has_malformed_date(old_obj, new_obj, rule, diff):
             return diff.new_value == f"20{old[6:8]}-{old[:5]} 00:00:00"
         raise ValueError(f"unexpected date format: {old}")
     return False
+
+
+def deleted_index(old_obj, new_obj, rule, diff):
+    return not diff.new_value.get('referenced_id')

--- a/corehq/apps/reports/view_helpers.py
+++ b/corehq/apps/reports/view_helpers.py
@@ -189,7 +189,7 @@ def get_case_hierarchy(case, type_info):
         seen.add(case.case_id)
         children = [
             get_children(i.referenced_case, i.referenced_type, seen) for i in case.reverse_indices
-            if i.referenced_id not in seen
+            if i.referenced_id and i.referenced_id not in seen
         ]
 
         children = [c for c in children if c is not None]

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -190,7 +190,8 @@ class RetireUserTestCase(TestCase):
 
         # check that the index is removed via a new form
         child = CaseAccessors(self.domain).get_case(child_id)
-        self.assertEqual(0, len(child.indices))
+        self.assertEqual(1, len(child.indices))
+        self.assertEqual('', child.indices[0].referenced_id)
         self.assertEqual(2, len(child.xform_ids))
 
     @run_with_all_backends

--- a/corehq/ex-submodules/casexml/apps/case/sharedmodels.py
+++ b/corehq/ex-submodules/casexml/apps/case/sharedmodels.py
@@ -132,15 +132,11 @@ class IndexHoldingMixIn(object):
                 # case here but is moved into the pre save processing
                 pass
             if self.has_index(index_update.identifier):
-                if not index_update.referenced_id:
-                    # empty ID = delete
-                    self.indices.remove(self.get_index(index_update.identifier))
-                else:
-                    # update
-                    index = self.get_index(index_update.identifier)
-                    index.referenced_type = index_update.referenced_type
-                    index.referenced_id = index_update.referenced_id
-                    index.relationship = index_update.relationship
+                # update
+                index = self.get_index(index_update.identifier)
+                index.referenced_type = index_update.referenced_type
+                index.referenced_id = index_update.referenced_id
+                index.relationship = index_update.relationship
             else:
                 # no id, no index
                 if index_update.referenced_id:

--- a/corehq/ex-submodules/casexml/apps/case/sharedmodels.py
+++ b/corehq/ex-submodules/casexml/apps/case/sharedmodels.py
@@ -32,7 +32,10 @@ class CommCareCaseIndex(LooselyEqualDocumentSchema):
         """
         if not hasattr(self, "_case"):
             from casexml.apps.case.models import CommCareCase
-            self._case = CommCareCase.get(self.referenced_id)
+            if self.referenced_id:
+                self._case = CommCareCase.get(self.referenced_id)
+            else:
+                self._case = None
         return self._case
 
     @classmethod

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
@@ -115,7 +115,7 @@ class IndexTest(TestCase):
             user_id=self.user.user_id,
             owner_id=self.user.user_id,
             create=True,
-            index={'dad': ('father-case', self.FATHER_CASE_ID)},
+            index={'mom': ('mother-case', ''), 'dad': ('father-case', self.FATHER_CASE_ID)},
             date_modified=now,
             date_opened=now.date()
         ).as_xml()

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -190,17 +190,12 @@ class SqlCaseUpdateStrategy(UpdateStrategy):
 
         for index_update in action.indices:
             if self.case.has_index(index_update.identifier):
-                if not index_update.referenced_id:
-                    # empty ID = delete
-                    index = self.case.get_index(index_update.identifier)
-                    self.case.track_delete(index)
-                else:
-                    # update
-                    index = self.case.get_index(index_update.identifier)
-                    index.referenced_type = index_update.referenced_type
-                    index.referenced_id = index_update.referenced_id
-                    index.relationship = index_update.relationship
-                    self.case.track_update(index)
+                # update
+                index = self.case.get_index(index_update.identifier)
+                index.referenced_type = index_update.referenced_type
+                index.referenced_id = index_update.referenced_id
+                index.relationship = index_update.relationship
+                self.case.track_update(index)
             else:
                 # no id, no index
                 if index_update.referenced_id:

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -999,7 +999,7 @@ class CommCareCaseSQL(PartitionedModel, models.Model, RedisLockableMixIn,
         if relationship:
             indices = [index for index in indices if index.relationship_id == relationship]
 
-        return [index.referenced_case for index in indices]
+        return [index.referenced_case for index in indices if index.referenced_id]
 
     @property
     def parent(self):
@@ -1190,7 +1190,10 @@ class CommCareCaseIndexSQL(PartitionedModel, models.Model, SaveStateMixin):
         :return: referenced case
         """
         from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
-        return CaseAccessorSQL.get_case(self.referenced_id)
+        if self.referenced_id:
+            return CaseAccessorSQL.get_case(self.referenced_id)
+        else:
+            return None
 
     @property
     def relationship(self):

--- a/corehq/form_processor/tests/test_basics.py
+++ b/corehq/form_processor/tests/test_basics.py
@@ -296,7 +296,7 @@ class FundamentalCaseTests(FundamentalBaseTests):
         )
         case = self.casedb.get_case(child_case_id)
         self.assertEqual(len(case.indices), 1)
-        self.assertEqual(indices[0].referenced_id, '')
+        self.assertEqual(case.indices[0].referenced_id, '')
 
     def test_invalid_index(self):
         invalid_case_id = uuid.uuid4().hex

--- a/corehq/form_processor/tests/test_basics.py
+++ b/corehq/form_processor/tests/test_basics.py
@@ -295,7 +295,8 @@ class FundamentalCaseTests(FundamentalBaseTests):
             }
         )
         case = self.casedb.get_case(child_case_id)
-        self.assertEqual(len(case.indices), 0)
+        self.assertEqual(len(case.indices), 1)
+        self.assertEqual(indices[0].referenced_id, '')
 
     def test_invalid_index(self):
         invalid_case_id = uuid.uuid4().hex


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-843
Deleted indices were not previously sent down to the phone in restores. This PR addresses that by storing them as indices with no `referenced_id` rather than deleting them outright from the database, since that is the form the XML deletion action already takes. This means that any restore including the index does not need to do anything special to ensure the deletion action is included in the restore and sent to the phone.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Both `casexml` and `form_processor` have a number of tests that address index deletion and minimal changes were needed to adapt those to new behavior, including no changes in the casexml sync tests.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
In addition to automated tests, this will be tested on staging, both actively and passively.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
