### PR TITLE
[SSO] refactor activate_new_user method

### DIFF
--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -52,14 +52,38 @@ _soft_assert_registration_issues = soft_assert(
 
 
 def activate_new_user_via_reg_form(form, created_by, created_via, is_domain_admin=True, domain=None, ip=None):
-    username = form.cleaned_data['email']
-    password = form.cleaned_data['password']
     full_name = form.cleaned_data['full_name']
+    new_user = activate_new_user(
+        username=form.cleaned_data['email'],
+        password=form.cleaned_data['password'],
+        created_by=created_by,
+        created_via=created_via,
+        first_name=full_name[0],
+        last_name=full_name[1],
+        is_domain_admin=is_domain_admin,
+        domain=domain,
+        ip=ip,
+        atypical_user=form.cleaned_data.get('atypical_user', False),
+    )
+    return new_user
+
+
+def activate_new_user(
+    username, password, created_by, created_via, first_name=None, last_name=None,
+    is_domain_admin=True, domain=None, ip=None, atypical_user=False
+):
     now = datetime.utcnow()
 
-    new_user = WebUser.create(domain, username, password, created_by, created_via, is_admin=is_domain_admin)
-    new_user.first_name = full_name[0]
-    new_user.last_name = full_name[1]
+    new_user = WebUser.create(
+        domain,
+        username,
+        password,
+        created_by,
+        created_via,
+        is_admin=is_domain_admin
+    )
+    new_user.first_name = first_name
+    new_user.last_name = last_name
     new_user.email = username
     new_user.subscribed_to_commcare_users = False
     new_user.eula.signed = True
@@ -74,7 +98,7 @@ def activate_new_user_via_reg_form(form, created_by, created_via, is_domain_admi
     new_user.last_login = now
     new_user.date_joined = now
     new_user.last_password_set = now
-    new_user.atypical_user = form.cleaned_data.get('atypical_user', False)
+    new_user.atypical_user = atypical_user
     new_user.save()
 
     return new_user

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -51,7 +51,7 @@ _soft_assert_registration_issues = soft_assert(
 )
 
 
-def activate_new_user(form, created_by, created_via, is_domain_admin=True, domain=None, ip=None):
+def activate_new_user_via_reg_form(form, created_by, created_via, is_domain_admin=True, domain=None, ip=None):
     username = form.cleaned_data['email']
     password = form.cleaned_data['password']
     full_name = form.cleaned_data['full_name']

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -45,7 +45,7 @@ from corehq.apps.registration.forms import (
 )
 from corehq.apps.registration.models import RegistrationRequest
 from corehq.apps.registration.utils import (
-    activate_new_user,
+    activate_new_user_via_reg_form,
     request_new_domain,
     send_domain_registration_email,
     send_mobile_experience_reminder,
@@ -79,7 +79,7 @@ class ProcessRegistrationView(JSONResponseMixin, View):
         raise Http404()
 
     def _create_new_account(self, reg_form, additional_hubspot_data=None):
-        activate_new_user(reg_form, created_by=None, created_via=USER_CHANGE_VIA_WEB, ip=get_ip(self.request))
+        activate_new_user_via_reg_form(reg_form, created_by=None, created_via=USER_CHANGE_VIA_WEB, ip=get_ip(self.request))
         new_user = authenticate(
             username=reg_form.cleaned_data['email'],
             password=reg_form.cleaned_data['password']

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -73,7 +73,7 @@ from corehq.apps.registration.forms import (
     AdminInvitesUserForm,
     WebUserInvitationForm,
 )
-from corehq.apps.registration.utils import activate_new_user
+from corehq.apps.registration.utils import activate_new_user_via_reg_form
 from corehq.apps.reports.util import get_possible_reports
 from corehq.apps.sms.mixin import BadSMSConfigException
 from corehq.apps.sms.verify import (
@@ -987,8 +987,12 @@ class UserInvitationView(object):
                 if form.is_valid():
                     # create the new user
                     invited_by_user = CouchUser.get_by_user_id(invitation.invited_by)
-                    user = activate_new_user(form, created_by=invited_by_user,
-                                             created_via=USER_CHANGE_VIA_INVITATION, domain=invitation.domain)
+                    user = activate_new_user_via_reg_form(
+                        form,
+                        created_by=invited_by_user,
+                        created_via=USER_CHANGE_VIA_INVITATION,
+                        domain=invitation.domain
+                    )
                     user.save()
                     messages.success(request, _("User account for %s created!") % form.cleaned_data["email"])
                     self._invite(invitation, user)


### PR DESCRIPTION
## Summary
This is a very quick, isolated refactor to split the `activate_new_user` method into a method that does not require that a form is passed in. Tested creating a new user and accepting an invitation locally, no issues. The change is very carefully isolated and straightforward.

Doing this because I am going to use this new method in the SSO work for creating a user, but wanted to create a separate PR for this change since it is a very isolated but higher risk area. Want to keep the change very small and clear and don't want to obfuscate it with additional SSO changes.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Nothing automated, but a test of going through the sign-up form locally produced no errors. None of the core logic was changed in this mini refactor

### QA Plan
none

### Safety story
Very small straightforward change and did a sanity check locally to confirm that the sign up form and invitation workflow is not interrupted by this change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
