### PR TITLE
Add flake8_polyfill to test_requirements

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -234,7 +234,7 @@ faker==5.0.2
 fixture==1.5.11
     # via -r dev-requirements.in
 flake8-polyfill==1.0.2
-    # via -r test-requirements.in
+    # via radon
 flake8==3.9.1
     # via
     #   -r dev-requirements.in
@@ -504,7 +504,7 @@ qrcode==4.0.4
     #   django-two-factor-auth
 quickcache==0.5.4
     # via -r base-requirements.in
-radon==4.5.0
+radon[flake8]==4.5.0
     # via -r test-requirements.in
 rcssmin==1.0.6
     # via django-compressor

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -233,8 +233,12 @@ faker==5.0.2
     # via -r base-requirements.in
 fixture==1.5.11
     # via -r dev-requirements.in
+flake8-polyfill==1.0.2
+    # via -r test-requirements.in
 flake8==3.9.1
-    # via -r dev-requirements.in
+    # via
+    #   -r dev-requirements.in
+    #   flake8-polyfill
 flaky==3.7.0
     # via -r test-requirements.in
 freezegun==1.1.0

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -12,5 +12,4 @@ requests-mock
 sqlalchemy-postgres-copy==0.5.0
 flaky==3.7.0
 freezegun~=1.1
-radon
-flake8-polyfill  # Needed only for a bug in radon's dependency management
+radon[flake8]  # flake8 extra needed due to bug in radon's dependency management

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -13,3 +13,4 @@ sqlalchemy-postgres-copy==0.5.0
 flaky==3.7.0
 freezegun~=1.1
 radon
+flake8_polyfill

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -13,4 +13,4 @@ sqlalchemy-postgres-copy==0.5.0
 flaky==3.7.0
 freezegun~=1.1
 radon
-flake8_polyfill
+flake8-polyfill  # Needed only for a bug in radon's dependency management

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -206,6 +206,10 @@ fakecouch==0.0.15
     # via -r test-requirements.in
 faker==5.0.2
     # via -r base-requirements.in
+flake8-polyfill==1.0.2
+    # via -r test-requirements.in
+flake8==3.9.2
+    # via flake8-polyfill
 flaky==3.7.0
     # via -r test-requirements.in
 freezegun==1.1.0
@@ -240,6 +244,7 @@ idna==2.10
     #   requests
 importlib-metadata==3.4.0
     # via
+    #   flake8
     #   jsonschema
     #   pep517
 intervaltree==3.1.0
@@ -301,6 +306,8 @@ markupsafe==1.1.1
     # via
     #   jinja2
     #   mako
+mccabe==0.6.1
+    # via flake8
 mock==2.0.0
     # via -r base-requirements.in
 nose-exclude==0.5.0
@@ -352,10 +359,14 @@ py-kissmetrics==1.1.0
     # via -r base-requirements.in
 pycco==0.5.1
     # via -r base-requirements.in
+pycodestyle==2.7.0
+    # via flake8
 pycparser==2.20
     # via cffi
 pycryptodome==3.9.9
     # via -r base-requirements.in
+pyflakes==2.3.1
+    # via flake8
 pygithub==1.54.1
     # via -r base-requirements.in
 pygments==2.8.1

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -207,7 +207,7 @@ fakecouch==0.0.15
 faker==5.0.2
     # via -r base-requirements.in
 flake8-polyfill==1.0.2
-    # via -r test-requirements.in
+    # via radon
 flake8==3.9.2
     # via flake8-polyfill
 flaky==3.7.0
@@ -426,7 +426,7 @@ qrcode==4.0.4
     #   django-two-factor-auth
 quickcache==0.5.4
     # via -r base-requirements.in
-radon==4.5.0
+radon[flake8]==4.5.0
     # via -r test-requirements.in
 rcssmin==1.0.6
     # via django-compressor


### PR DESCRIPTION
## Summary
There's a bug in radon's setup.py - this is essentially un undeclared requirement, though we don't actually need it.

I tested by setting up a new virtual env, seeing that flake8 errored out, made this change, installed dev requirements, and saw that flake8 succeeded in linting a file.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Only affects test and dev requirements

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
