### PR TITLE
Fix data dictionary upload

### DIFF
--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -375,7 +375,7 @@ def _process_bulk_upload(bulk_file, domain):
                 if len(row) < expected_columns_in_prop_sheet:
                     error = _('Not enough columns')
                 else:
-                    error, fhir_resource_prop_path, remove_path = None, None, None
+                    error, fhir_resource_prop_path, fhir_resource_type, remove_path = None, None, None, None
                     name, group, data_type, description, deprecated = [cell.value for cell in row[:5]]
                     if import_fhir_data:
                         fhir_resource_prop_path, remove_path = row[5:]


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Fixes https://sentry.io/organizations/dimagi/issues/2338044587/?environment=staging&project=136860&query=is%3Aunresolved
It broke data dictionary upload. It's behind a feature flag, has occurred only on staging and effects only bulk upload so should not need urgent deploy.

Introduced in https://github.com/dimagi/commcare-hq/pull/29484/commits/c8c38b6148335dc0649760297a67a1dca6964214

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`DATA_DICTIONARY`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

This itself is a bugfix. Can be reverted if introduces further issues or makes things worse, though should not.
