### PR TITLE
Update form mm export to use same filter as other export download

### DIFF
--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -321,11 +321,11 @@ def get_export_file(export_instances, filters, temp_path, progress_tracker=None)
 
 def get_export_documents(export_instance, filters):
     # Pull doc ids from elasticsearch and stream to disk
-    query = _get_export_query(export_instance, filters)
+    query = get_export_query(export_instance, filters)
     return iter_es_docs_from_query(query)
 
 
-def _get_export_query(export_instance, filters):
+def get_export_query(export_instance, filters):
     query = _get_base_query(export_instance)
     for filter in filters:
         query = query.filter(filter.to_es_filter())
@@ -333,7 +333,7 @@ def _get_export_query(export_instance, filters):
 
 
 def get_export_size(export_instance, filters):
-    return _get_export_query(export_instance, filters).count()
+    return get_export_query(export_instance, filters).count()
 
 
 def write_export_instance(writer, export_instance, documents, progress_tracker=None):

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -53,7 +53,6 @@ from corehq.apps.reports.filters.users import (
 )
 from corehq.apps.reports.models import HQUserType
 from corehq.apps.reports.util import datespan_from_beginning
-from corehq.pillows import utils
 from corehq.toggles import FILTER_ON_GROUPS_AND_LOCATIONS
 from corehq.util import flatten_non_iterable_list
 
@@ -970,46 +969,10 @@ class EmwfFilterFormExport(EmwfFilterExportMixin, GenericFilterFormExportDownloa
             self.cleaned_data['date_range'],
         )
 
-    def _get_mapped_user_types(self, selected_user_types):
-        user_types = []
-        if HQUserType.ACTIVE in selected_user_types:
-            user_types.append(BaseFilterExportDownloadForm._USER_MOBILE)
-        if HQUserType.ADMIN in selected_user_types:
-            user_types.append(BaseFilterExportDownloadForm._USER_ADMIN)
-        if HQUserType.UNKNOWN in selected_user_types:
-            user_types.append(BaseFilterExportDownloadForm._USER_UNKNOWN)
-        if HQUserType.DEMO_USER in selected_user_types:
-            user_types.append(BaseFilterExportDownloadForm._USER_DEMO)
-
-        return user_types
-
     def get_edit_url(self, export):
         from corehq.apps.export.views.edit import EditNewCustomFormExportView
         return reverse(EditNewCustomFormExportView.urlname,
                        args=(self.domain_object.name, export._id))
-
-    def get_es_user_types(self, filter_form_data):
-        """
-        Return a list of elastic search user types (each item in the return list
-        is in corehq.pillows.utils.USER_TYPES) corresponding to the selected
-        export user types.
-        """
-        mobile_user_and_group_slugs = self.get_mobile_user_and_group_slugs(filter_form_data)
-        es_user_types = []
-        export_user_types = self._get_mapped_user_types(
-            self._get_selected_es_user_types(mobile_user_and_group_slugs)
-        )
-        export_to_es_user_types_map = {
-            BaseFilterExportDownloadForm._USER_MOBILE: [utils.MOBILE_USER_TYPE],
-            BaseFilterExportDownloadForm._USER_DEMO: [utils.DEMO_USER_TYPE],
-            BaseFilterExportDownloadForm._USER_UNKNOWN: [
-                utils.UNKNOWN_USER_TYPE, utils.SYSTEM_USER_TYPE, utils.WEB_USER_TYPE
-            ],
-            BaseFilterExportDownloadForm._USER_SUPPLY: [utils.COMMCARE_SUPPLY_USER_TYPE]
-        }
-        for type_ in export_user_types:
-            es_user_types.extend(export_to_es_user_types_map[type_])
-        return es_user_types
 
 
 class FilterCaseESExportDownloadForm(EmwfFilterExportMixin, BaseFilterExportDownloadForm):

--- a/corehq/apps/export/models/incremental.py
+++ b/corehq/apps/export/models/incremental.py
@@ -7,7 +7,7 @@ from couchexport.models import Format
 from corehq.apps.export.dbaccessors import get_properly_wrapped_export_instance
 from corehq.apps.export.export import (
     ExportFile,
-    _get_export_query,
+    get_export_query,
     get_export_writer,
     write_export_instance,
 )
@@ -125,7 +125,7 @@ def _generate_incremental_export(incremental_export, last_doc_date=None):
     with TransientTempfile() as temp_path, metrics_track_errors('generate_incremental_exports'):
         writer = get_export_writer([export_instance], temp_path, allow_pagination=False)
         with writer.open([export_instance]):
-            query = _get_export_query(export_instance, filters)
+            query = get_export_query(export_instance, filters)
             query = query.sort('server_modified_on')  # reset sort to this instead of opened_on
             docs = LastDocTracker(query.run().hits)
             write_export_instance(writer, export_instance, docs)

--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -40,8 +40,8 @@ from corehq.apps.export.exceptions import (
     ExportFormValidationException,
 )
 from corehq.apps.export.export import (
-    _get_export_query,
     get_export_download,
+    get_export_query,
     get_export_size,
 )
 from corehq.apps.export.forms import (
@@ -442,7 +442,7 @@ def prepare_form_multimedia(request, domain):
 
     export = view_helper.get_export(export_specs[0]['export_id'])
     filters = filter_form.get_export_filters(request, filter_form_data)
-    export_es_query = _get_export_query(export, filters)
+    export_es_query = get_export_query(export, filters)
 
     if media_export_is_too_big(export_es_query):
         return json_response({

--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -39,7 +39,11 @@ from corehq.apps.export.exceptions import (
     ExportAsyncException,
     ExportFormValidationException,
 )
-from corehq.apps.export.export import get_export_download, get_export_size
+from corehq.apps.export.export import (
+    _get_export_query,
+    get_export_download,
+    get_export_size,
+)
 from corehq.apps.export.forms import (
     EmwfFilterFormExport,
     FilterCaseESExportDownloadForm,
@@ -59,7 +63,7 @@ from corehq.apps.reports.analytics.esaccessors import media_export_is_too_big
 from corehq.apps.reports.filters.case_list import CaseListFilter
 from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter
 from corehq.apps.reports.models import HQUserType
-from corehq.apps.reports.tasks import build_form_multimedia_zip
+from corehq.apps.reports.tasks import build_form_multimedia_zipfile
 from corehq.apps.reports.util import datespan_from_beginning
 from corehq.apps.settings.views import BaseProjectDataView
 from corehq.apps.users.models import CouchUser
@@ -437,10 +441,10 @@ def prepare_form_multimedia(request, domain):
         })
 
     export = view_helper.get_export(export_specs[0]['export_id'])
-    datespan = filter_form.cleaned_data['date_range']
-    user_types = filter_form.get_es_user_types(filter_form_data)
+    filters = filter_form.get_export_filters(request, filter_form_data)
+    export_es_query = _get_export_query(export, filters)
 
-    if media_export_is_too_big(domain, export.app_id, export.xmlns, datespan, user_types):
+    if media_export_is_too_big(export_es_query):
         return json_response({
             'success': False,
             'error': _("This is too many files to export at once.  "
@@ -448,11 +452,10 @@ def prepare_form_multimedia(request, domain):
         })
 
     download = DownloadBase()
-    download.set_task(build_form_multimedia_zip.delay(
+    download.set_task(build_form_multimedia_zipfile.delay(
         domain=domain,
         export_id=export.get_id,
-        datespan=datespan,
-        user_types=user_types,
+        es_filters=filters,
         download_id=download.download_id,
         owner_id=request.couch_user.get_id,
     ))

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -20,7 +20,7 @@ from corehq.apps.domain.calculations import all_domain_stats, calced_props
 from corehq.apps.domain.models import Domain
 from corehq.apps.es import AppES, DomainES, FormES, filters
 from corehq.apps.export.const import MAX_MULTIMEDIA_EXPORT_SIZE
-from corehq.apps.export.export import _get_export_query
+from corehq.apps.export.export import get_export_query
 from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.reports.util import send_report_download_email
 from corehq.blobs import CODES, get_blob_db
@@ -245,7 +245,7 @@ def build_form_multimedia_zipfile(
 ):
     from corehq.apps.export.models import FormExportInstance
     export = FormExportInstance.get(export_id)
-    es_query = _get_export_query(export, es_filters)
+    es_query = get_export_query(export, es_filters)
     form_ids = get_form_ids_with_multimedia(es_query)
     _generate_form_multimedia_zipfile(domain, export, form_ids, download_id, owner_id,
                                       build_form_multimedia_zipfile)

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -20,6 +20,7 @@ from corehq.apps.domain.calculations import all_domain_stats, calced_props
 from corehq.apps.domain.models import Domain
 from corehq.apps.es import AppES, DomainES, FormES, filters
 from corehq.apps.export.const import MAX_MULTIMEDIA_EXPORT_SIZE
+from corehq.apps.export.export import _get_export_query
 from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.reports.util import send_report_download_email
 from corehq.blobs import CODES, get_blob_db
@@ -34,6 +35,7 @@ from corehq.util.view_utils import absolute_reverse
 
 from .analytics.esaccessors import (
     get_form_ids_having_multimedia,
+    get_form_ids_with_multimedia,
     scroll_case_names,
 )
 
@@ -234,6 +236,23 @@ def _store_excel_in_blobdb(report_class, file, domain, report_slug):
 
 
 @task(serializer='pickle')
+def build_form_multimedia_zipfile(
+        domain,
+        export_id,
+        es_filters,
+        download_id,
+        owner_id,
+):
+    from corehq.apps.export.models import FormExportInstance
+    export = FormExportInstance.get(export_id)
+    es_query = _get_export_query(export, es_filters)
+    form_ids = get_form_ids_with_multimedia(es_query)
+    _generate_form_multimedia_zipfile(domain, export, form_ids, download_id, owner_id,
+                                      build_form_multimedia_zipfile)
+
+
+# ToDo: Remove post build_form_multimedia_zipfile rollout
+@task(serializer='pickle')
 def build_form_multimedia_zip(
         domain,
         export_id,
@@ -247,10 +266,14 @@ def build_form_multimedia_zip(
     form_ids = get_form_ids_having_multimedia(
         domain, export.app_id, export.xmlns, datespan, user_types
     )
+    _generate_form_multimedia_zipfile(domain, export, form_ids, download_id, owner_id, build_form_multimedia_zip)
+
+
+def _generate_form_multimedia_zipfile(domain, export, form_ids, download_id, owner_id, task_name):
     forms_info = _get_form_attachment_info(domain, form_ids, export)
 
     num_forms = len(forms_info)
-    DownloadBase.set_progress(build_form_multimedia_zip, 0, num_forms)
+    DownloadBase.set_progress(task_name, 0, num_forms)
 
     all_case_ids = set.union(*(info['case_ids'] for info in forms_info)) if forms_info else set()
     case_id_to_name = _get_case_names(domain, all_case_ids)
@@ -262,7 +285,7 @@ def build_form_multimedia_zip(
             zip_name = 'multimedia-{}'.format(unidecode(export.name))
             _save_and_expose_zip(f, zip_name, domain, download_id, owner_id)
 
-    DownloadBase.set_progress(build_form_multimedia_zip, num_forms, num_forms)
+    DownloadBase.set_progress(task_name, num_forms, num_forms)
 
 
 def _get_form_attachment_info(domain, form_ids, export):

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -20,7 +20,6 @@ from corehq.apps.domain.calculations import all_domain_stats, calced_props
 from corehq.apps.domain.models import Domain
 from corehq.apps.es import AppES, DomainES, FormES, filters
 from corehq.apps.export.const import MAX_MULTIMEDIA_EXPORT_SIZE
-from corehq.apps.export.export import get_export_query
 from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.reports.util import send_report_download_email
 from corehq.blobs import CODES, get_blob_db
@@ -244,6 +243,7 @@ def build_form_multimedia_zipfile(
         owner_id,
 ):
     from corehq.apps.export.models import FormExportInstance
+    from corehq.apps.export.export import get_export_query
     export = FormExportInstance.get(export_id)
     es_query = get_export_query(export, es_filters)
     form_ids = get_form_ids_with_multimedia(es_query)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/INDIV-12

Review by commit.

Currently the form multimedia download only considers the date filter and user types, whereas when one filters for forms, all filters are applied. This is confusing on the UI, since its on the same page.
Looks like a pending improvement in multimedia exports. Last change was in 2016, https://github.com/dimagi/commcare-hq/pull/13477.

This PR updates form multimedia download to use the same filter setup as the usual form download in order to consider the same set of forms, to filter for ones with multimedia.

More context and details in comment https://github.com/dimagi/commcare-hq/pull/29552#issuecomment-829562388

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When downloading form multimedia, users will now get the **correct** set of form multimedia according to the filters set.
Do we need to notify users in a certain way?

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-2886
Majorly looking for that things are still working. The specifics of the filters need not be worried about since they are already working in form export.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
QA was done.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
