### PR TITLE
match sentry release name to commcare-cloud

### DIFF
--- a/settingshelper.py
+++ b/settingshelper.py
@@ -271,7 +271,7 @@ def configure_sentry(base_dir, server_env, dsn):
 def get_release_name(base_dir, server_env):
     release_dir = base_dir.split('/')[-1]
     if re.match(r'\d{4}-\d{2}-\d{2}_\d{2}.\d{2}', release_dir):
-        return "{}-{}-deploy".format(release_dir, server_env)
+        return "{}-{}".format(release_dir, server_env)
     else:
         return get_git_commit(base_dir) or 'unknown'
 

--- a/settingshelper.py
+++ b/settingshelper.py
@@ -269,6 +269,9 @@ def configure_sentry(base_dir, server_env, dsn):
 
 
 def get_release_name(base_dir, server_env):
+    """Return the release name. This should match the name of the release
+    created by commcare-cloud
+    """
     release_dir = base_dir.split('/')[-1]
     if re.match(r'\d{4}-\d{2}-\d{2}_\d{2}.\d{2}', release_dir):
         return "{}-{}".format(release_dir, server_env)


### PR DESCRIPTION
## Summary
See https://github.com/dimagi/commcare-cloud/pull/4708

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
String only change for Sentry release name

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
