### PR TITLE
case search default sorting

### DIFF
--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -54,7 +54,8 @@ class CaseSearchCriteria(object):
                      .domain(self.domain)
                      .case_type(self.case_type)
                      .is_closed(False)
-                     .size(CASE_SEARCH_MAX_RESULTS))
+                     .size(CASE_SEARCH_MAX_RESULTS)
+                     .set_sorting_block(['_score', '_id']))
         return search_es
 
     def _assemble_optional_search_params(self):

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -55,7 +55,7 @@ class CaseSearchCriteria(object):
                      .case_type(self.case_type)
                      .is_closed(False)
                      .size(CASE_SEARCH_MAX_RESULTS)
-                     .set_sorting_block(['_score', '_id']))
+                     .set_sorting_block(['_score', '_doc']))
         return search_es
 
     def _assemble_optional_search_params(self):

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -99,6 +99,10 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
                     }
                 }
             },
+            "sort": [
+                "_score",
+                "_doc"
+            ],
             "size": CASE_SEARCH_MAX_RESULTS
         }
 
@@ -287,6 +291,10 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
                     }
                 }
             },
+            "sort": [
+                "_score",
+                "_doc"
+            ],
             "size": CASE_SEARCH_MAX_RESULTS
         }
         self.checkQuery(


### PR DESCRIPTION
[USH-897](https://dimagi-dev.atlassian.net/browse/USH-897) (work done by @sravfeyn)

## Summary
Add sorting to case search query in an attempt to produce more repeatable results between successive searches. This is particularly important when the search is re-run during end of form workflows.

The sorting is done on the search score (`_score`) and the default index order (`_doc`). `_doc` is chosen since it is the most efficient sort order and since we only want the sorting to provide consistency the actual order isn't important: https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-request-sort.html

Note that when the sort isn't specified ES will sort by `_score` by default. This means that this change only adds `_doc` as a secondary sort field but keeps `_score` as the primary.

## Feature Flag
Case search

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan
This should not have a big impact on the results seen by users since they are currently sorted by `_score` (ES defuault). The addition of the `_doc` order should only affect documents that have the same score.

I've run a number of tests against the production case search index and noted that the performance does not appear to be impacted. I also manually inspected some resultsets to ensure that the result order was roughly consistent with the ordering prior to the change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
