### PR TITLE
[OData] Use hyphen as expanded header/checkboxes delimiter instead of pipe

### DIFF
--- a/corehq/apps/api/odata/utils.py
+++ b/corehq/apps/api/odata/utils.py
@@ -44,7 +44,10 @@ def _get_odata_fields_from_columns(export_config, special_types, table_id):
 
     metadata = []
     for column in table.selected_columns:
-        for header in column.get_headers(split_column=export_config.split_multiselects):
+        for header in column.get_headers(
+            split_column=export_config.split_multiselects,
+            is_odata=True
+        ):
             metadata.append(FieldMetadata(
                 header,
                 special_types.get(_get_dot_path(column), 'Edm.String')

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -404,7 +404,7 @@ class ExportColumn(DocumentSchema):
     def is_deidentifed(self):
         return bool(self.deid_transform)
 
-    def get_headers(self, split_column=False):
+    def get_headers(self, split_column=False, is_odata=False):
         if self.is_deidentifed:
             return [f"{self.label} *sensitive*"]
         else:
@@ -473,13 +473,13 @@ class TableConfiguration(DocumentSchema, ReadablePathMixin):
         """The columns that should be included in the export"""
         return [c for c in self.columns if c.selected]
 
-    def get_headers(self, split_columns=False):
+    def get_headers(self, split_columns=False, is_odata=False):
         """
         Return a list of column headers
         """
         headers = []
         for column in self.selected_columns:
-            headers.extend(column.get_headers(split_column=split_columns))
+            headers.extend(column.get_headers(split_column=split_columns, is_odata=is_odata))
         return headers
 
     def get_rows(self, document, row_number, split_columns=False,
@@ -2467,7 +2467,7 @@ class MultiMediaExportColumn(ExportColumn):
 class SplitGPSExportColumn(ExportColumn):
     item = SchemaProperty(GeopointItem)
 
-    def get_headers(self, split_column=False):
+    def get_headers(self, split_column=False, is_odata=False):
         if not split_column:
             return super(SplitGPSExportColumn, self).get_headers()
         header = self.label
@@ -2557,7 +2557,7 @@ class SplitExportColumn(ExportColumn):
             row.append(" ".join(selected))
         return row
 
-    def get_headers(self, split_column=False):
+    def get_headers(self, split_column=False, is_odata=False):
         if not split_column:
             return super(SplitExportColumn, self).get_headers()
         header = self.label

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -519,7 +519,7 @@ class TableConfiguration(DocumentSchema, ReadablePathMixin):
                     transform_dates=transform_dates,
                 )
                 if as_json:
-                    for index, header in enumerate(col.get_headers(split_column=split_columns)):
+                    for index, header in enumerate(col.get_headers(split_column=split_columns, is_odata=True)):
                         if isinstance(val, list):
                             row_data[header] = "{}".format(val[index])
                         else:
@@ -2421,22 +2421,26 @@ class SplitUserDefinedExportColumn(ExportColumn):
         return row
 
     def get_headers(self, **kwargs):
+        is_odata = kwargs.pop('is_odata', False)
         if self.split_type == PLAIN_USER_DEFINED_SPLIT_TYPE:
             return super(SplitUserDefinedExportColumn, self).get_headers()
         header = self.label
-        header_template = header if '{option}' in header else "{name} | {option}"
+        delimiter = "-" if is_odata else "|"
+        header_template = header if '{option}' in header else "{name} {delimiter} {option}"
         headers = []
         for option in self.user_defined_options:
             headers.append(
                 header_template.format(
                     name=header,
-                    option=option
+                    option=option,
+                    delimiter=delimiter,
                 )
             )
         headers.append(
             header_template.format(
                 name=header,
-                option='extra'
+                option='extra',
+                delimiter=delimiter,
             )
         )
         return headers
@@ -2561,20 +2565,23 @@ class SplitExportColumn(ExportColumn):
         if not split_column:
             return super(SplitExportColumn, self).get_headers()
         header = self.label
-        header_template = header if '{option}' in header else "{name} | {option}"
+        delimiter = "-" if is_odata else "|"
+        header_template = header if '{option}' in header else "{name} {delimiter} {option}"
         headers = []
         for option in self.item.options:
             headers.append(
                 header_template.format(
                     name=header,
-                    option=option.value
+                    option=option.value,
+                    delimiter=delimiter,
                 )
             )
         if not self.ignore_unspecified_options:
             headers.append(
                 header_template.format(
                     name=header,
-                    option='extra'
+                    option='extra',
+                    delimiter=delimiter,
                 )
             )
         return headers


### PR DESCRIPTION
## Summary
This is potentially related to some of the issues faced in this ticket https://dimagi-dev.atlassian.net/browse/SAAS-11934
as well as some issues that @czue was reporting

Apparently, Power BI is not a big fan of the pipe (`|`) character. Tableau seems to have no problem with it, which is why issues likely did not arise in QA. This PR replaces the `|` character with `-` in OData feeds, which largely applies to expanded checkboxes.

I will be asking QA to do a round of smoke tests on exports and OData feeds, with a special focus on expanded checkbox questions in OData Form feeds.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
QA will happen.

### Safety story
QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
