### PR TITLE
Create RepeaterStubs

### DIFF
--- a/corehq/motech/repeaters/dbaccessors.py
+++ b/corehq/motech/repeaters/dbaccessors.py
@@ -185,6 +185,17 @@ def _iter_repeat_records_by_repeater(domain, repeater_id, chunk_size,
             yield doc['id']
 
 
+def iter_repeaters():
+    from .models import Repeater
+
+    for result in Repeater.get_db().view(
+        'repeaters/repeaters',
+        include_docs=True,
+        reduce=False,
+    ).all():
+        yield Repeater.wrap(result['doc'])
+
+
 def get_repeat_records_by_payload_id(domain, payload_id):
     repeat_records = get_sql_repeat_records_by_payload_id(domain, payload_id)
     if repeat_records:

--- a/corehq/motech/repeaters/migration_functions.py
+++ b/corehq/motech/repeaters/migration_functions.py
@@ -1,0 +1,27 @@
+"""
+Functions used by RunPython operations in migrations.
+
+.. note::
+   Placing them in a separate module makes it easier to import them in
+   unittests.
+
+"""
+from django.db import transaction, IntegrityError
+
+from corehq.motech.repeaters.dbaccessors import iter_repeaters
+from corehq.motech.repeaters.models import RepeaterStub
+
+
+def create_repeaterstubs(apps, schema_editor):
+    for repeater in iter_repeaters():
+        with transaction.atomic():
+            try:
+                RepeaterStub.objects.create(
+                    domain=repeater.domain,
+                    repeater_id=repeater.get_id,
+                    is_paused=repeater.paused,
+                )
+            except IntegrityError:
+                # It's faster to violate uniqueness constraint and ask
+                # forgiveness than to use `.get()` or `.exists()` first.
+                pass

--- a/corehq/motech/repeaters/migrations/0004_create_repeaterstubs.py
+++ b/corehq/motech/repeaters/migrations/0004_create_repeaterstubs.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+from ..migration_functions import create_repeaterstubs
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('repeaters', '0003_migrate_connectionsettings'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_repeaterstubs,
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
+    ]

--- a/corehq/motech/repeaters/migrations/0005_repeater_uniq.py
+++ b/corehq/motech/repeaters/migrations/0005_repeater_uniq.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('repeaters', '0004_create_repeaterstubs'),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name='repeaterstub',
+            constraint=models.UniqueConstraint(fields=('repeater_id',),
+                                               name='one_to_one_repeater'),
+        ),
+    ]

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -212,6 +212,10 @@ class RepeaterStub(models.Model):
             models.Index(fields=['domain']),
             models.Index(fields=['repeater_id']),
         ]
+        constraints = [
+            models.UniqueConstraint(fields=['repeater_id'],
+                                    name='one_to_one_repeater')
+        ]
 
     @property
     @memoized

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -22,6 +22,7 @@ from ..const import (
     RECORD_PENDING_STATE,
     RECORD_SUCCESS_STATE,
 )
+from ..migration_functions import create_repeaterstubs
 from ..models import (
     FormRepeater,
     RepeaterStub,
@@ -477,3 +478,15 @@ class SaveDeleteRepeaterTests(TestCase):
             domain=DOMAIN,
             repeater_id=self.repeater.get_id,
         ).count(), 0)
+
+
+class TestMigrationCantDuplicate(RepeaterFixtureMixin, TestCase):
+
+    def test_migration_cant_duplicate(self):
+        self.assertEqual(RepeaterStub.objects.filter(
+            repeater_id=self.repeater.get_id,
+        ).count(), 1)
+        create_repeaterstubs(None, None)
+        self.assertEqual(RepeaterStub.objects.filter(
+            repeater_id=self.repeater.get_id,
+        ).count(), 1)

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -49,13 +49,9 @@ class RepeaterTestCase(TestCase):
             url='https://www.example.com/api/',
         )
         self.repeater.save()
-        self.repeater_stub = RepeaterStub.objects.create(
-            domain=DOMAIN,
-            repeater_id=self.repeater.get_id,
-        )
+        self.repeater_stub = self.repeater.repeater_stub
 
     def tearDown(self):
-        self.repeater_stub.delete()
         self.repeater.delete()
         super().tearDown()
 

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -490,3 +490,32 @@ class TestMigrationCantDuplicate(RepeaterFixtureMixin, TestCase):
         self.assertEqual(RepeaterStub.objects.filter(
             repeater_id=self.repeater.get_id,
         ).count(), 1)
+
+
+class PauseResumeRetireRepeaterTests(RepeaterFixtureMixin, TestCase):
+
+    def _get_repeater_stub(self):
+        return RepeaterStub.objects.get(
+            domain=DOMAIN,
+            repeater_id=self.repeater.get_id,
+        )
+
+    def test_pause(self):
+        self.assertFalse(self._get_repeater_stub().is_paused)
+        self.repeater.pause()
+        self.assertTrue(self._get_repeater_stub().is_paused)
+
+    def test_resume(self):
+        repeater_stub = self._get_repeater_stub()
+        repeater_stub.is_paused = True
+        repeater_stub.save()
+
+        self.repeater.resume()
+        self.assertFalse(self._get_repeater_stub().is_paused)
+
+    def test_retire(self):
+        self.repeater.retire()
+        self.assertFalse(RepeaterStub.objects.filter(
+            domain=DOMAIN,
+            repeater_id=self.repeater.get_id,
+        ).exists())

--- a/corehq/motech/repeaters/tests/test_tasks.py
+++ b/corehq/motech/repeaters/tests/test_tasks.py
@@ -83,14 +83,14 @@ class TestProcessRepeaterStub(TestCase):
             name='Test API',
             url="http://localhost/api/"
         )
-        cls.repeater = FormRepeater(
-            domain=DOMAIN,
-            connection_settings_id=cls.connection_settings.id,
-        )
-        cls.repeater.save()
 
     def setUp(self):
-        self.repeater_stub = RepeaterStub.objects.create(
+        self.repeater = FormRepeater(
+            domain=DOMAIN,
+            connection_settings_id=self.connection_settings.id,
+        )
+        self.repeater.save()
+        self.repeater_stub = RepeaterStub.objects.get(
             domain=DOMAIN,
             repeater_id=self.repeater.get_id,
         )
@@ -104,11 +104,10 @@ class TestProcessRepeaterStub(TestCase):
             just_now += timedelta(seconds=1)
 
     def tearDown(self):
-        self.repeater_stub.delete()
+        self.repeater.delete()
 
     @classmethod
     def tearDownClass(cls):
-        cls.repeater.delete()
         cls.connection_settings.delete()
         cls.domain.delete()
         super().tearDownClass()

--- a/corehq/motech/repeaters/tests/test_views.py
+++ b/corehq/motech/repeaters/tests/test_views.py
@@ -1,0 +1,90 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.reports.dispatcher import DomainReportDispatcher
+from corehq.apps.users.models import WebUser
+from corehq.motech.models import ConnectionSettings
+
+from ..models import FormRepeater, RepeaterStub, are_repeat_records_migrated
+from ..views import SQLRepeatRecordReport
+
+DOMAIN = 'gaidhlig'
+
+
+class TestReportQueries(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = create_domain(DOMAIN)
+        cls.user = WebUser.create(DOMAIN, 'username', 'password',
+                                  created_by=None, created_via=None)
+
+    def setUp(self):
+        are_repeat_records_migrated.clear(DOMAIN)
+        now = timezone.now()
+        self.connection_settings = ConnectionSettings.objects.create(
+            domain=DOMAIN,
+            name='Example API',
+            url="https://www.example.com/api/"
+        )
+        self.repeater = FormRepeater(
+            domain=DOMAIN,
+            connection_settings_id=self.connection_settings.id,
+        )
+        self.repeater.save()
+        self.repeater_stub = RepeaterStub.objects.get(
+            domain=DOMAIN,
+            repeater_id=self.repeater.get_id,
+        )
+        for payload_id in [
+            'aon', 'dha', 'trì', 'ceithir', 'coig', 'sia', 'seachd',
+            'ochd', 'naoi', 'deich',
+        ]:
+            self.repeater_stub.repeat_records.create(
+                domain=self.repeater_stub.domain,
+                payload_id=payload_id,
+                registered_at=now,
+            )
+
+    def tearDown(self):
+        self.repeater.delete()
+        self.connection_settings.delete()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete(deleted_by=None)
+        cls.domain.delete()
+        super().tearDownClass()
+
+    def test_report_num_queries(self):
+        self.client.login(username='username', password='password')
+
+        with self.assertNumQueries(18):
+            # Queries we don't care about:
+            # 1. SELECT ... FROM "auth_user" ...
+            # 2. SELECT ... FROM "users_domainpermissionsmirror" ...
+            # 3. SELECT ... FROM "users_domainpermissionsmirror" ...
+            # 4. SELECT ... FROM "accounting_defaultproductplan" ...
+            # 5. SELECT ... FROM "django_prbac_role" ...
+            # 6. SELECT ... FROM "auth_user" ...
+            # 7. UPDATE "auth_user" ...
+            # 8. SELECT  ... FROM "accounting_defaultproductplan" ...
+            # 9. SELECT ...FROM "auditcare_viewname" ...
+            # 10. SAVEPOINT "s140263734662976_x3"
+            # 11. INSERT INTO "auditcare_viewname" ...
+            # 12. RELEASE SAVEPOINT "s140263734662976_x3"
+            # ...
+            # 18. INSERT INTO "auditcare_navigationeventaudit" ...
+            #
+            # Queries we do care about:
+            # 13. SELECT (1) AS "a" FROM "repeaters_repeatrecord" ...
+            # 14. SELECT ... FROM "repeaters_repeatrecord" ...
+            # 15. SELECT ... FROM "repeaters_repeatrecordattempt" ...
+            # 16. SELECT ... FROM "motech_connectionsettings" ...
+            # 17. EXPLAIN SELECT ... FROM "repeaters_repeatrecord" ...
+            report_json_url = reverse(DomainReportDispatcher.name(), args=[
+                DOMAIN, 'json/', SQLRepeatRecordReport.slug])
+            self.client.get(report_json_url)


### PR DESCRIPTION
## Summary

#### Repeat Records Couch-to-SQL migration PR 4 of 6

* [CEP](https://github.com/dimagi/commcare-hq/issues/28314)

I'm opening this as a draft PR to give context to the conversation around this migration. Following on for a conversation with Danny, this and the two PRs that build on it will need some changes, in order to roll out this migration with more caution.

The changes to these PRs that we discussed are:
* Mirroring repeat record creation and updates across both Couch and SQL (following migration best practices) to allow us to switch from one backend to the other as easily as possible.
* Repeat records and RepeaterStub to live in their own database.
* Splitting out the change in behavior from the migration.

Currently this series of PRs introduces a change in behavior enabled by the switch to SQL; instead of iterating repeat records we can iterate repeaters, send payloads in the order they were created, and handle offline services more intelligently. But to reduce the risk inherent in behavior changes, we should deploy the behavior change after the switch to SQL, instead of with it.


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Automated test coverage

PR includes test coverage. If there are aspects that are not covered by tests, please point them out.


### QA Plan

Left to the discretion of the SaaS team.


### Safety story

This PR will be subject to change. It is not safe to merge.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
