### PR TITLE
Remove unittest2

### DIFF
--- a/corehq/apps/es/tests/test_esqueryset.py
+++ b/corehq/apps/es/tests/test_esqueryset.py
@@ -1,5 +1,4 @@
-from unittest import TestCase
-from unittest2 import skipIf
+from unittest import TestCase, skipIf
 
 from django.conf import settings
 from corehq.apps.es.es_query import ESQuerySet, HQESQuery

--- a/corehq/ex-submodules/dimagi/test_utils/base.py
+++ b/corehq/ex-submodules/dimagi/test_utils/base.py
@@ -6,7 +6,7 @@ if not settings.configured:
 
 
 from mock import MagicMock, NonCallableMock, patch
-from unittest2 import TestCase
+from unittest import TestCase
 
 from memoized import memoized
 from dimagi.utils.chunked import chunked

--- a/corehq/ex-submodules/dimagi/utils/tests/cache_tests.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/cache_tests.py
@@ -2,7 +2,7 @@ import os
 import io
 
 from PIL import Image
-from unittest2 import TestCase
+from unittest import TestCase
 
 from dimagi.utils.django import cached_object
 from dimagi.utils.django.cached_object import CachedObject, CachedImage, IMAGE_SIZE_ORDERING, OBJECT_ORIGINAL

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -11,7 +11,7 @@ from django.test.utils import override_settings
 from django.utils.decorators import classproperty
 from nose.plugins.attrib import attr
 from nose.tools import nottest
-from unittest2 import skipIf, skipUnless
+from unittest import skipIf, skipUnless
 
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.phone.models import SyncLogSQL

--- a/custom/_legacy/pact/tests/dot_ordering.py
+++ b/custom/_legacy/pact/tests/dot_ordering.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from django.test import TestCase
 import json
 from django.test.utils import override_settings
-from unittest2 import skip
+from unittest import skip
 
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.domain.shortcuts import create_domain

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -12,8 +12,6 @@ amqp==2.6.1
     # via kombu
 architect==0.5.6
     # via -r base-requirements.in
-argparse==1.4.0
-    # via unittest2
 attrs==18.2.0
     # via
     #   -r base-requirements.in
@@ -334,8 +332,6 @@ kombu==4.2.2.post1
     #   celery
 laboratory==0.2.0
     # via -r base-requirements.in
-linecache2==1.0.0
-    # via traceback2
 lxml==4.6.3
     # via
     #   -r base-requirements.in
@@ -588,7 +584,6 @@ six==1.15.0
     #   traitlets
     #   transifex-client
     #   twilio
-    #   unittest2
 smartypants==2.0.1
     # via pycco
 smmap==4.0.0
@@ -658,8 +653,6 @@ tinys3==0.1.12
     # via -r base-requirements.in
 toml==0.10.2
     # via pep517
-traceback2==1.4.0
-    # via unittest2
 traitlets==4.3.3
     # via ipython
 transifex-client==0.14.2
@@ -672,8 +665,6 @@ twilio==6.5.1
     # via -r base-requirements.in
 ua-parser==0.10.0
     # via user-agents
-unittest2==1.1.0
-    # via -r test-requirements.in
 urllib3==1.25.10
     # via
     #   botocore

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -7,7 +7,6 @@ nose==1.3.7
 nose-exclude==0.5.0
 pip-tools==6.1.0
 testil
-unittest2
 requests-mock
 sqlalchemy-postgres-copy==0.5.0
 flaky==3.7.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -10,8 +10,6 @@ amqp==2.6.1
     # via kombu
 architect==0.5.6
     # via -r base-requirements.in
-argparse==1.4.0
-    # via unittest2
 attrs==18.2.0
     # via
     #   -r base-requirements.in
@@ -282,8 +280,6 @@ kombu==4.2.2.post1
     #   celery
 laboratory==0.2.0
     # via -r base-requirements.in
-linecache2==1.0.0
-    # via traceback2
 lxml==4.6.3
     # via
     #   -r base-requirements.in
@@ -493,7 +489,6 @@ six==1.15.0
     #   sqlalchemy-postgres-copy
     #   tenacity
     #   twilio
-    #   unittest2
 smartypants==2.0.1
     # via pycco
 socketpool==0.5.3
@@ -535,8 +530,6 @@ tinys3==0.1.12
     # via -r base-requirements.in
 toml==0.10.2
     # via pep517
-traceback2==1.4.0
-    # via unittest2
 tropo-webapi-python==0.1.3
     # via -r base-requirements.in
 turn-python==0.0.1
@@ -547,8 +540,6 @@ typing-extensions==3.7.4.3
     # via importlib-metadata
 ua-parser==0.10.0
     # via user-agents
-unittest2==1.1.0
-    # via -r test-requirements.in
 urllib3==1.25.10
     # via
     #   botocore


### PR DESCRIPTION
## Summary

Change all references of `unittest2` to use `unittest` instead. This removes several Python 2 libraries from the dependency list:

- unittest2
- linecache2
- traceback2
- argparse

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Changes only affect tests.

### QA Plan

No QA.

### Safety story

Changes are safe because they do not touch customer-facing code. If the changes pass all tests, they are 100% safe.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
