### PR TITLE
[SSO] Update Create User Workflow to user AsyncSignupRequest instead of session storage

### DIFF
--- a/corehq/apps/registration/models.py
+++ b/corehq/apps/registration/models.py
@@ -70,6 +70,11 @@ class AsyncSignupRequest(models.Model):
     Use this model to store information from signup or invitation forms when
     the user is redirected to login elsewhere (like SSO) but the signup/invitation
     process must resume when they return.
+
+    NOTE: The reason we use this instead of storing data in request.session
+    is that during the SAML handshake for SSO, the Identity Provider
+    acknowledges the handshake by posting to a view that is CSRF exempt.
+    For security reasons, Django wipes the session data during this process.
     """
     username = models.CharField(max_length=255, db_index=True)
     invitation = models.ForeignKey('users.Invitation', null=True, blank=True, on_delete=models.SET_NULL)

--- a/corehq/apps/registration/tests/test_tasks.py
+++ b/corehq/apps/registration/tests/test_tasks.py
@@ -1,0 +1,40 @@
+import datetime
+from django.test import TestCase
+
+from corehq.apps.registration.models import AsyncSignupRequest
+from corehq.apps.registration.tasks import delete_old_async_signup_requests
+
+
+class TestDeleteAsyncSignupRequestsTask(TestCase):
+
+    def tearDown(self):
+        super().tearDown()
+        AsyncSignupRequest.objects.all().delete()
+
+    def test_request_greater_than_one_day_is_deleted(self):
+        """
+        Ensure that AsyncSignupRequests older than one day are all deleted.
+        """
+        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1, minutes=2)
+
+        first_request = AsyncSignupRequest.objects.create(username="firstuser@gmail.com")
+        first_request.date_created = yesterday  # done here because of auto_now_add
+        first_request.save()
+
+        second_request = AsyncSignupRequest.objects.create(username="seconduser@gmail.com")
+        second_request.date_created = yesterday
+        second_request.save()
+
+        self.assertEqual(AsyncSignupRequest.objects.count(), 2)
+        delete_old_async_signup_requests()
+        self.assertEqual(AsyncSignupRequest.objects.count(), 0)
+
+    def test_request_less_than_one_day_are_kept(self):
+        """
+        Ensure that AsyncSignupRequests less than 1 day old are not deleted.
+        """
+        AsyncSignupRequest.objects.create(username="today1@gmail.com")
+        AsyncSignupRequest.objects.create(username="today2@gmail.com")
+        self.assertEqual(AsyncSignupRequest.objects.count(), 2)
+        delete_old_async_signup_requests()
+        self.assertEqual(AsyncSignupRequest.objects.count(), 2)

--- a/corehq/apps/sso/backends.py
+++ b/corehq/apps/sso/backends.py
@@ -179,7 +179,6 @@ class SsoBackend(ModelBackend):
         :param invitation: Invitation or None
         :param web_user: WebUser
         """
-        request.sso_invitation_status = {}
         if invitation.is_expired:
             request.sso_new_user_messages['error'].append(
                 _("Could not accept invitation because it is expired.")

--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -6,12 +6,12 @@ from django.test import TestCase, RequestFactory
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.registration.forms import RegisterWebUserForm
+from corehq.apps.registration.models import AsyncSignupRequest
 from corehq.apps.sso.models import IdentityProvider, AuthenticatedEmailDomain
 from corehq.apps.sso.tests import generator
 from corehq.apps.sso.tests.generator import create_request_session
 from corehq.apps.sso.utils.session_helpers import (
     prepare_session_with_new_sso_user_data,
-    prepare_session_for_sso_invitation,
 )
 from corehq.apps.users.models import WebUser, Invitation, UserRole
 
@@ -264,7 +264,7 @@ class TestSsoBackend(TestCase):
             role=admin_role.get_qualified_id(),
         )
         invitation.save()
-        prepare_session_for_sso_invitation(self.request, invitation)
+        AsyncSignupRequest.create_from_invitation(invitation)
         generator.store_full_name_in_saml_user_data(
             self.request,
             'Isa',
@@ -300,7 +300,7 @@ class TestSsoBackend(TestCase):
             invited_on=datetime.datetime.utcnow() - relativedelta(months=2),
         )
         invitation.save()
-        prepare_session_for_sso_invitation(self.request, invitation)
+        AsyncSignupRequest.create_from_invitation(invitation)
         generator.store_full_name_in_saml_user_data(
             self.request,
             'Zee',

--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -56,6 +56,7 @@ class TestSsoBackend(TestCase):
             'isa@vaultwax.com',
             'zee@vaultwax.com',
             'exist@vaultwax.com',
+            'aart@vaultwax.com',
         ]:
             web_user = WebUser.get_by_username(username)
             if web_user:
@@ -366,6 +367,36 @@ class TestSsoBackend(TestCase):
             self.request.sso_new_user_messages['success'],
             [
                 f'You have been added to the "{invitation.domain}" project space.',
+            ]
+        )
+
+    def test_new_user_with_no_async_signup_request_creates_new_user(self):
+        """
+        There is a use case where brand new users can click on the CommCare HQ
+        App icon right from their Active Directory home screen. In this case,
+        we want to create the user's account and then present them with any
+        project invitations once they have logged in.
+        """
+        username = 'aart@vaultwax.com'
+        generator.store_full_name_in_saml_user_data(
+            self.request,
+            'Aart',
+            'Janssen'
+        )
+        user = auth.authenticate(
+            request=self.request,
+            username=username,
+            idp_slug=self.idp.slug,
+            is_handshake_successful=True,
+        )
+        self.assertIsNotNone(user)
+        self.assertEqual(user.username, username)
+        self.assertEqual(user.first_name, 'Aart')
+        self.assertEqual(user.last_name, 'Janssen')
+        self.assertEqual(
+            self.request.sso_new_user_messages['success'],
+            [
+                f'User account for {username} created.',
             ]
         )
 

--- a/corehq/apps/sso/utils/session_helpers.py
+++ b/corehq/apps/sso/utils/session_helpers.py
@@ -112,15 +112,6 @@ def get_new_sso_user_data_from_session(request):
     return request.session.get('ssoNewUserData', {})
 
 
-def get_new_sso_user_project_name_from_session(request):
-    """
-    This gets the project name from sso user data stored in the session.
-    :param request: HttpRequest
-    :return: String (project name) or None
-    """
-    return request.session.get('ssoNewUserData', {}).get('project_name')
-
-
 def clear_sso_registration_data_from_session(request):
     """
     Clears up any registration / invitation related data from the request's

--- a/corehq/apps/sso/utils/session_helpers.py
+++ b/corehq/apps/sso/utils/session_helpers.py
@@ -73,17 +73,3 @@ def get_sso_username_from_session(request):
     :return: string or None - username
     """
     return request.session.get('ssoNewUsername')
-
-
-def clear_sso_registration_data_from_session(request):
-    """
-    Clears up any registration / invitation related data from the request's
-    session.
-    :param request: HttpRequest
-    """
-    if 'ssoNewUserData' in request.session:
-        del request.session['ssoNewUserData']
-    if 'ssoNewUsername' in request.session:
-        del request.session['ssoNewUsername']
-    if 'ssoInvitation' in request.session:
-        del request.session['ssoInvitation']

--- a/corehq/apps/sso/utils/session_helpers.py
+++ b/corehq/apps/sso/utils/session_helpers.py
@@ -1,7 +1,5 @@
 import logging
 
-from corehq.apps.users.models import Invitation
-
 log = logging.getLogger(__name__)
 
 
@@ -55,32 +53,6 @@ def get_sso_user_last_name_from_session(request):
         request,
         'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname'
     )
-
-
-def prepare_session_for_sso_invitation(request, invitation):
-    """
-    This prepares the Request's Session to store invitation details for use
-    when logging in as a new or existing user through SSO.
-    :param request: HttpRequest
-    :param invitation: Invitation
-    """
-    request.session['ssoInvitation'] = invitation.uuid
-
-
-def get_sso_invitation_from_session(request):
-    """
-    Fetches an Invitation object from the ssoInvitation information
-    (if available) stored in the request session.
-    :param request: HttpRequest
-    :return: Invitation or None
-    """
-    uuid = request.session.get('ssoInvitation')
-    try:
-        return Invitation.objects.get(uuid=uuid) if uuid else None
-    except Invitation.DoesNotExist:
-        log.exception(
-            f"Error fetching invitation from sso create user request: {uuid}"
-        )
 
 
 def prepare_session_with_sso_username(request, username):

--- a/corehq/apps/sso/utils/session_helpers.py
+++ b/corehq/apps/sso/utils/session_helpers.py
@@ -75,43 +75,6 @@ def get_sso_username_from_session(request):
     return request.session.get('ssoNewUsername')
 
 
-def prepare_session_with_new_sso_user_data(request, reg_form,
-                                           additional_hubspot_data=None):
-    """
-    Prepares the Request's Session to store registration form details
-    when a user is signing up for an account on HQ and using SSO to login.
-    :param request: HttpRequest
-    :param reg_form: RegisterWebUserForm
-    :param additional_hubspot_data: dict or None (Hubspot related data from A/B tests etc)
-    """
-    persona = reg_form.cleaned_data['persona']
-    persona_other = reg_form.cleaned_data['persona_other']
-    additional_hubspot_data = additional_hubspot_data or {}
-    additional_hubspot_data.update({
-        'buyer_persona': persona,
-        'buyer_persona_other': persona_other,
-    })
-
-    request.session['ssoNewUserData'] = {
-        'phone_number': reg_form.cleaned_data['phone_number'],
-        'persona': persona,
-        'persona_other': persona_other,
-        'project_name': reg_form.cleaned_data['project_name'],
-        'atypical_user': reg_form.cleaned_data.get('atypical_user'),
-        'additional_hubspot_data': additional_hubspot_data,
-    }
-
-
-def get_new_sso_user_data_from_session(request):
-    """
-    Fetches data related to the a new user that is registering and logging on
-    using sso (if that data is available).
-    :param request: HttpRequest
-    :return: dict or None
-    """
-    return request.session.get('ssoNewUserData', {})
-
-
 def clear_sso_registration_data_from_session(request):
     """
     Clears up any registration / invitation related data from the request's

--- a/corehq/apps/sso/views/saml.py
+++ b/corehq/apps/sso/views/saml.py
@@ -16,6 +16,7 @@ from onelogin.saml2.settings import OneLogin_Saml2_Settings
 
 from corehq.apps.domain.decorators import login_required
 from corehq.apps.domain.exceptions import NameUnavailableException
+from corehq.apps.registration.models import AsyncSignupRequest
 from corehq.apps.registration.utils import request_new_domain
 from corehq.apps.sso.decorators import (
     identity_provider_required,
@@ -28,7 +29,6 @@ from corehq.apps.sso.utils.session_helpers import (
     get_sso_username_from_session,
     prepare_session_with_sso_username,
     get_new_sso_user_project_name_from_session,
-    prepare_session_for_sso_invitation,
     clear_sso_registration_data_from_session,
 )
 from corehq.apps.users.models import Invitation
@@ -247,6 +247,6 @@ def sso_test_create_user(request, idp_slug):
     invitation_uuid = request.GET.get('invitation')
     invitation = Invitation.objects.get(uuid=invitation_uuid)
     if invitation:
-        prepare_session_for_sso_invitation(request, invitation)
+        AsyncSignupRequest.create_from_invitation(invitation)
 
     return HttpResponseRedirect(reverse("sso_saml_login", args=(idp_slug,)))

--- a/corehq/apps/sso/views/saml.py
+++ b/corehq/apps/sso/views/saml.py
@@ -245,7 +245,7 @@ def sso_test_create_user(request, idp_slug):
         prepare_session_with_sso_username(request, username)
 
     invitation_uuid = request.GET.get('invitation')
-    invitation = Invitation.objects.get(uuid=invitation_uuid)
+    invitation = Invitation.objects.get(uuid=invitation_uuid) if invitation_uuid else None
     if invitation:
         AsyncSignupRequest.create_from_invitation(invitation)
 

--- a/corehq/apps/sso/views/saml.py
+++ b/corehq/apps/sso/views/saml.py
@@ -28,7 +28,6 @@ from corehq.apps.sso.utils.session_helpers import (
     store_saml_data_in_session,
     get_sso_username_from_session,
     prepare_session_with_sso_username,
-    clear_sso_registration_data_from_session,
 )
 from corehq.apps.users.models import Invitation
 
@@ -111,7 +110,7 @@ def sso_saml_acs(request, idp_slug):
                           "Please contact support.")
                     )
 
-            clear_sso_registration_data_from_session(request)
+            AsyncSignupRequest.clear_data_for_username(user.username)
             return redirect("homepage")
 
         # todo for debugging purposes to dump into the response below


### PR DESCRIPTION
## Summary
This is a followup to https://github.com/dimagi/commcare-hq/pull/29631

Automatic `Risk: High` label is misleading because I only added a comment to `registration/models.py` and tests to the `registration` app. There's nothing risky about this PR. I'm manually removing it to reduce confusion.

There was an issue with the create user workflow in that resulted in invitation / user information not properly being fetched/stored in `request.session`. This is due to the fact that during a SAML handshake, the Identity Provider has to post data to a CSRF exempt view. When this happens Django wipes session information for security reasons.

## Feature Flag
`ENTERPRISE_SSO`

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Well-tested code.

### QA Plan
No QA needed at this point

### Safety story
This is an area of the codebase that is still in active development and not used by any production workflows.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
