### PR TITLE
Revert "Bump flake8 from 3.8.4 to 3.9.1 in /requirements"

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -233,7 +233,7 @@ faker==5.0.2
     # via -r base-requirements.in
 fixture==1.5.11
     # via -r dev-requirements.in
-flake8==3.9.1
+flake8==3.8.4
     # via -r dev-requirements.in
 flaky==3.7.0
     # via -r test-requirements.in
@@ -423,13 +423,13 @@ py-kissmetrics==1.1.0
     # via -r base-requirements.in
 pycco==0.5.1
     # via -r base-requirements.in
-pycodestyle==2.7.0
+pycodestyle==2.6.0
     # via flake8
 pycparser==2.20
     # via cffi
 pycryptodome==3.9.9
     # via -r base-requirements.in
-pyflakes==2.3.1
+pyflakes==2.2.0
     # via flake8
 pygithub==1.54.1
     # via -r base-requirements.in


### PR DESCRIPTION
Reverts dimagi/commcare-hq#29590

Reverting due to a `ModuleNotFoundError: No module named 'flake8_polyfill'` error when using the 3.9.1 version of flake8. The temporary fix appeared to be installing `flake8_polyflil`, but I'd like to understand why this isn't marked as a dependency of flake8 if it is needed. 

Worth noting after installing `flake8_polyfill` there is an additional dependency for `flake8` - `radon: 4.5.0`