### PR TITLE
add ability to know if advancedform needs access to parent case

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2615,6 +2615,11 @@ class AdvancedForm(IndexedFormBase, FormMediaMixin, NavMenuItemMediaMixin):
         """
         return any(not action.auto_select for action in self.actions.load_update_cases)
 
+    @staticmethod
+    def uses_parent_case():
+        # Safer to assume that AdvanceForm always uses parent case
+        return True
+
     @property
     def requires(self):
         return 'case' if self.requires_case() else 'none'


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/INDIV-10?focusedCommentId=138185

https://sentry.io/organizations/dimagi/issues/2257623181/?environment=production&project=136860&query=is%3Aunresolved+Error+processing+SMS&statsPeriod=14d

In order to support using `AdvancedForm`, the first blocker is to have a way for the form to know if it uses parent cases which is needed by sms workflow [here](https://github.com/dimagi/commcare-hq/blob/61df4fb439d3b969e3970b98e00a16e80716808d/corehq/apps/smsforms/app.py#L48)
This was originally added in 2015, https://github.com/dimagi/commcare-hq/pull/7638. Not sure if there will be more issues to support AdvancedForm past this point, but this was a small effort so thought of simply adding this first and then take it from there.

The change is applicable to sms workflows using keywords that initiate an AdvancedForm in the app and need a case preloaded. I believe there are no such workflows currently set on environments since its broken and this PR fixes it.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`APP_BUILDER_ADVANCED`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This workflow isn't in action since its not working anyway. So should be safe to rollout

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
