### PR TITLE
Improvements to Hubspot analytics

### DIFF
--- a/corehq/apps/analytics/management/commands/manually_cleanup_blocked_hubspot_contacts.py
+++ b/corehq/apps/analytics/management/commands/manually_cleanup_blocked_hubspot_contacts.py
@@ -1,0 +1,14 @@
+from django.core.management import BaseCommand
+
+from corehq.apps.analytics.utils import (
+    remove_blocked_email_domains_from_hubspot,
+    remove_blocked_domain_contacts_from_hubspot,
+)
+
+
+class Command(BaseCommand):
+    help = "Manually cleans up blocked Hubspot contacts"
+
+    def handle(self, **options):
+        remove_blocked_email_domains_from_hubspot(self.stdout)
+        remove_blocked_domain_contacts_from_hubspot(self.stdout)

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -206,9 +206,12 @@ def _get_user_hubspot_id(web_user, retry_num=0):
             if req.status_code == 404:
                 return None
             req.raise_for_status()
-        except (ConnectionError, requests.exceptions.HTTPError):
+        except (ConnectionError, requests.exceptions.HTTPError) as e:
             if retry_num <= MAX_API_RETRIES:
                 return _get_user_hubspot_id(web_user, retry_num + 1)
+            else:
+                logger.error(f"Failed to get Hubspot user id for WebUser "
+                             f"{web_user.username} due to {str(e)}.")
         else:
             return req.json().get("vid", None)
     elif api_key:

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -946,7 +946,22 @@ def cleanup_blocked_hubspot_contacts():
     if not HUBSPOT_ENABLED:
         return
 
-    # First delete any user information from users that are members of
+    # First delete any user info from users that have emails or usernames ending
+    # in blocked email-domains
+    blocked_email_domains = get_blocked_hubspot_email_domains()
+    for email_domain in blocked_email_domains:
+        ids_to_delete = _get_contact_ids_for_email_domain(email_domain)
+        num_deleted = sum(_delete_hubspot_contact(vid) for vid in ids_to_delete)
+        metrics_gauge(
+            'commcare.hubspot_data.deleted_user.blocked_email_domain',
+            num_deleted,
+            tags={
+                'email_domain': email_domain,
+                'ids_deleted': ids_to_delete,
+            }
+        )
+
+    # Next delete any user information from users that are members of
     # blocked domains
     blocked_domains = get_blocked_hubspot_domains()
     for domain in blocked_domains:
@@ -979,18 +994,3 @@ def cleanup_blocked_hubspot_contacts():
                     'ids_deleted': ids_to_delete,
                 }
             )
-
-    # Next delete any user info from users that have emails or usernames ending
-    # in blocked email-domains
-    blocked_email_domains = get_blocked_hubspot_email_domains()
-    for email_domain in blocked_email_domains:
-        ids_to_delete = _get_contact_ids_for_email_domain(email_domain)
-        num_deleted = sum(_delete_hubspot_contact(vid) for vid in ids_to_delete)
-        metrics_gauge(
-            'commcare.hubspot_data.deleted_user.blocked_email_domain',
-            num_deleted,
-            tags={
-                'email_domain': email_domain,
-                'ids_deleted': ids_to_delete,
-            }
-        )

--- a/corehq/apps/analytics/tests/test_hubspot.py
+++ b/corehq/apps/analytics/tests/test_hubspot.py
@@ -3,12 +3,11 @@ from django.test import RequestFactory, TestCase, override_settings
 import mock
 
 from corehq.apps.accounting.models import (
-    BillingAccount,
     DefaultProductPlan,
     SoftwarePlanEdition,
     Subscription,
-    SubscriptionAdjustment,
 )
+from corehq.apps.accounting.tests import generator
 from corehq.apps.analytics.utils import (
     get_blocked_hubspot_domains,
     get_blocked_hubspot_email_domains,
@@ -19,7 +18,7 @@ from corehq.apps.analytics.utils import (
     hubspot_enabled_for_email,
 )
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.users.models import WebUser
+from corehq.apps.users.models import WebUser, CouchUser, CommCareUser
 
 from ..tasks import (
     HUBSPOT_COOKIE,
@@ -67,23 +66,98 @@ class TestSendToHubspot(TestCase):
 
 
 class TestBlockedHubspotData(TestCase):
-    blocked_domain = 'block-domain-hubspot'
-    allowed_domain = 'allow-domain-hubspot'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        plan = DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.ADVANCED)
+
+        cls.blocked_account = generator.billing_account('test@diamgi.com', 'test@test.com')
+        cls.blocked_account.block_hubspot_data_for_all_users = True
+        cls.blocked_account.block_email_domains_from_hubspot = [
+            'blocked.com',
+            'foo.org',
+            'gmail.com',
+        ]
+        cls.blocked_account.save()
+
+        # this is one domain linked to the billing account that blocks hubspot
+        cls.blocked_domain = create_domain('block-domain-hubspot')
+        first_blocked_sub = Subscription.new_domain_subscription(
+            cls.blocked_account, cls.blocked_domain.name, plan
+        )
+        first_blocked_sub.is_active = True
+        first_blocked_sub.save()
+
+        # this is another domain linked to the billing account that blocks hubspot
+        cls.second_blocked_domain = create_domain('block-domain-hubspot-002')
+        second_blocked_sub = Subscription.new_domain_subscription(
+            cls.blocked_account, cls.second_blocked_domain.name, plan
+        )
+        second_blocked_sub.is_active = True
+        second_blocked_sub.save()
+
+        # this domain is not linked to an account that is blocking hubspot
+        cls.allowed_domain = create_domain('allow-domain-hubspot')
+        allowed_account = generator.billing_account('test@diamgi.com', 'test@test.com')
+        allowed_sub = Subscription.new_domain_subscription(
+            allowed_account, cls.allowed_domain.name, plan
+        )
+        allowed_sub.is_active = True
+        allowed_sub.save()
+
+        cls.allowed_user = WebUser.create(
+            cls.allowed_domain.name, 'bob@allowed.com', '*****', None, None
+        )
+        cls.allowed_user.save()
+
+        cls.blocked_by_email_user = WebUser.create(
+            cls.allowed_domain.name, 'jjj@blocked.com', '*****', None, None
+        )
+        cls.blocked_by_email_user.save()
+
+        cls.blocked_user = WebUser.create(
+            cls.blocked_domain.name, 'fff@example.com', '*****', None, None
+        )
+        cls.blocked_user.save()
+
+        cls.blocked_couch_user = CouchUser.get_by_username(cls.blocked_user.username)
+
+        cls.blocked_commcare_user = CommCareUser.create(
+            cls.blocked_domain.name, 'testuser', '****', None, None
+        )
+        cls.blocked_commcare_user.save()
 
     def test_get_blocked_domains(self):
-        self.assertEqual(get_blocked_hubspot_domains(), [self.blocked_domain])
+        self.assertListEqual(
+            get_blocked_hubspot_domains(),
+            [self.blocked_domain.name, self.second_blocked_domain.name]
+        )
 
     def test_get_blocked_email_domains(self):
-        self.assertEqual(get_blocked_hubspot_email_domains(), ['blocked.com'])
+        """
+        Ensure that gmail.com is never included in the list of blocked hubspot
+        email domains, and that if multiple values were specified, that they
+        are included.
+        """
+        self.assertListEqual(
+            sorted(get_blocked_hubspot_email_domains()),
+            sorted([
+                'blocked.com',
+                'foo.org',
+            ])
+        )
 
     def test_get_blocked_hubspot_accounts(self):
-        self.assertEqual(get_blocked_hubspot_accounts(), [
+        self.assertListEqual(get_blocked_hubspot_accounts(), [
             f'{self.blocked_account.name} - ID # {self.blocked_account.id}',
         ])
 
     def test_is_domain_blocked_from_hubspot(self):
-        self.assertTrue(is_domain_blocked_from_hubspot(self.blocked_domain))
-        self.assertFalse(is_domain_blocked_from_hubspot(self.allowed_domain))
+        self.assertTrue(is_domain_blocked_from_hubspot(self.blocked_domain.name))
+        self.assertTrue(is_domain_blocked_from_hubspot(self.second_blocked_domain.name))
+        self.assertFalse(is_domain_blocked_from_hubspot(self.allowed_domain.name))
 
     def test_is_email_blocked_from_hubspot(self):
         self.assertTrue(is_email_blocked_from_hubspot(self.blocked_by_email_user.username))
@@ -99,54 +173,19 @@ class TestBlockedHubspotData(TestCase):
         self.assertFalse(hubspot_enabled_for_email(self.blocked_user.username))
         self.assertTrue(hubspot_enabled_for_email(self.allowed_user.username))
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        plan = DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.ADVANCED)
-
-        cls.blocked_domain_obj = create_domain(cls.blocked_domain)
-        cls.blocked_account = BillingAccount.get_or_create_account_by_domain(
-            cls.blocked_domain, created_by='test'
-        )[0]
-        cls.blocked_account.block_hubspot_data_for_all_users = True
-        cls.blocked_account.block_email_domains_from_hubspot = ['blocked.com']
-        cls.blocked_account.save()
-        blocked_sub = Subscription.new_domain_subscription(
-            cls.blocked_account, cls.blocked_domain, plan
-        )
-        blocked_sub.is_active = True
-        blocked_sub.save()
-
-        cls.allowed_domain_obj = create_domain(cls.allowed_domain)
-        allowed_account = BillingAccount.get_or_create_account_by_domain(
-            cls.allowed_domain, created_by='test'
-        )[0]
-        allowed_sub = Subscription.new_domain_subscription(
-            allowed_account, cls.allowed_domain, plan
-        )
-        allowed_sub.is_active = True
-        allowed_sub.save()
-
-        cls.allowed_user = WebUser.create(
-            cls.allowed_domain, 'bob@allowed.com', '*****', None, None
-        )
-        cls.allowed_user.save()
-
-        cls.blocked_by_email_user = WebUser.create(
-            cls.allowed_domain, 'jjj@blocked.com', '*****', None, None
-        )
-        cls.blocked_by_email_user.save()
-
-        cls.blocked_user = WebUser.create(
-            cls.blocked_domain, 'fff@example.com', '*****', None, None
-        )
-        cls.blocked_user.save()
+    def test_couch_user_is_blocked(self):
+        """
+        Make sure that hubspot_enabled_for_user does not throw an error if a
+        CouchUser is passed to it (rather than a WebUser).
+        """
+        self.assertFalse(hubspot_enabled_for_user(self.blocked_couch_user))
 
     @classmethod
     def tearDownClass(cls):
-        cls.blocked_domain_obj.delete()
-        cls.allowed_domain_obj.delete()
-        SubscriptionAdjustment.objects.all().delete()
-        Subscription.visible_and_suppressed_objects.all().delete()
-        BillingAccount.objects.all().delete()
+        cls.blocked_user.delete(None)
+        cls.blocked_by_email_user.delete(None)
+        cls.allowed_user.delete(None)
+        cls.blocked_domain.delete()
+        cls.second_blocked_domain.delete()
+        cls.allowed_domain.delete()
         super().tearDownClass()

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -73,14 +73,17 @@ def get_blocked_hubspot_domains():
 
 
 def get_blocked_hubspot_email_domains():
-    return [_email for email_list in BillingAccount.objects.filter(
+    email_domains = {_email for email_list in BillingAccount.objects.filter(
         is_active=True,
     ).exclude(
         block_email_domains_from_hubspot=[],
     ).values_list(
         'block_email_domains_from_hubspot',
         flat=True,
-    ) for _email in email_list]
+    ) for _email in email_list}
+    # we want to ensure that gmail.com is never a part of this list
+    email_domains.difference_update(['gmail.com'])
+    return list(email_domains)
 
 
 def get_blocked_hubspot_accounts():

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -65,6 +65,11 @@ def hubspot_enabled_for_email(email_address):
 
 
 def get_blocked_hubspot_domains():
+    """
+    Get the list of domains / project spaces that have active subscriptions
+    with accounts that have blocked hubspot data.
+    :return: list
+    """
     return list(Subscription.visible_objects.filter(
         account__block_hubspot_data_for_all_users=True,
         is_active=True,
@@ -73,6 +78,11 @@ def get_blocked_hubspot_domains():
 
 
 def get_blocked_hubspot_email_domains():
+    """
+    Get the list of email domains (everything after the @ in an email address)
+    that have been blocked from Hubspot by BillingAccounts (excluding gmail.com)
+    :return: list
+    """
     email_domains = {_email for email_list in BillingAccount.objects.filter(
         is_active=True,
     ).exclude(

--- a/corehq/apps/analytics/views.py
+++ b/corehq/apps/analytics/views.py
@@ -20,7 +20,8 @@ class HubspotClickDeployView(View):
 
     def post(self, request, *args, **kwargs):
         meta = get_meta(request)
-        track_clicked_deploy_on_hubspot.delay(request.couch_user, request.COOKIES.get(HUBSPOT_COOKIE), meta)
+        if hasattr(request, 'couch_user'):
+            track_clicked_deploy_on_hubspot.delay(request.couch_user, request.COOKIES.get(HUBSPOT_COOKIE), meta)
         return HttpResponse()
 
 


### PR DESCRIPTION
## Summary
There has been a handful of regularly occurring errors related to our Hubspot tasks in Sentry, and additional concern from USH that some users are not being kept out of Hubspot marketing/analytics. This PR addresses some of these issues by making our cleanup scripts more robust and allowing us to manually run the cleanup command to check for any errors.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Yes.

### QA Plan
None needed, as the current state is partially broken and I've already tested out the changes in a limited release. Also, this doesn't affect user workflows.

### Safety story
Has no effect on existing user workflows as these are all background tasks

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
