### PR TITLE
Unlink reports when deleting domain link

### DIFF
--- a/corehq/apps/linked_domain/tests/test_delete_domain_links.py
+++ b/corehq/apps/linked_domain/tests/test_delete_domain_links.py
@@ -89,14 +89,17 @@ class UnlinkApplicationsForDomainTests(TestCase):
         self.assertEqual(0, len(unlinked_apps))
 
 
-class UnlinkUCRTest(SimpleTestCase):
+class UnlinkUCRTest(TestCase):
 
     domain = 'unlink-ucr-test'
 
     def test_unlink_ucr_returns_none_if_not_linked(self):
         report = ReportConfiguration()
         report.domain = self.domain
+        report.config_id = '123abd'
         report.report_meta = ReportMeta()
+        report.save()
+        self.addCleanup(report.delete)
 
         unlinked_report = unlink_report(report)
 
@@ -105,7 +108,10 @@ class UnlinkUCRTest(SimpleTestCase):
     def test_unlink_ucr_returns_unlinked_report(self):
         report = ReportConfiguration()
         report.domain = self.domain
+        report.config_id = '123abd'
         report.report_meta = ReportMeta(master_id='abc123')
+        report.save()
+        self.addCleanup(report.delete)
 
         unlinked_report = unlink_report(report)
 

--- a/corehq/apps/linked_domain/ucr.py
+++ b/corehq/apps/linked_domain/ucr.py
@@ -186,5 +186,6 @@ def unlink_report(report):
         return None
 
     report.report_meta.master_id = None
+    report.save()
 
     return report

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -78,6 +78,7 @@ from corehq.apps.linked_domain.tasks import (
     pull_missing_multimedia_for_app_and_notify_task,
     push_models,
 )
+from corehq.apps.linked_domain.ucr import unlink_reports_in_domain
 from corehq.apps.linked_domain.updates import update_model_type
 from corehq.apps.linked_domain.util import (
     convert_app_for_remote_linking,
@@ -502,6 +503,7 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
 
         if toggles.ERM_DEVELOPMENT.enabled(self.domain):
             _ = unlink_apps_in_domain(linked_domain)
+            _ = unlink_reports_in_domain(linked_domain)
 
         track_workflow(self.request.couch_user.username, "Linked domain: domain link deleted")
 

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -502,8 +502,8 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
         link.save()
 
         if toggles.ERM_DEVELOPMENT.enabled(self.domain):
-            _ = unlink_apps_in_domain(linked_domain)
-            _ = unlink_reports_in_domain(linked_domain)
+            unlink_apps_in_domain(linked_domain)
+            unlink_reports_in_domain(linked_domain)
 
         track_workflow(self.request.couch_user.username, "Linked domain: domain link deleted")
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-104)

Use method implemented [here](https://github.com/dimagi/commcare-hq/pull/29672) to unlink reports when deleting a domain link. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`ERM_DEVELOPMENT` and `LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests added on previous PR.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary at this time.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Behind a feature flag. 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
