### PR TITLE
Removed nodeset sorting from short detail overwrite

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2026,11 +2026,12 @@ class Detail(IndexedSchema, CaseListLookupMixin):
         """
         return self.persist_tile_on_forms and (self.use_case_tiles or self.custom_xml)
 
-    def overwrite_from_module_detail(self, src_module_detail_type, attr_dict):
+    def overwrite_attrs(self, src_detail, attrs):
         """
-        This method is used to overwrite configurations present
-        in attr_dict(column, filter, and other_configurations)
-        from source module to current object.
+        This method is used to overwrite a limited set of attributes
+        based on a detail from another module and a list of attributes.
+
+        This method is relevant only for short details.
         """
         case_tile_configuration_list = [
             'use_case_tiles',
@@ -2040,13 +2041,12 @@ class Detail(IndexedSchema, CaseListLookupMixin):
             'persist_case_context',
             'persistent_case_context_xml',
         ]
-        for k, v in attr_dict.items():
-            if v:
-                if k == "case_tile_configuration":
-                    for ele in case_tile_configuration_list:
-                        setattr(self, ele, getattr(src_module_detail_type, ele))
-                else:
-                    setattr(self, k, getattr(src_module_detail_type, k))
+        for attr in attrs:
+            if attr == "case_tile_configuration":
+                for ele in case_tile_configuration_list:
+                    setattr(self, ele, getattr(src_detail, ele))
+            else:
+                setattr(self, attr, getattr(src_detail, attr))
 
 
 class CaseList(IndexedSchema, NavMenuItemMediaMixin):

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
@@ -22,24 +22,18 @@
             <br>
             <div class="row">
               <div class="checkbox col-sm-4 col-sm-offset-1">
-                <label for="display_properties">
-                  <input type="checkbox" name="display_properties" id="display_properties"/>
+                <label for="columns">
+                  <input type="checkbox" name="columns" id="columns"/>
                   {% trans "Display properties" %}
                 </label><br>
-                <label for="case_list_filter">
-                  <input type="checkbox" name="case_list_filter" id="case_list_filter"/>
+                <label for="filter">
+                  <input type="checkbox" name="filter" id="filter"/>
                   {% trans "Case list filter" %}
                 </label><br>
-                <label for="sort_configuration">
-                  <input type="checkbox" name="sort_configuration" id="sort_configuration"/>
+                <label for="sort_elements">
+                  <input type="checkbox" name="sort_elements" id="sort_elements"/>
                   {% trans "Sort configuration" %}
                 </label><br>
-                {% if request|toggle_enabled:'DETAIL_LIST_TAB_NODESETS' %}
-                  <label for="nodeset_sorting">
-                    <input type="checkbox" name="nodeset_sorting" id="nodeset_sorting"/>
-                    {% trans "Nodeset sorting" %}
-                  </label><br>
-                {% endif %}
                 {% if request|toggle_enabled:'CASE_LIST_CUSTOM_VARIABLES' %}
                   <label for="custom_variables">
                     <input type="checkbox" name="custom_variables" id="custom_variables"/>
@@ -47,8 +41,8 @@
                   </label><br>
                 {% endif %}
                 {% if request|toggle_enabled:'CASE_LIST_CUSTOM_XML' %}
-                  <label for="custom_case_list_xml">
-                    <input type="checkbox" name="custom_case_list_xml" id="custom_case_list_xml"/>
+                  <label for="custom_xml">
+                    <input type="checkbox" name="custom_xml" id="custom_xml"/>
                     {% trans "Custom case list XML" %}
                   </label><br>
                 {% endif %}

--- a/corehq/apps/app_manager/tests/test_modules.py
+++ b/corehq/apps/app_manager/tests/test_modules.py
@@ -157,78 +157,50 @@ class ReportModuleTests(SimpleTestCase):
 class OverwriteModuleDetailTests(SimpleTestCase):
 
     def setUp(self):
-        self.attrs_dict1 = {
-            'columns': True,
-            'filter': True,
-            'sort_elements': True,
-            'sort_nodeset_columns': True,
-            'custom_variables': True,
-            'custom_xml': True,
-            'case_tile_configuration': True,
-            'print_template': True
-        }
-        self.attrs_dict2 = {
-            'columns': True,
-            'filter': True,
-            'sort_elements': False,
-            'sort_nodeset_columns': False,
-            'custom_variables': False,
-            'custom_xml': False,
-            'case_tile_configuration': False,
-            'print_template': False
-        }
-        self.attrs_dict3 = {
-            'columns': False,
-            'filter': False,
-            'sort_elements': False,
-            'sort_nodeset_columns': False,
-            'custom_variables': False,
-            'custom_xml': False,
-            'case_tile_configuration': True,
-            'print_template': False
-        }
+        self.all_attrs = ['columns', 'filter', 'sort_elements', 'custom_variables', 'custom_xml',
+                          'case_tile_configuration', 'print_template']
+        self.cols_and_filter = ['columns', 'filter']
+        self.case_tile = ['case_tile_configuration']
 
         self.app = Application.new_app('domain', "Untitled Application")
         self.src_module = self.app.add_module(Module.new_module('Src Module', lang='en'))
-        self.src_module_detail_type = getattr(self.src_module.case_details, "short")
-        self.header_ = getattr(self.src_module_detail_type.columns[0], 'header')
+        self.src_detail = getattr(self.src_module.case_details, "short")
+        self.header_ = getattr(self.src_detail.columns[0], 'header')
         self.header_['en'] = 'status'
-        self.filter_ = setattr(self.src_module_detail_type, 'filter', 'a > b')
-        self.sort_nodeset_columns = setattr(self.src_module_detail_type, 'sort_nodeset_columns', True)
-        self.custom_variables = setattr(self.src_module_detail_type, 'custom_variables', 'def')
-        self.custom_xml = setattr(self.src_module_detail_type, 'custom_xml', 'ghi')
-        self.print_template = getattr(self.src_module_detail_type, 'print_template')
+        self.filter_ = setattr(self.src_detail, 'filter', 'a > b')
+        self.custom_variables = setattr(self.src_detail, 'custom_variables', 'def')
+        self.custom_xml = setattr(self.src_detail, 'custom_xml', 'ghi')
+        self.print_template = getattr(self.src_detail, 'print_template')
         self.print_template['name'] = 'test'
-        self.case_tile_configuration = setattr(self.src_module_detail_type, 'persist_tile_on_forms', True)
+        self.case_tile_configuration = setattr(self.src_detail, 'persist_tile_on_forms', True)
 
     def test_overwrite_all(self):
         dest_module = self.app.add_module(Module.new_module('Dest Module', lang='en'))
-        dest_module_detail_type = getattr(dest_module.case_details, "short")
-        dest_module_detail_type.overwrite_from_module_detail(self.src_module_detail_type, self.attrs_dict1)
-        self.assertEqual(self.src_module_detail_type.to_json(), dest_module_detail_type.to_json())
+        dest_detail = getattr(dest_module.case_details, "short")
+        dest_detail.overwrite_attrs(self.src_detail, self.all_attrs)
+        self.assertEqual(self.src_detail.to_json(), dest_detail.to_json())
 
     def test_overwrite_filter_column(self):
         dest_module = self.app.add_module(Module.new_module('Dest Module', lang='en'))
-        dest_module_detail_type = getattr(dest_module.case_details, "short")
-        dest_module_detail_type.overwrite_from_module_detail(self.src_module_detail_type, self.attrs_dict2)
+        dest_detail = getattr(dest_module.case_details, "short")
+        dest_detail.overwrite_attrs(self.src_detail, self.cols_and_filter)
 
-        self.assertEqual(self.src_module_detail_type.columns, dest_module_detail_type.columns)
-        self.assertEqual(self.src_module_detail_type.filter, dest_module_detail_type.filter)
-        self.remove_attrs(dest_module_detail_type)
-        self.assertNotEqual(self.src_module_detail_type.to_json(), dest_module_detail_type.to_json())
+        self.assertEqual(self.src_detail.columns, dest_detail.columns)
+        self.assertEqual(self.src_detail.filter, dest_detail.filter)
+        self.remove_attrs(dest_detail)
+        self.assertNotEqual(self.src_detail.to_json(), dest_detail.to_json())
 
     def test_overwrite_other_configs(self):
         dest_module = self.app.add_module(Module.new_module('Dest Module', lang='en'))
-        dest_module_detail_type = getattr(dest_module.case_details, "short")
-        dest_module_detail_type.overwrite_from_module_detail(self.src_module_detail_type, self.attrs_dict3)
+        dest_detail = getattr(dest_module.case_details, "short")
+        dest_detail.overwrite_attrs(self.src_detail, self.case_tile)
 
-        self.assertNotEqual(str(self.src_module_detail_type.columns), str(dest_module_detail_type.columns))
-        self.assertNotEqual(self.src_module_detail_type.filter, dest_module_detail_type.filter)
-        self.assertEqual(self.src_module_detail_type.persist_tile_on_forms,
-                 dest_module_detail_type.persist_tile_on_forms)
+        self.assertNotEqual(str(self.src_detail.columns), str(dest_detail.columns))
+        self.assertNotEqual(self.src_detail.filter, dest_detail.filter)
+        self.assertEqual(self.src_detail.persist_tile_on_forms, dest_detail.persist_tile_on_forms)
 
-    def remove_attrs(self, dest_module_detail_type):
-        delattr(self.src_module_detail_type, 'filter')
-        delattr(self.src_module_detail_type, 'columns')
-        delattr(dest_module_detail_type, 'filter')
-        delattr(dest_module_detail_type, 'columns')
+    def remove_attrs(self, dest_detail):
+        delattr(self.src_detail, 'filter')
+        delattr(self.src_detail, 'columns')
+        delattr(dest_detail, 'filter')
+        delattr(dest_detail, 'columns')

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -819,20 +819,20 @@ def upgrade_shadow_module(request, domain, app_id, module_unique_id):
 def overwrite_module_case_list(request, domain, app_id, module_unique_id):
     app = get_app(domain, app_id)
     dest_module_unique_ids = request.POST.getlist('dest_module_unique_ids')
-    attrs_dict = {
-        'columns': request.POST.get('display_properties') == 'on',
-        'filter': request.POST.get('case_list_filter') == 'on',
-        'sort_elements': request.POST.get('sort_configuration') == 'on',
-        'sort_nodeset_columns': request.POST.get('nodeset_sorting') == 'on',
-        'custom_variables': request.POST.get('custom_variables') == 'on',
-        'custom_xml': request.POST.get('custom_case_list_xml') == 'on',
-        'case_tile_configuration': request.POST.get('case_tile_configuration') == 'on',
-        'print_template': request.POST.get('print_template') == 'on',
-    }
+    all_attrs = [
+        'columns',
+        'filter',
+        'sort_elements',
+        'custom_variables',
+        'custom_xml',
+        'case_tile_configuration',
+        'print_template',
+    ]
+    short_attrs = [a for a in all_attrs if request.POST.get(a) == 'on']
     src_module = app.get_module_by_unique_id(module_unique_id)
     detail_type = request.POST['detail_type']
 
-    error_list = _validate_overwrite_request(request, detail_type, dest_module_unique_ids, attrs_dict)
+    error_list = _validate_overwrite_request(request, detail_type, dest_module_unique_ids, short_attrs)
     if error_list:
         for err in error_list:
             messages.error(
@@ -845,20 +845,15 @@ def overwrite_module_case_list(request, domain, app_id, module_unique_id):
     not_updated_modules = []
     for dest_module_unique_id in dest_module_unique_ids:
         dest_module = app.get_module_by_unique_id(dest_module_unique_id)
-        if not hasattr(dest_module, 'case_details'):
+        if dest_module.case_type != src_module.case_type:
             messages.error(
                 request,
-                _("Sorry, couldn't find case list configuration for module {}. "
-                "Please report an issue if you believe this is a mistake.").format(dest_module.default_name()))
-        elif dest_module.case_type != src_module.case_type:
-            messages.error(
-                request,
-                _("Please choose a module with the same case type as the current one ({}).").format(
+                _("Please choose a menu with the same case type as the current one ({}).").format(
                     src_module.case_type)
             )
         else:
             try:
-                _update_module_case_list(detail_type, src_module, dest_module, attrs_dict)
+                _update_module_detail(detail_type, src_module, dest_module, short_attrs)
                 updated_modules.append(dest_module.default_name())
             except Exception:
                 notify_exception(
@@ -881,27 +876,25 @@ def overwrite_module_case_list(request, domain, app_id, module_unique_id):
     return back_to_main(request, domain, app_id=app_id, module_unique_id=module_unique_id)
 
 
-def _validate_overwrite_request(request, detail_type, dest_modules, attrs_dict):
+def _validate_overwrite_request(request, detail_type, dest_modules, short_attrs):
     assert detail_type in ['short', 'long']
     error_list = []
 
     if not dest_modules:
         error_list.append(_("Please choose at least one menu to overwrite."))
     if detail_type == 'short':
-        if not any(attrs_dict.values()):
+        if not short_attrs:
             error_list.append(_("Please choose at least one option to overwrite."))
     return error_list
 
 
-def _update_module_case_list(detail_type, src_module, dest_module, attrs_dict):
+def _update_module_detail(detail_type, src_module, dest_module, short_attrs):
     if detail_type == 'long':
         setattr(dest_module.case_details, detail_type, getattr(src_module.case_details, detail_type))
     else:
-        src_module_detail_type = getattr(src_module.case_details, detail_type)
-        dest_module_detail_type = getattr(dest_module.case_details, detail_type)
-
-        # begin overwrite
-        dest_module_detail_type.overwrite_from_module_detail(src_module_detail_type, attrs_dict)
+        src_detail = getattr(src_module.case_details, detail_type)
+        dest_detail = getattr(dest_module.case_details, detail_type)
+        dest_detail.overwrite_attrs(src_detail, short_attrs)
 
 
 def _update_search_properties(module, search_properties, lang='en'):


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-960

Still haven't been able to reproduce the bug, but the flag to sort nodesets is only relevant for long details, so it doesn't belong in the partial overwrite logic, which is only used for short details.

Also includes minor refactoring:
* change `attrs_dict` from an attr_name => boolean dicttionary to a plain list of attribute names
* renames of variables named `foo_detail_type` that are `Detail` objects, not strings
* some renames to make it clearer that the attributes list logic is only relevant for short details

## Feature Flag
Associate a nodeset with a case detail tab

## Product Description
Removes the "Nodeset sorting" option from the UI to overwrite one case list detail with another.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

The overwrite logic has tests, updated in this PR.

### QA Plan

Not requesting QA.

### Safety story
Removing the option is trivial, and the refactors are straightforward renames.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
