### PR TITLE
update wording for overwrite menu

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_actions.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_actions.html
@@ -27,12 +27,12 @@
 <div class="panel panel-appmanager">
   <div class="panel-heading">
     <h4 class="panel-title panel-title-nolink">
-      {% trans "Overwrite Case List" %}
+      {% trans "Copy Case List to another menu" %}
     </h4>
   </div>
   <div class="panel-body">
     <p class="help-block">
-      {% trans "This will <strong>overwrite</strong> the selected case list configuration with that of the current menu." %}
+      {% trans "This will <strong>overwrite</strong> the case list of the selected menu with the current menu's case list configuration." %}
     </p>
     {% with detail_type="short" %}
       {% include 'app_manager/partials/modules/case_list_module_overwrite.html' %}
@@ -42,12 +42,12 @@
 <div class="panel panel-appmanager">
   <div class="panel-heading">
     <h4 class="panel-title panel-title-nolink">
-      {% trans "Overwrite Case Detail" %}
+      {% trans "Copy Case Detail to another menu" %}
     </h4>
   </div>
   <div class="panel-body">
     <p class="help-block">
-      {% trans "This will <strong>overwrite</strong> the selected case detail configuration with that of the current menu." %}
+      {% trans "This will <strong>overwrite</strong> the case detail of the selected menu with the current menu's case detail configuration." %}
     </p>
     <br><br>
     {% with detail_type="long" %}


### PR DESCRIPTION
## Summary
Suggested wording change to make it clear which direction the 'overwrite' is taking place. When I first used this I had thought that the menu of the current module would be overwritten by the menu of the one I selected but it turns out to be the other way around.

I think this wording change will make it clearer that the copy direction is from the current menu -> the menu selected.


## Product Description
Wording change for case list / case detail overwrite.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story
Text change only.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
