### PR TITLE
handles integrity error in enterprise permissions

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1297,4 +1297,3 @@ class CreateDomainPermissionsMirrorForm(forms.Form):
     def save_mirror_domain(self):
         mirror = DomainPermissionsMirror(source=self.domain, mirror=self.mirror_domain)
         mirror.save()
-

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -704,6 +704,7 @@ def create_domain_permission_mirror(request, domain):
         for field, message in form.errors.items():
             messages.error(request, message)
     else:
+        form.save_mirror_domain()
         mirror_domain_name = form.cleaned_data.get("mirror_domain")
         message = _('You have successfully added the project space "{mirror_domain_name}".')
         messages.success(request, message.format(mirror_domain_name=mirror_domain_name))

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -701,25 +701,13 @@ def delete_domain_permission_mirror(request, domain, mirror):
 @require_POST
 def create_domain_permission_mirror(request, domain):
     form = CreateDomainPermissionsMirrorForm(domain=request.domain, data=request.POST)
-    if form.is_valid():
-        mirror_domain_name = form.cleaned_data.get("mirror_domain")
-        mirror_domain = Domain.get_by_name(mirror_domain_name)
-        if mirror_domain is not None:
-            try:
-                mirror = DomainPermissionsMirror(source=domain, mirror=mirror_domain_name)
-                mirror.save()
-            except IntegrityError:
-                message = _('"{mirror_domain_name}" has already been added.')
-                messages.error(request, message.format(mirror_domain_name=mirror_domain_name))
-            else:
-                message = _('You have successfully added the project space "{mirror_domain_name}".')
-                messages.success(request, message.format(mirror_domain_name=mirror_domain_name))
-        else:
-            message = _('Please enter a valid project space.')
-            messages.error(request, message.format())
-    else:
+    if not form.is_valid():
         for field, message in form.errors.items():
             messages.error(request, message)
+    else:
+        mirror_domain_name = form.cleaned_data.get("mirror_domain")
+        message = _('You have successfully added the project space "{mirror_domain_name}".')
+        messages.success(request, message.format(mirror_domain_name=mirror_domain_name))
     redirect = reverse(DomainPermissionsMirrorView.urlname, args=[domain])
     return HttpResponseRedirect(redirect)
 

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -709,8 +709,8 @@ def create_domain_permission_mirror(request, domain):
                 mirror = DomainPermissionsMirror(source=domain, mirror=mirror_domain_name)
                 mirror.save()
             except IntegrityError:
-                message = _(mirror_domain_name + ' has already been added.')
-                messages.error(request, message)
+                message = _('"{mirror_domain_name}" has already been added.')
+                messages.error(request, message.format(mirror_domain_name=mirror_domain_name))
             else:
                 message = _('You have successfully added the project space "{mirror_domain_name}".')
                 messages.success(request, message.format(mirror_domain_name=mirror_domain_name))

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -20,7 +20,6 @@ from django.http import (
 )
 from django.shortcuts import redirect, render
 from django.urls import reverse
-from django.db.utils import IntegrityError
 from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _


### PR DESCRIPTION
## Summary
[USH-778](https://dimagi-dev.atlassian.net/browse/USH-778)

<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
COVID: Enterprise Permissions
<!-- If this is specific to a feature flag, which one? -->

## Product Description
If a user attempts to add a project space that has already been added, they are presented with a message indicating that they have already added that particular project space. 
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
none
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
Change should only affect the scope of this particular feature flag (Enterprise Permissions)
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
