### PR TITLE
Add metric counting new repeat records

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -352,6 +352,10 @@ class Repeater(QuickCachedDocumentMixin, Document):
             next_check=now,
             payload_id=payload.get_id
         )
+        metrics_counter('commcare.repeaters.new_record', tags={
+            'domain': self.domain,
+            'doc_type': self.doc_type
+        })
         repeat_record.save()
         repeat_record.attempt_forward_now()
         return repeat_record


### PR DESCRIPTION
## Summary

https://dimagi-dev.atlassian.net/browse/SAAS-12090

Add metric counting new repeat records by domain and type. We have metrics for other parts
of the repeat record lifecycle, but not for when they are created.
This can help us correlate peformance of this feature with
its volume of incoming usage.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Tests cover this area quite well.

### QA Plan

None

### Safety story

Tests cover this area, certainly enough that they would catch a syntax error, missing input, typo, missing attribute, etc., and those are really the only kinds of errors that emitting a metric can introduce (other than emitting an incorrect metric itself, which doesn't affect production safety).

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
