### PR TITLE
[SSO] add SAML user data debug view for staging

### DIFF
--- a/corehq/apps/sso/urls.py
+++ b/corehq/apps/sso/urls.py
@@ -4,6 +4,7 @@ from corehq.apps.sso.views.saml import (
     sso_saml_metadata,
     sso_saml_acs,
     sso_saml_login,
+    sso_debug_user_data,
     sso_saml_sls,
     sso_saml_logout,
 )
@@ -11,6 +12,7 @@ from corehq.apps.sso.views.saml import (
 saml_urls = [
     url(r'^metadata/$', sso_saml_metadata, name='sso_saml_metadata'),
     url(r'^acs/$', sso_saml_acs, name='sso_saml_acs'),
+    url(r'^debug/$', sso_debug_user_data, name='sso_debug_user_data'),
     url(r'^sls/$', sso_saml_sls, name='sso_saml_sls'),
     url(r'^logout/$', sso_saml_logout, name='sso_saml_logout'),
     url(r'^login/$', sso_saml_login, name='sso_saml_login'),


### PR DESCRIPTION
## Summary
Just a small debug view for me to see all the available user data we store from Azure AD when an SSO user logs in for current new user work. This is strictly limited to the staging environment.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
small view restricted to logged-in users in the staging environment only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
