### PR TITLE
Dockerfile from jessie to bionic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM python:3.6
 MAINTAINER Dimagi <devops@dimagi.com>
 
 ENV PYTHONUNBUFFERED=1 \
@@ -12,24 +12,31 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-x64.tar.gz"
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+     default-jdk \
+     wget \
+     libxml2-dev \
+     libxmlsec1-dev \
+     libxmlsec1-openssl
+
 # Install latest chrome dev package and fonts to support major
 # charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version
 # of Chromium that Puppeteer installs, work.
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-     openjdk-7-jdk \
-     wget \
-     libxml2-dev \
-     libxmlsec1-dev \
-     libxmlsec1-openssl \
-  && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
   && apt-get update \
-  && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
-    --no-install-recommends \
-  # this line deletes all package sources, so don't apt-get install anything after this:
-  && rm -rf /var/lib/apt/lists/* /src/*.deb
+  && apt-get install -y --no-install-recommends \
+     google-chrome-unstable \
+     fonts-ipafont-gothic \
+     fonts-wqy-zenhei \
+     fonts-thai-tlwg \
+     fonts-kacst \
+     fonts-freefont-ttf
+
+# Deletes all package sources, so don't apt-get install anything after this:
+RUN rm -rf /var/lib/apt/lists/* /src/*.deb
 
 COPY requirements/test-requirements.txt package.json /vendor/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-jessie
+FROM ubuntu:18.04
 MAINTAINER Dimagi <devops@dimagi.com>
 
 ENV PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
## Summary

`Dockerfile` uses the `python:3.6-jessie` image, Debian Jessie.

> Regular security support updates have been discontinued as of June 17th, 2018.
> --- <https://www.debian.org/releases/jessie/>

This PR switches to the `ubuntu:18.04` image instead, bringing it in line with commcare-cloud.

An alternative might be to use the `python:3.6` or `python:3.6-buster` image, but keeping Dockerfile in line with commcare-cloud seems right.

...

I'm making this change I couldn't bring up the "web" image. It fails for me because pip can't install xmlsec. (I'm guessing it's because the xmlsec1-dev apt package does not install successfully, but I couldn't find that in my console output.)

```
web_1             | Building wheels for collected packages: xmlsec
web_1             |   Building wheel for xmlsec (PEP 517): started
web_1             |   Building wheel for xmlsec (PEP 517): finished with status 'error'
...
web_1             |   running build_ext
web_1             |   error: xmlsec1 is not installed or not in path.
web_1             |   ----------------------------------------
web_1             |   ERROR: Failed building wheel for xmlsec
web_1             | Failed to build xmlsec
web_1             | ERROR: Could not build wheels for xmlsec which use PEP 517 and cannot be installed directly
```

However, Travis uses `Dockerfile` on `python:3.6-jessie` ... doesn't it? **Why does it work for Travis?**

Pinging people who know more about how HQ is used on Docker than I do.


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story

* I'm labelling the risk as "high" because I think this change could affect Travis. If the build runs through successfully we should probably downgrade that.
* This change also affects users and self-hosted environments that run the "web" container.
* The change does not affect normal deployed environments.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
