### PR TITLE
Use API key authentication for FHIR API

### DIFF
--- a/corehq/motech/fhir/tests/test_fhir_views.py
+++ b/corehq/motech/fhir/tests/test_fhir_views.py
@@ -190,25 +190,29 @@ class TestFHIRSearchView(BaseFHIRViewTest):
 class ViewsPermissionsTests(BaseFHIRViewTest):
 
     def test_api_key_authenticated(self):
-        url = reverse(
-            "fhir_get_view",
-            args=[DOMAIN, FHIR_VERSION, "Patient", PERSON_CASE_ID],
-        )
-        request = _get_request(url, self.django_user, self.api_key.key)
-        is_authenticated = LoginAuthentication().is_authenticated(request)
-        self.assertTrue(is_authenticated)
+        for url in (
+            reverse("fhir_get_view",
+                    args=[DOMAIN, FHIR_VERSION, "Patient", PERSON_CASE_ID]),
+            reverse("fhir_search",
+                    args=[DOMAIN, FHIR_VERSION, "Observation"])
+        ):
+            request = _get_request(url, self.django_user, self.api_key.key)
+            is_authenticated = LoginAuthentication().is_authenticated(request)
+            self.assertTrue(is_authenticated)
 
     def test_superuser_not_authenticated(self):
         self.django_user.is_superuser = True
         self.django_user.save()
 
-        url = reverse(
-            "fhir_get_view",
-            args=[DOMAIN, FHIR_VERSION, "Patient", PERSON_CASE_ID],
-        )
-        request = _get_request(url, self.django_user)
-        is_authenticated = LoginAuthentication().is_authenticated(request)
-        self.assertFalse(is_authenticated)
+        for url in (
+            reverse("fhir_get_view",
+                    args=[DOMAIN, FHIR_VERSION, "Patient", PERSON_CASE_ID]),
+            reverse("fhir_search",
+                    args=[DOMAIN, FHIR_VERSION, "Observation"])
+        ):
+            request = _get_request(url, self.django_user)
+            is_authenticated = LoginAuthentication().is_authenticated(request)
+            self.assertFalse(is_authenticated)
 
 
 def _setup_cases(owner_id):

--- a/corehq/motech/fhir/tests/test_fhir_views.py
+++ b/corehq/motech/fhir/tests/test_fhir_views.py
@@ -51,7 +51,7 @@ class BaseFHIRViewTest(TestCase):
         cls.domain_obj.delete()
         super().tearDownClass()
 
-    def _client_get(self, path):
+    def _get_response(self, path):
         return self.client.get(
             path,
             HTTP_AUTHORIZATION=f'ApiKey {USERNAME}:{self.api_key.key}'
@@ -62,14 +62,14 @@ class TestFHIRGetView(BaseFHIRViewTest):
 
     def test_flag_not_enabled(self):
         url = reverse("fhir_get_view", args=[DOMAIN, FHIR_VERSION, "Patient", PERSON_CASE_ID])
-        response = self._client_get(url)
+        response = self._get_response(url)
         self.assertEqual(response.status_code, 404)
 
     @flag_enabled('FHIR_INTEGRATION')
     def test_unsupported_fhir_version(self):
         url = reverse("fhir_get_view", args=[DOMAIN, FHIR_VERSION, "Patient", TEST_CASE_ID])
         url = url.replace(FHIR_VERSION, 'A4')
-        response = self._client_get(url)
+        response = self._get_response(url)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
@@ -79,14 +79,14 @@ class TestFHIRGetView(BaseFHIRViewTest):
     @flag_enabled('FHIR_INTEGRATION')
     def test_missing_case_id(self):
         url = reverse("fhir_get_view", args=[DOMAIN, FHIR_VERSION, "Patient", 'just-a-case-id'])
-        response = self._client_get(url)
+        response = self._get_response(url)
         self.assertEqual(response.status_code, 404)
 
     @flag_enabled('FHIR_INTEGRATION')
     def test_auth_bad_resource(self):
         # requesting for a patient i.e person but case id of a test case type
         url = reverse("fhir_get_view", args=[DOMAIN, FHIR_VERSION, "Patient", TEST_CASE_ID])
-        response = self._client_get(url)
+        response = self._get_response(url)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
@@ -96,7 +96,7 @@ class TestFHIRGetView(BaseFHIRViewTest):
     @flag_enabled('FHIR_INTEGRATION')
     def test_get(self):
         url = reverse("fhir_get_view", args=[DOMAIN, FHIR_VERSION, "Patient", PERSON_CASE_ID])
-        response = self._client_get(url)
+        response = self._get_response(url)
         response_json = response.json()
         self.assertEqual(
             response_json,
@@ -111,14 +111,14 @@ class TestFHIRGetView(BaseFHIRViewTest):
 class TestFHIRSearchView(BaseFHIRViewTest):
     def test_flag_not_enabled(self):
         url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"]) + f"?patient_id={PERSON_CASE_ID}"
-        response = self._client_get(url)
+        response = self._get_response(url)
         self.assertEqual(response.status_code, 404)
 
     @flag_enabled('FHIR_INTEGRATION')
     def test_unsupported_fhir_version(self):
         url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"]) + f"?patient_id={PERSON_CASE_ID}"
         url = url.replace(FHIR_VERSION, 'A4')
-        response = self._client_get(url)
+        response = self._get_response(url)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
@@ -128,7 +128,7 @@ class TestFHIRSearchView(BaseFHIRViewTest):
     @flag_enabled('FHIR_INTEGRATION')
     def test_no_patient_id(self):
         url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"])
-        response = self._client_get(url)
+        response = self._get_response(url)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
@@ -138,7 +138,7 @@ class TestFHIRSearchView(BaseFHIRViewTest):
     @flag_enabled('FHIR_INTEGRATION')
     def test_deleted_case(self):
         url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"]) + f"?patient_id={DELETED_CASE_ID}"
-        response = self._client_get(url)
+        response = self._get_response(url)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
@@ -148,7 +148,7 @@ class TestFHIRSearchView(BaseFHIRViewTest):
     @flag_enabled('FHIR_INTEGRATION')
     def test_missing_case_id(self):
         url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"]) + "?patient_id=just-a-case-id"
-        response = self._client_get(url)
+        response = self._get_response(url)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
@@ -159,7 +159,7 @@ class TestFHIRSearchView(BaseFHIRViewTest):
     def test_no_case_types_for_resource_type(self):
         url = reverse("fhir_search",
                       args=[DOMAIN, FHIR_VERSION, "DiagnosticReport"]) + f"?patient_id={PERSON_CASE_ID}"
-        response = self._client_get(url)
+        response = self._get_response(url)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
@@ -169,7 +169,7 @@ class TestFHIRSearchView(BaseFHIRViewTest):
     @flag_enabled('FHIR_INTEGRATION')
     def test_search(self):
         url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"]) + f"?patient_id={PERSON_CASE_ID}"
-        response = self._client_get(url)
+        response = self._get_response(url)
         self.assertEqual(
             response.json(),
             {

--- a/corehq/motech/fhir/tests/test_fhir_views.py
+++ b/corehq/motech/fhir/tests/test_fhir_views.py
@@ -381,11 +381,9 @@ def user_is_superuser(user):
     is_superuser = user.is_superuser
     try:
         user.is_superuser = True
-        user.save()
         yield
     finally:
         user.is_superuser = is_superuser
-        user.save()
 
 
 def _setup_cases(owner_id):

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -3,7 +3,8 @@ from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.http import require_GET
 
-from corehq import toggles
+from corehq import privileges, toggles
+from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.domain.decorators import api_key_auth
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
@@ -45,6 +46,7 @@ class EditFHIRRepeaterView(EditRepeaterView, AddFHIRRepeaterView):
 
 @require_GET
 @api_key_auth
+@requires_privilege_with_fallback(privileges.API_ACCESS)
 @toggles.FHIR_INTEGRATION.required_decorator()
 def get_view(request, domain, fhir_version_name, resource_type, resource_id):
     fhir_version = _get_fhir_version(fhir_version_name)
@@ -70,6 +72,7 @@ def get_view(request, domain, fhir_version_name, resource_type, resource_id):
 
 @require_GET
 @api_key_auth
+@requires_privilege_with_fallback(privileges.API_ACCESS)
 @toggles.FHIR_INTEGRATION.required_decorator()
 def search_view(request, domain, fhir_version_name, resource_type):
     fhir_version = _get_fhir_version(fhir_version_name)

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -87,6 +87,10 @@ def search_view(request, domain, fhir_version_name, resource_type):
     case_accessor = CaseAccessors(domain)
     try:
         patient_case = case_accessor.get_case(patient_case_id)
+        if patient_case.domain != domain:
+            return JsonResponse(status=404, data={
+                'message': f"Could not find patient with ID {patient_case_id}"
+            })
         if patient_case.is_deleted:
             return JsonResponse(status=400, data={'message': f"Patient with ID {patient_case_id} was removed"})
     except CaseNotFound:

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -5,6 +5,7 @@ from django.views.decorators.http import require_GET
 
 from corehq import privileges, toggles
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
+from corehq.apps.case_importer.views import require_can_edit_data
 from corehq.apps.domain.decorators import api_key_auth
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
@@ -46,6 +47,7 @@ class EditFHIRRepeaterView(EditRepeaterView, AddFHIRRepeaterView):
 
 @require_GET
 @api_key_auth
+@require_can_edit_data
 @requires_privilege_with_fallback(privileges.API_ACCESS)
 @toggles.FHIR_INTEGRATION.required_decorator()
 def get_view(request, domain, fhir_version_name, resource_type, resource_id):
@@ -72,6 +74,7 @@ def get_view(request, domain, fhir_version_name, resource_type, resource_id):
 
 @require_GET
 @api_key_auth
+@require_can_edit_data
 @requires_privilege_with_fallback(privileges.API_ACCESS)
 @toggles.FHIR_INTEGRATION.required_decorator()
 def search_view(request, domain, fhir_version_name, resource_type):

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -4,7 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.http import require_GET
 
 from corehq import toggles
-from corehq.apps.domain.decorators import login_or_api_key, require_superuser
+from corehq.apps.domain.decorators import api_key_auth
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.exceptions import ConfigurationError
@@ -44,8 +44,7 @@ class EditFHIRRepeaterView(EditRepeaterView, AddFHIRRepeaterView):
 
 
 @require_GET
-@login_or_api_key
-@require_superuser
+@api_key_auth
 @toggles.FHIR_INTEGRATION.required_decorator()
 def get_view(request, domain, fhir_version_name, resource_type, resource_id):
     fhir_version = _get_fhir_version(fhir_version_name)
@@ -70,8 +69,7 @@ def get_view(request, domain, fhir_version_name, resource_type, resource_id):
 
 
 @require_GET
-@login_or_api_key
-@require_superuser
+@api_key_auth
 @toggles.FHIR_INTEGRATION.required_decorator()
 def search_view(request, domain, fhir_version_name, resource_type):
     fhir_version = _get_fhir_version(fhir_version_name)


### PR DESCRIPTION
## Summary

Switch FHIR API authentication from superuser to API key.

Required for the EmptyBoxes project to allow non-superusers to use the FHIR API.

Please raise security concerns if you have any. I'm also interested to know if there are authorization tests I should add.


## Feature Flag
"FHIR Integration"


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Automated test coverage


### Safety story

Not yet used in production projects


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
