### PR TITLE
Fix argument validation in motech connection verification command

### DIFF
--- a/corehq/apps/formplayer_api/management/commands/clear_formplayer_dbs.py
+++ b/corehq/apps/formplayer_api/management/commands/clear_formplayer_dbs.py
@@ -10,7 +10,7 @@ from corehq.apps.formplayer_api.management.commands.prime_formplayer_restores im
     _get_user_rows, _get_users_from_csv
 )
 from corehq.apps.users.models import CouchUser
-from corehq.util.argparse_types import validate_integer
+from corehq.util.argparse_types import validate_range
 from custom.covid.tasks import get_prime_restore_user_params, clear_formplayer_db_for_user
 
 
@@ -48,14 +48,15 @@ class Command(BaseCommand):
                                  'only users in this file will be synced.')
 
         parser.add_argument('--domains', nargs='+', help='Match users in these domains.')
-        parser.add_argument('--last-synced-hours', action=validate_integer(gt=0, lt=673), default=48,
+        parser.add_argument('--last-synced-hours', type=int, action=validate_range(gt=0, lt=673), default=48,
                             help='Match users who have synced within the given window. '
-                                 'Defaults to 48 hours. Max = 472 (4 week).')
-        parser.add_argument('--not-synced-hours', action=validate_integer(gt=0, lt=169),
+                                 'Defaults to %(default)s hours. Max = 472 (4 weeks).')
+        parser.add_argument('--not-synced-hours', type=int, action=validate_range(gt=0, lt=169),
                             help='Exclude users who have synced within the given window. '
                                  'Max = 168 (1 week).')
 
-        parser.add_argument('--limit', action=validate_integer(gt=0), help='Limit the number of users matched.')
+        parser.add_argument('--limit', type=int, action=validate_range(gt=0),
+                            help='Limit the number of users matched.')
         parser.add_argument('--dry-run', action='store_true', help='Only print the list of users.')
         parser.add_argument('--dry-run-count', action='store_true', help='Only print the count of matched users.')
 

--- a/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
+++ b/corehq/apps/formplayer_api/management/commands/prime_formplayer_restores.py
@@ -8,7 +8,7 @@ from dateutil.relativedelta import relativedelta
 from django.core.management.base import BaseCommand
 
 from corehq.apps.users.models import CouchUser
-from corehq.util.argparse_types import validate_integer
+from corehq.util.argparse_types import validate_range
 from custom.covid.tasks import get_users_for_priming, get_prime_restore_user_params, prime_formplayer_db_for_user
 
 
@@ -46,19 +46,21 @@ class Command(BaseCommand):
                                  'only users in this file will be synced.')
 
         parser.add_argument('--domains', nargs='+', help='Match users in these domains.')
-        parser.add_argument('--last-synced-hours', action=validate_integer(gt=0, lt=673), default=48,
+        parser.add_argument('--last-synced-hours', type=int, action=validate_range(gt=0, lt=673), default=48,
                             help='Match users who have synced within the given window. '
-                                 'Defaults to 48 hours. Max = 673 (4 weeks).')
-        parser.add_argument('--not-synced-hours', action=validate_integer(gt=-1, lt=169),
+                                 'Defaults to %(default)s hours. Max = 673 (4 weeks).')
+        parser.add_argument('--not-synced-hours', type=int, action=validate_range(gt=-1, lt=169),
                             help='Exclude users who have synced within the given window. '
                                  'Max = 168 (1 week).')
-        parser.add_argument('--min-cases', action=validate_integer(gt=0),
+        parser.add_argument('--min-cases', type=int, action=validate_range(gt=0),
                             help='Match users with this many cases or more.')
 
-        parser.add_argument('--limit', action=validate_integer(gt=0), help='Limit the number of users matched.')
+        parser.add_argument('--limit', type=int, action=validate_range(gt=0),
+                            help='Limit the number of users matched.')
         parser.add_argument('--dry-run', action='store_true', help='Only print the list of users.')
         parser.add_argument('--dry-run-count', action='store_true', help='Only print the count of matched users.')
-        parser.add_argument('--clear-user-data', action='store_true', help='Clear user data prior to performing sync.')
+        parser.add_argument('--clear-user-data', action='store_true',
+                            help='Clear user data prior to performing sync.')
 
     def handle(self,
                from_csv=None,

--- a/corehq/motech/management/commands/verify_motech_connections.py
+++ b/corehq/motech/management/commands/verify_motech_connections.py
@@ -9,6 +9,7 @@ from oauthlib.oauth2.rfc6749.errors import OAuth2Error
 from requests.exceptions import HTTPError, RequestException, SSLError
 
 from corehq.motech.models import ConnectionSettings
+from corehq.util.argparse_types import validate_range
 from corehq.util.log import with_progress_bar
 from corehq.util.urlvalidate.ip_resolver import CannotResolveHost
 
@@ -31,6 +32,7 @@ class Command(BaseCommand):
         parser.add_argument("-c", "--ca-bundle", metavar="FILE",
             help="Use a custom CA trust store for SSL verifications.")
         parser.add_argument("--connect-timeout", metavar="SECONDS", type=float,
+            action=validate_range(gt=0.0),
             help="Use custom HTTP connection timeout value.")
         parser.add_argument("--ssl-only", action="store_true", default=False,
             help="Skip normal connection checks and perform only SSL "
@@ -46,8 +48,6 @@ class Command(BaseCommand):
         castore = options["ca_bundle"]
 
         # sanity-check options
-        if timeout < 0:
-            raise CommandError(f"Invalid timeout value: {timeout}")
         if castore is not None and not os.path.isfile(castore):
             raise CommandError(f"Invalid CA store file: {castore}")
 

--- a/corehq/util/argparse_types.py
+++ b/corehq/util/argparse_types.py
@@ -21,19 +21,31 @@ def date_type(value):
             "Expected date in the format: YYYY-MM-DD" % value
         )
 
+# NOTE: The `validate_integer` function has been renamed to `validate_range`,
+# and it no longer enforces the argument type. This requires specifying the
+# argument type (for non-default types) when using `action=validate_range(...)`.
+# To compare, the previous function could be used as such:
+#
+#   parser.add_argument("value", action=validate_integer(gt=0))
+#
+# Using the new function, `type` must be specified as well:
+#
+#   parser.add_argument("value", type=int, action=validate_range(gt=0))
+#
+def validate_range(gt=None, lt=None):
+    """Create an argparse.Action subclass for validating comparable inputs.
 
-def validate_integer(gt=None, lt=None):
-    """Return argparser action to validate integer inputs:
+    :param gt: value which the argument cannot be greater than
+    :param lt: value which the argument cannot be less than
+    :returns: argparse.Action subclass
 
-    parser.add_argument('--count', action=validate_integer(gt=0, lt=11), help="Integer between 1 and 10")
+    Example:
+    parser.add_argument('--fraction', action=validate_range(gt=0.0, lt=1.0),
+        type=float, help="Number between 0 and 1")
     """
 
-    class ValidateIntegerRange(argparse.Action):
+    class ValidateRange(argparse.Action):
         def __call__(self, parser, namespace, values, option_string=None):
-            try:
-                values = int(values)
-            except ValueError:
-                raise argparse.ArgumentError(self, f"Invalid integer: {values}")
 
             if gt is not None and gt >= values:
                 raise argparse.ArgumentError(self, f"Must be greater than {gt}")
@@ -43,4 +55,4 @@ def validate_integer(gt=None, lt=None):
 
             setattr(namespace, self.dest, values)
 
-    return ValidateIntegerRange
+    return ValidateRange

--- a/corehq/util/argparse_types.py
+++ b/corehq/util/argparse_types.py
@@ -36,8 +36,8 @@ def date_type(value):
 def validate_range(gt=None, lt=None):
     """Create an argparse.Action subclass for validating comparable inputs.
 
-    :param gt: value which the argument cannot be greater than
-    :param lt: value which the argument cannot be less than
+    :param gt: value which the argument must be greater than
+    :param lt: value which the argument must be less than
     :returns: argparse.Action subclass
 
     Example:

--- a/corehq/util/argparse_types.py
+++ b/corehq/util/argparse_types.py
@@ -39,7 +39,7 @@ def validate_integer(gt=None, lt=None):
                 raise argparse.ArgumentError(self, f"Must be greater than {gt}")
 
             if lt is not None and lt <= values:
-                raise argparse.ArgumentError(self, f"Must be less than than {lt}")
+                raise argparse.ArgumentError(self, f"Must be less than {lt}")
 
             setattr(namespace, self.dest, values)
 

--- a/corehq/util/argparse_types.py
+++ b/corehq/util/argparse_types.py
@@ -21,6 +21,7 @@ def date_type(value):
             "Expected date in the format: YYYY-MM-DD" % value
         )
 
+
 # NOTE: The `validate_integer` function has been renamed to `validate_range`,
 # and it no longer enforces the argument type. This requires specifying the
 # argument type (for non-default types) when using `action=validate_range(...)`.

--- a/corehq/util/tests/test_argparse_types.py
+++ b/corehq/util/tests/test_argparse_types.py
@@ -1,0 +1,64 @@
+import re
+from argparse import ArgumentParser
+from contextlib import contextmanager
+from io import StringIO
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from .. argparse_types import validate_integer
+
+
+class SystemExitError(Exception):
+    pass
+
+
+@contextmanager
+def wrap_system_exit():
+    stderr = StringIO()
+    with patch("sys.stderr", stderr):
+        try:
+            yield stderr
+        except SystemExit:
+            raise SystemExitError(repr(stderr.getvalue()))
+
+
+class TestValidateInteger(SimpleTestCase):
+
+    def setUp(self):
+        self.parser = ArgumentParser()
+
+    def add_validated_int(self, *args, **kw):
+        self.parser.add_argument("value", action=validate_integer(*args, **kw))
+
+    def assert_parsed_value(self, argv, value):
+        with wrap_system_exit():
+            opts = self.parser.parse_args(argv)
+        self.assertEqual(opts.value, value)
+
+    def assert_parser_error(self, argv, err_suffix):
+        with self.assertRaises(SystemExitError):
+            with wrap_system_exit() as stderr:
+                self.parser.parse_args(argv)
+        err_msg = stderr.getvalue().strip().split("\n")[-1]
+        self.assertRegexpMatches(err_msg, f": {re.escape(err_suffix)}$")
+
+    def test_validate_integer_invalid(self):
+        self.add_validated_int(gt=0)
+        self.assert_parser_error(["foo"], "Invalid integer: foo")
+
+    def test_validate_integer_gt5(self):
+        self.add_validated_int(gt=5)
+        self.assert_parsed_value(["6"], 6)
+
+    def test_validate_integer_gt5_err(self):
+        self.add_validated_int(gt=5)
+        self.assert_parser_error(["5"], "Must be greater than 5")
+
+    def test_validate_integer_lt5(self):
+        self.add_validated_int(lt=5)
+        self.assert_parsed_value(["4"], 4)
+
+    def test_validate_integer_lt5_err(self):
+        self.add_validated_int(lt=5)
+        self.assert_parser_error(["5"], "Must be less than 5")

--- a/corehq/util/tests/test_argparse_types.py
+++ b/corehq/util/tests/test_argparse_types.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
-from .. argparse_types import validate_integer
+from .. argparse_types import validate_range
 
 
 class SystemExitError(Exception):
@@ -28,8 +28,9 @@ class TestValidateInteger(SimpleTestCase):
     def setUp(self):
         self.parser = ArgumentParser()
 
-    def add_validated_int(self, *args, **kw):
-        self.parser.add_argument("value", action=validate_integer(*args, **kw))
+    def add_validated_arg(self, type, *val_args, **val_kw):
+        self.parser.add_argument("value", type=type,
+            action=validate_range(*val_args, **val_kw))
 
     def assert_parsed_value(self, argv, value):
         with wrap_system_exit():
@@ -43,22 +44,18 @@ class TestValidateInteger(SimpleTestCase):
         err_msg = stderr.getvalue().strip().split("\n")[-1]
         self.assertRegexpMatches(err_msg, f": {re.escape(err_suffix)}$")
 
-    def test_validate_integer_invalid(self):
-        self.add_validated_int(gt=0)
-        self.assert_parser_error(["foo"], "Invalid integer: foo")
-
-    def test_validate_integer_gt5(self):
-        self.add_validated_int(gt=5)
+    def test_validate_range_int_gt5(self):
+        self.add_validated_arg(int, gt=5)
         self.assert_parsed_value(["6"], 6)
 
-    def test_validate_integer_gt5_err(self):
-        self.add_validated_int(gt=5)
+    def test_validate_range_int_gt5_err(self):
+        self.add_validated_arg(int, gt=5)
         self.assert_parser_error(["5"], "Must be greater than 5")
 
-    def test_validate_integer_lt5(self):
-        self.add_validated_int(lt=5)
+    def test_validate_range_int_lt5(self):
+        self.add_validated_arg(int, lt=5)
         self.assert_parsed_value(["4"], 4)
 
-    def test_validate_integer_lt5_err(self):
-        self.add_validated_int(lt=5)
+    def test_validate_range_int_lt5_err(self):
+        self.add_validated_arg(int, lt=5)
         self.assert_parser_error(["5"], "Must be less than 5")

--- a/corehq/util/tests/test_argparse_types.py
+++ b/corehq/util/tests/test_argparse_types.py
@@ -26,6 +26,7 @@ def wrap_system_exit():
 class TestValidateInteger(SimpleTestCase):
 
     def setUp(self):
+        super().setUp()
         self.parser = ArgumentParser()
 
     def add_validated_arg(self, type, *val_args, **val_kw):

--- a/corehq/util/tests/test_argparse_types.py
+++ b/corehq/util/tests/test_argparse_types.py
@@ -59,3 +59,11 @@ class TestValidateInteger(SimpleTestCase):
     def test_validate_range_int_lt5_err(self):
         self.add_validated_arg(int, lt=5)
         self.assert_parser_error(["5"], "Must be less than 5")
+
+    def test_validate_range_float_gt0(self):
+        self.add_validated_arg(float, gt=0.0)
+        self.assert_parsed_value(["1.5"], 1.5)
+
+    def test_validate_range_float_gt0_err(self):
+        self.add_validated_arg(float, gt=0.0)
+        self.assert_parser_error(["-1.5"], "Must be greater than 0.0")


### PR DESCRIPTION
## Summary

I set out to fix an argument validation bug (arg defaults to `None`, cannot compare `None` with `int`). The resolution was to use `corehq.util.argparse_types.validate_integer` (suggested in #29635).  The `validate_integer` function was hard-coded to cast the argument to an `int`, which seemed to over-constrain argparse's `type` argument. I decided to take on the task of changing this as a "writing tests" exercise (inspired by Kent Beck's *TDD: By Example*).

I made an attempt to keep the `validate_integer` function based on top of the `validate_range` logic, but the implementation was really ugly and didn't seem to justify the ability to use it as a shortcut for specifying `type=int`.

Commit-by-commit review is recommended.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

New tests added.

### QA Plan

No QA needed.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
