### PR TITLE
Refactor method to build view models for pulling content

### DIFF
--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -1,4 +1,6 @@
-from corehq.apps.linked_domain.models import DomainLink
+from django.db.models.expressions import RawSQL
+
+from corehq.apps.linked_domain.models import DomainLink, DomainLinkHistory
 from corehq.util.quickcache import quickcache
 
 
@@ -29,3 +31,10 @@ def get_linked_domains(domain, include_deleted=False):
 @quickcache(['domain'], timeout=60 * 60)
 def is_master_linked_domain(domain):
     return DomainLink.objects.filter(master_domain=domain).exists()
+
+
+def get_actions_in_domain_link_history(link):
+    return DomainLinkHistory.objects.filter(link=link).annotate(row_number=RawSQL(
+        'row_number() OVER (PARTITION BY model, model_detail ORDER BY date DESC)',
+        []
+    ))

--- a/corehq/apps/linked_domain/tests/test_view_helpers.py
+++ b/corehq/apps/linked_domain/tests/test_view_helpers.py
@@ -77,117 +77,6 @@ def _create_fixture(domain, tag="table", should_save=True):
     return data_type
 
 
-class TestBuildViewModels(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        super(TestBuildViewModels, cls).setUpClass()
-        cls.domain_obj = create_domain('test-create-view-model-domain')
-        cls.domain = cls.domain_obj.name
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.domain_obj.delete()
-        super(TestBuildViewModels, cls).tearDownClass()
-
-    def test_build_app_view_model_returns_match(self):
-        app = Application.new_app(self.domain, "Test Application")
-        # set _id rather than actually saving the object
-        app._id = 'abc123'
-
-        expected_view_model = {
-            'type': 'app',
-            'name': 'Application (Test Application)',
-            'detail': {'app_id': 'abc123'},
-            'last_update': None,
-            'can_update': True
-        }
-
-        actual_view_model = build_app_view_model(app)
-        self.assertEqual(expected_view_model, actual_view_model)
-
-    def test_build_app_view_model_with_none_returns_none(self):
-        app = None
-        view_model = build_app_view_model(app)
-        self.assertIsNone(view_model)
-
-    def test_build_app_view_model_with_empty_dict_returns_none(self):
-        app = {}
-        view_model = build_app_view_model(app)
-        self.assertIsNone(view_model)
-
-    def test_build_fixture_view_model_returns_match(self):
-        fixture = _create_fixture(self.domain, tag="test-table", should_save=False)
-        expected_view_model = {
-            'type': 'fixture',
-            'name': 'Lookup Table (test-table)',
-            'detail': {'tag': 'test-table'},
-            'last_update': None,
-            'can_update': True
-        }
-
-        actual_view_model = build_fixture_view_model(fixture)
-        self.assertEqual(expected_view_model, actual_view_model)
-
-    def test_build_fixture_view_model_with_none_returns_none(self):
-        fixture = None
-        view_model = build_fixture_view_model(fixture)
-        self.assertIsNone(view_model)
-
-    def test_build_fixture_view_model_with_empty_returns_none(self):
-        fixture = {}
-        view_model = build_fixture_view_model(fixture)
-        self.assertIsNone(view_model)
-
-    def test_build_report_view_model(self):
-        report = _create_report(self.domain, title='report-test', should_save=False)
-        report._id = 'abc123'
-        expected_view_model = {
-            'type': 'report',
-            'name': 'Report (report-test)',
-            'detail': {'report_id': 'abc123'},
-            'last_update': None,
-            'can_update': True
-        }
-
-        actual_view_model = build_report_view_model(report)
-        self.assertEqual(expected_view_model, actual_view_model)
-
-    def test_build_report_view_model_with_none_returns_none(self):
-        report = None
-        view_model = build_report_view_model(report)
-        self.assertIsNone(view_model)
-
-    def test_build_report_view_model_with_empty_returns_none(self):
-        report = {}
-        view_model = build_report_view_model(report)
-        self.assertIsNone(view_model)
-
-    def test_build_keyword_view_model_returns_match(self):
-        keyword = _create_keyword(self.domain, name='keyword-test', should_save=False)
-        keyword.id = '100'
-
-        expected_view_model = {
-            'type': 'keyword',
-            'name': 'Keyword (keyword-test)',
-            'detail': {'keyword_id': '100', 'linked_keyword_id': None},
-            'last_update': None,
-            'can_update': True
-        }
-
-        actual_view_model = build_keyword_view_model(keyword)
-        self.assertEqual(expected_view_model, actual_view_model)
-
-    def test_build_keyword_view_model_with_none_returns_none(self):
-        keyword = None
-        view_model = build_keyword_view_model(keyword)
-        self.assertIsNone(view_model)
-
-    def test_build_keyword_view_model_with_empty_returns_none(self):
-        keyword = {}
-        view_model = build_keyword_view_model(keyword)
-        self.assertIsNone(view_model)
-
-
 class TestGetDataModels(TestCase):
     file_path = ('data',)
 
@@ -319,3 +208,178 @@ class TestGetDataModels(TestCase):
 
         self.assertEqual(expected_original_fixtures, actual_original_fixtures)
         self.assertEqual(expected_linked_fixtures, actual_linked_fixtures)
+
+
+class TestBuildIndividualViewModels(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestBuildIndividualViewModels, cls).setUpClass()
+        cls.domain_obj = create_domain('test-create-view-model-domain')
+        cls.domain = cls.domain_obj.name
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_obj.delete()
+        super(TestBuildIndividualViewModels, cls).tearDownClass()
+
+    def test_build_app_view_model_returns_match(self):
+        app = Application.new_app(self.domain, "Test Application")
+        # set _id rather than actually saving the object
+        app._id = 'abc123'
+
+        expected_view_model = {
+            'type': 'app',
+            'name': 'Application (Test Application)',
+            'detail': {'app_id': 'abc123'},
+            'last_update': None,
+            'can_update': True
+        }
+
+        actual_view_model = build_app_view_model(app)
+        self.assertEqual(expected_view_model, actual_view_model)
+
+    def test_build_app_view_model_with_none_returns_unknown(self):
+        app = None
+        expected_view_model = {
+            'type': 'app',
+            'name': 'Application (Unknown App)',
+            'detail': None,
+            'last_update': None,
+            'can_update': False
+        }
+
+        actual_view_model = build_app_view_model(app)
+        self.assertEqual(expected_view_model, actual_view_model)
+
+    def test_build_app_view_model_with_empty_dict_returns_unknown(self):
+        app = {}
+        expected_view_model = {
+            'type': 'app',
+            'name': 'Application (Unknown App)',
+            'detail': None,
+            'last_update': None,
+            'can_update': False
+        }
+
+        actual_view_model = build_app_view_model(app)
+        self.assertEqual(expected_view_model, actual_view_model)
+
+    def test_build_fixture_view_model_returns_match(self):
+        fixture = _create_fixture(self.domain, tag="test-table", should_save=False)
+        expected_view_model = {
+            'type': 'fixture',
+            'name': 'Lookup Table (test-table)',
+            'detail': {'tag': 'test-table'},
+            'last_update': None,
+            'can_update': True
+        }
+
+        actual_view_model = build_fixture_view_model(fixture)
+        self.assertEqual(expected_view_model, actual_view_model)
+
+    def test_build_fixture_view_model_with_none_returns_unknown(self):
+        fixture = None
+        expected_view_model = {
+            'type': 'fixture',
+            'name': 'Lookup Table (Unknown Table)',
+            'detail': None,
+            'last_update': None,
+            'can_update': False
+        }
+
+        actual_view_model = build_fixture_view_model(fixture)
+        self.assertEqual(expected_view_model, actual_view_model)
+
+    def test_build_fixture_view_model_with_empty_returns_none(self):
+        fixture = {}
+        expected_view_model = {
+            'type': 'fixture',
+            'name': 'Lookup Table (Unknown Table)',
+            'detail': None,
+            'last_update': None,
+            'can_update': False
+        }
+
+        actual_view_model = build_fixture_view_model(fixture)
+        self.assertEqual(expected_view_model, actual_view_model)
+
+    def test_build_report_view_model(self):
+        report = _create_report(self.domain, title='report-test', should_save=False)
+        report._id = 'abc123'
+        expected_view_model = {
+            'type': 'report',
+            'name': 'Report (report-test)',
+            'detail': {'report_id': 'abc123'},
+            'last_update': None,
+            'can_update': True
+        }
+
+        actual_view_model = build_report_view_model(report)
+        self.assertEqual(expected_view_model, actual_view_model)
+
+    def test_build_report_view_model_with_none_returns_unknown(self):
+        report = None
+        expected_view_model = {
+            'type': 'report',
+            'name': 'Report (Unknown Report)',
+            'detail': None,
+            'last_update': None,
+            'can_update': False
+        }
+
+        actual_view_model = build_report_view_model(report)
+        self.assertEqual(expected_view_model, actual_view_model)
+
+    def test_build_report_view_model_with_empty_returns_unknown(self):
+        report = {}
+        expected_view_model = {
+            'type': 'report',
+            'name': 'Report (Unknown Report)',
+            'detail': None,
+            'last_update': None,
+            'can_update': False
+        }
+
+        actual_view_model = build_report_view_model(report)
+        self.assertEqual(expected_view_model, actual_view_model)
+
+    def test_build_keyword_view_model_returns_match(self):
+        keyword = _create_keyword(self.domain, name='keyword-test', should_save=False)
+        keyword.id = '100'
+
+        expected_view_model = {
+            'type': 'keyword',
+            'name': 'Keyword (keyword-test)',
+            'detail': {'keyword_id': '100', 'linked_keyword_id': None},
+            'last_update': None,
+            'can_update': True
+        }
+
+        actual_view_model = build_keyword_view_model(keyword)
+        self.assertEqual(expected_view_model, actual_view_model)
+
+    def test_build_keyword_view_model_with_none_returns_unknown(self):
+        keyword = None
+        expected_view_model = {
+            'type': 'keyword',
+            'name': 'Keyword (Deleted Keyword)',
+            'detail': None,
+            'last_update': None,
+            'can_update': False
+        }
+
+        actual_view_model = build_keyword_view_model(keyword)
+        self.assertEqual(expected_view_model, actual_view_model)
+
+    def test_build_keyword_view_model_with_empty_returns_unknown(self):
+        keyword = {}
+        expected_view_model = {
+            'type': 'keyword',
+            'name': 'Keyword (Deleted Keyword)',
+            'detail': None,
+            'last_update': None,
+            'can_update': False
+        }
+
+        actual_view_model = build_keyword_view_model(keyword)
+        self.assertEqual(expected_view_model, actual_view_model)

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -77,11 +77,11 @@ from corehq.apps.linked_domain.util import (
     server_to_user_time,
 )
 from corehq.apps.linked_domain.view_helpers import (
+    build_pullable_view_models_from_data_models,
+    build_view_models_from_data_models,
     get_apps,
     get_fixtures,
     get_keywords,
-    get_master_model_status,
-    get_model_status,
     get_reports,
 )
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
@@ -238,13 +238,11 @@ class DomainLinkView(BaseAdminProjectSettingsView):
         master_reports, linked_reports = get_reports(self.domain)
         master_keywords, linked_keywords = get_keywords(self.domain)
 
-        # Models belonging to this domain's master domain, for the purpose of pulling
-        model_status = get_model_status(
+        view_models_to_pull = build_pullable_view_models_from_data_models(
             self.domain, master_link, linked_apps, linked_fixtures, linked_reports, linked_keywords
         )
 
-        # Models belonging to this domain, for the purpose of pushing to linked domains
-        master_model_status = get_master_model_status(
+        view_models_to_push = build_view_models_from_data_models(
             self.domain, master_apps, master_fixtures, master_reports, master_keywords
         )
 
@@ -255,8 +253,8 @@ class DomainLinkView(BaseAdminProjectSettingsView):
             'is_master_domain': bool(len(linked_domains)),
             'view_data': {
                 'master_link': self._link_context(master_link, timezone) if master_link else None,
-                'model_status': sorted(model_status, key=lambda m: m['name']),
-                'master_model_status': sorted(master_model_status, key=lambda m: m['name']),
+                'model_status': sorted(view_models_to_pull, key=lambda m: m['name']),
+                'master_model_status': sorted(view_models_to_push, key=lambda m: m['name']),
                 'linked_domains': sorted(linked_domains, key=lambda d: d['linked_domain']),
                 'models': [
                     {'slug': model[0], 'name': model[1]}


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Based on [this PR](https://github.com/dimagi/commcare-hq/pull/29563), this continues to refactor this area of linked domains to allow for better testing. 

Rather than have two separate but very similar paths for creating a linked data view model, it seemed fitting to translate an action (DomainLinkHistory object) into a data model first (apps, fixtures, etc), and then use the same method to build a view model from that data object, with the one difference being a `last_update` value included. 

I updated the tests for the None and empty dictionary cases to return an unknown or deleted view model which should be supported since we are referencing DomainLinkHistory (emphasis on the history). This lacks tests around the `pop` methods, and if a reviewer feels strongly that those should be included I can do that.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will run through QA with the previously mentioned ticket.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tests.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
