### PR TITLE
static admin and default roles

### DIFF
--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -10,7 +10,7 @@ from corehq.apps.registration.models import AsyncSignupRequest
 from corehq.apps.sso.models import IdentityProvider, AuthenticatedEmailDomain
 from corehq.apps.sso.tests import generator
 from corehq.apps.sso.tests.generator import create_request_session
-from corehq.apps.users.models import WebUser, Invitation, UserRole
+from corehq.apps.users.models import WebUser, Invitation, StaticRole
 
 
 class TestSsoBackend(TestCase):
@@ -260,7 +260,7 @@ class TestSsoBackend(TestCase):
         invitation should add the user to the invited project
         space and accept the invitation
         """
-        admin_role = UserRole.admin_role(self.domain.name)
+        admin_role = StaticRole.domain_admin(self.domain.name)
         invitation = Invitation(
             domain=self.domain.name,
             email='isa@vaultwax.com',
@@ -342,7 +342,7 @@ class TestSsoBackend(TestCase):
         user data from a registration form and/or the samlUserdata are all
         properly saved to the User model.
         """
-        admin_role = UserRole.admin_role(domain=self.domain.name)
+        admin_role = StaticRole.domain_admin(domain=self.domain.name)
         existing_user = WebUser.create(
             None, 'exist@vaultwax.com', 'testpwd', None, None
         )

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -92,7 +92,7 @@ from corehq.util.quickcache import quickcache
 from corehq.util.view_utils import absolute_reverse
 
 from .models_sql import (  # noqa
-    SQLUserRole, SQLPermission, RolePermission, RoleAssignableBy,
+    SQLUserRole, SQLPermission, RolePermission, RoleAssignableBy, StaticRole,
     migrate_role_permissions_to_sql,
     migrate_role_assignable_by_to_sql,
 )
@@ -274,6 +274,7 @@ class Permissions(DocumentSchema):
             setattr(perms, name, value)
         return perms
 
+
 class UserRolePresets(object):
     # this is kind of messy, but we're only marking for translation (and not using ugettext_lazy)
     # because these are in JSON and cannot be serialized
@@ -387,16 +388,8 @@ class UserRole(SyncCouchToSQLMixin, QuickCachedDocumentMixin, Document):
         return role
 
     @classmethod
-    def get_default(cls, domain=None):
-        return cls(permissions=Permissions(), domain=domain, name=None)
-
-    @classmethod
     def get_preset_role_id(cls, name):
         return UserRolePresets.get_preset_role_id(name)
-
-    @classmethod
-    def admin_role(cls, domain):
-        return AdminUserRole(domain=domain)
 
     @property
     def has_users_assigned(self):
@@ -429,15 +422,6 @@ class UserRole(SyncCouchToSQLMixin, QuickCachedDocumentMixin, Document):
             sql_object.save(sync_to_couch=False)
         migrate_role_permissions_to_sql(self, sql_object)
         migrate_role_assignable_by_to_sql(self, sql_object)
-
-
-class AdminUserRole(UserRole):
-
-    def __init__(self, domain):
-        super(AdminUserRole, self).__init__(domain=domain, name='Admin', permissions=Permissions.max())
-
-    def get_qualified_id(self):
-        return 'admin'
 
 
 class DomainMembershipError(Exception):
@@ -504,7 +488,7 @@ class DomainMembership(Membership):
     @memoized
     def role(self):
         if self.is_admin:
-            return UserRole.admin_role(self.domain)
+            return StaticRole.domain_admin(self.domain)
         elif self.role_id:
             try:
                 return UserRole.get(self.role_id)
@@ -698,7 +682,7 @@ class _AuthorizableMixin(IsMemberOfMixin):
                 domain = None
 
         if checking_global_admin and self.is_global_admin():
-            return UserRole.admin_role(domain)
+            return StaticRole.domain_admin(domain)
         if self.is_member_of(domain, allow_mirroring):
             return self.get_domain_membership(domain, allow_mirroring).role
         else:

--- a/corehq/apps/users/models_sql.py
+++ b/corehq/apps/users/models_sql.py
@@ -66,6 +66,9 @@ class SQLUserRole(SyncSQLToCouchMixin, models.Model):
     def get_qualified_id(self):
         return 'user-role:%s' % self.get_id
 
+    def to_json(self):
+        return role_to_dict(self)
+
     def set_permissions(self, permission_infos):
         permissions_by_name = {
             rp.permission: rp
@@ -195,3 +198,14 @@ def migrate_role_assignable_by_to_sql(couch_role, sql_role):
                 assignable_by_mapping[couch_id] = assignable_by_sql_role.id
 
     sql_role.set_assignable_by(list(assignable_by_mapping.values()))
+
+
+def role_to_dict(role):
+    data = {}
+    for field in SQLUserRole._migration_get_fields():
+        data[field] = getattr(role, field)
+    data["permissions"] = role.permissions.to_json()
+    data["assignable_by"] = role.assignable_by
+    if role.couch_id:
+        data["_id"] = role.couch_id
+    return data

--- a/corehq/apps/users/tests/test_migrate_roles_to_sql.py
+++ b/corehq/apps/users/tests/test_migrate_roles_to_sql.py
@@ -2,8 +2,10 @@ from django.test import TestCase
 
 from corehq.apps.users.landing_pages import ALL_LANDING_PAGES
 from corehq.apps.users.management.commands.populate_user_role import Command
-from corehq.apps.users.models import UserRole, Permissions, UserRolePresets, PermissionInfo
-from corehq.apps.users.models_sql import SQLUserRole, SQLPermission
+from corehq.apps.users.models import (
+    UserRole, Permissions, UserRolePresets, PermissionInfo,
+    SQLUserRole, SQLPermission
+)
 from corehq.apps.users.role_utils import get_custom_roles_for_domain
 
 

--- a/corehq/apps/users/tests/test_migrate_roles_to_sql.py
+++ b/corehq/apps/users/tests/test_migrate_roles_to_sql.py
@@ -159,6 +159,29 @@ class UserRoleCouchToSqlTests(TestCase):
             f"assignable_by: couch value 'other_id' != sql value '{self.app_editor.get_id}'"
         ])
 
+    def test_to_json(self):
+        permissions = Permissions(
+            edit_data=True, edit_reports=True, access_all_locations=False,
+            view_report_list=['report1']
+        )
+        couch_role = make_couch_role(
+            self.domain, "test-to-json",
+            permissions=permissions,
+            assignable_by=[self.app_editor.get_id]
+        )
+        sql_role = couch_role._migration_get_sql_object()
+        self.assertIsNotNone(sql_role)
+
+        couch_dict = _drop_couch_only_fields(couch_role.to_json())
+        sql_dict = sql_role.to_json()
+
+        # sql uses SQL primary keys, couch uses couch IDs
+        couch_assignable_by = couch_dict.pop("assignable_by")
+        sql_assignable_by = sql_dict.pop("assignable_by")
+        self.assertEqual(len(sql_assignable_by), len(couch_assignable_by))
+
+        self.assertDictEqual(couch_dict, sql_dict)
+
     def _create_identical_objects_for_diff(self):
         permissions = Permissions(
             edit_data=True, edit_reports=True, access_all_locations=False,
@@ -190,3 +213,10 @@ def make_couch_role(domain, name, **kwargs):
         **kwargs
     )
     couch_role.save()
+    return couch_role
+
+
+def _drop_couch_only_fields(couch_dict):
+    for field in ('_rev', 'doc_type'):
+        couch_dict.pop(field, None)
+    return couch_dict

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -103,6 +103,7 @@ from corehq.apps.users.models import (
     DomainRemovalRecord,
     DomainRequest,
     Invitation,
+    StaticRole,
     UserRole,
     WebUser,
 )
@@ -502,7 +503,7 @@ class BaseRoleAccessView(BaseUserSettingsView):
     @property
     @memoized
     def user_roles(self):
-        user_roles = [UserRole.admin_role(self.domain)]
+        user_roles = [StaticRole.domain_admin(self.domain)]
         user_roles.extend(sorted(
             UserRole.by_domain(self.domain),
             key=lambda role: role.name if role.name else '\uFFFF'
@@ -660,7 +661,7 @@ class ListRolesView(BaseRoleAccessView):
             'user_roles': self.user_roles,
             'non_admin_roles': self.user_roles[1:],
             'can_edit_roles': self.can_edit_roles,
-            'default_role': UserRole.get_default(),
+            'default_role': StaticRole.domain_default(self.domain),
             'report_list': get_possible_reports(self.domain),
             'web_apps_list': get_cloudcare_apps(self.domain),
             'apps_list': get_brief_apps_in_domain(self.domain),

--- a/corehq/apps/users/views/utils.py
+++ b/corehq/apps/users/views/utils.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 
 from corehq.apps.users.models import (
     DomainMembershipError,
+    StaticRole,
     UserRole,
 )
 
@@ -30,7 +31,7 @@ def get_editable_role_choices(domain, couch_user, allow_admin_role, use_qualifie
             if role.accessible_by_non_admin_role(user_role_id)
         ]
     elif allow_admin_role:
-        roles = [UserRole.admin_role(domain)] + roles
+        roles = [StaticRole.domain_admin(domain)] + roles
     return [role_to_choice(role) for role in roles]
 
 


### PR DESCRIPTION
PR into https://github.com/dimagi/commcare-hq/pull/29688

## Summary
Convert 'Admin' role and 'default' user role into static (mostly immutable) class instead of using the Django model.

This has the advantage that these objects cannot be saved and for the most part can't be changed once created. The downside is that the fields need to be kept in sync with the other model. Considering how infrequently these change I don't see this as an real issue. There is also a test to ensure the 'to_json' output matches.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
