### PR TITLE
Improve readability of import_app

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5708,19 +5708,19 @@ class LinkedApplication(Application):
 
 def import_app(app_id_or_doc, domain, extra_properties=None, request=None):
     source_app = _get_source_app(app_id_or_doc)
-    source = source_app.export_json(dump_json=False)
+    source_doc = source_app.export_json(dump_json=False)
 
-    attachments = _get_attachments(source)
-    source['_attachments'] = {}
+    attachments = _get_attachments(source_doc)
+    source_doc['_attachments'] = {}
 
     if extra_properties is not None:
-        source.update(extra_properties)
+        source_doc.update(extra_properties)
 
     # Allow the wrapper to update to the current default build_spec
-    if 'build_spec' in source:
-        del source['build_spec']
+    if 'build_spec' in source_doc:
+        del source_doc['build_spec']
 
-    app = _create_app_from_source(domain, source)
+    app = _create_app_from_doc(domain, source_doc)
     if source_app.domain == domain:
         app.family_id = source_app.origin_id
 
@@ -5751,18 +5751,18 @@ def _get_source_app(app_id_or_doc):
     return source_app
 
 
-def _get_attachments(source):
+def _get_attachments(doc):
     try:
-        attachments = source['_attachments']
+        attachments = doc['_attachments']
     except KeyError:
         attachments = {}
 
     return attachments
 
 
-def _create_app_from_source(domain, source):
-    app_class = get_correct_app_class(source)
-    app = app_class.from_source(source, domain)
+def _create_app_from_doc(domain, doc):
+    app_class = get_correct_app_class(doc)
+    app = app_class.from_source(doc, domain)
     app.convert_build_to_app()
     app.date_created = datetime.datetime.utcnow()
     app.cloudcare_enabled = domain_has_privilege(domain, privileges.CLOUDCARE)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5730,7 +5730,7 @@ def import_app(app_id_or_doc, domain, extra_properties=None, request=None):
     app.save_attachments(attachments)
 
     try:
-        _update_valid_domains_for_media(domain, app)
+        _update_valid_domains_for_media(app, domain)
     except ReportConfigurationNotFoundError:
         if request:
             messages.warning(request, _("Copying the application succeeded, but the application will have errors "

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5707,62 +5707,88 @@ class LinkedApplication(Application):
 
 
 def import_app(app_id_or_source, domain, source_properties=None, request=None, check_all_reports=True):
+    source_app = _get_source_app(app_id_or_source)
+    source = source_app.export_json(dump_json=False)
+
+    attachments = _get_attachments(source)
+    source['_attachments'] = {}
+
+    if source_properties is not None:
+        source.update(source_properties)
+
+    # Allow the wrapper to update to the current default build_spec
+    if 'build_spec' in source:
+        del source['build_spec']
+
+    app = _create_app_from_source(domain, source)
+    if source_app.domain == domain:
+        app.family_id = source_app.origin_id
+
+    report_map = get_static_report_mapping(source_app.domain, domain)
+    _update_report_config_ids(app, report_map, source_app.domain, check_all_reports)
+
+    app.save_attachments(attachments)
+
+    _update_valid_domains_for_media(domain, app, request)
+
+    if not app.is_remote_app():
+        enable_usercase_if_necessary(app)
+
+    return app
+
+
+def _get_source_app(app_id_or_source):
     if isinstance(app_id_or_source, str):
         source_app = get_app(None, app_id_or_source)
     else:
         source_app = wrap_app(app_id_or_source)
-    source_domain = source_app.domain
-    source = source_app.export_json(dump_json=False)
+    return source_app
+
+
+def _get_attachments(source):
     try:
         attachments = source['_attachments']
     except KeyError:
         attachments = {}
-    finally:
-        source['_attachments'] = {}
-    if source_properties is not None:
-        for key, value in source_properties.items():
-            source[key] = value
-    cls = get_correct_app_class(source)
-    # Allow the wrapper to update to the current default build_spec
-    if 'build_spec' in source:
-        del source['build_spec']
-    app = cls.from_source(source, domain)
+
+    return attachments
+
+
+def _create_app_from_source(domain, source):
+    app_class = get_correct_app_class(source)
+    app = app_class.from_source(source, domain)
     app.convert_build_to_app()
     app.date_created = datetime.datetime.utcnow()
     app.cloudcare_enabled = domain_has_privilege(domain, privileges.CLOUDCARE)
-    if source_domain == domain:
-        app.family_id = source_app.origin_id
 
-    report_map = get_static_report_mapping(source_domain, domain)
+    return app
+
+
+def _update_report_config_ids(app, report_map, domain, check_all_reports):
     if report_map:
         for module in app.get_report_modules():
             for config in module.report_configs:
                 try:
                     config.report_id = report_map[config.report_id]
                 except KeyError:
-                    if check_all_reports or config.report(source_domain).is_static:
+                    if check_all_reports or config.report(domain).is_static:
                         raise AppEditingError(
                             "Report {} not found in {}".format(config.report_id, domain)
                         )
 
-    app.save_attachments(attachments)
 
+def _update_valid_domains_for_media(app, domain_to_add, request):
     try:
         if not app.is_remote_app():
             for path, media in app.get_media_objects(remove_unused=True):
-                if domain not in media.valid_domains:
-                    media.valid_domains.append(domain)
+                if domain_to_add not in media.valid_domains:
+                    media.valid_domains.append(domain_to_add)
                     media.save()
     except ReportConfigurationNotFoundError:
         if request:
             messages.warning(request, _("Copying the application succeeded, but the application will have errors "
                                         "because your application contains a Mobile Report Module that references "
                                         "a UCR configured in this project space. Multimedia may be absent."))
-
-    if not app.is_remote_app():
-        enable_usercase_if_necessary(app)
-
-    return app
 
 
 def enable_usercase_if_necessary(app):


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I was trying to understand this and felt overwhelmed by everything going on in this method. I still don't understand every responsibility of this method so hopefully reviewers can help suggest better names/organization to improve readability. 

Additionally if this feels like a downgrade I'm curious to hear why. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
App manager automated tests.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
