### PR TITLE
Duplicate Linked Projects UI for ERM

### DIFF
--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -71,6 +71,7 @@ from corehq.apps.domain.views.settings import (
     RecoveryMeasuresHistory,
 )
 from corehq.apps.domain.views.sms import SMSRatesView
+from corehq.apps.enterprise.views import LinkedDomainsView
 from corehq.apps.integration.urls import settings_patterns as integration_settings
 from corehq.apps.linked_domain.views import DomainLinkView
 from corehq.apps.reports.dispatcher import DomainReportDispatcher
@@ -181,6 +182,7 @@ domain_settings = [
     url(r'^transfer/$', TransferDomainView.as_view(), name=TransferDomainView.urlname),
     url(r'^case_search/$', CaseSearchConfigView.as_view(), name=CaseSearchConfigView.urlname),
     url(r'^domain_links/$', DomainLinkView.as_view(), name=DomainLinkView.urlname),
+    url(r'^linked_domains/$', LinkedDomainsView.as_view(), name=LinkedDomainsView.urlname),
     url(r'^location_settings/$', LocationFixtureConfigView.as_view(), name=LocationFixtureConfigView.urlname),
     url(r'^commtrack/settings/$', RedirectView.as_view(url='commtrack_settings', permanent=True)),
     url(r'^internal/info/$', EditInternalDomainInfoView.as_view(), name=EditInternalDomainInfoView.urlname),

--- a/corehq/apps/enterprise/static/enterprise/js/linked_domains.js
+++ b/corehq/apps/enterprise/static/enterprise/js/linked_domains.js
@@ -1,0 +1,144 @@
+hqDefine("enterprise/js/linked_domains", [
+    'jquery.rmi/jquery.rmi',
+    'hqwebapp/js/initial_page_data',
+    'underscore',
+    'knockout',
+    'hqwebapp/js/alert_user',
+    'hqwebapp/js/multiselect_utils',
+], function (
+    RMI,
+    initialPageData,
+    _,
+    ko,
+    alertUser
+) {
+    var _private = {};
+    _private.RMI = function () {};
+
+    var ModelStatus = function (data) {
+        var self = {};
+        self.type = data.type;
+        self.name = data.name;
+        self.last_update = ko.observable(data.last_update);
+        self.detail = data.detail;
+        self.showUpdate = ko.observable(data.can_update);
+        self.update_url = null;
+
+        if (self.type === 'app' && self.detail && self.detail.app_id) {
+            self.update_url = initialPageData.reverse('app_settings', self.detail.app_id);
+        }
+        self.error = ko.observable("");
+        self.hasSuccess = ko.observable(false);
+        self.showSpinner = ko.observable(false);
+
+        self.update = function () {
+            self.showSpinner(true);
+            self.showUpdate(false);
+            _private.RMI("update_linked_model", {"model": {
+                'type': self.type,
+                'detail': self.detail,
+            }}).done(function (data) {
+                if (data.error) {
+                    self.error(data.error);
+                } else {
+                    self.last_update(data.last_update);
+                    self.hasSuccess(true);
+                }
+                self.showSpinner(false);
+            }).fail(function () {
+                self.error(gettext("Error updating."));
+                self.showSpinner(false);
+            });
+        };
+
+        return self;
+    };
+
+    var LinkedDomainsViewModel = function (data) {
+        var self = {};
+        self.domain = data.domain;
+        self.master_link = data.master_link;
+        if (self.master_link) {
+            if (self.master_link.is_remote) {
+                self.master_href = self.master_link.master_domain;
+            } else {
+                self.master_href = initialPageData.reverse('linked_domains', self.master_link.master_domain);
+            }
+        }
+
+        self.can_update = data.can_update;
+        self.models = data.models;
+
+        self.model_status = _.map(data.model_status, ModelStatus);
+
+        self.linked_domains = ko.observableArray(_.map(data.linked_domains, function (link) {
+            return DomainLink(link);
+        }));
+
+        self.deleteLink = function (link) {
+            _private.RMI("delete_domain_link", {
+                "linked_domain": link.linked_domain(),
+            }).done(function () {
+                self.linked_domains.remove(link);
+            }).fail(function () {
+                alertUser.alert_user(gettext('Something unexpected happened.\n' +
+                    'Please try again, or report an issue if the problem persists.'), 'danger');
+            });
+        };
+
+        self.domainsToRelease = ko.observableArray();
+        self.modelsToRelease = ko.observableArray();
+        self.buildAppsOnRelease = ko.observable(false);
+        self.releaseInProgress = ko.observable(false);
+        self.enableReleaseButton = ko.computed(function () {
+            return self.domainsToRelease().length && self.modelsToRelease().length && !self.releaseInProgress();
+        });
+        self.createRelease = function () {
+            self.releaseInProgress(true);
+            _private.RMI("create_release", {
+                models: _.map(self.modelsToRelease(), JSON.parse),
+                linked_domains: self.domainsToRelease(),
+                build_apps: self.buildAppsOnRelease(),
+            }).done(function (data) {
+                alertUser.alert_user(data.message, data.success ? 'success' : 'danger');
+                self.releaseInProgress(false);
+            }).fail(function () {
+                alertUser.alert_user(gettext('Something unexpected happened.\nPlease try again, or report an issue if the problem persists.'), 'danger');
+                self.releaseInProgress(false);
+            });
+        };
+
+        return self;
+    };
+
+    var DomainLink = function (link) {
+        var self = {};
+        self.linked_domain = ko.observable(link.linked_domain);
+        self.is_remote = link.is_remote;
+        self.master_domain = link.master_domain;
+        self.remote_base_url = ko.observable(link.remote_base_url);
+        self.last_update = link.last_update;
+        if (self.is_remote) {
+            self.domain_link = self.linked_domain;
+        } else {
+            self.domain_link = initialPageData.reverse('linked_domains', self.linked_domain());
+        }
+        return self;
+    };
+
+    var setRMI = function (rmiUrl, csrfToken) {
+        var _rmi = RMI(rmiUrl, csrfToken);
+        _private.RMI = function (remoteMethod, data) {
+            return _rmi("", data, {headers: {"DjNg-Remote-Method": remoteMethod}});
+        };
+    };
+
+    $(function () {
+        var view_data = initialPageData.get('view_data');
+        var csrfToken = $("#csrfTokenContainer").val();
+        setRMI(initialPageData.reverse('linked_domains_rmi'), csrfToken);
+
+        var model = LinkedDomainsViewModel(view_data);
+        $("#domain_links").koApplyBindings(model);
+    });
+});

--- a/corehq/apps/enterprise/static/enterprise/js/linked_domains.js
+++ b/corehq/apps/enterprise/static/enterprise/js/linked_domains.js
@@ -134,11 +134,11 @@ hqDefine("enterprise/js/linked_domains", [
     };
 
     $(function () {
-        var view_data = initialPageData.get('view_data');
+        var viewData = initialPageData.get('view_data');
         var csrfToken = $("#csrfTokenContainer").val();
         setRMI(initialPageData.reverse('linked_domains_rmi'), csrfToken);
 
-        var model = LinkedDomainsViewModel(view_data);
+        var model = LinkedDomainsViewModel(viewData);
         $("#domain_links").koApplyBindings(model);
     });
 });

--- a/corehq/apps/enterprise/templates/enterprise/linked_domains.html
+++ b/corehq/apps/enterprise/templates/enterprise/linked_domains.html
@@ -1,0 +1,167 @@
+{% extends "hqwebapp/base_section.html" %}
+{% load hq_shared_tags %}
+{% load i18n %}
+
+{% requirejs_main "enterprise/js/linked_domains" %}
+
+{% block page_content %}
+  {% initial_page_data 'view_data' view_data %}
+  {% registerurl 'linked_domains_rmi' domain %}
+  {% registerurl 'linked_domains' '---' %}
+  {% registerurl 'app_settings' domain '---' %}
+
+  {% if not is_master_domain and not is_linked_domain %}
+    <div class="alert alert-info">
+      {% trans "This project has no links to other projects." %}
+    </div>
+  {% endif %}
+
+  {% if is_master_domain %}
+    {% comment %}
+      Keep the tab headers out of the .ko-template div because they use .sticky-tabs, which is subject
+      to race condition problems if the tabs aren't visible when its document ready handler runs.
+    {% endcomment %}
+    <ul class="nav nav-tabs sticky-tabs">
+      {% if is_linked_domain %}
+        <li class="active"><a data-toggle="tab" href="#tabs-master">{% trans "Project Link" %}</a></li>
+      {% endif %}
+      <li{% if not is_linked_domain %} class="active"{% endif %}><a data-toggle="tab" href="#tabs-linked">{% trans "Projects linked to this one" %}</a></li>
+      <li><a data-toggle="tab" href="#tabs-release">{% trans "Release Content" %}</a></li>
+    </ul>
+    <div class="spacer"></div>
+  {% elif is_linked_domain %}
+    <h2>{% trans "Project Link" %}</h2>  {# header for the only tab that will be displayed #}
+  {% endif %}
+
+  <div id="domain_links" class="ko-template">
+    <div class="tab-content">
+      {% if is_linked_domain %}
+        <div class="tab-pane fade in active" id="tabs-master">
+          <div data-bind="if: master_link">
+            <p>{% trans "This project is linked to " %}<a data-bind="attr: {'href': master_href}, text: master_link.master_domain"></a></p>
+            <div>
+              <table class="table table-striped table-hover">
+                <thead>
+                <tr>
+                  <th class="col-sm-5">{% trans "Linked Model" %}</th>
+                  <th class="col-sm-2">{% trans "Last Updated" %} ({{ timezone }})</th>
+                  <th class="col-sm-5"></th>
+                </tr>
+                </thead>
+                <tbody data-bind="foreach: model_status">
+                <tr>
+                  <td data-bind="text: name"></td>
+                  <td data-bind="text: last_update"></td>
+                  <td data-bind="css: {'has-error': error}">
+                    <button class="btn btn-danger" data-bind="visible: showUpdate() && !update_url, click: update">
+                      {% trans "Overwrite" %}
+                    </button>
+                    <button class="btn btn-default disabled" data-bind="visible: showSpinner">
+                      <i class="fa fa-spinner"></i>
+                    </button>
+                    <button class="btn btn-success disabled" data-bind="visible: hasSuccess">
+                      <i class="fa fa-check"></i> {% trans "Success" %}
+                    </button>
+                    <button class="btn btn-danger disabled" data-bind="visible: error">
+                      <i class="fa fa-times"></i> {% trans "Error" %}
+                    </button>
+                    <span class="help-block" data-bind="visible: error, text: error"></span>
+                    <a data-bind="visible: showUpdate && update_url, attr: {href: update_url}">{% trans "Go to update page" %}</a>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      {% endif %}
+      <div class="tab-pane fade{% if not is_linked_domain %} in active{% endif %}" id="tabs-linked">
+        <div data-bind="if: linked_domains().length">
+          <table class="table table-striped table-hover">
+            <thead>
+            <tr>
+              <th>{% trans "Project Name" %}</th>
+              <th>{% trans "Last Updated" %} ({{ timezone }})</th>
+              <th></th>
+            </tr>
+            </thead>
+            <tbody data-bind="foreach: linked_domains">
+            <tr>
+              <td><a data-bind="attr: {'href': domain_link}, text: linked_domain"></a></td>
+              <td data-bind="text: last_update"></td>
+              <td>
+                <button type="button" class="btn btn-danger" data-bind="click: $root.deleteLink.bind($data)">
+                  <i class="fa fa-trash"></i>
+                  {% trans 'Delete Link' %}
+                </button>
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="tab-pane fade" id="tabs-release">
+        <form class="form-horizontal">
+          <div class="form-group">
+            <label class="col-sm-3 col-md-2 control-label">
+              {% trans "Models" %}
+            </label>
+            <div class="col-sm-9 col-md-10 controls">
+              <select multiple class="form-control"
+                      data-bind="selectedOptions: modelsToRelease,
+                                 multiselect: {
+                                     selectableHeaderTitle: '{% trans_html_attr "All content" %}',
+                                     selectedHeaderTitle: '{% trans_html_attr "Content to release" %}',
+                                     searchItemTitle: '{% trans_html_attr "Search content" %}',
+                                }">
+                {% for model in view_data.master_model_status %}
+                  <option value="{% html_attr model %}">{{ model.name }}</option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="col-sm-3 col-md-2 control-label">
+              {% trans "Projects" %}
+            </label>
+            <div class="col-sm-9 col-md-10 controls">
+              <select multiple class="form-control"
+                      data-bind="selectedOptions: domainsToRelease,
+                                 multiselect: {
+                                     selectableHeaderTitle: '{% trans_html_attr "All projects" %}',
+                                     selectedHeaderTitle: '{% trans_html_attr "Projects to release to" %}',
+                                     searchItemTitle: '{% trans_html_attr "Search projects" %}',
+                                }">
+                {% for link in view_data.linked_domains %}
+                  {% if not linked_domain.is_remote %}
+                    <option value="{{ link.linked_domain }}">{{ link.linked_domain }}</option>
+                  {% endif %}
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="col-sm-3 col-md-2 control-label" for="build-apps">
+              {% trans "Create and release new build for apps" %}
+            </label>
+            <div class="col-sm-9 col-md-10 controls">
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" data-bind="checked: buildAppsOnRelease" />
+                </label>
+              </div>
+            </div>
+          </div>
+          <div class="form-actions">
+            <div class="col-sm-offset-3 col-md-offset-2 controls col-sm-9 col-md-8 col-lg-6">
+              <button type="button" class="btn btn-primary" data-bind="click: createRelease, enable: enableReleaseButton">
+                <i class="fa fa-refresh fa-spin icon-refresh icon-spin" data-bind="visible: releaseInProgress"></i>
+                {% trans "Create Release" %}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/corehq/apps/enterprise/urls.py
+++ b/corehq/apps/enterprise/urls.py
@@ -7,6 +7,7 @@ from corehq.apps.enterprise.views import (
     enterprise_dashboard_email,
     enterprise_dashboard_total,
     enterprise_settings,
+    LinkedDomainsRMIView,
 )
 from corehq.apps.enterprise.views import EnterpriseBillingStatementsView
 from corehq.apps.sso.views.enterprise_admin import (
@@ -30,4 +31,5 @@ domain_specific = [
         name=ManageSSOEnterpriseView.urlname),
     url(r'^sso/(?P<idp_slug>[^/]*)/$', EditIdentityProviderEnterpriseView.as_view(),
         name=EditIdentityProviderEnterpriseView.urlname),
+    url(r'^service/$', LinkedDomainsRMIView.as_view(), name=LinkedDomainsRMIView.urlname),
 ]

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -1,10 +1,12 @@
 import json
+from datetime import datetime
 
 from django.conf import settings
 from django.contrib import messages
 from django.core.files.base import ContentFile
 from django.core.paginator import Paginator
 from django.db.models import Sum
+from django.db.models.expressions import RawSQL
 from django.http import (
     HttpResponse,
     HttpResponseNotFound,
@@ -14,39 +16,105 @@ from django.http import (
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _, ugettext_lazy
+from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy
+from django.views import View
 from django.views.decorators.http import require_POST
 
+from couchdbkit import ResourceNotFound
 from django_prbac.utils import has_privilege
+from djng.views.mixins import JSONResponseMixin, allow_remote_invocation
 from memoized import memoized
 
-from corehq.apps.accounting.decorators import always_allow_project_access
-from corehq.apps.enterprise.decorators import require_enterprise_admin
 from couchexport.export import Format
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 
-from corehq import privileges
-from corehq.apps.accounting.models import CustomerInvoice, CustomerBillingRecord
-from corehq.apps.accounting.utils import get_customer_cards, quantize_accounting_decimal, log_accounting_error
-from corehq.apps.domain.views import DomainAccountingSettings, BaseDomainView
-from corehq.apps.domain.views.accounting import PAYMENT_ERROR_MESSAGES, InvoiceStripePaymentView, \
-    BulkStripePaymentView, WireInvoiceView, BillingStatementPdfView
-
-from corehq.apps.enterprise.enterprise import EnterpriseReport
-
-from corehq.apps.enterprise.forms import (
-    EnterpriseSettingsForm,
+from corehq import privileges, toggles
+from corehq.apps.accounting.decorators import always_allow_project_access
+from corehq.apps.accounting.models import (
+    CustomerBillingRecord,
+    CustomerInvoice,
 )
-from corehq.apps.enterprise.tasks import email_enterprise_report
-
+from corehq.apps.accounting.utils import (
+    get_customer_cards,
+    log_accounting_error,
+    quantize_accounting_decimal,
+)
+from corehq.apps.accounting.utils.subscription import get_account_or_404
+from corehq.apps.analytics.tasks import track_workflow
+from corehq.apps.app_manager.dbaccessors import get_brief_apps_in_domain
+from corehq.apps.app_manager.util import is_linked_app
 from corehq.apps.domain.decorators import (
+    domain_admin_required,
     login_and_domain_required,
 )
-
-from corehq.apps.accounting.utils.subscription import get_account_or_404
+from corehq.apps.domain.views import (
+    BaseAdminProjectSettingsView,
+    BaseDomainView,
+    DomainAccountingSettings,
+    DomainViewMixin,
+)
+from corehq.apps.domain.views.accounting import (
+    PAYMENT_ERROR_MESSAGES,
+    BillingStatementPdfView,
+    BulkStripePaymentView,
+    InvoiceStripePaymentView,
+    WireInvoiceView,
+)
+from corehq.apps.enterprise.decorators import require_enterprise_admin
+from corehq.apps.enterprise.enterprise import EnterpriseReport
+from corehq.apps.enterprise.forms import EnterpriseSettingsForm
+from corehq.apps.enterprise.tasks import email_enterprise_report
 from corehq.apps.export.utils import get_default_export_settings_if_available
+from corehq.apps.fixtures.dbaccessors import (
+    get_fixture_data_type_by_tag,
+    get_fixture_data_types,
+)
+from corehq.apps.hqwebapp.decorators import use_multiselect
+from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id
+from corehq.apps.hqwebapp.templatetags.hq_shared_tags import pretty_doc_info
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
+from corehq.apps.linked_domain.const import (
+    LINKED_MODELS,
+    LINKED_MODELS_MAP,
+    MODEL_APP,
+    MODEL_CASE_SEARCH,
+    MODEL_DATA_DICTIONARY,
+    MODEL_DIALER_SETTINGS,
+    MODEL_FIXTURE,
+    MODEL_HMAC_CALLOUT_SETTINGS,
+    MODEL_KEYWORD,
+    MODEL_OTP_SETTINGS,
+    MODEL_REPORT,
+)
+from corehq.apps.linked_domain.dbaccessors import (
+    get_domain_master_link,
+    get_linked_domains,
+)
+from corehq.apps.linked_domain.exceptions import (
+    DomainLinkError,
+    UnsupportedActionError,
+)
+from corehq.apps.linked_domain.models import (
+    AppLinkDetail,
+    DomainLink,
+    DomainLinkHistory,
+    FixtureLinkDetail,
+    KeywordLinkDetail,
+    ReportLinkDetail,
+    wrap_detail,
+)
+from corehq.apps.linked_domain.tasks import push_models
+from corehq.apps.linked_domain.updates import update_model_type
+from corehq.apps.linked_domain.util import server_to_user_time
+from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
+from corehq.apps.reports.dispatcher import DomainReportDispatcher
+from corehq.apps.reports.generic import GenericTabularReport
+from corehq.apps.sms.models import Keyword
+from corehq.apps.userreports.dbaccessors import get_report_configs_for_domain
+from corehq.apps.userreports.models import ReportConfiguration
 from corehq.const import USER_DATE_FORMAT
+from corehq.util.timezones.utils import get_timezone_for_request
 
 
 @always_allow_project_access
@@ -324,3 +392,452 @@ class EnterpriseBillingStatementsView(DomainAccountingSettings, CRUDPaginatedVie
 
     def post(self, *args, **kwargs):
         return self.paginate_crud_response
+
+
+@method_decorator(toggles.ERM_DEVELOPMENT.required_decorator(), name='dispatch')
+class LinkedDomainsView(BaseAdminProjectSettingsView):
+    urlname = 'linked_domains'
+    page_title = ugettext_lazy("Linked Project Spaces")
+    template_name = 'enterprise/linked_domains.html'
+
+    @use_multiselect
+    def dispatch(self, request, *args, **kwargs):
+        return super().dispatch(request, *args, **kwargs)
+
+    @property
+    def page_context(self):
+        """
+        This view services both domains that are master domains and domains that are linked domains
+        (and legacy domains that are both).
+        """
+        timezone = get_timezone_for_request()
+        master_link = get_domain_master_link(self.domain)
+        linked_domains = [self._link_context(link, timezone) for link in get_linked_domains(self.domain)]
+        (master_apps, linked_apps) = self._get_apps()
+        (master_fixtures, linked_fixtures) = self._get_fixtures(master_link)
+        (master_reports, linked_reports) = self._get_reports()
+        (master_keywords, linked_keywords) = self._get_keywords()
+
+        # Models belonging to this domain's master domain, for the purpose of pulling
+        model_status = self._get_model_status(
+            master_link, linked_apps, linked_fixtures, linked_reports, linked_keywords
+        )
+
+        # Models belonging to this domain, for the purpose of pushing to linked domains
+        master_model_status = self._get_master_model_status(
+            master_apps, master_fixtures, master_reports, master_keywords
+        )
+
+        return {
+            'domain': self.domain,
+            'timezone': timezone.localize(datetime.utcnow()).tzname(),
+            'is_linked_domain': bool(master_link),
+            'is_master_domain': bool(len(linked_domains)),
+            'view_data': {
+                'master_link': self._link_context(master_link, timezone) if master_link else None,
+                'model_status': sorted(model_status, key=lambda m: m['name']),
+                'master_model_status': sorted(master_model_status, key=lambda m: m['name']),
+                'linked_domains': sorted(linked_domains, key=lambda d: d['linked_domain']),
+                'models': [
+                    {'slug': model[0], 'name': model[1]}
+                    for model in LINKED_MODELS
+                ]
+            },
+        }
+
+    def _get_apps(self):
+        master_list = {}
+        linked_list = {}
+        briefs = get_brief_apps_in_domain(self.domain, include_remote=False)
+        for brief in briefs:
+            if is_linked_app(brief):
+                linked_list[brief._id] = brief
+            else:
+                master_list[brief._id] = brief
+        return (master_list, linked_list)
+
+    def _get_fixtures(self, master_link):
+        master_list = self._get_fixtures_for_domain(self.domain)
+        linked_list = self._get_fixtures_for_domain(master_link.master_domain) if master_link else {}
+        return (master_list, linked_list)
+
+    def _get_fixtures_for_domain(self, domain):
+        fixtures = get_fixture_data_types(domain)
+        return {f.tag: f for f in fixtures if f.is_global}
+
+    def _get_reports(self):
+        master_list = {}
+        linked_list = {}
+        reports = get_report_configs_for_domain(self.domain)
+        for report in reports:
+            if report.report_meta.master_id:
+                linked_list[report.get_id] = report
+            else:
+                master_list[report.get_id] = report
+        return (master_list, linked_list)
+
+    def _get_keywords(self):
+        master_list = {}
+        linked_list = {}
+        keywords = Keyword.objects.filter(domain=self.domain)
+        for keyword in keywords:
+            if keyword.upstream_id:
+                linked_list[str(keyword.id)] = keyword
+            else:
+                master_list[str(keyword.id)] = keyword
+        return (master_list, linked_list)
+
+    def _link_context(self, link, timezone):
+        return {
+            'linked_domain': link.linked_domain,
+            'master_domain': link.qualified_master,
+            'remote_base_url': link.remote_base_url,
+            'is_remote': link.is_remote,
+            'last_update': server_to_user_time(link.last_pull, timezone) if link.last_pull else 'Never',
+        }
+
+    def _get_master_model_status(self, apps, fixtures, reports, keywords, ignore_models=None):
+        model_status = []
+        ignore_models = ignore_models or []
+
+        for model, name in LINKED_MODELS:
+            if (
+                model not in ignore_models
+                and model not in (MODEL_APP, MODEL_FIXTURE, MODEL_REPORT, MODEL_KEYWORD)
+                and (model != MODEL_CASE_SEARCH or toggles.SYNC_SEARCH_CASE_CLAIM.enabled(self.domain))
+                and (model != MODEL_DATA_DICTIONARY or toggles.DATA_DICTIONARY.enabled(self.domain))
+                and (model != MODEL_DIALER_SETTINGS or toggles.WIDGET_DIALER.enabled(self.domain))
+                and (model != MODEL_OTP_SETTINGS or toggles.GAEN_OTP_SERVER.enabled(self.domain))
+                and (model != MODEL_HMAC_CALLOUT_SETTINGS or toggles.HMAC_CALLOUT.enabled(self.domain))
+            ):
+                model_status.append({
+                    'type': model,
+                    'name': name,
+                    'last_update': _('Never'),
+                    'detail': None,
+                    'can_update': True
+                })
+
+        linked_models = dict(LINKED_MODELS)
+        for app in apps.values():
+            update = {
+                'type': MODEL_APP,
+                'name': '{} ({})'.format(linked_models['app'], app.name),
+                'last_update': None,
+                'detail': AppLinkDetail(app_id=app._id).to_json(),
+                'can_update': True
+            }
+            model_status.append(update)
+        for fixture in fixtures.values():
+            update = {
+                'type': MODEL_FIXTURE,
+                'name': '{} ({})'.format(linked_models['fixture'], fixture.tag),
+                'last_update': None,
+                'detail': FixtureLinkDetail(tag=fixture.tag).to_json(),
+                'can_update': fixture.is_global,
+            }
+            model_status.append(update)
+        for report in reports.values():
+            report = ReportConfiguration.get(report.get_id)
+            update = {
+                'type': MODEL_REPORT,
+                'name': f"{linked_models['report']} ({report.title})",
+                'last_update': None,
+                'detail': ReportLinkDetail(report_id=report.get_id).to_json(),
+                'can_update': True,
+            }
+            model_status.append(update)
+
+        for keyword in keywords.values():
+            update = {
+                'type': MODEL_KEYWORD,
+                'name': f"{linked_models['keyword']} ({keyword.keyword})",
+                'last_update': None,
+                'detail': KeywordLinkDetail(keyword_id=str(keyword.id)).to_json(),
+                'can_update': True,
+            }
+            model_status.append(update)
+
+        return model_status
+
+    def _get_model_status(self, master_link, apps, fixtures, reports, keywords):
+        model_status = []
+        if not master_link:
+            return model_status
+
+        models_seen = set()
+        history = DomainLinkHistory.objects.filter(link=master_link).annotate(row_number=RawSQL(
+            'row_number() OVER (PARTITION BY model, model_detail ORDER BY date DESC)',
+            []
+        ))
+        linked_models = dict(LINKED_MODELS)
+        timezone = get_timezone_for_request()
+        for action in history:
+            models_seen.add(action.model)
+            if action.row_number != 1:
+                # first row is the most recent
+                continue
+            name = linked_models[action.model]
+            update = {
+                'type': action.model,
+                'name': name,
+                'last_update': server_to_user_time(action.date, timezone),
+                'detail': action.model_detail,
+                'can_update': True
+            }
+            if action.model == 'app':
+                app_name = _('Unknown App')
+                if action.model_detail:
+                    detail = action.wrapped_detail
+                    app = apps.pop(detail.app_id, None)
+                    app_name = app.name if app else detail.app_id
+                    if app:
+                        update['detail'] = action.model_detail
+                    else:
+                        update['can_update'] = False
+                else:
+                    update['can_update'] = False
+                update['name'] = '{} ({})'.format(name, app_name)
+
+            if action.model == 'fixture':
+                tag_name = _('Unknown Table')
+                can_update = False
+                if action.model_detail:
+                    detail = action.wrapped_detail
+                    tag = action.wrapped_detail.tag
+                    fixture = fixtures.pop(tag, None)
+                    if not fixture:
+                        fixture = get_fixture_data_type_by_tag(self.domain, tag)
+                    if fixture:
+                        tag_name = fixture.tag
+                        can_update = fixture.is_global
+                update['name'] = f'{name} ({tag_name})'
+                update['can_update'] = can_update
+            if action.model == 'report':
+                report_id = action.wrapped_detail.report_id
+                try:
+                    report = reports.get(report_id)
+                    del reports[report_id]
+                except KeyError:
+                    report = ReportConfiguration.get(report_id)
+                update['name'] = f'{name} ({report.title})'
+            if action.model == 'keyword':
+                keyword_id = action.wrapped_detail.linked_keyword_id
+                try:
+                    keyword = keywords[keyword_id].keyword
+                    del keywords[keyword_id]
+                except KeyError:
+                    try:
+                        keyword = Keyword.objects.get(id=keyword_id).keyword
+                    except Keyword.DoesNotExist:
+                        keyword = ugettext_lazy("Deleted Keyword")
+                        update['can_update'] = False
+                update['name'] = f'{name} ({keyword})'
+
+            model_status.append(update)
+
+        # Add in models and apps that have never been synced
+        model_status.extend(
+            self._get_master_model_status(
+                apps, fixtures, reports, keywords, ignore_models=models_seen)
+        )
+
+        return model_status
+
+
+@method_decorator(domain_admin_required, name='dispatch')
+class LinkedDomainsRMIView(JSONResponseMixin, View, DomainViewMixin):
+    urlname = "linked_domains_rmi"
+
+    @allow_remote_invocation
+    def update_linked_model(self, in_data):
+        model = in_data['model']
+        type_ = model['type']
+        detail = model['detail']
+        detail_obj = wrap_detail(type_, detail) if detail else None
+
+        master_link = get_domain_master_link(self.domain)
+        error = ""
+        try:
+            update_model_type(master_link, type_, detail_obj)
+            model_detail = detail_obj.to_json() if detail_obj else None
+            master_link.update_last_pull(type_, self.request.couch_user._id, model_detail=model_detail)
+        except (DomainLinkError, UnsupportedActionError) as e:
+            error = str(e)
+
+        track_workflow(self.request.couch_user.username, "Linked domain: updated '{}' model".format(type_))
+
+        timezone = get_timezone_for_request()
+        return {
+            'success': not error,
+            'error': error,
+            'last_update': server_to_user_time(master_link.last_pull, timezone)
+        }
+
+    @allow_remote_invocation
+    def delete_domain_link(self, in_data):
+        linked_domain = in_data['linked_domain']
+        link = DomainLink.objects.filter(linked_domain=linked_domain, master_domain=self.domain).first()
+        link.deleted = True
+        link.save()
+
+        track_workflow(self.request.couch_user.username, "Linked domain: domain link deleted")
+
+        return {
+            'success': True,
+        }
+
+    @allow_remote_invocation
+    def create_release(self, in_data):
+        push_models.delay(self.domain, in_data['models'], in_data['linked_domains'],
+                          in_data['build_apps'], self.request.couch_user.username)
+        return {
+            'success': True,
+            'message': _('''
+                Your release has begun. You will receive an email when it is complete.
+                Until then, to avoid linked domains receiving inconsistent content, please
+                avoid editing any of the data contained in the release.
+            '''),
+        }
+
+
+class LinkedDomainsHistoryReport(GenericTabularReport):
+    name = 'Linked Project Space History'
+    base_template = "reports/base_template.html"
+    section_name = 'Project Settings'
+    slug = 'linked_domains_history'
+    dispatcher = DomainReportDispatcher
+    ajax_pagination = True
+    asynchronous = False
+    sortable = False
+
+    @property
+    def fields(self):
+        if self.master_link:
+            fields = []
+        else:
+            fields = ['corehq.apps.linked_domain.filters.DomainLinkFilter']
+        fields.append('corehq.apps.linked_domain.filters.DomainLinkModelFilter')
+        return fields
+
+    @property
+    def link_model(self):
+        return self.request.GET.get('domain_link_model')
+
+    @property
+    @memoized
+    def domain_link(self):
+        if self.request.GET.get('domain_link'):
+            try:
+                return DomainLink.all_objects.get(
+                    pk=self.request.GET.get('domain_link'),
+                    master_domain=self.domain
+                )
+            except DomainLink.DoesNotExist:
+                pass
+
+    @property
+    @memoized
+    def master_link(self):
+        return get_domain_master_link(self.domain)
+
+    @property
+    @memoized
+    def selected_link(self):
+        return self.master_link or self.domain_link
+
+    @property
+    def total_records(self):
+        query = self._base_query()
+        return query.count()
+
+    def _base_query(self):
+        query = DomainLinkHistory.objects.filter(link=self.selected_link)
+        if self.link_model:
+            query = query.filter(model=self.link_model)
+
+        return query
+
+    @property
+    def shared_pagination_GET_params(self):
+        link_id = str(self.selected_link.pk) if self.selected_link else ''
+        return [
+            {'name': 'domain_link', 'value': link_id},
+            {'name': 'domain_link_model', 'value': self.link_model},
+        ]
+
+    @property
+    def rows(self):
+        if not self.selected_link:
+            return []
+        rows = self._base_query()[self.pagination.start:self.pagination.start + self.pagination.count + 1]
+        return [self._make_row(record, self.selected_link) for record in rows]
+
+    def _make_row(self, record, link):
+        row = [
+            '{} -> {}'.format(link.master_domain, link.linked_domain),
+            server_to_user_time(record.date, self.timezone),
+            self._make_model_cell(record),
+            pretty_doc_info(get_doc_info_by_id(self.domain, record.user_id))
+        ]
+        return row
+
+    @memoized
+    def linked_app_names(self, domain):
+        return {
+            app._id: app.name for app in get_brief_apps_in_domain(domain)
+            if is_linked_app(app)
+        }
+
+    def _make_model_cell(self, record):
+        name = LINKED_MODELS_MAP[record.model]
+        if record.model == MODEL_APP:
+            detail = record.wrapped_detail
+            app_name = ugettext_lazy('Unknown App')
+            if detail:
+                app_names = self.linked_app_names(self.selected_link.linked_domain)
+                app_name = app_names.get(detail.app_id, detail.app_id)
+            return '{} ({})'.format(name, app_name)
+
+        if record.model == MODEL_FIXTURE:
+            detail = record.wrapped_detail
+            tag = ugettext_lazy('Unknown')
+            if detail:
+                data_type = get_fixture_data_type_by_tag(self.selected_link.linked_domain, detail.tag)
+                if data_type:
+                    tag = data_type.tag
+            return '{} ({})'.format(name, tag)
+
+        if record.model == MODEL_REPORT:
+            detail = record.wrapped_detail
+            report_name = ugettext_lazy('Unknown Report')
+            if detail:
+                try:
+                    report_name = ReportConfiguration.get(detail.report_id).title
+                except ResourceNotFound:
+                    pass
+            return '{} ({})'.format(name, report_name)
+
+        if record.model == MODEL_KEYWORD:
+            detail = record.wrapped_detail
+            keyword_name = ugettext_lazy('Unknown Keyword')
+            if detail:
+                try:
+                    keyword_name = Keyword.objects.get(detail.keyword_id)
+                except Keyword.DoesNotExist:
+                    pass
+            return f'{name} ({keyword_name})'
+
+        return name
+
+    @property
+    def headers(self):
+        tzname = self.timezone.localize(datetime.utcnow()).tzname()
+        columns = [
+            DataTablesColumn(_('Link')),
+            DataTablesColumn(_('Date ({})'.format(tzname))),
+            DataTablesColumn(_('Data Model')),
+            DataTablesColumn(_('User')),
+        ]
+
+        return DataTablesHeader(*columns)

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -29,7 +29,7 @@ from corehq.apps.data_interfaces.interfaces import (
     CaseReassignmentInterface,
 )
 from corehq.apps.domain.dbaccessors import get_doc_ids_in_domain_by_class
-from corehq.apps.domain.models import Domain
+from corehq.apps.enterprise.views import LinkedDomainsHistoryReport
 from corehq.apps.export.views.incremental import IncrementalExportLogView
 from corehq.apps.fixtures.interface import (
     FixtureEditInterface,
@@ -364,5 +364,6 @@ DOMAIN_REPORTS = (
         SQLRepeatRecordReport,
         DomainLinkHistoryReport,
         IncrementalExportLogView,
+        LinkedDomainsHistoryReport,
     )),
 )

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1688,6 +1688,10 @@ class ProjectSettingsTab(UITab):
         if feature_flag_items and user_is_admin and has_project_access:
             items.append((_('Pre-release Features'), feature_flag_items))
 
+        if toggles.ERM_DEVELOPMENT.enabled(self.domain) and user_is_admin:
+            release_management_items = _get_release_management_items(self.domain)
+            items.append((_('Enterprise Release Management'), release_management_items))
+
         from corehq.apps.users.models import WebUser
         if isinstance(self.couch_user, WebUser):
             if (user_is_billing_admin or self.couch_user.is_superuser) and not settings.ENTERPRISE_MODE:
@@ -1928,6 +1932,19 @@ def _get_feature_flag_items(domain):
             'url': reverse('domain_report_dispatcher', args=[domain, 'project_link_report'])
         })
     return feature_flag_items
+
+
+def _get_release_management_items(domain):
+    release_management_items = []
+    release_management_items.append({
+        'title': _('Linked Project Spaces'),
+        'url': reverse('linked_domains', args=[domain])
+    })
+    release_management_items.append({
+        'title': _('Linked Project Space History'),
+        'url': reverse('domain_report_dispatcher', args=[domain, 'linked_domains_history'])
+    })
+    return release_management_items
 
 
 class MySettingsTab(UITab):


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-12078)

Adds an `Enterprise Release Management` section in `Project Settings` and nests duplicate views for Linked Projects and Linked Project History (slightly renamed). This is only accessible via the ERM feature flag.

This will make it easy to make improvements/modifications to the linked projects feature without disrupting current users, and is ultimately where we want this feature to live (in enterprise app).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`ERM_DEVELOPMENT`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
UI changes.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested for noticeable errors on any of the pages and did not encounter any. 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
