### PR TITLE
customize 503 message for superusers and support

### DIFF
--- a/corehq/apps/cloudcare/decorators.py
+++ b/corehq/apps/cloudcare/decorators.py
@@ -3,7 +3,7 @@ from functools import wraps
 from django.http import HttpResponse
 
 from corehq.apps.domain.decorators import login_and_domain_required
-from corehq.toggles import DISABLE_WEB_APPS
+from corehq import toggles
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 
@@ -16,8 +16,12 @@ def require_cloudcare_access_ex():
     def decorator(view_func):
         @wraps(view_func)
         def _inner(request, domain, *args, **kwargs):
-            if DISABLE_WEB_APPS.enabled_for_request(request):
-                return HttpResponse('Service Temporarily Unavailable', content_type='text/plain', status=503)
+            if toggles.DISABLE_WEB_APPS.enabled_for_request(request):
+                message = 'Service Temporarily Unavailable'
+                is_superuser = hasattr(request, "couch_user") and request.couch_user.is_superuser
+                if is_superuser or toggles.SUPPORT.enabled_for_request(request):
+                    message += " (due to 'disable_web_apps' feature flag)"
+                return HttpResponse(message, content_type='text/plain', status=503)
             if hasattr(request, "couch_user"):
                 if request.couch_user.is_web_user():
                     return require_permission(Permissions.access_web_apps)(view_func)(request, domain, *args, **kwargs)


### PR DESCRIPTION
## Summary
Give more into in 503 message for Dimagi users.

## Feature Flag
https://confluence.dimagi.com/display/ccinternal/Disable+access+to+Web+Apps+UI

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
