### PR TITLE
Searching and matching FHIR patients.

### DIFF
--- a/corehq/motech/fhir/forms.py
+++ b/corehq/motech/fhir/forms.py
@@ -1,6 +1,8 @@
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 
+from crispy_forms import bootstrap as twbscrispy
+
 from corehq.motech.repeaters.forms import GenericRepeaterForm
 
 from .const import FHIR_VERSION_4_0_1, FHIR_VERSIONS
@@ -12,7 +14,23 @@ class FHIRRepeaterForm(GenericRepeaterForm):
         choices=FHIR_VERSIONS,
         initial=FHIR_VERSION_4_0_1,
     )
+    patient_registration_enabled = forms.BooleanField(
+        label=_('Enable patient registration'),
+        initial=True,
+        required=False,
+        help_text=_('Register new patients on the remote FHIR service?'),
+    )
+    patient_search_enabled = forms.BooleanField(
+        label=_('Enable patient search'),
+        initial=False,
+        required=False,
+        help_text=_('Search the remote FHIR service for matching patients?'),
+    )
 
     def get_ordered_crispy_form_fields(self):
         fields = super().get_ordered_crispy_form_fields()
-        return fields + ['fhir_version']
+        return fields + [
+            'fhir_version',
+            twbscrispy.PrependedText('patient_registration_enabled', ''),
+            twbscrispy.PrependedText('patient_search_enabled', ''),
+        ]

--- a/corehq/motech/fhir/matchers.py
+++ b/corehq/motech/fhir/matchers.py
@@ -1,0 +1,245 @@
+from collections import namedtuple
+from decimal import Decimal
+from typing import Iterable, List, Optional, Type
+
+import attr
+
+from corehq.motech.finders import le_days_diff, le_levenshtein_percent
+from jsonpath_ng.ext.parser import parse as jsonpath_parse
+
+from corehq.motech.utils import simplify_list
+
+CandidateScore = namedtuple('CandidateScore', 'candidate score')
+
+
+class DuplicateWarning(Warning):
+    pass
+
+
+class ResourceMatcher:
+    """
+    Finds matching FHIR resources.
+
+    The properties of resources are compared. Each matching property has
+    a weight. The sum of the weights give a score. If the score is
+    greater than 1, the resources are considered a match.
+
+    If more than one candidate matches, but one has a significantly
+    higher score than the rest, it is the match. Otherwise a
+    ``DuplicateWarning`` exception is raised.
+    """
+
+    property_weights: List['PropertyWeight']
+    confidence_margin = 0.5
+
+    def __init__(self, resource: dict):
+        self.resource = resource
+
+    def find_match(self, candidates: Iterable[dict]):
+        matches = self.find_matches(candidates, keep_dups=False)
+        match = simplify_list(matches)
+        if isinstance(match, list):
+            raise DuplicateWarning('Duplicate matches found for resource '
+                                   f'{self.resource}')
+        return match
+
+    def find_matches(self, candidates: Iterable[dict], *, keep_dups=True):
+        """
+        Returns a list of matches.
+
+        If ``keep_dups`` is False, allows for an arbitrary number of
+        candidates but only returns the best two, or fewer.
+        """
+
+        def top_two(list_):
+            return sorted(list_, key=lambda l: l.score, reverse=True)[:2]
+
+        candidates_scores = []
+        for candidate in candidates:
+            score = self.get_score(candidate)
+            if score >= 1:
+                candidates_scores.append(CandidateScore(candidate, score))
+            if not keep_dups:
+                candidates_scores = top_two(candidates_scores)
+
+        if len(candidates_scores) > 1:
+            best, second = top_two(candidates_scores)
+            if best.score / second.score >= 1 + self.confidence_margin:
+                return [best.candidate]
+        return [cs.candidate for cs in candidates_scores]
+
+    def get_score(self, candidate):
+        return sum(self.iter_weights(candidate))
+
+    def iter_weights(self, candidate):
+        for pw in self.property_weights:
+            is_match = pw.method.is_match(self.resource, candidate)
+            if is_match is None:
+                # method was unable to compare values
+                continue
+            yield pw.weight if is_match else -1 * pw.negative_weight
+
+
+class ComparisonMethod:
+    """
+    A method of comparing resource properties.
+    """
+
+    def __init__(self, jsonpath: str):
+        self.jsonpath = jsonpath_parse(jsonpath)
+
+    def is_match(self, resource: dict, candidate: dict) -> Optional[bool]:
+        a = simplify_list([x.value for x in self.jsonpath.find(resource)])
+        b = simplify_list([x.value for x in self.jsonpath.find(candidate)])
+        if a is None or b is None:
+            return None
+        return self.compare(a, b)
+
+    @staticmethod
+    def compare(a, b) -> bool:
+        raise NotImplementedError
+
+
+class IsEqual(ComparisonMethod):
+
+    @staticmethod
+    def compare(a, b):
+        return a == b
+
+
+class GivenName(ComparisonMethod):
+
+    @staticmethod
+    def compare(a, b):
+        return any(a_name == b_name for a_name, b_name in zip(a, b))
+
+
+class Age(ComparisonMethod):
+
+    @staticmethod
+    def compare(a, b):
+        max_days = 364
+        return le_days_diff(max_days, a, b)
+
+
+class OrganizationName(ComparisonMethod):
+
+    @staticmethod
+    def compare(a, b):
+        percent = 0.2
+        return le_levenshtein_percent(percent, a.lower(), b.lower())
+
+
+class NegativeIdentifier(ComparisonMethod):
+    """
+    Returns False if the identifier system is the same, and the
+    identifier value is not close.
+
+    Used for giving a negative score to candidates with different IDs
+    from the same system.
+    """
+
+    @staticmethod
+    def compare(a, b):
+        system_a, value_a = a.split('|')
+        system_b, value_b = b.split('|')
+        return not (
+            system_a == system_b
+            and not le_levenshtein_percent(0.2, value_a, value_b)
+        )
+
+
+def _value_ge_zero(instance, attrib, value):
+    return value >= 0
+
+
+@attr.s
+class PropertyWeight:
+    """
+    Associates a matching property with a weight
+    """
+    jsonpath = attr.ib(type=str)
+    weight = attr.ib(type=Decimal, validator=_value_ge_zero)
+    method_class = attr.ib(type=Type[ComparisonMethod], default=IsEqual)
+    # Score negatively if values are different
+    negative_weight = attr.ib(type=Decimal,
+                              default=Decimal('0'),
+                              validator=_value_ge_zero)
+
+    @property
+    def method(self):
+        return self.method_class(self.jsonpath)
+
+
+class PersonMatcher(ResourceMatcher):
+    """
+    Finds matching FHIR Persons
+    """
+    property_weights = [
+        PropertyWeight(
+            '$.identifier[0].system + "|" + $.identifier[0].value',
+            Decimal('0.8'),
+        ),
+        PropertyWeight(
+            '$.identifier[0].system + "|" + $.identifier[0].value',
+            Decimal('0'),
+            NegativeIdentifier,
+            negative_weight=Decimal('1.1'),
+        ),
+        PropertyWeight('$.name[0].given', Decimal('0.3'), GivenName),
+        # PropertyWeight('$.name[0].given', 0.1, AnyGivenName),
+        PropertyWeight('$.name[0].family', Decimal('0.4')),
+        PropertyWeight('$.telecom[0].value', Decimal('0.4')),
+        PropertyWeight(
+            '$.gender',
+            Decimal('0.05'),
+            negative_weight=Decimal('0.6')
+        ),
+        PropertyWeight('$.birthDate', Decimal('0.1')),
+        PropertyWeight(
+            '$.birthDate',
+            Decimal('0.05'),
+            Age,
+            negative_weight=Decimal('0.2')
+        ),
+    ]
+
+
+class PatientMatcher(ResourceMatcher):
+    """
+    Finds matching FHIR Patients
+    """
+    property_weights = PersonMatcher.property_weights + [
+        PropertyWeight('$.multipleBirthInteger', Decimal('0.1'))
+    ]
+
+
+class OrganizationMatcher(ResourceMatcher):
+    property_weights = [
+        PropertyWeight('$.name', Decimal('0.8'), OrganizationName),
+        PropertyWeight('$.telecom[0].value', Decimal('0.4')),
+    ]
+
+
+def get_matcher(resource: dict) -> ResourceMatcher:
+    """
+    Returns a subclass of ``ResourceMatcher`` instantiated with
+    ``resource``.
+
+    .. IMPORTANT::
+       ``get_matcher()`` assumes that subclasses of ``ResourceMatcher``
+       are named for the resource type they are implemented for.
+       e.g. ``PatientMatcher`` matches Patient resources.
+
+    """
+    suffix = len('Matcher')
+    classes_by_resource_type = {cls.__name__[:-suffix]: cls
+                                for cls in ResourceMatcher.__subclasses__()}
+    try:
+        matcher_class = classes_by_resource_type[resource['resourceType']]
+    except KeyError:
+        raise NotImplementedError(
+            'ResourceMatcher not implemented for resource type '
+            f"{resource['resourceType']!r}"
+        )
+    return matcher_class(resource)

--- a/corehq/motech/fhir/matchers.py
+++ b/corehq/motech/fhir/matchers.py
@@ -114,6 +114,23 @@ class GivenName(ComparisonMethod):
         return any(a_name == b_name for a_name, b_name in zip(a, b))
 
 
+class AnyGivenName(ComparisonMethod):
+    """
+    This ComparisonMethod might be better suited to negative weights
+    because the chances of false positives are high.
+
+    e.g.
+
+    >>> AnyGivenName.compare(['H.', 'John'], ['Santa', 'H.'])
+    True
+
+    """
+
+    @staticmethod
+    def compare(a, b):
+        return bool(set(a) & set(b))
+
+
 class Age(ComparisonMethod):
 
     @staticmethod
@@ -187,7 +204,12 @@ class PersonMatcher(ResourceMatcher):
             negative_weight=Decimal('1.1'),
         ),
         PropertyWeight('$.name[0].given', Decimal('0.3'), GivenName),
-        # PropertyWeight('$.name[0].given', 0.1, AnyGivenName),
+        PropertyWeight(
+            '$.name[0].given',
+            Decimal('0'),
+            AnyGivenName,
+            negative_weight=Decimal('0.3'),
+        ),
         PropertyWeight('$.name[0].family', Decimal('0.4')),
         PropertyWeight('$.telecom[0].value', Decimal('0.4')),
         PropertyWeight(

--- a/corehq/motech/fhir/matchers.py
+++ b/corehq/motech/fhir/matchers.py
@@ -219,27 +219,3 @@ class OrganizationMatcher(ResourceMatcher):
         PropertyWeight('$.name', Decimal('0.8'), OrganizationName),
         PropertyWeight('$.telecom[0].value', Decimal('0.4')),
     ]
-
-
-def get_matcher(resource: dict) -> ResourceMatcher:
-    """
-    Returns a subclass of ``ResourceMatcher`` instantiated with
-    ``resource``.
-
-    .. IMPORTANT::
-       ``get_matcher()`` assumes that subclasses of ``ResourceMatcher``
-       are named for the resource type they are implemented for.
-       e.g. ``PatientMatcher`` matches Patient resources.
-
-    """
-    suffix = len('Matcher')
-    classes_by_resource_type = {cls.__name__[:-suffix]: cls
-                                for cls in ResourceMatcher.__subclasses__()}
-    try:
-        matcher_class = classes_by_resource_type[resource['resourceType']]
-    except KeyError:
-        raise NotImplementedError(
-            'ResourceMatcher not implemented for resource type '
-            f"{resource['resourceType']!r}"
-        )
-    return matcher_class(resource)

--- a/corehq/motech/fhir/repeater_helpers.py
+++ b/corehq/motech/fhir/repeater_helpers.py
@@ -19,6 +19,8 @@ from .utils import resource_url
 def register_patients(
     requests: Requests,
     info_resource_list: List[tuple],
+    registration_enabled: bool,
+    search_enabled: bool,
     repeater_id: str,
 ) -> List[tuple]:
 
@@ -31,11 +33,14 @@ def register_patients(
             # Patient is already registered
             info_resource_list_to_send.append((info, resource))
             continue
-        patient = find_patient(requests, resource)  # Raises DuplicateWarning
+        if search_enabled:
+            patient = find_patient(requests, resource)  # Raises DuplicateWarning
+        else:
+            patient = None
         if patient:
             _set_external_id(info, patient['id'], repeater_id)
             info_resource_list_to_send.append((info, resource))
-        else:
+        elif registration_enabled:
             patient = register_patient(requests, resource)
             _set_external_id(info, patient['id'], repeater_id)
             # Don't append `resource` to `info_resource_list_to_send`

--- a/corehq/motech/fhir/repeater_helpers.py
+++ b/corehq/motech/fhir/repeater_helpers.py
@@ -5,11 +5,14 @@ from requests import HTTPError, Response
 from casexml.apps.case.mock import CaseBlock
 
 from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.motech.requests import Requests
+from corehq.motech.repeater_helpers import RepeaterResponse
+from corehq.motech.requests import Requests, json_or_http_error
 from corehq.motech.value_source import CaseTriggerInfo
 
 from .const import FHIR_BUNDLE_TYPES, FHIR_VERSIONS, XMLNS_FHIR
+from .matchers import PatientMatcher
 from .models import build_fhir_resource_for_info
+from .searchers import PatientSearcher
 from .utils import resource_url
 
 
@@ -28,11 +31,44 @@ def register_patients(
             # Patient is already registered
             info_resource_list_to_send.append((info, resource))
             continue
-        send_resource(requests, info, resource, repeater_id,
-                      raise_on_ext_id=True)
-        # Don't append `resource` to `info_resource_list_to_send`
-        # because the remote service has all its data now.
+        patient = find_patient(requests, resource)  # Raises DuplicateWarning
+        if patient:
+            _set_external_id(info, patient['id'], repeater_id)
+            info_resource_list_to_send.append((info, resource))
+        else:
+            patient = register_patient(requests, resource)
+            _set_external_id(info, patient['id'], repeater_id)
+            # Don't append `resource` to `info_resource_list_to_send`
+            # because the remote service has all its data now.
     return info_resource_list_to_send
+
+
+def find_patient(requests, resource):
+    searcher = PatientSearcher(requests, resource)
+    matcher = PatientMatcher(resource)
+    for search in searcher.iter_searches():
+        candidates = search.iter_candidates()
+        match = matcher.find_match(candidates)  # Raises DuplicateWarning
+        if match:
+            _check_id(match)
+            return match
+    return None
+
+
+def register_patient(requests, resource):
+    response = requests.post('Patient/', json=resource, raise_for_status=True)
+    patient = json_or_http_error(response)
+    _check_id(patient)
+    return patient
+
+
+def _check_id(patient):
+    if 'id' not in patient:
+        response = RepeaterResponse(status_code=500, reason='Bad response')
+        raise HTTPError(
+            'Remote service returned a patient missing an "id" property',
+            response=response,
+        )
 
 
 def get_info_resource_list(
@@ -171,3 +207,5 @@ def _set_external_id(info, external_id, repeater_id):
         xmlns=XMLNS_FHIR,
         device_id=f'FHIRRepeater-{repeater_id}',
     )
+    # If case was matched, set external_id to update remote resource
+    info.extra_fields['external_id'] = external_id

--- a/corehq/motech/fhir/searchers.py
+++ b/corehq/motech/fhir/searchers.py
@@ -1,0 +1,275 @@
+from typing import Generator, List, Optional, Type, Union
+
+import attr
+from jsonpath_ng.ext.parser import parse as jsonpath_parse
+
+from corehq.motech.requests import Requests, json_or_http_error
+from corehq.motech.utils import simplify_list
+
+from .const import SYSTEM_URI_CASE_ID
+
+
+class ResourceSearcher:
+    """
+    Searches a remote FHIR API in increasingly broad terms.
+
+    Used in conjunction with ResourceMatcher to find matching resources.
+    """
+    # A list of searches, and for each one, the list of search params to
+    # filter by
+    search_search_params: List[List['SearchParam']]
+
+    def __init__(self, requests: Requests, resource: dict):
+        self.requests = requests
+        self.resource = resource
+
+    def iter_searches(self) -> Generator['Search', None, None]:
+        # Separate out searches so that the caller can stop if they find
+        # the resource they need with a narrow search, before trying a
+        # broader search.
+        return (Search(self.requests, self.resource, search_params)
+                for search_params in self.search_search_params)
+
+
+class Search:
+    """
+    A search, based on a list of ``SearchParam``s to filter by.
+    """
+
+    def __init__(
+        self,
+        requests: Requests,
+        resource: dict,
+        search_params: List['SearchParam'],
+    ):
+        self.requests = requests
+        self.resource = resource
+        self.search_params = search_params
+
+    def iter_candidates(self) -> Generator:
+        """
+        Iterates the candidates returned by the search.
+        """
+        for params in self._get_request_params():
+            # One search usually involves one dictionary of request
+            # params, but can involve many. e.g. Searching for a
+            # patient by each of their given names is done with a series
+            # of requests.
+            endpoint = f"{self.resource['resourceType']}/"
+            searchset_bundle = self._get_bundle(endpoint, params=params)
+            while True:
+                yield from self._iter_bundle(searchset_bundle)
+                url = get_next_url(searchset_bundle)
+                if url:
+                    searchset_bundle = self._get_bundle(url=url)
+                else:
+                    break
+
+    def _get_request_params(self) -> List[dict]:
+        request_params = [{}]
+        for sp in self.search_params:
+            value = sp.param.get_value(self.resource)
+            if value is None:
+                continue
+            elif isinstance(value, list):
+                request_params = multiply(request_params, sp.param_name, value)
+            else:
+                update_all(request_params, sp.param_name, value)
+        return request_params
+
+    def _get_bundle(self, endpoint=None, *, url=None, **kwargs) -> dict:
+        assert endpoint or url, 'No API endpoint or url given'
+        if endpoint:
+            response = self.requests.get(endpoint, **kwargs)
+            return json_or_http_error(response)
+        response = self.requests.send_request('GET', url, **kwargs)
+        return json_or_http_error(response)
+
+    @staticmethod
+    def _iter_bundle(bundle: dict) -> Generator:
+        for entry in bundle.get('entry', {}):
+            if 'resource' in entry:
+                yield entry['resource']
+
+
+class ParamHelper:
+    """
+    Formats search parameter values.
+
+    If ``get_value()`` returns a list of values, ``Search.iter_candidates()``
+    will send a request for each value.
+    """
+
+    def __init__(self, jsonpath: str):
+        self.jsonpath = jsonpath_parse(jsonpath)
+
+    def get_value(self, resource: dict) -> Union[None, str, List[str]]:
+        value = simplify_list([x.value for x in self.jsonpath.find(resource)])
+        return None if value is None else self.prepare_value(value)
+
+    @staticmethod
+    def prepare_value(value) -> Union[str, List[str]]:
+        if isinstance(value, list):
+            return [str(v) for v in value]
+        return str(value)
+
+
+class GivenName(ParamHelper):
+
+    @staticmethod
+    def prepare_value(value):
+        """
+        ``value`` is a given name or a list of given names. Returns a
+        string by joining given names with " ".
+        """
+        if isinstance(value, list):
+            return ' '.join(value)
+        return value
+
+
+class EachUniqueValue(ParamHelper):
+
+    @staticmethod
+    def prepare_value(value):
+        """
+        Returns a list of unique values, or the value if there is only
+        one.
+        """
+        if isinstance(value, list):
+            if value and isinstance(value[0], list):
+                set_ = {item for list_ in value for item in list_}
+                return simplify_list(list(set_))
+            return simplify_list(list(set(value)))
+        return value
+
+
+@attr.s(auto_attribs=True)
+class SystemCode:
+    """
+    A search parameter value that is made up of a system and a code.
+
+    e.g. To search by case ID, we use the "identifier" param, and
+    provide both the case ID under "code" and a URI for CommCare under
+    "system".
+    """
+    system: str
+    code: str
+
+    def __str__(self):
+        if self.system and self.code:
+            return f'{self.system}|{self.code}'
+        return self.system or self.code or ''
+
+
+class SystemCodeParam(ParamHelper):
+
+    @staticmethod
+    def prepare_value(value):
+        """
+        ``value`` is a dictionary with "system" and "value" keys.
+        """
+        system_code = SystemCode(system=value['system'], code=value['value'])
+        return str(system_code)
+
+
+@attr.s(auto_attribs=True)
+class SearchParam:
+    """
+    SearchParam has a ``jsonpath`` that specifies where to get the
+    search parameter's value, and an optional ``ParamHelper`` to format
+    the value for use as a search parameter.
+    """
+    param_name: str  # e.g. "given"
+    jsonpath: str  # e.g. "$.name[0].given"
+    param_class: Type[ParamHelper] = ParamHelper
+
+    @property
+    def param(self):
+        return self.param_class(self.jsonpath)
+
+
+class PatientSearcher(ResourceSearcher):
+    search_search_params = [
+        # First search: Case name and case ID
+        [
+            SearchParam('name', '$.name[0].text'),
+            SearchParam(
+                param_name='identifier',
+                jsonpath=f"$.identifier[?system='{SYSTEM_URI_CASE_ID}']",
+                param_class=SystemCodeParam,
+            ),
+        ],
+
+        # Second search: Personal details
+        [
+            SearchParam('given', '$.name[0].given', GivenName),
+            SearchParam('family', '$.name[0].family'),
+            SearchParam('gender', '$.gender'),
+            SearchParam('birthdate', '$.birthDate'),
+            SearchParam('email', "$.telecom[?system='email'].value",
+                        EachUniqueValue),
+            SearchParam('phone', "$.telecom[?system='phone'].value",
+                        EachUniqueValue),
+            SearchParam('address-country', '$.address[*].country',
+                        EachUniqueValue),
+            SearchParam('address-state', '$.address[*].state',
+                        EachUniqueValue),
+            SearchParam('address-city', '$.address[*].city',
+                        EachUniqueValue),
+        ],
+
+        # Third time's the charm: Broad searches by names
+        [
+            SearchParam('given', '$.name[*].given', EachUniqueValue),
+            SearchParam('family', '$.name[*].family'),
+        ],
+    ]
+
+
+def update_all(dicts: List[dict], key, value):
+    for dict_ in dicts:
+        dict_[key] = value
+
+
+def multiply(dicts: List[dict], key, values: list) -> List[dict]:
+    """
+    Duplicates and updates ``dicts`` for each value in ``values``.
+
+    >>> multiply([{'foo': 1}], key='bar', values=[2, 3])
+    [{'foo': 1, 'bar': 2}, {'foo': 1, 'bar': 3}]
+
+    """
+    return [
+        {**dict_, **{key: value}}
+        for dict_ in dicts
+        for value in values
+    ]
+
+
+def get_next_url(bundle: dict) -> Optional[str]:
+    """
+    Returns the URL for the next page of a paginated ``bundle``.
+
+    >>> bundle = {
+    ...     "link": [
+    ...         {"relation": "self", "url": "https://example.com/page/2"},
+    ...         {"relation": "next", "url": "https://example.com/page/3"},
+    ...         {"relation": "previous", "url": "https://example.com/page/1"},
+    ...     ]
+    ... }
+    >>> get_next_url(bundle)
+    "https://example.com/page/3"
+
+    >>> bundle = {
+    ...     "link": [
+    ...         {"relation": "self", "url": "https://example.com/page/1"},
+    ...     ]
+    ... }
+    >>> get_next_url(bundle)
+    None
+
+    """
+    if 'link' in bundle:
+        for link in bundle['link']:
+            if link['relation'] == 'next':
+                return link['url']

--- a/corehq/motech/fhir/tests/test_matchers.py
+++ b/corehq/motech/fhir/tests/test_matchers.py
@@ -1,3 +1,4 @@
+import doctest
 from decimal import Decimal
 from uuid import uuid4
 
@@ -5,6 +6,7 @@ from django.test import SimpleTestCase
 
 from nose.tools import assert_equal
 
+from .. import matchers
 from ..const import SYSTEM_URI_CASE_ID
 from ..matchers import (
     GivenName,
@@ -130,7 +132,12 @@ class TestPatientCandidates(SimpleTestCase):
         scores = [matcher.get_score(c) for c in candidates]
         expected = [
             Decimal('-0.4'),  # Same name, different ID
-            Decimal('0.8'),  # Same ID, different name
+            Decimal('0.5'),  # Same ID, different name
             Decimal('1.2'),  # Same ID, same family name
         ]
         self.assertEqual(scores, expected)
+
+
+def test_doctests():
+    results = doctest.testmod(matchers)
+    assert_equal(results.failed, 0)

--- a/corehq/motech/fhir/tests/test_matchers.py
+++ b/corehq/motech/fhir/tests/test_matchers.py
@@ -1,0 +1,136 @@
+from decimal import Decimal
+from uuid import uuid4
+
+from django.test import SimpleTestCase
+
+from nose.tools import assert_equal
+
+from ..const import SYSTEM_URI_CASE_ID
+from ..matchers import (
+    GivenName,
+    NegativeIdentifier,
+    OrganizationMatcher,
+    OrganizationName,
+    PatientMatcher,
+    PersonMatcher,
+    PropertyWeight,
+)
+
+
+def test_given_name_method():
+    """
+    Test the GivenName ComparisonMethod as used by PersonMatcher
+    """
+    pw = PropertyWeight('$.name[0].given', Decimal('0.3'), GivenName)
+    assert pw in PersonMatcher.property_weights
+    method = pw.method
+
+    john = {'name': [{'given': 'Henry John Colchester'.split()}]}
+    for resource, candidate, expected in [
+        # candidate "H. John" matches patient "Henry John Colchester"
+        (john, {'name': [{'given': ['H.', 'John']}]}, True),
+        # candidate "John" does not match patient "Henry John Colchester"
+        (john, {'name': [{'given': ['John']}]}, False),
+        (john, {'name': [{'given': ['Henry']}]}, True),
+        (john, {'name': [{'given': ['H.', 'J.', 'C.']}]}, False),
+        # candidate "Eric John Marwood" matches "Henry John Colchester"
+        (john, {'name': [{'given': ['Eric', 'John', 'Marwood']}]}, True),
+    ]:
+        yield check_method, method, resource, candidate, expected
+
+
+def test_organization_name_method():
+    """
+    Test the OrganizationName method as used by OrganizationMatcher
+    """
+    pw = PropertyWeight('$.name', Decimal('0.8'), OrganizationName)
+    assert pw in OrganizationMatcher.property_weights
+    method = pw.method
+
+    dimagi = {'name': 'Dimagi'}
+    for resource, candidate, expected in [
+        (dimagi, {'name': 'Dimagi'}, True),
+        (dimagi, {'name': 'DiMaggi'}, True),
+        (dimagi, {'name': 'Di Maggi'}, False),
+        (dimagi, {'name': 'dimCGI'}, True),
+    ]:
+        yield check_method, method, resource, candidate, expected
+
+
+def check_method(method, a, b, expected):
+    result = method.is_match(a, b)
+    assert_equal(result, expected)
+
+
+def test_negative_identifier():
+    for a, b, expected in [
+        ('name|Beth Harmon', 'name|Elizabeth Harmon', False),
+        ('name|Beth', 'name|Beth', True),
+        ('name|Elizabeth Harmon', 'name|Elisabeth Harmon', True),
+        ('given_name|Elizabeth', 'family_name|Harmon', True),
+    ]:
+        yield check_compare, NegativeIdentifier, a, b, expected
+
+
+def check_compare(method_class, a, b, expected):
+    result = method_class.compare(a, b)
+    assert_equal(result, expected)
+
+
+class TestPatientCandidates(SimpleTestCase):
+
+    def test_with_commcare_id(self):
+        case_id = uuid4().hex
+        patient = {
+            'id': case_id,
+            'name': [{
+                'text': 'Beth Harmon',
+                'given': ['Elizabeth'],
+                'family': 'Harmon',
+            }],
+            'identifier': [{
+                'system': SYSTEM_URI_CASE_ID,
+                'value': case_id,
+            }]
+        }
+        candidates = [
+            {
+                'id': '1',
+                'name': [{
+                    'given': ['Elizabeth'],
+                    'family': 'Harmon',
+                }],
+                'identifier': [{
+                    'system': SYSTEM_URI_CASE_ID,
+                    'value': uuid4().hex,
+                }],
+            },
+            {
+                'id': '2',
+                'name': [{'given': ['Jolene']}],
+                'identifier': [{
+                    'system': SYSTEM_URI_CASE_ID,
+                    'value': case_id,
+                }],
+            },
+            {
+                'id': '3',
+                'name': [{'family': 'Harmon'}],
+                'identifier': [{
+                    'system': SYSTEM_URI_CASE_ID,
+                    'value': case_id,
+                }],
+            },
+        ]
+        matcher = PatientMatcher(patient)
+        matches = matcher.find_matches(candidates)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0]['id'], '3')
+
+        scores = [matcher.get_score(c) for c in candidates]
+        expected = [
+            Decimal('-0.4'),  # Same name, different ID
+            Decimal('0.8'),  # Same ID, different name
+            Decimal('1.2'),  # Same ID, same family name
+        ]
+        self.assertEqual(scores, expected)

--- a/corehq/motech/fhir/tests/test_searchers.py
+++ b/corehq/motech/fhir/tests/test_searchers.py
@@ -1,0 +1,301 @@
+from unittest.mock import Mock
+
+import attr
+from nose.tools import assert_equal, assert_in, assert_true
+
+from corehq.motech.auth import BasicAuthManager
+from corehq.motech.requests import Requests
+
+from ..searchers import (
+    EachUniqueValue,
+    GivenName,
+    ParamHelper,
+    PatientSearcher,
+    Search,
+    SearchParam,
+)
+
+
+def test_param_helper():
+    search_param = SearchParam('family', '$.name[*].family', ParamHelper)
+    for resource, expected_valueset in [
+        (
+            {'name': [{'given': ['Jane'], 'family': 'Fonda'}]},
+            'Fonda',
+        ),
+        (
+            {'name': [
+                {'given': ['Jane'], 'family': 'Fonda'},
+                {'given': ['Jane'], 'family': 'Plemiannikov'},
+            ]},
+            {'Fonda', 'Plemiannikov'},
+        ),
+    ]:
+        yield check_param_helper, search_param, resource, expected_valueset
+
+
+def test_given_name():
+    search_param = SearchParam('given', '$.name[0].given', GivenName)
+    for resource, expected_valueset in [
+        (
+            {'name': [{'given': ['Jane'], 'family': 'Fonda'}]},
+            'Jane',
+        ),
+        (
+            {'name': [{'given': ['Jane', 'Seymour'], 'family': 'Fonda'}]},
+            'Jane Seymour',
+        ),
+        (
+            {'name': [{'family': 'Fonda'}]},
+            None,
+        ),
+    ]:
+        yield check_param_helper, search_param, resource, expected_valueset
+
+
+def test_each_unique_value_given_names():
+    search_param = SearchParam('given', '$.name[*].given', EachUniqueValue)
+    for resource, expected_valueset in [
+        (
+            {'name': [{'given': ['Jane'], 'family': 'Fonda'}]},
+            'Jane',
+        ),
+        (
+            {'name': [{'given': ['Jane', 'Seymour'], 'family': 'Fonda'}]},
+            {'Jane', 'Seymour'},
+        ),
+        (
+            {'name': [{'family': 'Fonda'}]},
+            None,
+        ),
+        (
+            {'name': [
+                {'given': ['Jane'], 'family': 'Fonda'},
+                {'given': ['Jane'], 'family': 'Plemiannikov'},
+            ]},
+            'Jane',
+        ),
+        (
+            {'name': [
+                {'given': ['Jane', 'Seymour'], 'family': 'Fonda'},
+                {'given': ['Jane', 'Seymour'], 'family': 'Plemiannikov'},
+            ]},
+            {'Jane', 'Seymour'},
+        ),
+        (
+            {'name': [
+                {'given': ['Jane', 'Seymour'], 'family': 'Fonda'},
+                {'given': ['Jane', 'S.'], 'family': 'Plemiannikov'},
+            ]},
+            {'Jane', 'S.', 'Seymour'},
+        ),
+        (
+            {'name': [
+                {'family': 'Fonda'},
+                {'family': 'Plemiannikov'},
+            ]},
+            None,
+        ),
+    ]:
+        yield check_param_helper, search_param, resource, expected_valueset
+
+
+def test_each_unique_value_countries():
+    search_param = SearchParam('country', '$.address[*].country',
+                               EachUniqueValue)
+    for resource, expected_valueset in [
+        (
+            {'address': [{'country': 'USA'}]},
+            'USA',
+        ),
+        (
+            {'address': [
+                {'country': 'USA'},
+                {'country': 'France'},
+            ]},
+            {'USA', 'France'},
+        ),
+        (
+            {'address': [
+                {'state': 'New York'},
+                {'state': 'Île-de-France'},
+            ]},
+            None,
+        ),
+        (
+            {'address': [
+                {'state': 'New York'},
+                {'country': 'France'},
+            ]},
+            'France',
+        ),
+    ]:
+        yield check_param_helper, search_param, resource, expected_valueset
+
+
+def test_each_unique_value_phones():
+    search_param = SearchParam('phone', "$.telecom[?system='phone'].value",
+                               EachUniqueValue)
+    for resource, expected_valueset in [
+        (
+            {'telecom': [{'system': 'phone', 'value': '(555) 675 5745'}]},
+            '(555) 675 5745',
+        ),
+        (
+            {'telecom': [
+                {'system': 'phone', 'value': '+1 555 675 5745'},
+                {'system': 'phone', 'value': '(555) 675 5745'},
+            ]},
+            {'+1 555 675 5745', '(555) 675 5745'},
+        ),
+        (
+            {'telecom': [
+                {'system': 'email', 'value': 'user@example.com'},
+                {'system': 'email', 'value': 'admin@example.com'},
+            ]},
+            None,
+        ),
+        (
+            {'telecom': [
+                {'system': 'phone', 'value': '+1 555 675 5745'},
+                {'system': 'email', 'value': 'user@example.com'},
+            ]},
+            '+1 555 675 5745',
+        ),
+    ]:
+        yield check_param_helper, search_param, resource, expected_valueset
+
+
+def check_param_helper(search_param, resource, expected_valueset):
+    value = search_param.param.get_value(resource)
+    if isinstance(value, list):
+        value = set(value)
+    assert_equal(value, expected_valueset)
+
+
+def test_get_request_params_multiplies():
+    # Broad searches by names:
+    #     '$.name[*].given'
+    #     '$.name[*].family'
+    search_params = PatientSearcher.search_search_params[2]
+    resource = {
+        'name': [
+            {'given': ['Jane', 'Seymour'], 'family': 'Fonda'},
+            {'given': ['Jane', 'Seymour'], 'family': 'Plemiannikov'},
+        ]
+    }
+    search = Search(None, resource, search_params)
+    request_params = search._get_request_params()
+    assert_equal(len(request_params), 4)
+    assert_in({'given': 'Jane', 'family': 'Fonda'}, request_params)
+    assert_in({'given': 'Seymour', 'family': 'Fonda'}, request_params)
+    assert_in({'given': 'Jane', 'family': 'Plemiannikov'}, request_params)
+    assert_in({'given': 'Seymour', 'family': 'Plemiannikov'}, request_params)
+
+
+def test_get_request_params_incomplete_data():
+    # Personal details:
+    #     '$.name[0].given'
+    #     '$.name[0].family'
+    #     '$.gender'
+    #     '$.birthDate'
+    #     "$.telecom[?system='email'].value"
+    #     "$.telecom[?system='phone'].value"
+    #     '$.address[*].country'
+    #     '$.address[*].state'
+    #     '$.address[*].city'
+    search_params = PatientSearcher.search_search_params[1]
+    resource = {
+        'name': [{'given': ['Jane', 'Seymour'], 'family': 'Fonda'}],
+        'gender': 'female',
+        'birthDate': '1937-12-21',
+        'address': [{'country': 'United States of America'}],
+    }
+    search = Search(None, resource, search_params)
+    request_params = search._get_request_params()
+    assert_equal(len(request_params), 1)
+    assert_equal(request_params[0], {
+        'given': 'Jane Seymour',
+        'family': 'Fonda',
+        'gender': 'female',
+        'birthdate': '1937-12-21',
+        'address-country': 'United States of America',
+    })
+
+
+def test_paginated_bundle():
+
+    @attr.s(auto_attribs=True)
+    class Response:
+        data: dict
+
+        def json(self):
+            return self.data
+
+    fane_jonda = {
+        'resourceType': 'Patient',
+        'name': [{'given': ['Fane'], 'family': 'Jonda'}],
+    }
+    jone_fanda = {
+        'resourceType': 'Patient',
+        'name': [{'given': ['Jone'], 'family': 'Fanda'}],
+    }
+    jane_fonda = {
+        'resourceType': 'Patient',
+        'name': [{'given': ['Jane'], 'family': 'Fonda'}],
+    }
+
+    base_url = 'https://example.com/api/'
+    requests = Requests('test-domain', base_url,
+                        auth_manager=BasicAuthManager('user', 'pass'))
+    # First requests.get should be called with a search endpoint
+    requests.get = Mock(return_value=Response({
+        'resourceType': 'bundle',
+        'link': [
+            {'relation': 'self', 'url': base_url + 'Patient/page/1'},  # Page 1
+            {'relation': 'next', 'url': base_url + 'Patient/page/2'},
+        ],
+        'entry': [
+            {'resource': fane_jonda},
+            {'resource': jone_fanda},
+        ],
+    }))
+    # requests.send_request should be called with urls for subsequent pages
+    requests.send_request = Mock(return_value=Response({
+        'resourceType': 'bundle',
+        'link': [
+            {'relation': 'self', 'url': base_url + 'Patient/page/2'},  # Page 2
+            {'relation': 'previous', 'url': base_url + 'Patient/page/1'},
+        ],
+        'entry': [{'resource': jane_fonda}],
+    }))
+
+    resource = {
+        'resourceType': 'Patient',
+        'name': [{'given': ['Jane', 'Seymour'], 'family': 'Fonda'}],
+        'gender': 'female',
+        'birthDate': '1937-12-21',
+        'address': [{'country': 'United States of America'}],
+    }
+    search_params = PatientSearcher.search_search_params[1]
+    search = Search(requests, resource, search_params)
+    candidates = search.iter_candidates()
+
+    assert_equal(next(candidates), fane_jonda)
+    assert_equal(next(candidates), jone_fanda)
+    assert_equal(next(candidates), jane_fonda)
+
+    # The first request searched the Patient endpoint
+    assert_true(requests.get.called_with('Patient/', params={
+        'given': 'Jane Seymour',
+        'family': 'Fonda',
+        'gender': 'female',
+        'birthdate': '1937-12-21',
+        'address-country': 'United States of America',
+    }))
+
+    # The next request called the "next" URL
+    assert_true(requests.get.called_with(
+        'GET',
+        'https://example.com/api/Patient/page/2',
+    ))

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -32,18 +32,19 @@ class AddFHIRRepeaterView(AddRepeaterView):
 
     def set_repeater_attr(self, repeater, cleaned_data):
         repeater = super().set_repeater_attr(repeater, cleaned_data)
-        repeater.fhir_version = (self.add_repeater_form
-                                 .cleaned_data['fhir_version'])
+        for attr in (
+            'fhir_version',
+            'patient_registration_enabled',
+            'patient_search_enabled',
+        ):
+            value = self.add_repeater_form.cleaned_data[attr]
+            setattr(repeater, attr, value)
         return repeater
 
 
 class EditFHIRRepeaterView(EditRepeaterView, AddFHIRRepeaterView):
     urlname = 'edit_fhir_repeater'
     page_title = _('Edit FHIR Repeater')
-
-    @property
-    def page_url(self):
-        return reverse(self.urlname, args=[self.domain])
 
 
 @require_GET

--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -4,6 +4,7 @@ from typing import Callable, Optional
 
 from django.conf import settings
 from django.utils.translation import gettext as _
+from requests import HTTPError
 
 from requests.structures import CaseInsensitiveDict
 
@@ -270,6 +271,16 @@ def simple_post(domain, url, data, *, headers, auth_manager, verify,
         message = f'HTTP status code {response.status_code}: {response.text}'
         requests.notify_error(message)
     return response
+
+
+def json_or_http_error(response):
+    try:
+        return response.json()
+    except ValueError as err:
+        raise HTTPError(
+            'Invalid JSON response from remote service',
+            response=response,
+        ) from err
 
 
 def validate_user_input_url_for_repeaters(url, domain, src):

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -1,6 +1,6 @@
 import json
 from base64 import b64decode, b64encode
-from typing import Optional
+from typing import Optional, Sequence
 
 from django.conf import settings
 
@@ -168,3 +168,22 @@ def get_endpoint_url(
     if endpoint is None:
         return base_url
     return '/'.join((base_url.rstrip('/'), endpoint.lstrip('/')))
+
+
+def simplify_list(seq: Sequence):
+    """
+    Reduces ``seq`` to its only element, or ``None`` if it is empty.
+
+    >>> simplify_list([1])
+    1
+    >>> simplify_list([1, 2, 3])
+    [1, 2, 3]
+    >>> type(simplify_list([]))
+    <class 'NoneType'>
+
+    """
+    if len(seq) == 1:
+        return seq[0]
+    if not seq:
+        return None
+    return seq

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -22,8 +22,10 @@ from corehq.motech.const import (
     DIRECTION_IMPORT,
     DIRECTIONS,
 )
-from corehq.motech.exceptions import ConfigurationError, JsonpathError
-from corehq.motech.serializers import serializers
+
+from .exceptions import ConfigurationError, JsonpathError
+from .serializers import serializers
+from .utils import simplify_list
 
 
 @attr.s
@@ -137,12 +139,7 @@ class ValueSource:
             raise JsonpathError from err
         matches = jsonpath.find(external_data)
         values = [m.value for m in matches]
-        if not values:
-            return None
-        elif len(values) == 1:
-            return values[0]
-        else:
-            return values
+        return simplify_list(values)
 
     def set_external_value(self, external_data: dict, info: CaseTriggerInfo):
         """


### PR DESCRIPTION
## Summary

Adds the ability for FHIRRepeater to search a remote FHIR service for matching patients.

Allows searching for patients like this to be optional, and for registering new patients also to be optional.

![image](https://user-images.githubusercontent.com/708421/117703011-8a31e280-b1c9-11eb-9d6a-b6215a66a09e.png)


:blowfish: Easier to review by commit

:atom_symbol: The "[ResourceMatcher](https://github.com/dimagi/commcare-hq/commit/b1de8f4e43014b79d537abe26f36714a2d95b37a)" and "[ResourceSearcher](https://github.com/dimagi/commcare-hq/commit/cfc9a75b5dca0b36cb3a413c05534cf51b895843)" commits are dense. Hit me up to talk through them if you'd like.


## Feature Flag

"FHIR Integration"


## Product Description

* Data forwarding using FHIR can find matching patients on the remote service.
* Registering new patients on the remote service is optional.


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Includes tests. Please point out any missing test coverage.


### Safety story

Not yet used in production projects.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
