### PR TITLE
Switch over

### DIFF
--- a/corehq/motech/repeaters/const.py
+++ b/corehq/motech/repeaters/const.py
@@ -23,3 +23,8 @@ RECORD_STATES = [
     (RECORD_FAILURE_STATE, _('Failed')),
     (RECORD_CANCELLED_STATE, _('Cancelled')),
 ]
+# State for Couch records that have been migrated to SQL. If the
+# migration is rolled back, the `migrated` property is set to False, and
+# `RepeatRecord.state` will return PENDING or FAILED as it did before
+# migration.
+RECORD_MIGRATED_STATE = 'MIGRATED'

--- a/corehq/motech/repeaters/dbaccessors.py
+++ b/corehq/motech/repeaters/dbaccessors.py
@@ -365,3 +365,45 @@ def delete_all_repeaters():
     from .models import Repeater
     for repeater in Repeater.get_db().view('repeaters/repeaters', reduce=False, include_docs=True).all():
         Repeater.wrap(repeater['doc']).delete()
+
+
+# Functions for evaluating scale
+def get_repeat_record_domain_total():
+    from corehq.motech.repeaters.dbaccessors import get_domains_that_have_repeat_records
+
+    return len(get_domains_that_have_repeat_records())
+
+
+def get_couch_repeater_total():
+    from corehq.motech.repeaters.dbaccessors import get_domains_that_have_repeat_records
+    from corehq.motech.repeaters.models import Repeater
+
+    total = 0
+    for domain in get_domains_that_have_repeat_records():
+        result = Repeater.get_db().view(
+            'repeaters/repeaters',
+            startkey=[domain],
+            endkey=[domain, {}],
+            include_docs=False,
+            reduce=True,
+        ).one()
+        total += result['value'] if result else 0
+    return total
+
+
+def get_couch_repeat_record_total():
+    from corehq.motech.repeaters.dbaccessors import get_domains_that_have_repeat_records
+    from corehq.motech.repeaters.models import RepeatRecord
+
+    total = 0
+    for domain in get_domains_that_have_repeat_records():
+        result = RepeatRecord.get_db().view(
+            'repeaters/repeat_records',
+            startkey=[domain, None, {}],
+            endkey=[domain, None],
+            include_docs=False,
+            reduce=True,
+            descending=True,
+        ).one()
+        total += result['value'] if result else 0
+    return total

--- a/corehq/motech/repeaters/management/commands/migrate_records.py
+++ b/corehq/motech/repeaters/management/commands/migrate_records.py
@@ -1,0 +1,42 @@
+from inspect import cleandoc
+
+from django.core.management.base import BaseCommand
+
+from corehq.util.log import with_progress_bar
+
+from ...dbaccessors import (
+    get_domains_that_have_repeat_records,
+    get_repeaters_by_domain,
+    iter_repeat_records_by_repeater,
+)
+from ...models import Repeater, RepeaterStub
+from ...tasks import migrate_repeat_record
+
+
+class Command(BaseCommand):
+    help = cleandoc("""
+    Migrate Couch RepeatRecords to SQL.
+
+    If a Couch RepeatRecord cannot be migrated (usually because it
+    encounters a ResourceConflict error when trying to set its
+    "migrated" state) then this command can be run again, and
+    already-migrated RepeatRecords will be skipped.
+
+    See the "roll_back_record_migration" management command for
+    instructions to roll the migration back, if necessary.
+    """)
+
+    def handle(self, *args, **options):
+        # Migrate by domain to minimise impact on Repeat Record report
+        domains = get_domains_that_have_repeat_records()
+        for domain in with_progress_bar(domains):
+            for repeater in get_repeaters_by_domain(domain):
+                migrate_repeater(repeater)
+
+
+def migrate_repeater(repeater: Repeater):
+    for couch_record in iter_repeat_records_by_repeater(repeater.domain,
+                                                        repeater.get_id):
+        if couch_record.migrated:
+            continue
+        migrate_repeat_record.delay(repeater.repeater_stub, couch_record)

--- a/corehq/motech/repeaters/management/commands/sample_repeaters.py
+++ b/corehq/motech/repeaters/management/commands/sample_repeaters.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+from uuid import uuid4
+
+from django.core.management.base import BaseCommand
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.motech.models import ConnectionSettings
+from corehq.motech.repeaters.models import (
+    FormRepeater,
+    RepeatRecord,
+    RepeatRecordAttempt,
+)
+from corehq.util.log import with_progress_bar
+
+# NUM_DOMAINS = 500  # Prod
+NUM_DOMAINS = 5
+REPEATERS_PER_DOMAIN = 3
+# RECORDS_PER_REPEATER = 50_000  # Prod
+RECORDS_PER_REPEATER = 250
+ATTEMPTS_PER_RECORD = 3
+
+
+class Command(BaseCommand):
+    help = 'Create a ton of repeaters to mimic Prod'
+
+    def handle(self, *args, **options):
+        create_sample_repeaters()
+
+
+def create_sample_repeaters():
+    for domain_name in with_progress_bar(get_domain_names(),
+                                         length=NUM_DOMAINS):
+        create_domain(domain_name)
+        connset = ConnectionSettings.objects.create(
+            domain=domain_name,
+            name='local httpbin',
+            url='http://127.0.0.1:10080/anything',
+        )
+        for i in range(1, REPEATERS_PER_DOMAIN + 1):
+            rep = FormRepeater(
+                domain=domain_name,
+                connection_settings_id=connset.pk,
+            )
+            rep.save()
+            for j in range(1, RECORDS_PER_REPEATER + 1):
+                now = datetime.utcnow()
+                attempts = third_time_is_the_charm()
+                rec = RepeatRecord(
+                    domain=domain_name,
+                    repeater_id=rep.get_id,
+                    repeater_type=rep.__class__.__name__,
+                    payload_id=str(uuid4()),
+                    registered_on=now,
+                    next_check=None,
+                    succeeded=True,
+                    overall_tries=len(attempts),
+                    attempts=attempts,
+                )
+                rec.save()
+
+
+def get_domain_names():
+    for i in range(1, NUM_DOMAINS + 1):
+        yield f'repeaters-{i:03d}'
+
+
+def third_time_is_the_charm():
+    return [
+        RepeatRecordAttempt(
+            datetime=datetime.utcnow(),
+            failure_reason='Boo',
+        ),
+        RepeatRecordAttempt(
+            datetime=datetime.utcnow(),
+            failure_reason='Boo',
+        ),
+        RepeatRecordAttempt(
+            datetime=datetime.utcnow(),
+            success_response='Yay',
+            succeeded=True,
+        ),
+    ]

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -129,6 +129,7 @@ from .const import (
     MIN_RETRY_WAIT,
     RECORD_CANCELLED_STATE,
     RECORD_FAILURE_STATE,
+    RECORD_MIGRATED_STATE,
     RECORD_PENDING_STATE,
     RECORD_STATES,
     RECORD_SUCCESS_STATE,
@@ -878,6 +879,7 @@ class RepeatRecord(Document):
     failure_reason = StringProperty()
     next_check = DateTimeProperty()
     succeeded = BooleanProperty(default=False)
+    migrated = BooleanProperty(default=False)
 
     @property
     def record_id(self):
@@ -922,6 +924,8 @@ class RepeatRecord(Document):
             state = RECORD_SUCCESS_STATE
         elif self.cancelled:
             state = RECORD_CANCELLED_STATE
+        elif self.migrated:
+            state = RECORD_MIGRATED_STATE
         elif self.failure_reason:
             state = RECORD_FAILURE_STATE
         return state

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -374,25 +374,22 @@ class Repeater(QuickCachedDocumentMixin, Document):
         return None
 
     def register(self, payload):
+        """
+        Registers a SQLRepeatRecord.
+        """
         if not self.allowed_to_forward(payload):
             return
 
-        now = datetime.utcnow()
-        repeat_record = RepeatRecord(
-            repeater_id=self.get_id,
-            repeater_type=self.doc_type,
+        self.repeater_stub.repeat_records.create(
             domain=self.domain,
-            registered_on=now,
-            next_check=now,
-            payload_id=payload.get_id
+            payload_id=payload.get_id,
+            registered_at=timezone.now(),
         )
         metrics_counter('commcare.repeaters.new_record', tags={
             'domain': self.domain,
             'doc_type': self.doc_type
         })
-        repeat_record.save()
-        repeat_record.attempt_forward_now()
-        return repeat_record
+        attempt_forward_now(self.repeater_stub)
 
     def allowed_to_forward(self, payload):
         """

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -380,6 +380,15 @@ class Repeater(QuickCachedDocumentMixin, Document):
         if not self.allowed_to_forward(payload):
             return
 
+        if SQLRepeatRecord.objects.filter(
+            domain=self.domain,
+            repeater_stub=self.repeater_stub,
+            payload_id=payload.get_id,
+            state__in=(RECORD_PENDING_STATE, RECORD_FAILURE_STATE),
+        ).exists():
+            # Payload is already waiting to be sent
+            return
+
         self.repeater_stub.repeat_records.create(
             domain=self.domain,
             payload_id=payload.get_id,


### PR DESCRIPTION
## Summary

#### Repeat Records Couch-to-SQL migration PR 6 of 6

* [CEP](https://github.com/dimagi/commcare-hq/issues/28314)
* Note the base branch is that of the previous PR

See PR #29599 for more context.

The work I intended for this branch is not complete. You will notice "--wip--" commits at the end. I left myself a note to write the following tests to check that we don't create duplicate repeat records waiting to be sent:
* Test register() drops payload if pending
* Test register() drops payload if failed
* Test register() drops payload if failed max times


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Automated test coverage

**Test coverage for this PR is not complete.**


### QA Plan

Left to the discretion of the SaaS team.


### Safety story

This PR will be subject to change. It is not safe to merge.


### Rollback instructions

- [ ] This PR can be reverted after deploy with no further considerations 

False^^^. PR #29600 includes documentation and a management command to be used if this PR needs to be reverted. But those should be moot, because the way this Couch-to-SQL migration is to be deployed will change.
