### PR TITLE
add s3 blobdb for tests

### DIFF
--- a/dev_settings.py
+++ b/dev_settings.py
@@ -6,6 +6,7 @@ Add `from dev_settings import *` to the top of your localsettings file to use.
 You can then override or append to any of these settings there.
 """
 import os
+import settingshelper
 
 LOCAL_APPS = (
     'django_extensions',
@@ -121,3 +122,15 @@ FORMPLAYER_INTERNAL_AUTH_KEY = "secretkey"
 
 # use console email by default
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+if settingshelper.is_testing():
+    S3_BLOB_DB_SETTINGS = {
+        "url": "http://localhost:9980",
+        "access_key": "admin-key",
+        "secret_key": "admin-secret",
+        "config": {
+            "connect_timeout": 3,
+            "read_timeout": 5,
+            "signature_version": "s3"
+        },
+    }


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Some of our tests require the s3 blobdb instead of the filesystem one. This ensures when tests are run, a valid configuration exists for that blobdb that matches our default docker containers.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This only affects local code. `devsettings` is not used in production.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
