### PR TITLE
fix + improvements to PopulateSQLCommand diff utilities

### DIFF
--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -64,7 +64,7 @@ class PopulateSQLCommand(BaseCommand):
             couch = wrap_couch(couch) if couch is not None else None
         if wrap_sql:
             sql = wrap_sql(sql) if sql is not None else None
-        cls.diff_value(name, couch, sql, name_prefix)
+        return cls.diff_value(name, couch, sql, name_prefix)
 
     @classmethod
     def diff_value(cls, name, couch, sql, name_prefix=None):
@@ -81,7 +81,7 @@ class PopulateSQLCommand(BaseCommand):
             for couch_field, sql_field in list(zip(docs, objects)):
                 if attr_list:
                     for attr in attr_list:
-                        diffs.append(cls.diff_attr(attr, couch_field, sql_field, name))
+                        diffs.append(cls.diff_attr(attr, couch_field, sql_field, name_prefix=name))
                 else:
                     diffs.append(cls.diff_value(name, couch_field, sql_field))
         return diffs

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -47,8 +47,9 @@ class PopulateSQLCommand(BaseCommand):
     def diff_couch_and_sql(cls, couch, sql):
         """
         This should compare each attribute of the given couch document and sql object.
-        Return a human-reaedable string describing their differences, or None if the
-        two are equivalent.
+        Return a list of human-reaedable strings describing their differences, or None if the
+        two are equivalent. The list may contain `None` or empty strings which will be filtered
+        out before display.
         """
         raise NotImplementedError()
 
@@ -205,6 +206,9 @@ class PopulateSQLCommand(BaseCommand):
             couch_id_name = getattr(self.sql_class(), '_migration_couch_id_name', 'couch_id')
             obj = self.sql_class().objects.get(**{couch_id_name: doc["_id"]})
             diff = self.diff_couch_and_sql(doc, obj)
+            if isinstance(diff, list):
+                diffs = filter(None, diff)
+                diff = "\n".join(diffs) if diffs else None
             if diff:
                 logger.info(f"Doc {getattr(obj, couch_id_name)} has differences:\n{diff}")
                 self.diff_count += 1

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -53,7 +53,7 @@ class PopulateSQLCommand(BaseCommand):
         raise NotImplementedError()
 
     @classmethod
-    def diff_attr(cls, name, doc, obj, wrap_couch=None, wrap_sql=None):
+    def diff_attr(cls, name, doc, obj, wrap_couch=None, wrap_sql=None, name_prefix=None):
         """
         Helper for diff_couch_and_sql
         """
@@ -64,17 +64,18 @@ class PopulateSQLCommand(BaseCommand):
         if wrap_sql:
             sql = wrap_sql(sql) if sql is not None else None
         if couch != sql:
-            return f"{name}: couch value {couch!r} != sql value {sql!r}"
+            name_prefix = "" if name_prefix is None else f"{name_prefix}."
+            return f"{name_prefix}{name}: couch value {couch!r} != sql value {sql!r}"
 
     @classmethod
-    def diff_lists(cls, docs, objects, attr_list):
+    def diff_lists(cls, name, docs, objects, attr_list=None):
         diffs = []
         if len(docs) != len(objects):
-            diffs.append(f"{len(docs)} in couch != {len(objects)} in sql")
+            diffs.append(f"{name}: {len(docs)} in couch != {len(objects)} in sql")
         else:
             for couch_field, sql_field in list(zip(docs, objects)):
                 for attr in attr_list:
-                    diffs.append(cls.diff_attr(attr, couch_field, sql_field))
+                    diffs.append(cls.diff_attr(attr, couch_field, sql_field, name))
         return diffs
 
     @classmethod

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -70,7 +70,7 @@ class PopulateSQLCommand(BaseCommand):
     def diff_lists(cls, docs, objects, attr_list):
         diffs = []
         if len(docs) != len(objects):
-            diffs.append(f"{len(docs)} in couch != {len(attr_list)} in sql")
+            diffs.append(f"{len(docs)} in couch != {len(objects)} in sql")
         else:
             for couch_field, sql_field in list(zip(docs, objects)):
                 for attr in attr_list:

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -63,6 +63,10 @@ class PopulateSQLCommand(BaseCommand):
             couch = wrap_couch(couch) if couch is not None else None
         if wrap_sql:
             sql = wrap_sql(sql) if sql is not None else None
+        cls.diff_value(name, couch, sql, name_prefix)
+
+    @classmethod
+    def diff_value(cls, name, couch, sql, name_prefix=None):
         if couch != sql:
             name_prefix = "" if name_prefix is None else f"{name_prefix}."
             return f"{name_prefix}{name}: couch value {couch!r} != sql value {sql!r}"
@@ -74,8 +78,11 @@ class PopulateSQLCommand(BaseCommand):
             diffs.append(f"{name}: {len(docs)} in couch != {len(objects)} in sql")
         else:
             for couch_field, sql_field in list(zip(docs, objects)):
-                for attr in attr_list:
-                    diffs.append(cls.diff_attr(attr, couch_field, sql_field, name))
+                if attr_list:
+                    for attr in attr_list:
+                        diffs.append(cls.diff_attr(attr, couch_field, sql_field, name))
+                else:
+                    diffs.append(cls.diff_value(name, couch_field, sql_field))
         return diffs
 
     @classmethod

--- a/corehq/apps/cleanup/management/commands/templates/populate_command.j2
+++ b/corehq/apps/cleanup/management/commands/templates/populate_command.j2
@@ -20,6 +20,19 @@ class Command(PopulateSQLCommand):
     def commit_adding_migration(cls):
         return "TODO: add once the PR adding this file is merged"
 
+    @classmethod
+    def diff_couch_and_sql(cls, couch, sql):
+        """
+        This should compare each attribute of the given couch document and sql object.
+        Return a list of human-reaedable strings describing their differences, or None if the
+        two are equivalent. The list may contain `None` or empty strings which will be filtered
+        out before display.
+
+        Note: `diff_value`, `diff_attr` and `diff_lists` methods of `PopulateSQLCommand` are useful
+        helpers.
+        """
+        return None
+
     def update_or_create_sql_object(self, doc):
         model, created = self.sql_class().objects.update_or_create(
             couch_id=doc['_id'],

--- a/corehq/apps/cleanup/tests/test_couch_to_sql_commtrack.py
+++ b/corehq/apps/cleanup/tests/test_couch_to_sql_commtrack.py
@@ -194,14 +194,14 @@ class TestCouchToSQLCommtrackConfig(TestCase):
     def test_diff_identical(self):
         couch = self._create_unsynced_couch().to_json()
         sql = self._create_unsynced_sql()
-        self.assertIsNone(Command.diff_couch_and_sql(couch, sql))
+        self.assertIsNone(Command.get_diff_as_string(couch, sql))
 
     def test_diff_top_level_attributes(self):
         couch = self._create_unsynced_couch().to_json()
         sql = self._create_unsynced_sql()
         couch['domain'] = 'other_project'
         couch['use_auto_emergency_levels'] = True
-        self.assertEqual(Command.diff_couch_and_sql(couch, sql), "\n".join([
+        self.assertEqual(Command.get_diff_as_string(couch, sql), "\n".join([
             "domain: couch value 'other_project' != sql value 'my_project'",
             "use_auto_emergency_levels: couch value True != sql value False",
         ]))
@@ -212,21 +212,21 @@ class TestCouchToSQLCommtrackConfig(TestCase):
         couch['consumption_config']['min_window'] = 4
         couch['ota_restore_config']['force_consumption_case_types'] = ['type2']
         couch['ota_restore_config']['section_to_consumption_types'] = {'s1': 'c1', 's2': 'c2'}
-        self.assertEqual(Command.diff_couch_and_sql(couch, sql), "\n".join([
-            "min_window: couch value 4 != sql value 2",
-            "section_to_consumption_types: couch value {'s1': 'c1', 's2': 'c2'} != sql value {'s1': 'c1'}",
-            "force_consumption_case_types: couch value ['type2'] != sql value ['type1']",
+        self.assertEqual(Command.get_diff_as_string(couch, sql), "\n".join([
+            "consumption_config.min_window: couch value 4 != sql value 2",
+            "ota_restore_config.section_to_consumption_types: couch value {'s1': 'c1', 's2': 'c2'} != sql value {'s1': 'c1'}",
+            "ota_restore_config.force_consumption_case_types: couch value ['type2'] != sql value ['type1']",
         ]))
 
     def test_diff_remove_submodel(self):
         couch = self._create_unsynced_couch().to_json()
         sql = self._create_unsynced_sql()
         couch.pop('alert_config')
-        self.assertEqual(Command.diff_couch_and_sql(couch, sql), "\n".join([
-            "stock_out_facilities: couch value None != sql value True",
-            "stock_out_commodities: couch value None != sql value True",
-            "stock_out_rates: couch value None != sql value True",
-            "non_report: couch value None != sql value True",
+        self.assertEqual(Command.get_diff_as_string(couch, sql), "\n".join([
+            "alert_config.stock_out_facilities: couch value None != sql value True",
+            "alert_config.stock_out_commodities: couch value None != sql value True",
+            "alert_config.stock_out_rates: couch value None != sql value True",
+            "alert_config.non_report: couch value None != sql value True",
         ]))
 
     def test_diff_action_attributes(self):
@@ -234,9 +234,9 @@ class TestCouchToSQLCommtrackConfig(TestCase):
         sql = self._create_unsynced_sql()
         couch['actions'][0]['subaction'] = 'other-subaction'
         couch['actions'][1]['_keyword'] = 'dos'
-        self.assertEqual(Command.diff_couch_and_sql(couch, sql), "\n".join([
-            "subaction: couch value 'other-subaction' != sql value 'sub-receipts'",
-            "_keyword: couch value 'dos' != sql value 'two'",
+        self.assertEqual(Command.get_diff_as_string(couch, sql), "\n".join([
+            "actions.subaction: couch value 'other-subaction' != sql value 'sub-receipts'",
+            "actions._keyword: couch value 'dos' != sql value 'two'",
         ]))
 
     def test_diff_action_order(self):
@@ -244,11 +244,11 @@ class TestCouchToSQLCommtrackConfig(TestCase):
         sql = self._create_unsynced_sql()
         (action1, action2) = couch['actions']
         couch['actions'] = [action2, action1]
-        self.assertEqual(Command.diff_couch_and_sql(couch, sql), "\n".join([
-            "_keyword: couch value 'two' != sql value 'one'",
-            "caption: couch value 'second action' != sql value 'first action'",
-            "_keyword: couch value 'one' != sql value 'two'",
-            "caption: couch value 'first action' != sql value 'second action'",
+        self.assertEqual(Command.get_diff_as_string(couch, sql), "\n".join([
+            "actions._keyword: couch value 'two' != sql value 'one'",
+            "actions.caption: couch value 'second action' != sql value 'first action'",
+            "actions._keyword: couch value 'one' != sql value 'two'",
+            "actions.caption: couch value 'first action' != sql value 'second action'",
         ]))
 
     def test_wrap_action_config(self):

--- a/corehq/apps/cleanup/tests/test_couch_to_sql_mobile_auth.py
+++ b/corehq/apps/cleanup/tests/test_couch_to_sql_mobile_auth.py
@@ -30,7 +30,7 @@ class TestCouchToSQLMobileAuth(TestCase):
         expires = valid + timedelta(days=30)
         couch = MobileAuthKeyRecord(domain='my-domain', user_id='123', valid=valid, expires=expires, key=key)
         sql = SQLMobileAuthKeyRecord(domain='my-domain', user_id='123', valid=valid, expires=expires, key=key)
-        self.assertIsNone(Command.diff_couch_and_sql(couch.to_json(), sql))
+        self.assertIsNone(Command.get_diff_as_string(couch.to_json(), sql))
 
     def test_diff_top_level_attributes(self):
         valid = datetime.utcnow()
@@ -39,7 +39,7 @@ class TestCouchToSQLMobileAuth(TestCase):
         couch = MobileAuthKeyRecord(domain='my-domain', user_id='123', valid=valid, expires=expires1)
         sql = SQLMobileAuthKeyRecord(domain='other-domain', user_id='123', valid=valid, expires=expires2)
 
-        (domain_diff, key_diff, expires_diff) = Command.diff_couch_and_sql(couch.to_json(), sql).split("\n")
+        (domain_diff, key_diff, expires_diff) = Command.get_diff_as_string(couch.to_json(), sql).split("\n")
         self.assertEqual(domain_diff, "domain: couch value 'my-domain' != sql value 'other-domain'")
         self.assertRegex(
             key_diff,

--- a/corehq/apps/commtrack/management/commands/populate_commtrackconfig.py
+++ b/corehq/apps/commtrack/management/commands/populate_commtrackconfig.py
@@ -43,8 +43,7 @@ class Command(PopulateSQLCommand):
             for attr in spec['fields']:
                 diffs.append(cls.diff_attr(attr, couch_submodel, sql_submodel,
                              wrap_couch=normalize, wrap_sql=normalize, name_prefix=spec['couch_attr']))
-        diffs = [d for d in diffs if d]
-        return "\n".join(diffs) if diffs else None
+        return diffs
 
     @classmethod
     def attrs_to_sync(cls):

--- a/corehq/apps/commtrack/management/commands/populate_commtrackconfig.py
+++ b/corehq/apps/commtrack/management/commands/populate_commtrackconfig.py
@@ -33,7 +33,7 @@ class Command(PopulateSQLCommand):
         diffs = []
         for attr in cls.attrs_to_sync():
             diffs.append(cls.diff_attr(attr, doc, obj))
-        diffs.extend(cls.diff_lists(doc.get('actions', []), obj.all_actions, [
+        diffs.extend(cls.diff_lists('actions', doc.get('actions', []), obj.all_actions, [
             'action', 'subaction', '_keyword', 'caption'
         ]))
         for spec in cls.one_to_one_submodels():
@@ -42,7 +42,7 @@ class Command(PopulateSQLCommand):
             couch_submodel = doc.get(spec['couch_attr'], {})
             for attr in spec['fields']:
                 diffs.append(cls.diff_attr(attr, couch_submodel, sql_submodel,
-                             wrap_couch=normalize, wrap_sql=normalize))
+                             wrap_couch=normalize, wrap_sql=normalize, name_prefix=spec['couch_attr']))
         diffs = [d for d in diffs if d]
         return "\n".join(diffs) if diffs else None
 

--- a/corehq/apps/commtrack/tests/test_utils.py
+++ b/corehq/apps/commtrack/tests/test_utils.py
@@ -84,7 +84,7 @@ class CommtrackUtilsTest(TestCase):
             }
         })
         doc = CommtrackConfig.get_db().get(config.couch_id)
-        self.assertIsNone(Command.diff_couch_and_sql(doc, config))
+        self.assertIsNone(Command.get_diff_as_string(doc, config))
         config.delete()
         domain_obj.delete()
 

--- a/corehq/apps/custom_data_fields/management/commands/populate_custom_data_fields.py
+++ b/corehq/apps/custom_data_fields/management/commands/populate_custom_data_fields.py
@@ -28,8 +28,7 @@ class Command(PopulateSQLCommand):
         diffs.extend(cls.diff_lists('fields', doc.get('fields', []), obj.get_fields(), [
             'slug', 'is_required', 'label', 'choices', 'regex', 'regex_msg'
         ]))
-        diffs = [d for d in diffs if d]
-        return "\n".join(diffs) if diffs else None
+        return diffs
 
     def update_or_create_sql_object(self, doc):
         model, created = self.sql_class().objects.update_or_create(

--- a/corehq/apps/custom_data_fields/management/commands/populate_custom_data_fields.py
+++ b/corehq/apps/custom_data_fields/management/commands/populate_custom_data_fields.py
@@ -25,7 +25,7 @@ class Command(PopulateSQLCommand):
         diffs = []
         for attr in ('field_type', 'domain'):
             diffs.append(cls.diff_attr(attr, doc, obj))
-        diffs.extend(cls.diff_lists(doc.get('fields', []), obj.get_fields(), [
+        diffs.extend(cls.diff_lists('fields', doc.get('fields', []), obj.get_fields(), [
             'slug', 'is_required', 'label', 'choices', 'regex', 'regex_msg'
         ]))
         diffs = [d for d in diffs if d]

--- a/corehq/apps/mobile_auth/management/commands/populate_mobileauthkeyrecord.py
+++ b/corehq/apps/mobile_auth/management/commands/populate_mobileauthkeyrecord.py
@@ -24,8 +24,7 @@ class Command(PopulateSQLCommand):
             diffs.append(cls.diff_attr(attr, couch, sql))
         for attr in ["valid", "expires"]:
             diffs.append(cls.diff_attr(attr, couch, sql, wrap_couch=string_to_utc_datetime))
-        diffs = [d for d in diffs if d]
-        return "\n".join(diffs) if diffs else None
+        return diffs
 
     def update_or_create_sql_object(self, doc):
         # Use get_or_create so that if sql model exists we don't bother saving it,


### PR DESCRIPTION
## Summary
* fix to the diff message
* allow including a name for lists and for submodels
* allow diffing plain lists
* allow returning a raw list of diffs instead of a string
* add diff_couch_and_sql to the populate command template

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
