### PR TITLE
add lodash to require_config so that WIPs can start importing during migration

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/requirejs_config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/requirejs_config.js
@@ -4,6 +4,7 @@ requirejs.config({
     paths: {
         "jquery": "jquery/dist/jquery.min",
         "underscore": "underscore/underscore",
+        "lodash": "lodash/lodash",
         "bootstrap": "bootstrap/dist/js/bootstrap.min",
         "knockout": "knockout/build/output/knockout-latest.debug",
         "ko.mapping": "hqwebapp/js/lib/knockout_plugins/knockout_mapping.ko.min",


### PR DESCRIPTION
## Summary
We are officially beginning the migration from `underscore` to `lodash`. The recent CVE for `underscore` prompted us to fast-track the upgrade progress for `underscore`, which we realized breaks lots of things including `require.js` imports. 

This PR adds 'lodash' to the short-hand paths so that it can be available for devs to use right now for any WIPs not yet merged into `master`.

By the way, these breaking changes for minor versions are [not the first time](https://github.com/jashkenas/underscore/issues/1805) this has happened. If you read this thread, it's very clear the maintainers do not care about breaking changes or your "problematic" legacy applications. See [sentimental versioning](http://sentimentalversioning.org/) for some other similarly-versioned libraries (and a good laugh).

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
We will do a QA round on the actual migration. 

### Safety story
This just makes lodash easily available. Does not change any active code.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
