### PR TITLE
add enabled toggles and previews to session details response

### DIFF
--- a/corehq/apps/hqwebapp/session_details_endpoint/tests.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/tests.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 
 from django.utils.dateparse import parse_datetime
 
+from corehq import toggles
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import CommCareUser
 from corehq.util.hmac_request import get_hmac_digest
@@ -29,7 +30,9 @@ class SessionDetailsViewTest(TestCase):
             'superUser': cls.sql_user.is_superuser,
             'authToken': None,
             'domains': [cls.domain.name],
-            'anonymous': False
+            'anonymous': False,
+            'enabled_toggles': {},
+            'enabled_previews': {},
         }
         cls.url = reverse('session_details')
 
@@ -214,3 +217,17 @@ class SessionDetailsViewTest(TestCase):
             HTTP_X_MAC_DIGEST='bad signature'
         )
         self.assertEqual(401, response.status_code)
+
+    @override_settings(DEBUG=True)
+    @softer_assert()
+    @flag_enabled('FORM_LINK_WORKFLOW')
+    @flag_enabled('CALC_XPATHS', is_preview=True)
+    def test_session_details_view_toggles(self):
+        toggles.all_toggles()
+        data = json.dumps({'sessionId': self.session_key, 'domain': 'domain'})
+        response = Client().post(self.url, data, content_type="application/json")
+        self.assertEqual(200, response.status_code)
+        expected_response = self.expected_response.copy()
+        expected_response['enabled_toggles'] = {'FORM_LINK_WORKFLOW': True}
+        expected_response['enabled_previews'] = {'CALC_XPATHS': True}
+        self.assertJSONEqual(response.content, expected_response)

--- a/corehq/apps/hqwebapp/session_details_endpoint/tests.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/tests.py
@@ -31,8 +31,8 @@ class SessionDetailsViewTest(TestCase):
             'authToken': None,
             'domains': [cls.domain.name],
             'anonymous': False,
-            'enabled_toggles': {},
-            'enabled_previews': {},
+            'enabled_toggles': [],
+            'enabled_previews': [],
         }
         cls.url = reverse('session_details')
 
@@ -228,6 +228,6 @@ class SessionDetailsViewTest(TestCase):
         response = Client().post(self.url, data, content_type="application/json")
         self.assertEqual(200, response.status_code)
         expected_response = self.expected_response.copy()
-        expected_response['enabled_toggles'] = {'FORM_LINK_WORKFLOW': True}
-        expected_response['enabled_previews'] = {'CALC_XPATHS': True}
+        expected_response['enabled_toggles'] = ['FORM_LINK_WORKFLOW']
+        expected_response['enabled_previews'] = ['CALC_XPATHS']
         self.assertJSONEqual(response.content, expected_response)

--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -75,6 +75,6 @@ class SessionDetailsView(View):
             'authToken': None,
             'domains': list(domains),
             'anonymous': False,
-            'enabled_toggles': toggles.toggle_values_by_name(user.username, domain, include_disabled=False),
-            'enabled_previews': feature_previews.preview_values_by_name(domain, include_disabled=False)
+            'enabled_toggles': list(toggles.toggle_values_by_name(user.username, domain, include_disabled=False)),
+            'enabled_previews': list(feature_previews.preview_values_by_name(domain, include_disabled=False))
         })

--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -11,7 +11,7 @@ from corehq.apps.domain.auth import formplayer_auth
 from corehq.apps.hqadmin.utils import get_django_user_from_session, get_session
 from corehq.apps.users.models import CouchUser, DomainPermissionsMirror
 from corehq.middleware import TimeoutMiddleware
-from corehq import toggles
+from corehq import toggles, feature_previews
 
 
 @method_decorator(csrf_exempt, name='dispatch')
@@ -74,5 +74,7 @@ class SessionDetailsView(View):
             'superUser': user.is_superuser,
             'authToken': None,
             'domains': list(domains),
-            'anonymous': False
+            'anonymous': False,
+            'enabled_toggles': toggles.toggle_values_by_name(user.username, domain, include_disabled=False),
+            'enabled_previews': feature_previews.preview_values_by_name(domain, include_disabled=False)
         })

--- a/corehq/feature_previews.py
+++ b/corehq/feature_previews.py
@@ -5,6 +5,7 @@ slug is kept intact.
 """
 from django.utils.translation import ugettext_lazy as _
 from django_prbac.utils import has_privilege as prbac_has_privilege
+from memoized import memoized
 
 from corehq.apps.accounting.models import SoftwarePlanEdition
 from corehq.util.quickcache import quickcache
@@ -60,7 +61,7 @@ def all_previews():
     return list(all_previews_by_name().values())
 
 
-@quickcache([])
+@memoized
 def all_previews_by_name():
     return all_toggles_by_name_in_scope(globals(), toggle_class=FeaturePreview)
 

--- a/corehq/feature_previews.py
+++ b/corehq/feature_previews.py
@@ -70,9 +70,20 @@ def previews_dict(domain):
     return {t.slug: True for t in all_previews() if t.enabled(domain)}
 
 
-def preview_values_by_name(domain):
-    return {toggle_name: toggle.enabled(domain)
-            for toggle_name, toggle in all_previews_by_name().items()}
+def preview_values_by_name(domain, include_disabled=True):
+    """
+    Loads all feature previews into a dictionary for use in JS & Formplayer
+    """
+    all_by_name = {
+        toggle_name: toggle.enabled(domain)
+        for toggle_name, toggle in all_previews_by_name().items()
+    }
+    if include_disabled:
+        return all_by_name
+
+    return {
+        name: value for name, value in all_by_name.items() if value
+    }
 
 
 CALC_XPATHS = FeaturePreview(

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -465,15 +465,20 @@ def toggles_dict(username=None, domain=None):
                                                     t.enabled(domain, NAMESPACE_DOMAIN))}
 
 
-def toggle_values_by_name(username=None, domain=None):
+def toggle_values_by_name(username=None, domain=None, include_disabled=True):
     """
-    Loads all toggles into a dictionary for use in JS
+    Loads all toggles into a dictionary for use in JS & Formplayer
+    """
+    all_by_name = {
+        toggle_name: (toggle.enabled(username, NAMESPACE_USER) or toggle.enabled(domain, NAMESPACE_DOMAIN))
+        for toggle_name, toggle in all_toggles_by_name().items()
+    }
+    if include_disabled:
+        return all_by_name
 
-    all toggles (including those not enabled) are included
-    """
-    return {toggle_name: (toggle.enabled(username, NAMESPACE_USER) or
-                          toggle.enabled(domain, NAMESPACE_DOMAIN))
-            for toggle_name, toggle in all_toggles_by_name().items()}
+    return {
+        name: value for name, value in all_by_name.items() if value
+    }
 
 
 def _ensure_valid_namespaces(namespaces):


### PR DESCRIPTION
[USH-807](https://dimagi-dev.atlassian.net/browse/USH-807)

## Summary
Adds a list of enabled toggles & previews to the JSON response of the session details view. This is the HQ part of the work required to allow Formplayer to make use of feature flags.

e.g. 
```diff
+    "enabled_toggles": ["FORM_LINK_WORKFLOW"],
+    "enabled_previews": [],
```

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added tests

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
