### PR TITLE
Get flattened data nodes once for each form

### DIFF
--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1032,6 +1032,7 @@ class XForm(WrappedNode):
         # we also need to look at the data tree (the <model> in the xform's <head>). Getting the leaves
         # of the data tree should be sufficient to fill in what's not available from the question tree.
         control_nodes = self._get_control_nodes()
+        flattened_data_nodes = self._get_flattened_data_nodes()
         leaf_data_nodes = self._get_leaf_data_nodes()
         external_instances = self.get_external_instances()
 
@@ -1061,7 +1062,7 @@ class XForm(WrappedNode):
                 "relevant": cnode.relevant,
                 "required": cnode.required == "true()",
                 "constraint": cnode.constraint,
-                "comment": self._get_comment(path),
+                "comment": self._get_comment(flattened_data_nodes, path),
                 "hashtagValue": self.hashtag_path(path),
                 "setvalue": self._get_setvalue(path),
                 "is_group": is_group,
@@ -1136,7 +1137,7 @@ class XForm(WrappedNode):
                     "calculate": bind.attrib.get('calculate') if hasattr(bind, 'attrib') else None,
                     "relevant": bind.attrib.get('relevant') if hasattr(bind, 'attrib') else None,
                     "constraint": bind.attrib.get('constraint') if hasattr(bind, 'attrib') else None,
-                    "comment": self._get_comment(path),
+                    "comment": self._get_comment(flattened_data_nodes, path),
                     "setvalue": self._get_setvalue(path)
                 }
 
@@ -1293,9 +1294,9 @@ class XForm(WrappedNode):
         for_each_control_node(self.find('{h}body'))
         return control_nodes
 
-    def _get_comment(self, path):
+    def _get_comment(self, flattened_data_nodes, path):
         try:
-            return self._get_flattened_data_nodes()[path].attrib.get('{v}comment')
+            return flattened_data_nodes[path].attrib.get('{v}comment')
         except KeyError:
             return None
 

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1032,7 +1032,6 @@ class XForm(WrappedNode):
         # we also need to look at the data tree (the <model> in the xform's <head>). Getting the leaves
         # of the data tree should be sufficient to fill in what's not available from the question tree.
         control_nodes = self._get_control_nodes()
-        flattened_data_nodes = self._get_flattened_data_nodes()
         leaf_data_nodes = self._get_leaf_data_nodes()
         external_instances = self.get_external_instances()
 
@@ -1062,7 +1061,7 @@ class XForm(WrappedNode):
                 "relevant": cnode.relevant,
                 "required": cnode.required == "true()",
                 "constraint": cnode.constraint,
-                "comment": self._get_comment(flattened_data_nodes, path),
+                "comment": self._get_comment(path),
                 "hashtagValue": self.hashtag_path(path),
                 "setvalue": self._get_setvalue(path),
                 "is_group": is_group,
@@ -1137,7 +1136,7 @@ class XForm(WrappedNode):
                     "calculate": bind.attrib.get('calculate') if hasattr(bind, 'attrib') else None,
                     "relevant": bind.attrib.get('relevant') if hasattr(bind, 'attrib') else None,
                     "constraint": bind.attrib.get('constraint') if hasattr(bind, 'attrib') else None,
-                    "comment": self._get_comment(flattened_data_nodes, path),
+                    "comment": self._get_comment(path),
                     "setvalue": self._get_setvalue(path)
                 }
 
@@ -1294,9 +1293,9 @@ class XForm(WrappedNode):
         for_each_control_node(self.find('{h}body'))
         return control_nodes
 
-    def _get_comment(self, flattened_data_nodes, path):
+    def _get_comment(self, path):
         try:
-            return flattened_data_nodes[path].attrib.get('{v}comment')
+            return self._get_flattened_data_nodes()[path].attrib.get('{v}comment')
         except KeyError:
             return None
 
@@ -1329,6 +1328,7 @@ class XForm(WrappedNode):
     def _get_leaf_data_nodes(self):
         return self._get_flattened_data_nodes(leaves_only=True)
 
+    @memoized
     def _get_flattened_data_nodes(self, leaves_only=False):
         if not self.exists():
             return {}


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
While exploring why the eCHIS app takes so long to build, I found that we parse and fetch every single data node some massive number of times because that method isn't cached. Locally, this reduced the build time for a very similarly sized app by 40% (cold cache, no reports or multimedia) -- from 270 seconds to 170 seconds.

I have been unable to use the profiler on production for some unrelated reason, but if tests pass I believe this can only be beneficial. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
While this is a change to a high impact area of code, it is also well tested and the change itself is pretty simple. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
