### PR TITLE
handle and report backend missmatch in change feed

### DIFF
--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from kafka import KafkaConsumer
 from kafka.common import TopicPartition
 
+from corehq.form_processor.document_stores import UnexpectedBackend
 from dimagi.utils.logging import notify_error
 from pillowtop.checkpoints.manager import PillowCheckpointEventHandler
 from pillowtop.feed.interface import Change, ChangeFeed, ChangeMeta
@@ -207,6 +208,9 @@ def change_from_kafka_message(message):
     except UnknownDocumentStore:
         document_store = None
         notify_error("Unknown document store: {}".format(change_meta.data_source_type))
+    except UnexpectedBackend:
+        document_store = None
+        notify_error("Change from incorrect backend", details=change_meta.to_json())
     return Change(
         id=change_meta.document_id,
         sequence_id=message.offset,


### PR DESCRIPTION
## Summary
https://sentry.io/organizations/dimagi/issues/2402536370/

This appears to be due to a recent migration of a domain from the Couch backend to SQL. It appears to have been published to Kafka after the migration for the domain completed. Based on `change_meta.attempts` this was most likely from the pillow error queue.

@millerdev perhaps we should clear (all or some) pillow errors for the domain after a successful migration?

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
