### PR TITLE
ignore deleted indexes

### DIFF
--- a/corehq/apps/api/models.py
+++ b/corehq/apps/api/models.py
@@ -199,7 +199,7 @@ class ESCase(DictObject, CaseToXMLMixin):
     @property
     def indices(self):
         from casexml.apps.case.sharedmodels import CommCareCaseIndex
-        return [CommCareCaseIndex.wrap(index) for index in self._data['indices']]
+        return [CommCareCaseIndex.wrap(index) for index in self._data['indices'] if index["referenced_id"]]
 
     def get_index_map(self):
         from corehq.form_processor.abstract_models import get_index_map
@@ -250,7 +250,7 @@ class ESCase(DictObject, CaseToXMLMixin):
         accessor = CaseAccessors(self.domain)
         return {
             index['identifier']: case_to_es_case(accessor.get_case(index['referenced_id']))
-            for index in self.indices
+            for index in self.indices if index['referenced_id']
         }
 
     @property

--- a/corehq/apps/hqcase/api/core.py
+++ b/corehq/apps/hqcase/api/core.py
@@ -23,7 +23,7 @@ def serialize_case(case):
                 "@case_type": index.referenced_type,
                 "@relationship": index.relationship,
             }
-            for index in case.indices
+            for index in case.indices if not index.is_deleted
         }
     }
 

--- a/corehq/apps/reports/view_helpers.py
+++ b/corehq/apps/reports/view_helpers.py
@@ -25,11 +25,11 @@ def case_hierarchy_context(case, get_case_url, show_view_buttons=True, timezone=
     )
 
     parent_cases = []
-    if case.indices:
+    if case.live_indices:
         # has parent case(s)
         # todo: handle duplicates in ancestor path (bubbling up of parent-child
         # relationships)
-        for idx in case.indices:
+        for idx in case.live_indices:
             try:
                 parent_cases.append(idx.referenced_case)
             except ResourceNotFound:

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -191,7 +191,7 @@ class RetireUserTestCase(TestCase):
         # check that the index is removed via a new form
         child = CaseAccessors(self.domain).get_case(child_id)
         self.assertEqual(1, len(child.indices))
-        self.assertEqual('', child.indices[0].referenced_id)
+        self.assertTrue(child.indices[0].is_deleted)
         self.assertEqual(2, len(child.xform_ids))
 
     @run_with_all_backends

--- a/corehq/ex-submodules/casexml/apps/case/mock/mock.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/mock.py
@@ -72,7 +72,6 @@ class CaseFactory(object):
         self.domain = domain
         self.case_defaults = case_defaults if case_defaults is not None else {}
         self.form_extras = form_extras if form_extras is not None else {}
-        self.case_accessors = CaseAccessors(self.domain)
 
     def get_case_block(self, case_id, **kwargs):
         for k, v in self.case_defaults.items():
@@ -133,6 +132,7 @@ class CaseFactory(object):
         return self.create_or_update_cases([case_structure], form_extras, user_id=user_id)
 
     def create_or_update_cases(self, case_structures, form_extras=None, user_id=None, device_id=None):
+        from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
         self.post_case_blocks(
             self.get_case_blocks(case_structures),
             form_extras,
@@ -141,4 +141,4 @@ class CaseFactory(object):
         )
 
         case_ids = [id for structure in case_structures for id in structure.walk_ids()]
-        return list(self.case_accessors.get_cases(case_ids, ordered=True))
+        return list(CaseAccessors(self.domain).get_cases(case_ids, ordered=True))

--- a/corehq/ex-submodules/casexml/apps/case/mock/mock.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/mock.py
@@ -68,9 +68,11 @@ class CaseFactory(object):
     """
 
     def __init__(self, domain=None, case_defaults=None, form_extras=None):
+        from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
         self.domain = domain
         self.case_defaults = case_defaults if case_defaults is not None else {}
         self.form_extras = form_extras if form_extras is not None else {}
+        self.case_accessors = CaseAccessors(self.domain)
 
     def get_case_block(self, case_id, **kwargs):
         for k, v in self.case_defaults.items():
@@ -131,8 +133,6 @@ class CaseFactory(object):
         return self.create_or_update_cases([case_structure], form_extras, user_id=user_id)
 
     def create_or_update_cases(self, case_structures, form_extras=None, user_id=None, device_id=None):
-        from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-
         self.post_case_blocks(
             self.get_case_blocks(case_structures),
             form_extras,
@@ -141,4 +141,4 @@ class CaseFactory(object):
         )
 
         case_ids = [id for structure in case_structures for id in structure.walk_ids()]
-        return list(CaseAccessors(self.domain).get_cases(case_ids, ordered=True))
+        return list(self.case_accessors.get_cases(case_ids, ordered=True))

--- a/corehq/ex-submodules/casexml/apps/case/mock/mock.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/mock.py
@@ -68,7 +68,6 @@ class CaseFactory(object):
     """
 
     def __init__(self, domain=None, case_defaults=None, form_extras=None):
-        from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
         self.domain = domain
         self.case_defaults = case_defaults if case_defaults is not None else {}
         self.form_extras = form_extras if form_extras is not None else {}

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -231,7 +231,7 @@ class CommCareCase(DeferredBlobMixin, SafeSaveDocument, IndexHoldingMixIn,
         if relationship:
             indices = [index for index in indices if index.relationship == relationship]
 
-        return [CommCareCase.get(index.referenced_id) for index in indices]
+        return [CommCareCase.get(index.referenced_id) for index in indices if not index.is_deleted]
 
     @property
     def parent(self):

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -278,8 +278,12 @@ class CommCareCase(DeferredBlobMixin, SafeSaveDocument, IndexHoldingMixIn,
         return self.doc_type.endswith(DELETED_SUFFIX)
 
     @property
+    def live_indices(self):
+        return [i for i in self.indices if not i.is_deleted]
+
+    @property
     def has_indices(self):
-        return self.indices or self.reverse_indices
+        return self.live_indices or self.reverse_indices
 
     @property
     def deletion_id(self):

--- a/corehq/ex-submodules/casexml/apps/case/sharedmodels.py
+++ b/corehq/ex-submodules/casexml/apps/case/sharedmodels.py
@@ -22,6 +22,10 @@ class CommCareCaseIndex(LooselyEqualDocumentSchema):
     relationship = StringProperty('child', choices=['child', 'extension'])
 
     @property
+    def is_deleted(self):
+        return not self.referenced_id
+
+    @property
     def referenced_case(self):
         """
         For a 'forward' index this is the case that the the index points to.

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -246,7 +246,7 @@ class TestCaseHierarchy(TestCase):
         )
 
         # re-fetch case to clear memoized properties
-        parent = factory.case_accessors.get_case(parent.case_id)
+        parent = CaseAccessors(parent.domain).get_case(parent.case_id)
         hierarchy = get_case_hierarchy(parent, {})
         self.assertEqual(1, len(hierarchy['case_list']))
         self.assertEqual(0, len(hierarchy['child_cases']))
@@ -419,8 +419,9 @@ class TestCaseHierarchyContext(TestCase):
         )
 
         # re-fetch case to clear memoized properties
-        self.parent = self.factory.case_accessors.get_case(self.parent.case_id)
-        self.child = self.factory.case_accessors.get_case(self.child.case_id)
+        accessors = CaseAccessors(self.parent.domain)
+        self.parent = accessors.get_case(self.parent.case_id)
+        self.child = accessors.get_case(self.child.case_id)
 
 
 @use_sql_backend

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -7,7 +7,7 @@ from django.test.utils import override_settings
 from casexml.apps.case.const import CASE_INDEX_EXTENSION
 from casexml.apps.case.mock import CaseBlock, CaseFactory, CaseStructure, CaseIndex
 from casexml.apps.case.models import CommCareCase
-from corehq.apps.reports.view_helpers import get_case_hierarchy
+from corehq.apps.reports.view_helpers import get_case_hierarchy, case_hierarchy_context
 from casexml.apps.case.util import post_case_blocks
 from casexml.apps.case.xml import V2, V1
 from corehq.apps.hqcase.utils import submit_case_blocks
@@ -228,6 +228,28 @@ class TestCaseHierarchy(TestCase):
         hierarchy = get_case_hierarchy(cp, {})
         self.assertEqual(2, len(hierarchy['case_list']))
         self.assertEqual(1, len(hierarchy['child_cases']))
+        return hierarchy
+
+    def test_deleted_index(self):
+        hierarchy = self.test_normal_index()
+        parent, child = hierarchy['case_list']
+
+        factory = CaseFactory()
+        ref = CaseStructure()
+        ref.case_id = ""  # reset case_id to empty
+        factory.create_or_update_case(
+            CaseStructure(
+                case_id=child.case_id,
+                indices=[CaseIndex(ref, related_type='parent')],
+                walk_related=False
+            ),
+        )
+
+        # re-fetch case to clear memoized properties
+        parent = factory.case_accessors.get_case(parent.case_id)
+        hierarchy = get_case_hierarchy(parent, {})
+        self.assertEqual(1, len(hierarchy['case_list']))
+        self.assertEqual(0, len(hierarchy['child_cases']))
 
     def test_extension_index(self):
         factory = CaseFactory()
@@ -340,4 +362,67 @@ class TestCaseHierarchy(TestCase):
 
 @use_sql_backend
 class TestCaseHierarchySQL(TestCaseHierarchy):
+    pass
+
+
+def _get_case_url_blank(case_id):
+    return ""
+
+
+class TestCaseHierarchyContext(TestCase):
+    def setUp(self):
+        self.factory = CaseFactory()
+        parent_id = uuid.uuid4().hex
+        [self.parent] = self.factory.create_or_update_case(
+            CaseStructure(case_id=parent_id, attrs={'case_type': 'parent', 'create': True})
+        )
+
+        child_id = uuid.uuid4().hex
+        [self.child] = self.factory.create_or_update_case(CaseStructure(
+            case_id=child_id,
+            attrs={'case_type': 'child', 'create': True},
+            indices=[CaseIndex(CaseStructure(case_id=parent_id), related_type='parent')],
+            walk_related=False
+        ))
+
+    def tearDown(self):
+        self.parent.delete()
+        self.child.delete()
+
+    def test_case_hierarchy_context_parent(self):
+        hierarchy = case_hierarchy_context(self.parent, _get_case_url_blank)
+        self.assertEqual(2, len(hierarchy['case_list']))
+
+    def test_case_hierarchy_context_parent_deleted_index(self):
+        self._delete_child_index()
+        hierarchy = case_hierarchy_context(self.parent, _get_case_url_blank)
+        self.assertEqual(1, len(hierarchy['case_list']))
+
+    def test_case_hierarchy_context_child(self):
+        hierarchy = case_hierarchy_context(self.child, _get_case_url_blank)
+        self.assertEqual(2, len(hierarchy['case_list']))
+
+    def test_case_hierarchy_context_child_deleted_index(self):
+        self._delete_child_index()
+        hierarchy = case_hierarchy_context(self.child, _get_case_url_blank)
+        self.assertEqual(1, len(hierarchy['case_list']))
+
+    def _delete_child_index(self):
+        ref = CaseStructure()
+        ref.case_id = ""  # reset case_id to empty
+        self.factory.create_or_update_case(
+            CaseStructure(
+                case_id=self.child.case_id,
+                indices=[CaseIndex(ref, related_type='parent')],
+                walk_related=False
+            ),
+        )
+
+        # re-fetch case to clear memoized properties
+        self.parent = self.factory.case_accessors.get_case(self.parent.case_id)
+        self.child = self.factory.case_accessors.get_case(self.child.case_id)
+
+
+@use_sql_backend
+class TestCaseHierarchyContextSQL(TestCaseHierarchyContext):
     pass

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/load_testing.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/load_testing.py
@@ -13,7 +13,7 @@ def transform_loadtest_update(update, factor):
         return '{}-{}'.format(id, count)
     case = deepcopy(update.case)
     case.set_case_id(_map_id(case.case_id, factor))
-    for index in case.indices:
+    for index in case.live_indices:
         index.referenced_id = _map_id(index.referenced_id, factor)
     case.name = '{} ({})'.format(case.name, factor)
     return CaseSyncUpdate(case, update.sync_token, required_updates=update.required_updates)

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -856,8 +856,12 @@ class CommCareCaseSQL(PartitionedModel, models.Model, RedisLockableMixIn,
         return indices
 
     @property
+    def live_indices(self):
+        return [i for i in self.indices if not i.is_deleted]
+
+    @property
     def has_indices(self):
-        return self.indices or self.reverse_indices
+        return self.live_indices or self.reverse_indices
 
     def has_index(self, index_id):
         return any(index.identifier == index_id for index in self.indices)
@@ -1178,6 +1182,10 @@ class CommCareCaseIndexSQL(PartitionedModel, models.Model, SaveStateMixin):
         # necessary for dumping models from a sharded DB so that we exclude the
         # SQL 'id' field which won't be unique across all the DB's
         return self.domain, self.case, self.identifier
+
+    @property
+    def is_deleted(self):
+        return not self.referenced_id
 
     @property
     @memoized

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -314,7 +314,7 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
         case_id_map = {}
         for case in cases_to_forward:
             original_id = case.case_id
-            indices = case.indices
+            indices = case.live_indices
             case.case_id = self._get_updated_case_id(original_id, case_id_map)
             case.owner_id = new_owner
             for index in indices:

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -505,7 +505,7 @@ class SupercaseValueSource(ValueSource):
 
         case_accessor = CaseAccessors(info.domain)
         case = case_accessor.get_case(info.case_id)
-        for index in case.indices:
+        for index in case.live_indices:
             if filter_index(index):
                 supercase = case_accessor.get_case(index.referenced_id)
                 yield get_case_trigger_info_for_case(

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -16,7 +16,7 @@ DEVICE_ID = __name__ + ".update_case_index_relationship"
 
 
 def should_skip(case, traveler_location_id, inactive_location):
-    if len(case.indices) != 1:
+    if len(case.live_indices) != 1:
         return True
     if case.type == 'contact' and case.get_case_property('has_index_case') == 'no':
         return True


### PR DESCRIPTION
[USH-1026](https://dimagi-dev.atlassian.net/browse/USH-1026)

## Summary
One spot that was missed in https://github.com/dimagi/commcare-hq/pull/29536 where a deleted index was being used to produce the case hierarchy for the case data view.

## Product Description
bug fix

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
