### PR TITLE
Make "generate DET config files" generally available

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -762,6 +762,8 @@ class ExportInstance(BlobMixin, Document):
     is_daily_saved_export = BooleanProperty(default=False)
     auto_rebuild_enabled = BooleanProperty(default=True)
 
+    show_det_config_download = BooleanProperty(default=False)
+
     # daily saved export fields:
     last_updated = DateTimeProperty()
     last_accessed = DateTimeProperty()

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -48,6 +48,7 @@ hqDefine("export/js/export_list", [
             'deleteUrl',
             'description',
             'downloadUrl',
+            'showDetDownload',
             'detSchemaUrl',
             'editUrl',
             'emailedExport',

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -516,6 +516,7 @@ hqDefine('export/js/models', [
             'case_type',
             'xmlns',
             'is_daily_saved_export',
+            'show_det_config_download',
         ],
         tables: {
             create: function (options) {

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -169,7 +169,8 @@
                 <strong>{% trans "Generate a Data Export Tool config file?" %}</strong><br/>
                 {% blocktrans %}
                   Checking this will add a button to download a configuration file
-                  for the CommCare Data Export Tool for the export.
+                  for the <a href="https://confluence.dimagi.com/display/commcarepublic/CommCare+Data+Export+Tool" target="_blank">
+                  CommCare Data Export Tool</a> for the export.
                 {% endblocktrans %}
               </label>
             </div>

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -161,6 +161,18 @@
                 {% endif %}
               </div>
             {% endif %}
+            <div class="checkbox">
+              <label>
+                <input type="checkbox"
+                       id="det-config-checkbox"
+                       data-bind="checked: show_det_config_download" />
+                <strong>{% trans "Generate a Data Export Tool config file?" %}</strong><br/>
+                {% blocktrans %}
+                  Checking this will add a button to download a configuration file
+                  for the CommCare Data Export Tool for the export.
+                {% endblocktrans %}
+              </label>
+            </div>
 
 
             {% if export_instance.type == 'form' %}

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -519,7 +519,8 @@
           {% trans "Edit Filters" %}
         </a>
       {% endif %}
-      <a data-bind="visible: showDetDownload, attr: {href: detSchemaUrl}" class="btn btn-default">
+      {% trans "Download a Data Export Tool configuration file for this export" as det_help %}
+      <a data-bind="visible: showDetDownload, attr: {href: detSchemaUrl}" class="btn btn-default" title="{{ det_help }}">
         <i class="fa fa-download"></i>
         {% trans "DET Config" %}
       </a>

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -510,7 +510,7 @@
       {% if request|toggle_enabled:"DATA_EXPORT_TOOL_SCHEMA_EXPORT" %}
       <br>
       <br>
-      <a data-bind="attr: {href: detSchemaUrl}" class="btn btn-default btn-xs">
+      <a data-bind="visible: showDetDownload, attr: {href: detSchemaUrl}" class="btn btn-default btn-xs">
         {% trans "Download DET Config" %}
       </a>
       {% endif %}

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -507,13 +507,11 @@
          class="btn btn-primary">
         {{ export_type_caps }}
       </a>
-      {% if request|toggle_enabled:"DATA_EXPORT_TOOL_SCHEMA_EXPORT" %}
       <br>
       <br>
       <a data-bind="visible: showDetDownload, attr: {href: detSchemaUrl}" class="btn btn-default btn-xs">
         {% trans "Download DET Config" %}
       </a>
-      {% endif %}
       {% if has_edit_permissions %}
         <a class="btn btn-default"
            data-bind="visible: showSavedFilters && isLocationSafeForUser(),

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -20,7 +20,7 @@
     <th class="col-sm-1">
       {% if export_filter_form %}
         {% if has_edit_permissions %}
-          {% trans "Edit Filters" %}
+          {% trans "Filters and Files" %}
         {% endif %}
       {% else %}
         {{ export_type_caps }}
@@ -500,17 +500,12 @@
       </td>
     {% endif %}
 
-    <td>
+    <td nowrap>
       <a data-bind="attr: {href: downloadUrl},
                     visible: !showSavedFilters,
                     click: $root.sendExportAnalytics"
          class="btn btn-primary">
         {{ export_type_caps }}
-      </a>
-      <br>
-      <br>
-      <a data-bind="visible: showDetDownload, attr: {href: detSchemaUrl}" class="btn btn-default btn-xs">
-        {% trans "Download DET Config" %}
       </a>
       {% if has_edit_permissions %}
         <a class="btn btn-default"
@@ -524,6 +519,10 @@
           {% trans "Edit Filters" %}
         </a>
       {% endif %}
+      <a data-bind="visible: showDetDownload, attr: {href: detSchemaUrl}" class="btn btn-default">
+        <i class="fa fa-download"></i>
+        {% trans "DET Config" %}
+      </a>
     </td>
 
     {% if allow_bulk_export %}

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -225,6 +225,7 @@ class ExportListHelper(object):
             'deleteUrl': reverse(DeleteNewCustomExportView.urlname,
                                  args=(self.domain, export.type, export.get_id)),
             'downloadUrl': reverse(self._download_view(export).urlname, args=(self.domain, export.get_id)),
+            'showDetDownload': export.show_det_config_download,
             'detSchemaUrl': reverse(DownloadDETSchemaView.urlname,
                                     args=(self.domain, export.get_id)),
             'editUrl': reverse(self._edit_view(export).urlname, args=(self.domain, export.get_id)),

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1298,15 +1298,6 @@ ALLOW_USER_DEFINED_EXPORT_COLUMNS = StaticToggle(
 )
 
 
-DATA_EXPORT_TOOL_SCHEMA_EXPORT = StaticToggle(
-    'data_export_tool_schema_export',
-    'Show an option to download data export tool schemas from the exports list view (Experimental)',
-    TAG_SOLUTIONS_OPEN,
-    [NAMESPACE_DOMAIN, NAMESPACE_USER],
-    help_link='https://confluence.dimagi.com/display/ccinternal/Download+Data+Export+Tool+Schemas+from+the+Exports+List+View',
-)
-
-
 DISABLE_COLUMN_LIMIT_IN_UCR = StaticToggle(
     'disable_column_limit_in_ucr',
     'Enikshay: Disable column limit in UCR',


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

This makes it possible for anyone to create DET schema downloads from any export. [Spec doc](https://docs.google.com/document/d/1HecsnOT7n4YxuJKeBEzeo9xibz_iFeF8N8tHktAV0zY/edit)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

The flag "Show an option to download data export tool schemas from the exports list view (Experimental)" was removed.

Anyone previously using this flag will now have to turn the feature back on at the export-level (instructions below).

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

New checkbox on the edit / create export page (at the bottom):
![image](https://user-images.githubusercontent.com/66555/118620951-3e34fe00-b7c6-11eb-9360-a3b529027a61.png)

New download UI:

![image](https://user-images.githubusercontent.com/66555/118621045-4ee57400-b7c6-11eb-9d47-5bafab2037b4.png)

The other export list views have a similar UI, but the button sits next to the "Edit Filters" button, due to some quirks about how the table gets rendered. To accommodate this, I changed the column heading for those pages from "Edit Filters" to "Filters and Files" as per below:

![image](https://user-images.githubusercontent.com/66555/118643829-56fcde00-b7dd-11eb-95dc-404a558b7e35.png)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

I've tested everything I could think of locally, including all export types (case, form, daily saved, excel dashboard, and odata). 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

No tests for the front end.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

I'm not pushing for QA since this is a small and power-user feature.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

This has a small surface area, so I'm not expecting any issues. I think the biggest possible risk would be the button showing up in a funny place after someone has enabled it, if there's an edge case I didn't test well. For example, I didn't test all permutations of "edit" vs "non-edit" permissions, and the `EXPORT_OWNERSHIP` feature flag. However based on a read of the code I don't believe this would happen, and if it did it wouldn't be a high-priority issue.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
