### PR TITLE
Case API updates

### DIFF
--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -65,6 +65,7 @@ FILTERS = {
     'owner_id': case_es.owner,
     'case_name': case_es.case_name,
     'closed': lambda val: case_es.is_closed(_to_boolean(val)),
+    'index': case_search.reverse_index_case_query,
 }
 FILTERS.update(chain(*[
     _to_date_filters('last_modified', case_es.modified_range),

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -95,7 +95,7 @@ def get_list(domain, params):
     es_result = query.run()
     hits = es_result.hits
     ret = {
-        "total": es_result.total,
+        "matching_records": es_result.total,
         "cases": [serialize_es_case(case) for case in hits],
     }
     cases_in_result = len(hits)

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -21,6 +21,7 @@ from .core import UserError, serialize_es_case
 DEFAULT_PAGE_SIZE = 20
 MAX_PAGE_SIZE = 5000
 CUSTOM_PROPERTY_PREFIX = 'property.'
+INDEX_PREFIX = 'indices.'
 
 
 def _to_boolean(val):
@@ -65,7 +66,6 @@ FILTERS = {
     'owner_id': case_es.owner,
     'case_name': case_es.case_name,
     'closed': lambda val: case_es.is_closed(_to_boolean(val)),
-    'index': case_search.reverse_index_case_query,
 }
 FILTERS.update(chain(*[
     _to_date_filters('last_modified', case_es.modified_range),
@@ -110,6 +110,8 @@ def _run_query(domain, params):
     for key, val in params.items():
         if key.startswith(CUSTOM_PROPERTY_PREFIX):
             query = query.filter(_get_custom_property_filter(key, val))
+        elif key.startswith(INDEX_PREFIX):
+            query = query.filter(_get_index_filter(key, val))
         elif key == 'xpath':
             query = query.filter(_get_xpath_filter(domain, val))
         elif key in FILTERS:
@@ -125,6 +127,11 @@ def _get_custom_property_filter(key, val):
     if val == "":
         return case_search.case_property_missing(prop)
     return case_search.exact_case_property_text_query(prop, val)
+
+
+def _get_index_filter(key, case_id):
+    identifier = key[len(INDEX_PREFIX):]
+    return case_search.reverse_index_case_query(case_id, identifier)
 
 
 def _get_xpath_filter(domain, xpath):

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -25,6 +25,9 @@ from ..api.core import UserError
 from ..api.get_list import MAX_PAGE_SIZE, get_list
 from ..utils import submit_case_blocks
 
+GOOD_GUYS_ID = str(uuid.uuid4())
+BAD_GUYS_ID = str(uuid.uuid4())
+
 
 @es_test
 @privilege_enabled(privileges.API_ACCESS)
@@ -48,9 +51,7 @@ class TestCaseListAPI(TestCase):
     @classmethod
     def _mk_cases(cls):
         case_blocks = []
-        good_id = str(uuid.uuid4())
-        bad_id = str(uuid.uuid4())
-        for team_id, name in [(good_id, 'good_guys'), (bad_id, 'bad_guys')]:
+        for team_id, name in [(GOOD_GUYS_ID, 'good_guys'), (BAD_GUYS_ID, 'bad_guys')]:
             case_blocks.append(CaseBlock(
                 case_id=team_id,
                 case_type='team',
@@ -62,11 +63,11 @@ class TestCaseListAPI(TestCase):
 
         date_opened = datetime.datetime(1878, 2, 17, 12)
         for external_id, name, properties, team_id in [
-                ('mattie', "Mattie Ross", {}, good_id),
-                ('rooster', "Reuben Cogburn", {"alias": "Rooster"}, good_id),
-                ('laboeuf', "LaBoeuf", {"alias": ""}, good_id),
-                ('chaney', "Tom Chaney", {"alias": "The Coward"}, bad_id),
-                ('ned', "Ned Pepper", {"alias": "Lucky Ned"}, bad_id),
+                ('mattie', "Mattie Ross", {}, GOOD_GUYS_ID),
+                ('rooster', "Reuben Cogburn", {"alias": "Rooster"}, GOOD_GUYS_ID),
+                ('laboeuf', "LaBoeuf", {"alias": ""}, GOOD_GUYS_ID),
+                ('chaney', "Tom Chaney", {"alias": "The Coward"}, BAD_GUYS_ID),
+                ('ned', "Ned Pepper", {"alias": "Lucky Ned"}, BAD_GUYS_ID),
         ]:
             case_blocks.append(CaseBlock(
                 case_id=str(uuid.uuid4()),
@@ -142,6 +143,7 @@ class TestCaseListAPI(TestCase):
     ('property.foo={"test": "json"}', []),  # This is escaped as expected
     ("case_type=person&property.alias=", ["mattie", "laboeuf"]),
     ('xpath=(alias="Rooster" or name="Mattie Ross")', ["mattie", "rooster"]),
+    (f"index={GOOD_GUYS_ID}", ['mattie', 'rooster', 'laboeuf']),
 ], TestCaseListAPI)
 def test_case_list_queries(self, querystring, expected):
     params = QueryDict(querystring).dict()

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -1,5 +1,6 @@
 import datetime
 import uuid
+from base64 import b64decode
 
 from django.http import QueryDict
 from django.test import TestCase
@@ -102,11 +103,11 @@ class TestCaseListAPI(TestCase):
             ['mattie', 'rooster', 'laboeuf'],
             [c['external_id'] for c in res['cases']]
         )
-        self.assertDictContainsSubset({
-            "limit": "3",
-            "case_type": "person",
-        }, res['next'])
-        self.assertIn('indexed_on.gte', res['next'])
+
+        cursor = b64decode(res['next']['cursor']).decode('utf-8')
+        self.assertIn('limit=3', cursor)
+        self.assertIn('case_type=person', cursor)
+        self.assertIn('indexed_on.gte', cursor)
 
         res = get_list(self.domain, res['next'])
         self.assertEqual(res['matching_records'], 3)

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -160,6 +160,7 @@ def test_case_list_queries(self, querystring, expected):
     ("password=1234", "'password' is not a valid parameter."),
     ("case_name.gte=a", "'case_name.gte' is not a valid parameter."),
     ("date_opened=2020-01-30", "'date_opened' is not a valid parameter."),
+    ("date_opened.start=2020-01-30", "'start' is not a valid type of date range."),
     ('xpath=gibberish',
      "Bad XPath: Your search query is required to have at least one boolean "
      "operator (>, >=, <, <=, =, !=)"),

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -96,8 +96,8 @@ class TestCaseListAPI(TestCase):
 
     def test_pagination(self):
         res = get_list(self.domain, {"limit": "3", "case_type": "person"})
-        self.assertItemsEqual(res.keys(), ['next', 'cases', 'total'])
-        self.assertEqual(res['total'], 5)
+        self.assertItemsEqual(res.keys(), ['next', 'cases', 'matching_records'])
+        self.assertEqual(res['matching_records'], 5)
         self.assertEqual(
             ['mattie', 'rooster', 'laboeuf'],
             [c['external_id'] for c in res['cases']]
@@ -109,7 +109,7 @@ class TestCaseListAPI(TestCase):
         self.assertIn('indexed_on.gte', res['next'])
 
         res = get_list(self.domain, res['next'])
-        self.assertEqual(res['total'], 3)
+        self.assertEqual(res['matching_records'], 3)
         self.assertEqual(
             ['laboeuf', 'chaney', 'ned'],
             [c['external_id'] for c in res['cases']]

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -143,7 +143,7 @@ class TestCaseListAPI(TestCase):
     ('property.foo={"test": "json"}', []),  # This is escaped as expected
     ("case_type=person&property.alias=", ["mattie", "laboeuf"]),
     ('xpath=(alias="Rooster" or name="Mattie Ross")', ["mattie", "rooster"]),
-    (f"index={GOOD_GUYS_ID}", ['mattie', 'rooster', 'laboeuf']),
+    (f"indices.parent={GOOD_GUYS_ID}", ['mattie', 'rooster', 'laboeuf']),
 ], TestCaseListAPI)
 def test_case_list_queries(self, querystring, expected):
     params = QueryDict(querystring).dict()


### PR DESCRIPTION
## Summary
Read by commit.  Does a few things:
* `s/total/matched_records/`
* b64 encodes cursors, so the next param looks like http://localhost:8000/a/esoergel/api/v0.6/case/?cursor=aW5kZXhlZF9vbi5ndGU9MjAyMS0wNS0xN1QyMCUzQTM2JTNBMjcuMTk3MzQ3Wg%3D%3D
* Adds the ability to filter by indices.

On that last point, you can already see what a case indices by looking at the serialization of the case.  This lets you traverse the lookups in the reverse direction by querying for cases which index the ID you're looking at.

## Feature Flag
"Enable the v0.6 Case API"

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Unreleased feature

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
