### PR TITLE
mark unsucessful forms as errors without retry

### DIFF
--- a/corehq/ex-submodules/couchforms/openrosa_response.py
+++ b/corehq/ex-submodules/couchforms/openrosa_response.py
@@ -1,4 +1,4 @@
-from lxml import etree as ElementTree
+from lxml import etree as ElementTree, etree
 from django.http import HttpResponse
 from django.utils.translation import ugettext_lazy as _
 import six
@@ -79,3 +79,18 @@ BLACKLISTED_RESPONSE = get_openrosa_reponse(
     nature=ResponseNature.SUBMIT_ERROR,
     status=509,
 )
+
+
+def parse_openrosa_response(response):
+    """Parse an OpenRosaResponse from the response XML.
+    :returns: OpenRosaResponse object or None"""
+    try:
+        root = etree.fromstring(response)
+    except etree.XMLSyntaxError:
+        return
+
+    message = root.find(f'{{{RESPONSE_XMLNS}}}message')
+    if message is None:
+        return
+
+    return OpenRosaResponse(message.text.strip(), message.get("nature"), None)

--- a/corehq/ex-submodules/couchforms/tests/test_openrosa_response.py
+++ b/corehq/ex-submodules/couchforms/tests/test_openrosa_response.py
@@ -1,0 +1,37 @@
+from django.test import SimpleTestCase
+
+from corehq.util.test_utils import generate_cases
+from couchforms.openrosa_response import parse_openrosa_response, ResponseNature
+
+MESSAGE = "InvalidCaseIndex: Case 'X' references non-existent case 'Y'"
+VALID = f"""
+    <OpenRosaResponse xmlns="http://openrosa.org/http/response">
+        <message nature="{ResponseNature.SUBMIT_ERROR}">
+            {MESSAGE}
+        </message>
+    </OpenRosaResponse>
+    """
+INVALID = "<Anything></Anything>"
+BAD_XML = """
+    <OpenRosaResponse xmlns="http://openrosa.org/http/response">
+    """
+
+
+class TestOpenRosaResponse(SimpleTestCase):
+    pass
+
+
+@generate_cases([
+    (VALID, ResponseNature.SUBMIT_ERROR, MESSAGE),
+    (INVALID, None, None),
+    (BAD_XML, None, None),
+], TestOpenRosaResponse)
+def test_parse_openrosa_response(self, xml, nature, message):
+    response = parse_openrosa_response(xml)
+    print(response)
+    if message and nature:
+        self.assertEqual(response.message, message)
+        self.assertEqual(response.nature, nature)
+    else:
+        self.assertIsNone(response)
+

--- a/corehq/ex-submodules/couchforms/tests/test_openrosa_response.py
+++ b/corehq/ex-submodules/couchforms/tests/test_openrosa_response.py
@@ -34,4 +34,3 @@ def test_parse_openrosa_response(self, xml, nature, message):
         self.assertEqual(response.nature, nature)
     else:
         self.assertIsNone(response)
-

--- a/corehq/motech/repeater_helpers.py
+++ b/corehq/motech/repeater_helpers.py
@@ -15,6 +15,7 @@ class RepeaterResponse:
     status_code = attr.ib()
     reason = attr.ib()
     text = attr.ib(default="")
+    retry = attr.ib(default=True)
 
 
 def get_relevant_case_updates_from_form_json(domain, form_json, case_types, extra_fields,

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -732,10 +732,12 @@ class ReferCaseRepeater(CreateCaseRepeater):
             return response
 
         if response.status_code == 422:
+            # openrosa v3
             retry = openrosa_response.nature != ResponseNature.PROCESSING_FAILURE
             return RepeaterResponse(422, openrosa_response.nature, openrosa_response.message, retry)
 
         if response.status_code == 201 and openrosa_response.nature == ResponseNature.SUBMIT_ERROR:
+            # openrosa v2
             return RepeaterResponse(422, ResponseNature.SUBMIT_ERROR, openrosa_response.message, False)
 
         return response

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -69,7 +69,6 @@ from collections import OrderedDict
 from datetime import datetime, timedelta
 from typing import Any, Optional
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
-from lxml import etree
 
 from django.conf import settings
 from django.db import models

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -69,6 +69,7 @@ from collections import OrderedDict
 from datetime import datetime, timedelta
 from typing import Any, Optional
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+from lxml import etree
 
 from django.conf import settings
 from django.db import models
@@ -151,6 +152,7 @@ from .repeater_generators import (
     ShortFormRepeaterJsonPayloadGenerator,
     UserPayloadGenerator,
 )
+from ..repeater_helpers import RepeaterResponse
 from ...util.urlvalidate.urlvalidate import PossibleSSRFAttempt
 
 
@@ -464,7 +466,8 @@ class Repeater(QuickCachedDocumentMixin, Document):
     def allow_retries(self, response):
         """Whether to requeue the repeater when it fails
         """
-        return True
+        # respect the `retry` field of RepeaterResponse
+        return getattr(response, 'retry', True)
 
     def get_headers(self, repeat_record):
         # to be overridden
@@ -714,6 +717,28 @@ class ReferCaseRepeater(CreateCaseRepeater):
     def get_url(self, repeat_record):
         new_domain = self.payload_doc(repeat_record).get_case_property('new_domain')
         return self.connection_settings.url.format(domain=new_domain)
+
+    def send_request(self, repeat_record, payload):
+        """Add custom response handling to allow more nuanced handling of form errors"""
+        response = super().send_request(repeat_record, payload)
+        return self.get_response(response)
+
+    @staticmethod
+    def get_response(response):
+        from couchforms.openrosa_response import ResponseNature, parse_openrosa_response
+        openrosa_response = parse_openrosa_response(response.text)
+        if not openrosa_response:
+            # unable to parse response so just let normal handling take place
+            return response
+
+        if response.status_code == 422:
+            retry = openrosa_response.nature != ResponseNature.PROCESSING_FAILURE
+            return RepeaterResponse(422, openrosa_response.nature, openrosa_response.message, retry)
+
+        if response.status_code == 201 and openrosa_response.nature == ResponseNature.SUBMIT_ERROR:
+            return RepeaterResponse(422, ResponseNature.SUBMIT_ERROR, openrosa_response.message, False)
+
+        return response
 
 
 class ShortFormRepeater(Repeater):
@@ -1121,14 +1146,14 @@ class SQLRepeatRecord(models.Model):
         self.state = RECORD_SUCCESS_STATE
         self.save()
 
-    def add_client_failure_attempt(self, message):
+    def add_client_failure_attempt(self, message, retry=True):
         """
         Retry when ``self.repeater`` is next processed. The remote
         service is assumed to be in a good state, so do not back off, so
         that this repeat record does not hold up the rest.
         """
         self.repeater_stub.reset_next_attempt()
-        self._add_failure_attempt(message, MAX_ATTEMPTS)
+        self._add_failure_attempt(message, MAX_ATTEMPTS, retry)
 
     def add_server_failure_attempt(self, message):
         """
@@ -1144,8 +1169,8 @@ class SQLRepeatRecord(models.Model):
         self.repeater_stub.set_next_attempt()
         self._add_failure_attempt(message, MAX_BACKOFF_ATTEMPTS)
 
-    def _add_failure_attempt(self, message, max_attempts):
-        if self.num_attempts < max_attempts:
+    def _add_failure_attempt(self, message, max_attempts, retry=True):
+        if retry and self.num_attempts < max_attempts:
             state = RECORD_FAILURE_STATE
         else:
             state = RECORD_CANCELLED_STATE
@@ -1290,6 +1315,10 @@ def send_request(
             or resp is True
         )
 
+    def allow_retries(response):
+        # respect the `retry` field of RepeaterResponse
+        return getattr(response, 'retry', True)
+
     def later_might_be_better(resp):
         return is_response(resp) and resp.status_code in (
             502,  # Bad Gateway
@@ -1320,7 +1349,8 @@ def send_request(
             if later_might_be_better(response):
                 repeat_record.add_server_failure_attempt(message)
             else:
-                repeat_record.add_client_failure_attempt(message)
+                retry = allow_retries(response)
+                repeat_record.add_client_failure_attempt(message, retry)
     return repeat_record.state in (RECORD_SUCCESS_STATE,
                                    RECORD_CANCELLED_STATE)  # Don't retry
 

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -12,6 +12,8 @@ from django.utils.translation import ugettext_lazy as _
 
 from casexml.apps.case.xform import get_case_ids_from_form
 from casexml.apps.case.xml import V2
+from corehq.const import OPENROSA_VERSION_3
+from corehq.middleware import OPENROSA_VERSION_HEADER
 from dimagi.utils.parsing import json_format_datetime
 
 from corehq.apps.receiverwrapper.exceptions import DuplicateFormatException
@@ -260,6 +262,11 @@ class CaseTypeReferralConfig(object):
 
 
 class ReferCasePayloadGenerator(BasePayloadGenerator):
+
+    def get_headers(self):
+        headers = super().get_headers()
+        headers[OPENROSA_VERSION_HEADER] = OPENROSA_VERSION_3
+        return headers
 
     def get_payload(self, repeat_record, payload_doc):
 

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -372,6 +372,17 @@ class AddAttemptsTests(RepeaterTestCase):
         self.assertEqual(attempts[-1].message, message)
         self.assertEqual(attempts[-1].traceback, '')
 
+    def test_add_client_failure_attempt_no_retry(self):
+        message = '422: Unprocessable Entity'
+        while self.repeat_record.state != RECORD_CANCELLED_STATE:
+            self.repeat_record.add_client_failure_attempt(message=message, retry=False)
+        self.assertIsNone(self.repeater_stub.last_attempt_at)
+        self.assertIsNone(self.repeater_stub.next_attempt_at)
+        self.assertEqual(self.repeat_record.num_attempts, 1)
+        self.assertEqual(self.repeat_record.attempts[0].state, RECORD_CANCELLED_STATE)
+        self.assertEqual(self.repeat_record.attempts[0].message, message)
+        self.assertEqual(self.repeat_record.attempts[0].traceback, '')
+
     def test_add_payload_exception_attempt(self):
         message = 'ValueError: Schema validation failed'
         tb_str = 'Traceback ...'

--- a/corehq/motech/repeaters/tests/test_refer_case_repeater.py
+++ b/corehq/motech/repeaters/tests/test_refer_case_repeater.py
@@ -41,9 +41,8 @@ class TestReferCaseRepeater(SimpleTestCase):
     (422, V3_ERROR, RepeaterResponse(422, ResponseNature.PROCESSING_FAILURE, '', False)),
     (422, V3_RETRY_ERROR, RepeaterResponse(422, ResponseNature.POST_PROCESSING_FAILURE, '', True)),
 ], TestReferCaseRepeater)
-def test_parse_openrosa_response(self, status_code, text, expected_response):
+def test_get_response(self, status_code, text, expected_response):
     response = ReferCaseRepeater.get_response(RepeaterResponse(status_code, responses[status_code], text))
-    print(response)
     self.assertEqual(response.status_code, expected_response.status_code)
     self.assertEqual(response.reason, expected_response.reason)
     self.assertEqual(response.retry, expected_response.retry)

--- a/corehq/motech/repeaters/tests/test_refer_case_repeater.py
+++ b/corehq/motech/repeaters/tests/test_refer_case_repeater.py
@@ -1,0 +1,49 @@
+from django.test import SimpleTestCase
+
+from corehq.motech.repeater_helpers import RepeaterResponse
+from corehq.motech.repeaters.models import ReferCaseRepeater
+from corehq.util.test_utils import generate_cases
+from couchforms.openrosa_response import ResponseNature
+from http.client import responses
+
+SUCCESS = f"""
+    <OpenRosaResponse xmlns="http://openrosa.org/http/response">
+        <message nature="{ResponseNature.SUBMIT_SUCCESS}">success</message>
+    </OpenRosaResponse>
+    """
+
+V3_RETRY_ERROR = f"""
+    <OpenRosaResponse xmlns="http://openrosa.org/http/response">
+        <message nature="{ResponseNature.POST_PROCESSING_FAILURE}">success</message>
+    </OpenRosaResponse>
+    """
+
+V3_ERROR = f"""
+    <OpenRosaResponse xmlns="http://openrosa.org/http/response">
+        <message nature="{ResponseNature.PROCESSING_FAILURE}">success</message>
+    </OpenRosaResponse>
+    """
+
+V2_ERROR = f"""
+    <OpenRosaResponse xmlns="http://openrosa.org/http/response">
+        <message nature="{ResponseNature.SUBMIT_ERROR}">success</message>
+    </OpenRosaResponse>
+    """
+
+
+class TestReferCaseRepeater(SimpleTestCase):
+    pass
+
+
+@generate_cases([
+    (201, SUCCESS, RepeaterResponse(201, 'Created', '')),
+    (201, V2_ERROR, RepeaterResponse(422, ResponseNature.SUBMIT_ERROR, '', False)),
+    (422, V3_ERROR, RepeaterResponse(422, ResponseNature.PROCESSING_FAILURE, '', False)),
+    (422, V3_RETRY_ERROR, RepeaterResponse(422, ResponseNature.POST_PROCESSING_FAILURE, '', True)),
+], TestReferCaseRepeater)
+def test_parse_openrosa_response(self, status_code, text, expected_response):
+    response = ReferCaseRepeater.get_response(RepeaterResponse(status_code, responses[status_code], text))
+    print(response)
+    self.assertEqual(response.status_code, expected_response.status_code)
+    self.assertEqual(response.reason, expected_response.reason)
+    self.assertEqual(response.retry, expected_response.retry)


### PR DESCRIPTION
## Summary
When submitting forms to CommCare the response code is not always enough to determine if the form was processed successfully due to different protocol versions of the OpenRosa spec (see https://confluence.dimagi.com/display/commcarepublic/Submission+API#SubmissionAPI-Response).

This PR updates the `ReferCaseRepeater` response handling to allow it to deal with the different responses.

v2:
* 201: message nature = "submit_error"
  * The form was not processed and should not be retried

v3:
* 422: message nature = "processing_failure" 
  * The form was not processed and should not be retried
* 422: message nature = anything else
  * The form was not FULLY processed and may be retried

In the data forwarding report this will now show the correct status for records that failed.

## Product Description
Better error handling for the "Forward Cases To Another Commcare Project" data forwarding type.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Existing + new tests

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
