### PR TITLE
ignore deleted indexes

### DIFF
--- a/corehq/apps/api/models.py
+++ b/corehq/apps/api/models.py
@@ -199,7 +199,7 @@ class ESCase(DictObject, CaseToXMLMixin):
     @property
     def indices(self):
         from casexml.apps.case.sharedmodels import CommCareCaseIndex
-        return [CommCareCaseIndex.wrap(index) for index in self._data['indices']]
+        return [CommCareCaseIndex.wrap(index) for index in self._data['indices'] if index["referenced_id"]]
 
     def get_index_map(self):
         from corehq.form_processor.abstract_models import get_index_map
@@ -250,7 +250,7 @@ class ESCase(DictObject, CaseToXMLMixin):
         accessor = CaseAccessors(self.domain)
         return {
             index['identifier']: case_to_es_case(accessor.get_case(index['referenced_id']))
-            for index in self.indices
+            for index in self.indices if index['referenced_id']
         }
 
     @property

--- a/corehq/apps/hqcase/api/core.py
+++ b/corehq/apps/hqcase/api/core.py
@@ -23,7 +23,7 @@ def serialize_case(case):
                 "@case_type": index.referenced_type,
                 "@relationship": index.relationship,
             }
-            for index in case.indices
+            for index in case.indices if not index.is_deleted
         }
     }
 

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -191,7 +191,7 @@ class RetireUserTestCase(TestCase):
         # check that the index is removed via a new form
         child = CaseAccessors(self.domain).get_case(child_id)
         self.assertEqual(1, len(child.indices))
-        self.assertEqual('', child.indices[0].referenced_id)
+        self.assertTrue(child.indices[0].is_deleted)
         self.assertEqual(2, len(child.xform_ids))
 
     @run_with_all_backends

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -231,7 +231,7 @@ class CommCareCase(DeferredBlobMixin, SafeSaveDocument, IndexHoldingMixIn,
         if relationship:
             indices = [index for index in indices if index.relationship == relationship]
 
-        return [CommCareCase.get(index.referenced_id) for index in indices]
+        return [CommCareCase.get(index.referenced_id) for index in indices if not index.is_deleted]
 
     @property
     def parent(self):

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/load_testing.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/load_testing.py
@@ -13,7 +13,7 @@ def transform_loadtest_update(update, factor):
         return '{}-{}'.format(id, count)
     case = deepcopy(update.case)
     case.set_case_id(_map_id(case.case_id, factor))
-    for index in case.indices:
+    for index in case.live_indices:
         index.referenced_id = _map_id(index.referenced_id, factor)
     case.name = '{} ({})'.format(case.name, factor)
     return CaseSyncUpdate(case, update.sync_token, required_updates=update.required_updates)

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -314,7 +314,7 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
         case_id_map = {}
         for case in cases_to_forward:
             original_id = case.case_id
-            indices = case.indices
+            indices = case.live_indices
             case.case_id = self._get_updated_case_id(original_id, case_id_map)
             case.owner_id = new_owner
             for index in indices:

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -505,7 +505,7 @@ class SupercaseValueSource(ValueSource):
 
         case_accessor = CaseAccessors(info.domain)
         case = case_accessor.get_case(info.case_id)
-        for index in case.indices:
+        for index in case.live_indices:
             if filter_index(index):
                 supercase = case_accessor.get_case(index.referenced_id)
                 yield get_case_trigger_info_for_case(

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -16,7 +16,7 @@ DEVICE_ID = __name__ + ".update_case_index_relationship"
 
 
 def should_skip(case, traveler_location_id, inactive_location):
-    if len(case.indices) != 1:
+    if len(case.live_indices) != 1:
         return True
     if case.type == 'contact' and case.get_case_property('has_index_case') == 'no':
         return True


### PR DESCRIPTION
## Summary
More places that I think should ignore deleted indexes (see https://github.com/dimagi/commcare-hq/pull/29536)

Note this is a PR into https://github.com/dimagi/commcare-hq/pull/29698

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Existing tests

### Safety story
I have reviewed each place and determined that deleted indexes should be ignored. I have added a risk label since I think this needs a second set of eyes to confirm my findings.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
