### PR TITLE
Documentation changes for code review location

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -75,7 +75,7 @@ to see how that works.
 .. _Standards and Best Practices: STANDARDS.rst
 .. _Style Guide: https://www.commcarehq.org/styleguide/
 .. _Javascript Guide: docs/js-guide/README.md
-.. _Guide to Authoring Pull Requests: https://github.com/dimagi/code-review/blob/master/Writing_PRs.md
+.. _Guide to Authoring Pull Requests: https://github.com/dimagi/open-source/blob/master/docs/Writing_PRs.md
 .. _Developers category: https://forum.dimagi.com/c/developers
 .. _CommCare Forum: https://forum.dimagi.com/
 .. _Read the Docs: https://commcare-hq.readthedocs.io/


### PR DESCRIPTION
## Summary
Documentation only change.

Updates internal documentation to reflect the new structure of the contribution / PR docs

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
