### PR TITLE
[SSO] Updates to My Account Settings for SSO logged in users

### DIFF
--- a/corehq/apps/domain/templates/login_and_password/two_factor/profile/profile.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/profile/profile.html
@@ -2,72 +2,87 @@
 {% load i18n two_factor %}
 
 {% block page_content %}
-  {% if default_device %}
-    <fieldset>
-      <legend>{% trans "Backup Phone Numbers" %}</legend>
-      <p>{% blocktrans %}If your primary method is not available, we are able to
-        send backup tokens to the phone numbers listed below.{% endblocktrans %}</p>
-      <ul>
-        {% for phone in backup_phones %}
-          <li>
-            {{ phone|device_action }}
-            <form method="post" action="{% url 'two_factor:phone_delete' phone.id %}"
-                  onsubmit="return confirm('Are you sure?')">
-              {% csrf_token %}
-              <button class="btn btn-xs btn-danger"
-                      type="submit">{% trans "Unregister" %}</button>
-            </form>
-          </li>
-        {% endfor %}
-      </ul>
-      <p><a href="{% url 'two_factor:phone_create' %}"
-            class="btn btn-default">{% trans "Add Phone Number" %}</a></p>
-      <br/>
-    </fieldset>
-
-    <fieldset>
-      <legend>{% trans "Backup Tokens" %}</legend>
-      <p>
-        {% blocktrans %}If you don't have any device with you, you can access
-          your account using backup tokens.{% endblocktrans %}
-        {% blocktrans count counter=backup_tokens %}
-          You have only one backup token remaining.
-        {% plural %}
-          You have {{ counter }} backup tokens remaining.
-        {% endblocktrans %}
-      </p>
-      <p><a href="{% url 'two_factor:backup_tokens' %}"
-            class="btn btn-default">{% trans "Show Codes" %}</a></p>
-      <br/>
-    </fieldset>
-
-    <fieldset>
-      <legend>{% trans "Remove Two-Factor Authentication" %}</legend>
-      <p>{% blocktrans %}However strongly we discourage you to do so, you can
-        also <strong>remove</strong> two-factor authentication for your account.{% endblocktrans %}</p>
-      <p><a class="btn btn-danger" href="{% url 'two_factor:disable' %}">
-        {% trans "Remove Two-Factor Authentication" %}</a></p>
-      <br/>
-    </fieldset>
-    <fieldset>
-      <legend>{% trans "Reset Two-Factor Authentication" %}</legend>
-      <p>{% blocktrans %}
-        Clicking below will disable your current two-factor authentication and rerun Two-Factor Authentication setup,
-        so make sure you have a backup device or tokens available in case you are unable to complete the process.
-      {% endblocktrans %}</p>
-      <p><a class="btn btn-default" href="{% url 'reset' %}">
-        {% trans "Reset Two-Factor Authentication" %}</a></p>
-      <br/>
-    </fieldset>
+  {% if is_using_sso %}
+    <p class="lead">
+      {% blocktrans %}
+        Two-Factor Authentication is not managed here.
+      {% endblocktrans %}
+    </p>
+    <p>
+      {% blocktrans %}
+        Your account is managed by <strong>{{ idp_name }}</strong>.<br />
+        Please see your organization's documentation for how to update
+        your Two-Factor Authentication settings with Single Sign-On.
+      {% endblocktrans %}
+    </p>
   {% else %}
-    <fieldset>
-      <legend>Two-Factor Authentication</legend>
-      <p>{% blocktrans %}Two-factor authentication is not enabled for your
-        account. Enable two-factor authentication for enhanced account
-        security.{% endblocktrans %}</p>
-      <p><a href="{% url 'two_factor:setup' %}" class="btn btn-primary">
-        {% trans "Enable Two-Factor Authentication" %}</a>
-      </p>
-    </fieldset>
+    {% if default_device %}
+      <fieldset>
+        <legend>{% trans "Backup Phone Numbers" %}</legend>
+        <p>{% blocktrans %}If your primary method is not available, we are able to
+          send backup tokens to the phone numbers listed below.{% endblocktrans %}</p>
+        <ul>
+          {% for phone in backup_phones %}
+            <li>
+              {{ phone|device_action }}
+              <form method="post" action="{% url 'two_factor:phone_delete' phone.id %}"
+                    onsubmit="return confirm('Are you sure?')">
+                {% csrf_token %}
+                <button class="btn btn-xs btn-danger"
+                        type="submit">{% trans "Unregister" %}</button>
+              </form>
+            </li>
+          {% endfor %}
+        </ul>
+        <p><a href="{% url 'two_factor:phone_create' %}"
+              class="btn btn-default">{% trans "Add Phone Number" %}</a></p>
+        <br/>
+      </fieldset>
+
+      <fieldset>
+        <legend>{% trans "Backup Tokens" %}</legend>
+        <p>
+          {% blocktrans %}If you don't have any device with you, you can access
+            your account using backup tokens.{% endblocktrans %}
+          {% blocktrans count counter=backup_tokens %}
+            You have only one backup token remaining.
+          {% plural %}
+            You have {{ counter }} backup tokens remaining.
+          {% endblocktrans %}
+        </p>
+        <p><a href="{% url 'two_factor:backup_tokens' %}"
+              class="btn btn-default">{% trans "Show Codes" %}</a></p>
+        <br/>
+      </fieldset>
+
+      <fieldset>
+        <legend>{% trans "Remove Two-Factor Authentication" %}</legend>
+        <p>{% blocktrans %}However strongly we discourage you to do so, you can
+          also <strong>remove</strong> two-factor authentication for your account.{% endblocktrans %}</p>
+        <p><a class="btn btn-danger" href="{% url 'two_factor:disable' %}">
+          {% trans "Remove Two-Factor Authentication" %}</a></p>
+        <br/>
+      </fieldset>
+      <fieldset>
+        <legend>{% trans "Reset Two-Factor Authentication" %}</legend>
+        <p>{% blocktrans %}
+          Clicking below will disable your current two-factor authentication and rerun Two-Factor Authentication setup,
+          so make sure you have a backup device or tokens available in case you are unable to complete the process.
+        {% endblocktrans %}</p>
+        <p><a class="btn btn-default" href="{% url 'reset' %}">
+          {% trans "Reset Two-Factor Authentication" %}</a></p>
+        <br/>
+      </fieldset>
+    {% else %}
+      <fieldset>
+        <legend>Two-Factor Authentication</legend>
+        <p>{% blocktrans %}Two-factor authentication is not enabled for your
+          account. Enable two-factor authentication for enhanced account
+          security.{% endblocktrans %}</p>
+        <p><a href="{% url 'two_factor:setup' %}" class="btn btn-primary">
+          {% trans "Enable Two-Factor Authentication" %}</a>
+        </p>
+      </fieldset>
+    {% endif %}
   {% endif %}
 {% endblock %}

--- a/corehq/apps/settings/templates/settings/change_my_password.html
+++ b/corehq/apps/settings/templates/settings/change_my_password.html
@@ -6,6 +6,21 @@
 {% requirejs_main 'settings/js/change_my_password' %}
 
 {% block page_content %}
-  {% initial_page_data "hide_password_feedback" hide_password_feedback %}
-  {% crispy form %}
+  {% if is_using_sso %}
+    <p class="lead">
+      {% blocktrans %}
+        Your password is not stored here.
+      {% endblocktrans %}
+    </p>
+    <p>
+      {% blocktrans %}
+        Your account is managed by <strong>{{ idp_name }}</strong>.<br />
+        Please see your organization's documentation for how to change
+        your Single Sign-On password.
+      {% endblocktrans %}
+    </p>
+  {% else %}
+    {% initial_page_data "hide_password_feedback" hide_password_feedback %}
+    {% crispy form %}
+  {% endif %}
 {% endblock %}

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -28,6 +28,8 @@ from two_factor.views import (
 )
 
 from corehq.apps.domain.extension_points import has_custom_clean_password
+from corehq.apps.sso.models import IdentityProvider
+from corehq.apps.sso.utils.request_helpers import is_request_using_sso
 from dimagi.utils.web import json_response
 
 import langcodes
@@ -287,9 +289,21 @@ class ChangeMyPasswordView(BaseMyAccountView):
 
     @property
     def page_context(self):
+        is_using_sso = (
+            toggles.ENTERPRISE_SSO.enabled_for_request(self.request)
+            and is_request_using_sso(self.request)
+        )
+        idp_name = None
+        if is_using_sso:
+            idp = IdentityProvider.get_active_identity_provider_by_username(
+                self.request.user.username
+            )
+            idp_name = idp.name
         return {
             'form': self.password_change_form,
             'hide_password_feedback': has_custom_clean_password(),
+            'is_using_sso': is_using_sso,
+            'idp_name': idp_name,
         }
 
     @method_decorator(sensitive_post_parameters())

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -324,6 +324,20 @@ class TwoFactorProfileView(BaseMyAccountView, ProfileView):
         # this is only here to add the login_required decorator
         return super(TwoFactorProfileView, self).dispatch(request, *args, **kwargs)
 
+    @property
+    def page_context(self):
+        if not (toggles.ENTERPRISE_SSO.enabled_for_request(self.request)
+                and is_request_using_sso(self.request)):
+            return {}
+
+        idp = IdentityProvider.get_active_identity_provider_by_username(
+            self.request.user.username
+        )
+        return {
+            'is_using_sso': True,
+            'idp_name': idp.name,
+        }
+
 
 class TwoFactorSetupView(BaseMyAccountView, SetupView):
     urlname = 'two_factor_setup'

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -21,6 +21,8 @@ from crispy_forms.layout import Fieldset, Layout, Submit
 from django_countries.data import COUNTRIES
 from memoized import memoized
 
+from corehq.apps.sso.models import IdentityProvider
+from corehq.apps.sso.utils.request_helpers import is_request_using_sso
 from dimagi.utils.django.fields import TrimmedCharField
 
 from corehq import toggles
@@ -245,6 +247,10 @@ class UpdateMyAccountInfoForm(BaseUpdateUserForm, BaseUserInfoForm):
     def __init__(self, *args, **kwargs):
         from corehq.apps.settings.views import ApiKeyView
         self.user = kwargs['existing_user']
+        self.is_using_sso = (
+            toggles.ENTERPRISE_SSO.enabled_for_request(kwargs['request'])
+            and is_request_using_sso(kwargs['request'])
+        )
         super(UpdateMyAccountInfoForm, self).__init__(*args, **kwargs)
         self.username = self.user.username
 
@@ -269,8 +275,23 @@ class UpdateMyAccountInfoForm(BaseUpdateUserForm, BaseUserInfoForm):
             crispy.Div(*username_controls),
             hqcrispy.Field('first_name'),
             hqcrispy.Field('last_name'),
-            hqcrispy.Field('email'),
         ]
+
+        if self.is_using_sso:
+            idp = IdentityProvider.get_active_identity_provider_by_username(
+                self.request.user.username
+            )
+            self.fields['email'].initial = self.user.email
+            self.fields['email'].help_text = _(
+                "This email is managed by {} and cannot be edited."
+            ).format(idp.name)
+
+            # It is the presence of the "readonly" attribute that determines
+            # whether an input is readonly. Its value does not matter.
+            basic_fields.append(hqcrispy.Field('email', readonly="readonly"))
+        else:
+            basic_fields.append(hqcrispy.Field('email'))
+
         if self.set_analytics_enabled:
             basic_fields.append(twbscrispy.PrependedText('analytics_enabled', ''),)
 
@@ -309,6 +330,8 @@ class UpdateMyAccountInfoForm(BaseUpdateUserForm, BaseUserInfoForm):
     @property
     def direct_properties(self):
         result = list(self.fields)
+        if self.is_using_sso:
+            result.remove('email')
         if not self.set_analytics_enabled:
             result.remove('analytics_enabled')
         return result


### PR DESCRIPTION
## Summary
All updates here are carefully made behind the `ENTERPRISE_SSO` feature flag.

When users are logged in through SSO, they should not be able to:
- update their email address
- update / add two-factor auth settings (as this is managed by the IdP)
- change their password (also managed by the IdP)

## Feature Flag
`ENTERPRISE_SSO`

## Product Description
Some pix:
<img width="1282" alt="Screen Shot 2021-04-27 at 5 36 12 PM" src="https://user-images.githubusercontent.com/716573/116446532-aa9e8c00-a81c-11eb-9512-33ee2dc8a506.png">
<img width="1041" alt="Screen Shot 2021-04-27 at 5 36 31 PM" src="https://user-images.githubusercontent.com/716573/116446542-ac684f80-a81c-11eb-9522-8d7705470398.png">
<img width="858" alt="Screen Shot 2021-04-27 at 5 36 20 PM" src="https://user-images.githubusercontent.com/716573/116446546-ac684f80-a81c-11eb-9a6e-afb3bcc1888d.png">


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
No tests for these UIs unfortunately

### QA Plan
QA happens with the final feature release

### Safety story
Everything is very carefully feature flagged and tested locally with the flag on and off.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
