### PR TITLE
Fix test remote link ucr

### DIFF
--- a/corehq/apps/linked_domain/tests/test_linked_userreports.py
+++ b/corehq/apps/linked_domain/tests/test_linked_userreports.py
@@ -167,4 +167,4 @@ class TestLinkedUCR(BaseLinkedAppsTest):
 
         update_linked_ucr(self.domain_link, linked_report_info.report.get_id)
         report = ReportConfiguration.get(linked_report_info.report.get_id)
-        self.assertEqual("Another new title", report.title)
+        self.assertEqual("CommBugz", report.title)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Fix test written in https://github.com/dimagi/commcare-hq/pull/27569/files#diff-8d78b6d1e646bac1a3da6c579ac539ec19b0a6ff5bab0c04a690170cb9bbdba5R145 to do remote request as expected

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`Linked Domains`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
