### PR TITLE
Updated save button logic to not fire on page load

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -23,7 +23,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         options = _.defaults(options, {
             'instance_id': '',
             'instance_uri': '',
-            'nodeset': '',
+            'nodeset': null,
             'label': '',
             'value': '',
             'sort': '',


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SUPPORT-9228

`lookupTableNodeset` enforces that the "blank" value for the nodeset observable is null, not blank string, so the model's default value for nodeset should also use null.

Followup for https://github.com/dimagi/commcare-hq/pull/29435/

## Feature Flag
Case search & claim

## Product Description
Fixes bug where some menus in projects that use case search would have the "Save" button on the case list tab immediately enabled, so you'd get the saved changes message when navigating away from the page even if you hadn't changed anything.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

Not requesting QA. Smoke tested locally I can still edit case search lookup table fields.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
