### PR TITLE
Removed RESTRICT_APP_RELEASE flag

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -105,7 +105,7 @@
                 'error': build_broken
             }">
       <div class="panel-heading">
-        {% if can_manage_releases and request|toggle_enabled:"SUPPORT" %}
+        {% if request|toggle_enabled:"SUPPORT" %}
           <div class="release-trash-container">
             <a href="#"
                class="hide release-remove"
@@ -133,38 +133,29 @@
           <span class="label label-info"
                 data-bind="visible: version() === $root.latestReleasedVersion()">{% trans "Latest" %}</span>
 
-          {% if can_manage_releases %}
-            <i class="fa fa-spin fa-refresh hide js-release-waiting"></i>
-            <div class="btn-group">
-              <button type="button"
-                      class="btn btn-xs"
-                      data-bind="click: $root.toggleRelease,
-                                             css: {
-                                                'active': is_released(),
-                                                'btn-primary': is_released(),
-                                                'btn-default': !is_released()
-                                             }">
-                {% trans "Released" %}
-              </button>
-              <button type="button"
-                      class="btn btn-xs btn-default"
-                      data-bind="click: $root.toggleRelease,
-                                             css: {
-                                                'active': !is_released(),
-                                                'btn-primary': !is_released(),
-                                                'btn-default': is_released()
-                                             }">
-                {% trans "In Test" %}
-              </button>
-            </div>
-          {% else %}
-            <span class="label label-success" data-bind="visible: is_released()">
-                          {% trans "Released" %}
-                      </span>
-            <span class="label label-primary" data-bind="visible: !is_released()">
-                          {% trans "In Test" %}
-                      </span>
-          {% endif %}
+          <i class="fa fa-spin fa-refresh hide js-release-waiting"></i>
+          <div class="btn-group">
+            <button type="button"
+                    class="btn btn-xs"
+                    data-bind="click: $root.toggleRelease,
+                                           css: {
+                                              'active': is_released(),
+                                              'btn-primary': is_released(),
+                                              'btn-default': !is_released()
+                                           }">
+              {% trans "Released" %}
+            </button>
+            <button type="button"
+                    class="btn btn-xs btn-default"
+                    data-bind="click: $root.toggleRelease,
+                                           css: {
+                                              'active': !is_released(),
+                                              'btn-primary': !is_released(),
+                                              'btn-default': is_released()
+                                           }">
+              {% trans "In Test" %}
+            </button>
+          </div>
 
           <!--/ko-->
         </div>

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -84,7 +84,6 @@ from corehq.apps.locations.permissions import location_safe
 from corehq.apps.sms.views import get_sms_autocomplete_context
 from corehq.apps.userreports.exceptions import ReportConfigurationNotFoundError
 from corehq.apps.users.models import CommCareUser, CouchUser
-from corehq.apps.users.permissions import can_manage_releases
 from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.view_utils import reverse
 
@@ -204,7 +203,6 @@ def get_releases_context(request, domain, app_id):
         'prompt_settings_url': reverse(PromptSettingsUpdateView.urlname, args=[domain, app_id]),
         'prompt_settings_form': prompt_settings_form,
         'full_name': request.couch_user.full_name,
-        'can_manage_releases': can_manage_releases(request.couch_user, request.domain, app_id),
         'can_edit_apps': request.couch_user.can_edit_apps(),
     }
     if not app.is_remote_app():

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -109,7 +109,6 @@ from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput, Select2Ajax, GeoCoderInput
 from corehq.apps.sms.phonenumbers_helper import parse_phone_number
 from corehq.apps.users.models import CouchUser, WebUser
-from corehq.apps.users.permissions import can_manage_releases
 from corehq.toggles import HIPAA_COMPLIANCE_CHECKBOX, MOBILE_UCR, \
     SECURE_SESSION_TIMEOUT
 from corehq.util.timezones.fields import TimeZoneField
@@ -2453,11 +2452,6 @@ class CreateManageReleasesByAppProfileForm(BaseManageReleasesByAppProfileForm):
                 self.version_build_id
             except BuildNotFoundException as e:
                 self.add_error('version', e)
-        app_id = self.cleaned_data.get('app_id')
-        if app_id:
-            if not can_manage_releases(self.request.couch_user, self.domain, app_id):
-                self.add_error('app_id',
-                               _("You don't have permission to set restriction for this application"))
 
     def clean_build_profile_id(self):
         return self.data.getlist('build_profile_id')

--- a/corehq/apps/domain/views/releases.py
+++ b/corehq/apps/domain/views/releases.py
@@ -32,7 +32,6 @@ from corehq.apps.domain.forms import (
 )
 from corehq.apps.domain.views import BaseProjectSettingsView
 from corehq.apps.locations.models import SQLLocation
-from corehq.apps.users.permissions import can_manage_releases
 
 
 @method_decorator([toggles.MANAGE_RELEASES_PER_LOCATION.required_decorator(),
@@ -213,9 +212,6 @@ def toggle_release_restriction_by_app_profile(request, domain, restriction_id):
     release = LatestEnabledBuildProfiles.objects.get(id=restriction_id)
     if not release:
         return HttpResponseBadRequest()
-    if not can_manage_releases(request.couch_user, domain, release.app_id):
-        return JsonResponse(data={
-            'message': _("You don't have permission to set restriction for this application")})
     if request.POST.get('active') == 'false':
         return _update_release_restriction_by_app_profile(release, restriction_id, active=False)
     elif request.POST.get('active') == 'true':

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -148,8 +148,6 @@ class Permissions(DocumentSchema):
 
     view_file_dropzone = BooleanProperty(default=False)
     edit_file_dropzone = BooleanProperty(default=False)
-    manage_releases = BooleanProperty(default=True)
-    manage_releases_list = StringListProperty(default=[])
 
     login_as_all_users = BooleanProperty(default=False)
     limited_login_as = BooleanProperty(default=False)

--- a/corehq/apps/users/permissions.py
+++ b/corehq/apps/users/permissions.py
@@ -75,22 +75,3 @@ def has_permission_to_view_report(couch_user, domain, report_to_check):
             data=report_to_check
         )
     )
-
-
-def can_manage_releases(couch_user, domain, app_id):
-    if _can_manage_releases_for_all_apps(couch_user, domain):
-        return True
-    role = couch_user.get_role(domain)
-    return app_id in role.permissions.manage_releases_list
-
-
-def _can_manage_releases_for_all_apps(couch_user, domain):
-    from corehq.apps.users.decorators import get_permission_name
-    from corehq.apps.users.models import Permissions
-    restricted_app_release = toggles.RESTRICT_APP_RELEASE.enabled(domain)
-    if not restricted_app_release:
-        return True
-    return couch_user.has_permission(
-        domain, get_permission_name(Permissions.manage_releases),
-        restrict_global_admin=True
-    )

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -36,17 +36,6 @@ hqDefine('users/js/roles',[
                     }),
                 };
 
-                data.manageAppReleasePermissions = {
-                    all: data.permissions.manage_releases,
-                    specific: ko.utils.arrayMap(root.appsList, function (app) {
-                        return {
-                            path: app._id,
-                            name: app.name,
-                            value: data.permissions.manage_releases_list.indexOf(app._id) !== -1,
-                        };
-                    }),
-                };
-
                 data.manageRoleAssignments = {
                     all: data.is_non_admin_editable,
                     specific: ko.utils.arrayMap(o.nonAdminRoles, function (role) {
@@ -284,12 +273,6 @@ hqDefine('users/js/roles',[
 
                 data.permissions.view_web_apps = data.webAppsPermissions.all;
                 data.permissions.view_web_apps_list = ko.utils.arrayMap(ko.utils.arrayFilter(data.webAppsPermissions.specific, function (app) {
-                    return app.value;
-                }), function (app) {
-                    return app.path;
-                });
-                data.permissions.manage_releases = data.manageAppReleasePermissions.all;
-                data.permissions.manage_releases_list = ko.utils.arrayMap(ko.utils.arrayFilter(data.manageAppReleasePermissions.specific, function (app) {
                     return app.value;
                 }), function (app) {
                     return app.path;

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -340,47 +340,6 @@
             </div>
             {# END MOBILE permission #}
             {% endif %}
-            {% if request|toggle_enabled:"RESTRICT_APP_RELEASE" %}
-              <div class="form-group">
-                <label class="col-sm-4 control-label">
-                  {% trans "Manage Releases" %}
-                </label>
-                <div class="col-sm-8 controls">
-                  <div class="form-check">
-                    <input type="checkbox"
-                           id="manage-releases-checkbox"
-                           data-bind="checked: manageAppReleasePermissions.all" />
-                    <label for="manage-releases-checkbox">
-                      {% trans "Allow role to manage all Apps." %}
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div class="form-group"
-                   data-bind="visible: !manageAppReleasePermissions.all()">
-                <label class="col-sm-4 control-label">
-                  {% trans "Manage Releases Permissions" %}
-                </label>
-                <div class="col-sm-8 controls">
-                  <div class="panel panel-default">
-                    <div class="panel-heading">
-                      {% trans "Select which Apps this role can manage:" %}
-                    </div>
-                    <div class="panel-body"
-                         data-bind="foreach: manageAppReleasePermissions.specific, slideVisible: !manageAppReleasePermissions.all()">
-                      <div class="form-check">
-                        <input type="checkbox"
-                               data-bind="checked: value, attr: { 'id': 'release-' + path() + '-checkbox' },
-                                          disable: !$root.allowEdit" />
-                        <label data-bind="attr: { 'for': 'release-' + path() + '-checkbox' }">
-                          <span data-bind="text: name"></span>
-                        </label>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            {% endif %}
             <div class="form-group">
               <label class="col-sm-4 control-label"
                      for="landing-page">

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1675,15 +1675,6 @@ SORT_OUT_OF_ORDER_FORM_SUBMISSIONS_SQL = DynamicallyPredictablyRandomToggle(
 )
 
 
-RESTRICT_APP_RELEASE = StaticToggle(
-    'restrict_app_release',
-    'ICDS: Show permission to manage app releases on user roles',
-    TAG_CUSTOM,
-    namespaces=[NAMESPACE_DOMAIN],
-    relevant_environments={"icds", "icds-staging"}
-)
-
-
 RELEASE_BUILDS_PER_PROFILE = StaticToggle(
     'release_builds_per_profile',
     'Do not release builds for all app profiles by default. Then manage via Source files view',


### PR DESCRIPTION
## Summary
This was ICDS-only, and USH is motivated to reduce complexity in roles & permissions code.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Limited, this is mostly UI changes.

### QA Plan

Not requesting QA.

### Safety story
Dead code removal in an area of code that's pretty rote.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
