### PR TITLE
safer timer name

### DIFF
--- a/corehq/util/metrics/__init__.py
+++ b/corehq/util/metrics/__init__.py
@@ -259,7 +259,9 @@ def metrics_histogram_timer(metric: str, timing_buckets: Iterable[int], tags: Di
             bucket_tag=bucket_tag, buckets=timing_buckets, bucket_unit='s',
             tags=tags
         )
-        timer_name = ".".join(metric.split('.')[1:])  # remove the 'commcare.' prefix
+        timer_name = metric
+        if metric.startswith('commcare.'):
+            timer_name = ".".join(metric.split('.')[1:])  # remove the 'commcare.' prefix
         add_breadcrumb(
             category="timing",
             message=f"{timer_name}: {timer.duration:0.3f}",


### PR DESCRIPTION
## Summary
Just being defensive since the metric name prefix is only enforced if the code is exercised in tests.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
