### PR TITLE
remove custom ICDS settings

### DIFF
--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -245,16 +245,3 @@ REPORTING_DATABASES = {
     'aaa-data': 'default',
     'icds-ucr-citus': 'icds-ucr'
 }
-
-if os.path.exists("extensions/icds/custom/icds"):
-    # code is not present in fork PR builds
-    LOCAL_APPS = (
-        # these are necessary to facilitate ICDS tests
-        "custom.icds",
-        "custom.icds_reports",
-    )
-    COMMCARE_EXTENSIONS = ["custom.icds.commcare_extensions"]
-
-    LOCAL_CUSTOM_DB_ROUTING = {
-        "icds_reports": "icds-ucr-citus"
-    }

--- a/testsettings.py
+++ b/testsettings.py
@@ -139,18 +139,4 @@ METRICS_PROVIDERS = [
 # timeout faster in tests
 ES_SEARCH_TIMEOUT = 5
 
-# icds version = ab702b37a1  (to force a build)
-if os.path.exists("extensions/icds/custom/icds"):
-    icds_apps = [
-        "custom.icds",
-        "custom.icds_reports"
-    ]
-    for app in icds_apps:
-        if app not in INSTALLED_APPS:
-            INSTALLED_APPS = (app,) + tuple(INSTALLED_APPS)
-
-    if "custom.icds.commcare_extensions" not in COMMCARE_EXTENSIONS:
-        COMMCARE_EXTENSIONS.append("custom.icds.commcare_extensions")
-        CUSTOM_DB_ROUTING["icds_reports"] = "icds-ucr-citus"
-
 FORMPLAYER_INTERNAL_AUTH_KEY = "abc123"


### PR DESCRIPTION
## Summary
Remove settings only related to ICDS

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Changes isolated to test / dev environment settings

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
