### PR TITLE
mark case owner as safe

### DIFF
--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -206,7 +206,7 @@ class CaseDisplay:
     def owner_display(self):
         owner_type, owner = self.owner
         if owner_type == 'group':
-            return '<span class="label label-default">%s</span>' % owner['name']
+            return format_html('<span class="label label-default">{}</span>', owner['name'])
         else:
             return owner['name']
     owner_name = owner_display


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12117

Mark span used when case owner is a group as safe using `format_html`

## Product Description
Bug fix

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan
Tested locally

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
