### PR TITLE
Display correct error messages instead of failing hard

### DIFF
--- a/corehq/apps/fixtures/upload/validation.py
+++ b/corehq/apps/fixtures/upload/validation.py
@@ -4,7 +4,7 @@ from corehq.apps.fixtures.exceptions import FixtureUploadError
 from corehq.apps.fixtures.upload.failure_messages import FAILURE_MESSAGES
 from corehq.apps.fixtures.upload.workbook import get_workbook
 from corehq.apps.fixtures.utils import get_fields_without_attributes
-from corehq.util.workbook_json.excel import WorksheetNotFound
+from corehq.util.workbook_json.excel import JSONReaderError, WorksheetNotFound
 
 
 def validate_fixture_file_format(file_or_filename):
@@ -25,6 +25,8 @@ def _validate_fixture_upload(workbook):
         type_sheets = workbook.get_all_type_sheets()
     except FixtureUploadError as e:
         return e.errors
+    except JSONReaderError as e:
+        return e.args
 
     error_messages = []
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12143

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
We were not handling `JSONReaderError` because of which users were getting a 500 page. The reason for failure would not be known to them. The PR fixes the issue.

The errors will be displayed like-
 
![image-20210526-095616](https://user-images.githubusercontent.com/7694243/119769877-f0f91080-bed8-11eb-977f-924c7bbcb830.png)


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Changes are small and have been tested locally.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
