### PR TITLE
basic tests for FormplayerInterface (opening for feedback)

### DIFF
--- a/corehq/apps/formplayer_api/smsforms/tests/test_formplayer_interface.py
+++ b/corehq/apps/formplayer_api/smsforms/tests/test_formplayer_interface.py
@@ -1,0 +1,67 @@
+import uuid
+
+import requests_mock
+from django.conf import settings
+from django.test import TestCase
+
+from corehq.apps.formplayer_api.smsforms.api import FormplayerInterface
+from corehq.apps.formplayer_api.utils import get_formplayer_url
+from corehq.util.hmac_request import get_hmac_digest
+
+
+class TestFormplayerInterface(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.session_id = uuid.uuid4().hex
+        self.domain = uuid.uuid4().hex
+        self.user_id = uuid.uuid4().hex
+        self.interface = FormplayerInterface(self.session_id, self.domain, self.user_id)
+
+    def test_get_raw_instance(self):
+        expected_request_data = {
+            'action': 'get-instance',
+            'session-id': self.session_id,
+            'session_id': self.session_id,
+            'domain': self.domain,
+            'oneQuestionPerScreen': True,
+            'nav_mode': 'prompt',
+        }
+        self._test_request("get-instance", self.interface.get_raw_instance, expected_request_data, {})
+
+    def test_answer_question(self):
+        mock_response = {"event": {
+            "datatype": "select",
+            "choices": ["red", "green", "blue"],
+            "caption": "What's your favorite color?",
+            "type": "question",
+            "answer": None,
+            "required": 0,
+            "ix": "1",
+            "help": None
+        }}
+
+        expected_request_data = {
+            'action': 'answer',
+            'answer': 'answer1',
+            'session-id': self.session_id,
+            'session_id': self.session_id,
+            'domain': self.domain,
+            'oneQuestionPerScreen': True,
+            'nav_mode': 'prompt',
+        }
+
+        def request_callable():
+            self.interface.answer_question("answer1")
+
+        self._test_request("answer", request_callable, expected_request_data, mock_response)
+
+    def _test_request(self, action, request_callable, expected_request_data, mock_response):
+        with requests_mock.Mocker() as m:
+            m.post(f"{get_formplayer_url()}/{action}", json=mock_response)
+            request_callable()
+            request = m.request_history[0]
+            self.assertEqual(request.json(), expected_request_data)
+            headers = request.headers
+            self.assertEqual(headers["X-FORMPLAYER-SESSION"], self.user_id)
+            digest = get_hmac_digest(settings.FORMPLAYER_INTERNAL_AUTH_KEY, request.text)
+            self.assertEqual(headers["X-MAC-DIGEST"], digest)

--- a/corehq/apps/formplayer_api/smsforms/tests/test_formplayer_interface.py
+++ b/corehq/apps/formplayer_api/smsforms/tests/test_formplayer_interface.py
@@ -8,19 +8,33 @@ SESSION_ID = "SESSION_ID"
 DOMAIN = "smsforms_domain"
 USER_ID = "USER_ID"
 
+QUESTION_RESPONSE = {
+    "event": {
+        "datatype": "select",
+        "choices": ["red", "green", "blue"],
+        "caption": "What's your favorite color?",
+        "type": "question",
+        "answer": None,
+        "required": 0,
+        "ix": "1",
+        "help": None
+    }
+}
+
 
 class FormplayerInterfaceTests(SimpleTestCase):
     interface = FormplayerInterface(SESSION_ID, DOMAIN, USER_ID)
 
     def test_get_raw_instance(self):
-        with MockFormplayerRequest("get-instance", {}) as mocker:
+        action = 'get-instance'
+        with MockFormplayerRequest(action, {}) as mocker:
             self.interface.get_raw_instance()
 
         mocker.assert_exactly_one_request()
         request = mocker.get_last_request()
 
         expected_request_data = {
-            'action': 'get-instance',
+            'action': action,
             'session-id': SESSION_ID,
             'session_id': SESSION_ID,
             'domain': DOMAIN,
@@ -30,26 +44,52 @@ class FormplayerInterfaceTests(SimpleTestCase):
         self.validate_request(request, expected_request_data)
 
     def test_answer_question(self):
-        mock_response = {"event": {
-            "datatype": "select",
-            "choices": ["red", "green", "blue"],
-            "caption": "What's your favorite color?",
-            "type": "question",
-            "answer": None,
-            "required": 0,
-            "ix": "1",
-            "help": None
-        }}
-
-        with MockFormplayerRequest("answer", mock_response) as mocker:
+        action = 'answer'
+        with MockFormplayerRequest(action, QUESTION_RESPONSE) as mocker:
             self.interface.answer_question("answer1")
 
         mocker.assert_exactly_one_request()
         request = mocker.get_last_request()
 
         expected_request_data = {
-            'action': 'answer',
+            'action': action,
             'answer': 'answer1',
+            'session-id': SESSION_ID,
+            'session_id': SESSION_ID,
+            'domain': DOMAIN,
+            'oneQuestionPerScreen': True,
+            'nav_mode': 'prompt',
+        }
+        self.validate_request(request, expected_request_data)
+
+    def test_current_question(self):
+        action = 'current'
+        with MockFormplayerRequest(action, QUESTION_RESPONSE) as mocker:
+            self.interface.current_question()
+
+        mocker.assert_exactly_one_request()
+        request = mocker.get_last_request()
+
+        expected_request_data = {
+            'action': action,
+            'session-id': SESSION_ID,
+            'session_id': SESSION_ID,
+            'domain': DOMAIN,
+            'oneQuestionPerScreen': True,
+            'nav_mode': 'prompt',
+        }
+        self.validate_request(request, expected_request_data)
+
+    def test_next(self):
+        action = "next"
+        with MockFormplayerRequest(action, QUESTION_RESPONSE) as mocker:
+            self.interface.next()
+
+        mocker.assert_exactly_one_request()
+        request = mocker.get_last_request()
+
+        expected_request_data = {
+            'action': action,
             'session-id': SESSION_ID,
             'session_id': SESSION_ID,
             'domain': DOMAIN,


### PR DESCRIPTION
## Summary
Thinking about options for integration tests between Formplayer and HQ and I think most of the value can be gained by validating request / response to / from the API. These tests are very basic and only the 'happy path'.

I'm interested to get feedback on this approach.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story
Only tests

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
