### PR TITLE
Move signals into separate module

### DIFF
--- a/corehq/motech/fhir/__init__.py
+++ b/corehq/motech/fhir/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'corehq.motech.fhir.apps.FHIRAppConfig'

--- a/corehq/motech/fhir/apps.py
+++ b/corehq/motech/fhir/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class FHIRAppConfig(AppConfig):
+    name = 'corehq.motech.fhir'
+
+    def ready(self):
+        from . import signals  # noqa # pylint: disable=unused-import

--- a/corehq/motech/fhir/models.py
+++ b/corehq/motech/fhir/models.py
@@ -20,7 +20,6 @@ from corehq.motech.value_source import (
     as_value_source,
 )
 from corehq.motech.fhir import serializers  # noqa # pylint: disable=unused-import
-from corehq.motech.fhir import signals  # noqa # pylint: disable=unused-import
 
 from .const import FHIR_VERSION_4_0_1, FHIR_VERSIONS
 from .validators import validate_supported_type

--- a/corehq/motech/fhir/models.py
+++ b/corehq/motech/fhir/models.py
@@ -20,6 +20,7 @@ from corehq.motech.value_source import (
     as_value_source,
 )
 from corehq.motech.fhir import serializers  # noqa # pylint: disable=unused-import
+from corehq.motech.fhir import signals  # noqa # pylint: disable=unused-import
 
 from .const import FHIR_VERSION_4_0_1, FHIR_VERSIONS
 from .validators import validate_supported_type

--- a/corehq/motech/fhir/repeaters.py
+++ b/corehq/motech/fhir/repeaters.py
@@ -6,7 +6,6 @@ from memoized import memoized
 
 from casexml.apps.case.xform import extract_case_blocks
 from couchforms.const import TAG_FORM, TAG_META
-from couchforms.signals import successful_form_received
 from dimagi.ext.couchdbkit import BooleanProperty, StringProperty
 
 from corehq.apps.accounting.utils import domain_has_privilege
@@ -20,7 +19,6 @@ from corehq.motech.repeaters.models import CaseRepeater
 from corehq.motech.repeaters.repeater_generators import (
     FormDictPayloadGenerator,
 )
-from corehq.motech.repeaters.signals import create_repeat_records
 from corehq.motech.utils import pformat_json
 from corehq.motech.value_source import (
     CaseTriggerInfo,
@@ -165,10 +163,3 @@ def _get_resource_types_by_case_type(domain, fhir_version, cases):
         )
     )
     return {rt.case_type.name: rt for rt in fhir_resource_types}
-
-
-def create_fhir_repeat_records(sender, xform, **kwargs):
-    create_repeat_records(FHIRRepeater, xform)
-
-
-successful_form_received.connect(create_fhir_repeat_records)

--- a/corehq/motech/fhir/signals.py
+++ b/corehq/motech/fhir/signals.py
@@ -1,0 +1,11 @@
+from couchforms.signals import successful_form_received
+
+from corehq.motech.repeaters.signals import create_repeat_records
+
+
+def create_fhir_repeat_records(sender, xform, **kwargs):
+    from .repeaters import FHIRRepeater
+    create_repeat_records(FHIRRepeater, xform)
+
+
+successful_form_received.connect(create_fhir_repeat_records)

--- a/corehq/motech/fhir/signals.py
+++ b/corehq/motech/fhir/signals.py
@@ -1,11 +1,11 @@
+from django.dispatch import receiver
+
 from couchforms.signals import successful_form_received
 
 from corehq.motech.repeaters.signals import create_repeat_records
 
 
+@receiver(successful_form_received, dispatch_uid="create_fhir_repeat_records")
 def create_fhir_repeat_records(sender, xform, **kwargs):
     from .repeaters import FHIRRepeater
     create_repeat_records(FHIRRepeater, xform)
-
-
-successful_form_received.connect(create_fhir_repeat_records)

--- a/corehq/motech/fhir/tests/test_signals.py
+++ b/corehq/motech/fhir/tests/test_signals.py
@@ -1,0 +1,7 @@
+from couchforms.signals import successful_form_received
+from nose.tools import assert_in
+
+
+def test_create_fhir_repeat_records_in_receivers():
+    receivers = [r[1]().__name__ for r in successful_form_received.receivers]
+    assert_in('create_fhir_repeat_records', receivers)


### PR DESCRIPTION
## Summary

Small: Ensures `create_repeat_records()` is called on `successful_form_received` signal for `FHIRRepeater`.


## Feature Flag
"FHIR Integration"


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Automated test coverage

Includes test


### Safety story

Feature not yet released.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
