### PR TITLE
Patch ledgers in forms & cases Couch to SQL migration

### DIFF
--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -444,6 +444,7 @@ class LedgerPatches:
         form_diff = unpatched.get(form_key)
         if form_diff and form_diff.new_value == form.form_id:
             unpatched.pop(form_key)
+            unpatched.pop(("last_modified",), None)
         if unpatched:
             discard_expected_diffs(patch_diffs, unpatched)
 

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -84,8 +84,10 @@ def diff_cases(couch_cases, log_cases=False):
     dd_count = partial(metrics_counter, tags={"domain": get_domain()})
     case_ids = list(couch_cases)
     sql_case_ids = set()
+    sql_cases = {}
     for sql_case in get_sql_cases(case_ids):
         case_id = sql_case.case_id
+        sql_cases[case_id] = sql_case
         sql_case_ids.add(case_id)
         doc_type = couch_cases[case_id]['doc_type']
         diffs, changes = diff_case(sql_case, couch_cases[case_id], dd_count)
@@ -99,7 +101,7 @@ def diff_cases(couch_cases, log_cases=False):
         if log_cases:
             log.info("case %s -> %s diffs", case_id, len(diffs))
 
-    diffs, changes = diff_ledgers(case_ids, dd_count)
+    diffs, changes = diff_ledgers(case_ids, sql_cases, dd_count)
     data.diffs.extend(diffs)
     data.changes.extend(changes)
     add_missing_docs(data, couch_cases, sql_case_ids, dd_count)
@@ -171,7 +173,7 @@ def hard_rebuild(couch_case):
     ).to_json()
 
 
-def diff_ledgers(case_ids, dd_count):
+def diff_ledgers(case_ids, sql_cases, dd_count):
     def diff(couch_state, ledger_value):
         couch_json = couch_state.to_json() if couch_state is not None else {}
         diffs = json_diff(couch_json, ledger_value.to_json(), track_list_indices=False)
@@ -181,6 +183,7 @@ def diff_ledgers(case_ids, dd_count):
         state.ledger_reference: state
         for state in StockState.objects.filter(case_id__in=case_ids)
     }
+    patches = LedgerPatches(sql_cases)
     sql_refs = set()
     all_diffs = []
     all_changes = []
@@ -192,24 +195,27 @@ def diff_ledgers(case_ids, dd_count):
         if couch_state is None:
             couch_state = stock_tx.get_stock_state(ref)
             dd_count("commcare.couchsqlmigration.ledger.rebuild")
+        changes = []
         if couch_state is None:
             diffs = [stock_tx.diff_missing_ledger(ledger_value)]
             old_value = diffs[0].old_value
             if old_value["form_state"] == FORM_PRESENT and "ledger" not in old_value:
                 changes = diffs_to_changes(diffs, "missing couch stock transaction")
-                all_changes.append(("stock state", ref.as_id(), changes))
-                dd_count("commcare.couchsqlmigration.ledger.did_change")
                 diffs = []
         else:
             diffs = diff(couch_state, ledger_value)
             if diffs and stock_tx.has_duplicate_transactions(ref):
                 changes = diffs_to_changes(diffs, "duplicate stock transaction")
-                all_changes.append(("stock state", ref.as_id(), changes))
-                dd_count("commcare.couchsqlmigration.ledger.did_change")
                 diffs = []
+        assert not (diffs and changes), (diffs, changes)
+        if (diffs or changes) and patches.is_patched(ref, diffs or changes):
+            continue
         if diffs:
             dd_count("commcare.couchsqlmigration.ledger.has_diff")
         all_diffs.append(("stock state", ref.as_id(), diffs))
+        if changes:
+            dd_count("commcare.couchsqlmigration.ledger.did_change")
+            all_changes.append(("stock state", ref.as_id(), changes))
     for ref, couch_state in couch_state_map.items():
         if ref not in sql_refs:
             diffs = [stock_tx.diff_missing_ledger(couch_state, sql_miss=True)]
@@ -341,26 +347,17 @@ def is_case_patched(case_id, diffs):
         forms = get_sql_forms(form_ids, ordered=True)
         for form in reversed(forms):
             if form.xmlns == PatchForm.xmlns:
-                discard_expected_diffs(form.form_data.get("diff"))
+                patch_diffs = get_case_patch_diffs(form, case_id)
+                discard_expected_diffs(patch_diffs, unpatched)
                 if not unpatched:
                     return True
         return False
-
-    def discard_expected_diffs(patch_data):
-        data = json.loads(unescape(patch_data)) if patch_data else {}
-        if data.get("case_id") != case_id:
-            return
-        for diff in data.get("diffs", []):
-            diff.pop("reason", None)
-            path = tuple(diff["path"])
-            if path in unpatched and diff_to_json(unpatched[path], ANY) == diff:
-                unpatched.pop(path)
 
     def expected_patch_diff(diff):
         return not is_patchable(diff) or (
             diff.old_value is MISSING and diff.new_value == "")
 
-    from .casepatch import PatchForm, is_patchable, diff_to_json
+    from .casepatch import PatchForm, is_patchable
     unpatched = {tuple(d.path): d for d in diffs if expected_patch_diff(d)}
     xform_ids = unpatched.pop(("xform_ids", "[*]"), None)
     return (
@@ -370,6 +367,85 @@ def is_case_patched(case_id, diffs):
         and len(diffs) == len(unpatched) + 1  # false if any diffs are patchable
         and is_patched(xform_ids.new_value.split(","))
     )
+
+
+def get_case_patch_diffs(form, case_id):
+    data = get_patch_data(form)
+    return without_reason(data.get("diffs", [])) if data.get("case_id") == case_id else []
+
+
+def get_patch_data(form):
+    data = form.form_data.get("diff")
+    return json.loads(unescape(data)) if data else {}
+
+
+def without_reason(diffs):
+    # note: this mutates the given diffs
+    for diff in diffs:
+        diff.pop("reason", None)
+    return diffs
+
+
+def discard_expected_diffs(patch_diffs, unpatched):
+    """Discard `patch_diffs` that have been patched from `unpatched`
+
+    :param patch_diffs: List of diffs from a patch form.
+    :param unpatched: Dict of possibly unpatched diffs by diff path.
+    """
+    from .casepatch import diff_to_json
+    for diff in patch_diffs:
+        path = tuple(diff["path"])
+        if path in unpatched and diff_to_json(unpatched[path], ANY) == diff:
+            unpatched.pop(path)
+
+
+class LedgerPatches:
+
+    def __init__(self, sql_cases):
+        self.sql_cases = sql_cases
+        self.forms = {}  # {case_id: forms, ...}
+
+    def is_patched(self, ref, diffs):
+        """Check if ledger diffs have been patched"""
+        from .casepatch import LedgerDiff, is_ledger_patchable
+        assert diffs, ref
+        if not any(is_ledger_patchable(d) for d in diffs):
+            unpatched = {tuple(d.path): LedgerDiff(d, ref) for d in diffs}
+            for form in reversed(self.get_patch_forms(ref.case_id)):
+                patch_diffs = self.get_ledger_patch_diffs(form, ref)
+                self.discard_expected_ledger_diffs(form, patch_diffs, unpatched)
+                if not unpatched:
+                    return True
+        return False
+
+    def get_patch_forms(self, case_id):
+        try:
+            forms = self.forms[case_id]
+        except KeyError:
+            forms = self.forms[case_id] = self.load_patch_forms(case_id)
+        return forms
+
+    def load_patch_forms(self, case_id):
+        from .casepatch import PatchForm
+        case = self.sql_cases.get(case_id)
+        if case is None:
+            return []
+        forms = get_sql_forms(case.xform_ids)
+        return [f for f in forms if f.xmlns == PatchForm.xmlns]
+
+    @staticmethod
+    def get_ledger_patch_diffs(form, ref):
+        ledgers = get_patch_data(form).get("ledgers", {})
+        return without_reason(ledgers.get(ref.as_id(), []))
+
+    @staticmethod
+    def discard_expected_ledger_diffs(form, patch_diffs, unpatched):
+        form_key = "last_modified_form_id",
+        form_diff = unpatched.get(form_key)
+        if form_diff and form_diff.new_value == form.form_id:
+            unpatched.pop(form_key)
+        if unpatched:
+            discard_expected_diffs(patch_diffs, unpatched)
 
 
 def diff_case_forms(couch_json, sql_json):

--- a/corehq/apps/couch_sql_migration/casepatch.py
+++ b/corehq/apps/couch_sql_migration/casepatch.py
@@ -381,7 +381,11 @@ UNPATCHABLE_LEDGER_PATHS = {
 def get_ledger_patch_xml(diff):
     path = list(diff.path)
     if path == ["balance"]:
-        element = ledger_balance_patch(diff)
+        try:
+            element = ledger_balance_patch(diff)
+        except StockState.DoesNotExist:
+            log.warning("Skipping patch of missing stock state: %s", diff)
+            element = None
     elif (
         path == ["*"]
         and diff.diff_type == "missing"

--- a/corehq/apps/couch_sql_migration/casepatch.py
+++ b/corehq/apps/couch_sql_migration/casepatch.py
@@ -370,6 +370,7 @@ def is_ledger_patchable(diff):
 
 
 UNPATCHABLE_LEDGER_PATHS = {
+    ("last_modified",),
     ("last_modified_form_id",),
 }
 

--- a/corehq/apps/couch_sql_migration/casepatch.py
+++ b/corehq/apps/couch_sql_migration/casepatch.py
@@ -1,8 +1,11 @@
 import json
 import logging
+from collections import defaultdict
 from datetime import datetime
+from decimal import Decimal
 from functools import partial, wraps
 from uuid import uuid4
+from xml.etree import cElementTree as ElementTree
 from xml.sax.saxutils import escape
 
 from django.template.loader import render_to_string
@@ -14,9 +17,12 @@ from casexml.apps.case import const
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from casexml.apps.case.xml.parser import KNOWN_PROPERTIES
 from casexml.apps.phone.xml import get_case_xml
+from casexml.apps.stock.mock import Balance, Entry
+from casexml.apps.stock.models import StockTransaction
 from dimagi.utils.parsing import json_format_datetime
 
-from corehq.apps.tzmigration.timezonemigration import MISSING
+from corehq.apps.commtrack.models import StockState
+from corehq.apps.tzmigration.timezonemigration import FormJsonDiff, MISSING
 from corehq.blobs import get_blob_db
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import (
@@ -24,6 +30,7 @@ from corehq.form_processor.models import (
     XFormInstanceSQL,
     XFormOperationSQL,
 )
+from corehq.form_processor.parsers.ledgers.helpers import UniqueLedgerReference
 from corehq.util.metrics import metrics_counter
 
 from .casediff import get_domain
@@ -63,23 +70,18 @@ def patch_diffs(doc_diffs, log_cases=False):
 
 
 def patch_case(case_id, diffs):
-    case_diffs = [d.json_diff for d in diffs if d.kind != "stock state"]
-    if case_diffs:
-        try:
-            couch_case = get_couch_case(case_id)
-        except CaseNotFound:
-            raise CannotPatch(case_diffs)
-        assert couch_case.domain == get_domain(), (couch_case, get_domain())
-        case = PatchCase(couch_case, case_diffs)
-        form = PatchForm(case)
-        process_patch(form)
-    patch_ledgers([d for d in diffs if d.kind == "stock state"])
-
-
-def patch_ledgers(diffs):
-    if diffs:
-        # TODO implement ledger patch
-        raise CannotPatch([d.json_diff for d in diffs])
+    def is_ledger(diff):
+        return diff.kind == "stock state"
+    try:
+        couch_case = get_couch_case(case_id)
+    except CaseNotFound:
+        raise CannotPatch(diffs)
+    assert couch_case.domain == get_domain(), (couch_case, get_domain())
+    case_diffs = [d.json_diff for d in diffs if not is_ledger(d)]
+    ledger_diffs = [LedgerDiff(d) for d in diffs if is_ledger(d)]
+    case = PatchCase(couch_case, case_diffs, ledger_diffs)
+    form = PatchForm(case)
+    process_patch(form)
 
 
 def aslist(generator_func):
@@ -93,8 +95,10 @@ def aslist(generator_func):
 class PatchCase:
     case = attr.ib()
     diffs = attr.ib()
+    ledger_diffs = attr.ib()
 
     def __attrs_post_init__(self):
+        assert self.diffs or self.ledger_diffs, "PatchCase must have diffs"
         self.case_attachments = []
         self._updates = updates = []
         if is_missing_in_sql(self.diffs):
@@ -146,6 +150,16 @@ class PatchCase:
                 )
             else:
                 raise CannotPatch([diff])
+
+    def iter_xml_blocks(self):
+        yield get_case_xml(self, self._updates, version='2.0')
+        yield from self._ledger_blocks()
+        yield get_diff_block(self).encode('utf-8')
+
+    def _ledger_blocks(self):
+        for diff in self.ledger_diffs:
+            if is_ledger_patchable(diff):
+                yield get_ledger_patch_xml(diff)
 
 
 def has_illegal_props(diffs):
@@ -233,12 +247,9 @@ class PatchForm:
 
     @memoized
     def get_xml(self):
-        updates = self._case._updates
-        case_block = get_case_xml(self._case, updates, version='2.0')
-        diff_block = get_diff_block(self._case)
         return render_to_string('hqcase/xml/case_block.xml', {
             'xmlns': self.xmlns,
-            'case_block': case_block.decode('utf-8') + diff_block,
+            'case_block': b''.join(self._case.iter_xml_blocks()).decode('utf-8'),
             'time': json_format_datetime(self.received_on),
             'uid': self.form_id,
             'username': "",
@@ -289,7 +300,7 @@ def get_diff_block(case):
     ```json
     {
         "case_id": case.case_id,
-        "diffs": [
+        "diffs": [  # optional, omitted if there are no case diffs
             {
                 "path": diff.path,
                 "old": diff.old_value,  # omitted if old_value is MISSING
@@ -298,31 +309,157 @@ def get_diff_block(case):
                 "reason": "...",  # omitted if reason for change is unknown
             },
             ...
-        ]
+        ],
+        "ledgers": {  # optional, omitted if there are no ledger diffs
+            diff.doc_id: [
+                {
+                    # same fields as case diffs
+                    # plus extra field if path == ["balance"]:
+                    "couch_transactions": [
+                        # items produced by ledger_transaction_json()
+                    ]
+                },
+                ...
+            ],
+            ...
+        }
     }
     ```
     """
-    diffs = [diff_to_json(d) for d in sorted(case.diffs, key=lambda d: d.path)]
-    data = {"case_id": case.case_id, "diffs": diffs}
+    data = {"case_id": case.case_id}
+    if case.diffs:
+        data["diffs"] = [
+            diff_to_json(d)
+            for d in sorted(case.diffs, key=lambda d: d.path)
+        ]
+    if case.ledger_diffs:
+        ledger_diffs = defaultdict(list)
+        for diff in sorted(case.ledger_diffs, key=lambda d: d.path):
+            ledger_data = diff_to_json(diff)
+            if ledger_data["path"] == ["balance"]:
+                ledger_data["couch_transactions"] = get_couch_transactions(diff.ref)
+            ledger_diffs[diff.doc_id].append(ledger_data)
+        data["ledgers"] = dict(ledger_diffs)
     return f"<diff>{escape(json.dumps(data))}</diff>"
 
 
 def diff_to_json(diff, new_value=None):
     assert diff.old_value is not MISSING or diff.new_value is not MISSING, diff
+    assert not isinstance(diff.path, str), diff  # PlanningDiff not allowed
     obj = {"path": list(diff.path), "patch": is_patchable(diff)}
     if diff.old_value is not MISSING:
-        obj["old"] = diff.old_value
+        obj["old"] = jsonify(diff.old_value)
     if diff.new_value is not MISSING:
-        obj["new"] = diff.new_value if new_value is None else new_value
+        obj["new"] = jsonify(diff.new_value) if new_value is None else new_value
     if getattr(diff, "reason", ""):
         obj["reason"] = diff.reason
     return obj
 
 
 def is_patchable(diff):
+    if isinstance(diff, LedgerDiff):
+        return is_ledger_patchable(diff)
+    assert not isinstance(diff.path, str), diff  # PlanningDiff not allowed
     return not (diff.path[0] in UNPATCHABLE_PROPS or (
         list(diff.path) == ["closed"] and not diff.old_value and diff.new_value
     ))
+
+
+def is_ledger_patchable(diff):
+    return tuple(diff.path) not in UNPATCHABLE_LEDGER_PATHS
+
+
+UNPATCHABLE_LEDGER_PATHS = {
+    ("last_modified_form_id",),
+}
+
+
+def get_ledger_patch_xml(diff):
+    path = list(diff.path)
+    if path == ["balance"]:
+        element = ledger_balance_patch(diff)
+    else:
+        raise CannotPatch([diff])
+    return ElementTree.tostring(element.as_xml(), encoding='utf-8')
+
+
+def ledger_balance_patch(diff):
+    assert isinstance(diff.old_value, (Decimal, int, float)), diff
+    ref = diff.ref
+    stock = StockState.objects.get(
+        case_id=ref.case_id,
+        section_id=ref.section_id,
+        product_id=ref.entry_id,
+    )
+    return Balance(
+        entity_id=ref.case_id,
+        date=stock.last_modified_date.date(),
+        section_id=ref.section_id,
+        entry=Entry(id=ref.entry_id, quantity=diff.old_value),
+    )
+
+
+def get_couch_transactions(ref):
+    return [ledger_transaction_json(tx) for tx in reversed(
+        StockTransaction.get_ordered_transactions_for_stock(
+            case_id=ref.case_id,
+            section_id=ref.section_id,
+            product_id=ref.entry_id,
+        ).select_related("report")
+    )]
+
+
+def ledger_transaction_json(tx):
+    return {
+        "form_id": tx.report.form_id,
+        "type": tx.type,
+        "delta": jsonify(tx.quantity),
+        "balance": jsonify(tx.stock_on_hand),
+    }
+
+
+def jsonify(value):
+    if isinstance(value, Decimal):
+        return int(value) if int(value) == value else float(value)
+    return value
+
+
+class LedgerDiff:
+    """Ledger diff
+
+    Has the same fields as `FormJsonDiff` in addition to `doc_id`
+    (`str`) and `ref` (`UniqueLedgerReference`) attributes. May be
+    instantiated two ways:
+
+    - Single argument: PlanningDiff-like with `json_diff` and `doc_id`
+      attributes.
+    - Two arguments: FormJsonDiff-like, UniqueLedgerReference
+
+    Yes, keeping all the diff types straight is a nightmare! Fixing that
+    would require refactoring the `tzmigration` app and migrating data
+    in various SQLite databases, which is out of scope.
+    """
+
+    def __init__(self, diff, ref=None):
+        if ref is None:
+            ref = UniqueLedgerReference.from_id(diff.doc_id)
+            diff = diff.json_diff
+        else:
+            assert not isinstance(diff.path, str), (ref, diff)
+        self.ref = ref
+        for name in FormJsonDiff._fields:
+            setattr(self, name, getattr(diff, name))
+
+    def __repr__(self):
+        fields = " ".join(
+            f"{name}={getattr(self, name)!r}"
+            for name in FormJsonDiff._fields
+        )
+        return f"<LedgerDiff {self.doc_id} {fields}>"
+
+    @property
+    def doc_id(self):
+        return self.ref.as_id()
 
 
 class CannotPatch(Exception):
@@ -333,6 +470,8 @@ class CannotPatch(Exception):
 
 
 def is_missing_in_sql(diffs):
+    if not diffs:
+        return False
     diff = diffs[0]
     return (
         len(diffs) == 1

--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -67,7 +67,9 @@ load_ignore_rules = memoized(lambda: add_duplicate_rules({
     ],
     'HQSubmission': [],
     'XFormArchived': [],
-    'XFormError': [],
+    'XFormError': [
+        Ignore('diff', 'doc_type', old='XFormError', new='XFormInstance'),
+    ],
     'XFormDuplicate': [],
     'XFormDeprecated': [
         ignore_renamed('deprecated_date', 'edited_on'),

--- a/corehq/apps/couch_sql_migration/tests/ledgers.py
+++ b/corehq/apps/couch_sql_migration/tests/ledgers.py
@@ -1,0 +1,192 @@
+from itertools import chain, groupby
+
+import attr
+
+from casexml.apps.stock.models import StockTransaction
+
+from corehq.apps.commtrack.models import StockState
+from corehq.form_processor.backends.sql.dbaccessors import LedgerAccessorSQL
+
+
+def print_ledger_history(ledger_ref, verbose=False):
+    case_id, section_id, entry_id = ledger_ref.split("/")
+    cch_trans = list(summarize_trans(
+        CouchTransaction.to_ledgers(
+            get_couch_transactions(case_id, section_id, entry_id))))
+    sql_trans = list(
+        summarize_trans(get_sql_transactions(case_id, section_id, entry_id)))
+    print("Ledger", ledger_ref)
+    print("date                      couch         sql  form/tx type")
+    print("                      +/-     =   +/-     =")
+    for ccht, sqlt in merge_transactions(cch_trans, sql_trans):
+        both = ccht or sqlt
+        ptx = verbose or \
+            (ccht and sqlt and ccht.updated_balance != sqlt.updated_balance)
+        header = both.report_date.strftime("%Y-%m-%d %H:%M:%S")
+        footer = f"{both.form_id}  {both.server_date}"
+        print_tx(header, ccht, sqlt, footer)
+        if ptx:
+            print_transactions(ccht, sqlt)
+
+    stock = StockState.objects.get(
+        case_id=case_id, section_id=section_id, product_id=entry_id)
+    ledger = LedgerAccessorSQL.get_ledger_value(
+        case_id=case_id, section_id=section_id, entry_id=entry_id)
+    print(f"ledger value: {num(stock.balance):>17} {num(ledger.balance):>11}")
+
+
+def print_tx(header, ctx, stx, footer):
+    print(
+        f"{header:<19}",
+        f"{delta(ctx.delta) if ctx else '':>5}",
+        f"{num(ctx.updated_balance) if ctx else '':>5}",
+        f"{delta(stx.delta) if stx else '':>5}",
+        f"{num(stx.updated_balance) if stx else '':>5} ",
+        footer,
+    )
+
+
+def print_transactions(ccht, sqlt):
+    def meaningful(tx):
+        return (tx.readable_type in "stockonhand balance stockout" or (
+            tx.delta and tx.readable_type in "consumption receipts transfer"
+        ))
+    ctxx = [tx for tx in ccht.trans if meaningful(tx)]
+    stxx = [tx for tx in sqlt.trans if meaningful(tx)]
+    while True:
+        if not (ctxx and stxx):
+            for tx in chain(ctxx, stxx):
+                print_tx("", None, tx, tx.readable_type)
+            break
+        if (
+            ctxx[0].readable_type in "consumption receipts"
+            and stxx[0].readable_type == "transfer"
+        ) or (
+            ctxx[0].readable_type in "stockonhand stockout"
+            and stxx[0].readable_type == "balance"
+        ):
+            ctx = ctxx.pop(0)
+            stx = stxx.pop(0)
+            print_tx("", ctx, stx, f"{ctx.readable_type}/{stx.readable_type}")
+        else:
+            ctx = ctxx.pop(0)
+            print_tx("", ctx, None, ctx.readable_type)
+    print("")
+
+
+def print_trans(tx):
+    if isinstance(tx, CouchTransaction):
+        off1 = " " * 19
+        off2 = " " * 12
+    else:
+        off1 = " " * 31
+        off2 = " " * 0
+    tp = tx.readable_type
+    if not (
+        (tx.delta and tp in "consumption receipts transfer")
+        or (tx.updated_balance and tp in "stockonhand balance")
+        or tp == "stockout"
+    ):
+        return
+    print(off1, f"{delta(tx.delta):>5} {num(tx.updated_balance):>5}" + off2, tp)
+
+
+def num(value):
+    if value is None or isinstance(value, int):
+        return value
+    if value == 0:
+        return 0
+    return f"{value}".rstrip("0").rstrip(".")
+
+
+def delta(value):
+    if value is None:
+        return value
+    if value == 0:
+        return 0
+    return f"{value:+f}".rstrip("0").rstrip(".")
+
+
+def summarize_trans(transactions):
+    for key, group in groupby(transactions, key=lambda t: t.form_id):
+        yield FormTransactions(list(group))
+
+
+def merge_transactions(cch_trans, sql_trans):
+    cch_by_form = {ft.form_id: ft for ft in cch_trans}
+    sql_by_form = {ft.form_id: ft for ft in sql_trans}
+    seen = set()
+    all_trans = chain(cch_trans, sql_trans)
+    for trans in sorted(all_trans, key=lambda t: (t.report_date, t.form_id)):
+        if trans.form_id not in seen:
+            yield cch_by_form.get(trans.form_id), sql_by_form.get(trans.form_id)
+            seen.add(trans.form_id)
+
+
+@attr.s
+class FormTransactions:
+    trans = attr.ib()
+
+    def __getattr__(self, name):
+        values = {getattr(t, name) for t in self.trans}
+        if len(values) == 1:
+            return values.pop()
+        raise ValueError(f"multiple values for {name}: {values}")
+
+    @property
+    def delta(self):
+        return sum(t.delta for t in self.trans)
+
+    @property
+    def updated_balance(self):
+        return self.trans[-1].updated_balance
+
+
+@attr.s
+class CouchTransaction:
+    trans = attr.ib()
+
+    @classmethod
+    def to_ledgers(cls, transactions):
+        return (cls(t) for t in transactions)
+
+    def __getattr__(self, name):
+        return getattr(self.trans, name)
+
+    @property
+    def report_date(self):
+        return self.trans.report.date
+
+    @property
+    def server_date(self):
+        return self.trans.report.server_date
+
+    @property
+    def delta(self):
+        return self.trans.quantity
+
+    @property
+    def updated_balance(self):
+        return self.trans.stock_on_hand
+
+    @property
+    def readable_type(self):
+        return self.trans.type
+
+    @property
+    def form_id(self):
+        return self.trans.report.form_id
+
+
+def get_couch_transactions(case_id, section_id, product_id):
+    return list(reversed(
+        StockTransaction.get_ordered_transactions_for_stock(
+            case_id=case_id, section_id=section_id, product_id=product_id)
+        .select_related("report")
+    ))
+
+
+def get_sql_transactions(case_id, section_id, entry_id):
+    transactions = LedgerAccessorSQL.get_ledger_transactions_for_case(
+        case_id=case_id, section_id=section_id, entry_id=entry_id)
+    return sorted(transactions, key=lambda t: (t.report_date, t.id))

--- a/corehq/apps/couch_sql_migration/tests/test_casedifftool.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casedifftool.py
@@ -16,6 +16,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAcce
 from corehq.form_processor.models import CommCareCaseIndexSQL
 from corehq.form_processor.utils.general import (
     clear_local_domain_sql_backend_override,
+    should_use_sql_backend,
 )
 from corehq.util.dates import iso_string_to_datetime
 from corehq.util.test_utils import capture_log_output
@@ -225,8 +226,8 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
     def test_patch_ledger_with_out_of_order_transactions(self):
         from .ledgers import print_ledger_history
         product = self.make_product()
-        self.update_stock(product, "2020-09-28", "2020-09-24T00:00:00.000Z", delta=0)
-        self.update_stock(product, "2020-09-27", "2020-09-25T00:00:01.000Z", delta=0)
+        self.update_stock(product, "2020-09-28", "2020-09-24T00:00:00.000Z", qty=0)
+        self.update_stock(product, "2020-09-27", "2020-09-25T00:00:01.000Z", qty=0)
         self.do_migration(case_diff='none')
         self.do_case_diffs()
         ref_id = f"test-case/things/{product._id}"
@@ -241,7 +242,7 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
         from corehq.apps.commtrack.models import StockState
         from .ledgers import print_ledger_history
         product = self.make_product()
-        self.update_stock(product, "2020-09-28", "2020-09-24T00:00:00.000Z", delta=0)
+        self.update_stock(product, "2020-09-28", "2020-09-24T00:00:00.000Z", qty=0)
         stock = StockState.objects.get(case_id="test-case", section_id="things", product_id=product._id)
         stock.stock_on_hand = 2
         stock.save()
@@ -257,7 +258,7 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
     def test_patch_ledger_missing_in_sql(self):
         from .ledgers import print_ledger_history
         product = self.make_product()
-        form = self.update_stock(product, delta=1)
+        form = self.update_stock(product, qty=1)
         FormAccessors(self.domain_name).soft_delete_forms([form.form_id], datetime.utcnow(), 'test')
         self.do_migration(case_diff='none')
         self.do_case_diffs()
@@ -269,6 +270,29 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
             Diff("test-case", type="missing", path=["*"], old="*", new=MISSING),
         ])
         self.do_migration(forms="missing", case_diff="patch")
+
+    def test_patch_ledger_daily_consumption_diff(self):
+        from corehq.apps.commtrack.models import StockState
+        from corehq.pillows.ledger import _get_daily_consumption_for_ledger
+        with self.enable_commtrack_daily_consumption():
+            product = self.make_product()
+            for num in [-3, -2, -1]:
+                params = {
+                    "reported": (datetime.now() + timedelta(days=num)).strftime("%Y-%m-%d"),
+                    "section": "stock",
+                }
+                self.update_stock(product, balance=True, qty=3, **params)
+                self.update_stock(product, qty=num, **params)
+            stock = StockState.objects.get(case_id="test-case", section_id="stock", product_id=product._id)
+            assert not should_use_sql_backend(self.domain_name), self.domain_name
+            _get_daily_consumption_for_ledger(stock.to_json())
+            self.do_migration(case_diff='none')
+            self.do_case_diffs()
+            ref_id = f"test-case/stock/{product._id}"
+            self.compare_diffs([
+                Diff(ref_id, type="type", path=["daily_consumption"], old="2.50000", new=None),
+            ])
+            self.do_migration(forms="missing", case_diff="patch")
 
     def test_patch_known_properties(self):
         self.submit_form(make_test_form("form-1", case_id="case-1"))
@@ -642,17 +666,26 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
         from corehq.apps.commtrack.helpers import make_product
         return make_product(self.domain_name, name, name)
 
-    def update_stock(self, product, reported="2014-08-04", submitted=None, delta=1):
+    def update_stock(self, product, reported="2014-08-04", submitted=None,
+            qty=1, balance=False, section="things", tx_type="write_things_to_ledger"):
         submission_date = "2014-08-04T18:25:56.656Z"
-        return self.submit_form(
+        if balance:
+            tx_type = "stock_balance"
+        xml = (
             LEDGER_FORM
             .replace('thing-1', product._id)
             .replace('ledger-form', uuid4().hex)
+            .replace('section-id="things"', f'section-id="{section}"')
+            .replace('type="write_things_to_ledger"', f'type="{tx_type}"')
             .replace('date="2014-08-04"', f'date="{reported}"')
             .replace(submission_date, submitted or submission_date)
-            .replace('quantity="1"', f'quantity="{delta}"'),
-            received_on=submitted,
+            .replace('quantity="1"', f'quantity="{qty if balance else abs(qty)}"')
         )
+        if balance:
+            xml = xml.replace("n2:transfer", "n2:balance").replace('dest=', 'entity-id=')
+        elif qty < 0:
+            xml = xml.replace("dest=", "src=")
+        return self.submit_form(xml, received_on=submitted)
 
     def do_migration(self, *args, **kw):
         if kw.get("case_diff") != "patch":
@@ -668,6 +701,26 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
         self.migration_success = True  # clear migration failure on diff cases
         migrator = mod.get_migrator(self.domain_name, self.state_dir)
         return mod.do_case_patch(migrator, cases, stop=stop, batch_size=100)
+
+    @contextmanager
+    def enable_commtrack_daily_consumption(self):
+        from corehq.apps.commtrack.util import make_domain_commtrack
+        old_commtrack_enabled = self.domain.commtrack_enabled
+        old_locations_enabled = getattr(self.domain, 'locations_enabled', None)
+        make_domain_commtrack(self.domain)
+        config = self.domain.commtrack_settings
+        config.sqlconsumptionconfig.min_window = 2
+        config.sqlconsumptionconfig.save()
+        try:
+            yield
+        finally:
+            self.domain.commtrack_settings.delete()
+            self.domain.commtrack_enabled = old_commtrack_enabled
+            if old_locations_enabled is not None:
+                self.domain.locations_enabled = old_locations_enabled
+            else:
+                del self.domain.locations_enabled
+            self.domain.save()
 
     @contextmanager
     def augmented_couch_case(self, case_id):

--- a/corehq/apps/couch_sql_migration/tests/test_casepatch.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casepatch.py
@@ -13,19 +13,19 @@ from .. import casepatch as mod
 
 def test_patch_opened_by():
     diffs = [Diff("diff", ["opened_by"], "old", "new")]
-    case = mod.PatchCase(FakeCase(), diffs)
+    case = mod.PatchCase(FakeCase(), diffs, [])
     check_diff_block(case, diffs)
 
 
 def test_patch_closed_by():
     diffs = [Diff("diff", ["closed_by"], "old", "new")]
-    case = mod.PatchCase(FakeCase(), diffs)
+    case = mod.PatchCase(FakeCase(), diffs, [])
     check_diff_block(case, diffs)
 
 
 def test_patch_modified_by():
     diffs = [Diff("diff", ["modified_by"], "old", "new")]
-    case = mod.PatchCase(FakeCase(), diffs)
+    case = mod.PatchCase(FakeCase(), diffs, [])
     check_diff_block(case, diffs)
 
 
@@ -34,7 +34,7 @@ def test_patch_opened_by_with_xform_ids():
         Diff("diff", ["opened_by"], "old", "new"),
         Diff("set_mismatch", ["xform_ids", "[*]"], "old", "new"),
     ]
-    case = mod.PatchCase(FakeCase(), diffs)
+    case = mod.PatchCase(FakeCase(), diffs, [])
     check_diff_block(case, diffs)
 
 
@@ -43,16 +43,22 @@ def test_can_patch_opened_by_with_user_id():
         Diff("diff", ["opened_by"], "old", "new"),
         Diff("diff", ["user_id"], "old", "new"),
     ]
-    case = mod.PatchCase(FakeCase(), diffs)
+    case = mod.PatchCase(FakeCase(), diffs, [])
     eq(case.dynamic_case_properties(), {})
     check_diff_block(case, diffs)
 
 
 def test_patch_missing_case_property():
     diffs = [Diff("diff", ["gone"], MISSING, "new")]
-    case = mod.PatchCase(FakeCase(), diffs)
+    case = mod.PatchCase(FakeCase(), diffs, [])
     eq(case.dynamic_case_properties(), {"gone": ""})
     check_diff_block(case, diffs, [Diff("diff", ["gone"], MISSING, "")])
+
+
+def test_patch_ledger_balance():
+    ledger_diffs = [ledger_diff("diff", ["balance"], 34, 3)]
+    case = mod.PatchCase(FakeCase(), [], ledger_diffs)
+    check_ledger_diffs(case, ledger_diffs)
 
 
 def check_diff_block(case, diffs, patched_diffs=None):
@@ -60,6 +66,7 @@ def check_diff_block(case, diffs, patched_diffs=None):
     data = json.loads(unescape(form.form_data["diff"]))
     eq(data["case_id"], case.case_id)
     eq(data["diffs"], [mod.diff_to_json(y) for y in diffs])
+    assert "ledgers" not in data, data
 
     assert_patched(form, patched_diffs or diffs)
     if patched_diffs:
@@ -80,6 +87,15 @@ def assert_patched(form, diffs, expect_patched=True):
     )
 
 
+def check_ledger_diffs(case, diffs, patched_diffs=None):
+    with patch.object(mod, "get_couch_transactions", lambda ref: [ref]):
+        form = FakeForm(mod.get_diff_block(case))
+        data = json.loads(unescape(form.form_data["diff"]))
+    eq(data["case_id"], case.case_id)
+    eq(data["ledgers"], {"led/ger/ref": [ledger_json(y) for y in diffs]})
+    assert "diffs" not in data, data
+
+
 class FakeCase:
     case_id = "fake"
     closed = False
@@ -96,3 +112,15 @@ class FakeForm:
         assert xml.startswith("<diff>"), xml
         assert xml.endswith("</diff>"), xml
         return {"diff": xml[6:-7]}
+
+
+def ledger_diff(*args):
+    ref = mod.UniqueLedgerReference.from_id("led/ger/ref")
+    return mod.LedgerDiff(Diff(*args), ref)
+
+
+def ledger_json(diff):
+    data = mod.diff_to_json(diff)
+    if data["path"] == ["balance"]:
+        data["couch_transactions"] = [list(diff.ref)]
+    return data

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -133,6 +133,17 @@ class DiffTestCases(SimpleTestCase):
             )]
         )
 
+    def test_form_error_type_change(self):
+        couch_form = {
+            "doc_type": "XFormError",
+            "problem": "something went wrong",
+        }
+        sql_form = {
+            "doc_type": "XFormInstance",
+            "problem": "something went wrong",
+        }
+        self._test_form_diff_filter(couch_form, sql_form)
+
     def test_filter_form_deletion_fields(self):
         couch_doc = {
             'doc_type': 'XFormInstance-Deleted',

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -264,6 +264,8 @@ class BaseMigrationTestCase(TestCase, TestFileMixin):
         if received_on is not None:
             if isinstance(received_on, timedelta):
                 received_on = datetime.utcnow() + received_on
+            elif isinstance(received_on, str):
+                received_on = parse_date(received_on).replace(tzinfo=None)
             return {"received_on": received_on}
         return {}
 

--- a/custom/apps/crs_reports/reports.py
+++ b/custom/apps/crs_reports/reports.py
@@ -1,3 +1,6 @@
+# WARNING this module looks up cases in Couch, but the domain (crs-remind) has
+# been migrated to SQL, so any cases created or updated after the migration was
+# completed (2021-05-12) will either cause errors or incorrect report output.
 from datetime import timedelta
 import datetime
 from django.utils.translation import ugettext_noop

--- a/custom/apps/crs_reports/views.py
+++ b/custom/apps/crs_reports/views.py
@@ -1,3 +1,6 @@
+# WARNING this module looks up cases in Couch, but the domain (crs-remind) has
+# been migrated to SQL, so any cases created or updated after the migration was
+# completed (2021-05-12) will either cause errors or incorrect report output.
 from couchdbkit.exceptions import ResourceNotFound
 from casexml.apps.case.models import CommCareCase
 from django.shortcuts import render


### PR DESCRIPTION
Three new types of patches for ledgers
- balance diff
- ledger missing in SQL
- daily_consumption diff

Plus a few other misc. items.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Yes.

### QA Plan

No.

### Safety story

All non-comment changes in this PR affect only the Couch to SQL migration management commands. The "custom" package changes are comments only.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
