### PR TITLE
refactor user role classmethods to utils package

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -247,18 +247,6 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
         from corehq.apps.accounting.models import SoftwarePlanEdition
         if not custom_roles or (new_plan_version.plan.edition == SoftwarePlanEdition.PAUSED):
             return True
-        # temporarily disable this part of the downgrade until we
-        # have a better user experience for notifying the downgraded user
-        # read_only_role = get_read_only_role_for_domain(self.domain.name)
-        # web_users = WebUser.by_domain(self.domain.name)
-        # for web_user in web_users:
-        #     if web_user.get_domain_membership(self.domain.name).role_id in custom_roles:
-        #         web_user.set_role(self.domain.name, read_only_role.get_qualified_id())
-        #         web_user.save()
-        # for cc_user in CommCareUser.by_domain(self.domain.name):
-        #     if cc_user.get_domain_membership(self.domain.name).role_id in custom_roles:
-        #         cc_user.set_role(self.domain.name, 'none')
-        #         cc_user.save()
         archive_custom_roles_for_domain(domain.name)
         reset_initial_roles_for_domain(domain.name)
         return True

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -243,7 +243,7 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
             return True
         # temporarily disable this part of the downgrade until we
         # have a better user experience for notifying the downgraded user
-        # read_only_role = UserRole.get_read_only_role_by_domain(self.domain.name)
+        # read_only_role = get_read_only_role_for_domain(self.domain.name)
         # web_users = WebUser.by_domain(self.domain.name)
         # for web_user in web_users:
         #     if web_user.get_domain_membership(self.domain.name).role_id in custom_roles:

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -19,7 +19,11 @@ from corehq.apps.userreports.exceptions import (
     DataSourceConfigurationNotFoundError,
 )
 from corehq.apps.users.models import CommCareUser, UserRole
-from corehq.apps.users.role_utils import get_custom_roles_for_domain
+from corehq.apps.users.role_utils import (
+    get_custom_roles_for_domain,
+    archive_custom_roles_for_domain,
+    unarchive_roles_for_domain,
+)
 from corehq.const import USER_DATE_FORMAT
 from corehq.messaging.scheduling.models import (
     AlertSchedule,
@@ -254,7 +258,7 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
         #     if cc_user.get_domain_membership(self.domain.name).role_id in custom_roles:
         #         cc_user.set_role(self.domain.name, 'none')
         #         cc_user.save()
-        UserRole.archive_custom_roles_for_domain(domain.name)
+        archive_custom_roles_for_domain(domain.name)
         UserRole.reset_initial_roles_for_domain(domain.name)
         return True
 
@@ -370,7 +374,7 @@ class DomainUpgradeActionHandler(BaseModifySubscriptionActionHandler):
         Perform Role Based Access Upgrade
         - Un-archive custom roles.
         """
-        UserRole.unarchive_roles_for_domain(domain.name)
+        unarchive_roles_for_domain(domain.name)
         return True
 
     @staticmethod

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -19,6 +19,7 @@ from corehq.apps.userreports.exceptions import (
     DataSourceConfigurationNotFoundError,
 )
 from corehq.apps.users.models import CommCareUser, UserRole
+from corehq.apps.users.role_utils import get_custom_roles_for_domain
 from corehq.const import USER_DATE_FORMAT
 from corehq.messaging.scheduling.models import (
     AlertSchedule,
@@ -237,7 +238,7 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
         - Set user roles using custom roles to Read Only.
         - Reset initial roles to standard permissions.
         """
-        custom_roles = [r.get_id for r in UserRole.get_custom_roles_by_domain(domain.name)]
+        custom_roles = [r.get_id for r in get_custom_roles_for_domain(domain.name)]
         from corehq.apps.accounting.models import SoftwarePlanEdition
         if not custom_roles or (new_plan_version.plan.edition == SoftwarePlanEdition.PAUSED):
             return True
@@ -658,7 +659,7 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         """
         Alert the user if there are currently custom roles set up for the domain.
         """
-        custom_roles = [r.name for r in UserRole.get_custom_roles_by_domain(domain.name)]
+        custom_roles = [r.name for r in get_custom_roles_for_domain(domain.name)]
         num_roles = len(custom_roles)
         from corehq.apps.accounting.models import SoftwarePlanEdition
         if new_plan_version.plan.edition == SoftwarePlanEdition.PAUSED:

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -18,11 +18,12 @@ from corehq.apps.fixtures.models import FixtureDataType
 from corehq.apps.userreports.exceptions import (
     DataSourceConfigurationNotFoundError,
 )
-from corehq.apps.users.models import CommCareUser, UserRole
+from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.role_utils import (
     get_custom_roles_for_domain,
     archive_custom_roles_for_domain,
     unarchive_roles_for_domain,
+    reset_initial_roles_for_domain,
 )
 from corehq.const import USER_DATE_FORMAT
 from corehq.messaging.scheduling.models import (
@@ -259,7 +260,7 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
         #         cc_user.set_role(self.domain.name, 'none')
         #         cc_user.save()
         archive_custom_roles_for_domain(domain.name)
-        UserRole.reset_initial_roles_for_domain(domain.name)
+        reset_initial_roles_for_domain(domain.name)
         return True
 
     @staticmethod

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -32,6 +32,7 @@ from corehq.apps.users.models import (
     UserRolePresets,
     WebUser,
 )
+from corehq.apps.users.role_utils import get_read_only_role_for_domain
 from corehq.messaging.scheduling.models import (
     AlertSchedule,
     ImmediateBroadcast,
@@ -87,7 +88,7 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
                 view_roles=True,
             )
         )
-        self.read_only_role = UserRole.get_read_only_role_by_domain(self.domain.name)
+        self.read_only_role = get_read_only_role_for_domain(self.domain.name)
 
         self.admin_username = generator.create_arbitrary_web_user_name()
 

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -76,18 +76,17 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
         self.other_domain.save()
         UserRole.init_domain_with_presets(self.domain.name)
         self.user_roles = UserRole.by_domain(self.domain.name)
-        self.custom_role = UserRole.get_or_create_with_permissions(
+        self.custom_role = UserRole.create(
             self.domain.name,
-            Permissions(
+            "Custom Role",
+            permissions=Permissions(
                 edit_apps=True,
                 view_apps=True,
                 edit_web_users=True,
                 view_web_users=True,
                 view_roles=True,
-            ),
-            "Custom Role"
+            )
         )
-        self.custom_role.save()
         self.read_only_role = UserRole.get_read_only_role_by_domain(self.domain.name)
 
         self.admin_username = generator.create_arbitrary_web_user_name()

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -32,7 +32,7 @@ from corehq.apps.users.models import (
     UserRolePresets,
     WebUser,
 )
-from corehq.apps.users.role_utils import get_read_only_role_for_domain
+from corehq.apps.users.role_utils import get_read_only_role_for_domain, init_domain_with_presets
 from corehq.messaging.scheduling.models import (
     AlertSchedule,
     ImmediateBroadcast,
@@ -75,7 +75,7 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
             is_active=True,
         )
         self.other_domain.save()
-        UserRole.init_domain_with_presets(self.domain.name)
+        init_domain_with_presets(self.domain.name)
         self.user_roles = UserRole.by_domain(self.domain.name)
         self.custom_role = UserRole.create(
             self.domain.name,

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -32,7 +32,7 @@ from corehq.apps.users.models import (
     UserRolePresets,
     WebUser,
 )
-from corehq.apps.users.role_utils import get_read_only_role_for_domain, init_domain_with_presets
+from corehq.apps.users.role_utils import init_domain_with_presets
 from corehq.messaging.scheduling.models import (
     AlertSchedule,
     ImmediateBroadcast,
@@ -88,7 +88,6 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
                 view_roles=True,
             )
         )
-        self.read_only_role = get_read_only_role_for_domain(self.domain.name)
 
         self.admin_username = generator.create_arbitrary_web_user_name()
 
@@ -124,18 +123,6 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
         custom_role = UserRole.get(self.custom_role.get_id)
         self.assertTrue(custom_role.is_archived)
 
-        # disable this part of the test until we improve the UX for notifying
-        # downgraded users of their privilege changes
-        # custom_web_user = WebUser.get(self.web_users[0].get_id)
-        # custom_commcare_user = CommCareUser.get(self.commcare_users[0].get_id)
-        # self.assertEqual(
-        #     custom_web_user.get_domain_membership(self.domain.name).role_id,
-        #     self.read_only_role.get_id
-        # )
-        # self.assertIsNone(
-        #     custom_commcare_user.get_domain_membership(self.domain.name).role_id
-        # )
-        
         self._assertInitialRoles()
         self._assertStdUsers()
 
@@ -151,18 +138,6 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
         new_subscription.change_plan(self.advanced_plan, web_user=self.admin_username)
         custom_role = UserRole.get(self.custom_role.get_id)
         self.assertFalse(custom_role.is_archived)
-
-        # disable this part of the test until we improve the UX for notifying
-        # downgraded users of their privilege changes
-        # custom_web_user = WebUser.get(self.web_users[0].get_id)
-        # custom_commcare_user = CommCareUser.get(self.commcare_users[0].get_id)
-        # self.assertEqual(
-        #     custom_web_user.get_domain_membership(self.domain.name).role_id,
-        #     self.read_only_role.get_id
-        # )
-        # self.assertIsNone(
-        #     custom_commcare_user.get_domain_membership(self.domain.name).role_id
-        # )
 
         self._assertInitialRoles()
         self._assertStdUsers()

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -41,7 +41,6 @@ from corehq.apps.api.resources.auth import (
 from corehq.apps.api.resources.meta import CustomResourceMeta
 from corehq.apps.api.util import get_obj
 from corehq.apps.app_manager.models import Application
-from corehq.apps.domain.auth import HQApiKeyAuthentication
 from corehq.apps.domain.forms import clean_password
 from corehq.apps.domain.models import Domain
 from corehq.apps.es import UserES
@@ -83,6 +82,7 @@ from corehq.apps.users.models import (
     UserRole,
     WebUser,
 )
+from corehq.apps.users.role_utils import get_all_role_names_for_domain
 from corehq.apps.users.util import raw_username
 from corehq.const import USER_CHANGE_VIA_API
 from corehq.util import get_document_or_404
@@ -391,7 +391,7 @@ class WebUserResource(v0_1.WebUserResource):
         return bundle
 
     def _invalid_user_role(self, request, details):
-        return details.get('role') not in UserRole.preset_and_domain_role_names(request.domain)
+        return details.get('role') not in get_all_role_names_for_domain(request.domain)
 
     def _admin_assigned_another_role(self, details):
         # default value Admin since that will be assigned later anyway since is_admin is True

--- a/corehq/apps/api/tests/test_auth.py
+++ b/corehq/apps/api/tests/test_auth.py
@@ -159,14 +159,14 @@ class RequirePermissionAuthenticationTest(AuthenticationTestBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.role_with_permission = UserRole.get_or_create_with_permissions(
-            cls.domain, Permissions(edit_data=True), 'edit-data'
+        cls.role_with_permission = UserRole.create(
+            cls.domain, 'edit-data', permissions=Permissions(edit_data=True)
         )
-        cls.role_without_permission = UserRole.get_or_create_with_permissions(
-            cls.domain, Permissions(edit_data=False), 'no-edit-data'
+        cls.role_without_permission = UserRole.create(
+            cls.domain, 'no-edit-data', permissions=Permissions(edit_data=False)
         )
-        cls.role_with_permission_but_no_api_access = UserRole.get_or_create_with_permissions(
-            cls.domain, Permissions(edit_data=True, access_api=False), 'no-api-access'
+        cls.role_with_permission_but_no_api_access = UserRole.create(
+            cls.domain, 'no-api-access', permissions=Permissions(edit_data=True, access_api=False)
         )
         cls.domain_admin = WebUser.create(cls.domain, 'domain_admin', cls.password, None, None, is_admin=True)
         cls.user_with_permission = WebUser.create(cls.domain, 'permission', cls.password, None, None,

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -18,7 +18,6 @@ from corehq.apps.es.tests.utils import es_test
 from corehq.apps.users.analytics import update_analytics_indexes
 from corehq.apps.users.models import (
     CommCareUser,
-    Permissions,
     UserRole,
     WebUser,
 )
@@ -381,11 +380,7 @@ class TestWebUserResource(APIResourceTest):
         user_back.delete(deleted_by=None)
 
     def test_create_with_custom_role(self):
-        new_user_role = UserRole.create(
-            self.domain.name,
-            'awesomeness',
-            permissions=Permissions(edit_apps=True, view_apps=True, view_reports=True),
-        )
+        new_user_role = UserRole.create(self.domain.name, 'awesomeness')
         user_json = deepcopy(self.default_user_json)
         user_json["role"] = new_user_role.name
         user_json["is_admin"] = False

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -381,10 +381,11 @@ class TestWebUserResource(APIResourceTest):
         user_back.delete(deleted_by=None)
 
     def test_create_with_custom_role(self):
-        new_user_role = UserRole.get_or_create_with_permissions(
+        new_user_role = UserRole.create(
             self.domain.name,
-            Permissions(edit_apps=True, view_apps=True, view_reports=True),
-            'awesomeness')
+            'awesomeness',
+            permissions=Permissions(edit_apps=True, view_apps=True, view_reports=True),
+        )
         user_json = deepcopy(self.default_user_json)
         user_json["role"] = new_user_role.name
         user_json["is_admin"] = False

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -6,6 +6,7 @@ from django.utils.translation import ugettext as _
 
 from dateutil.relativedelta import relativedelta
 
+from corehq.apps.users.role_utils import get_custom_roles_for_domain
 from couchforms.analytics import (
     domain_has_submission_in_last_30_days,
     get_first_form_submission_received,
@@ -441,7 +442,7 @@ def use_domain_security_settings(domain_obj):
 
 
 def num_custom_roles(domain):
-    custom_roles = [r for r in UserRole.get_custom_roles_by_domain(domain) if not r.is_archived]
+    custom_roles = [r for r in get_custom_roles_for_domain(domain) if not r.is_archived]
     return len(custom_roles)
 
 

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -32,8 +32,8 @@ class TestCaseAPI(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.domain_obj = create_domain(cls.domain)
-        role = UserRole.get_or_create_with_permissions(
-            cls.domain, Permissions(edit_data=True), 'edit-data'
+        role = UserRole.create(
+            cls.domain, 'edit-data', permissions=Permissions(edit_data=True)
         )
         cls.web_user = WebUser.create(cls.domain, 'netflix', 'password', None, None, role_id=role.get_id)
         cls.case_accessor = CaseAccessors(cls.domain)

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext
 
 from celery import chord
 
+from corehq.apps.users.role_utils import init_domain_with_presets
 from corehq.util.soft_assert import soft_assert
 from dimagi.utils.couch import CriticalSection
 from dimagi.utils.couch.database import get_safe_write_kwargs
@@ -145,7 +146,7 @@ def request_new_domain(request, project_name, is_new_user=True):
     if not settings.ENTERPRISE_MODE:
         _setup_subscription(new_domain.name, current_user)
 
-    UserRole.init_domain_with_presets(new_domain.name)
+    init_domain_with_presets(new_domain.name)
 
     if request.user.is_authenticated:
         if not current_user:

--- a/corehq/apps/reports/tests/test_case_list_report.py
+++ b/corehq/apps/reports/tests/test_case_list_report.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from django.test.client import RequestFactory
 
 from casexml.apps.case.models import CommCareCase
+from corehq.apps.users.role_utils import init_domain_with_presets
 from pillowtop.es_utils import initialize_index_and_mapping
 
 from corehq.apps.reports.standard.cases.basic import CaseListReport
@@ -28,7 +29,7 @@ class TestCaseListReport(TestCase):
         cls.domain = 'case-list-test'
         cls.user = WebUser(username='test@cchq.com', domains=[cls.domain])
         cls.user.domain_memberships = [DomainMembership(domain=cls.domain, role_id='admin')]
-        UserRole.init_domain_with_presets(cls.domain)
+        init_domain_with_presets(cls.domain)
         cls.request_factory = RequestFactory()
 
         from corehq.apps.reports.tests.data.case_list_report_data import (

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -872,7 +872,7 @@ class TestWebUserBulkUpload(TestCase, DomainSubscriptionMixin):
         cls.other_domain = Domain.get_or_create_with_name(name='other-domain')
         cls.role = UserRole.create(cls.domain.name, 'edit-apps')
         cls.other_role = UserRole.create(cls.domain.name, 'admin')
-        cls.other_domain_role = UserRole.create(cls.domain.name, 'view-apps')
+        cls.other_domain_role = UserRole.create(cls.other_domain.name, 'view-apps')
         cls.patcher = patch('corehq.apps.user_importer.tasks.UserUploadRecord')
         cls.patcher.start()
 

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -21,7 +21,7 @@ from corehq.apps.user_importer.models import UserUploadRecord
 from corehq.apps.user_importer.tasks import import_users_and_groups
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import (
-    CommCareUser, DomainPermissionsMirror, Permissions, UserRole, WebUser, Invitation, CouchUser
+    CommCareUser, DomainPermissionsMirror, UserRole, WebUser, Invitation
 )
 from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
 from corehq.const import USER_CHANGE_VIA_BULK_IMPORTER
@@ -39,9 +39,8 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         cls.uploading_user = WebUser.create(cls.domain_name, "admin@xyz.com", 'password', None, None,
                                             is_superuser=True)
 
-        permissions = Permissions(edit_apps=True, view_apps=True, view_reports=True)
-        cls.role = UserRole.create(cls.domain.name, 'edit-apps', permission=permissions)
-        cls.other_role = UserRole.create(cls.domain.name, 'admin', permissions=permissions)
+        cls.role = UserRole.create(cls.domain.name, 'edit-apps')
+        cls.other_role = UserRole.create(cls.domain.name, 'admin')
         cls.patcher = patch('corehq.apps.user_importer.tasks.UserUploadRecord')
         cls.patcher.start()
 
@@ -871,10 +870,9 @@ class TestWebUserBulkUpload(TestCase, DomainSubscriptionMixin):
         cls.domain_name = 'mydomain'
         cls.domain = Domain.get_or_create_with_name(name=cls.domain_name)
         cls.other_domain = Domain.get_or_create_with_name(name='other-domain')
-        permissions = Permissions(edit_apps=True, view_apps=True, view_reports=True)
-        cls.role = UserRole.create(cls.domain.name, 'edit-apps', permissions=permissions)
-        cls.other_role = UserRole.create(cls.domain.name, 'admin', permissions=permissions)
-        cls.other_domain_role = UserRole.create(cls.domain.name, 'view-apps', permissions=permissions)
+        cls.role = UserRole.create(cls.domain.name, 'edit-apps')
+        cls.other_role = UserRole.create(cls.domain.name, 'admin')
+        cls.other_domain_role = UserRole.create(cls.domain.name, 'view-apps')
         cls.patcher = patch('corehq.apps.user_importer.tasks.UserUploadRecord')
         cls.patcher.start()
 

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -40,8 +40,8 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
                                             is_superuser=True)
 
         permissions = Permissions(edit_apps=True, view_apps=True, view_reports=True)
-        cls.role = UserRole.get_or_create_with_permissions(cls.domain.name, permissions, 'edit-apps')
-        cls.other_role = UserRole.get_or_create_with_permissions(cls.domain.name, permissions, 'admin')
+        cls.role = UserRole.create(cls.domain.name, 'edit-apps', permission=permissions)
+        cls.other_role = UserRole.create(cls.domain.name, 'admin', permissions=permissions)
         cls.patcher = patch('corehq.apps.user_importer.tasks.UserUploadRecord')
         cls.patcher.start()
 
@@ -872,10 +872,9 @@ class TestWebUserBulkUpload(TestCase, DomainSubscriptionMixin):
         cls.domain = Domain.get_or_create_with_name(name=cls.domain_name)
         cls.other_domain = Domain.get_or_create_with_name(name='other-domain')
         permissions = Permissions(edit_apps=True, view_apps=True, view_reports=True)
-        cls.role = UserRole.get_or_create_with_permissions(cls.domain.name, permissions, 'edit-apps')
-        cls.other_role = UserRole.get_or_create_with_permissions(cls.domain.name, permissions, 'admin')
-        cls.other_domain_role = UserRole.get_or_create_with_permissions(cls.other_domain.name, permissions,
-                                                                        'view-apps')
+        cls.role = UserRole.create(cls.domain.name, 'edit-apps', permissions=permissions)
+        cls.other_role = UserRole.create(cls.domain.name, 'admin', permissions=permissions)
+        cls.other_domain_role = UserRole.create(cls.domain.name, 'view-apps', permissions=permissions)
         cls.patcher = patch('corehq.apps.user_importer.tasks.UserUploadRecord')
         cls.patcher.start()
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -334,10 +334,6 @@ class UserRole(QuickCachedDocumentMixin, Document):
         return role
 
     @classmethod
-    def get_custom_roles_by_domain(cls, domain):
-        return [x for x in cls.by_domain(domain) if x.name not in UserRolePresets.INITIAL_ROLES]
-
-    @classmethod
     def reset_initial_roles_for_domain(cls, domain):
         initial_roles = [x for x in cls.by_domain(domain) if x.name in UserRolePresets.INITIAL_ROLES]
         for role in initial_roles:
@@ -346,7 +342,8 @@ class UserRole(QuickCachedDocumentMixin, Document):
 
     @classmethod
     def archive_custom_roles_for_domain(cls, domain):
-        custom_roles = cls.get_custom_roles_by_domain(domain)
+        from corehq.apps.users.role_utils import get_custom_roles_for_domain
+        custom_roles = get_custom_roles_for_domain(domain)
         for role in custom_roles:
             role.is_archived = True
             role.save()

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -334,14 +334,6 @@ class UserRole(QuickCachedDocumentMixin, Document):
         return role
 
     @classmethod
-    def init_domain_with_presets(cls, domain):
-        from corehq.apps.users.role_utils import get_or_create_role_with_permissions
-        for role_name in UserRolePresets.INITIAL_ROLES:
-            get_or_create_role_with_permissions(
-                domain, role_name, UserRolePresets.get_permissions(role_name)
-            )
-
-    @classmethod
     def get_default(cls, domain=None):
         return cls(permissions=Permissions(), domain=domain, name=None)
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -328,6 +328,12 @@ class UserRole(QuickCachedDocumentMixin, Document):
         return list(all_roles)
 
     @classmethod
+    def create(cls, domain, name, **kwargs):
+        role = cls(domain=domain, name=name, **kwargs)
+        role.save()
+        return role
+
+    @classmethod
     def get_or_create_with_permissions(cls, domain, permissions, name=None):
         if isinstance(permissions, dict):
             permissions = Permissions.wrap(permissions)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -342,12 +342,6 @@ class UserRole(QuickCachedDocumentMixin, Document):
         return UserRolePresets.get_preset_role_id(name)
 
     @classmethod
-    def preset_and_domain_role_names(cls, domain_name):
-        presets = set(UserRolePresets.NAME_ID_MAP.keys())
-        custom = set([role.name for role in cls.by_domain(domain_name)])
-        return presets | custom
-
-    @classmethod
     def admin_role(cls, domain):
         return AdminUserRole(domain=domain)
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -634,6 +634,8 @@ class _AuthorizableMixin(IsMemberOfMixin):
         """
         role_qualified_id is either 'admin' 'user-role:[id]'
         """
+        from corehq.apps.users.role_utils import get_or_create_role_with_permissions
+
         dm = self.get_domain_membership(domain)
         dm.is_admin = False
         if role_qualified_id == "admin":
@@ -644,7 +646,7 @@ class _AuthorizableMixin(IsMemberOfMixin):
         elif role_qualified_id in UserRolePresets.ID_NAME_MAP:
             role_name = UserRolePresets.get_preset_role_name(role_qualified_id)
             permissions = UserRolePresets.get_permissions(role_name)
-            dm.role_id = UserRole.get_or_create_with_permissions(domain, permissions, role_name).get_id
+            dm.role_id = get_or_create_role_with_permissions(domain, role_name, permissions).get_id
         elif role_qualified_id == 'none':
             dm.role_id = None
         else:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -334,16 +334,6 @@ class UserRole(QuickCachedDocumentMixin, Document):
         return role
 
     @classmethod
-    def get_read_only_role_by_domain(cls, domain):
-        from corehq.apps.users.role_utils import get_or_create_role_with_permissions
-        try:
-            return cls.by_domain_and_name(domain, UserRolePresets.READ_ONLY)[0]
-        except (IndexError, TypeError):
-            return get_or_create_role_with_permissions(
-                domain, UserRolePresets.READ_ONLY, UserRolePresets.get_permissions(UserRolePresets.READ_ONLY)
-            )
-
-    @classmethod
     def get_custom_roles_by_domain(cls, domain):
         return [x for x in cls.by_domain(domain) if x.name not in UserRolePresets.INITIAL_ROLES]
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -334,13 +334,6 @@ class UserRole(QuickCachedDocumentMixin, Document):
         return role
 
     @classmethod
-    def reset_initial_roles_for_domain(cls, domain):
-        initial_roles = [x for x in cls.by_domain(domain) if x.name in UserRolePresets.INITIAL_ROLES]
-        for role in initial_roles:
-            role.permissions = UserRolePresets.get_permissions(role.name)
-            role.save()
-
-    @classmethod
     def init_domain_with_presets(cls, domain):
         from corehq.apps.users.role_utils import get_or_create_role_with_permissions
         for role_name in UserRolePresets.INITIAL_ROLES:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -341,22 +341,6 @@ class UserRole(QuickCachedDocumentMixin, Document):
             role.save()
 
     @classmethod
-    def archive_custom_roles_for_domain(cls, domain):
-        from corehq.apps.users.role_utils import get_custom_roles_for_domain
-        custom_roles = get_custom_roles_for_domain(domain)
-        for role in custom_roles:
-            role.is_archived = True
-            role.save()
-
-    @classmethod
-    def unarchive_roles_for_domain(cls, domain):
-        all_roles = cls.by_domain(domain, include_archived=True)
-        for role in all_roles:
-            if role.is_archived:
-                role.is_archived = False
-                role.save()
-
-    @classmethod
     def init_domain_with_presets(cls, domain):
         from corehq.apps.users.role_utils import get_or_create_role_with_permissions
         for role_name in UserRolePresets.INITIAL_ROLES:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -334,7 +334,7 @@ class UserRole(QuickCachedDocumentMixin, Document):
         return role
 
     @classmethod
-    def get_or_create_with_permissions(cls, domain, permissions, name=None):
+    def get_or_create_with_permissions(cls, domain, permissions, name):
         if isinstance(permissions, dict):
             permissions = Permissions.wrap(permissions)
         roles = cls.by_domain(domain)
@@ -342,13 +342,9 @@ class UserRole(QuickCachedDocumentMixin, Document):
         for role in roles:
             if role.permissions == permissions:
                 return role
-        # otherwise create it
 
-        def get_name():
-            if name:
-                return name
-            return UserRolePresets.get_role_name_with_matching_permissions(permissions)
-        role = cls(domain=domain, permissions=permissions, name=get_name())
+        # otherwise create it
+        role = cls(domain=domain, permissions=permissions, name=name)
         role.save()
         return role
 

--- a/corehq/apps/users/role_utils.py
+++ b/corehq/apps/users/role_utils.py
@@ -21,20 +21,6 @@ def get_or_create_role_with_permissions(domain, name, permissions):
     return role
 
 
-def get_read_only_role_for_domain(domain):
-    """Get role with name "Read Only" or else create it
-    with default permissions.
-
-    Note: This does not check if the permissions of the returned role match the presets.
-    """
-    try:
-        return UserRole.by_domain_and_name(domain, UserRolePresets.READ_ONLY)[0]
-    except (IndexError, TypeError):
-        return get_or_create_role_with_permissions(
-            domain, UserRolePresets.READ_ONLY, UserRolePresets.get_permissions(UserRolePresets.READ_ONLY)
-        )
-
-
 def get_custom_roles_for_domain(domain):
     return [x for x in UserRole.by_domain(domain) if x.name not in UserRolePresets.INITIAL_ROLES]
 

--- a/corehq/apps/users/role_utils.py
+++ b/corehq/apps/users/role_utils.py
@@ -1,4 +1,4 @@
-from corehq.apps.users.models import Permissions, UserRole
+from corehq.apps.users.models import Permissions, UserRole, UserRolePresets
 
 
 def get_or_create_role_with_permissions(domain, name, permissions):
@@ -19,3 +19,17 @@ def get_or_create_role_with_permissions(domain, name, permissions):
     role = UserRole.create(domain, name, permissions=permissions)
     role.save()
     return role
+
+
+def get_read_only_role_for_domain(domain):
+    """Get role with name "Read Only" or else create it
+    with default permissions.
+
+    Note: This does not check if the permissions of the returned role match the presets.
+    """
+    try:
+        return UserRole.by_domain_and_name(domain, UserRolePresets.READ_ONLY)[0]
+    except (IndexError, TypeError):
+        return get_or_create_role_with_permissions(
+            domain, UserRolePresets.READ_ONLY, UserRolePresets.get_permissions(UserRolePresets.READ_ONLY)
+        )

--- a/corehq/apps/users/role_utils.py
+++ b/corehq/apps/users/role_utils.py
@@ -37,3 +37,18 @@ def get_read_only_role_for_domain(domain):
 
 def get_custom_roles_for_domain(domain):
     return [x for x in UserRole.by_domain(domain) if x.name not in UserRolePresets.INITIAL_ROLES]
+
+
+def archive_custom_roles_for_domain(domain):
+    custom_roles = get_custom_roles_for_domain(domain)
+    for role in custom_roles:
+        role.is_archived = True
+        role.save()
+
+
+def unarchive_roles_for_domain(domain):
+    all_roles = UserRole.by_domain(domain, include_archived=True)
+    for role in all_roles:
+        if role.is_archived:
+            role.is_archived = False
+            role.save()

--- a/corehq/apps/users/role_utils.py
+++ b/corehq/apps/users/role_utils.py
@@ -59,3 +59,10 @@ def reset_initial_roles_for_domain(domain):
     for role in initial_roles:
         role.permissions = UserRolePresets.get_permissions(role.name)
         role.save()
+
+
+def init_domain_with_presets(domain):
+    for role_name in UserRolePresets.INITIAL_ROLES:
+        get_or_create_role_with_permissions(
+            domain, role_name, UserRolePresets.get_permissions(role_name)
+        )

--- a/corehq/apps/users/role_utils.py
+++ b/corehq/apps/users/role_utils.py
@@ -33,3 +33,7 @@ def get_read_only_role_for_domain(domain):
         return get_or_create_role_with_permissions(
             domain, UserRolePresets.READ_ONLY, UserRolePresets.get_permissions(UserRolePresets.READ_ONLY)
         )
+
+
+def get_custom_roles_for_domain(domain):
+    return [x for x in UserRole.by_domain(domain) if x.name not in UserRolePresets.INITIAL_ROLES]

--- a/corehq/apps/users/role_utils.py
+++ b/corehq/apps/users/role_utils.py
@@ -66,3 +66,9 @@ def init_domain_with_presets(domain):
         get_or_create_role_with_permissions(
             domain, role_name, UserRolePresets.get_permissions(role_name)
         )
+
+
+def get_all_role_names_for_domain(domain_name):
+    presets = set(UserRolePresets.NAME_ID_MAP.keys())
+    custom = set([role.name for role in UserRole.by_domain(domain_name)])
+    return presets | custom

--- a/corehq/apps/users/role_utils.py
+++ b/corehq/apps/users/role_utils.py
@@ -1,0 +1,21 @@
+from corehq.apps.users.models import Permissions, UserRole
+
+
+def get_or_create_role_with_permissions(domain, name, permissions):
+    """This function will check all existing roles in the domain
+    for a role with matching permissions before creating a new role.
+    """
+    if isinstance(permissions, dict):
+        permissions = Permissions.wrap(permissions)
+
+    roles = UserRole.by_domain(domain)
+
+    # try to get a matching role from the db
+    for role in roles:
+        if role.permissions == permissions:
+            return role
+
+    # otherwise create it
+    role = UserRole.create(domain, name, permissions=permissions)
+    role.save()
+    return role

--- a/corehq/apps/users/role_utils.py
+++ b/corehq/apps/users/role_utils.py
@@ -52,3 +52,10 @@ def unarchive_roles_for_domain(domain):
         if role.is_archived:
             role.is_archived = False
             role.save()
+
+
+def reset_initial_roles_for_domain(domain):
+    initial_roles = [x for x in UserRole.by_domain(domain) if x.name in UserRolePresets.INITIAL_ROLES]
+    for role in initial_roles:
+        role.permissions = UserRolePresets.get_permissions(role.name)
+        role.save()

--- a/corehq/apps/users/tests/test_dbaccessors.py
+++ b/corehq/apps/users/tests/test_dbaccessors.py
@@ -18,7 +18,6 @@ from corehq.apps.users.dbaccessors import (
 from corehq.apps.users.dbaccessors import get_user_id_by_username
 from corehq.apps.users.models import (
     CommCareUser,
-    Permissions,
     UserRole,
     WebUser,
 )
@@ -40,17 +39,7 @@ class AllCommCareUsersTest(TestCase):
 
         UserRole.init_domain_with_presets(cls.ccdomain.name)
         cls.user_roles = UserRole.by_domain(cls.ccdomain.name)
-        cls.custom_role = UserRole.create(
-            cls.ccdomain.name,
-            "Custom Role",
-            permissions=Permissions(
-                edit_apps=True,
-                view_apps=True,
-                edit_web_users=True,
-                view_web_users=True,
-                view_roles=True,
-            )
-        )
+        cls.custom_role = UserRole.create(cls.ccdomain.name, "Custom Role")
 
         cls.loc1 = make_loc('spain', domain=cls.ccdomain.name, type="district")
         cls.loc2 = make_loc('madagascar', domain=cls.ccdomain.name, type="district")

--- a/corehq/apps/users/tests/test_dbaccessors.py
+++ b/corehq/apps/users/tests/test_dbaccessors.py
@@ -21,6 +21,7 @@ from corehq.apps.users.models import (
     UserRole,
     WebUser,
 )
+from corehq.apps.users.role_utils import init_domain_with_presets
 
 
 @es_test
@@ -37,7 +38,7 @@ class AllCommCareUsersTest(TestCase):
         cls.other_domain.save()
         bootstrap_location_types(cls.ccdomain.name)
 
-        UserRole.init_domain_with_presets(cls.ccdomain.name)
+        init_domain_with_presets(cls.ccdomain.name)
         cls.user_roles = UserRole.by_domain(cls.ccdomain.name)
         cls.custom_role = UserRole.create(cls.ccdomain.name, "Custom Role")
 

--- a/corehq/apps/users/tests/test_dbaccessors.py
+++ b/corehq/apps/users/tests/test_dbaccessors.py
@@ -40,18 +40,17 @@ class AllCommCareUsersTest(TestCase):
 
         UserRole.init_domain_with_presets(cls.ccdomain.name)
         cls.user_roles = UserRole.by_domain(cls.ccdomain.name)
-        cls.custom_role = UserRole.get_or_create_with_permissions(
+        cls.custom_role = UserRole.create(
             cls.ccdomain.name,
-            Permissions(
+            "Custom Role",
+            permissions=Permissions(
                 edit_apps=True,
                 view_apps=True,
                 edit_web_users=True,
                 view_web_users=True,
                 view_roles=True,
-            ),
-            "Custom Role"
+            )
         )
-        cls.custom_role.save()
 
         cls.loc1 = make_loc('spain', domain=cls.ccdomain.name, type="district")
         cls.loc2 = make_loc('madagascar', domain=cls.ccdomain.name, type="district")

--- a/corehq/apps/users/tests/test_role_utils.py
+++ b/corehq/apps/users/tests/test_role_utils.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+
+from corehq.apps.users.models import UserRole, Permissions
+from corehq.apps.users.role_utils import get_or_create_role_with_permissions
+
+
+class RoleUtilsTests(TestCase):
+    domain = 'role-utils'
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.role1_permissions = Permissions(edit_web_users=True)
+        cls.role1 = UserRole.create(cls.domain, 'role1', permissions=cls.role1_permissions)
+
+    @classmethod
+    def tearDownClass(cls):
+        for role in UserRole.by_domain(cls.domain):
+            role.delete()
+        super().tearDownClass()
+
+    def test_get_or_create_role_with_permissions_create(self):
+        permissions = Permissions(view_web_users=True)
+        role = get_or_create_role_with_permissions(self.domain, 'new_role', permissions)
+        self.assertNotEqual(role.get_id, self.role1.get_id)
+        self.assertEqual(role.name, 'new_role')
+
+    def test_get_or_create_role_with_permissions_get_existing(self):
+        role = get_or_create_role_with_permissions(self.domain, 'new_role', self.role1_permissions)
+        self.assertEqual(role.get_id, self.role1.get_id)
+        self.assertEqual(role.name, 'role1')


### PR DESCRIPTION
## Summary
Reduce the scope of the `UserRole` class by moving most of the class level methods to standalone functions.

This is part of ongoing work for moving `UserRole` to SQL.

Can review by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Some added, but mostly just moving code

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
