### PR TITLE
add sentry breadcrumb for metric timings

### DIFF
--- a/corehq/util/metrics/__init__.py
+++ b/corehq/util/metrics/__init__.py
@@ -116,6 +116,8 @@ from typing import Iterable, Callable, Dict
 from celery.task import periodic_task
 
 from django.conf import settings
+from sentry_sdk import add_breadcrumb
+
 from corehq.util.timer import TimingContext
 from dimagi.utils.modules import to_function
 from .const import COMMON_TAGS, ALERT_INFO, MPM_ALL
@@ -256,6 +258,12 @@ def metrics_histogram_timer(metric: str, timing_buckets: Iterable[int], tags: Di
             metric, timer.duration,
             bucket_tag=bucket_tag, buckets=timing_buckets, bucket_unit='s',
             tags=tags
+        )
+        timer_name = ".".join(metric.split('.')[1:])  # remove the 'commcare.' prefix
+        add_breadcrumb(
+            category="timing",
+            message=f"{timer_name}: {timer.duration:0.3f}",
+            level="info",
         )
 
     timer.stop = new_stop


### PR DESCRIPTION
[USH-836](https://dimagi-dev.atlassian.net/browse/USH-836)

## Summary
Update to https://github.com/dimagi/commcare-hq/pull/29395 to add timing breadcrumbs for locks. I've added the breadcrumb into the generic `metrics_histogram_timer` method which will add breadcrumbs in all places this context manager get's used (not only for lock timings) since any other timing breadcrumbs would also be useful to have.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
