### PR TITLE
Fix escaping on custom icon badges

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/menu_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/menu_list.html
@@ -30,12 +30,12 @@
   <td class="module-column module-column-icon">
     <% if (imageUrl) { %>
     <div class="module-icon-image badge-container" style="background-image: url('<%- imageUrl %>');">
-      <%- _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
+      <%= _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>{# maybe-custom-badge-template output is already escaped #}
     </div>
     <% } else { %>
     <div class="module-icon-container badge-container">
       <i class="fa fa-pencil module-icon" aria-hidden="true"></i>
-      <%- _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
+      <%= _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>{# maybe-custom-badge-template output is already escaped #}
     </div>
     <% } %>
   </td>
@@ -55,7 +55,7 @@
   <td class="module-column module-column-icon">
     <% if (imageUrl) { %>
     <div class="module-icon-image badge-container" style="background-image: url('<%- imageUrl %>');">
-      <%- _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
+      <%= _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>{# maybe-custom-badge-template output is already escaped #}
     </div>
     <% } else { %>
     <div class="module-icon-container badge-container">
@@ -64,7 +64,7 @@
       <% } else { %>
       <i class="fa fa-folder module-icon" aria-hidden="true"></i>
       <% } %>
-      <%- _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
+      <%= _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>{# maybe-custom-badge-template output is already escaped #}
     </div>
     <% } %>
   </td>
@@ -77,7 +77,7 @@
   <div class="col-xs-6 col-sm-4 col-md-3">
     <% if (imageUrl) { %>
     <div class="gridicon badge-container" style="background-image: url('<%- imageUrl %>');">
-      <%- _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
+      <%= _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>{# maybe-custom-badge-template output is already escaped #}
     </div>
     <% } else { %>
     <div class="gridicon gridicon-circle badge-container">
@@ -86,7 +86,7 @@
       <% } else { %>
       <i class="fa fa-folder gridicon-icon" aria-hidden="true"></i>
       <% } %>
-      <%- _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
+      <%= _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>{# maybe-custom-badge-template output is already escaped #}
     </div>
     <% } %>
     <div class="module-column-name text-center">


### PR DESCRIPTION
## Summary

https://dimagi-dev.atlassian.net/browse/USH-965

Fixes issue introduced by https://github.com/dimagi/commcare-hq/pull/29471/files#diff-c1fc1a98445d08653d70a6292e5ec61642ed6742c656d196079075a3e70448e0. 

## Feature Flag
CUSOM_ICON_BADGES

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
This returns this code to how it was until recently. The change itself is very small. It won't introduce XSS because the template whose output is being raw-interpolated does already escape correctly itself. Have smoke tested on staging (without the CUSOM_ICON_BADGES flag) that it's not generally broken, and also (by inspecting source) that the `{# #}` comments behave as expected and don't appear in the page source at all.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
 
Reverting this would reintroduce a bug