### PR TITLE
Close all select2 dropdowns before showing timed-out modal.

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -117,7 +117,7 @@ hqDefine('hqwebapp/js/inactivity', [
                 type: 'GET',
                 success: function (data) {
                     if (!data.success) {
-                        _.each($(".select2-hidden-accessible"), function(el) {
+                        _.each($(".select2-hidden-accessible"), function (el) {
                             $(el).select2('close');
                         });
                         log("ping_login failed, showing login modal");
@@ -134,7 +134,6 @@ hqDefine('hqwebapp/js/inactivity', [
                             $body.html(content);
                             $body.find("iframe").on("load", pollToHideModal);
                         });
-
                         $body.html('<h1 class="text-center"><i class="fa fa-spinner fa-spin"></i></h1>');
                         hideWarningModal(true);
                     } else {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -117,6 +117,9 @@ hqDefine('hqwebapp/js/inactivity', [
                 type: 'GET',
                 success: function (data) {
                     if (!data.success) {
+                        _.each($(".select2-hidden-accessible"), function(el) {
+                            $(el).select2('close');
+                        });
                         log("ping_login failed, showing login modal");
                         var $body = $modal.find(".modal-body");
                         var src = initialPageData.reverse('iframe_domain_login');
@@ -131,6 +134,7 @@ hqDefine('hqwebapp/js/inactivity', [
                             $body.html(content);
                             $body.find("iframe").on("load", pollToHideModal);
                         });
+
                         $body.html('<h1 class="text-center"><i class="fa fa-spinner fa-spin"></i></h1>');
                         hideWarningModal(true);
                     } else {


### PR DESCRIPTION
## Summary
When a user session times out while a select2 dropdown is open, the dropdown is visible over the timed-out/login modal. 
This closes all open dropdowns before modal is displayed.

[USH-842](https://dimagi-dev.atlassian.net/browse/USH-842)
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Product Description
When user session times out any open select2 dropdown is closed and hidden as expected.
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
none
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
none required
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
Changes affect a very specific case of open dropdown during session timeout. Unlikely to have any effect outside this scenario.
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
