### PR TITLE
remove redundant footprint filter

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1668,14 +1668,6 @@ class Form(IndexedFormBase, FormMediaMixin, NavMenuItemMediaMixin):
     def requires_referral(self):
         return self.requires == "referral"
 
-    def uses_parent_case(self):
-        """
-        Returns True if any of the load/update properties references the
-        parent case; False otherwise
-        """
-        return any([name.startswith('parent/')
-            for name in self.actions.all_property_names()])
-
     def get_registration_actions(self, case_type):
         """
         :return: List of actions that create a case. Subcase actions are included

--- a/corehq/apps/cloudcare/touchforms_api.py
+++ b/corehq/apps/cloudcare/touchforms_api.py
@@ -31,8 +31,6 @@ class BaseSessionDataHelper(object):
         root_extras = root_extras or {}
         session_extras = session_extras or {}
         session_data = self.get_session_data()
-        # always tell touchforms to include footprinted cases in its case db
-        session_data["additional_filters"] = {"footprint": True}
         session_data.update(session_extras)
         xform_url = root_extras.get('formplayer_url')
         ret = {

--- a/corehq/apps/sms/handlers/keyword.py
+++ b/corehq/apps/sms/handlers/keyword.py
@@ -306,7 +306,7 @@ def get_app_module_form(domain, app_id, form_unique_id, logged_subevent=None):
         return (None, None, None, True, MSG_FORM_NOT_FOUND)
 
 
-def start_session_for_structured_sms(domain, contact, phone_number, app, module, form,
+def start_session_for_structured_sms(domain, contact, phone_number, app, form,
         case_id, keyword, logged_subevent=None):
     """
     Returns (session, responses, error, error_code)
@@ -324,7 +324,6 @@ def start_session_for_structured_sms(domain, contact, phone_number, app, module,
             domain,
             contact,
             app,
-            module,
             form,
             case_id=case_id,
             yield_responses=True
@@ -380,7 +379,7 @@ def handle_structured_sms(survey_keyword, survey_keyword_action, contact,
         return False
 
     session, responses, error_occurred, error_code = start_session_for_structured_sms(
-        domain, contact, verified_number, app, module, form, case_id, keyword, logged_subevent)
+        domain, contact, verified_number, app, form, case_id, keyword, logged_subevent)
     if error_occurred:
         error_msg = get_message(error_code, verified_number)
         clean_up_and_send_response(msg, contact, session, error_occurred, error_msg,

--- a/corehq/apps/sms/handlers/keyword.py
+++ b/corehq/apps/sms/handlers/keyword.py
@@ -2,7 +2,6 @@ from functools import cmp_to_key
 
 from dimagi.utils.logging import notify_exception
 
-from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.formplayer_api.smsforms.api import (
     FormplayerInterface,

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -45,12 +45,10 @@ def start_session(session, domain, contact, app, module, form, case_id=None, yie
     if is_commcarecase(contact) and form.requires_case():
         session_data["additional_filters"] = {
             "case_id": case_id,
-            "footprint": "true" if form.uses_parent_case() else "false",
         }
     elif isinstance(contact, CouchUser):
         session_data["additional_filters"] = {
             "user_id": contact.get_id,
-            "footprint": "true"
         }
 
     kwargs = {}

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -21,8 +21,7 @@ from .models import SQLXFormsSession
 COMMCONNECT_DEVICE_ID = "commconnect"
 
 
-def start_session(session, domain, contact, app, form, case_id=None, yield_responses=False,
-                  case_for_case_submission=False):
+def start_session(session, domain, contact, app, form, case_id=None, yield_responses=False):
     """
     Starts a session in touchforms and saves the record in the database.
     
@@ -31,9 +30,6 @@ def start_session(session, domain, contact, app, form, case_id=None, yield_respo
     
     Special params:
     yield_responses - If True, the list of xforms responses is returned, otherwise the text prompt for each is returned
-    session_type - XFORMS_SESSION_SMS or XFORMS_SESSION_IVR
-    case_for_case_submission - True if this is a submission that a case is making to alter another related case. For example, if a parent case is filling out
-        an SMS survey which will update its child case, this should be True.
     """
     # NOTE: this call assumes that "contact" will expose three
     # properties: .raw_username, .get_id, and .get_language_code

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -13,7 +13,6 @@ from corehq.apps.formplayer_api.smsforms.api import (
     XFormsConfig,
 )
 from corehq.apps.receiverwrapper.util import submit_form_locally
-from corehq.apps.users.models import CouchUser
 from corehq.form_processor.utils import is_commcarecase
 from corehq.messaging.scheduling.util import utcnow
 

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -22,7 +22,7 @@ from .models import SQLXFormsSession
 COMMCONNECT_DEVICE_ID = "commconnect"
 
 
-def start_session(session, domain, contact, app, module, form, case_id=None, yield_responses=False,
+def start_session(session, domain, contact, app, form, case_id=None, yield_responses=False,
                   case_for_case_submission=False):
     """
     Starts a session in touchforms and saves the record in the database.

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -38,7 +38,8 @@ def start_session(session, domain, contact, app, module, form, case_id=None, yie
     """
     # NOTE: this call assumes that "contact" will expose three
     # properties: .raw_username, .get_id, and .get_language_code
-    session_data = CaseSessionDataHelper(domain, contact, case_id, app, form).get_session_data(COMMCONNECT_DEVICE_ID)
+    session_data = CaseSessionDataHelper(domain, contact, case_id, app, form).get_session_data(
+        COMMCONNECT_DEVICE_ID)
 
     kwargs = {}
     if is_commcarecase(contact):

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -40,17 +40,6 @@ def start_session(session, domain, contact, app, module, form, case_id=None, yie
     # properties: .raw_username, .get_id, and .get_language_code
     session_data = CaseSessionDataHelper(domain, contact, case_id, app, form).get_session_data(COMMCONNECT_DEVICE_ID)
 
-    # since the API user is a superuser, force touchforms to query only
-    # the contact's cases by specifying it as an additional filter
-    if is_commcarecase(contact) and form.requires_case():
-        session_data["additional_filters"] = {
-            "case_id": case_id,
-        }
-    elif isinstance(contact, CouchUser):
-        session_data["additional_filters"] = {
-            "user_id": contact.get_id,
-        }
-
     kwargs = {}
     if is_commcarecase(contact):
         kwargs['restore_as_case_id'] = contact.case_id

--- a/corehq/apps/smsforms/tests/test_app.py
+++ b/corehq/apps/smsforms/tests/test_app.py
@@ -1,0 +1,152 @@
+import uuid
+
+from django.test import TestCase
+
+from mock import patch
+
+from corehq.apps.app_manager.tests.app_factory import AppFactory
+from corehq.apps.app_manager.xform_builder import XFormBuilder
+from corehq.apps.formplayer_api.smsforms.api import (
+    TouchformsError,
+    XformsResponse,
+)
+from corehq.apps.formplayer_api.smsforms.sms import SessionStartInfo
+from corehq.apps.smsforms.app import start_session
+from corehq.apps.smsforms.models import SQLXFormsSession
+from corehq.apps.users.models import WebUser
+from corehq.form_processor.models import CommCareCaseSQL
+
+
+@patch('corehq.apps.smsforms.app.tfsms.start_session')
+class TestStartSession(TestCase):
+    domain = "test-domain"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.factory = AppFactory(domain=cls.domain)
+        cls.app = cls.factory.app
+        cls.module, cls.basic_form = cls.factory.new_basic_module('basic', 'patient')
+
+        # necessary to render_xform
+        builder = XFormBuilder(cls.basic_form.name)
+        builder.new_question(name='name', label='Name')
+        cls.basic_form.source = builder.tostring(pretty_print=True).decode('utf-8')
+
+        cls.phone_number = "+919999999999"
+        cls.case_id = uuid.uuid4().hex
+        cls.recipient = None
+
+        cls.case = CommCareCaseSQL(domain=cls.domain, case_id=cls.case_id, case_json={'language_code': 'fr'})
+        cls.web_user = WebUser(username='web-user@example.com', _id=uuid.uuid4().hex, language='hin')
+
+    @classmethod
+    def tearDownClass(cls):
+        SQLXFormsSession.objects.all().delete()
+
+    def _start_session(self, yield_responses=False):
+        if not self.recipient:
+            raise Exception("Set recipient")
+        return start_session(
+            SQLXFormsSession.create_session_object(
+                self.domain,
+                self.recipient,
+                self.phone_number,
+                self.app,
+                self.basic_form,
+            ),
+            self.domain,
+            self.recipient,
+            self.app,
+            self.basic_form,
+            yield_responses=yield_responses
+        )
+
+    def _mock_xform_response(self, tfsms_start_session_mock, status, additional_response=None):
+        response_dict = {
+            'session_id': uuid.uuid4().hex,
+            'status': status
+        }
+        if additional_response:
+            response_dict.update(additional_response)
+        xform_response = XformsResponse(response_dict)
+        tfsms_start_session_mock.return_value = SessionStartInfo(
+            xform_response,
+            self.domain
+        )
+        return xform_response
+
+    @patch('corehq.apps.smsforms.app.XFormsConfig')
+    def test_start_session_as_case(self, xform_config_mock, tfsms_start_session_mock):
+        self.recipient = self.case
+
+        event_response = {'output': 'result', 'type': 'question'}  # move to next question
+        xform_response = self._mock_xform_response(tfsms_start_session_mock, status='success',
+                                                   additional_response={'event': event_response})
+
+        session, responses = self._start_session(yield_responses=True)
+
+        expected_session_data = {
+            'device_id': 'commconnect', 'app_version': '2.0', 'domain': self.domain,
+            'username': self.recipient.raw_username, 'user_id': self.recipient.get_id,
+            'user_data': {},
+            'app_id': None
+        }
+        xform_config_mock.assert_called_once_with(
+            form_content=self.basic_form.render_xform().decode('utf-8'),
+            language=self.recipient.get_language_code(),
+            session_data=expected_session_data,
+            domain=self.domain,
+            restore_as_case_id=self.recipient.case_id
+        )
+
+        self.assertEqual(session.session_id, xform_response.session_id)
+        self.assertEqual(len(responses), 1)
+        self.assertEqual(responses[0], xform_response)
+
+    @patch('corehq.apps.smsforms.app.XFormsConfig')
+    def test_start_session_as_user(self, xform_config_mock, tfsms_start_session_mock):
+        self.recipient = self.web_user
+
+        xform_response = self._mock_xform_response(tfsms_start_session_mock, status="validation-error")
+
+        session, responses = self._start_session(yield_responses=True)
+
+        expected_session_data = {
+            'device_id': 'commconnect', 'app_version': '2.0', 'domain': self.domain,
+            'username': self.recipient.raw_username, 'user_id': self.recipient.get_id,
+            'user_data': {'commcare_first_name': None, 'commcare_last_name': None, 'commcare_phone_number': None},
+            'app_id': None
+        }
+        xform_config_mock.assert_called_once_with(
+            form_content=self.basic_form.render_xform().decode('utf-8'),
+            language=self.recipient.get_language_code(),
+            session_data=expected_session_data,
+            domain=self.domain,
+            restore_as=self.recipient.raw_username
+        )
+
+        self.assertEqual(session.session_id, xform_response.session_id)
+        self.assertEqual(len(responses), 1)
+        self.assertEqual(responses[0], xform_response)
+
+    def test_http_error(self, tfsms_start_session_mock):
+        self.recipient = self.case
+
+        xform_response = self._mock_xform_response(tfsms_start_session_mock, status='http-error')
+
+        with self.assertRaisesMessage(TouchformsError, 'Cannot connect to touchforms.'):
+            self._start_session()
+
+        session = SQLXFormsSession.objects.first()
+        self.assertFalse(session.completed)
+        self.assertEqual(session.session_id, xform_response.session_id)
+
+    def test_text_responses(self, tfsms_start_session_mock):
+        self.recipient = self.case
+
+        self._mock_xform_response(tfsms_start_session_mock, status="validation-error",
+                                  additional_response={'reason': 'human-error'})
+
+        session, responses = self._start_session(yield_responses=False)
+
+        self.assertEqual(responses, ["human-error"])

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -262,7 +262,6 @@ class SMSSurveyContent(Content):
                 logged_subevent,
                 self.get_workflow(logged_event),
                 app,
-                module,
                 form
             )
 
@@ -284,7 +283,7 @@ class SMSSurveyContent(Content):
                 )
 
     def start_smsforms_session(self, domain, recipient, case_id, phone_entry_or_number, logged_subevent, workflow,
-            app, module, form):
+            app, form):
         # Close all currently open sessions
         SQLXFormsSession.close_all_open_sms_sessions(domain, recipient.get_id)
 
@@ -307,7 +306,6 @@ class SMSSurveyContent(Content):
                 domain,
                 recipient,
                 app,
-                module,
                 form,
                 case_id,
                 yield_responses=True


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Started as https://github.com/dimagi/commcare-hq/pull/29582 but then was simply about removing redundant code https://github.com/dimagi/commcare-hq/pull/29582#pullrequestreview-641188896.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Removing an unused session parameter for formplayer, generated by HQ.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
