### PR TITLE
Don't let requests for "system" "user" hit the db

### DIFF
--- a/corehq/apps/users/tests/test_util.py
+++ b/corehq/apps/users/tests/test_util.py
@@ -8,7 +8,8 @@ from corehq.apps.users.util import (
     user_display_string,
     username_to_user_id,
     user_id_to_username,
-    cached_user_id_to_user_display
+    cached_user_id_to_user_display,
+    cached_user_id_to_username,
 )
 
 
@@ -87,6 +88,32 @@ class TestUserIdToUsernameToUserName(TestCase):
         # set username back because other tests rely on it
         self.user_with_first_name.first_name = 'Alice'
         self.user_with_first_name.save()
+
+    def test_cached_user_id_to_username(self):
+        self.assertEqual('first_name',
+                         cached_user_id_to_username(self.user_with_first_name.user_id))
+        self.assertEqual('full_name',
+                         cached_user_id_to_username(self.user_with_full_name.user_id))
+        self.user_with_first_name.first_name = 'Betty'
+        self.user_with_first_name.save()
+        self.assertEqual('first_name',
+                         cached_user_id_to_username(self.user_with_first_name.user_id))
+        self.assertEqual('full_name',
+                         cached_user_id_to_username(self.user_with_full_name.user_id))
+        # set username back because other tests rely on it
+        self.user_with_first_name.first_name = 'Alice'
+        self.user_with_first_name.save()
+
+    def test_cached_user_id_to_username__demo_user(self):
+        self.assertEqual(cached_user_id_to_username('demo_user'), 'demo_user')
+
+    def test_cached_user_id_to_username__weird_ids(self):
+        self.assertEqual(cached_user_id_to_username('system'), None)
+        self.assertEqual(cached_user_id_to_username('commtrack-system'), None)
+        self.assertEqual(cached_user_id_to_username('demo_user_group_id'), None)
+        self.assertEqual(cached_user_id_to_username('-'), None)
+        self.assertEqual(cached_user_id_to_username('_archive_'), None)
+        self.assertEqual(cached_user_id_to_username('callcenter-system'), None)
 
 
 class TestUserDisplayString(SimpleTestCase):

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -126,18 +126,12 @@ def user_id_to_username(user_id, use_name_if_available=False):
         return raw_username(user_object['username']) if "username" in user_object else None
 
 
+@quickcache(['user_id'])
 def cached_user_id_to_username(user_id):
-    if not user_id:
+    if not user_id or user_id == 'system':
         return None
 
-    key = 'user_id_username_cache_{id}'.format(id=user_id)
-    ret = cache.get(key)
-    if ret:
-        return ret
-    else:
-        ret = user_id_to_username(user_id)
-        cache.set(key, ret)
-        return ret
+    return user_id_to_username(user_id)
 
 
 @quickcache(['user_id'])

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -128,7 +128,7 @@ def user_id_to_username(user_id, use_name_if_available=False):
 
 @quickcache(['user_id'])
 def cached_user_id_to_username(user_id):
-    if not user_id or user_id in WEIRD_USER_IDS:
+    if not user_id or (user_id in WEIRD_USER_IDS and user_id != DEMO_USER_ID):
         return None
 
     return user_id_to_username(user_id)

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -128,7 +128,7 @@ def user_id_to_username(user_id, use_name_if_available=False):
 
 @quickcache(['user_id'])
 def cached_user_id_to_username(user_id):
-    if not user_id or user_id == 'system':
+    if not user_id or user_id in WEIRD_USER_IDS:
         return None
 
     return user_id_to_username(user_id)


### PR DESCRIPTION
## Summary
We noticed a lot of requests coming in from odata feeds asking for a doc in commcarehq_user with id "system" which always 404s. I'm pretty sure it traces back to this function, but even if it doesn't, this change should never return anything different from what was being returned before.

## Feature Flag
None

## Product Description
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

There wasn't clear test coverage, so I added some tests in this PR.

### QA Plan

None

### Safety story

Very small change that uses well-used conventions. The tests I added have been run on master as well as this PR, so I know  the behavior of what's being tested hasn't changed. (The process of doing that actually caught a simple mistake, yay tests.)

On first deploy, the function will be using a cold cache because the cache key has changed. This isn't a problem because the cache duration is already short (5m) and so mostly useful for repeated requests in one burst (which you still get on a cold cache), not for carrying over between bursts (which a only warm cache does).

### Rollback instructions


- [x] This PR can be reverted after deploy with no further considerations 
