### PR TITLE
permission model cleanup + util tests

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -180,14 +180,6 @@ class Permissions(DocumentSchema):
         else:
             return getattr(self, permission)
 
-    def set(self, permission, value, data=None):
-        if self.has(permission, data) == value:
-            return
-        if data:
-            getattr(self, permission)(data, value)
-        else:
-            setattr(self, permission, value)
-
     def _getattr(self, name):
         a = getattr(self, name)
         if isinstance(a, list):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -173,20 +173,8 @@ class Permissions(DocumentSchema):
             return True
         return master_app_id in self.view_web_apps_list
 
-    def view_report(self, report, value=None):
-        """Both a getter (when value=None) and setter (when value=True|False)"""
-
-        if value is None:
-            return self.view_reports or report in self.view_report_list
-        else:
-            if value:
-                if report not in self.view_report_list:
-                    self.view_report_list.append(report)
-            else:
-                try:
-                    self.view_report_list.remove(report)
-                except ValueError:
-                    pass
+    def view_report(self, report):
+        return self.view_reports or report in self.view_report_list
 
     def has(self, permission, data=None):
         if data:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -331,7 +331,7 @@ class UserRole(QuickCachedDocumentMixin, Document):
         return [x for x in all_roles if not x.is_archived]
 
     @classmethod
-    def by_domain_and_name(cls, domain, name, is_archived=False):
+    def by_domain_and_name(cls, domain, name):
         # todo change this view to show is_archived status or move to PRBAC UserRole
         all_roles = cls.view(
             'users/roles_by_domain',
@@ -339,7 +339,7 @@ class UserRole(QuickCachedDocumentMixin, Document):
             include_docs=True,
             reduce=False,
         )
-        return [x for x in all_roles if x.is_archived == is_archived]
+        return list(all_roles)
 
     @classmethod
     def get_or_create_with_permissions(cls, domain, permissions, name=None):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -318,7 +318,6 @@ class UserRole(QuickCachedDocumentMixin, Document):
 
     @classmethod
     def by_domain(cls, domain, include_archived=False):
-        # todo change this view to show is_archived status or move to PRBAC UserRole
         all_roles = cls.view(
             'users/roles_by_domain',
             startkey=[domain],
@@ -332,7 +331,6 @@ class UserRole(QuickCachedDocumentMixin, Document):
 
     @classmethod
     def by_domain_and_name(cls, domain, name):
-        # todo change this view to show is_archived status or move to PRBAC UserRole
         all_roles = cls.view(
             'users/roles_by_domain',
             key=[domain, name],

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -169,9 +169,7 @@ class Permissions(DocumentSchema):
         return super(Permissions, cls).wrap(data)
 
     def view_web_app(self, master_app_id):
-        if self.view_web_apps:
-            return True
-        return master_app_id in self.view_web_apps_list
+        return self.view_web_apps or master_app_id in self.view_web_apps_list
 
     def view_report(self, report):
         return self.view_reports or report in self.view_report_list

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -186,18 +186,6 @@ class Permissions(DocumentSchema):
             a = set(a)
         return a
 
-    def _setattr(self, name, value):
-        if isinstance(value, set):
-            value = list(value)
-        setattr(self, name, value)
-
-    def __or__(self, other):
-        permissions = Permissions()
-        for name, value in permissions.properties().items():
-            if isinstance(value, (BooleanProperty, ListProperty)):
-                permissions._setattr(name, self._getattr(name) | other._getattr(name))
-        return permissions
-
     def __eq__(self, other):
         for name in self.properties():
             if self._getattr(name) != other._getattr(name):

--- a/corehq/apps/users/permissions.py
+++ b/corehq/apps/users/permissions.py
@@ -67,13 +67,10 @@ def can_view_sms_exports(couch_user, domain):
 def has_permission_to_view_report(couch_user, domain, report_to_check):
     from corehq.apps.users.decorators import get_permission_name
     from corehq.apps.users.models import Permissions
-    return (
-        couch_user.can_view_reports(domain) or
-        couch_user.has_permission(
-            domain,
-            get_permission_name(Permissions.view_report),
-            data=report_to_check
-        )
+    return couch_user.has_permission(
+        domain,
+        get_permission_name(Permissions.view_report),
+        data=report_to_check
     )
 
 

--- a/corehq/apps/users/tests/permissions.py
+++ b/corehq/apps/users/tests/permissions.py
@@ -16,33 +16,6 @@ from corehq.apps.users.permissions import DEID_EXPORT_PERMISSION, has_permission
 from corehq.util.test_utils import flag_enabled
 
 
-class PermissionsTest(TestCase):
-
-    def test_OR(self):
-        p1 = Permissions(
-            edit_web_users=True,
-            view_web_users=True,
-            view_roles=True,
-            view_reports=True,
-            view_report_list=['report1'],
-        )
-        p2 = Permissions(
-            edit_apps=True,
-            view_apps=True,
-            view_reports=True,
-            view_report_list=['report2'],
-        )
-        self.assertEqual(p1 | p2, Permissions(
-            edit_apps=True,
-            view_apps=True,
-            edit_web_users=True,
-            view_web_users=True,
-            view_roles=True,
-            view_reports=True,
-            view_report_list=['report1', 'report2'],
-        ))
-
-
 @mock.patch('corehq.apps.export.views.utils.domain_has_privilege',
             lambda domain, privilege: True)
 class PermissionsHelpersTest(SimpleTestCase):


### PR DESCRIPTION
## Summary
Removing some unused code + adding some tests

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Some existing tests + some new ones.

### Safety story
##### remove ability to set report permission via 'view_report'

I have reviewed every call or reference to this function as well as the code that saves / updates roles. I've also tested making changes via the UI.

##### simplify view_web_app

Purely a stylistic change

##### remove Permission.set

Function is unused (as is evident via audit of all usages of `.set(`). Function added in https://github.com/dimagi/commcare-hq/commit/beaf755a2ac27051bf70ce389d6c814b858b5e2d. Last usage removed in https://github.com/dimagi/commcare-hq/commit/c37bad55fb59489702e3052821e7798ab5e06179

##### remove redundant permission check

Removing a redundant check. Function is covered by unit tests.

##### test for can_manage_releases

Addition of tests cases

##### remove unused arg

Function only used in 2 places and neither make use of the `is_archived` argument.

##### remove irrelevant comments

Comments only.

##### remove ability to 'or' permissions
This was only used when there were multiple sets of permissions per user. It is no longer used.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
