### PR TITLE
A few more usercase renames

### DIFF
--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -9,7 +9,7 @@ from corehq.apps.app_manager.xpath import (
     IndicatorXpath,
     LedgerdbXpath,
     LocationXpath,
-    UserCaseXPath,
+    UsercaseXPath,
     XPath,
     dot_interpolate,
 )
@@ -591,7 +591,7 @@ class PropertyXpathGenerator(BaseXpathGenerator):
             case = CaseXPath('')
 
         if indexes and indexes[0] == 'user':
-            case = CaseXPath(UserCaseXPath().case())
+            case = CaseXPath(UsercaseXPath().case())
         else:
             for index in indexes:
                 case = case.index_id(index).case()

--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -148,7 +148,7 @@ class CaseXPathValidationError(XPathValidationError):
     pass
 
 
-class UserCaseXPathValidationError(XPathValidationError):
+class UsercaseXPathValidationError(XPathValidationError):
     pass
 
 

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -32,7 +32,7 @@ from corehq.apps.app_manager.exceptions import (
     ParentModuleReferenceError,
     PracticeUserException,
     SuiteValidationError,
-    UserCaseXPathValidationError,
+    UsercaseXPathValidationError,
     XFormException,
     XFormValidationError,
     XFormValidationFailed,
@@ -79,7 +79,7 @@ class ApplicationBaseValidator(object):
                 'module': cve.module,
                 'form': cve.form,
             })
-        except UserCaseXPathValidationError as ucve:
+        except UsercaseXPathValidationError as ucve:
             errors.append({
                 'type': 'invalid user property xpath reference',
                 'module': ucve.module,

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -28,7 +28,7 @@ from corehq.apps.app_manager.xpath import (
     CaseIDXPath,
     ItemListFixtureXpath,
     ProductInstanceXpath,
-    UserCaseXPath,
+    UsercaseXPath,
     XPath,
     interpolate_xpath,
     session_var,
@@ -298,7 +298,7 @@ class EntriesHelper(object):
         datums = []
         actions = form.active_actions()
         if form.form_type == 'module_form' and actions_use_usercase(actions):
-            case = UserCaseXPath().case()
+            case = UsercaseXPath().case()
             datums.append(FormDatumMeta(
                 datum=SessionDatum(id=USERCASE_ID, function=('%s/@case_id' % case)),
                 case_type=USERCASE_TYPE,
@@ -511,7 +511,7 @@ class EntriesHelper(object):
                 )
             ]
         elif auto_select.mode == AUTO_SELECT_USERCASE:
-            case = UserCaseXPath().case()
+            case = UsercaseXPath().case()
             return SessionDatum(
                 id=action.case_session_var,
                 function=case.slash('@case_id')

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -4,7 +4,7 @@ from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.exceptions import (
     CaseXPathValidationError,
     ScheduleError,
-    UserCaseXPathValidationError,
+    UsercaseXPathValidationError,
 )
 from corehq.apps.app_manager.suite_xml.contributors import (
     SuiteContributorByModule,
@@ -237,7 +237,7 @@ class MenuContributor(SuiteContributorByModule):
                     raise CaseXPathValidationError(module=module, form=form)
 
                 if xpath_references_usercase(interpolated_xpath) and not domain_uses_usercase():
-                    raise UserCaseXPathValidationError(module=module, form=form)
+                    raise UsercaseXPathValidationError(module=module, form=form)
 
                 command.relevant = interpolated_xpath
 

--- a/corehq/apps/app_manager/tests/test_child_module.py
+++ b/corehq/apps/app_manager/tests/test_child_module.py
@@ -332,7 +332,7 @@ class BasicModuleAsChildTest(ModuleAsChildTestBase, SimpleTestCase):
         )
 
 
-class UserCaseOnlyModuleAsChildTest(ModuleAsChildTestBase, SimpleTestCase):
+class UsercaseOnlyModuleAsChildTest(ModuleAsChildTestBase, SimpleTestCase):
     """
     Even though a module might be usercase-only, if it acts as a parent module
     then the user should still be prompted for a case of the parent module's

--- a/corehq/apps/app_manager/tests/test_suite_regex.py
+++ b/corehq/apps/app_manager/tests/test_suite_regex.py
@@ -2,7 +2,7 @@ from django.test import SimpleTestCase
 
 from corehq.apps.app_manager.exceptions import CaseXPathValidationError
 from corehq.apps.app_manager.xpath import (
-    UserCaseXPath,
+    UsercaseXPath,
     dot_interpolate,
     interpolate_xpath,
 )
@@ -31,7 +31,7 @@ class RegexTest(SimpleTestCase):
     def test_interpolate_xpath(self):
         replacements = {
             'case': "<casedb stuff>",
-            'user': UserCaseXPath().case(),
+            'user': UsercaseXPath().case(),
             'session': "instance('commcaresession')/session",
         }
         cases = [

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -35,7 +35,7 @@ from corehq.apps.app_manager.exceptions import (
 )
 from corehq.apps.app_manager.tasks import create_usercases
 from corehq.apps.app_manager.xform import XForm, parse_xml
-from corehq.apps.app_manager.xpath import UserCaseXPath
+from corehq.apps.app_manager.xpath import UsercaseXPath
 from corehq.apps.builds.models import CommCareBuildConfig
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.models import SQLLocation
@@ -55,7 +55,7 @@ CASE_XPATH_SUBSTRING_MATCHES = [
 
 USERCASE_XPATH_SUBSTRING_MATCHES = [
     "#user",
-    UserCaseXPath().case(),
+    UsercaseXPath().case(),
 ]
 
 

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -85,7 +85,7 @@ def interpolate_xpath(string, case_xpath=None, fixture_xpath=None, module=None, 
         # If that changes, amend the error message accordingly.
         raise CaseXPathValidationError(_(CASE_REFERENCE_VALIDATION_ERROR), module=module, form=form)
     replacements = {
-        '#user': UserCaseXPath().case(),
+        '#user': UsercaseXPath().case(),
         '#session/': session_var('', path=''),
     }
     if fixture_xpath:
@@ -219,7 +219,7 @@ class CaseTypeXpath(CaseSelectionXPath):
         return super(CaseTypeXpath, quoted).case(instance_name, case_name)
 
 
-class UserCaseXPath(XPath):
+class UsercaseXPath(XPath):
 
     def case(self):
         user_id = session_var(var='userid', path='context')

--- a/corehq/apps/callcenter/tests/test_utils.py
+++ b/corehq/apps/callcenter/tests/test_utils.py
@@ -227,10 +227,10 @@ class CallCenterUtilsTestsSQL(CallCenterUtilsTests):
 
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
-class CallCenterUtilsUserCaseTests(TestCase):
+class CallCenterUtilsUsercaseTests(TestCase):
     @classmethod
     def setUpClass(cls):
-        super(CallCenterUtilsUserCaseTests, cls).setUpClass()
+        super().setUpClass()
         cls.domain = create_domain(TEST_DOMAIN)
         cls.domain.usercase_enabled = True
         cls.domain.save()
@@ -245,7 +245,7 @@ class CallCenterUtilsUserCaseTests(TestCase):
     def tearDownClass(cls):
         delete_all_cases()
         cls.domain.delete()
-        super(CallCenterUtilsUserCaseTests, cls).tearDownClass()
+        super().tearDownClass()
 
     def test_sync_usercase_custom_user_data_on_create(self):
         """
@@ -407,7 +407,7 @@ class CallCenterUtilsUserCaseTests(TestCase):
 
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
-class CallCenterUtilsUserCaseTestsSQL(CallCenterUtilsUserCaseTests):
+class CallCenterUtilsUsercaseTestsSQL(CallCenterUtilsUsercaseTests):
     pass
 
 


### PR DESCRIPTION
## Summary
I missed grepping for "UserCase" in https://github.com/dimagi/commcare-hq/pull/29550

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
No QA, this is a small mechanical change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
