### PR TITLE
add ability to copy case search config from one module to another

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2125,6 +2125,17 @@ class CaseSearch(DocumentSchema):
                 relevant = default_condition
         return relevant
 
+    def overwrite_attrs(self, src_config, slugs):
+        if 'search_properties' in slugs:
+            self.properties = src_config.properties
+        if 'search_default_properties' in slugs:
+            self.default_properties = src_config.default_properties
+        if 'search_claim_options' in slugs:
+            # all options other than 'properties' and 'default_properties'
+            attrs = self.keys() - self.dynamic_properties().keys() - {'properties', 'default_properties'}
+            for attr in attrs:
+                setattr(self, attr, getattr(src_config, attr))
+
 
 class ParentSelect(DocumentSchema):
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
@@ -56,7 +56,22 @@
                   <label for="print_template">
                     <input type="checkbox" name="print_template" id="print_template"/>
                     {% trans "Print template" %}
-                  </label>
+                  </label><br>
+                {% endif %}
+                {% if request|toggle_enabled:'SYNC_SEARCH_CASE_CLAIM' %}
+                  {# prefix these with 'search_' to make it easier to filter on the backend #}
+                  <label for="search_properties">
+                    <input type="checkbox" name="search_properties" id="search_properties"/>
+                    {% trans "Search properties" %}
+                  </label><br>
+                  <label for="search_default_properties">
+                    <input type="checkbox" name="search_default_properties" id="search_default_properties"/>
+                    {% trans "Default search properties" %}
+                  </label><br>
+                  <label for="search_claim_options">
+                    <input type="checkbox" name="search_claim_options" id="search_claim_options"/>
+                    {% trans "Search and claim options" %}
+                  </label><br>
                 {% endif %}
             </div>
           </div>


### PR DESCRIPTION
[USH-908](https://dimagi-dev.atlassian.net/browse/USH-908)

## Summary
Spec: https://docs.google.com/document/d/1PaC6OL-eoy_au1z6jcvuXzaYPPyJbSCYqXlQ8M4p76s/edit#

Add options to the UI for copying case list to another module so that users can copy the case search config:

![image](https://user-images.githubusercontent.com/249606/116993026-30b44a00-acd7-11eb-92bd-007b85b8f133.png)

## Feature Flag
Case search

## Product Description
Adds 3 checkboxes to the list of options for copying case lists to other modules:

  - Search properties
  - Default Search properties
  - Search and claim options

These three options correspond to the three sections in the case search configuration UI.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Tests added

### QA Plan
I've done some QA locally and don't think more formal QA is necessary.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
