### PR TITLE
Include only locations in the domain

### DIFF
--- a/corehq/apps/case_migrations/views.py
+++ b/corehq/apps/case_migrations/views.py
@@ -94,4 +94,5 @@ def migration_restore(request, domain, case_id):
 
 def _add_limited_fixtures(domain, case_id, content):
     serializer = FlatLocationSerializer()
-    content.extend(serializer.get_xml_nodes('locations', domain, case_id, SQLLocation.active_objects))
+    content.extend(serializer.get_xml_nodes('locations', domain, case_id,
+                                            SQLLocation.active_objects.filter(domain=domain)))


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Introduced in https://github.com/dimagi/commcare-hq/pull/29482 where I passed all active locations instead of the ones present in the domain only that lead to [time out errors](https://sentry.io/organizations/dimagi/issues/2351842962/events/?environment=production&project=142105&project=136860&statsPeriod=1h)
These were enabled on one domain on prod and one of india, both for just testing. Have removed those domains so these don't get triggered even accidentally.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`ADD_LIMITED_FIXTURES_TO_CASE_RESTORE`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added new test to ensure only domain locations are present

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
