### PR TITLE
add celery task name to couch logs

### DIFF
--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -206,7 +206,7 @@ class HQRequestFilter(Filter):
             record.username = request.couch_user.username if getattr(request, 'couch_user', None) else ''
             record.hq_url = request.path
         else:
-            record.domain = record.username = record.hq_url = None
+            record.domain = record.username = record.hq_url = '-'
         return True
 
 
@@ -222,7 +222,7 @@ class CeleryTaskFilter(Filter):
             record.task_id = task.request.id
             record.task_name = task.name
         else:
-            record.task_id = record.task_name = None
+            record.task_id = record.task_name = '-'
         return True
 
 

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -5,6 +5,7 @@ from logging import Filter
 import traceback
 from datetime import timedelta, datetime
 
+from celery._state import get_current_task
 from pygments import highlight
 from pygments.lexers import PythonLexer
 from pygments.formatters import HtmlFormatter
@@ -206,6 +207,22 @@ class HQRequestFilter(Filter):
             record.hq_url = request.path
         else:
             record.domain = record.username = record.hq_url = None
+        return True
+
+
+class CeleryTaskFilter(Filter):
+    """
+    Filter that adds custom context to log records for celery task ID and name.
+
+    This lets you add custom log formatters to include this information.
+    """
+    def filter(self, record):
+        task = get_current_task()
+        if task and task.request:
+            record.task_id = task.request.id
+            record.task_name = task.name
+        else:
+            record.task_id = record.task_name = None
         return True
 
 

--- a/settings.py
+++ b/settings.py
@@ -1221,7 +1221,7 @@ LOGGING = {
             'format': '%(asctime)s %(levelname)s %(module)s %(message)s'
         },
         'couch-request-formatter': {
-            'format': '%(asctime)s [%(username)s:%(domain)s] %(hq_url)s %(database)s %(method)s %(status_code)s %(content_length)s %(path)s %(duration)s'
+            'format': '%(asctime)s [%(username)s:%(domain)s] %(hq_url)s %(task_name)s %(database)s %(method)s %(status_code)s %(content_length)s %(path)s %(duration)s'
         },
         'formplayer_timing': {
             'format': '%(asctime)s, %(action)s, %(control_duration)s, %(candidate_duration)s'
@@ -1243,8 +1243,11 @@ LOGGING = {
         },
     },
     'filters': {
-        'hqcontext': {
+        'hqrequest': {
             '()': 'corehq.util.log.HQRequestFilter',
+        },
+        'celerytask': {
+            '()': 'corehq.util.log.CeleryTaskFilter',
         },
         'exclude_static': {
             '()': 'corehq.util.log.SuppressStaticLogs',
@@ -1273,7 +1276,7 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.handlers.RotatingFileHandler',
             'formatter': 'couch-request-formatter',
-            'filters': ['hqcontext'],
+            'filters': ['hqrequest', 'celerytask'],
             'filename': COUCH_LOG_FILE,
             'maxBytes': 10 * 1024 * 1024,  # 10 MB
             'backupCount': 20  # Backup 200 MB of logs


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12083

## Summary
Add new logging filter to allow referencing the current celery task in couch timing logs.


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Repeating an already used pattern

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
