### PR TITLE
Altered calculate_physical_size to accept multiple domains

### DIFF
--- a/corehq/apps/domain/management/commands/calculate_physical_size.py
+++ b/corehq/apps/domain/management/commands/calculate_physical_size.py
@@ -13,11 +13,13 @@ from couchforms.analytics import (
 
 
 class Command(BaseCommand):
-    help = "Estimates the physical size of a domain's forms and cases."
+    help = "Estimates the physical size of one or more domains' forms and cases."
 
     def add_arguments(self, parser):
         parser.add_argument(
             'domains',
+            help="Enter a list of domains surrounded by quotation marks with only spaces between the domains."
+            "A single domain can also be entered",
         )
         parser.add_argument(
             '--sample_size',
@@ -52,10 +54,18 @@ class Command(BaseCommand):
         show_only_forms = options.get('only_forms', False)
         show_only_cases = options.get('only_cases', False)
 
+        if not show_only_cases:
+            self.stdout.write(f"\n\nCalculating size of forms with a sample "
+                            f"size of {sample_size} per XMLNS...")
+
+        if not show_only_forms:
+            self.stdout.write(f"\n\nCalculating size of cases with a sample "
+                            f"size of {sample_size} per Case Type...")
+            if use_case_search:
+                self.stdout.write("The Case search index is being used.")
+
         for domain in domains_list:
             if not show_only_cases:
-                self.stdout.write(f"\n\nCalculating size of forms with a sample "
-                                f"size of {sample_size} per XMLNS...")
                 num_forms, size_of_forms = _get_form_size_stats(domain, sample_size)
                 final_num_forms += num_forms
                 final_size_forms += size_of_forms
@@ -66,10 +76,6 @@ class Command(BaseCommand):
                                 f"physical space.")
 
             if not show_only_forms:
-                self.stdout.write(f"\n\nCalculating size of cases with a sample "
-                                f"size of {sample_size} per Case Type...")
-                if use_case_search:
-                    self.stdout.write("The Case search index is being used.")
                 num_cases, size_of_cases = _get_case_size_stats(
                     domain, sample_size, use_case_search
                 )
@@ -82,12 +88,12 @@ class Command(BaseCommand):
                                 f"physical space.")
 
         if not show_only_cases:
-            self.stdout.write(f"\n These domains have a total of {final_num_forms} forms, "
+            self.stdout.write(f"\nThese domains have a total of {final_num_forms} forms, "
                             f"taking up approximately {final_size_forms} bytes "
                             f"({_get_human_bytes(final_size_forms)}) of physical space.")
 
         if not show_only_forms:
-            self.stdout.write(f"\n These domains have a total of {final_num_cases} cases, "
+            self.stdout.write(f"\nThese domains have a total of {final_num_cases} cases, "
                             f"taking up approximately {final_size_cases} bytes "
                             f"({_get_human_bytes(final_size_cases)}) of physical space.")
 

--- a/corehq/apps/domain/management/commands/calculate_physical_size.py
+++ b/corehq/apps/domain/management/commands/calculate_physical_size.py
@@ -18,8 +18,8 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             'domains',
-            help="Enter a list of domains surrounded by quotation marks with only spaces between the domains."
-            "A single domain can also be entered",
+            help="a list of domains",
+            nargs='+',
         )
         parser.add_argument(
             '--sample_size',
@@ -47,8 +47,6 @@ class Command(BaseCommand):
         final_size_forms = 0
         final_size_cases = 0
 
-        domains_list = domains.split()
-
         sample_size = int(options['sample_size'] or 10)
         use_case_search = options.get('use_case_search', False)
         show_only_forms = options.get('only_forms', False)
@@ -64,7 +62,7 @@ class Command(BaseCommand):
             if use_case_search:
                 self.stdout.write("The Case search index is being used.")
 
-        for domain in domains_list:
+        for domain in domains:
             if not show_only_cases:
                 num_forms, size_of_forms = _get_form_size_stats(domain, sample_size)
                 final_num_forms += num_forms


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The management command calculate_physical_size will now allow for a list of domains to be passed through.
Link to ticket: https://dimagi-dev.atlassian.net/browse/SAAS-12086

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below
Code has been tested both locally and on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Local testing

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally with single domains and lists

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
