### PR TITLE
case search auto_launch expression

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -299,17 +299,7 @@ class DetailContributor(SectionContributor):
 
     @staticmethod
     def _get_case_search_action(module, in_search=False):
-        action_kwargs = {}
-        if not in_search and module.search_config.search_button_display_condition:
-            action_kwargs = dict(
-                relevant=XPath(module.search_config.search_button_display_condition),
-            )
-
-        allow_auto_launch = toggles.USH_CASE_CLAIM_UPDATES.enabled(module.get_app().domain) and not in_search
-        auto_launch_expression = "false()"
-        if allow_auto_launch and module.search_config.auto_launch:
-            auto_launch_expression = AUTO_LAUNCH_EXPRESSION
-
+        action_kwargs = DetailContributor._get_action_kwargs(module, in_search)
         action = Action(
             display=Display(
                 text=Text(locale_id=(
@@ -318,7 +308,7 @@ class DetailContributor(SectionContributor):
                 ))
             ),
             stack=Stack(),
-            auto_launch=auto_launch_expression,
+            auto_launch=DetailContributor._get_auto_launch_expression(module, in_search),
             redo_last=in_search,
             **action_kwargs
         )
@@ -327,6 +317,27 @@ class DetailContributor(SectionContributor):
         frame.add_command(XPath.string(id_strings.search_command(module)))
         action.stack.add_frame(frame)
         return action
+
+    @staticmethod
+    def _get_action_kwargs(module, in_search):
+        action_kwargs = {}
+        relevant = DetailContributor._get_relevant_expression(module, in_search)
+        if relevant:
+            action_kwargs["relevant"] = relevant
+        return action_kwargs
+
+    @staticmethod
+    def _get_relevant_expression(module, in_search):
+        if not in_search and module.search_config.search_button_display_condition:
+            return XPath(module.search_config.search_button_display_condition)
+
+    @staticmethod
+    def _get_auto_launch_expression(module, in_search):
+        allow_auto_launch = toggles.USH_CASE_CLAIM_UPDATES.enabled(module.get_app().domain) and not in_search
+        auto_launch_expression = "false()"
+        if allow_auto_launch and module.search_config.auto_launch:
+            auto_launch_expression = XPath(AUTO_LAUNCH_EXPRESSION)
+        return auto_launch_expression
 
     def _get_custom_xml_detail(self, module, detail, detail_type):
         d = load_xmlobject_from_string(

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -738,7 +738,7 @@ class Action(ActionMixin):
     """ For CC < 2.21 """
 
     display = NodeField('display', Display)
-    auto_launch = SimpleBooleanField("@auto_launch", "true", "false")
+    auto_launch = StringField("@auto_launch")
     redo_last = SimpleBooleanField("@redo_last", "true", "false")
 
 

--- a/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
@@ -61,7 +61,7 @@
          </text>
        </template>
      </field>
-    <action auto_launch="false" redo_last="false">
+    <action auto_launch="false()" redo_last="false">
       <display>
         <text>
           <locale id="case_search.m0"/>
@@ -172,7 +172,7 @@
         </text>
       </template>
     </field>
-    <action auto_launch="false" redo_last="true">
+    <action auto_launch="false()" redo_last="true">
       <display>
         <text>
           <locale id="case_search.m0.again"/>
@@ -239,7 +239,7 @@
         </text>
       </template>
     </field>
-    <action auto_launch="false" redo_last="false">
+    <action auto_launch="false()" redo_last="false">
       <display>
         <text>
           <locale id="case_search.m1"/>
@@ -290,7 +290,7 @@
         </text>
       </template>
     </field>
-    <action auto_launch="false" redo_last="true">
+    <action auto_launch="false()" redo_last="true">
       <display>
         <text>
           <locale id="case_search.m1.again"/>

--- a/corehq/apps/app_manager/tests/data/suite/sort-cache-search.xml
+++ b/corehq/apps/app_manager/tests/data/suite/sort-cache-search.xml
@@ -17,7 +17,7 @@
         </text>
       </template>
     </field>
-    <action auto_launch="false" redo_last="true">
+    <action auto_launch="false()" redo_last="true">
       <display>
         <text>
           <locale id="case_search.m0.again"/>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -12,6 +12,7 @@ from corehq.apps.app_manager.models import (
     Itemset,
     Module,
 )
+from corehq.apps.app_manager.suite_xml.sections.details import AUTO_LAUNCH_EXPRESSION
 from corehq.apps.app_manager.suite_xml.sections.remote_requests import RESULTS_INSTANCE
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
@@ -213,7 +214,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         suite = self.app.create_suite()
         expected = """
         <partial>
-          <action auto_launch="false" redo_last="false">
+          <action auto_launch="false()" redo_last="false">
             <display>
               <text>
                 <locale id="case_search.m0"/>
@@ -234,9 +235,9 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     def test_case_search_auto_launch(self, *args):
         self.module.search_config.auto_launch = True
         suite = self.app.create_suite()
-        expected = """
+        expected = f"""
         <partial>
-          <action auto_launch="true" redo_last="false">
+          <action auto_launch="{AUTO_LAUNCH_EXPRESSION}" redo_last="false">
             <display>
               <text>
                 <locale id="case_search.m0"/>


### PR DESCRIPTION
## Summary
HQ portion of https://dimagi-dev.atlassian.net/browse/USH-914

Convert case search `auto_launch` attribute from a string (`true`, `false`) to an expression:
* "$next_input = '' or count(instance('casedb')/casedb/case[@case_id=$next_input]) = 0"
* "false()"

## Feature Flag
USH_CASE_CLAIM_UPDATES (case_claim_autolaunch)

## Product Description
Fix for edge case interaction between case claim and end-of-form navigation

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Existing tests

### QA Plan
QA alongside:
* https://github.com/dimagi/formplayer/pull/958
* https://github.com/dimagi/commcare-core/pull/989

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations
