### PR TITLE
Fixed covid autodoc

### DIFF
--- a/corehq/messaging/smsbackends/amazon_pinpoint/models.py
+++ b/corehq/messaging/smsbackends/amazon_pinpoint/models.py
@@ -1,4 +1,3 @@
-import boto3
 from botocore.exceptions import ClientError
 from corehq.apps.sms.models import SQLSMSBackend
 from corehq.apps.sms.util import clean_phone_number
@@ -36,6 +35,7 @@ class PinpointBackend(SQLSMSBackend):
         return PinpointBackendForm
 
     def send(self, msg, *args, **kwargs):
+        import boto3    # avoid top-level import that breaks docs build
         phone_number = clean_phone_number(msg.phone_number)
         config = self.config
         client = boto3.client(

--- a/custom/covid/rules/custom_actions.py
+++ b/custom/covid/rules/custom_actions.py
@@ -1,3 +1,9 @@
+"""
+COVID: Available Actions
+------------------------
+
+The following actions can be used in messaging in projects using the ``covid`` custom module.
+"""
 from corehq.apps.es.case_search import CaseSearchES, flatten_result
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.es.cases import case_type
@@ -10,8 +16,12 @@ def close_cases_assigned_to_checkin(checkin_case, rule):
     """
     For any associated checkin case that matches the rule criteria, the following occurs:
 
-    1. For all cases of type [x] find all fields where [assigned_to_primary_checkin_case_id] is set
-           to the case ID of the associated checkin case. These are the assigned cases.
+    1. For all cases of a given type, find all assigned cases. \
+       An assigned case is a case for which all of the following are true:
+
+       - Case type patient or contact
+       - Exists in the same domain as the user case
+       - The case property assigned_to_primary_checkin_case_id equals an associated checkin case's case_id
 
     2. For every assigned case, the following case properties are blanked out (set to ""):
 
@@ -58,15 +68,6 @@ def close_cases_assigned_to_checkin(checkin_case, rule):
 
 
 def _get_assigned_cases(checkin_case):
-    """
-    An assigned case is a case for which all of the following are true:
-
-    - Case type patient or contact
-    - Exists in the same domain as the user case
-    - The case property assigned_to_primary_checkin_case_id equals an associated checkin case's case_id
-
-    """
-
     query = (
         CaseSearchES()
         .domain(checkin_case.domain)

--- a/custom/covid/rules/custom_criteria.py
+++ b/custom/covid/rules/custom_criteria.py
@@ -1,3 +1,9 @@
+"""
+COVID: Available Criteria
+-------------------------
+
+The following criteria can be used in messaging in projects using the ``covid`` custom module.
+"""
 from corehq.apps.es.case_search import CaseSearchES, flatten_result
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.app_manager.const import USERCASE_TYPE

--- a/docs/icds_dashboard.rst
+++ b/docs/icds_dashboard.rst
@@ -1,5 +1,0 @@
-ICDS Dashboard
-==============
-
-.. automodule:: custom.icds_reports.models.views
-   :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ Data is transmitted from the phone to the server (and vis-a-versa) over a secure
     apps/advanced_app_features
     apps/builds
     cloudcare
+    formplayer
 
 .. toctree::
     :caption: Application Data Layer
@@ -67,6 +68,7 @@ Data is transmitted from the phone to the server (and vis-a-versa) over a secure
     ucr
     change_feeds
     pillows
+    email_monitoring_SES
 
 .. toctree::
     :caption: Messaging
@@ -116,6 +118,8 @@ Data is transmitted from the phone to the server (and vis-a-versa) over a secure
     commtrack
     elasticsearch
     es_query
+    middleware
+    migration_command_pattern
     nfs
     forms_and_cases
     couchdb


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/29707

This is a little bit awful, which seems to be par for the course with docs build issues. Build was failing with

```
WARNING: autodoc: failed to import module 'custom_actions' from module 'custom.covid.rules'; the following exception was raised:
Traceback (most recent call last):
  File "/Users/jschweers/.pyenv/versions/3.6.8/lib/python3.6/site-packages/sphinx/ext/autodoc/importer.py", line 71, in import_module
    return importlib.import_module(modname)
  File "/Users/jschweers/.pyenv/versions/3.6.8/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
...
  File "/Users/jschweers/.pyenv/versions/3.6.8/lib/python3.6/site-packages/botocore/httpsession.py", line 17, in <module>
    from urllib3.contrib.pyopenssl import orig_util_SSLContext as SSLContext
  File "/Users/jschweers/.pyenv/versions/3.6.8/lib/python3.6/site-packages/urllib3/contrib/pyopenssl.py", line 101, in <module>
    + OpenSSL.SSL.VERIFY_FAIL_IF_NO_PEER_CERT,
TypeError: unsupported operand type(s) for +: 'VERIFY_PEER' and 'VERIFY_FAIL_IF_NO_PEER_CERT'
```

https://github.com/dimagi/commcare-hq/pull/29141 configured the docs build to mock OpenSSL because ReadTheDocs can't support it, but one of our dependencies leads to a top-level import of some constants in OpenSSL. Presumably, these get interpreted as None due to the mock, which then causes the operand error.

The simplest way to fix this is to get the erroring import out of the top-level imports.

This PR also fixes a very small number of our very many docs warnings.