### PR TITLE
catch empty strings as well

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -383,7 +383,7 @@ class ConfigurableReportPillowProcessor(ConfigurableReportTableManagerMixin, Bul
                                     except Exception as e:
                                         change_exceptions.append((change, e))
                                     eval_context.reset_iteration()
-                            elif (doc_subtype is None
+                            elif (not doc_subtype
                                     or doc_subtype in adapter.config.get_case_type_or_xmlns_filter()):
                                 # Delete if the subtype is unknown or
                                 # if the subtype matches our filters, but the full filter no longer applies


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-998
Sometimes cases have case types that are `''` instead of `None`, such as when the initial form that created the case is amended to no longer create that case. This code should catch that case too.

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Cases with an empty string for a case type will be properly deleted from UCR data sources they had previously been added to.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This is a `tiny change that doesn't change the intent of the modified code.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
