### PR TITLE
Add warning to toggle

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -2053,7 +2053,9 @@ ERM_DEVELOPMENT = StaticToggle(
 
 ADD_LIMITED_FIXTURES_TO_CASE_RESTORE = StaticToggle(
     'fixtures_in_case_restore',
-    'Allow limited fixtures to be available in case restore for SMS workflows',
+    'Allow limited fixtures to be available in case restore for SMS workflows. '
+    'WARNING: To be used only for small templates since the performance implication has not been evaluated. '
+    'Do not enable on your own.',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN]
 )


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Just want to make it explicit that toggle should not be enabled since the performance aspect is still not clear.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`ADD_LIMITED_FIXTURES_TO_CASE_RESTORE`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Just documentation change

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
