### PR TITLE
change 'None' columns to display as empty

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -412,9 +412,15 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     def sanitize_page(cls, page):
         result = []
         for row in page:
-            result.append({k: escape(v) for (k, v) in row.items()})
+            result.append({k: cls._sanitize_column(v) for (k, v) in row.items()})
 
         return result
+
+    def _sanitize_column(col):
+        if isinstance(col, str):
+            return escape(col)
+
+        return col
 
     def get_ajax(self, params):
         sort_column = params.get('iSortCol_0')

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -416,7 +416,8 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
 
         return result
 
-    def _sanitize_column(col):
+    @classmethod
+    def _sanitize_column(cls, col):
         if isinstance(col, str):
             return escape(col)
 
@@ -571,7 +572,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     def sanitize_export_table(cls, table):
         result = []
         for row in table:
-            result.append([escape(x) for x in row])
+            result.append([cls._sanitize_column(x) for x in row])
 
         return result
 


### PR DESCRIPTION
## Summary
User reports were displayed empty columns with 'None' rather than blanks.


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

I would like to write a meaningful test for this in the future. Right now I don't see a reasonable seam in the code that would allow me to write that test.

### QA Plan

No QA

### Safety story

This was verified via local testing -- 'None' values once again appear blank.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
