### PR TITLE
[ERM] Unlink linked applications

### DIFF
--- a/corehq/apps/linked_domain/applications.py
+++ b/corehq/apps/linked_domain/applications.py
@@ -91,6 +91,16 @@ def create_linked_app(master_domain, master_id, target_domain, target_name, remo
     return link_app(linked_app, master_domain, master_id, remote_details)
 
 
+def get_linked_apps_for_domain(domain):
+    linked_apps = []
+    briefs = get_brief_apps_in_domain(domain, include_remote=False)
+    for brief in briefs:
+        if is_linked_app(brief):
+            linked_apps.append(brief)
+
+    return linked_apps
+
+
 def link_app(linked_app, master_domain, master_id, remote_details=None):
     DomainLink.link_domains(linked_app.domain, master_domain, remote_details)
 

--- a/corehq/apps/linked_domain/applications.py
+++ b/corehq/apps/linked_domain/applications.py
@@ -11,6 +11,7 @@ from corehq.apps.app_manager.dbaccessors import (
     wrap_app,
 )
 from corehq.apps.app_manager.exceptions import AppLinkError
+from corehq.apps.app_manager.util import is_linked_app
 from corehq.apps.linked_domain.models import DomainLink
 from corehq.apps.linked_domain.exceptions import MultipleDownstreamAppsError, RemoteRequestError
 from corehq.apps.linked_domain.remote_accessors import (
@@ -105,3 +106,19 @@ def link_app(linked_app, master_domain, master_id, remote_details=None):
 
     _get_downstream_app_id_map.clear(linked_app.domain)
     return linked_app
+
+
+def unlink_app(linked_app):
+    if not is_linked_app(linked_app):
+        return None
+
+    from corehq.apps.app_manager.models import import_app
+    extra_properties = {'name': linked_app.name}
+    app_copy = import_app(linked_app._id, linked_app.domain, extra_properties)
+    app_copy = app_copy.convert_to_application()
+    app_copy.save()
+
+    # remove linked app
+    linked_app.delete()
+
+    return app_copy

--- a/corehq/apps/linked_domain/applications.py
+++ b/corehq/apps/linked_domain/applications.py
@@ -8,7 +8,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_build_doc_by_version,
     get_latest_released_app,
     get_latest_released_app_versions_by_app_id,
-    wrap_app,
+    wrap_app, get_app,
 )
 from corehq.apps.app_manager.exceptions import AppLinkError
 from corehq.apps.app_manager.util import is_linked_app
@@ -118,6 +118,16 @@ def link_app(linked_app, master_domain, master_id, remote_details=None):
     return linked_app
 
 
+def unlink_apps_in_domain(domain):
+    linked_apps = get_linked_apps_for_domain(domain)
+    unlinked_apps = []
+    for app in linked_apps:
+        unlinked_app = unlink_app(app)
+        unlinked_apps.append(unlinked_app)
+
+    return unlinked_apps
+
+
 def unlink_app(linked_app):
     if not is_linked_app(linked_app):
         return None
@@ -129,6 +139,7 @@ def unlink_app(linked_app):
     app_copy.save()
 
     # remove linked app
-    linked_app.delete()
+    full_linked_app = get_app(linked_app.domain, linked_app._id)
+    full_linked_app.delete()
 
     return app_copy

--- a/corehq/apps/linked_domain/tests/test_application_util_methods.py
+++ b/corehq/apps/linked_domain/tests/test_application_util_methods.py
@@ -1,0 +1,19 @@
+from django.test import TestCase
+
+from corehq.apps.app_manager.models import LinkedApplication
+from corehq.apps.linked_domain.applications import get_linked_apps_for_domain
+
+
+class ApplicationUtilTests(TestCase):
+
+    def test_get_linked_apps_for_domain(self):
+        linked_app1 = LinkedApplication.new_app('domain', 'One')
+        linked_app2 = LinkedApplication.new_app('domain', 'Two')
+        linked_app1.save()
+        linked_app2.save()
+        self.addCleanup(linked_app1.delete)
+        self.addCleanup(linked_app2.delete)
+
+        linked_apps = get_linked_apps_for_domain('domain')
+        linked_app_ids = [app._id for app in linked_apps]
+        self.assertEqual([linked_app1._id, linked_app2._id], linked_app_ids)

--- a/corehq/apps/linked_domain/tests/test_delete_domain_links.py
+++ b/corehq/apps/linked_domain/tests/test_delete_domain_links.py
@@ -1,0 +1,33 @@
+from couchdbkit import ResourceNotFound
+from django.test import TestCase
+
+from corehq.apps.app_manager.models import Application, LinkedApplication
+from corehq.apps.linked_domain.applications import unlink_app
+
+
+class UnlinkApplicationsTest(TestCase):
+
+    def test_unlink_app_returns_none_if_not_linked(self):
+        app = Application.new_app('domain', 'Application')
+        app.save()
+        self.addCleanup(app.delete)
+
+        unlinked_app = unlink_app(app)
+
+        self.assertIsNone(unlinked_app)
+
+    def test_unlink_app_returns_regular_app_if_linked(self):
+        linked_app = LinkedApplication.new_app('domain', 'Linked Application')
+        # unlink_app will handle cleanup of this doc
+        linked_app.save()
+        old_app_id = linked_app._id
+
+        unlinked_app = unlink_app(linked_app)
+        self.addCleanup(unlinked_app.delete)
+
+        # ensure linked_app is deleted
+        with self.assertRaises(ResourceNotFound):
+            LinkedApplication.get(old_app_id)
+
+        # ensure new app is not linked
+        self.assertEqual('Application', unlinked_app.get_doc_type())

--- a/corehq/apps/linked_domain/tests/test_delete_domain_links.py
+++ b/corehq/apps/linked_domain/tests/test_delete_domain_links.py
@@ -1,4 +1,3 @@
-from couchdbkit import ResourceNotFound
 from django.test import TestCase
 
 from corehq.apps.app_manager.models import Application, LinkedApplication
@@ -20,48 +19,37 @@ class UnlinkApplicationTest(TestCase):
 
     def test_unlink_app_returns_regular_app_if_linked(self):
         linked_app = LinkedApplication.new_app(self.domain, 'Linked Application')
-        # unlink_app will handle cleanup of this doc
         linked_app.save()
-        deleted_app_id = linked_app._id
+        expected_app_id = linked_app._id
 
         unlinked_app = unlink_app(linked_app)
         self.addCleanup(unlinked_app.delete)
 
-        # ensure linked_app is deleted
-        with self.assertRaises(ResourceNotFound):
-            LinkedApplication.get(deleted_app_id)
-
         # ensure new app is not linked, and converted properly
         self.assertEqual('Application', unlinked_app.get_doc_type())
-        self.assertEqual('Linked Application', unlinked_app.name)
+        self.assertEqual(expected_app_id, unlinked_app._id)
 
 
 class UnlinkApplicationsForDomainTests(TestCase):
 
     domain = 'unlink-apps-test'
 
-    def test_unlink_apps_for_domain_succeeds(self):
+    def test_unlink_apps_for_domain_successfully_unlinks_app(self):
         linked_app = LinkedApplication.new_app(self.domain, 'Linked')
-        # unlink_apps_in_domain will handle cleanup of this doc
         linked_app.save()
-        deleted_app_id = linked_app._id
+        expected_app_id = linked_app._id
 
         unlinked_apps = unlink_apps_in_domain(self.domain)
         for app in unlinked_apps:
             self.addCleanup(app.delete)
 
-        # ensure linked apps are deleted
-        with self.assertRaises(ResourceNotFound):
-            LinkedApplication.get(deleted_app_id)
-
         # ensure new app exists that is not linked
         self.assertEqual('Application', unlinked_apps[0].get_doc_type())
-        self.assertEqual('Linked', unlinked_apps[0].name)
+        self.assertEqual(expected_app_id, unlinked_apps[0]._id)
 
-    def test_unlink_multiple_apps_for_domain_succeeds(self):
+    def test_unlink_apps_for_domain_processes_multiple_apps(self):
         linked_app1 = LinkedApplication.new_app(self.domain, 'Linked1')
         linked_app2 = LinkedApplication.new_app(self.domain, 'Linked2')
-        # unlink_apps_in_domain will handle cleanup of these docs
         linked_app1.save()
         linked_app2.save()
 
@@ -71,7 +59,22 @@ class UnlinkApplicationsForDomainTests(TestCase):
 
         self.assertEqual(2, len(unlinked_apps))
 
-    def test_unlink_apps_for_domain_fails_if_no_linked_apps(self):
+    def test_unlink_apps_for_domain_only_processes_linked_apps(self):
+        app = Application.new_app(self.domain, 'Original')
+        linked_app = LinkedApplication.new_app(self.domain, 'Linked')
+        app.save()
+        self.addCleanup(app.delete)
+        linked_app.save()
+        expected_app_id = linked_app._id
+
+        unlinked_apps = unlink_apps_in_domain(self.domain)
+        for app in unlinked_apps:
+            self.addCleanup(app.delete)
+
+        self.assertEqual(1, len(unlinked_apps))
+        self.assertEqual(expected_app_id, unlinked_apps[0]._id)
+
+    def test_unlink_apps_for_domain_returns_zero_if_no_linked_apps(self):
         app = Application.new_app(self.domain, 'Original')
         app.save()
         self.addCleanup(app.delete)

--- a/corehq/apps/linked_domain/tests/test_delete_domain_links.py
+++ b/corehq/apps/linked_domain/tests/test_delete_domain_links.py
@@ -2,13 +2,15 @@ from couchdbkit import ResourceNotFound
 from django.test import TestCase
 
 from corehq.apps.app_manager.models import Application, LinkedApplication
-from corehq.apps.linked_domain.applications import unlink_app
+from corehq.apps.linked_domain.applications import unlink_app, unlink_apps_in_domain
 
 
-class UnlinkApplicationsTest(TestCase):
+class UnlinkApplicationTest(TestCase):
+
+    domain = 'unlink-app-test'
 
     def test_unlink_app_returns_none_if_not_linked(self):
-        app = Application.new_app('domain', 'Application')
+        app = Application.new_app(self.domain, 'Application')
         app.save()
         self.addCleanup(app.delete)
 
@@ -17,17 +19,65 @@ class UnlinkApplicationsTest(TestCase):
         self.assertIsNone(unlinked_app)
 
     def test_unlink_app_returns_regular_app_if_linked(self):
-        linked_app = LinkedApplication.new_app('domain', 'Linked Application')
+        linked_app = LinkedApplication.new_app(self.domain, 'Linked Application')
         # unlink_app will handle cleanup of this doc
         linked_app.save()
-        old_app_id = linked_app._id
+        deleted_app_id = linked_app._id
 
         unlinked_app = unlink_app(linked_app)
         self.addCleanup(unlinked_app.delete)
 
         # ensure linked_app is deleted
         with self.assertRaises(ResourceNotFound):
-            LinkedApplication.get(old_app_id)
+            LinkedApplication.get(deleted_app_id)
 
-        # ensure new app is not linked
+        # ensure new app is not linked, and converted properly
         self.assertEqual('Application', unlinked_app.get_doc_type())
+        self.assertEqual('Linked Application', unlinked_app.name)
+
+
+class UnlinkApplicationsForDomainTests(TestCase):
+
+    domain = 'unlink-apps-test'
+
+    def test_unlink_apps_for_domain_succeeds(self):
+        linked_app = LinkedApplication.new_app(self.domain, 'Linked')
+        # unlink_apps_in_domain will handle cleanup of this doc
+        linked_app.save()
+        deleted_app_id = linked_app._id
+
+        unlinked_apps = unlink_apps_in_domain(self.domain)
+        for app in unlinked_apps:
+            self.addCleanup(app.delete)
+
+        # ensure linked apps are deleted
+        with self.assertRaises(ResourceNotFound):
+            LinkedApplication.get(deleted_app_id)
+
+        # ensure new app exists that is not linked
+        self.assertEqual('Application', unlinked_apps[0].get_doc_type())
+        self.assertEqual('Linked', unlinked_apps[0].name)
+
+    def test_unlink_multiple_apps_for_domain_succeeds(self):
+        linked_app1 = LinkedApplication.new_app(self.domain, 'Linked1')
+        linked_app2 = LinkedApplication.new_app(self.domain, 'Linked2')
+        # unlink_apps_in_domain will handle cleanup of these docs
+        linked_app1.save()
+        linked_app2.save()
+
+        unlinked_apps = unlink_apps_in_domain(self.domain)
+        for app in unlinked_apps:
+            self.addCleanup(app.delete)
+
+        self.assertEqual(2, len(unlinked_apps))
+
+    def test_unlink_apps_for_domain_fails_if_no_linked_apps(self):
+        app = Application.new_app(self.domain, 'Original')
+        app.save()
+        self.addCleanup(app.delete)
+
+        unlinked_apps = unlink_apps_in_domain(self.domain)
+        for app in unlinked_apps:
+            self.addCleanup(app.delete)
+
+        self.assertEqual(0, len(unlinked_apps))


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-106)

Keeping this PR low risk by not adding this behavior into the actual delete flow yet.

When a domain link is deleted, any LinkedApplication in the downstream domain should be converted to an Application. This builds on existing copy behavior and deletes the LinkedApplication doc once converted as well.

This could be more sophisticated and only unlink applications with an upstream_id correlating to the upstream domain, but since we do not support a domain having more than 1 upstream domain, it does not seem worth implementing that.

Review by commit.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Wrote tests along the way
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary yet.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Nothing calls this code besides tests at the moment.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
