### PR TITLE
Added @skip_on_fresh_install to couch to sql django migrations

### DIFF
--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -8,6 +8,7 @@ from django.db import transaction
 
 from corehq.dbaccessors.couchapps.all_docs import get_all_docs_with_doc_types, get_doc_count_by_type
 from corehq.util.couchdb_management import couch_config
+from corehq.util.django_migrations import skip_on_fresh_install
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +93,7 @@ class PopulateSQLCommand(BaseCommand):
         return None
 
     @classmethod
+    @skip_on_fresh_install
     def migrate_from_migration(cls, apps, schema_editor):
         """
             Should only be called from within a django migration.


### PR DESCRIPTION
Tiny and invisible, though maybe it'll speed up tests a smidgen.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
