### PR TITLE
send blank messages and handle error responses

### DIFF
--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -311,10 +311,6 @@ def send_message_via_backend(msg, backend=None, orig_phone_number=None):
                 msg.set_system_error(SMS.ERROR_PHONE_NUMBER_OPTED_OUT)
                 return False
 
-        if not msg.text:
-            msg.set_system_error(SMS.ERROR_MESSAGE_BLANK)
-            return False
-
         if not backend:
             backend = msg.outbound_backend
 

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -177,7 +177,6 @@ class SMSBase(UUIDGeneratorMixin, Log):
     ERROR_PHONE_NUMBER_OPTED_OUT = 'PHONE_NUMBER_OPTED_OUT'
     ERROR_INVALID_DESTINATION_NUMBER = 'INVALID_DESTINATION_NUMBER'
     ERROR_MESSAGE_TOO_LONG = 'MESSAGE_TOO_LONG'
-    ERROR_MESSAGE_BLANK = 'MESSAGE_BLANK'
     ERROR_CONTACT_IS_INACTIVE = 'CONTACT_IS_INACTIVE'
     ERROR_TRIAL_SMS_EXCEEDED = 'TRIAL_SMS_EXCEEDED'
     ERROR_MESSAGE_FORMAT_INVALID = 'MESSAGE_FORMAT_INVALID'
@@ -196,7 +195,7 @@ class SMSBase(UUIDGeneratorMixin, Log):
             ugettext_noop("The gateway can't reach the destination number."),
         ERROR_MESSAGE_TOO_LONG:
             ugettext_noop("The gateway could not process the message because it was too long."),
-        ERROR_MESSAGE_BLANK:
+        'MESSAGE_BLANK':
             ugettext_noop("The message was blank."),
         ERROR_CONTACT_IS_INACTIVE:
             ugettext_noop("The recipient has been deactivated."),

--- a/corehq/apps/smsforms/tasks.py
+++ b/corehq/apps/smsforms/tasks.py
@@ -61,9 +61,6 @@ def send_first_message(domain, recipient, phone_entry_or_number, session, respon
             xforms_session_couch_id=session.couch_id,
             messaging_subevent_id=logged_subevent.pk
         )
-        if not message:
-            logged_subevent.error(MessagingEvent.ERROR_NO_MESSAGE)
-            return
 
         if isinstance(phone_entry_or_number, PhoneNumber):
             send_sms_to_verified_number(

--- a/corehq/messaging/smsbackends/twilio/models.py
+++ b/corehq/messaging/smsbackends/twilio/models.py
@@ -18,6 +18,7 @@ INVALID_TO_PHONE_NUMBER_ERROR_CODE = 21211
 WHATSAPP_LIMITATION_ERROR_CODE = 63032
 TO_FROM_BLACKLIST_ERROR_CODE = 21610
 REGION_PERMISSION_ERROR_CODE = 21408
+MESSAGE_BODY_REQUIRED_ERROR_CODE = 21602
 
 WHATSAPP_PREFIX = "whatsapp:"
 WHATSAPP_SANDBOX_PHONE_NUMBER = "14155238886"
@@ -111,6 +112,9 @@ class SQLTwilioBackend(SQLSMSBackend, PhoneLoadBalancingMixin):
                 return
             elif e.code == REGION_PERMISSION_ERROR_CODE:
                 msg.set_gateway_error("Destination region not enabled for this backend.")
+                return
+            elif e.code == MESSAGE_BODY_REQUIRED_ERROR_CODE:
+                msg.set_gateway_error("Message body is required.")
                 return
             else:
                 raise


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12140

## Summary
Revert changes to not send blank SMS messages but also add error handling for Twilio's "message body require" error.


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
