### PR TITLE
Updated case search button label

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -108,11 +108,11 @@
               </div>
             {% endif %}
           </div>
-          <div class="form-group" data-bind="slideVisible: !autoLaunch()">
+          <div class="form-group">
             <label for="search_command_label" class="{% css_label_class %} control-label">
-              {% trans "Button Label on Case List" %}
-              <span class="hq-help-template" data-title="{% trans "Button Label on Case List" %}"
-                    data-content="{% trans_html_attr "This text will be used for the first search button users see, on the case list." %}">
+              {% trans "Label for Searching" %}
+              <span class="hq-help-template" data-title="{% trans "Label for Searching" %}"
+                    data-content="{% trans_html_attr "This text is for the button to enter case search. It is also the header on the search results screen." %}">
             </label>
             <div class="{% css_field_class %}">
               {% input_trans module.search_config.command_label langs input_name='search_command_label' input_id='search_command_label' data_bind="value: searchCommandLabel" %}
@@ -120,9 +120,9 @@
           </div>
           <div class="form-group">
             <label for="search_again_label" class="{% css_label_class %} control-label">
-              {% trans "Button Label on Search Results" %}
-              <span class="hq-help-template" data-title="{% trans "Button Label for on Search Results" %}"
-                    data-content="{% trans_html_attr "This text will be used for the search button displayed at the bottom of search results, so users can search again." %}">
+              {% trans "Label for Searching Again" %}
+              <span class="hq-help-template" data-title="{% trans "Label for Searching Again" %}"
+                    data-content="{% trans_html_attr "This text is for the search button displayed at the bottom of search results, so users can search again." %}">
             </label>
             <div class="{% css_field_class %}">
               {% input_trans module.search_config.again_label langs input_name='search_again_label' input_id='search_again_label' data_bind="value: searchAgainLabel" %}


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-941

Updates this label to reflect this text is both a button label and a header. Also removes logic that show/hid this button based on the selected case search workflow. Since all workflows display the search screen & header, this label is relevant to all workflows.

![Screen Shot 2021-04-15 at 7 43 33 PM](https://user-images.githubusercontent.com/1486591/114951674-e3a12e80-9e22-11eb-9b73-fb5af020d9e6.png)


## Feature Flag
Case search & claim

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

No QA.

### Safety story
Tiny change, mostly HTML, tested locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
