### PR TITLE
[ERM] Unlink apps if ERM_DEVELOPMENT enabled

### DIFF
--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -35,6 +35,7 @@ from corehq.apps.fixtures.dbaccessors import get_fixture_data_type_by_tag, get_f
 from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id
 from corehq.apps.hqwebapp.decorators import use_multiselect
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import pretty_doc_info
+from corehq.apps.linked_domain.applications import unlink_apps_in_domain
 from corehq.apps.linked_domain.const import (
     LINKED_MODELS,
     LINKED_MODELS_MAP,
@@ -498,6 +499,9 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
         link = DomainLink.objects.filter(linked_domain=linked_domain, master_domain=self.domain).first()
         link.deleted = True
         link.save()
+
+        if toggles.ERM_DEVELOPMENT.enabled(self.domain):
+            _ = unlink_apps_in_domain(linked_domain)
 
         track_workflow(self.request.couch_user.username, "Linked domain: domain link deleted")
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-106)

Small PR that enables unlinking apps when deleting a domain link which was added [here](https://github.com/dimagi/commcare-hq/pull/29661). 

I'd like to test locally but my local environment is messed up at the moment so staging seems like the next best thing. Figured I'd PR it anyway. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`ERM_DEVELOPMENT` and `LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
The feature itself has automated test coverage. 
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary at the moment.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Behind the `ERM_DEVELOPMENT` feature flag. 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
