### PR TITLE
Automatic build version retrieval management command

### DIFF
--- a/corehq/apps/builds/README.rst
+++ b/corehq/apps/builds/README.rst
@@ -107,7 +107,6 @@ Adding CommCare (J2ME) Builds to CommCare HQ
 - In the second section `Import a new build from the build server`
 
    #. In the Version field input the version in `x.y.z` format
-   #. In `Build Number` input any number (it doesn't matter what number)
    #. Click `Import Build`
 - In the first section `Menu Options` add the version to HQ to make sure the build is available in the app settings.
 

--- a/corehq/apps/builds/management/commands/add_commcare_build.py
+++ b/corehq/apps/builds/management/commands/add_commcare_build.py
@@ -1,6 +1,8 @@
-from django.core.management.base import BaseCommand, CommandError
+import random
+from github import Github
 
-from corehq.apps.builds.models import CommCareBuild
+from django.core.management.base import BaseCommand, CommandError
+from corehq.apps.builds.models import CommCareBuild, CommCareBuildConfig, BuildMenuItem, BuildSpec
 
 
 class Command(BaseCommand):
@@ -8,19 +10,82 @@ class Command(BaseCommand):
             'to get started see https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/builds/README.md')
 
     def add_arguments(self, parser):
-        parser.add_argument('build_path')
-        parser.add_argument('version')
-        parser.add_argument('build_number')
+        parser.add_argument('build_path', nargs='?')
+        parser.add_argument('version', nargs='?')
+        parser.add_argument('build_number', nargs='?')
+        parser.add_argument(
+            '-l',
+            '--latest',
+            action='store_true',
+            help="add the latest remote CommCare build version"
+        )
 
     def handle(self, build_path, version, build_number, **options):
-        try:
-            build_number = int(build_number)
-        except ValueError:
-            raise CommandError("Build Number %r is not an integer" % build_number)
+        if options.get('latest'):
+            _create_build_from_latest_remote_version()
+        else:
+            if build_path and version and build_number:
+                try:
+                    build_number = int(build_number)
+                except ValueError:
+                    raise CommandError("Build Number %r is not an integer" % build_number)
 
-        try:
-            CommCareBuild.create_from_zip(build_path, version, build_number)
-        except Exception as e:
-            raise CommandError("%s" % e)
-        self.stdout.write('Build %s #%s created\n' % (version, build_number))
-        self.stdout.write('You can see a list of builds at [your-server]/builds/\n')
+                try:
+                    CommCareBuild.create_from_zip(build_path, version, build_number)
+                except Exception as e:
+                    raise CommandError("%s" % e)
+                self.stdout.write('Build %s #%s created\n' % (version, build_number))
+                self.stdout.write('You can see a list of builds at [your-server]/builds/\n')
+            else:
+                raise CommandError("<build_path>, <version> or <build_number> not specified!")
+
+
+def _create_build_from_latest_remote_version():
+    version = _get_latest_commcare_build_version()
+    # arbitrary build_number
+    build_number = random.randint(0, 100)
+
+    CommCareBuild.create_without_artifacts(version, build_number)
+    _update_commcare_build_menu(version, build_number)
+
+
+def _get_latest_commcare_build_version():
+    repo = Github().get_organization('dimagi').get_repo("commcare-android")
+    latest_release_tag = repo.get_latest_release().tag_name
+
+    return latest_release_tag.split('commcare_')[1]
+
+
+def _update_commcare_build_menu(version, build_number):
+    doc = CommCareBuildConfig.fetch()
+    _add_build_menu_item(doc, version, build_number)
+    _update_default_build_spec_to_version(doc, version)
+
+    CommCareBuildConfig.get_db().save_doc(doc)
+    CommCareBuildConfig.clear_local_cache()
+
+
+def _add_build_menu_item(doc, version, build_number):
+    build_menu_items = doc.menu
+
+    build_menu_item = next(
+        (build_item for build_item in build_menu_items if build_item.build.version == version),
+        None
+    )
+    if build_menu_item is None:
+        build = BuildSpec(version=version, build_number=build_number, latest=True)
+        build_menu_item = BuildMenuItem(build=build, label="CommCare {}".format(version), j2me_enabled=False)
+        build_menu_items.append(build_menu_item)
+
+
+def _update_default_build_spec_to_version(doc, version):
+    major_version = version[0]
+    defaults = doc.defaults
+
+    major_default_build_spec = next(
+        (default for default in defaults if default.version.startswith(major_version)),
+        None
+    )
+
+    if major_default_build_spec and major_default_build_spec.version != version:
+        major_default_build_spec.version = version

--- a/corehq/apps/builds/static/builds/js/edit-builds.js
+++ b/corehq/apps/builds/static/builds/js/edit-builds.js
@@ -95,13 +95,13 @@ hqDefine('builds/js/edit-builds', [
     $("#menu-form").koApplyBindings(buildsMenu);
 
     function legacySupportViewModel() {
-         var self = {};
-         self.legacy_support_checked = ko.observable(false);
+        var self = {};
+        self.legacy_support_checked = ko.observable(false);
 
-         self.toggle_show_legacy = function() {
-               self.legacy_support_checked(!self.legacy_support_checked());
-         };
-         return self;
+        self.toggle_show_legacy = function() {
+            self.legacy_support_checked(!self.legacy_support_checked());
+        };
+        return self;
     }
     $("#legacy-support").koApplyBindings(new legacySupportViewModel());
 

--- a/corehq/apps/builds/static/builds/js/edit-builds.js
+++ b/corehq/apps/builds/static/builds/js/edit-builds.js
@@ -94,16 +94,16 @@ hqDefine('builds/js/edit-builds', [
     var buildsMenu = menuModel();
     $("#menu-form").koApplyBindings(buildsMenu);
 
-    function legacySupportViewModel() {
+    function LegacySupportViewModel() {
         var self = {};
         self.legacy_support_checked = ko.observable(false);
 
-        self.toggle_show_legacy = function() {
+        self.toggle_show_legacy = function () {
             self.legacy_support_checked(!self.legacy_support_checked());
         };
         return self;
     }
-    $("#legacy-support").koApplyBindings(new legacySupportViewModel());
+    $("#legacy-support").koApplyBindings(LegacySupportViewModel());
 
     function postGo(url, params) {
         var $form = $("#submit-menu-form")

--- a/corehq/apps/builds/static/builds/js/edit-builds.js
+++ b/corehq/apps/builds/static/builds/js/edit-builds.js
@@ -94,6 +94,17 @@ hqDefine('builds/js/edit-builds', [
     var buildsMenu = menuModel();
     $("#menu-form").koApplyBindings(buildsMenu);
 
+    function legacySupportViewModel() {
+         var self = {};
+         self.legacy_support_checked = ko.observable(false);
+
+         self.toggle_show_legacy = function() {
+               self.legacy_support_checked(!self.legacy_support_checked());
+         };
+         return self;
+    }
+    $("#legacy-support").koApplyBindings(new legacySupportViewModel());
+
     function postGo(url, params) {
         var $form = $("#submit-menu-form")
             .attr("action", url);

--- a/corehq/apps/builds/static/builds/js/edit-builds.js
+++ b/corehq/apps/builds/static/builds/js/edit-builds.js
@@ -94,17 +94,6 @@ hqDefine('builds/js/edit-builds', [
     var buildsMenu = menuModel();
     $("#menu-form").koApplyBindings(buildsMenu);
 
-    function LegacySupportViewModel() {
-        var self = {};
-        self.legacy_support_checked = ko.observable(false);
-
-        self.toggle_show_legacy = function () {
-            self.legacy_support_checked(!self.legacy_support_checked());
-        };
-        return self;
-    }
-    $("#legacy-support").koApplyBindings(LegacySupportViewModel());
-
     function postGo(url, params) {
         var $form = $("#submit-menu-form")
             .attr("action", url);

--- a/corehq/apps/builds/templates/builds/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/edit_menu.html
@@ -132,45 +132,83 @@
             {% trans "Version*" %}
           </label>
           <div class="col-sm-8">
-            <input id="import_build_version" type="text" name="version" class="form-control" />
-          </div>
-        </div>
-        <div class="form-group">
-          <label class="control-label col-sm-3" for="import_build_build_number">
-            {% trans "Build Number*" %}
-          </label>
-          <div class="col-sm-8">
-            <input id="import_build_build_number" type="text" name="build_number" class="form-control" />
+            <input id="import_build_version" type="text" name="version" class="form-control"/>
             <ol class="help-block">
-              <li><a href="http://jenkins.dimagi.com/view/CommCare%20Mobile/" target="_blank">{% trans "Browse builds" %}</a></li>
               <li>
-                {% blocktrans %}
-                  Click on the appropriate commcare-android-2.X link
-                {% endblocktrans %}
+                <a href="https://github.com/dimagi/commcare-android/releases" target="_blank">
+                  {% trans "Browse versions" %}
+                </a>
               </li>
-              <li>{% trans "Click on the most recent successful build in the table at left" %}</li>
-              <li>{% trans "Grab the version, a six-digit number, from the URL" %}</li>
+              <li>{% trans "Paste the latest version in the box above in the format x.y.z" %}</li>
+              <li>{% trans "Click Import Build" %}</li>
+              <li>
+                {% trans "You can alternatively follow" %}
+                <a
+                  href="https://github.com/dimagi/commcare-cloud/blob/master/docs/setup/new_environment.md#add-a-new-commcare-build"
+                  target="_blank">
+                  {% trans "these steps" %}
+                </a>
+                {% trans "to automatically get the latest version" %}
+              </li>
             </ol>
           </div>
         </div>
-        <div class="form-group">
-          <label class="control-label col-sm-3" for="import_build_name">
-            {% trans "Source for artifacts.zip (J2ME only)" %}
-          </label>
-          <div class="col-sm-8">
-            <input id="import_build_name" type="text" name="source" class="form-control" />
-            <ol class="help-block">
-              <li><a href="http://jenkins.dimagi.com/view/CommCare%20Mobile/" target="_blank">{% trans "Browse builds" %}</a></li>
-              <li>
-                {% blocktrans %}
-                  Click on the appropriate commcare-core-2.X link
-                {% endblocktrans %}
-              </li>
-              <li>{% trans "Click on the most recent successful build in the table at left" %}</li>
-              <li>{% trans "Click 'Build Artifacts' -> 'application' -> 'posttmp'" %}</li>
-              <li>{% trans "Right-click on 'artifacts.zip' and select 'Copy Link Address'" %}</li>
-              <li>{% trans "Paste the address into the box above" %}</li>
-            </ol>
+
+        <div id="legacy-support">
+          <div class="form-group">
+            <div class="col-sm-3">
+              <input id="j2me-toggle" type="checkbox"
+                     data-bind="checked: legacy_support_checked, onclick: toggle_show_legacy()"/>
+              <label for="j2me-toggle">{% trans "Import artifacts.zip" %}</label>
+            </div>
+          </div>
+          <div data-bind="hidden: !legacy_support_checked()">
+            <div class="form-group">
+              <label class="control-label col-sm-3" for="import_build_build_number">
+                {% trans "Build Number" %}
+              </label>
+              <div class="col-sm-8">
+                <input id="import_build_build_number" type="text" name="build_number" class="form-control"/>
+                <ol class="help-block">
+                  <li>
+                    <a href="http://jenkins.dimagi.com/view/CommCare%20Mobile/" target="_blank">
+                      {% trans "Browse builds" %}
+                    </a>
+                  </li>
+                  <li>
+                    {% blocktrans %}
+                    Click on the appropriate commcare-android-2.X link
+                    {% endblocktrans %}
+                  </li>
+                  <li>{% trans "Click on the most recent successful build in the table at left" %}</li>
+                  <li>{% trans "Grab the version, a six-digit number, from the URL" %}</li>
+                </ol>
+              </div>
+            </div>
+            <div class="form-group">
+              <label class="control-label col-sm-3" for="import_build_name">
+                {% trans "Source for artifacts.zip (J2ME only)" %}
+              </label>
+              <div class="col-sm-8">
+                <input id="import_build_name" type="text" name="source" class="form-control"/>
+                <ol class="help-block">
+                  <li>
+                    <a href="http://jenkins.dimagi.com/view/CommCare%20Mobile/" target="_blank">
+                      {% trans "Browse builds" %}
+                    </a>
+                  </li>
+                  <li>
+                    {% blocktrans %}
+                    Click on the appropriate commcare-core-2.X link
+                    {% endblocktrans %}
+                  </li>
+                  <li>{% trans "Click on the most recent successful build in the table at left" %}</li>
+                  <li>{% trans "Click 'Build Artifacts' -> 'application' -> 'posttmp'" %}</li>
+                  <li>{% trans "Right-click on 'artifacts.zip' and select 'Copy Link Address'" %}</li>
+                  <li>{% trans "Paste the address into the box above" %}</li>
+                </ol>
+              </div>
+            </div>
           </div>
         </div>
         <div class="form-actions">

--- a/corehq/apps/builds/templates/builds/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/edit_menu.html
@@ -6,220 +6,218 @@
 {% requirejs_main 'builds/js/edit-builds' %}
 
 {% block stylesheets %}
-  <style type="text/css">
+<style type="text/css">
     .container.ui-widget {
       border: none;
     }
     #menu-table td {
       line-height: 30px;
     }
-  </style>
+
+
+
+</style>
 {% endblock %}
 
 {% block page_title %}
-  {% trans "Editing CommCare Builds" %}
+{% trans "Editing CommCare Builds" %}
 {% endblock %}
 
 {% block page_content %}
-  {% initial_page_data 'doc' doc %}
-  {% initial_page_data 'available_versions' all_versions %}
-  {% initial_page_data 'j2me_enabled_versions' j2me_enabled_versions %}
-  <div class="alert alert-info"><strong>{% trans "Editing" %} {{ doc.ID }}</strong></div>
+{% initial_page_data 'doc' doc %}
+{% initial_page_data 'available_versions' all_versions %}
+{% initial_page_data 'j2me_enabled_versions' j2me_enabled_versions %}
+<div class="alert alert-info"><strong>{% trans "Editing" %} {{ doc.ID }}</strong></div>
 
 
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h3 class="panel-title">{% trans "Menu Options" %}</h3>
-    </div>
-    <div class="panel-body">
-      <form id="menu-form" class="form-horizontal" action="." method="POST">{% csrf_token %}
-        <table id="menu-table" class="table table-striped">
-          <thead>
-          <tr>
-            <th></th>
-            <th>{% trans "Version" %}</th>
-            <th>{% trans "Label" %}</th>
-            <th>{% trans "Superuser Only" %}</th>
-            <th>{% trans "J2me Enabled" %}</th>
-            <th></th>
-          </tr>
-          </thead>
-          <tbody data-bind="sortable: versions">
-          <tr>
-            <td class="sortable-handle">
-              <i class="fa fa-arrows-v"></i>
-            </td>
-            <td>
-              <select class="form-control" data-bind="
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title">{% trans "Menu Options" %}</h3>
+  </div>
+  <div class="panel-body">
+    <form id="menu-form" class="form-horizontal" action="." method="POST">{% csrf_token %}
+      <table id="menu-table" class="table table-striped">
+        <thead>
+        <tr>
+          <th></th>
+          <th>{% trans "Version" %}</th>
+          <th>{% trans "Label" %}</th>
+          <th>{% trans "Superuser Only" %}</th>
+          <th>{% trans "J2me Enabled" %}</th>
+          <th></th>
+        </tr>
+        </thead>
+        <tbody data-bind="sortable: versions">
+        <tr>
+          <td class="sortable-handle">
+            <i class="fa fa-arrows-v"></i>
+          </td>
+          <td>
+            <select class="form-control" data-bind="
                                     options: $root.available_versions,
                                     value: version
                                 ">
-              </select>
-            </td>
-            <td>
-              <input class="form-control" type="text" data-bind="value: label">
-            </td>
-            <td>
-              <input type="checkbox" value="superuser-only" data-bind="checked: superuser_only" />
-            </td>
-            <td class='j2me_enabled'>
-              <i class="fa fa-check" data-bind="visible: j2me_enabled"></i>
-            </td>
-            <td>
-              <button type="button" class="btn btn-danger" data-bind="click: $root.removeVersion">
-                <i class="fa fa-remove"></i>
-              </button>
-            </td>
-          </tr>
-          </tbody>
-          <tr>
-            <td colspan="5">
-              <button data-bind="click: addVersion" class="btn btn-default">
-                <i class="fa fa-plus"></i>
-                {% trans "Add a Version" %}
-              </button>
-            </td>
-          </tr>
-        </table>
+            </select>
+          </td>
+          <td>
+            <input class="form-control" type="text" data-bind="value: label">
+          </td>
+          <td>
+            <input type="checkbox" value="superuser-only" data-bind="checked: superuser_only"/>
+          </td>
+          <td class='j2me_enabled'>
+            <i class="fa fa-check" data-bind="visible: j2me_enabled"></i>
+          </td>
+          <td>
+            <button type="button" class="btn btn-danger" data-bind="click: $root.removeVersion">
+              <i class="fa fa-remove"></i>
+            </button>
+          </td>
+        </tr>
+        </tbody>
+        <tr>
+          <td colspan="5">
+            <button data-bind="click: addVersion" class="btn btn-default">
+              <i class="fa fa-plus"></i>
+              {% trans "Add a Version" %}
+            </button>
+          </td>
+        </tr>
+      </table>
 
-        <hr />
+      <hr/>
 
-        <fieldset>
-          <legend>Defaults</legend>
-          <div class="form-group">
-            <label class="control-label col-sm-3" for="select-default-1">
-              {% trans "Default 1.x Build" %}
-            </label>
-            <div class="col-sm-8">
-              <select class="form-control" id="select-default-1" data-bind="
-                                options: available_ones,
-                                value: default_one"></select>
-            </div>
-          </div>
-          <div class="form-group">
-            <label class="control-label col-sm-3" for="select-default-2">
-              {% trans "Default 2.x Build" %}
-            </label>
-            <div class="col-sm-8">
-              <select class="form-control" id="select-default-2" data-bind="
-                                    options: available_twos,
-                                    value: default_two"></select>
-            </div>
-          </div>
-          <div class="form-actions">
-            <div class="col-sm-offset-3">
-              <button class="btn btn-primary" type="button">Update Menu Options</button>
-            </div>
-          </div>
-        </fieldset>
-      </form>
-      <form id="submit-menu-form" method="POST">
-        {% csrf_token %}
-      </form>
-    </div>
-  </div>
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h3 class="panel-title">
-        {% trans "Import a new build from the build server" %}
-      </h3>
-    </div>
-    <div class="panel-body">
-      <form class="form-horizontal" action="{% url 'import_build' %}" method="post">
-        {% csrf_token %}
+      <fieldset>
+        <legend>Defaults</legend>
         <div class="form-group">
-          <label class="control-label col-sm-3" for="import_build_version">
-            {% trans "Version*" %}
+          <label class="control-label col-sm-3" for="select-default-1">
+            {% trans "Default 1.x Build" %}
           </label>
           <div class="col-sm-8">
-            <input id="import_build_version" type="text" name="version" class="form-control"/>
-            <ol class="help-block">
-              <li>
-                <a href="https://github.com/dimagi/commcare-android/releases" target="_blank">
-                  {% trans "Browse versions" %}
-                </a>
-              </li>
-              <li>{% trans "Paste the latest version in the box above in the format x.y.z" %}</li>
-              <li>{% trans "Click Import Build" %}</li>
-              <li>
-                {% blocktrans %}
-                You can alternatively follow
-                <a
-                  href="https://github.com/dimagi/commcare-cloud/blob/master/docs/setup/new_environment.md#add-a-new-commcare-build"
-                  target="_blank">
-                  these steps
-                </a>
-                to automatically get the latest version
-                {% endblocktrans %}
-              </li>
-            </ol>
+            <select class="form-control" id="select-default-1" data-bind="
+                                options: available_ones,
+                                value: default_one"></select>
           </div>
         </div>
-
-        <div id="legacy-support">
-          <div class="form-group">
-            <div class="col-sm-3">
-              <input id="j2me-toggle" type="checkbox"
-                     data-bind="checked: legacy_support_checked, onclick: toggle_show_legacy()"/>
-              <label for="j2me-toggle">{% trans "Import artifacts.zip" %}</label>
-            </div>
-          </div>
-          <div data-bind="hidden: !legacy_support_checked()">
-            <div class="form-group">
-              <label class="control-label col-sm-3" for="import_build_build_number">
-                {% trans "Build Number" %}
-              </label>
-              <div class="col-sm-8">
-                <input id="import_build_build_number" type="text" name="build_number" class="form-control"/>
-                <ol class="help-block">
-                  <li>
-                    <a href="http://jenkins.dimagi.com/view/CommCare%20Mobile/" target="_blank">
-                      {% trans "Browse builds" %}
-                    </a>
-                  </li>
-                  <li>
-                    {% blocktrans %}
-                    Click on the appropriate commcare-android-2.X link
-                    {% endblocktrans %}
-                  </li>
-                  <li>{% trans "Click on the most recent successful build in the table at left" %}</li>
-                  <li>{% trans "Grab the version, a six-digit number, from the URL" %}</li>
-                </ol>
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="control-label col-sm-3" for="import_build_name">
-                {% trans "Source for artifacts.zip (J2ME only)" %}
-              </label>
-              <div class="col-sm-8">
-                <input id="import_build_name" type="text" name="source" class="form-control"/>
-                <ol class="help-block">
-                  <li>
-                    <a href="http://jenkins.dimagi.com/view/CommCare%20Mobile/" target="_blank">
-                      {% trans "Browse builds" %}
-                    </a>
-                  </li>
-                  <li>
-                    {% blocktrans %}
-                    Click on the appropriate commcare-core-2.X link
-                    {% endblocktrans %}
-                  </li>
-                  <li>{% trans "Click on the most recent successful build in the table at left" %}</li>
-                  <li>{% trans "Click 'Build Artifacts' -> 'application' -> 'posttmp'" %}</li>
-                  <li>{% trans "Right-click on 'artifacts.zip' and select 'Copy Link Address'" %}</li>
-                  <li>{% trans "Paste the address into the box above" %}</li>
-                </ol>
-              </div>
-            </div>
+        <div class="form-group">
+          <label class="control-label col-sm-3" for="select-default-2">
+            {% trans "Default 2.x Build" %}
+          </label>
+          <div class="col-sm-8">
+            <select class="form-control" id="select-default-2" data-bind="
+                                    options: available_twos,
+                                    value: default_two"></select>
           </div>
         </div>
         <div class="form-actions">
           <div class="col-sm-offset-3">
-            <button type="submit" class="btn btn-primary">{% trans "Import Build" %}</button>
+            <button class="btn btn-primary" type="button">Update Menu Options</button>
           </div>
         </div>
-      </form>
-    </div>
+      </fieldset>
+    </form>
+    <form id="submit-menu-form" method="POST">
+      {% csrf_token %}
+    </form>
   </div>
+</div>
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title">
+      {% trans "Import a new build from the build server" %}
+    </h3>
+  </div>
+  <div class="panel-body">
+    <form class="form-horizontal" action="{% url 'import_build' %}" method="post">
+      {% csrf_token %}
+      <div class="form-group">
+        <label class="control-label col-sm-3" for="import_build_version">
+          {% trans "Version*" %}
+        </label>
+        <div class="col-sm-8">
+          <input id="import_build_version" type="text" name="version" class="form-control"/>
+          <ol class="help-block">
+            <li>
+              <a href="https://github.com/dimagi/commcare-android/releases" target="_blank">
+                {% trans "Browse versions" %}
+              </a>
+            </li>
+            <li>{% trans "Paste the latest version in the box above in the format x.y.z" %}</li>
+            <li>{% trans "Click Import Build" %}</li>
+            <li>
+              {% blocktrans %}
+              You can also automatically fetch the latest build from GitHub using the following management command:
+              <b>./manage.py add_commcare_build --latest </b>
+              {% endblocktrans %}
+            </li>
+          </ol>
+        </div>
+      </div>
+
+      <div id="legacy-support">
+        <div class="form-group">
+          <div class="col-sm-3">
+            <input id="j2me-toggle" type="checkbox"
+                   data-bind="checked: legacy_support_checked, onclick: toggle_show_legacy()"/>
+            <label for="j2me-toggle">{% trans "Import artifacts.zip" %}</label>
+          </div>
+        </div>
+        <div data-bind="hidden: !legacy_support_checked()">
+          <div class="form-group">
+            <label class="control-label col-sm-3" for="import_build_build_number">
+              {% trans "Build Number" %}
+            </label>
+            <div class="col-sm-8">
+              <input id="import_build_build_number" type="text" name="build_number" class="form-control"/>
+              <ol class="help-block">
+                <li>
+                  <a href="http://jenkins.dimagi.com/view/CommCare%20Mobile/" target="_blank">
+                    {% trans "Browse builds" %}
+                  </a>
+                </li>
+                <li>
+                  {% blocktrans %}
+                  Click on the appropriate commcare-android-2.X link
+                  {% endblocktrans %}
+                </li>
+                <li>{% trans "Click on the most recent successful build in the table at left" %}</li>
+                <li>{% trans "Grab the version, a six-digit number, from the URL" %}</li>
+              </ol>
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="control-label col-sm-3" for="import_build_name">
+              {% trans "Source for artifacts.zip (J2ME only)" %}
+            </label>
+            <div class="col-sm-8">
+              <input id="import_build_name" type="text" name="source" class="form-control"/>
+              <ol class="help-block">
+                <li>
+                  <a href="http://jenkins.dimagi.com/view/CommCare%20Mobile/" target="_blank">
+                    {% trans "Browse builds" %}
+                  </a>
+                </li>
+                <li>
+                  {% blocktrans %}
+                  Click on the appropriate commcare-core-2.X link
+                  {% endblocktrans %}
+                </li>
+                <li>{% trans "Click on the most recent successful build in the table at left" %}</li>
+                <li>{% trans "Click 'Build Artifacts' -> 'application' -> 'posttmp'" %}</li>
+                <li>{% trans "Right-click on 'artifacts.zip' and select 'Copy Link Address'" %}</li>
+                <li>{% trans "Paste the address into the box above" %}</li>
+              </ol>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="form-actions">
+        <div class="col-sm-offset-3">
+          <button type="submit" class="btn btn-primary">{% trans "Import Build" %}</button>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>
 
 {% endblock %}

--- a/corehq/apps/builds/templates/builds/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/edit_menu.html
@@ -132,7 +132,7 @@
       {% csrf_token %}
       <div class="form-group">
         <label class="control-label col-sm-3" for="import_build_version">
-          {% trans "Version*" %}
+          {% trans "Version" %}
         </label>
         <div class="col-sm-8">
           <input id="import_build_version" type="text" name="version" class="form-control"/>
@@ -151,64 +151,6 @@
               {% endblocktrans %}
             </li>
           </ol>
-        </div>
-      </div>
-
-      <div id="legacy-support">
-        <div class="form-group">
-          <div class="col-sm-3">
-            <input id="j2me-toggle" type="checkbox"
-                   data-bind="checked: legacy_support_checked, onclick: toggle_show_legacy()"/>
-            <label for="j2me-toggle">{% trans "Import artifacts.zip" %}</label>
-          </div>
-        </div>
-        <div data-bind="hidden: !legacy_support_checked()">
-          <div class="form-group">
-            <label class="control-label col-sm-3" for="import_build_build_number">
-              {% trans "Build Number" %}
-            </label>
-            <div class="col-sm-8">
-              <input id="import_build_build_number" type="text" name="build_number" class="form-control"/>
-              <ol class="help-block">
-                <li>
-                  <a href="http://jenkins.dimagi.com/view/CommCare%20Mobile/" target="_blank">
-                    {% trans "Browse builds" %}
-                  </a>
-                </li>
-                <li>
-                  {% blocktrans %}
-                  Click on the appropriate commcare-android-2.X link
-                  {% endblocktrans %}
-                </li>
-                <li>{% trans "Click on the most recent successful build in the table at left" %}</li>
-                <li>{% trans "Grab the version, a six-digit number, from the URL" %}</li>
-              </ol>
-            </div>
-          </div>
-          <div class="form-group">
-            <label class="control-label col-sm-3" for="import_build_name">
-              {% trans "Source for artifacts.zip (J2ME only)" %}
-            </label>
-            <div class="col-sm-8">
-              <input id="import_build_name" type="text" name="source" class="form-control"/>
-              <ol class="help-block">
-                <li>
-                  <a href="http://jenkins.dimagi.com/view/CommCare%20Mobile/" target="_blank">
-                    {% trans "Browse builds" %}
-                  </a>
-                </li>
-                <li>
-                  {% blocktrans %}
-                  Click on the appropriate commcare-core-2.X link
-                  {% endblocktrans %}
-                </li>
-                <li>{% trans "Click on the most recent successful build in the table at left" %}</li>
-                <li>{% trans "Click 'Build Artifacts' -> 'application' -> 'posttmp'" %}</li>
-                <li>{% trans "Right-click on 'artifacts.zip' and select 'Copy Link Address'" %}</li>
-                <li>{% trans "Paste the address into the box above" %}</li>
-              </ol>
-            </div>
-          </div>
         </div>
       </div>
       <div class="form-actions">

--- a/corehq/apps/builds/templates/builds/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/edit_menu.html
@@ -142,13 +142,15 @@
               <li>{% trans "Paste the latest version in the box above in the format x.y.z" %}</li>
               <li>{% trans "Click Import Build" %}</li>
               <li>
-                {% trans "You can alternatively follow" %}
+                {% blocktrans %}
+                You can alternatively follow
                 <a
                   href="https://github.com/dimagi/commcare-cloud/blob/master/docs/setup/new_environment.md#add-a-new-commcare-build"
                   target="_blank">
-                  {% trans "these steps" %}
+                  these steps
                 </a>
-                {% trans "to automatically get the latest version" %}
+                to automatically get the latest version
+                {% endblocktrans %}
               </li>
             </ol>
           </div>

--- a/corehq/apps/builds/views.py
+++ b/corehq/apps/builds/views.py
@@ -1,4 +1,5 @@
 import io
+import random
 
 from django.contrib import messages
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
@@ -143,6 +144,8 @@ def import_build(request):
             return json_response({
                 'reason': 'build_number must be an int'
             }, status_code=400)
+    else:
+        build_number = random.randint(0, 100)
 
     session = requests.session()
 

--- a/corehq/apps/builds/views.py
+++ b/corehq/apps/builds/views.py
@@ -1,5 +1,4 @@
 import io
-import random
 
 from django.contrib import messages
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
@@ -120,7 +119,8 @@ def import_build(request):
     """
     source = request.POST.get('source')
     version = request.POST.get('version')
-    build_number = request.POST.get('build_number')
+    # build_number must be strictly valid or None
+    build_number = request.POST.get('build_number') or None
 
     try:
         SemanticVersionProperty(required=True).validate(version)
@@ -144,8 +144,6 @@ def import_build(request):
             return json_response({
                 'reason': 'build_number must be an int'
             }, status_code=400)
-    else:
-        build_number = random.randint(0, 100)
 
     session = requests.session()
 

--- a/corehq/apps/builds/views.py
+++ b/corehq/apps/builds/views.py
@@ -30,9 +30,9 @@ from .utils import extract_build_info_from_filename, get_all_versions
 @json_error
 @require_api_user
 def post(request):
-    artifacts       = request.FILES.get('artifacts')
-    build_number    = request.POST.get('build_number')
-    version         = request.POST.get('version')
+    artifacts = request.FILES.get('artifacts')
+    build_number = request.POST.get('build_number')
+    version = request.POST.get('version')
     try:
         build_number = int(build_number)
     except Exception:
@@ -100,27 +100,14 @@ class EditMenuView(BasePageView):
         return HttpResponseRedirect(self.page_url)
 
 
-KNOWN_BUILD_SERVER_LOGINS = {
-    'http://build.dimagi.com:250/': (
-        lambda session:
-        session.get('http://build.dimagi.com:250/guestLogin.html?guest=1')
-    )
-}
-
-
 @require_POST
 def import_build(request):
     """
     example POST params:
-    source: 'http://build.dimagi.com:250/repository/downloadAll/bt97/14163:id/artifacts.zip'
     version: '2.13.0'
-    build_number: 32703
 
     """
-    source = request.POST.get('source')
     version = request.POST.get('version')
-    # build_number must be strictly valid or None
-    build_number = request.POST.get('build_number') or None
 
     try:
         SemanticVersionProperty(required=True).validate(version)
@@ -133,65 +120,12 @@ def import_build(request):
             }
         }, status_code=400)
 
-    if build_number:
-        # Strip and remove
-        # U+200B ZERO WIDTH SPACE
-        # https://manage.dimagi.com/default.asp?262198
-        build_number = build_number.strip().replace('\u200b', '')
-        try:
-            build_number = int(build_number)
-        except ValueError:
-            return json_response({
-                'reason': 'build_number must be an int'
-            }, status_code=400)
+    build = CommCareBuild.create_without_artifacts(version, None)
 
-    session = requests.session()
-
-    # log in to the build server if we know how
-    for key in KNOWN_BUILD_SERVER_LOGINS:
-        if source.startswith(key):
-            KNOWN_BUILD_SERVER_LOGINS[key](session)
-
-    if source:
-        r = session.get(source)
-
-        try:
-            r.raise_for_status()
-        except requests.exceptions.HTTPError:
-            return json_response({
-                'reason': 'Fetching artifacts.zip failed',
-                'response': {
-                    'status_code': r.status_code,
-                    'content': r.content,
-                    'headers': r.headers,
-                }
-            }, status_code=400)
-        try:
-            _, inferred_build_number = (
-                extract_build_info_from_filename(r.headers['content-disposition'])
-            )
-        except (KeyError, ValueError):  # no header or header doesn't match
-            inferred_build_number = None
-
-        if inferred_build_number:
-            build_number = inferred_build_number
-
-        if not build_number:
-            return json_response({
-                'reason': "You didn't give us a build number "
-                          "and we couldn't infer it"
-            }, status_code=400)
-
-        build = CommCareBuild.create_from_zip(
-            io.BytesIO(r.content), version, build_number)
-
-    else:
-        build = CommCareBuild.create_without_artifacts(version, build_number)
     return json_response({
         'message': 'New CommCare build added',
         'info': {
             'version': version,
-            'build_number': build_number,
             '_id': build.get_id,
         }
     })


### PR DESCRIPTION
## Summary
Changes:
- Expand the management command _add_commcare_build_ by allowing the user to retrieve the latest CommCare build version and automatically update the user's builds menu as well as defaults to the latest version. To be used like this: `add_commcare_build --latest`
- Obscures the input box for artifact.zip source specification on the /builds/edit_menu/ page by adding a checkbox in case the user still wishes to do so manually. This was done to make the UI less confusing.

See ticket [here](https://dimagi-dev.atlassian.net/browse/SC-751).

## Product Description
User has to click on a checkbox to be able to use local build imports; otherwise obscured.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
