### PR TITLE
User profiles bug fix on user upload

### DIFF
--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -358,6 +358,12 @@ def get_domain_info(domain, upload_domain, user_specs, domain_info_by_domain, up
         )
     else:
         roles_by_name = {role.name: role for role in UserRole.by_domain(domain)}
+        definition = CustomDataFieldsDefinition.get(domain, UserFieldsView.field_type)
+        if definition:
+            profiles_by_name = {
+                profile.name: profile
+                for profile in definition.get_profiles()
+            }
         validators = get_user_import_validators(
             domain_obj,
             domain_user_specs,
@@ -367,12 +373,6 @@ def get_domain_info(domain, upload_domain, user_specs, domain_info_by_domain, up
             list(profiles_by_name),
             upload_domain
         )
-        definition = CustomDataFieldsDefinition.get(domain, UserFieldsView.field_type)
-        if definition:
-            profiles_by_name = {
-                profile.name: profile
-                for profile in definition.get_profiles()
-            }
 
     domain_info = DomainInfo(
         validators,


### PR DESCRIPTION
## Summary
Flagged on this ticket: https://dimagi-dev.atlassian.net/browse/SUPPORT-9439 that treats valid User Profiles as if they are invalid for bulk mobile user upload. 

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
There is test coverage for user profiles in upload in `test_importer.py` but it did not catch this error. I will need to follow up to figure out why this slipped through and how to improve this test coverage.

### QA Plan
I am not requesting QA

### Safety story
Testing locally and could replicate the bug and  confirmed the fix. Just rearranging the order within the method-- matches to how is was prior to the change deployed monday

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
