### PR TITLE
explicitly drop support for ES version 1

### DIFF
--- a/corehq/util/es/elasticsearch.py
+++ b/corehq/util/es/elasticsearch.py
@@ -1,24 +1,10 @@
 from django.conf import settings
 
 if settings.ELASTICSEARCH_MAJOR_VERSION == 1:
-    import elasticsearch
-    from elasticsearch.exceptions import AuthorizationException
-    from elasticsearch import (
-        ConnectionError,
-        ConnectionTimeout,
-        Elasticsearch,
-        ElasticsearchException,
-        NotFoundError,
-        SerializationError,
-        ConflictError,
-        TransportError,
-        RequestError,
+    raise RuntimeError(
+        'Elasticsearch version 1 is no longer supported. Please upgrade Elasticsearch. Details: \n'
+        'https://github.com/dimagi/commcare-cloud/blob/master/changelog/0032-upgrade-to-elasticsearch-2.4.6.yml'
     )
-    from elasticsearch.client import (
-        IndicesClient,
-        SnapshotClient,
-    )
-    from elasticsearch.helpers import bulk, scan
 elif settings.ELASTICSEARCH_MAJOR_VERSION == 2:
     import elasticsearch2 as elasticsearch
     from elasticsearch2.exceptions import AuthorizationException
@@ -58,7 +44,7 @@ elif settings.ELASTICSEARCH_MAJOR_VERSION == 7:
     )
     from elasticsearch7.helpers import bulk, scan
 else:
-    raise ValueError("ELASTICSEARCH_MAJOR_VERSION must currently be 1 or 2 or 7, given {}".format(
+    raise ValueError("ELASTICSEARCH_MAJOR_VERSION must currently be 2 or 7, given {}".format(
         settings.ELASTICSEARCH_MAJOR_VERSION))
 
 

--- a/corehq/util/es/interface.py
+++ b/corehq/util/es/interface.py
@@ -195,7 +195,6 @@ class ElasticsearchInterface7(AbstractElasticsearchInterface):
 
 
 ElasticsearchInterface = {
-    1: ElasticsearchInterfaceDefault,
     2: ElasticsearchInterfaceDefault,
     7: ElasticsearchInterface7,
 }[settings.ELASTICSEARCH_MAJOR_VERSION]

--- a/settings.py
+++ b/settings.py
@@ -827,7 +827,7 @@ SUMOLOGIC_URL = None
 # on both a single instance or distributed setup this should assume localhost
 ELASTICSEARCH_HOST = 'localhost'
 ELASTICSEARCH_PORT = 9200
-ELASTICSEARCH_MAJOR_VERSION = 1
+ELASTICSEARCH_MAJOR_VERSION = 2
 # If elasticsearch queries take more than this, they result in timeout errors
 ES_SEARCH_TIMEOUT = 30
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This [was officially dropped more than a year ago](https://github.com/dimagi/commcare-cloud/blob/master/changelog/0032-upgrade-to-elasticsearch-2.4.6.yml#L9), so seems safe to remove.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

We aren't using ES version 1, and other people using it should have upgraded in the last year, so I don't anticipate any issues.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Not sure.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
n/a

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
