### PR TITLE
add 'send_email' command

### DIFF
--- a/corehq/apps/hqadmin/management/commands/mail_admins.py
+++ b/corehq/apps/hqadmin/management/commands/mail_admins.py
@@ -1,15 +1,12 @@
-import json
 import sys
+import warnings
 
-from django.conf import settings
 from django.core.mail import mail_admins
 from django.core.management.base import BaseCommand
 
-import requests
-
 
 class Command(BaseCommand):
-    help = 'Send args as a one-shot email to the admins.'
+    help = '[DEPRECATED] Send args as a one-shot email to the admins.'
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -22,6 +19,10 @@ class Command(BaseCommand):
         parser.add_argument('--environment', default='', help='The environment we are mailing about'),
 
     def handle(self, message, **options):
+        warnings.warn(
+            "mail_admins is deprecated. Use 'send_email --admins' instead.",
+            DeprecationWarning,
+        )
         if options['stdin']:
             message = sys.stdin.read()
         else:

--- a/corehq/apps/hqadmin/management/commands/mail_admins.py
+++ b/corehq/apps/hqadmin/management/commands/mail_admins.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
 
     def handle(self, message, **options):
         warnings.warn(
-            "mail_admins is deprecated. Use 'send_email --admins' instead.",
+            "mail_admins is deprecated. Use 'send_email --to-admins' instead.",
             DeprecationWarning,
         )
         if options['stdin']:

--- a/corehq/apps/hqadmin/management/commands/send_email.py
+++ b/corehq/apps/hqadmin/management/commands/send_email.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
         parser.add_argument('--subject'),
         parser.add_argument('--stdin', action='store_true', default=False, help='Read message body from stdin'),
         parser.add_argument('--html', action='store_true', default=False, help='HTML payload'),
-        parser.add_argument('--admins', action='store_true', default=False,
+        parser.add_argument('--to-admins', action='store_true', default=False,
                             help='Send to the list of configured admin addresses'),
         parser.add_argument('--recipients', default='',
                             help='Comma-separated list of additional recipient emails'),
@@ -31,7 +31,7 @@ class Command(BaseCommand):
             message = ' '.join(message)
 
         subject = options['subject']
-        admins = options['admins']
+        admins = options['to_admins']
         recipients = options['recipients']
         is_html = options['html']
 

--- a/corehq/apps/hqadmin/management/commands/send_email.py
+++ b/corehq/apps/hqadmin/management/commands/send_email.py
@@ -1,0 +1,56 @@
+import sys
+
+from django.core.mail import mail_admins, send_mail
+from django.core.management import CommandError
+from django.core.management.base import BaseCommand
+
+import settings
+from corehq.util.log import send_HTML_email
+
+
+class Command(BaseCommand):
+    help = 'Send once off email.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'message',
+            nargs='*',
+        )
+        parser.add_argument('--subject'),
+        parser.add_argument('--stdin', action='store_true', default=False, help='Read message body from stdin'),
+        parser.add_argument('--html', action='store_true', default=False, help='HTML payload'),
+        parser.add_argument('--admins', action='store_true', default=False,
+                            help='Send to the list of configured admin addresses'),
+        parser.add_argument('--recipients', default='',
+                            help='Comma-separated list of additional recipient emails'),
+
+    def handle(self, message, **options):
+        if options['stdin']:
+            message = sys.stdin.read()
+        else:
+            message = ' '.join(message)
+
+        subject = options['subject']
+        admins = options['admins']
+        recipients = options['recipients']
+        is_html = options['html']
+
+        if not subject:
+            subject = f"[{settings.SERVER_ENVIRONMENT}] Mail from CommCare HQ"
+
+        if not admins and not recipients:
+            raise CommandError("One of '--admins' or '--recipients' must be provided")
+
+        if admins:
+            mail_admins(subject, message, html_message=message if is_html else None)
+
+        if recipients:
+            recipients = recipients.split(',')
+            if is_html:
+                send_HTML_email(
+                    subject=subject, recipient=recipients, html_content=message
+                )
+            else:
+                send_mail(
+                    subject, message, settings.DEFAULT_FROM_EMAIL, recipient_list=recipients
+                )


### PR DESCRIPTION
## Summary
This performs the same function as mail_admins but also allows
specifying additional/alternate recipients

The impetus for this is to allow commcare-cloud to send deploy related emails to the the custom `DAILY_DEPLOY_EMAIL` address.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
