### PR TITLE
[SSO] refactor process for accepting an invitation and joining domain

### DIFF
--- a/corehq/apps/hqwebapp/utils/__init__.py
+++ b/corehq/apps/hqwebapp/utils/__init__.py
@@ -40,21 +40,6 @@ def sign(message):
     return signature
 
 
-def send_confirmation_email(invitation):
-    invited_user = invitation.email
-    subject = '%s accepted your invitation to CommCare HQ' % invited_user
-    recipient = WebUser.get_by_user_id(invitation.invited_by).get_email()
-    context = {
-        'invited_user': invited_user,
-    }
-    html_content = render_to_string('domain/email/invite_confirmation.html',
-                                    context)
-    text_content = render_to_string('domain/email/invite_confirmation.txt',
-                                    context)
-    send_html_email_async.delay(subject, recipient, html_content,
-                                text_content=text_content)
-
-
 def get_bulk_upload_form(context=None, context_key="bulk_upload", form_class=BulkUploadForm, app=None):
     context = context or {}
     form_context = context.get(context_key, {})

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -997,7 +997,7 @@ class UserInvitationView(object):
                     invitation.accept_invitation_and_join_domain(user)
                     messages.success(
                         self.request,
-                        _('You have been added to the "{}"" project space.').format(self.domain)
+                        _('You have been added to the "{}" project space.').format(self.domain)
                     )
                     authenticated = authenticate(username=form.cleaned_data["email"],
                                                  password=form.cleaned_data["password"])

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -63,7 +63,6 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.es import UserES
 from corehq.apps.hqwebapp.crispy import make_form_readonly
-from corehq.apps.hqwebapp.utils import send_confirmation_email
 from corehq.apps.hqwebapp.views import BasePageView, logout
 from corehq.apps.locations.permissions import (
     location_safe,
@@ -968,7 +967,7 @@ class UserInvitationView(object):
 
             if request.method == "POST":
                 couch_user = CouchUser.from_django_user(request.user, strict=True)
-                self._invite(invitation, couch_user)
+                invitation.accept_invitation_and_join_domain(couch_user)
                 track_workflow(request.couch_user.get_email(),
                                "Current user accepted a project invitation",
                                {"Current user accepted a project invitation": "yes"})
@@ -995,7 +994,11 @@ class UserInvitationView(object):
                     )
                     user.save()
                     messages.success(request, _("User account for %s created!") % form.cleaned_data["email"])
-                    self._invite(invitation, user)
+                    invitation.accept_invitation_and_join_domain(user)
+                    messages.success(
+                        self.request,
+                        _('You have been added to the "{}"" project space.').format(self.domain)
+                    )
                     authenticated = authenticate(username=form.cleaned_data["email"],
                                                  password=form.cleaned_data["password"])
                     if authenticated is not None and authenticated.is_active:
@@ -1016,13 +1019,6 @@ class UserInvitationView(object):
         context.update({"form": form})
         return render(request, self.template, context)
 
-    def _invite(self, invitation, user):
-        self.invite(invitation, user)
-        invitation.is_accepted = True
-        invitation.save()
-        messages.success(self.request, self.success_msg)
-        send_confirmation_email(invitation)
-
     def validate_invitation(self, invitation):
         assert invitation.domain == self.domain
 
@@ -1033,19 +1029,11 @@ class UserInvitationView(object):
     def inviting_entity(self):
         return self.domain
 
-    @property
-    def success_msg(self):
-        return _('You have been added to the "%s" project space.') % self.domain
-
     def redirect_to_on_success(self, email, domain):
         if Invitation.by_email(email).count() > 0 and not self.request.GET.get('no_redirect'):
             return reverse("domain_select_redirect")
         else:
             return reverse("domain_homepage", args=[domain,])
-
-    def invite(self, invitation, user):
-        user.add_as_web_user(invitation.domain, role=invitation.role,
-                             location_id=invitation.supply_point, program_id=invitation.program)
 
 
 @always_allow_project_access


### PR DESCRIPTION
## Summary
Cleanup the process for a user accepting an invitation so that it's all self-contained within the invitation itself rather than being random copy-pasted code in strange places with even stranger method names and all sorts of questionable design decisions.

Very carefully refactored and tested locally in all places a user could accept an invitation.

I did this because I need a nice clean way of accepting an invitation for the SSO work I'm doing. Since this is touching a high-risk part of the codebase, I wanted to make a separate PR so that the changes aren't obfuscated by other SSO work.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
None

### QA Plan
Not needed. I tested very extensively locally and carefully did this refactor.

### Safety story
Tested accepting invitations multiple ways (logged in, not logged in, from the domain list, etc). All works :)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
