### PR TITLE
update mobile UCRs for dynamic reports

### DIFF
--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -355,6 +355,7 @@ def update_linked_app(app, master_app_id_or_build, user_id):
             report_map.update({
                 c.report_meta.master_id: c._id
                 for c in get_report_configs_for_domain(app.domain)
+                if c.report_meta.master_id
             })
 
         try:

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -42,6 +42,7 @@ from corehq.apps.linked_domain.exceptions import (
 )
 from corehq.apps.linked_domain.models import AppLinkDetail
 from corehq.apps.linked_domain.util import pull_missing_multimedia_for_app
+from corehq.apps.userreports.dbaccessors import get_report_configs_for_domain
 from corehq.apps.userreports.util import get_static_report_mapping
 
 CASE_TYPE_CONFLICT_MSG = (
@@ -350,6 +351,11 @@ def update_linked_app(app, master_app_id_or_build, user_id):
     ):
         old_multimedia_ids = set([media_info.multimedia_id for path, media_info in app.multimedia_map.items()])
         report_map = get_static_report_mapping(master_build.domain, app['domain'])
+        if not app.domain_link.is_remote:
+            report_map.update({
+                c.report_meta.master_id: c._id
+                for c in get_report_configs_for_domain(app.domain)
+            })
 
         try:
             app = overwrite_app(app, master_build, report_map)

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -17,8 +17,8 @@ from corehq.apps.app_manager.models import (
     import_app,
 )
 from corehq.apps.app_manager.suite_xml.post_process.resources import (
-    add_xform_resource_overrides,
     ResourceOverride,
+    add_xform_resource_overrides,
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import TestXmlMixin
@@ -40,9 +40,14 @@ from corehq.apps.linked_domain.remote_accessors import (
     _convert_app_from_remote_linking_source,
     fetch_remote_media,
 )
+from corehq.apps.linked_domain.ucr import create_linked_ucr
 from corehq.apps.linked_domain.util import (
     _get_missing_multimedia,
     convert_app_for_remote_linking,
+)
+from corehq.apps.userreports.tests.utils import (
+    get_sample_data_source,
+    get_sample_report_config,
 )
 from corehq.util.test_utils import flag_enabled, softer_assert
 
@@ -130,6 +135,43 @@ class TestLinkedApps(BaseLinkedAppsTest):
         report_map = {'master_report_id': 'mapped_id'}
         linked_app = overwrite_app(self.linked_app, self.master_app_with_report_modules, report_map)
         self.assertEqual(linked_app.modules[0].report_configs[0].report_id, 'mapped_id')
+
+    def test_linked_reports_updated(self):
+        # add a report on the master app
+        master_data_source = get_sample_data_source()
+        master_data_source.domain = self.domain
+        master_data_source.save()
+
+        master_report = get_sample_report_config()
+        master_report.config_id = master_data_source.get_id
+        master_report.domain = self.domain
+        master_report.save()
+
+        master_reports_module = self.master1.add_module(ReportModule.new_module('Reports', None))
+        master_reports_module.report_configs = [
+            ReportAppConfig(report_id=master_report.get_id, header={'en': 'CommBugz'}),
+        ]
+
+        # link report on master app to linked domain
+        link_info = create_linked_ucr(self.domain_link, master_report.get_id)
+
+        updated_app = update_linked_app(self.linked_app, self.master1, 'a-user-id')
+
+        # report config added with the linked report id updated in report config
+        self.assertEqual(updated_app.modules[0].report_configs[0].report_id, link_info.report.get_id)
+
+    @patch('corehq.apps.app_manager.views.utils.get_report_configs_for_domain')
+    def test_linked_reports_not_updated_for_remote(self, get_report_configs_for_domain):
+        old_remote_base_url = self.domain_link.remote_base_url
+        self.domain_link.remote_base_url = "http://my/app"
+        self.domain_link.save()
+
+        update_linked_app(self.linked_app, self.master1, 'TestLinkedApps user')
+        get_report_configs_for_domain.assert_not_called()
+
+        # reset for other tests
+        self.domain_link.remote_base_url = old_remote_base_url
+        self.domain_link.save()
 
     def test_overwrite_app_update_form_unique_ids(self):
         module = self.master1.add_module(Module.new_module('M1', None))


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-1000

For a linked domain, on the same environment as the master domain, 
when updating the linked app,
update report IDs in app's mobile UCR configs with linked report IDs of the linked domain.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
LINKED_DOMAINS
MOBILE_UCR

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This would now allow linked domains apps to add mobile UCRs with non-static reports as well.
Earlier mobile UCRs in linked domains, were supported only with static reports.

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
I have added couple of tests to ensure the new code runs well, when it should.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
