### PR TITLE
cache values in ForeignValue

### DIFF
--- a/corehq/util/models.py
+++ b/corehq/util/models.py
@@ -273,6 +273,9 @@ class ForeignValue:
     memory rather than fetching from the database each time a new value
     is set or fetched. Pass `cache_size=0` disable the LRU-cache. Note that the
     `__set__` and `__get__` use different caches (each of the same size).
+
+    Note: corehq.util.test_utils.patch_foreign_value_caches for how the caches
+    are cleared in tests.
     """
 
     def __init__(self, foreign_key: models.ForeignKey, truncate=False, cache_size=1000):

--- a/corehq/util/models.py
+++ b/corehq/util/models.py
@@ -291,6 +291,9 @@ class ForeignValue:
         if obj is None:
             return self
         fobj_id = getattr(obj, f"{self.fk.name}_id")
+        if fobj_id is None:
+            fobj = getattr(obj, self.fk.name)
+            return fobj.value if fobj is not None else None
         return self.get_value(fobj_id)
 
     @cached_property

--- a/corehq/util/models.py
+++ b/corehq/util/models.py
@@ -271,10 +271,8 @@ class ForeignValue:
 
     An LRU cache is used to keep recently fetched related objects in
     memory rather than fetching from the database each time a new value
-    is set. Pass `cache_size=0` disable the LRU-cache. Note that the
-    cache is used by `__set__`, but not by `__get__` (unless `__set__`
-    was called first); this is optimize for current/known use cases,
-    optimizing `__get__` may make sense for future use cases.
+    is set or fetched. Pass `cache_size=0` disable the LRU-cache. Note that the
+    `__set__` and `__get__` use different caches (each of the same size).
     """
 
     def __init__(self, foreign_key: models.ForeignKey, truncate=False, cache_size=1000):

--- a/corehq/util/tests/test_models.py
+++ b/corehq/util/tests/test_models.py
@@ -97,6 +97,27 @@ class TestForeignValue(TestCase):
         # matching instances indicates LRU cache was used
         self.assertIs(self.log.user_agent_fk, log2.user_agent_fk)
 
+    def test_get_value(self):
+        self.log.user_agent = "Mozilla"
+        self.log.save()
+
+        UserAccessLog.user_agent.get_value.cache_clear()
+        info = UserAccessLog.user_agent.get_value.cache_info()
+        self.assertEqual(info.misses, 0)
+        self.assertEqual(info.hits, 0)
+
+        log = UserAccessLog.objects.get(id=self.log.id)
+        self.assertEqual(log.user_agent, "Mozilla")
+        info = UserAccessLog.user_agent.get_value.cache_info()
+        self.assertEqual(info.misses, 1)
+        self.assertEqual(info.hits, 0)
+
+        log = UserAccessLog.objects.get(id=self.log.id)
+        self.assertEqual(log.user_agent, "Mozilla")
+        info = UserAccessLog.user_agent.get_value.cache_info()
+        self.assertEqual(info.misses, 1)
+        self.assertEqual(info.hits, 1)
+
     def test_foreign_value_duplicate(self):
         ua1 = UserAgent(value="Mozilla")
         ua2 = UserAgent(value="Mozilla")
@@ -107,8 +128,8 @@ class TestForeignValue(TestCase):
         self.log.save()
         self.assertEqual(self.log.user_agent_fk.id, ua1.id)
 
-    def test_lru_cache_disabled(self):
-        with foreign_value_lru_cache_disabled():
+    def test_get_related_lru_cache_disabled(self):
+        with foreign_value_lru_cache_disabled("get_related"):
             self.log.user_agent = "Mozilla"
             log2 = UserAccessLog(user_agent="Mozilla")
             self.assertEqual(self.log.user_agent_fk.id, log2.user_agent_fk.id)
@@ -116,11 +137,24 @@ class TestForeignValue(TestCase):
             # different instances indicates LRU cache was not used
             self.assertIsNot(self.log.user_agent_fk, log2.user_agent_fk)
 
+    def test_get_value_lru_cache_disabled(self):
+        with foreign_value_lru_cache_disabled("get_value"):
+            self.log.user_agent = "Mozilla"
+            self.log.save()
+            log2 = UserAccessLog(user_agent="Mozilla")
+            with self.assertNumQueries(1):
+                self.assertEqual(log2.user_agent, "Mozilla")
+
+            # successive access to the save value hits the DB
+            log2 = UserAccessLog(user_agent="Mozilla")
+            with self.assertNumQueries(1):
+                self.assertEqual(log2.user_agent, "Mozilla")
+
 
 @contextmanager
-def foreign_value_lru_cache_disabled():
+def foreign_value_lru_cache_disabled(cached_func):
     def reset_cached_property():
-        fv_prop.__dict__.pop("get_related", None)
+        fv_prop.__dict__.pop(cached_func, None)
 
     fv_prop = UserAccessLog.user_agent
     reset_cached_property()


### PR DESCRIPTION
## Summary
Prevent DB calls for getting the values on access by using an LRU cache.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
