### PR TITLE
[SSO] refactor request_new_domain method

### DIFF
--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -80,7 +80,7 @@ def activate_new_user(form, created_by, created_via, is_domain_admin=True, domai
     return new_user
 
 
-def request_new_domain(request, form, is_new_user=True):
+def request_new_domain(request, project_name, is_new_user=True):
     now = datetime.utcnow()
     current_user = CouchUser.from_django_user(request.user, strict=True)
 
@@ -90,7 +90,6 @@ def request_new_domain(request, form, is_new_user=True):
         dom_req.request_ip = get_ip(request)
         dom_req.activation_guid = uuid.uuid1().hex
 
-    project_name = form.cleaned_data.get('hr_name') or form.cleaned_data.get('project_name')
     name = name_to_url(project_name, "project")
     with CriticalSection(['request_domain_name_{}'.format(name)]):
         name = Domain.generate_name(name)

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -108,9 +108,6 @@ def request_new_domain(request, form, is_new_user=True):
         # Avoid projects created by dimagi.com staff members as self started
         new_domain.internal.self_started = not current_user.is_dimagi
 
-        if form.cleaned_data.get('domain_timezone'):
-            new_domain.default_timezone = form.cleaned_data['domain_timezone']
-
         if not is_new_user:
             new_domain.is_active = True
 

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -140,7 +140,9 @@ class ProcessRegistrationView(JSONResponseMixin, View):
             })
             try:
                 request_new_domain(
-                    self.request, reg_form, is_new_user=True
+                    self.request,
+                    reg_form.cleaned_data['project_name'],
+                    is_new_user=True
                 )
             except NameUnavailableException:
                 # technically, the form should never reach this as names are
@@ -319,7 +321,11 @@ class RegisterDomainView(TemplateView):
             return render(request, 'error.html', context)
 
         try:
-            domain_name = request_new_domain(request, form, is_new_user=self.is_new_user)
+            domain_name = request_new_domain(
+                request,
+                form.cleaned_data['hr_name'],
+                is_new_user=self.is_new_user
+            )
         except NameUnavailableException:
             context.update({
                 'current_page': {'page_name': _('Oops!')},


### PR DESCRIPTION
## Summary
It would be nice if `request_new_domain` did not require that some random form be passed into it. I refactored the signature to explicitly require a `project_name` and made sure to update the two usages to pass in the correct form field. I also noticed that `domain_timezone` was not a field in any of the forms for the two usages (nor is it a field in ANY form), so I removed it.

Tested locally for both the sign-up user workflow and create new domain workflow. All fine.

I am doing this because I need `request_new_domain` to not require a form for the SSO Create User work I'm doing. I made this into a separate PR since it's a small change in a high risk area and i didn't want it being obfuscated by any SSO specific changes

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
None

### QA Plan
Not needed. very small isolated change and tested where I'm very confident nothing breaks.

### Safety story
Small, isolated change. tested the two workflows that use this method locally and there were no adverse effects.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
