### PR TITLE
Fixed an issue with ipv6 repeater addresses

### DIFF
--- a/corehq/util/urlsanitize/ip_resolver.py
+++ b/corehq/util/urlsanitize/ip_resolver.py
@@ -1,0 +1,19 @@
+from operator import itemgetter
+from socket import getaddrinfo
+
+
+def sort_ip_addresses(ip_addresses):
+    return sorted(ip_addresses, key=itemgetter(0))
+
+
+INDEX_SOCKADDR = 4
+INDEX_ADDRESS = 0
+
+
+def extract_ip(addr_info):
+    return addr_info[INDEX_SOCKADDR][INDEX_ADDRESS]
+
+
+def resolve_ip(address, port=80):
+    ips = sort_ip_addresses(getaddrinfo(address, port))
+    return extract_ip(ips[0])

--- a/corehq/util/urlsanitize/test/test_ip_resolver.py
+++ b/corehq/util/urlsanitize/test/test_ip_resolver.py
@@ -1,0 +1,49 @@
+from django.test import SimpleTestCase
+from socket import AddressFamily, SocketKind
+from unittest.mock import patch
+
+from ..ip_resolver import sort_ip_addresses, extract_ip, resolve_ip
+
+INDEX_ADDRESS_FAMILY = 0
+
+
+class SortIPAddressTests(SimpleTestCase):
+    def test_sorts_single_value(self):
+        input = [(AddressFamily.AF_INET, SocketKind.SOCK_STREAM, 6, '', ('142.250.64.110', 80))]
+        result = sort_ip_addresses(input)
+        self.assertEqual(result[0][INDEX_ADDRESS_FAMILY], AddressFamily.AF_INET)
+
+    def test_sorts_ipv4_before_ipv6(self):
+        input = [
+            (AddressFamily.AF_INET6, SocketKind.SOCK_STREAM, 6, '', ('2607:f8b0:4006:81b::200e', 80)),
+            (AddressFamily.AF_INET, SocketKind.SOCK_STREAM, 6, '', ('142.250.64.110', 80)),
+            (AddressFamily.AF_INET, SocketKind.SOCK_STREAM, 6, '', ('142.250.64.111', 80)),
+        ]
+        result = sort_ip_addresses(input)
+
+        self.assertEqual(result[0][INDEX_ADDRESS_FAMILY], AddressFamily.AF_INET)
+        self.assertEqual(result[1][INDEX_ADDRESS_FAMILY], AddressFamily.AF_INET)
+        self.assertEqual(result[2][INDEX_ADDRESS_FAMILY], AddressFamily.AF_INET6)
+
+
+class ExtractIPTests(SimpleTestCase):
+    def test_extracts_single_ip(self):
+        input = (AddressFamily.AF_INET, SocketKind.SOCK_STREAM, 6, '', ('142.250.64.110', 80))
+        self.assertEqual(extract_ip(input), '142.250.64.110')
+
+
+class ResolveIPTests(SimpleTestCase):
+    @patch('corehq.util.urlsanitize.ip_resolver.getaddrinfo')
+    def test_when_multiple_protocols_prefers_ipv4(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (AddressFamily.AF_INET6, SocketKind.SOCK_STREAM, 6, '', ('2607:f8b0:4006:81b::200e', 80)),
+            (AddressFamily.AF_INET, SocketKind.SOCK_STREAM, 6, '', ('142.250.64.110', 80)),
+        ]
+        self.assertEqual(resolve_ip('test.url'), '142.250.64.110')
+
+    @patch('corehq.util.urlsanitize.ip_resolver.getaddrinfo')
+    def test_when_only_ipv6_returns_ipv6(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (AddressFamily.AF_INET6, SocketKind.SOCK_STREAM, 6, '', ('2607:f8b0:4006:81b::200e', 80)),
+        ]
+        self.assertEqual(resolve_ip('test.url'), '2607:f8b0:4006:81b::200e')

--- a/corehq/util/urlsanitize/urlsanitize.py
+++ b/corehq/util/urlsanitize/urlsanitize.py
@@ -1,6 +1,7 @@
 import socket
 import ipaddress
 from urllib.parse import urlparse
+from .ip_resolver import resolve_ip
 
 
 def sanitize_user_input_url(url):
@@ -19,7 +20,7 @@ def sanitize_user_input_url(url):
     if scheme not in ['http', 'https']:
         raise PossibleSSRFAttempt('scheme not http(s)')
     try:
-        ip_address_text = socket.gethostbyname(hostname)
+        ip_address_text = resolve_ip(hostname)
     except socket.gaierror:
         raise CannotResolveHost()
     ip_address = ipaddress.ip_address(ip_address_text)


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12106
Because `gethostname` only supported IPv4, any IPv6 address would be identified as an `CannotResolveHost` error. However, because we wanted to support hosts that would be configured at a later date, this error was ignored, which meant we were still executing requests against these hosts.


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Augmented a test suite for IPv6, and created a new one for the `resolve_ip` function.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested locally to verify the erroneous addresses are not allowed through.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
