### PR TITLE
use setup_limited_release

### DIFF
--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -131,9 +131,9 @@ class PopulateSQLCommand(BaseCommand):
                 print(f"""
                 Run the following commands to run the migration and get up to date:
 
-                    commcare-cloud <env> deploy commcare --commcare-rev={cls.commit_adding_migration()}
+                    commcare-cloud <env> fab setup_limited_release --set code_branch={cls.commit_adding_migration()}
 
-                    commcare-cloud <env> django-manage {command_name}
+                    commcare-cloud <env> django-manage --release <release created by previous command> {command_name}
 
                     commcare-cloud <env> deploy commcare
                 """)


### PR DESCRIPTION
## Summary
Update migration instructions to use `setup_limited_release` instead of deploying an old commit. I don't think using the `deploy` command is a good idea since that will potentially revert the version of HQ to the commit specified which is always going to be in the past.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story
Management command only change (and only help text)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
