### PR TITLE
[ERM] Add ability to unlink keywords

### DIFF
--- a/corehq/apps/linked_domain/keywords.py
+++ b/corehq/apps/linked_domain/keywords.py
@@ -82,3 +82,23 @@ def _update_actions(domain_link, linked_keyword, keyword_actions):
                                             linked_domain=domain_link.linked_domain))
             keyword_action.app_id = app_id
         keyword_action.save()
+
+
+def unlink_keywords_in_domain(domain):
+    unlinked_keywords = []
+    keywords = Keyword.objects.filter(domain=domain, upstream_id__isnull=False)
+    for keyword in keywords:
+        unlinked_keyword = unlink_keyword(keyword)
+        unlinked_keywords.append(unlinked_keyword)
+
+    return unlinked_keywords
+
+
+def unlink_keyword(keyword):
+    if not keyword.upstream_id:
+        return None
+
+    keyword.upstream_id = None
+    keyword.save()
+
+    return keyword

--- a/corehq/apps/linked_domain/tests/test_delete_domain_links.py
+++ b/corehq/apps/linked_domain/tests/test_delete_domain_links.py
@@ -2,7 +2,9 @@ from django.test import TestCase, SimpleTestCase
 
 from corehq.apps.app_manager.models import Application, LinkedApplication
 from corehq.apps.linked_domain.applications import unlink_app, unlink_apps_in_domain
+from corehq.apps.linked_domain.keywords import unlink_keyword, unlink_keywords_in_domain
 from corehq.apps.linked_domain.ucr import unlink_report, unlink_reports_in_domain
+from corehq.apps.sms.models import Keyword
 from corehq.apps.userreports.models import ReportMeta, ReportConfiguration
 from corehq.apps.userreports.tests.utils import get_sample_data_source
 
@@ -165,3 +167,75 @@ class UnlinkUCRsForDomainTests(TestCase):
         unlinked_reports = unlink_reports_in_domain(self.domain)
 
         self.assertEqual(0, len(unlinked_reports))
+
+
+class UnlinkKeywordTests(TestCase):
+
+    def test_unlink_keyword_returns_none_if_not_linked(self):
+        keyword = Keyword()
+        keyword.save()
+
+        unlinked_keyword = unlink_keyword(keyword)
+
+        self.assertIsNone(unlinked_keyword)
+
+    def test_unlink_keyword_returns_unlinked_keyword(self):
+        keyword = Keyword(upstream_id='abc123')
+        keyword.save()
+
+        unlinked_keyword = unlink_keyword(keyword)
+
+        self.assertIsNone(unlinked_keyword.upstream_id)
+        self.assertEqual(keyword.id, unlinked_keyword.id)
+
+
+class UnlinkKeywordsInDomainTests(TestCase):
+
+    domain = 'unlink-keyword-test'
+
+    def test_unlink_keywords_in_domain_successfully_unlinks_keyword(self):
+        keyword = Keyword(domain=self.domain, upstream_id='abc123')
+        keyword.save()
+
+        unlinked_keywords = unlink_keywords_in_domain(self.domain)
+
+        self.assertEqual(1, len(unlinked_keywords))
+        self.assertIsNone(unlinked_keywords[0].upstream_id)
+        self.assertEqual(keyword.id, unlinked_keywords[0].id)
+
+    def test_unlink_keywords_in_domain_unlinks_multiple_keywords(self):
+        keyword1 = Keyword(domain=self.domain, upstream_id='abc123')
+        keyword2 = Keyword(domain=self.domain, upstream_id='abc123')
+        keyword1.save()
+        keyword2.save()
+
+        unlinked_keywords = unlink_keywords_in_domain(self.domain)
+
+        self.assertEqual(2, len(unlinked_keywords))
+        self.assertIsNone(unlinked_keywords[0].upstream_id)
+        self.assertIsNone(unlinked_keywords[1].upstream_id)
+        keyword_ids = [keyword.id for keyword in unlinked_keywords]
+        self.assertTrue(keyword1.id in keyword_ids)
+        self.assertTrue(keyword2.id in keyword_ids)
+
+    def test_unlink_keywords_in_domain_only_processes_linked_keywords(self):
+        original_keyword = Keyword(domain=self.domain)
+        linked_keyword = Keyword(domain=self.domain, upstream_id='abc123')
+        original_keyword.save()
+        linked_keyword.save()
+
+        unlinked_keywords = unlink_keywords_in_domain(self.domain)
+
+        self.assertEqual(1, len(unlinked_keywords))
+        self.assertIsNone(unlinked_keywords[0].upstream_id)
+        keyword_ids = [keyword.id for keyword in unlinked_keywords]
+        self.assertFalse(original_keyword.id in keyword_ids)
+        self.assertTrue(linked_keyword.id in keyword_ids)
+
+    def test_unlink_keywords_in_domain_returns_zero_if_no_linked_keywords(self):
+        keyword = Keyword(domain=self.domain)
+        keyword.save()
+
+        unlinked_keywords = unlink_keywords_in_domain(self.domain)
+
+        self.assertEqual(0, len(unlinked_keywords))


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-125)

Should be able to unlink all keywords in a domain that have an `upstream_id` since we only support one upstream domain at the moment it is safe to assume we can unlink by domain.

Only tests call this code so it is inherently safe.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`ERM_DEVELOPMENT` and `LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary at this time.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Only tests call this code.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
