### PR TITLE
Removed more of multi master

### DIFF
--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -160,13 +160,6 @@ class CommCareFeatureSupportMixin(object):
         return self._require_minimum_version('2.43')
 
     @property
-    def enable_multi_master(self):
-        return (
-            self._require_minimum_version('2.47.4')
-            and toggles.MULTI_MASTER_LINKED_DOMAINS.enabled(self.domain)
-        )
-
-    @property
     def enable_search_prompt_appearance(self):
         return self._require_minimum_version('2.50')
 

--- a/corehq/apps/app_manager/templates/app_manager/app_view_release_manager.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view_release_manager.html
@@ -31,8 +31,7 @@
   {% initial_page_data 'build_profiles' app.build_profiles %}
   {% initial_page_data 'latest_version_for_build_profiles' latest_version_for_build_profiles %}
   {% initial_page_data 'latestReleasedVersion' latest_released_version %}
-  {% initial_page_data 'master_briefs' master_briefs %}{# linked apps only #}
-  {% initial_page_data 'multiple_masters' multiple_masters %}{# linked apps only #}
+  {% initial_page_data 'master_briefs' master_briefs %}{# linked apps only #}{# TODO: there will only ever be one of these #}
   {% initial_page_data 'practice_users' practice_users %}
   {% initial_page_data 'enable_practice_users' app.enable_practice_users %}
   {% initial_page_data 'intro_only' intro_only %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -218,22 +218,7 @@
                 {% endif %}
               </p>
               <div class="form-horizontal">
-                {% if multiple_masters %}
-                  <div class="form-group">
-                    <div class="{% css_field_class %}">
-                      <select name="master_app_id" class="form-control hqwebapp-select2"
-                              data-placeholder="{% trans_html_attr "Select a master app to pull" %}">
-                        <option value="">{% trans "Select a master app to pull" %}</option>
-                        {% for brief in master_briefs %}
-                          {# Poor readability because any whitespace within the option will also appear in the title attribute and therefore on hover #}
-                          <option value="{{ brief.id }}">{{ brief.name }}{% for id, version in master_versions_by_id.items %}{% if id == brief.id %} ({% blocktrans with v=version %}version {{ v }}{% endblocktrans %}){% endif %}{% endfor %}</option>
-                        {% endfor %}
-                      </select>
-                    </div>
-                  </div>
-                {% else %}
                   <input name="master_app_id" type="hidden" value="{{ upstream_brief.get_id }}" />
-                {% endif %}
                 <div class="form-group">
                   <div class="{% css_field_class %}">
                     <div class="checkbox">

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -304,6 +304,7 @@ def get_app_view_context(request, app):
         'is_remote_app': is_remote_app(app),
     })
     if is_linked_app(app):
+        # TODO: there will only ever be one master brief
         try:
             master_versions_by_id = app.get_latest_master_releases_versions()
             master_briefs = [brief for brief in app.get_master_app_briefs() if brief.id in master_versions_by_id]
@@ -318,7 +319,6 @@ def get_app_view_context(request, app):
         context.update({
             'master_briefs': master_briefs,
             'master_versions_by_id': master_versions_by_id,
-            'multiple_masters': app.enable_multi_master and len(master_briefs) > 1,
             'upstream_version': app.upstream_version,
             'upstream_brief': upstream_brief,
             'upstream_url': _get_upstream_url(app, request.couch_user),

--- a/corehq/apps/app_manager/views/multimedia.py
+++ b/corehq/apps/app_manager/views/multimedia.py
@@ -33,19 +33,6 @@ def multimedia_ajax(request, domain, app_id):
             'is_linked_app': is_linked_app(app),
         }
 
-        if toggles.MULTI_MASTER_LINKED_DOMAINS.enabled_for_request(request):
-            missing_paths = {p for p in app.all_media_paths() if p not in app.multimedia_map}
-            import_apps = get_apps_in_domain(domain, include_remote=False)
-            import_app_counts = {
-                a.id: len(missing_paths.intersection(a.multimedia_map.keys()))
-                for a in import_apps
-            }
-            import_apps = [a for a in import_apps if import_app_counts[a.id]]
-            context.update({
-                'import_apps': import_apps,
-                'import_app_counts': import_app_counts,
-            })
-
         return render(request, "app_manager/partials/settings/multimedia_ajax.html", context)
     else:
         raise Http404()

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -348,7 +348,6 @@ def update_linked_app(app, master_app_id_or_build, user_id):
     if (
         previous is None
         or master_build.version > previous.upstream_version
-        or toggles.MULTI_MASTER_LINKED_DOMAINS.enabled(app.domain)
     ):
         old_multimedia_ids = set([media_info.multimedia_id for path, media_info in app.multimedia_map.items()])
         report_map = get_static_report_mapping(master_build.domain, app['domain'])

--- a/corehq/apps/linked_domain/README.md
+++ b/corehq/apps/linked_domain/README.md
@@ -119,10 +119,3 @@ A few fields are **not** copied from the master app to the linked app. They incl
 
 ## Overrides
 A small number of settings can be overridden in a linked app. App settings can be tagged with the `supports_linked_app` flag to make them appear on the linked app's settings page.
-
-## Multi-master
-The `MULTI_MASTER_LINKED_DOMAINS` feature flag allows a linked app to pull changes from more than one master app. The use case for multiple master apps is to support a branching-type workflow.
-
-A linked app may pull from all multiple upstream apps within a single "family." Families are created by copying apps; when an app is copied, its `family_id` is set to the id of the app it was copied from.
-
-When this flag is on, different builds of the same linked app may have different values for `upstream_app_id`. This id reflects the app that specific build was pulled from.

--- a/corehq/apps/linked_domain/applications.py
+++ b/corehq/apps/linked_domain/applications.py
@@ -57,6 +57,7 @@ def get_upstream_app_ids(downstream_domain):
     return list(_get_downstream_app_id_map(downstream_domain))
 
 
+# TODO: look at usages of this, now that multi master is dead
 @quickcache(vary_on=['downstream_domain'], skip_arg=lambda _: settings.UNIT_TESTING, timeout=5 * 60)
 def _get_downstream_app_id_map(downstream_domain):
     downstream_app_ids = defaultdict(list)

--- a/corehq/apps/linked_domain/tasks.py
+++ b/corehq/apps/linked_domain/tasks.py
@@ -127,9 +127,6 @@ The following linked project spaces received content:
         return linebreaksbr(message) if html else message
 
     def _release_app(self, domain_link, model, user, build_and_release=False):
-        if toggles.MULTI_MASTER_LINKED_DOMAINS.enabled(domain_link.linked_domain):
-            return self._error_tuple(_("Multi master flag is in use"))
-
         app_id = model['detail']['app_id']
         found = False
         error_prefix = ""

--- a/corehq/apps/linked_domain/tests/test_release_manager.py
+++ b/corehq/apps/linked_domain/tests/test_release_manager.py
@@ -124,12 +124,6 @@ class TestReleaseManager(BaseLinkedAppsTest):
             self._model_status(MODEL_APP, detail=AppLinkDetail(app_id='123').to_json()),
         ], error="Could not find app")
 
-    @flag_enabled('MULTI_MASTER_LINKED_DOMAINS')
-    def test_multi_master_app_fail(self):
-        self._assert_release([
-            self._model_status(MODEL_APP, detail=AppLinkDetail(app_id='123').to_json()),
-        ], error="Multi master flag is in use")
-
     @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
     def test_app_build_and_release(self, *args):
         self._make_master1_build(True)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1568,13 +1568,6 @@ LINKED_DOMAINS = StaticToggle(
     notification_emails=['aking'],
 )
 
-MULTI_MASTER_LINKED_DOMAINS = StaticToggle(
-    'multi_master_linked_domains',
-    "Allow linked apps to pull from multiple master apps in the upstream domain",
-    TAG_CUSTOM,
-    [NAMESPACE_DOMAIN],
-)
-
 SESSION_ENDPOINTS = StaticToggle(
     'session_endpoints',
     'Enable session endpoints',


### PR DESCRIPTION
## Summary
@gherceg There's a fair amount of multi master code that can be removed. This PR removes the code that's tied directly to the flag, and adds TODOs where code supports multiple master apps and could be simplified to only allow for one master app.

I don't love the thought of merging a PR with TODOs but also don't want it to linger and cause conflicts while you're working in this code. I'm also happy to close this if it'd make more sense to just leave the multi master code alone for now - not sure how much friction the extra code has caused you or will cause you. What do you think?

## Feature Flag
This removes the "Allow linked apps to pull from multiple master apps in the upstream domain" flag.

## Safety Assurance

- [ ] Risk label is set correctly
- [ ] All migrations are backwards compatible and won't block deploy
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
