### PR TITLE
Fix shell syntax error in docker/run.sh

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -39,7 +39,7 @@ function setup() {
 
 function run_tests() {
     TEST="$1"
-    if [ "$TEST" != "javascript" -a "$TEST" != "python" -a "$TEST" != "python-sharded" -a "$TEST" != "python-sharded-and-javascript"]; then
+    if [ "$TEST" != "javascript" -a "$TEST" != "python" -a "$TEST" != "python-sharded" -a "$TEST" != "python-sharded-and-javascript" ]; then
         echo "Unknown test suite: $TEST"
         exit 1
     fi


### PR DESCRIPTION
## Summary

Fix shell syntax error causing test suite check to fail in `docker/run.sh`. Error shows up in travis jobs as:

```sh
/mnt/run.sh: line 42: [: missing `]'
```

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
