### PR TITLE
Cache case restore

### DIFF
--- a/corehq/apps/case_migrations/tests/test_restore.py
+++ b/corehq/apps/case_migrations/tests/test_restore.py
@@ -20,12 +20,12 @@ from corehq.util.test_utils import flag_enabled
 from ..views import get_case_hierarchy_for_restore
 
 
-class TestRelatedCases(TestCase):
+class TestCaseRestore(TestCase):
     domain = 'related-cases-domain'
 
     @classmethod
     def setUpClass(cls):
-        super(TestRelatedCases, cls).setUpClass()
+        super(TestCaseRestore, cls).setUpClass()
         cls.domain_obj = create_domain(cls.domain)
         cls.factory = CaseFactory(domain=cls.domain)
 

--- a/corehq/apps/case_migrations/views.py
+++ b/corehq/apps/case_migrations/views.py
@@ -21,13 +21,14 @@ from casexml.apps.phone.xml import (
 from corehq.apps.domain.auth import formplayer_auth
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.domain.views.base import BaseDomainView
-from corehq.apps.locations.fixtures import (
-    FlatLocationSerializer
-)
+from corehq.apps.locations.fixtures import FlatLocationSerializer
 from corehq.apps.locations.models import SQLLocation
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.toggles import WEBAPPS_CASE_MIGRATION, ADD_LIMITED_FIXTURES_TO_CASE_RESTORE
+from corehq.toggles import (
+    ADD_LIMITED_FIXTURES_TO_CASE_RESTORE,
+    WEBAPPS_CASE_MIGRATION,
+)
 from corehq.util import reverse
 
 from .forms import MigrationForm


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Best review by commit :fish: 

I recently added locations in case restore in https://github.com/dimagi/commcare-hq/pull/29482.
There isn't a clear way yet of reducing the number of locations in the fixture and I have been requested to consider fixtures as well. I think caching the restore would be valuable even if we don't add any more fixtures.

Plus, In sms workflow, this request would come repeatedly from formplayer (Trying to confirm that on #formplayer channel) on each sms incoming (per question in the form), most of it coming in rapidly as user answers the question, so it felt worth caching it like we cache usual restores.

Currently, this PR caches all case restores, i am happy to limit to just when we are add additional fixtures if that looks like the right way to go about it.

There is also a threshold on restores to not cache at all. 
https://github.com/dimagi/commcare-hq/blob/579b52f1037d30c8e9184214f7278bb1d6a8b9d2/corehq/ex-submodules/casexml/apps/phone/const.py#L4-L7

Case restore isn't timed at all, so that would need to be added. I have not added that yes, considering that number of requests needing this would be high enough to just cache it instead and it wont be as rare as a mobile user restore.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [ ] Risk label is set correctly
- [ ] All migrations are backwards compatible and won't block deploy
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
