### PR TITLE
Fixed an error with deleting repeaters

### DIFF
--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -161,17 +161,21 @@ class ConnectionSettingsListView(BaseProjectSettingsView, CRUDPaginatedViewMixin
             }
 
     def _get_item_data(self, connection_settings):
-        return {
+        data = {
             'id': connection_settings.id,
             'name': connection_settings.name,
             'url': connection_settings.url,
             'notifyAddresses': ', '.join(connection_settings.notify_addresses),
             'usedBy': ', '.join(connection_settings.used_by),
-            'editUrl': reverse(
+        }
+
+        if connection_settings.id is not None:
+            data['editUrl'] = reverse(
                 ConnectionSettingsDetailView.urlname,
                 kwargs={'domain': self.domain, 'pk': connection_settings.id}
-            ),
-        }
+            )
+
+        return data
 
     def get_deleted_item_data(self, item_id):
         connection_settings = ConnectionSettings.objects.get(


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12122. Came across this while working on another repeater issue. If you delete an existing repeater, it will succeed, but when it tried to fetch the deleted information to display to the user, the id no longer exists and indicates a server error occurred.


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests

### QA Plan

No QA needed

### Safety story

This was locally tested

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
