### PR TITLE
cache enabled toggles for user / domain

### DIFF
--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -462,7 +462,7 @@ class FeaturePreviewsView(BaseAdminProjectSettingsView):
     def post(self, request, *args, **kwargs):
         for feature, enabled in self.features():
             self.update_feature(feature, enabled, feature.slug in request.POST)
-        feature_previews.previews_dict.clear(self.domain)
+        feature_previews.previews_enabled_for_domain.clear(self.domain)
 
         return redirect('feature_previews', domain=self.domain)
 

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -35,6 +35,8 @@ from corehq.toggles import (
     PredictablyRandomToggle,
     all_toggles,
     NAMESPACE_EMAIL_DOMAIN,
+    toggles_enabled_for_domain,
+    toggles_enabled_for_user,
 )
 from corehq.util.soft_assert import soft_assert
 
@@ -245,10 +247,12 @@ def _call_save_fn_and_clear_cache(static_toggle, previously_enabled, currently_e
             domain = entry
             if static_toggle.save_fn is not None:
                 static_toggle.save_fn(domain, enabled)
+            toggles_enabled_for_domain.clear(domain)
         elif namespace != NAMESPACE_EMAIL_DOMAIN:
             # these are sent down with no namespace
             assert ':' not in entry, entry
             username = entry
+            toggles_enabled_for_user.clear(username)
 
 
 def _clear_caches_for_dynamic_toggle(static_toggle):


### PR DESCRIPTION
## Summary
Each request to Formplayer calls the `user_details` endpoint which
responds with the list of enabled toggles and previews for the user
and domain. Prior to this PR that involved fetching each toggle out of
Redis at least once and in the worst case twice.

This PR aims to improve the performance of that endpoint.
Locally the difference is 135ms vs 2ms (364 redis requests vs 3)
for the portion that's compiling the list of enabled toggles & previews.

Although this isn't a large change in terms of total time it does add up over all
the formplayer requests.

This will also reduce request load on redis (as shown above) at the
expense of adding more data into redis. This only stores the names
of the enalbed toggles for a domain / user instead of ALL toggles names
with their enabled state.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Partially covered by existing tests for session details endpoint.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
