### PR TITLE
more handling of messaging errors

### DIFF
--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -311,6 +311,10 @@ def send_message_via_backend(msg, backend=None, orig_phone_number=None):
                 msg.set_system_error(SMS.ERROR_PHONE_NUMBER_OPTED_OUT)
                 return False
 
+        if not msg.text:
+            msg.set_system_error(SMS.ERROR_MESSAGE_BLANK)
+            return False
+
         if not backend:
             backend = msg.outbound_backend
 

--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -334,7 +334,7 @@ def send_message_via_backend(msg, backend=None, orig_phone_number=None):
         msg.backend_id = backend.couch_id
         msg.save()
         return True
-    except Exception:
+    except Exception as e:
         metrics_counter("commcare.sms.outbound_message", tags={
             'domain': msg.domain,
             'status': 'error',
@@ -343,7 +343,7 @@ def send_message_via_backend(msg, backend=None, orig_phone_number=None):
         should_log_exception = True
 
         if backend:
-            should_log_exception = should_log_exception_for_backend(backend)
+            should_log_exception = should_log_exception_for_backend(backend, e)
 
         if should_log_exception:
             log_sms_exception(msg)
@@ -368,13 +368,13 @@ def _get_backend_tag(backend=None, backend_id=None):
         return f'{backend.domain}/{backend.name}'
 
 
-def should_log_exception_for_backend(backend):
+def should_log_exception_for_backend(backend, exception):
     """
-    Only returns True if an exception hasn't been logged for the given backend
+    Only returns True if the exception hasn't been logged for the given backend
     in the last hour.
     """
     client = get_redis_client()
-    key = 'exception-logged-for-backend-%s' % backend.couch_id
+    key = f'exception-logged-for-backend-{backend.couch_id}-{hash(str(exception))}'
 
     if client.get(key):
         return False

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -177,6 +177,7 @@ class SMSBase(UUIDGeneratorMixin, Log):
     ERROR_PHONE_NUMBER_OPTED_OUT = 'PHONE_NUMBER_OPTED_OUT'
     ERROR_INVALID_DESTINATION_NUMBER = 'INVALID_DESTINATION_NUMBER'
     ERROR_MESSAGE_TOO_LONG = 'MESSAGE_TOO_LONG'
+    ERROR_MESSAGE_BLANK = 'MESSAGE_BLANK'
     ERROR_CONTACT_IS_INACTIVE = 'CONTACT_IS_INACTIVE'
     ERROR_TRIAL_SMS_EXCEEDED = 'TRIAL_SMS_EXCEEDED'
     ERROR_MESSAGE_FORMAT_INVALID = 'MESSAGE_FORMAT_INVALID'
@@ -195,6 +196,8 @@ class SMSBase(UUIDGeneratorMixin, Log):
             ugettext_noop("The gateway can't reach the destination number."),
         ERROR_MESSAGE_TOO_LONG:
             ugettext_noop("The gateway could not process the message because it was too long."),
+        ERROR_MESSAGE_BLANK:
+            ugettext_noop("The message was blank."),
         ERROR_CONTACT_IS_INACTIVE:
             ugettext_noop("The recipient has been deactivated."),
         ERROR_TRIAL_SMS_EXCEEDED:

--- a/corehq/apps/smsforms/tasks.py
+++ b/corehq/apps/smsforms/tasks.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from corehq import toggles
 from corehq.apps.formplayer_api.smsforms.api import FormplayerInterface, TouchformsError
 from corehq.apps.sms.api import MessageMetadata, send_sms_to_verified_number, send_sms
-from corehq.apps.sms.models import PhoneNumber
+from corehq.apps.sms.models import PhoneNumber, MessagingEvent
 from corehq.apps.sms.util import format_message_list
 from corehq.apps.smsforms.models import SQLXFormsSession, XFormsSessionSynchronization
 from corehq.apps.smsforms.util import critical_section_for_smsforms_sessions
@@ -61,6 +61,10 @@ def send_first_message(domain, recipient, phone_entry_or_number, session, respon
             xforms_session_couch_id=session.couch_id,
             messaging_subevent_id=logged_subevent.pk
         )
+        if not message:
+            logged_subevent.error(MessagingEvent.ERROR_NO_MESSAGE)
+            return
+
         if isinstance(phone_entry_or_number, PhoneNumber):
             send_sms_to_verified_number(
                 phone_entry_or_number,

--- a/corehq/apps/smsforms/tasks.py
+++ b/corehq/apps/smsforms/tasks.py
@@ -59,6 +59,7 @@ def send_first_message(domain, recipient, phone_entry_or_number, session, respon
         metadata = MessageMetadata(
             workflow=workflow,
             xforms_session_couch_id=session.couch_id,
+            messaging_subevent_id=logged_subevent.pk
         )
         if isinstance(phone_entry_or_number, PhoneNumber):
             send_sms_to_verified_number(
@@ -111,16 +112,18 @@ def handle_due_survey_action(domain, contact_id, session_id):
             # Resend the current question in the open survey to the contact
             p = PhoneNumber.get_phone_number_for_owner(session.connection_id, session.phone_number)
             if p:
+                subevent = session.related_subevent
                 metadata = MessageMetadata(
                     workflow=session.workflow,
                     xforms_session_couch_id=session._id,
+                    messaging_subevent_id=subevent.pk if subevent else None
                 )
                 resp = FormplayerInterface(session.session_id, domain).current_question()
                 send_sms_to_verified_number(
                     p,
                     resp.event.text_prompt,
                     metadata,
-                    logged_subevent=session.related_subevent
+                    logged_subevent=subevent
                 )
 
             session.move_to_next_action()

--- a/corehq/messaging/smsbackends/twilio/models.py
+++ b/corehq/messaging/smsbackends/twilio/models.py
@@ -17,6 +17,7 @@ from corehq.messaging.smsbackends.twilio.forms import TwilioBackendForm
 INVALID_TO_PHONE_NUMBER_ERROR_CODE = 21211
 WHATSAPP_LIMITATION_ERROR_CODE = 63032
 TO_FROM_BLACKLIST_ERROR = 21610
+REGION_PERMISSION_ERROR = 21408
 
 WHATSAPP_PREFIX = "whatsapp:"
 WHATSAPP_SANDBOX_PHONE_NUMBER = "14155238886"
@@ -108,6 +109,8 @@ class SQLTwilioBackend(SQLSMSBackend, PhoneLoadBalancingMixin):
             elif e.code == TO_FROM_BLACKLIST_ERROR:
                 msg.set_gateway_error("Message From/To pair violates a gateway blacklist rule")
                 return
+            elif e.code == REGION_PERMISSION_ERROR:
+                msg.set_gateway_error("Destination region not enabled for this backend.")
             else:
                 raise
 

--- a/corehq/messaging/smsbackends/twilio/models.py
+++ b/corehq/messaging/smsbackends/twilio/models.py
@@ -16,6 +16,7 @@ from corehq.messaging.smsbackends.twilio.forms import TwilioBackendForm
 # https://www.twilio.com/docs/api/errors/reference
 INVALID_TO_PHONE_NUMBER_ERROR_CODE = 21211
 WHATSAPP_LIMITATION_ERROR_CODE = 63032
+TO_FROM_BLACKLIST_ERROR = 21610
 
 WHATSAPP_PREFIX = "whatsapp:"
 WHATSAPP_SANDBOX_PHONE_NUMBER = "14155238886"
@@ -104,6 +105,9 @@ class SQLTwilioBackend(SQLSMSBackend, PhoneLoadBalancingMixin):
                 notify_exception(None, f"Error with Twilio Whatsapp: {e}")
                 kwargs['skip_whatsapp'] = True
                 self.send(msg, orig_phone_number, *args, **kwargs)
+            elif e.code == TO_FROM_BLACKLIST_ERROR:
+                msg.set_gateway_error("Message From/To pair violates a gateway blacklist rule")
+                return
             else:
                 raise
 

--- a/corehq/messaging/smsbackends/twilio/models.py
+++ b/corehq/messaging/smsbackends/twilio/models.py
@@ -111,6 +111,7 @@ class SQLTwilioBackend(SQLSMSBackend, PhoneLoadBalancingMixin):
                 return
             elif e.code == REGION_PERMISSION_ERROR_CODE:
                 msg.set_gateway_error("Destination region not enabled for this backend.")
+                return
             else:
                 raise
 

--- a/corehq/messaging/smsbackends/twilio/models.py
+++ b/corehq/messaging/smsbackends/twilio/models.py
@@ -16,8 +16,8 @@ from corehq.messaging.smsbackends.twilio.forms import TwilioBackendForm
 # https://www.twilio.com/docs/api/errors/reference
 INVALID_TO_PHONE_NUMBER_ERROR_CODE = 21211
 WHATSAPP_LIMITATION_ERROR_CODE = 63032
-TO_FROM_BLACKLIST_ERROR = 21610
-REGION_PERMISSION_ERROR = 21408
+TO_FROM_BLACKLIST_ERROR_CODE = 21610
+REGION_PERMISSION_ERROR_CODE = 21408
 
 WHATSAPP_PREFIX = "whatsapp:"
 WHATSAPP_SANDBOX_PHONE_NUMBER = "14155238886"
@@ -106,10 +106,10 @@ class SQLTwilioBackend(SQLSMSBackend, PhoneLoadBalancingMixin):
                 notify_exception(None, f"Error with Twilio Whatsapp: {e}")
                 kwargs['skip_whatsapp'] = True
                 self.send(msg, orig_phone_number, *args, **kwargs)
-            elif e.code == TO_FROM_BLACKLIST_ERROR:
+            elif e.code == TO_FROM_BLACKLIST_ERROR_CODE:
                 msg.set_gateway_error("Message From/To pair violates a gateway blacklist rule")
                 return
-            elif e.code == REGION_PERMISSION_ERROR:
+            elif e.code == REGION_PERMISSION_ERROR_CODE:
                 msg.set_gateway_error("Destination region not enabled for this backend.")
             else:
                 raise


### PR DESCRIPTION
## Summary
A few small changes to improve sms error handling.

See individual commits for changes.

## Product Description
On potential product change here is that messages with no actual message content will not be sent. Twilio and potentially other gateways reject messages with no content (it seems that the intent was always to not try to send messages with no content but at least one place wasn't checking correctly).

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
