### PR TITLE
Sk/payload links

### DIFF
--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -188,7 +188,7 @@ class BaseRepeatRecordReport(GenericTabularReport):
         return format_html(
             '<a href="{url}?q={payload_id}">'
             '<img src="{flower}" title="Search in HQ" width="14px" height="14px" />'
-            '</a> {payload_id}',
+            ' {payload_id}</a>',
             url=reverse('global_quick_find'),
             flower=static('hqwebapp/images/commcare-flower.png'),
             payload_id=payload_id,

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -188,8 +188,10 @@ class BaseRepeatRecordReport(GenericTabularReport):
         return format_html(
             '<a href="{url}?q={payload_id}">'
             '<img src="{flower}" title="Search in HQ" width="14px" height="14px" />'
-            ' {payload_id}</a>',
+            ' {payload_id}</a><br/>',
+            '<a href="{log_url}?filter_payload={payload_id}" target="_blank">View Logs</a>',
             url=reverse('global_quick_find'),
+            log_url=reverse('motech_log_list_view', args=[self.domain]),
             flower=static('hqwebapp/images/commcare-flower.png'),
             payload_id=payload_id,
         )


### PR DESCRIPTION
## Summary
Small changes to the data forwarding record report (only visible with the SUPPORT toggle).

* Make the payload link more obvious by including the ID text in the link
* Add a link to the Remote API Logs report pre-filtered by payload ID

![image](https://user-images.githubusercontent.com/249606/117942798-bc4b5d80-b30b-11eb-9fb3-57094c8189ec.png)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan
Tested locally


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
