### PR TITLE
Upgrade to latest pip version (21.1.1)

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -712,7 +712,7 @@ zipp==3.2.0
     #   pep517
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.0.1
+pip==21.1.1
     # via pip-tools
 setuptools==50.3.0
     # via

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -575,7 +575,7 @@ zipp==3.4.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.0.1
+pip==21.1.1
     # via -r prod-requirements.in
 setuptools==50.3.0
     # via

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -587,7 +587,7 @@ zipp==3.4.0
     #   pep517
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.0.1
+pip==21.1.1
     # via pip-tools
 setuptools==50.3.0
     # via


### PR DESCRIPTION
## Summary

Upgrade pip to the latest release. Fixes pip install warning:

```
WARNING: You are using pip version 21.0.1; however, version 21.1.1 is available.
```

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
