### PR TITLE
[UI Improvement] Use a Tab view in "Manage My Settings > My Information" for Web Users

### DIFF
--- a/corehq/apps/settings/templates/settings/edit_my_account.html
+++ b/corehq/apps/settings/templates/settings/edit_my_account.html
@@ -23,9 +23,25 @@
 {% endblock %}
 
 {% block page_content %}
-
-  {% crispy form form.new_helper %}
   {% if user_type == 'web' %}
-    {% include 'users/partials/manage_my_numbers.html' %}
+    <ul class="nav nav-tabs">
+      <li class="active">
+        <a data-toggle="tab" href="#user-settings-tab">{% trans "My Settings" %}</a>
+      </li>
+      <li>
+        <a data-toggle="tab" href="#manage-phone-numbers-tab">{% trans "Phone Numbers" %}</a></li>
+    </ul>
+    <div class="spacer"></div>
+    <div class="tab-content">
+      <div class="tab-pane active" id="user-settings-tab">
+        {% crispy form form.new_helper %}
+      </div>
+      <div class="tab-pane" id="manage-phone-numbers-tab">
+        {% include 'users/partials/manage_my_numbers.html' %}
+      </div>
+    </div>
+  {% else %}
+    {# just show the plain basic form without tabs #}
+    {% crispy form form.new_helper %}
   {% endif %}
 {% endblock %}

--- a/corehq/apps/users/templates/users/partials/manage_my_numbers.html
+++ b/corehq/apps/users/templates/users/partials/manage_my_numbers.html
@@ -8,7 +8,6 @@
         <legend>{% blocktrans %}Registered Phone Numbers{% endblocktrans %}</legend>
         {% for phone in phonenumbers %}
           <div class="form-group">
-            <div class="row">
               <label class="control-label col-sm-3 col-md-4 col-lg-2">+{{ phone.number }}<br />
                 {% if user_type == "mobile" %}
 
@@ -82,7 +81,6 @@
                   </button>
                 </form>
               {% endif %}
-            </div>
           </div>
         {% endfor %}
       </fieldset>

--- a/corehq/apps/users/templates/users/partials/manage_my_numbers.html
+++ b/corehq/apps/users/templates/users/partials/manage_my_numbers.html
@@ -8,79 +8,79 @@
         <legend>{% blocktrans %}Registered Phone Numbers{% endblocktrans %}</legend>
         {% for phone in phonenumbers %}
           <div class="form-group">
-              <label class="control-label col-sm-3 col-md-4 col-lg-2">+{{ phone.number }}<br />
-                {% if user_type == "mobile" %}
+            <label class="control-label col-sm-3 col-md-4 col-lg-2">+{{ phone.number }}<br />
+              {% if user_type == "mobile" %}
 
-                  {% ifequal phone.status "verified" %}
-                    <span class="label label-success">{% trans 'VERIFIED' %}</span>
-                  {% endifequal %}
-
-                  {% ifequal phone.status "pending" %}
-                    <span class="label label-default">{% trans 'VERIFICATION PENDING' %}</span>
-                  {% endifequal %}
-
-                  {% ifequal phone.status "duplicate" %}
-                    {% if phone.dup_url %}<a href="{{ phone.dup_url }}">{% endif %}
-                  <span class="label label-warning">{% trans 'ALREADY IN USE' %}</span>
-                  {% if phone.dup_url %}</a>{% endif %}
-                  {% endifequal %}
-
-                  {% ifequal phone.status "invalid" %}
-                    <span class="label label-default">{% trans 'INVALID FORMAT' %}</span>
-                  {% endifequal %}
-
-                {% endif %}
-              </label>
-              {% if user_type == "mobile" and can_use_inbound_sms %}
-                {% ifequal phone.status "unverified" %}
-                  <form method="post"
-                        action="{% url "verify_phone_number" domain couch_user.couch_id %}?phone_number={{phone.number|urlencode}}"
-                        style="display: inline;">
-                    {% csrf_token %}
-                    <button type="submit"
-                            data-title="{% trans 'Send a verification SMS to this phone. When the user replies to this SMS, the phone number will be verified.' %}"
-                            class="btn btn-primary verify-button"><i class="fa fa-signal"></i> {% trans 'Verify' %}
-                    </button>
-                  </form>
-                {% endifequal %}
-
-                {% ifequal phone.status "duplicate" %}
-                  <button data-title="You cannot verify this phone because it is already being used elsewhere"
-                          class="btn btn-primary disabled verify-button">
-                    <i class="fa fa-signal"></i> {% trans 'Verify' %}
-                  </button>
+                {% ifequal phone.status "verified" %}
+                  <span class="label label-success">{% trans 'VERIFIED' %}</span>
                 {% endifequal %}
 
                 {% ifequal phone.status "pending" %}
-                  <button data-title="Re-send the verification SMS to this phone"
-                          class="btn btn-primary verify-button"
-                          data-toggle="modal"
-                          href="#reverify_{{phone.number|urlencode}}">
-                    <i class="fa fa-signal"></i> {% trans 'Verify (retry)' %}
-                  </button>
+                  <span class="label label-default">{% trans 'VERIFICATION PENDING' %}</span>
                 {% endifequal %}
-              {% endif %}
 
-              <a class="btn btn-danger"
-                 data-toggle="modal"
-                 href="#delete_phonenumber_{{ forloop.counter }}">
-                <i class="fa fa-remove"></i> {% trans 'Delete' %}
-              </a>
-              {% if not forloop.first %}
-                <form class="input-inline input-group"
-                      name="make_phone_number_default"
-                  {% if user_type == "mobile" %}
-                      action="{% url "make_phone_number_default" domain couch_user.couch_id %}"
-                  {% endif %}
-                      method="POST">
+                {% ifequal phone.status "duplicate" %}
+                  {% if phone.dup_url %}<a href="{{ phone.dup_url }}">{% endif %}
+                <span class="label label-warning">{% trans 'ALREADY IN USE' %}</span>
+                {% if phone.dup_url %}</a>{% endif %}
+                {% endifequal %}
+
+                {% ifequal phone.status "invalid" %}
+                  <span class="label label-default">{% trans 'INVALID FORMAT' %}</span>
+                {% endifequal %}
+
+              {% endif %}
+            </label>
+            {% if user_type == "mobile" and can_use_inbound_sms %}
+              {% ifequal phone.status "unverified" %}
+                <form method="post"
+                      action="{% url "verify_phone_number" domain couch_user.couch_id %}?phone_number={{phone.number|urlencode}}"
+                      style="display: inline;">
                   {% csrf_token %}
-                  <input type="hidden" name="form_type" value="make-phone-number-default"/>
-                  <input type="hidden" name="phone_number" value="{{ phone.number }}"/>
-                  <button type="submit" class="btn btn-default">
-                    {% blocktrans %}Mark as primary{% endblocktrans %}
+                  <button type="submit"
+                          data-title="{% trans 'Send a verification SMS to this phone. When the user replies to this SMS, the phone number will be verified.' %}"
+                          class="btn btn-primary verify-button"><i class="fa fa-signal"></i> {% trans 'Verify' %}
                   </button>
                 </form>
-              {% endif %}
+              {% endifequal %}
+
+              {% ifequal phone.status "duplicate" %}
+                <button data-title="You cannot verify this phone because it is already being used elsewhere"
+                        class="btn btn-primary disabled verify-button">
+                  <i class="fa fa-signal"></i> {% trans 'Verify' %}
+                </button>
+              {% endifequal %}
+
+              {% ifequal phone.status "pending" %}
+                <button data-title="Re-send the verification SMS to this phone"
+                        class="btn btn-primary verify-button"
+                        data-toggle="modal"
+                        href="#reverify_{{phone.number|urlencode}}">
+                  <i class="fa fa-signal"></i> {% trans 'Verify (retry)' %}
+                </button>
+              {% endifequal %}
+            {% endif %}
+
+            <a class="btn btn-danger"
+               data-toggle="modal"
+               href="#delete_phonenumber_{{ forloop.counter }}">
+              <i class="fa fa-remove"></i> {% trans 'Delete' %}
+            </a>
+            {% if not forloop.first %}
+              <form class="input-inline input-group"
+                    name="make_phone_number_default"
+                {% if user_type == "mobile" %}
+                    action="{% url "make_phone_number_default" domain couch_user.couch_id %}"
+                {% endif %}
+                    method="POST">
+                {% csrf_token %}
+                <input type="hidden" name="form_type" value="make-phone-number-default"/>
+                <input type="hidden" name="phone_number" value="{{ phone.number }}"/>
+                <button type="submit" class="btn btn-default">
+                  {% blocktrans %}Mark as primary{% endblocktrans %}
+                </button>
+              </form>
+            {% endif %}
           </div>
         {% endfor %}
       </fieldset>


### PR DESCRIPTION
## Summary
The current double form / two `primary` buttons in `Manage My Settings > My Information` did not sit well with me, so I did some quick updates.

Easiest to review commit-by-commit, but nothing changed except the UI looks a little easier to follow.

NOTE: It's generally **not** good practice to have two top-level actions on a single page/tab.

The change was made to assure this only shows up for Web Users.

## Product Description
<img width="1301" alt="Screen Shot 2021-04-27 at 4 41 00 PM" src="https://user-images.githubusercontent.com/716573/116310703-f6472c00-a76f-11eb-82c3-a96f13adcaa7.png">
<img width="1298" alt="Screen Shot 2021-04-27 at 4 41 06 PM" src="https://user-images.githubusercontent.com/716573/116310710-f810ef80-a76f-11eb-9697-b42643f27108.png">


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
No test coverage of this

### QA Plan
None needed

### Safety story
Very small surface-level change. Tested locally.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
