### PR TITLE
Update flagspecs_v2020.yaml

### DIFF
--- a/custom/abt/reports/flagspecs_v2020.yaml
+++ b/custom/abt/reports/flagspecs_v2020.yaml
@@ -1423,7 +1423,7 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
   - question: [loose_items_removed]
     comment: [loose_items_removed_comments]
     base_path: [spray_observe_grp, Q18]
-    flag_name: "18. Are there any loose items (clothes, mosquito nets, posters/pictures on the wall) still in the house?
+    flag_name: "18. Are there any loose items (clothes, mosquito nets, posters/pictures on the wall) still in the house?"
     flag_name_fr: "18. Y a-t-il encore des objets en vrac (vêtements, moustiquaires, affiches / photos sur le mur) dans la maison?"
     flag_name_por: "18. Ainda há artigos soltos (roupas, redes mosquiteiras, cartazes, fotos na parede) na casa?"
     answer: "yes"

--- a/custom/abt/reports/flagspecs_v2020.yaml
+++ b/custom/abt/reports/flagspecs_v2020.yaml
@@ -1423,10 +1423,10 @@ http://openrosa.org/formdesigner/898DACE2-0BFF-47BA-B6A8-BF09ABE8B2D1:
   - question: [loose_items_removed]
     comment: [loose_items_removed_comments]
     base_path: [spray_observe_grp, Q18]
-    flag_name: "18. Have all loose items (clothes, mosquito nets, posters/pictures on the wall) been taken out of the house?"
-    flag_name_fr: "18. Est-ce-que tous les objets en vrac (vêtements, moustiquaires, affiches / photos sur le mur) ont été retirés de la maison?"
-    flag_name_por: "18. Todos os artigos (roupas, redes mosquiteiras, cartazes, fotos na parede) foram retirados para fora da casa?"
-    answer: "no"
+    flag_name: "18. Are there any loose items (clothes, mosquito nets, posters/pictures on the wall) still in the house?
+    flag_name_fr: "18. Y a-t-il encore des objets en vrac (vêtements, moustiquaires, affiches / photos sur le mur) dans la maison?"
+    flag_name_por: "18. Ainda há artigos soltos (roupas, redes mosquiteiras, cartazes, fotos na parede) na casa?"
+    answer: "yes"
     warning: "Problem reported: Loose items (clothes, mosquito nets, pictures/posters) not removed from the house before spraying"
     warning_fr: "Problème signalé: Les objets en vrac (vêtements, moustiquaires, photos / affiches) ne sont pas retirés de la maison avant d'être pulvérisés"
     warning_por: "Problema reportado: items soltos (roupa, rede mosquiteiras, fotografias/cartazes) não removidos da casa antes da pulverização"


### PR DESCRIPTION
Changed stuff on lines 1428-1429. Urgent. 
@kaapstorm


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story
Specific to Abt Vectorlink Project
Some wording changed, no logic touched

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
