### PR TITLE
Add display properties to messaging events API

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1094,7 +1094,7 @@ class MessagingEventResource(HqBaseResource, ModelResource):
     content_type_display = fields.CharField(attribute='get_content_type_display')
     recipient_type_display = fields.CharField(attribute='get_recipient_type_display')
     status_display = fields.CharField(attribute='get_status_display')
-    # source_display = fields.CharField(attribute='get_source_display')
+    source_display = fields.CharField(attribute='get_source_display')
 
     class Meta(object):
         queryset = MessagingEvent.objects.all()

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1091,6 +1091,10 @@ class ODataFormResource(BaseODataResource):
 
 
 class MessagingEventResource(HqBaseResource, ModelResource):
+    content_type_display = fields.CharField(attribute='get_content_type_display')
+    recipient_type_display = fields.CharField(attribute='get_recipient_type_display')
+    status_display = fields.CharField(attribute='get_status_display')
+    # source_display = fields.CharField(attribute='get_source_display')
 
     class Meta(object):
         queryset = MessagingEvent.objects.all()

--- a/corehq/apps/api/tests/test_messaging_event_api.py
+++ b/corehq/apps/api/tests/test_messaging_event_api.py
@@ -38,7 +38,7 @@ class TestMessagingEventResource(APIResourceTest):
             "recipient_type_display": None,
             "resource_uri": "",
             "source": MessagingEvent.SOURCE_OTHER,
-            # "source_display": 'Other',
+            "source_display": 'Other',
             "source_id": None,
             "status": MessagingEvent.STATUS_COMPLETED,
             "status_display": 'Completed',

--- a/corehq/apps/api/tests/test_messaging_event_api.py
+++ b/corehq/apps/api/tests/test_messaging_event_api.py
@@ -26,6 +26,7 @@ class TestMessagingEventResource(APIResourceTest):
             "additional_error_text": None,
             "app_id": None,
             "content_type": MessagingEvent.CONTENT_SMS,
+            "content_type_display": 'SMS Message',
             "date": "2016-01-01T12:00:00",
             "domain": "qwerty",
             "error_code": None,
@@ -34,10 +35,13 @@ class TestMessagingEventResource(APIResourceTest):
             # "id": 1,  # ids are explicitly removed from comparison
             "recipient_id": None,
             "recipient_type": None,
+            "recipient_type_display": None,
             "resource_uri": "",
             "source": MessagingEvent.SOURCE_OTHER,
+            # "source_display": 'Other',
             "source_id": None,
             "status": MessagingEvent.STATUS_COMPLETED,
+            "status_display": 'Completed',
         }
 
     def test_get_list_simple(self):

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from django.contrib.postgres.fields import ArrayField
 from django.db import IntegrityError, connection, models, transaction
 from django.http import Http404
+from django.utils.encoding import force_str
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
 import jsonfield
@@ -1077,6 +1078,12 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
 
     class Meta(object):
         app_label = 'sms'
+
+    def get_source_display(self):
+        # for some reason source choices aren't set in the field, so manually add this method.
+        # to mimic _get_FIELD_display in django.models.base.Model
+        # https://github.com/django/django/blob/main/django/db/models/base.py#L962-L966
+        return force_str(dict(self.SOURCE_CHOICES).get(self.source, self.source), strings_only=True)
 
     @classmethod
     def get_recipient_type_from_doc_type(cls, recipient_doc_type):


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

This adds four new fields to the messaging events API which are just readable versions of the underlying system fields.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

There are tests, it is backwards compatible, and also no one is using this API currently according to datadog.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Yes

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

n/a

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
