### PR TITLE
Added catch for CaseFilterError during case search

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -113,11 +113,11 @@ def app_aware_search(request, domain, app_id):
     except TooManyRelatedCasesError:
         return HttpResponse(_('Search has too many results. Please try a more specific search.'), status=400)
     except CaseFilterError as e:
-        # This is an app building error, so show user a generic message and notify
+        # This is an app building error, notify so we can track
         notify_exception(request, str(e), details=dict(
             exception_type=type(e),
         ))
-        return HttpResponse(_('Could not understand search.'), status=400)
+        return HttpResponse(str(e), status=400)
     search_es = case_search_criteria.search_es
 
     try:

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -37,7 +37,7 @@ from corehq.apps.app_manager.dbaccessors import (
 )
 from corehq.apps.app_manager.models import GlobalAppConfig
 from corehq.apps.builds.utils import get_default_build_spec
-from corehq.apps.case_search.filter_dsl import TooManyRelatedCasesError
+from corehq.apps.case_search.filter_dsl import CaseFilterError, TooManyRelatedCasesError
 from corehq.apps.case_search.utils import CaseSearchCriteria, get_related_cases
 from corehq.apps.domain.decorators import (
     check_domain_migration,
@@ -112,6 +112,12 @@ def app_aware_search(request, domain, app_id):
         case_search_criteria = CaseSearchCriteria(domain, case_type, criteria)
     except TooManyRelatedCasesError:
         return HttpResponse(_('Search has too many results. Please try a more specific search.'), status=400)
+    except CaseFilterError as e:
+        # This is an app building error, so show user a generic message and notify
+        notify_exception(request, str(e), details=dict(
+            exception_type=type(e),
+        ))
+        return HttpResponse(_('Could not understand search.'), status=400)
     search_es = case_search_criteria.search_es
 
     try:


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-793

## Feature Flag
Case search & claim

## Product Description
Replaces a nonsensical error (see screenshot in ticket).

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

Not requesting QA. I'll smoke test - marking as don't merge in the meantime.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
