### PR TITLE
Properly escape phone numbers for SMS gateways

### DIFF
--- a/corehq/apps/sms/templates/sms/add_gateway.html
+++ b/corehq/apps/sms/templates/sms/add_gateway.html
@@ -8,7 +8,7 @@
 {% block page_content %}
   {% initial_page_data 'give_other_domains_access' form.give_other_domains_access.value %}
   {% initial_page_data 'use_load_balancing' use_load_balancing %}
-  {% initial_page_data 'phone_numbers' form.phone_numbers.value|default:'[]'|safe %}
+  {% initial_page_data 'phone_numbers' form.phone_numbers.value|default:'[]' %}
 
   <div id="add-gateway-form">
     {% crispy form %}


### PR DESCRIPTION
## Summary
Phone numbers were not being properly escaped on the SMS Gateway page. This was likely caused by https://github.com/dimagi/commcare-hq/pull/29479/ or another XSS change, where the phone number was a field whose escaping behavior was changed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests

### QA Plan

No QA needed.

### Safety story

This is a visual change within the template. Was reproduced and the fix was verified locally.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
