### PR TITLE
[SSO] Update Sign In form to enforce SSO (ONLY when flag in localsettings is enabled)

### DIFF
--- a/corehq/apps/domain/templates/login_and_password/login.html
+++ b/corehq/apps/domain/templates/login_and_password/login.html
@@ -31,7 +31,14 @@
 
 {% block content %}
   {% initial_page_data "hide_password_feedback" hide_password_feedback %}
+  {% initial_page_data "enforce_sso_login" enforce_sso_login|BOOL %}
+  {% registerurl 'check_sso_login_status' %}
   {% block login-content %}
+    <div {% if enforce_sso_login %}
+         id="user-login-form"
+         class="ko-template"
+         {% endif %}>
       {% include "login_and_password/partials/login_full.html" %}
+    </div>
   {% endblock %}
 {% endblock content %}

--- a/corehq/apps/domain/templates/login_and_password/login.html
+++ b/corehq/apps/domain/templates/login_and_password/login.html
@@ -32,6 +32,6 @@
 {% block content %}
   {% initial_page_data "hide_password_feedback" hide_password_feedback %}
   {% block login-content %}
-    {% include "login_and_password/partials/login_full.html" %}
+      {% include "login_and_password/partials/login_full.html" %}
   {% endblock %}
 {% endblock content %}

--- a/corehq/apps/domain/templates/login_and_password/two_factor/_wizard_actions.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/_wizard_actions.html
@@ -6,7 +6,7 @@
           class="btn btn-default btn-lg">{% trans "Back" %}</button>
 {% endif %}
 {% if wizard.steps.current == 'auth' %}
-  <button type="submit" class="btn btn-primary btn-lg">{% trans "Sign In" %}</button>
+    <button type="submit" class="btn btn-primary btn-lg">{% trans "Sign In" %}</button>
 {% else %}
   <button type="submit" class="btn btn-primary btn-lg">{% trans "Next" %}</button>
 {% endif %}

--- a/corehq/apps/domain/templates/login_and_password/two_factor/_wizard_actions.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/_wizard_actions.html
@@ -6,7 +6,24 @@
           class="btn btn-default btn-lg">{% trans "Back" %}</button>
 {% endif %}
 {% if wizard.steps.current == 'auth' %}
+  {% if enforce_sso_login %}
+    <button type="button"
+            data-bind="visible: showContinueButton,
+                       click: proceedToNextStep,
+                       disable: isContinueDisabled"
+            class="btn btn-primary btn-lg">
+      <i class="fa fa-spinner fa-spin"
+         data-bind="visible:showContinueSpinner"></i>
+      <span data-bind="text:continueButtonText"></span>
+    </button>
+    <button type="submit"
+            data-bind="visible: showSignInButton"
+            class="btn btn-primary btn-lg">
+      {% trans "Sign In" %}
+    </button>
+  {% else %}
     <button type="submit" class="btn btn-primary btn-lg">{% trans "Sign In" %}</button>
+  {% endif %}
 {% else %}
   <button type="submit" class="btn btn-primary btn-lg">{% trans "Next" %}</button>
 {% endif %}

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/login.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/login.html
@@ -48,7 +48,7 @@
         {% trans "Looks like your CommCare session has expired." %}<br />
         {% trans "Please log in again to continue working." %}
       {% else %}
-        {% trans "Please sign in below to continue." %}
+          {% trans "Please sign in below to continue." %}
       {% endif %}
     </p>
 

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/login.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/login.html
@@ -48,7 +48,11 @@
         {% trans "Looks like your CommCare session has expired." %}<br />
         {% trans "Please log in again to continue working." %}
       {% else %}
+        {% if enforce_sso_login %}
+          {% trans "Please sign in below." %} {# removed "to continue" because of the two-part step involving a Continue button #}
+        {% else %}
           {% trans "Please sign in below to continue." %}
+        {% endif %}
       {% endif %}
     </p>
 

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -35,6 +35,19 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
     if settings.ADD_CAPTCHA_FIELD_TO_FORMS:
         captcha = CaptchaField(label=_("Type the letters in the box"))
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if settings.ENFORCE_SSO_LOGIN:
+            self.fields['username'].widget = forms.TextInput(attrs={
+                'class': 'form-control',
+                'data-bind': 'textInput: authUsername, onEnterKey: continueOnEnter',
+                'placeholder': _("Enter email address"),
+            })
+            self.fields['password'].widget = forms.PasswordInput(attrs={
+                'class': 'form-control',
+                'placeholder': _("Enter password"),
+            })
+
     def clean_username(self):
         username = self.cleaned_data.get('username', '').lower()
         return username

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
@@ -685,7 +685,7 @@ hqDefine("hqwebapp/js/knockout_bindings.ko", [
         // calls a function when the enter key is pressed on an input
         init: function (element, valueAccessor, allBindings, viewModel) {
             $(element).keypress(function (event) {
-                let keyCode = (event.which ? event.which : event.keyCode);
+                let keyCode = event.which ? event.which : event.keyCode;
                 if (event.key === "Enter" || keyCode === 13) {
                     valueAccessor()();
                     return false;

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
@@ -685,8 +685,7 @@ hqDefine("hqwebapp/js/knockout_bindings.ko", [
         // calls a function when the enter key is pressed on an input
         init: function (element, valueAccessor, allBindings, viewModel) {
             $(element).keypress(function (event) {
-                let keyCode = event.which ? event.which : event.keyCode;
-                if (event.key === "Enter" || keyCode === 13) {
+                if (event.key === "Enter" || event.keyCode === 13) {
                     valueAccessor()();
                     return false;
                 }

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
@@ -686,7 +686,7 @@ hqDefine("hqwebapp/js/knockout_bindings.ko", [
         init: function (element, valueAccessor, allBindings, viewModel) {
             $(element).keypress(function (event) {
                 let keyCode = (event.which ? event.which : event.keyCode);
-                if (keyCode === 13) {
+                if (event.key === "Enter" || keyCode === 13) {
                     valueAccessor()();
                     return false;
                 }

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
@@ -681,5 +681,19 @@ hqDefine("hqwebapp/js/knockout_bindings.ko", [
         },
     };
 
+    ko.bindingHandlers.onEnterKey = {
+        // calls a function when the enter key is pressed on an input
+        init: function (element, valueAccessor, allBindings, viewModel) {
+            $(element).keypress(function (event) {
+                let keyCode = (event.which ? event.which : event.keyCode);
+                if (keyCode === 13) {
+                    valueAccessor()();
+                    return false;
+                }
+                return true;
+            });
+        },
+    };
+
     return 1;
 });

--- a/corehq/apps/hqwebapp/tests/test_sso_enforced_login.py
+++ b/corehq/apps/hqwebapp/tests/test_sso_enforced_login.py
@@ -1,0 +1,242 @@
+import json
+
+from django.conf import settings
+from django.http import HttpResponseRedirect, JsonResponse
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.hqwebapp.forms import EmailAuthenticationForm
+from corehq.apps.sso.models import (
+    IdentityProvider,
+    AuthenticatedEmailDomain,
+    UserExemptFromSingleSignOn,
+)
+from corehq.apps.users.models import WebUser
+from corehq.apps.sso.tests import generator
+
+
+class TestHQLoginViewWithSso(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.account = generator.get_billing_account_for_idp()
+        cls.domain = Domain.get_or_create_with_name(
+            "helping-earth-001",
+            is_active=True
+        )
+        cls.non_sso_domain = Domain.get_or_create_with_name(
+            "my-project",
+            is_active=True
+        )
+        cls.user_sso_exempt = WebUser.create(
+            cls.domain.name, 'jorge@helpingearth.org', 'testpwd', None, None
+        )
+        cls.user_sso_required = WebUser.create(
+            cls.domain.name, 'sara@helpingearth.org', 'testpwd', None, None
+        )
+        cls.user_no_sso = WebUser.create(
+            cls.non_sso_domain.name, 'j@uni.edu', 'testpwd', None, None
+        )
+        cls.idp = IdentityProvider.objects.create(
+            owner=cls.account,
+            name='Azure AD for Helping Earth',
+            slug='helpingearth',
+            created_by='someadmin@dimagi.com',
+            last_modified_by='someadmin@dimagi.com',
+        )
+        cls.idp.create_service_provider_certificate()
+        email_domain = AuthenticatedEmailDomain.objects.create(
+            identity_provider=cls.idp,
+            email_domain='helpingearth.org'
+        )
+        UserExemptFromSingleSignOn.objects.create(
+            username=cls.user_sso_exempt.username,
+            email_domain=email_domain,
+        )
+        cls.idp.is_active = True
+        cls.idp.save()
+
+    def _get_login_response(self, username):
+        return self.client.post(
+            reverse('login'),
+            {
+                'auth-username': username,
+                'auth-password': 'testpwd',
+                'hq_login_view-current_step': 'auth',
+            },
+        )
+
+    def _get_sso_login_status_response(self, username):
+        return self.client.post(
+            reverse('check_sso_login_status'),
+            {
+                'username': username,
+            },
+        )
+
+    @override_settings(ENFORCE_SSO_LOGIN=True)
+    def test_get_context_has_sso_enabled_when_sso_is_enforced(self):
+        """
+        Ensure that on a get request of the login view that `enforce_sso_login`
+        in page's context is set to True if ENFORCE_SSO_LOGIN = True.
+        """
+        response = self.client.get(reverse('login'))
+        self.assertTrue(response.context['enforce_sso_login'])
+
+    @override_settings(ENFORCE_SSO_LOGIN=False)
+    def test_get_context_has_sso_disabled_when_sso_is_not_enforced(self):
+        """
+        Ensure that on a get request of the login view that `enforce_sso_login`
+        in page's context is set to False if ENFORCE_SSO_LOGIN = False.
+        """
+        response = self.client.get(reverse('login'))
+        self.assertFalse(response.context['enforce_sso_login'])
+
+    @override_settings(ENFORCE_SSO_LOGIN=False)
+    def test_login_works_if_sso_not_enforced(self):
+        """
+        Ensure that even an SSO-required user can login through the login
+        view if ENFORCE_SSO_LOGIN = False.
+        """
+        response = self._get_login_response(self.user_sso_required.username)
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertEqual(
+            response.url,
+            '/{}/'.format(settings.LOGIN_REDIRECT_URL)
+        )
+
+    @override_settings(ENFORCE_SSO_LOGIN=True)
+    def test_login_is_redirected_if_sso_is_enforced(self):
+        """
+        Ensure that an SSO-required user is redirected to the appropriate
+        login url for the Identity Provider if ENFORCE_SSO_LOGIN = True
+        """
+        response = self._get_login_response(self.user_sso_required.username)
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertEqual(
+            response.url,
+            self.idp.get_login_url(self.user_sso_required.username)
+        )
+
+    @override_settings(ENFORCE_SSO_LOGIN=True)
+    def test_login_works_for_non_sso_users_when_sso_is_enforced(self):
+        """
+        Ensure that a user without an SSO requirement can login
+        when ENFORCE_SSO_LOGIN = True
+        """
+        response = self._get_login_response(self.user_no_sso.username)
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertEqual(
+            response.url,
+            '/{}/'.format(settings.LOGIN_REDIRECT_URL)
+        )
+
+    @override_settings(ENFORCE_SSO_LOGIN=True)
+    def test_login_works_for_sso_exempt_users_when_sso_is_enforced(self):
+        """
+        Ensure that a user exempt from the SSO requirement can login
+        when ENFORCE_SSO_LOGIN = True
+        """
+        response = self._get_login_response(self.user_sso_exempt.username)
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertEqual(
+            response.url,
+            '/{}/'.format(settings.LOGIN_REDIRECT_URL)
+        )
+
+    def test_check_sso_login_status_for_non_sso_user(self):
+        """
+        Ensure that a user without an SSO login requirement returns the expected
+        response for the check_sso_login_status view.
+        """
+        response = self._get_sso_login_status_response(self.user_no_sso.username)
+        self.assertIsInstance(response, JsonResponse)
+        self.assertEqual(
+            json.loads(response.content),
+            {
+                'is_sso_required': False,
+                'sso_url': None,
+                'continue_text': None,
+            }
+        )
+
+    def test_check_sso_login_status_for_sso_user(self):
+        """
+        Ensure that an SSO user with an SSO login requirement returns the expected
+        response for the check_sso_login_status view.
+        """
+        response = self._get_sso_login_status_response(self.user_sso_required.username)
+        self.assertIsInstance(response, JsonResponse)
+        self.assertEqual(
+            json.loads(response.content),
+            {
+                'is_sso_required': True,
+                'sso_url': self.idp.get_login_url(self.user_sso_required.username),
+                'continue_text': 'Continue to {}'.format(self.idp.name),
+            }
+        )
+
+    def test_check_sso_login_status_for_sso_exempt_user(self):
+        """
+        Ensure that an SSO user exempt from theSSO login requirement returns
+        the expected response for the check_sso_login_status view.
+        """
+        response = self._get_sso_login_status_response(self.user_sso_exempt.username)
+        self.assertIsInstance(response, JsonResponse)
+        self.assertEqual(
+            json.loads(response.content),
+            {
+                'is_sso_required': False,
+                'sso_url': None,
+                'continue_text': None,
+            }
+        )
+
+
+class TestEmailAuthenticationFormWithSso(TestCase):
+
+    @override_settings(ENFORCE_SSO_LOGIN=True)
+    def test_form_has_extra_widget_attributes_when_sso_is_enforced(self):
+        """
+        Ensure that the attributes are inserted into the username and password
+        widgets of the EmailAuthenticationForm when ENFORCE_SSO_LOGIN = True
+        """
+        form = EmailAuthenticationForm()
+        self.assertEqual(
+            form.fields['username'].widget.attrs,
+            {
+                'class': 'form-control',
+                'data-bind': 'textInput: authUsername, onEnterKey: continueOnEnter',
+                'placeholder': "Enter email address",
+            }
+        )
+        self.assertEqual(
+            form.fields['password'].widget.attrs,
+            {
+                'class': 'form-control',
+                'placeholder': "Enter password",
+            }
+        )
+
+    @override_settings(ENFORCE_SSO_LOGIN=False)
+    def test_form_has_no_extra_widget_attributes_when_sso_is_not_enforced(self):
+        """
+        Ensure that the attributes remain the same on the widgets of username
+        and password in EmailAuthenticationForm when ENFORCE_SSO_LOGIN = False
+        """
+        form = EmailAuthenticationForm()
+        self.assertEqual(
+            form.fields['username'].widget.attrs,
+            {
+                'class': 'form-control',
+                'maxlength': '75',
+            }
+        )
+        self.assertEqual(
+            form.fields['password'].widget.attrs,
+            {
+                'class': 'form-control',
+            }
+        )

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -35,6 +35,7 @@ from corehq.apps.hqwebapp.views import (
     server_up,
     temporary_google_verify,
     yui_crossdomain,
+    check_sso_login_status,
 )
 from corehq.apps.settings.views import (
     TwoFactorBackupTokensView,
@@ -99,6 +100,7 @@ urlpatterns = [
         name=OauthApplicationRegistration.urlname
     ),
     url(r'^oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+    url(r'^check_sso_login_status/', check_sso_login_status, name='check_sso_login_status'),
 ]
 
 domain_specific = [

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -1372,3 +1372,29 @@ class OauthApplicationRegistration(BasePageView):
             ))
 
         return HttpResponseRedirect(reverse('oauth2_provider:detail', args=[str(base_application.id)]))
+
+
+@require_POST
+def check_sso_login_status(request):
+    """
+    Checks to see if a given username must sign in or sign up with SSO and
+    returns the url for the SSO's login endpoint.
+    :param request: HttpRequest
+    :return: HttpResponse (as JSON)
+    """
+    username = request.POST['username']
+    is_sso_required = False
+    sso_url = None
+    continue_text = None
+
+    idp = IdentityProvider.get_required_identity_provider(username)
+    if idp:
+        is_sso_required = True
+        sso_url = idp.get_login_url(username=username)
+        continue_text = _("Continue to {}").format(idp.name)
+
+    return JsonResponse({
+        'is_sso_required': is_sso_required,
+        'sso_url': sso_url,
+        'continue_text': continue_text,
+    })

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -475,6 +475,10 @@ class HQLoginView(LoginView):
     def get_context_data(self, **kwargs):
         context = super(HQLoginView, self).get_context_data(**kwargs)
         context.update(self.extra_context)
+        context['enforce_sso_login'] = (
+            settings.ENFORCE_SSO_LOGIN
+            and self.steps.current == 'auth'
+        )
         return context
 
 

--- a/corehq/apps/registration/static/registration/js/login.js
+++ b/corehq/apps/registration/static/registration/js/login.js
@@ -2,11 +2,15 @@ hqDefine('registration/js/login', [
     'jquery',
     'blazy/blazy',
     'analytix/js/kissmetrix',
+    'registration/js/user_login_form',
+    'hqwebapp/js/initial_page_data',
     'hqwebapp/js/captcha', // shows captcha
 ], function (
     $,
     blazy,
-    kissmetrics
+    kissmetrics,
+    userLoginForm,
+    initialPageData
 ) {
     $(function () {
         // Blazy for loading images asynchronously
@@ -24,6 +28,17 @@ hqDefine('registration/js/login', [
             if (usernameElt) {
                 usernameElt.value = username;
             }
+        }
+
+        if (initialPageData.get('enforce_sso_login')) {
+            let $passwordField = $('#id_auth-password');
+            let loginController = userLoginForm.loginController({
+                initialUsername: $('#id_auth-username').val(),
+                passwordField: $passwordField,
+                passwordFormGroup: $passwordField.closest('.form-group'),
+            });
+            $('#user-login-form').koApplyBindings(loginController);
+            loginController.init();
         }
 
         kissmetrics.whenReadyAlways(function () {

--- a/corehq/apps/registration/static/registration/js/user_login_form.js
+++ b/corehq/apps/registration/static/registration/js/user_login_form.js
@@ -1,0 +1,147 @@
+hqDefine('registration/js/user_login_form', [
+    'jquery',
+    'knockout',
+    'hqwebapp/js/initial_page_data',
+    'hqwebapp/js/assert_properties',
+    'hqwebapp/js/utils/email',
+    'hqwebapp/js/knockout_bindings.ko',
+], function (
+    $,
+    ko,
+    initialPageData,
+    assertProperties,
+    emailUtils
+) {
+    'use strict';
+
+    let loginController = function (options) {
+        assertProperties.assertRequired(options, [
+            'initialUsername',
+            'passwordField',
+            'passwordFormGroup',
+        ]);
+        let self = {};
+
+        self.checkSsoLoginStatusUrl = initialPageData.reverse('check_sso_login_status');
+        self.passwordField = options.passwordField;
+        self.passwordFormGroup = options.passwordFormGroup;
+        self.passwordFormGroup.hide();
+
+        self.authUsername = ko.observable(options.initialUsername);
+        self.authUsername.subscribe(function (newValue) {
+            if (emailUtils.validateEmail(newValue)) {
+                if (self.continueTextPromise) {
+                    self.continueTextPromise.abort();
+                }
+                self.updateContinueText();
+            }
+        });
+
+        self.continueTextPromise = null;
+        self.defaultContinueText = gettext("Continue");
+        self.continueButtonText = ko.observable(self.defaultContinueText);
+        self.showContinueButton = ko.observable(true);
+        self.showContinueSpinner = ko.observable(false);
+
+        self.isContinueDisabled = ko.computed(function () {
+            return !emailUtils.validateEmail(self.authUsername());
+        });
+
+        self.showSignInButton = ko.observable(false);
+
+        /**
+         * This updates the "Continue" Button text with either "Continue"
+         * or "Continue to <IdentityProvider>".
+         * @param {boolean} expandPasswordField - (optional) if this is true, auto expand password field
+         */
+        self.updateContinueText = function (expandPasswordField = false) {
+            self.continueTextPromise = $.post(self.checkSsoLoginStatusUrl, {
+                username: self.authUsername(),
+            }, function (data) {
+                if (data.continue_text) {
+                    self.continueButtonText(data.continue_text);
+                    if (self.showSignInButton()) {
+                        self.resetLoginState();
+                    }
+                } else {
+                    self.continueButtonText(self.defaultContinueText);
+                    if (expandPasswordField) self.continueToPasswordLogin();
+                }
+            })
+                .fail(function () {
+                    self.continueButtonText(self.defaultContinueText);
+                    if (expandPasswordField) self.continueToPasswordLogin();
+                });
+        };
+
+        /**
+         * This resets the login state to just the username field and the
+         * "Continue <etc>" button.
+         */
+        self.resetLoginState = function () {
+            self.passwordFormGroup.slideUp('fast', function() {
+                self.showContinueButton(true);
+                self.showSignInButton(false);
+            });
+        };
+
+        /**
+         * This decides whether we should ask the user for a password or
+         * redirect the user to the SSO login page.
+         */
+        self.proceedToNextStep = function () {
+            self.showContinueSpinner(true);
+            $.post(self.checkSsoLoginStatusUrl, {
+                username: self.authUsername(),
+            }, function (data) {
+                if (data.is_sso_required) {
+                    self.continueToSsoLogin(data.sso_url);
+                } else {
+                    self.continueToPasswordLogin();
+                }
+            })
+                .fail(function () {
+                    self.continueToPasswordLogin();
+                })
+                .always(function () {
+                    self.showContinueSpinner(false);
+                });
+        };
+
+        /**
+         * This overrides the natural "next step" for the enter key,
+         * which is to focus on the password field. Instead we want to "click"
+         * the continue button then re-focus on the password field if needed.
+         */
+        self.continueOnEnter = function () {
+            if (self.isContinueDisabled()) return;
+            self.proceedToNextStep();
+        };
+
+        self.continueToSsoLogin = function (sso_url) {
+            window.location = sso_url;
+        };
+
+        self.continueToPasswordLogin = function () {
+            self.passwordFormGroup.slideDown('fast', function() {
+                self.showContinueButton(false);
+                self.showSignInButton(true);
+                self.passwordField.focus();
+            });
+        };
+
+        self.init = function () {
+            if (self.authUsername()) {
+                // make sure that on initialization we update the continue text
+                // if the username field is already populated.
+                self.updateContinueText(true);
+            }
+        };
+
+        return self;
+    };
+
+    return {
+        loginController: loginController,
+    }
+});

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -313,9 +313,7 @@ class IdentityProvider(models.Model):
         :param username: String
         :return: IdentityProvider or None
         """
-        idp = cls.get_active_identity_provider_by_username(
-            username
-        )
+        idp = cls.get_active_identity_provider_by_username(username)
         if idp and not UserExemptFromSingleSignOn.objects.filter(
             username=username
         ).exists():

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -320,6 +320,7 @@ class IdentityProvider(models.Model):
             username=username
         ).exists():
             return idp
+        return None
 
 
 @receiver(post_save, sender=Subscription)

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
+from django.urls import reverse
 
 from corehq.apps.accounting.models import BillingAccount, Subscription
 from corehq.apps.sso import certificates
@@ -135,6 +136,19 @@ class IdentityProvider(models.Model):
         return UserExemptFromSingleSignOn.objects.filter(
             email_domain__identity_provider=self,
         ).values_list('username', flat=True)
+
+    def get_login_url(self, username=None):
+        """
+        Gets the login endpoint for the IdentityProvider based on the protocol
+        being used. Since we only support SAML2 right now, this redirects to
+        the SAML2 login endpoint.
+        :param username: (string) username to pre-populate IdP login with
+        :return: (String) identity provider login url
+        """
+        return '{}?username={}'.format(
+            reverse('sso_saml_login', args=(self.slug,)),
+            username
+        )
 
     def get_active_projects(self):
         """

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -305,6 +305,22 @@ class IdentityProvider(models.Model):
             return True
         return idp.does_domain_trust_this_idp(domain)
 
+    @classmethod
+    def get_required_identity_provider(cls, username):
+        """
+        Gets the Identity Provider for the given username only if that
+        user is required to login or sign up with that Identity Provider.
+        :param username: String
+        :return: IdentityProvider or None
+        """
+        idp = cls.get_active_identity_provider_by_username(
+            username
+        )
+        if idp and not UserExemptFromSingleSignOn.objects.filter(
+            username=username
+        ).exists():
+            return idp
+
 
 @receiver(post_save, sender=Subscription)
 @receiver(post_delete, sender=Subscription)

--- a/corehq/apps/sso/views/saml.py
+++ b/corehq/apps/sso/views/saml.py
@@ -204,7 +204,7 @@ def sso_saml_login(request, idp_slug):
     This view initiates a SAML 2.0 login request with the Identity Provider.
     """
     login_url = request.saml2_auth.login()
-    username = get_sso_username_from_session(request)
+    username = get_sso_username_from_session(request) or request.GET.get('username')
     if username:
         # verify that the stored user data actually the current IdP
         idp = IdentityProvider.get_active_identity_provider_by_username(username)

--- a/settings.py
+++ b/settings.py
@@ -21,6 +21,7 @@ VELLUM_DEBUG = None
 
 # For Single Sign On (SSO) Implementations
 SAML2_DEBUG = False
+ENFORCE_SSO_LOGIN = False
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## Summary
Review commit-by-commit.
This addresses the following ticket: https://dimagi-dev.atlassian.net/browse/SS-101

The Sign In user experience has been altered to ensure that we enforce SSO login for users whose email domain is tied to an active Identity Provider.

NOTE: This is only applicable when the `ENFORCE_SSO_LOGIN` in `localsettings` is set to `True` (it is `False` by default). Changes were very carefully applied to ensure that the current login experience is not altered by this update. Once reviewed, this code is safe to merge into production without QA as production will not have `ENFORCE_SSO_LOGIN` enabled.

## Feature Flag
more like a `localsettings` "flag": `ENFORCE_SSO_LOGIN`

## Product Description
<img width="591" alt="Screen Shot 2021-05-12 at 2 41 35 PM" src="https://user-images.githubusercontent.com/716573/118193255-0405de00-b40d-11eb-9869-418437865e1b.png">
<img width="521" alt="Screen Shot 2021-05-12 at 2 41 52 PM" src="https://user-images.githubusercontent.com/716573/118193276-0b2cec00-b40d-11eb-8c52-d8d13602dbac.png">
<img width="523" alt="Screen Shot 2021-05-12 at 2 41 57 PM" src="https://user-images.githubusercontent.com/716573/118193296-1253fa00-b40d-11eb-8934-f3fb2f1c896f.png">
<img width="698" alt="Screen Shot 2021-05-12 at 2 46 50 PM" src="https://user-images.githubusercontent.com/716573/118193309-1718ae00-b40d-11eb-8207-597ea7821f34.png">


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
In the process of assessing difficulty for writing JS tests for this. I am about to upgrade `sinon`, so I think I will dive into JS tests on a separate PR.

### QA Plan
QA will happen once all the SSO changes have been made and merged.

### Safety story
This feature is not active unless `ENFORCE_SSO_LOGIN` is set to `True` in `localsettings`, so it does not affect any existing active workflow.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
