### PR TITLE
Case API v0.6: Use cursors for deep pagination

### DIFF
--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -279,8 +279,8 @@ def external_id(external_id):
     return filters.term('external_id', external_id)
 
 
-def indexed_on(gt=None, gte=None, lt=None, lte=None, eq=None):
-    return filters.date_range('@indexed_on', gt=None, gte=None, lt=None, lte=None, eq=None)
+def indexed_on(gt=None, gte=None, lt=None, lte=None):
+    return filters.date_range('@indexed_on', gt, gte, lt, lte)
 
 
 def flatten_result(hit, include_score=False):

--- a/corehq/apps/es/filters.py
+++ b/corehq/apps/es/filters.py
@@ -15,6 +15,7 @@ Contributing:
 Additions to this file should be added to the ``builtin_filters`` method on
 either ESQuery or HQESQuery, as appropriate (is it an HQ thing?).
 """
+from .utils import es_format_datetime
 
 
 def match_all():
@@ -67,10 +68,8 @@ def range_filter(field, gt=None, gte=None, lt=None, lte=None):
 
 
 def date_range(field, gt=None, gte=None, lt=None, lte=None):
-    """Range filter that accepts datetime objects as arguments"""
-    def format_date(date):
-        return date if isinstance(date, str) else date.isoformat()
-    params = [d if d is None else format_date(d) for d in [gt, gte, lt, lte]]
+    """Range filter that accepts date and datetime objects as arguments"""
+    params = [d if d is None else es_format_datetime(d) for d in [gt, gte, lt, lte]]
     return range_filter(field, *params)
 
 

--- a/corehq/apps/es/tests/test_utils.py
+++ b/corehq/apps/es/tests/test_utils.py
@@ -21,7 +21,7 @@ def test_es_format_datetime():
             (datetime(2021, 4, 28, 11, 47, 22, 300000), "2021-04-28T11:47:22.300000"),
             (datetime(2021, 4, 28, 11, tzinfo=UTC), "2021-04-28T11:00:00+00:00"),
             (ET.localize(datetime(2021, 4, 28, 11)), "2021-04-28T11:00:00-04:00"),
-            # This is not a format we support in ES:
-            (ET.localize(datetime(2021, 4, 28, 11, microsecond=1)), "2021-04-28T11:00:00.000001-04:00"),
+            # 2021-04-28T11:00:00.000001-04:00 isn't supported in ES, so convert to server time
+            (ET.localize(datetime(2021, 4, 28, 11, microsecond=1)), "2021-04-28T15:00:00.000001"),
     ]:
         yield _assert_returns, date_or_datetime, expected

--- a/corehq/apps/es/tests/test_utils.py
+++ b/corehq/apps/es/tests/test_utils.py
@@ -1,0 +1,27 @@
+from datetime import date, datetime
+
+from pytz import UTC, timezone
+
+from ..utils import es_format_datetime
+
+ET = timezone('US/Eastern')
+
+
+def test_es_format_datetime():
+    def _assert_returns(date_or_datetime, expected):
+        actual = es_format_datetime(date_or_datetime)
+        assert actual == expected, f"Expected {expected}, got {actual}"
+
+    for date_or_datetime, expected in [
+            ("04/28/21", "04/28/21"),
+            (date(2021, 4, 28), "2021-04-28"),
+            (datetime(2021, 4, 28), "2021-04-28T00:00:00"),
+            (datetime(2021, 4, 28, 11, 47, 22), "2021-04-28T11:47:22"),
+            (datetime(2021, 4, 28, 11, 47, 22, 3), "2021-04-28T11:47:22.000003"),
+            (datetime(2021, 4, 28, 11, 47, 22, 300000), "2021-04-28T11:47:22.300000"),
+            (datetime(2021, 4, 28, 11, tzinfo=UTC), "2021-04-28T11:00:00+00:00"),
+            (ET.localize(datetime(2021, 4, 28, 11)), "2021-04-28T11:00:00-04:00"),
+            # This is not a format we support in ES:
+            (ET.localize(datetime(2021, 4, 28, 11, microsecond=1)), "2021-04-28T11:00:00.000001-04:00"),
+    ]:
+        yield _assert_returns, date_or_datetime, expected

--- a/corehq/apps/es/utils.py
+++ b/corehq/apps/es/utils.py
@@ -46,3 +46,12 @@ def track_es_report_load(domain, report_slug, owner_count):
             owner_count,
             tags={'report_slug': report_slug, 'domain': domain}
         )
+
+
+def es_format_datetime(date_or_datetime):
+    """
+    Takes a date or datetime object and converts it to a format ES can read
+    (see DATE_FORMATS_ARR). Timezone-aware values are converted to UTC. Strings
+    are returned unmodified.
+    """
+    return date_or_datetime if isinstance(date_or_datetime, str) else date_or_datetime.isoformat()

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -100,7 +100,7 @@ def get_list(domain, params):
     }
     cases_in_result = len(hits)
     if cases_in_result and es_result.total > cases_in_result:
-        ret['next'] = {**raw_params, **{'indexed_on.gt': hits[-1]["@indexed_on"]}}
+        ret['next'] = {**raw_params, **{'indexed_on.gte': hits[-1]["@indexed_on"]}}
     return ret
 
 

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -93,13 +93,14 @@ def get_list(domain, params):
             raise UserError(f"'{key}' is not a valid parameter.")
 
     es_result = query.run()
+    hits = es_result.hits
     ret = {
         "total": es_result.total,
-        "cases": [serialize_es_case(case) for case in es_result.hits],
+        "cases": [serialize_es_case(case) for case in hits],
     }
-    cases_in_result = len(es_result.hits)
+    cases_in_result = len(hits)
     if cases_in_result and es_result.total > cases_in_result:
-        ret['next'] = {**raw_params, **{'indexed_on.gt': es_result.hits[-1]["@indexed_on"]}}
+        ret['next'] = {**raw_params, **{'indexed_on.gt': hits[-1]["@indexed_on"]}}
     return ret
 
 

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -106,12 +106,12 @@ class TestCaseListAPI(TestCase):
             "limit": "3",
             "case_type": "person",
         }, res['next'])
-        self.assertIn('indexed_on.gt', res['next'])
+        self.assertIn('indexed_on.gte', res['next'])
 
         res = get_list(self.domain, res['next'])
-        self.assertEqual(res['total'], 2)
+        self.assertEqual(res['total'], 3)
         self.assertEqual(
-            ['chaney', 'ned'],
+            ['laboeuf', 'chaney', 'ned'],
             [c['external_id'] for c in res['cases']]
         )
         self.assertNotIn('next', res)  # No pages after this one

--- a/corehq/pillows/core.py
+++ b/corehq/pillows/core.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 
 
+# TODO add support for microseconds with timezones
 DATE_FORMATS_ARR = ["yyyy-MM-dd",
                    "yyyy-MM-dd'T'HH:mm:ssZZ",
                    "yyyy-MM-dd'T'HH:mm:ss.SSSSSS",


### PR DESCRIPTION
## Summary
https://github.com/dimagi/commcare-hq/pull/29275#discussion_r591230076
Each commit stands alone.  The big change is that this drops the `offset` parameter entirely, so the sole means of paginating is by cycling through `@indexed_on`.  It adds a `next` parameter to the result, with the same request pre-filtered by indexed date.

Eg:
```GET http://localhost:8000/a/esoergel/api/v0.6/case/?limit=20```
![image](https://user-images.githubusercontent.com/2367539/116447034-8dba8680-a825-11eb-8f07-7b52d63d9ab1.png)
![image](https://user-images.githubusercontent.com/2367539/116447092-9ca13900-a825-11eb-9395-588f2262fa62.png)
...
![image](https://user-images.githubusercontent.com/2367539/116447119-a460dd80-a825-11eb-9935-a33f87c09add.png)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This feature is still not released

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
