### PR TITLE
Fixed overwrite of case details

### DIFF
--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -852,7 +852,6 @@ def overwrite_module_case_list(request, domain, app_id, module_unique_id):
             )
         return back_to_main(request, domain, app_id=app_id, module_unique_id=module_unique_id)
 
-    not_updated_modules = []
     for dest_module_unique_id in dest_module_unique_ids:
         dest_module = app.get_module_by_unique_id(dest_module_unique_id)
         if dest_module.case_type != src_module.case_type:
@@ -874,12 +873,7 @@ def overwrite_module_case_list(request, domain, app_id, module_unique_id):
                     message=f'Error in updating module: {dest_module.default_name()}',
                     details={'domain': domain, 'app_id': app_id, }
                 )
-                not_updated_modules.append(dest_module.default_name())
-
-    if not_updated_modules:
-        _error_msg = _("Failed to overwrite case lists to menu(s): {}.").format(
-            ", ".join(map(str, not_updated_modules)))
-        messages.error(request, _error_msg)
+                messages.error(request, _("Could not update {}").format(dest_module.default_name()))
 
     app.save()
     return back_to_main(request, domain, app_id=app_id, module_unique_id=module_unique_id)

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -874,11 +874,11 @@ def overwrite_module_case_list(request, domain, app_id, module_unique_id):
             try:
                 if detail_type == "short":
                     if detail_attrs:
-                        _update_module_detail(detail_type, src_module, dest_module, detail_attrs)
+                        _update_module_short_detail(detail_type, src_module, dest_module, detail_attrs)
                     if search_attrs:
                         _update_module_search_config(src_module, dest_module, search_attrs)
                 else:
-                    _update_module_detail(detail_type, src_module, dest_module, detail_attrs)
+                    _update_module_long_detail(detail_type, src_module, dest_module)
                 updated_modules.append(dest_module.default_name())
             except Exception:
                 notify_exception(
@@ -919,13 +919,14 @@ def _update_module_search_config(src_module, dest_module, search_attrs):
     dest_config.overwrite_attrs(src_config, search_attrs)
 
 
-def _update_module_detail(detail_type, src_module, dest_module, detail_attrs):
-    if detail_type == 'long':
-        setattr(dest_module.case_details, detail_type, getattr(src_module.case_details, detail_type))
-    else:
-        src_detail = getattr(src_module.case_details, detail_type)
-        dest_detail = getattr(dest_module.case_details, detail_type)
-        dest_detail.overwrite_attrs(src_detail, detail_attrs)
+def _update_module_short_detail(src_module, dest_module, detail_attrs):
+    src_detail = getattr(src_module.case_details, "short")
+    dest_detail = getattr(dest_module.case_details, "short")
+    dest_detail.overwrite_attrs(src_detail, detail_attrs)
+
+
+def _update_module_long_detail(src_module, dest_module):
+    setattr(dest_module.case_details, "long", getattr(src_module.case_details, "long"))
 
 
 def _update_search_properties(module, search_properties, lang='en'):

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -827,6 +827,11 @@ def upgrade_shadow_module(request, domain, app_id, module_unique_id):
 def overwrite_module_case_list(request, domain, app_id, module_unique_id):
     app = get_app(domain, app_id)
     dest_module_unique_ids = request.POST.getlist('dest_module_unique_ids')
+    src_module = app.get_module_by_unique_id(module_unique_id)
+    detail_type = request.POST['detail_type']
+
+    # For short details, user selects which properties to copy.
+    # For long details, all properties are copied.
     short_attrs = {
         'columns',
         'filter',
@@ -840,8 +845,6 @@ def overwrite_module_case_list(request, domain, app_id, module_unique_id):
         'search_claim_options',
     }
     short_attrs = {a for a in short_attrs if request.POST.get(a) == 'on'}
-    src_module = app.get_module_by_unique_id(module_unique_id)
-    detail_type = request.POST['detail_type']
 
     error_list = _validate_overwrite_request(request, detail_type, dest_module_unique_ids, short_attrs)
     if error_list:

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -846,20 +846,13 @@ def overwrite_module_case_list(request, domain, app_id, module_unique_id):
     error_list = _validate_overwrite_request(request, detail_type, dest_module_unique_ids, short_attrs)
     if error_list:
         for err in error_list:
-            messages.error(
-                request,
-                err
-            )
+            messages.error(request, err)
         return back_to_main(request, domain, app_id=app_id, module_unique_id=module_unique_id)
 
     for dest_module_unique_id in dest_module_unique_ids:
         dest_module = app.get_module_by_unique_id(dest_module_unique_id)
         if dest_module.case_type != src_module.case_type:
-            messages.error(
-                request,
-                _("Please choose a menu with the same case type as the current one ({}).").format(
-                    src_module.case_type)
-            )
+            messages.error(request, _("Case type {} does not match current menu.").format(src_module.case_type))
         else:
             try:
                 if detail_type == "short":

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -859,9 +859,9 @@ def overwrite_module_case_list(request, domain, app_id, module_unique_id):
         else:
             try:
                 if detail_type == "short":
-                    _update_module_short_detail(detail_type, src_module, dest_module, short_attrs)
+                    _update_module_short_detail(src_module, dest_module, short_attrs)
                 else:
-                    _update_module_long_detail(detail_type, src_module, dest_module)
+                    _update_module_long_detail(src_module, dest_module)
                 messages.success(request, _("Updated {}").format(dest_module.default_name()))
             except Exception:
                 notify_exception(

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -852,7 +852,6 @@ def overwrite_module_case_list(request, domain, app_id, module_unique_id):
             )
         return back_to_main(request, domain, app_id=app_id, module_unique_id=module_unique_id)
 
-    updated_modules = []
     not_updated_modules = []
     for dest_module_unique_id in dest_module_unique_ids:
         dest_module = app.get_module_by_unique_id(dest_module_unique_id)
@@ -868,7 +867,7 @@ def overwrite_module_case_list(request, domain, app_id, module_unique_id):
                     _update_module_short_detail(detail_type, src_module, dest_module, short_attrs)
                 else:
                     _update_module_long_detail(detail_type, src_module, dest_module)
-                updated_modules.append(dest_module.default_name())
+                messages.success(request, _("Updated {}").format(dest_module.default_name()))
             except Exception:
                 notify_exception(
                     request,
@@ -882,11 +881,7 @@ def overwrite_module_case_list(request, domain, app_id, module_unique_id):
             ", ".join(map(str, not_updated_modules)))
         messages.error(request, _error_msg)
 
-    if updated_modules:
-        app.save()  # Save successfully overwritten menus.
-        _msg = _('Case list configuration updated from {} menu to {} menu(s).').format(
-            src_module.default_name(), ", ".join(map(str, updated_modules)))
-        messages.success(request, _msg)
+    app.save()
     return back_to_main(request, domain, app_id=app_id, module_unique_id=module_unique_id)
 
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -872,10 +872,13 @@ def overwrite_module_case_list(request, domain, app_id, module_unique_id):
             )
         else:
             try:
-                if detail_attrs:
+                if detail_type == "short":
+                    if detail_attrs:
+                        _update_module_detail(detail_type, src_module, dest_module, detail_attrs)
+                    if search_attrs:
+                        _update_module_search_config(src_module, dest_module, search_attrs)
+                else:
                     _update_module_detail(detail_type, src_module, dest_module, detail_attrs)
-                if search_attrs:
-                    _update_module_search_config(src_module, dest_module, search_attrs)
                 updated_modules.append(dest_module.default_name())
             except Exception:
                 notify_exception(

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -902,12 +902,6 @@ def _validate_overwrite_request(request, detail_type, dest_modules, short_attrs)
     return error_list
 
 
-def _update_module_search_config(src_module, dest_module, search_attrs):
-    src_config = src_module.search_config
-    dest_config = dest_module.search_config
-    dest_config.overwrite_attrs(src_config, search_attrs)
-
-
 # attrs may contain a both top-level Detail attributes and attributes that
 # belong to the detail's search config with should be prefixed with "search_"
 def _update_module_short_detail(src_module, dest_module, attrs):
@@ -920,6 +914,12 @@ def _update_module_short_detail(src_module, dest_module, attrs):
         src_detail = getattr(src_module.case_details, "short")
         dest_detail = getattr(dest_module.case_details, "short")
         dest_detail.overwrite_attrs(src_detail, attrs)
+
+
+def _update_module_search_config(src_module, dest_module, search_attrs):
+    src_config = src_module.search_config
+    dest_config = dest_module.search_config
+    dest_config.overwrite_attrs(src_config, search_attrs)
 
 
 def _update_module_long_detail(src_module, dest_module):


### PR DESCRIPTION
## Summary
Followup for https://github.com/dimagi/commcare-hq/pull/29643

Fixes issue reported in https://dimagi-dev.atlassian.net/browse/USH-960?focusedCommentId=143465 not the main issue in the ticket.

First commit fixes bug, the rest move code around to shorten `overwrite_module_case_list` which is unwieldy.

## Product Description
Fixes recently-introduced bug where case list detail overwrite was not doing anything.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

The model-level overwrite code is tested but not the view.

### QA Plan

Not requesting QA. Tested locally: case detail overwrite, case list overwrite with some and with all attributes checked.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
