### PR TITLE
Fixed migration save behavior

### DIFF
--- a/corehq/ex-submodules/dimagi/utils/couch/migration.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/migration.py
@@ -133,11 +133,11 @@ class SyncCouchToSQLMixin(object):
             sql_attr = getattr(sql_object, spec.sql_attr)
             sql_attr.all().delete()
             sql_attr.set(sql_submodels, bulk=False)
-        sql_object.save(sync_to_couch=False)
 
     def _migration_do_sync(self):
         sql_object = self._migration_get_or_create_sql_object()
         self._migration_sync_to_sql(sql_object)
+        sql_object.save(sync_to_couch=False)
 
     def save(self, *args, **kwargs):
         sync_to_sql = kwargs.pop('sync_to_sql', True)


### PR DESCRIPTION
## Summary
The `save` in migrations was previously implicit, hidden inside `_migration_sync_submodels_to_sql`. Normal `_migration_get_fields` fields would be saved, as would submodels, but anything added in `_get_custom_couch_to_sql_functions()` would rely on the callbacks themselves performing this save. This change moves the save to the end of `_migration_do_sync` so that it is clear all modifications to the SQL object will be saved.

Ideally, I would like to rename `_migration_sync_to_sql` to `_populate_sql_object`, and have it be independent of any database operations, so that we can unit test that, given a couch object, an expected SQL object is produced. The concerns around this are breaking existing migration branches which overrode `_migration_sync_to_sql`. Additionally, it appears that `_migration_sync_submodels_to_sql` needs to write to the database when it deletes the existing submodels. I'm not sure how to get around that.

Finally, it feels like all of this should be enclosed in a transaction. What happens if an error is raised in the middle of our delete/update loop of updating submodels?

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests

### QA Plan

No QA

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
