### PR TITLE
Add more ignore rules, lint cleanup, etc.

### DIFF
--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -196,6 +196,8 @@ def filter_form_diffs(couch_form, sql_form, diffs):
 
 def filter_case_diffs(couch_case, sql_case, diffs, statedb=None):
     doc_type = couch_case['doc_type']
+    while doc_type.endswith("-Deleted-Deleted"):
+        doc_type = doc_type[:-8]
     doc_types = [doc_type, 'CommCareCase*']
     diffs = _filter_ignored(couch_case, sql_case, diffs, doc_types)
     if statedb is not None:

--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -142,6 +142,7 @@ load_ignore_rules = memoized(lambda: add_duplicate_rules({
 
         Ignore('diff', 'name', check=is_truncated_255),
         Ignore('diff', check=has_date_values),
+        Ignore('diff', check=has_equivalent_times),
         Ignore('diff', check=sql_number_has_leading_zero),
         ignore_renamed('hq_user_id', 'external_id'),
         Ignore(path=('xform_ids', '[*]'), check=xform_ids_order),

--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -52,6 +52,7 @@ load_ignore_rules = memoized(lambda: add_duplicate_rules({
         Ignore('type', 'server_modified_on', old=None),
 
         Ignore('diff', check=has_date_values),
+        Ignore('diff', check=has_equivalent_times),
         Ignore('diff', check=sql_number_has_leading_zero),
         Ignore(check=is_text_xmlns),
     ],
@@ -343,6 +344,19 @@ def has_close_dates(old_obj, new_obj, rule, diff):
 
 def has_date_values(old_obj, new_obj, rule, diff):
     return _both_dates(diff.old_value, diff.new_value)
+
+
+def has_equivalent_times(old_obj, new_obj, rule, diff):
+    return normalize_time(diff.old_value) == diff.new_value
+
+
+def normalize_time(value):
+    if isinstance(value, str) and TIME_FORMAT.match(value):
+        return value + ".000"
+    return value
+
+
+TIME_FORMAT = re.compile(r"^\d\d:\d\d:\d\d$")
 
 
 def sql_number_has_leading_zero(old_obj, new_obj, rule, diff):

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -597,6 +597,19 @@ class DiffTestCases(SimpleTestCase):
         }
         self._test_form_diff_filter(couch_form, sql_form)
 
+    def test_case_time_value_diff(self):
+        couch_case = {
+            "doc_type": "CommCareCase",
+            "some_property": "11:49:00",
+        }
+        sql_case = {
+            "doc_type": "CommCareCase",
+            "some_property": "11:49:00.000",
+        }
+        diffs = json_diff(couch_case, sql_case, track_list_indices=False)
+        filtered = filter_case_diffs(couch_case, sql_case, diffs)
+        self.assertEqual(filtered, [])
+
     def test_form_with_number_with_extra_leading_zero(self):
         couch_form = {
             "doc_type": "XFormInstance",

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -586,6 +586,17 @@ class DiffTestCases(SimpleTestCase):
         }
         self._test_form_diff_filter(couch_form, sql_form)
 
+    def test_form_time_value_diff(self):
+        couch_form = {
+            "doc_type": "XFormInstance",
+            "form": {"end_time": "11:49:00"},
+        }
+        sql_form = {
+            "doc_type": "XFormInstance",
+            "form": {"end_time": "11:49:00.000"},
+        }
+        self._test_form_diff_filter(couch_form, sql_form)
+
     def test_form_with_number_with_extra_leading_zero(self):
         couch_form = {
             "doc_type": "XFormInstance",

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -212,6 +212,20 @@ class DiffTestCases(SimpleTestCase):
         filtered = filter_case_diffs(couch_case, sql_case, DELETION_DIFFS + REAL_DIFFS)
         self.assertEqual(filtered, REAL_DIFFS)
 
+    def test_delete_case_with_mangled_doc_type(self):
+        couch_case = {
+            'doc_type': 'CommCareCase-Deleted-Deleted-Deleted',
+            '-deletion_id': 'abc',
+            '-deletion_date': '123',
+        }
+        sql_case = {
+            'doc_type': 'CommCareCase-Deleted',
+            'deletion_id': 'abc',
+            'deleted_on': '123',
+        }
+        filtered = filter_case_diffs(couch_case, sql_case, DELETION_DIFFS + REAL_DIFFS)
+        self.assertEqual(filtered, REAL_DIFFS)
+
     def test_filter_case_diffs(self):
         couch_case = {'doc_type': 'CommCareCase'}
         diffs = _make_ignored_diffs('CommCareCase') + DATE_DIFFS + REAL_DIFFS

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -633,7 +633,6 @@ class MigrationTestCase(BaseMigrationTestCase):
             </n1:meta>
         </data>""".format(
             date='2016-03-01T12:04:16Z',
-            attachment_source=attachment_source,
             form_id=uuid.uuid4().hex
         )
         submit_form_locally(


### PR DESCRIPTION
Review by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

All changes except for lint cleanup have corresponding tests.

### Safety story

This PR affects migration code, which is only run by management commands.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
