### PR TITLE
dont' auto-convert dates in ReportConfiguration

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -655,6 +655,10 @@ class ReportConfiguration(QuickCachedDocumentMixin, Document):
     report_meta = SchemaProperty(ReportMeta)
     custom_query_provider = StringProperty(required=False)
 
+    class Meta(object):
+        # prevent JsonObject from auto-converting dates etc.
+        string_conversions = ()
+
     def __str__(self):
         return '{} - {}'.format(self.domain, self.title)
 

--- a/corehq/apps/userreports/tests/test_report_config.py
+++ b/corehq/apps/userreports/tests/test_report_config.py
@@ -131,6 +131,29 @@ class ReportConfigurationTest(SimpleTestCase):
         with self.assertRaises(BadSpecError):
             config.validate()
 
+    def test_constant_date_expression_column(self):
+        """
+        Used to fail at jsonobject.base_properties.AbstractDateProperty.wrap:
+
+            BadValueError: datetime.date(2020, 9, 9) is not a date-formatted string
+        """
+        spec = self.config._doc
+        spec['columns'].append({
+          "type": "expression",
+          "column_id": "month",
+          "display": "month",
+          "transform": {
+            "type": "custom",
+            "custom_type": "month_display"
+          },
+          "expression": {
+            "type": "constant",
+            "constant": "2020-09-09"
+          }
+        })
+        wrapped = ReportConfiguration.wrap(spec)
+        wrapped.validate()
+
 
 class ReportConfigurationDbTest(TestCase):
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12116

## Summary
Same fix as for https://github.com/dimagi/commcare-hq/pull/8042

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Covered by existing tests + new test added.

### Safety story
There are not date fields in the ReportConfiguration class so this change should have any further impact.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
