### PR TITLE
Treat app setting names as markup

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/commcare_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/commcare_settings.html
@@ -38,7 +38,7 @@
              data-bind="visible: visible() || showUpgradeText(),
                         css: {error: hasError()}">
           <div class="col-sm-2 control-label">
-            <label data-bind="text: name, attr: {for: inputId}" class="inner-control-label"></label>
+            <label data-bind="html: name, attr: {for: inputId}" class="inner-control-label"></label>
             <span data-bind="makeHqHelp: { name: name, description: $data.description, format: $data.description_format}, visible: $data.description"></span>
           </div>
           <div class="col-sm-4">


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12192. Just cleaning up an XSS display issue. I don't see a way around treating the name as markup, because we're using `<hr />` for formatting. I want to make sure that `html: name` only applies to the name, however, and not all the attributes.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No automated tests

### QA Plan

No QA required

### Safety story

This is just changing what gets displayed, so its blast radius is small. However, I want to make sure that this only treats the name as markup.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
