### PR TITLE
Assign sorting to correct field in case detail screen for detail tabs with nodesets

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -95,7 +95,7 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
 
             # To list app strings for properties used as sorting properties only
             if detail.sort_elements:
-                sort_only, sort_columns = get_sort_and_sort_only_columns(detail, detail.sort_elements)
+                sort_only, sort_columns = get_sort_and_sort_only_columns(detail.get_columns(), detail.sort_elements)
                 for field, sort_element, order in sort_only:
                     if sort_element.has_display_values():
                         column = create_temp_sort_column(sort_element, order)

--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -57,16 +57,18 @@ class SuiteGenerator(object):
         self.build_profile_id = build_profile_id
 
     def _add_sections(self, contributors):
+        elements = {}
         for contributor in contributors:
             section = contributor.section_name
-            getattr(self.suite, section).extend(
-                contributor.get_section_elements()
-            )
+            section_elements = contributor.get_section_elements()
+            elements[section] = section_elements
+            getattr(self.suite, section).extend(section_elements)
+        return elements
 
     def generate_suite(self):
         # Note: the order in which things happen in this function matters
 
-        self._add_sections([
+        basic_elements = self._add_sections([
             FormResourceContributor(self.suite, self.app, self.modules, self.build_profile_id),
             LocaleResourceContributor(self.suite, self.app, self.modules, self.build_profile_id),
             DetailContributor(self.suite, self.app, self.modules, self.build_profile_id),
@@ -88,7 +90,7 @@ class SuiteGenerator(object):
         else:
             training_menu = None
 
-        detail_section_elements = DetailContributor(None, self.app, self.modules).get_section_elements()
+        detail_section_elements = basic_elements[DetailContributor.section_name]
         for module in self.modules:
             self.suite.entries.extend(entries.get_module_contributions(module))
 

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -1,5 +1,5 @@
 import os
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 from xml.sax.saxutils import escape
 
 from eulxml.xmlmap.core import load_xmlobject_from_string
@@ -54,9 +54,6 @@ class DetailContributor(SectionContributor):
     section_name = 'details'
 
     def get_section_elements(self):
-        def include_sort(detail_type, detail):
-            return detail_type.endswith('short') or detail.sort_nodeset_columns_for_detail()
-
         if self.app.use_custom_suite:
             return []
 
@@ -69,11 +66,15 @@ class DetailContributor(SectionContributor):
                 if detail.custom_xml:
                     elements.append(self._get_custom_xml_detail(module, detail, detail_type))
                 else:
-                    detail_column_infos = get_detail_column_infos(
-                        detail_type,
-                        detail,
-                        include_sort=include_sort(detail_type, detail),
-                    )  # list of DetailColumnInfo named tuples
+                    if detail.sort_nodeset_columns_for_detail():
+                        # list of DetailColumnInfo named tuples
+                        detail_column_infos = get_detail_column_infos_for_tabs_with_sorting(detail)
+                    else:
+                        detail_column_infos = get_detail_column_infos(
+                            detail_type,
+                            detail,
+                            include_sort=detail_type.endswith('short'),
+                        )  # list of DetailColumnInfo named tuples
                     if detail_column_infos:
                         if detail.use_case_tiles:
                             helper = CaseTileHelper(self.app, module, detail,
@@ -427,14 +428,14 @@ class DetailsHelper(object):
 
 def get_nodeset_sort_elements(detail):
     from corehq.apps.app_manager.models import SortElement
-    sort_elements = []
+    sort_elements = defaultdict(list)
     tab_spans = detail.get_tab_spans()
     for tab in detail.get_tabs():
         if tab.nodeset:
             tab_span = tab_spans[tab.id]
             for column in detail.columns[tab_span[0]:tab_span[1]]:
                 if column.invisible:
-                    sort_elements.append(SortElement(
+                    sort_elements[tab.id].append(SortElement(
                         field=column.field,
                         type='string',
                         direction='ascending'
@@ -470,37 +471,25 @@ def get_default_sort_elements(detail):
     return sort_elements
 
 
-def get_detail_column_infos(detail_type, detail, include_sort):
-    """
-    This is not intented to be a widely used format
-    just a packaging of column info into a form most convenient for rendering
-    """
-    DetailColumnInfo = namedtuple('DetailColumnInfo',
-                                  'column sort_element order')
+# This is not intended to be a widely used format
+# just a packaging of column info into a form most convenient for rendering
+DetailColumnInfo = namedtuple('DetailColumnInfo', 'column sort_element order')
 
+
+def get_detail_column_infos(detail_type, detail, include_sort):
     if not include_sort:
         return [DetailColumnInfo(column, None, None) for column in detail.get_columns()]
 
     if detail.sort_elements:
         sort_elements = detail.sort_elements
-    elif detail.sort_nodeset_columns_for_detail():
-        sort_elements = get_nodeset_sort_elements(detail)
     else:
         sort_elements = get_default_sort_elements(detail)
 
-    sort_only, sort_columns = get_sort_and_sort_only_columns(detail, sort_elements)
+    sort_only, sort_columns = get_sort_and_sort_only_columns(detail.get_columns(), sort_elements)
 
     columns = []
-    invisible_fields = set()
-    if detail.sort_nodeset_columns_for_detail():
-        invisible_fields = {column.field for column in detail.get_columns() if column.invisible}
-
     for column in detail.get_columns():
-        if not column.invisible and column.field in invisible_fields:
-            # assign sorting to invisible fields with the same field name
-            sort_element, order = None, None
-        else:
-            sort_element, order = sort_columns.pop(column.field, (None, None))
+        sort_element, order = sort_columns.pop(column.field, (None, None))
         if getattr(sort_element, 'type', None) == 'index' and "search" in detail_type:
             columns.append(DetailColumnInfo(column, None, None))
         else:
@@ -512,6 +501,36 @@ def get_detail_column_infos(detail_type, detail, include_sort):
             columns.append(DetailColumnInfo(column, None, None))
         else:
             columns.append(DetailColumnInfo(column, sort_element, order))
+    return columns
+
+
+def get_detail_column_infos_for_tabs_with_sorting(detail):
+    """This serves the same purpose as `get_detail_column_infos` except
+    that it only applies to 'short' details that have tabs with nodesets and sorting
+    configured."""
+    sort_elements = get_nodeset_sort_elements(detail)
+
+    columns = []
+    tab_spans = detail.get_tab_spans()
+    detail_columns = list(detail.get_columns())  # do this to ensure we get the indexed values
+    for tab in detail.get_tabs():
+        tab_span = tab_spans[tab.id]
+        tab_columns = detail_columns[tab_span[0]:tab_span[1]]
+        if tab.nodeset and sort_elements[tab.id]:
+            tab_sorts = sort_elements[tab.id]
+            _, sort_columns = get_sort_and_sort_only_columns(tab_columns, tab_sorts)
+            for column in tab_columns:
+                if column.invisible:
+                    sort_element, order = sort_columns.pop(column.field, (None, None))
+                    columns.append(DetailColumnInfo(column, sort_element, order))
+                else:
+                    columns.append(DetailColumnInfo(column, None, None))
+        else:
+            columns.extend([
+                DetailColumnInfo(column, None, None)
+                for column in tab_columns
+            ])
+
     return columns
 
 

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -491,8 +491,16 @@ def get_detail_column_infos(detail_type, detail, include_sort):
     sort_only, sort_columns = get_sort_and_sort_only_columns(detail, sort_elements)
 
     columns = []
+    invisible_fields = set()
+    if detail.sort_nodeset_columns_for_detail():
+        invisible_fields = {column.field for column in detail.get_columns() if column.invisible}
+
     for column in detail.get_columns():
-        sort_element, order = sort_columns.pop(column.field, (None, None))
+        if not column.invisible and column.field in invisible_fields:
+            # assign sorting to invisible fields with the same field name
+            sort_element, order = None, None
+        else:
+            sort_element, order = sort_columns.pop(column.field, (None, None))
         if getattr(sort_element, 'type', None) == 'index' and "search" in detail_type:
             columns.append(DetailColumnInfo(column, None, None))
         else:

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -527,72 +527,175 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     def test_case_detail_tabs_with_nodesets_for_sorting_search_only_field(self, *args):
         app_json = self.get_json("app_case_detail_tabs_with_nodesets")
         app = Application.wrap(app_json)
-        # add duplicate column that gets displayed (2nd one is just for sorting)
-        # this is mostly done when the value is a date and you want to display
-        # a format that doesn't sort well
-        new_gender_col = DetailColumn.from_json(
+
+        # update app to add in 2 new columns both with the field 'gender'
+
+        # 1. add a column to the 2nd tab that is marked as 'search only'.
+        #    This should get sorting applied to it
+        tab_spans = app.modules[0].case_details.long.get_tab_spans()
+
+        # 2. add a second column to the last tab which already has a 'gender' field
+        #    This should result in the 'gender' field being displayed as well
+        #    as being used for sorting
+        sorted_gender_col = DetailColumn.from_json(
             app_json["modules"][0]["case_details"]["long"]["columns"][-1]
         )
-        new_gender_col.format = "plain"
+        app.modules[0].case_details.long.columns.insert(tab_spans[1][1] - 1, sorted_gender_col)
+        plain_gender_col = DetailColumn.from_json(
+            app_json["modules"][0]["case_details"]["long"]["columns"][-1]
+        )
+        plain_gender_col.format = "plain"
         index = len(app.modules[0].case_details.long.columns) - 1
-        app.modules[0].case_details.long.columns.insert(index, new_gender_col)
+        app.modules[0].case_details.long.columns.insert(index, plain_gender_col)
         app.modules[0].case_details.long.sort_nodeset_columns = True
         xml_partial = """
             <partial>
-                <detail nodeset="instance('commtrack:products')/some/data">
-                  <title>
-                    <text>
-                      <locale id="m0.case_long.tab.3.title"/>
-                    </text>
-                  </title>
-                  <field>
-                    <header>
+                <detail id="m0_case_long">
+                    <title>
                       <text>
-                        <locale id="m0.case_long.case_calculated_property_5.header"/>
+                        <locale id="cchq.case"/>
                       </text>
-                    </header>
-                    <template>
-                      <text>
-                        <xpath function="$calculated_property">
-                          <variable name="calculated_property">
-                            <xpath function="column"/>
-                          </variable>
-                        </xpath>
-                      </text>
-                    </template>
-                  </field>
-                  <field>
-                    <header>
-                      <text>
-                        <locale id="m0.case_long.case_gender_6.header"/>
-                      </text>
-                    </header>
-                    <template>
-                      <text>
-                        <xpath function="gender"/>
-                      </text>
-                    </template>
-                  </field>
-                  <field>
-                    <header width="0">
-                      <text/>
-                    </header>
-                    <template width="0">
-                      <text>
-                        <xpath function="gender"/>
-                      </text>
-                    </template>
-                    <sort type="string" order="1" direction="ascending">
-                      <text>
-                        <xpath function="gender"/>
-                      </text>
-                    </sort>
-                  </field>
-                </detail>
+                    </title>
+                    <detail>
+                      <title>
+                        <text>
+                          <locale id="m0.case_long.tab.1.title"/>
+                        </text>
+                      </title>
+                      <field>
+                        <header>
+                          <text>
+                            <locale id="m0.case_long.case_name_1.header"/>
+                          </text>
+                        </header>
+                        <template>
+                          <text>
+                            <xpath function="case_name"/>
+                          </text>
+                        </template>
+                      </field>
+                      <field>
+                        <header>
+                          <text>
+                            <locale id="m0.case_long.case_artist_2.header"/>
+                          </text>
+                        </header>
+                        <template>
+                          <text>
+                            <xpath function="artist"/>
+                          </text>
+                        </template>
+                      </field>
+                      <field>
+                        <header>
+                          <text>
+                            <locale id="m0.case_long.case_plays_3.header"/>
+                          </text>
+                        </header>
+                        <template>
+                          <text>
+                            <xpath function="plays"/>
+                          </text>
+                        </template>
+                      </field>
+                    </detail>
+                    <detail nodeset="some/data">
+                      <title>
+                        <text>
+                          <locale id="m0.case_long.tab.2.title"/>
+                        </text>
+                      </title>
+                      <field>
+                        <header width="0">
+                          <text/>
+                        </header>
+                        <template width="0">
+                          <text>
+                            <xpath function="gender"/>
+                          </text>
+                        </template>
+                        <sort type="string" order="1" direction="ascending">
+                          <text>
+                            <xpath function="gender"/>
+                          </text>
+                        </sort>
+                      </field>
+                    </detail>
+                    <detail nodeset="instance('commtrack:products')/some/data">
+                      <title>
+                        <text>
+                          <locale id="m0.case_long.tab.3.title"/>
+                        </text>
+                      </title>
+                      <field>
+                        <header>
+                          <text>
+                            <locale id="m0.case_long.case_calculated_property_5.header"/>
+                          </text>
+                        </header>
+                        <template>
+                          <text>
+                            <xpath function="$calculated_property">
+                              <variable name="calculated_property">
+                                <xpath function="column"/>
+                              </variable>
+                            </xpath>
+                          </text>
+                        </template>
+                      </field>
+                      <field>
+                        <header>
+                          <text>
+                            <locale id="m0.case_long.case_calculated_property_6.header"/>
+                          </text>
+                        </header>
+                        <template>
+                          <text>
+                            <xpath function="$calculated_property">
+                              <variable name="calculated_property">
+                                <xpath function="column"/>
+                              </variable>
+                            </xpath>
+                          </text>
+                        </template>
+                      </field>
+                      <field>
+                        <header>
+                          <text>
+                            <locale id="m0.case_long.case_gender_7.header"/>
+                          </text>
+                        </header>
+                        <template>
+                          <text>
+                            <xpath function="gender"/>
+                          </text>
+                        </template>
+                      </field>
+                      <field>
+                        <header width="0">
+                          <text/>
+                        </header>
+                        <template width="0">
+                          <text>
+                            <xpath function="gender"/>
+                          </text>
+                        </template>
+                        <sort type="string" order="1" direction="ascending">
+                          <text>
+                            <xpath function="gender"/>
+                          </text>
+                        </sort>
+                      </field>
+                    </detail>
+                    <variables>
+                      <case_id function="./@case_id"/>
+                    </variables>
+                  </detail>
+
             </partial>"""
         self.assertXmlPartialEqual(
             xml_partial, app.create_suite(),
-            './detail[@id="m0_case_long"]/detail[3]')
+            './detail[@id="m0_case_long"]')
 
     def test_case_detail_instance_adding(self, *args):
         # Tests that post-processing adds instances used in calculations

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -510,14 +510,14 @@ def purge_report_from_mobile_ucr(report_config):
 SortOnlyElement = namedtuple("SortOnlyElement", "field, sort_element, order")
 
 
-def get_sort_and_sort_only_columns(detail, sort_elements):
+def get_sort_and_sort_only_columns(detail_columns, sort_elements):
     """
     extracts out info about columns that are added as only sort fields and columns added as both
     sort and display fields
     """
     sort_elements = OrderedDict((s.field, (s, i + 1)) for i, s in enumerate(sort_elements))
     sort_columns = {}
-    for column in detail.get_columns():
+    for column in detail_columns:
         sort_element, order = sort_elements.pop(column.field, (None, None))
         if sort_element:
             sort_columns[column.field] = (sort_element, order)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-960

## Summary
Same manifestation as was fixed here but for a different reason: https://github.com/dimagi/commcare-hq/pull/28984

When the same field appears twice in a case list, the sort will be applied to the first column with the field name. Under the following conditions:

1. one of the columns is set to be "search only" and
2. the case list is using tab's with nodesets and
3. "Sort entries in the Nodeset tabs" is selected

The sort should be applied to the the column which is set to "search only", regardless of whether that column appears before or after the other column in the list.

(1st commit is a small refactor to reduce work during suite file generation)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Existing + new tests

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
