### PR TITLE
Remove ResumableFunctionIterator.retry()

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -1276,7 +1276,6 @@ def _iter_docs(domain, doc_type, resume_key, stopper):
         resume_key,
         data_function,
         args_provider,
-        item_getter=None,
         event_handler=MigrationPaginationEventHandler(domain, stopper)
     )
     if rows.state.is_resume() and rows.state.to_json().get("kwargs"):
@@ -1466,7 +1465,7 @@ class MissingFormLoader:
 
 def get_main_forms_iteration_stop_date(statedb):
     resume_key = f"{statedb.domain}.XFormInstance.{statedb.unique_id}"
-    itr = ResumableFunctionIterator(resume_key, None, None, None)
+    itr = ResumableFunctionIterator(resume_key, None, None)
     if itr.state.complete:
         return None
     kwargs = itr.state.kwargs

--- a/corehq/apps/couch_sql_migration/missingdocs.py
+++ b/corehq/apps/couch_sql_migration/missingdocs.py
@@ -207,7 +207,7 @@ class MissingIds:
 
     @staticmethod
     def discard_iteration_state(resume_key):
-        ResumableFunctionIterator(resume_key, None, None, None).discard_state()
+        ResumableFunctionIterator(resume_key, None, None).discard_state()
 
     def reset_doc_count(self, doc_type, count_key):
         count = self.counter.pop(count_key)

--- a/corehq/apps/couch_sql_migration/rewind.py
+++ b/corehq/apps/couch_sql_migration/rewind.py
@@ -53,7 +53,7 @@ class IterationState:
     def __attrs_post_init__(self):
         migration_id = self.statedb.unique_id
         resume_key = "%s.%s.%s" % (self.domain, self.doc_type, migration_id)
-        self.itr = ResumableFunctionIterator(resume_key, None, None, None)
+        self.itr = ResumableFunctionIterator(resume_key, None, None)
 
     @property
     def value(self):

--- a/corehq/apps/couch_sql_migration/staterebuilder.py
+++ b/corehq/apps/couch_sql_migration/staterebuilder.py
@@ -65,7 +65,7 @@ iter_id_chunks.chunk_size = 5000
 
 def get_endkey_docid(domain, doc_type, migration_id):
     resume_key = "%s.%s.%s" % (domain, doc_type, migration_id)
-    state = ResumableFunctionIterator(resume_key, None, None, None).state
+    state = ResumableFunctionIterator(resume_key, None, None).state
     assert getattr(state, '_rev', None), "rebuild not necessary (no resume state)"
     assert not state.complete, "iteration is complete"
     state_json = state.to_json()

--- a/corehq/apps/hqadmin/corrupt_couch.py
+++ b/corehq/apps/hqadmin/corrupt_couch.py
@@ -262,7 +262,7 @@ def _iter_missing_ids(db, min_tries, resume_key, view_name, view_params, repair)
         return [last_result]
 
     args_provider = NoSkipArgsProvider(view_params)
-    return ResumableFunctionIterator(resume_key, data_function, args_provider, item_getter=None)
+    return ResumableFunctionIterator(resume_key, data_function, args_provider)
 
 
 def repair_couch_docs(db, missing, get_doc_ids, min_tries):

--- a/corehq/blobs/migrate.py
+++ b/corehq/blobs/migrate.py
@@ -97,7 +97,6 @@ from corehq.util.doc_processor.couch import (
 from corehq.util.doc_processor.couch import CouchProcessorProgressLogger
 from corehq.util.doc_processor.sql import SqlDocumentProvider
 from corehq.util.doc_processor.progress import DOCS_SKIPPED_WARNING, ProgressManager
-from corehq.util.pagination import TooManyRetries
 from couchdbkit import ResourceConflict
 from corehq.form_processor.backends.sql.dbaccessors import ReindexAccessor
 
@@ -422,10 +421,7 @@ class Migrator(object):
                 if success:
                     progress.add()
                 else:
-                    try:
-                        iterable.retry(doc, max_retry)
-                    except TooManyRetries:
-                        progress.skip(doc)
+                    progress.skip(doc)
 
         if not progress.skipped:
             self.write_migration_completed_state()

--- a/corehq/ex-submodules/pillowtop/reindexer/change_providers/couch.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/change_providers/couch.py
@@ -78,7 +78,6 @@ class CouchDomainDocTypeChangeProvider(ChangeProvider):
                 resumable_key,
                 data_function,
                 args_provider,
-                lambda x: x.id,
                 event_handler=event_handler
             )
         else:

--- a/corehq/util/doc_processor/couch.py
+++ b/corehq/util/doc_processor/couch.py
@@ -39,13 +39,7 @@ def resumable_view_iterator(db, iteration_key, view_name, view_keys, chunk_size=
             for result in super(ResumableDocsIterator, self).__iter__():
                 yield result if full_row else result['doc']
 
-    def item_getter(doc_id):
-        try:
-            return {'doc': db.get(doc_id)}
-        except ResourceNotFound:
-            pass
-
-    return ResumableDocsIterator(iteration_key, data_function, args_provider, item_getter, view_event_handler)
+    return ResumableDocsIterator(iteration_key, data_function, args_provider, view_event_handler)
 
 
 def resumable_docs_by_type_iterator(db, doc_types, iteration_key, chunk_size=100,

--- a/corehq/util/doc_processor/interface.py
+++ b/corehq/util/doc_processor/interface.py
@@ -132,6 +132,12 @@ class DocumentProcessorController(object):
             self.progress.add()
         elif self.doc_processor.handle_skip(doc):
             self.progress.skip(doc)
+        else:
+            raise UnhandledDocumentError(doc)
+
+
+class UnhandledDocumentError(Exception):
+    pass
 
 
 class BulkDocProcessorEventHandler(PaginationEventHandler):

--- a/corehq/util/doc_processor/interface.py
+++ b/corehq/util/doc_processor/interface.py
@@ -3,7 +3,7 @@ from abc import ABCMeta, abstractmethod
 
 
 from .progress import ProgressManager, ProcessorProgressLogger
-from ..pagination import PaginationEventHandler, TooManyRetries
+from ..pagination import PaginationEventHandler
 
 
 class BulkProcessingFailed(Exception):
@@ -83,7 +83,7 @@ class DocumentProcessorController(object):
     :param doc_processor: A ``BaseDocProcessor`` object used to process documents.
     :param reset: Reset existing processor state (if any), causing all
     documents to be reconsidered for processing, if this is true.
-    :param max_retry: Number of times to retry processing a document before giving up.
+    :param max_retry: Obsolete, not used.
     :param chunk_size: Maximum number of records to read from couch at
     one time. It may be necessary to use a smaller chunk size if the
     records being processed are very large and the default chunk size of
@@ -91,11 +91,10 @@ class DocumentProcessorController(object):
     :param event_handler: A ``PaginateViewLogHandler`` object to be notified of pagination events.
     :param progress_logger: A ``ProcessorProgressLogger`` object to notify of progress events.
     """
-    def __init__(self, document_provider, doc_processor, reset=False, max_retry=2,
+    def __init__(self, document_provider, doc_processor, reset=False, max_retry=None,
                  chunk_size=100, event_handler=None, progress_logger=None):
         self.doc_processor = doc_processor
         self.reset = reset
-        self.max_retry = max_retry
         self.chunk_size = chunk_size
         self.document_provider = document_provider
 
@@ -131,14 +130,8 @@ class DocumentProcessorController(object):
         ok = self.doc_processor.process_doc(doc)
         if ok:
             self.progress.add()
-        else:
-            try:
-                self.document_iterator.retry(doc['_id'], self.max_retry)
-            except TooManyRetries:
-                if not self.doc_processor.handle_skip(doc):
-                    raise
-                else:
-                    self.progress.skip(doc)
+        elif self.doc_processor.handle_skip(doc):
+            self.progress.skip(doc)
 
 
 class BulkDocProcessorEventHandler(PaginationEventHandler):

--- a/corehq/util/doc_processor/progress.py
+++ b/corehq/util/doc_processor/progress.py
@@ -130,7 +130,10 @@ class ProcessorProgressLogger(object):
         print(f"{self.prefix}Processing {total} documents{suffix}: ...", file=self.stream)
 
     def document_skipped(self, doc_dict):
-        print(f"{self.prefix}Skip: {doc_dict['doc_type']} {doc_dict['id']}", file=self.stream)
+        doc_id = doc_dict.get('id')
+        if doc_id is None:
+            doc_id = doc_dict.get('_id')
+        print(f"{self.prefix}Skip: {doc_dict['doc_type']} {doc_id}", file=self.stream)
 
     def document_processed(self, doc_dict, doc_updates):
         pass

--- a/corehq/util/doc_processor/sql.py
+++ b/corehq/util/doc_processor/sql.py
@@ -63,9 +63,7 @@ def resumable_sql_model_iterator(iteration_key, reindex_accessor, chunk_size=100
             for doc in super(ResumableModelIterator, self).__iter__():
                 yield transform(doc)
 
-    item_getter = reindex_accessor.get_doc
-
-    return ResumableModelIterator(iteration_key, data_function, args_provider, item_getter, event_handler)
+    return ResumableModelIterator(iteration_key, data_function, args_provider, event_handler)
 
 
 class SqlDocumentProvider(DocumentProvider):

--- a/corehq/util/pagination.py
+++ b/corehq/util/pagination.py
@@ -223,17 +223,15 @@ class ResumableFunctionIterator(object):
     :param data_function: function to iterate over. Must return an list
     of data elements.
     :param args_provider: An instance of the ``ArgsProvider`` class.
-    :param item_getter: Obsolete/unused.
     :param event_handler: Instance of ``PaginationEventHandler`` to be
     notified on page events. May raise ``StopToResume`` to terminate the
     iteration immediately (it may be resumed later).
     """
 
-    def __init__(self, iteration_key, data_function, args_provider, item_getter, event_handler=None):
+    def __init__(self, iteration_key, data_function, args_provider, event_handler=None):
         self.iteration_key = iteration_key
         self.data_function = data_function
         self.args_provider = args_provider
-        self.item_getter = item_getter
         self.event_handler = event_handler
         self.iteration_id = hashlib.sha1(self.iteration_key.encode('utf-8')).hexdigest()
 
@@ -315,7 +313,6 @@ class ResumableFunctionIterator(object):
             self.iteration_key,
             self.data_function,
             self.args_provider,
-            self.item_getter,
             self.event_handler
         )
 

--- a/corehq/util/tests/test_doc_processor.py
+++ b/corehq/util/tests/test_doc_processor.py
@@ -18,7 +18,6 @@ from corehq.util.doc_processor.interface import (
     BaseDocProcessor, DocumentProcessorController, BulkDocProcessor, BulkProcessingFailed
 )
 from corehq.util.doc_processor.sql import resumable_sql_model_iterator
-from corehq.util.pagination import TooManyRetries
 from dimagi.ext.couchdbkit import Document
 from dimagi.utils.chunked import chunked
 from dimagi.utils.couch.database import get_db
@@ -112,14 +111,6 @@ class TestResumableDocsByTypeIterator(TestCase):
         self.itr.data_function = data_function
         self.assertEqual([doc["_id"] for doc in self.itr], self.sorted_keys[5:])
         self.assertEqual(chunks, [1, 0, 3, 0])  # max chunk: 3
-
-    def test_iteration_with_retry(self):
-        itr = iter(self.itr)
-        doc = next(itr)
-        self.itr.retry(doc['_id'])
-        self.assertEqual(doc["_id"], "foo-0")
-        self.assertEqual(["foo-0"] + [d["_id"] for d in itr],
-                         self.sorted_keys + ["foo-0"])
 
     def test_iteration_with_domain(self):
         itr_domain1 = self.get_iterator(domain=self.domain1)
@@ -233,14 +224,6 @@ class BaseResumableSqlModelIteratorTest(object):
         self.itr.data_function = data_function
         self.assertEqual([doc["_id"] for doc in self.itr], self.all_doc_ids[4:])
         self.assertEqual(chunks, [3, 2, 0])  # max chunk: 3
-
-    def test_iteration_with_retry(self):
-        itr = iter(self.itr)
-        doc = next(itr)
-        self.itr.retry(doc['_id'])
-        self.assertEqual(doc["_id"], self.first_doc_id)
-        self.assertEqual([self.first_doc_id] + [d["_id"] for d in itr],
-                         self.all_doc_ids + [self.first_doc_id])
 
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
@@ -470,12 +453,6 @@ class TestCouchDocProcessor(BaseCouchDocProcessorTest):
     def test_multiple_runs_no_skip(self):
         self._test_processor(4, list(range(4)))
         self._test_processor(0, [])
-
-    def test_multiple_runs_with_skip(self):
-        with self.assertRaises(TooManyRetries):
-            self._test_processor(3, list(range(3)), skip_docs=['bar-3'])
-
-        self._test_processor(1, [3])
 
 
 class TestBulkDocProcessor(BaseCouchDocProcessorTest):

--- a/corehq/util/tests/test_pagination.py
+++ b/corehq/util/tests/test_pagination.py
@@ -40,12 +40,7 @@ class TestResumableFunctionIterator(SimpleTestCase):
             except IndexError:
                 return []
 
-        def item_getter(item_id):
-            if missing_items and item_id in missing_items:
-                return None
-            return int(item_id)
-
-        itr = ResumableFunctionIterator('test', data_provider, TestArgsProvider(), item_getter)
+        itr = ResumableFunctionIterator('test', data_provider, TestArgsProvider())
         itr.couch_db = self.couch_db
         return itr
 

--- a/corehq/util/tests/test_pagination.py
+++ b/corehq/util/tests/test_pagination.py
@@ -3,7 +3,7 @@ import itertools
 from django.test.testcases import SimpleTestCase
 from fakecouch import FakeCouchDb
 
-from corehq.util.pagination import ResumableFunctionIterator, ArgsProvider, TooManyRetries
+from corehq.util.pagination import ResumableFunctionIterator, ArgsProvider
 
 
 class TestArgsProvider(ArgsProvider):
@@ -85,48 +85,3 @@ class TestResumableFunctionIterator(SimpleTestCase):
         self.itr = self.get_iterator()
         self.assertEqual(self.itr.get_iterator_detail('progress'), {"visited": "six"})
         self.assertEqual([item for item in self.itr], self.all_items[3:])
-
-    def test_iteration_with_retry(self):
-        itr = iter(self.itr)
-        item = next(itr)
-        self.itr.retry(str(item))
-        self.assertEqual(item, 0)
-        self.assertEqual([0] + [d for d in itr],
-                         self.all_items + [0])
-
-    def test_iteration_complete_after_retry(self):
-        itr = iter(self.itr)
-        self.itr.retry(str(next(itr)))
-        list(itr)
-        self.itr = self.get_iterator()
-        self.assertEqual([item for item in self.itr], [])
-
-    def test_iteration_with_max_retry(self):
-        itr = iter(self.itr)
-        item = next(itr)
-        ids = [item]
-        self.assertEqual(item, 0)
-        self.itr.retry(str(item))
-        retries = 1
-        for item in itr:
-            ids.append(item)
-            if item == 0:
-                if retries < 3:
-                    self.itr.retry(str(item))
-                    retries += 1
-                else:
-                    break
-        self.assertEqual(item, 0)
-        with self.assertRaises(TooManyRetries):
-            self.itr.retry(str(item))
-        self.assertEqual(ids, self.all_items + [0, 0, 0])
-        self.assertEqual(list(itr), [])
-        self.assertEqual(list(self.get_iterator()), [])
-
-    def test_iteration_with_missing_retry_doc(self):
-        iterator = self.get_iterator(missing_items=["0"])
-        itr = iter(iterator)
-        item = next(itr)
-        self.assertEqual(item, 0)
-        iterator.retry(str(item))
-        self.assertEqual([0] + [d for d in itr], self.all_items)


### PR DESCRIPTION
`ResumableFunctionIterator.retry()` is not a good solution for large-scale iterations where many documents may need to be retried. Better to stop the iteration on failure or retry failed documents using a storage mechanism that is appropriate to the particular iteration.

I've wanted to remove this for a long time. Hopefully I've addressed all tests that depend on it, but will revisit if travis says otherwise. If we really need this it should be implemented independently of `ResumableFunctionIterator`.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

There are no new features in this PR to be tested. A feature is being removed, and tests for that feature are being removed too.

### QA Plan

No.

### Safety story

Only two things used this feature:
- Couch attachment to blob db migrations, which have been completed for a long time.
- Pillows? How and when they retry is less clear, but I'm hoping it's not often. @snopoke to comment on that.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
