### PR TITLE
Tighten the checks on view_scheduled_report

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -845,6 +845,9 @@ def get_scheduled_report_response(couch_user, domain, scheduled_report_id,
         request.domain = domain
         request.couch_user.current_domain = domain
     notification = ReportNotification.get(scheduled_report_id)
+    if notification.doc_type != 'ReportNotification' or notification.domain != domain:
+        raise Http404
+
     return _render_report_configs(
         request,
         notification.configs,
@@ -883,7 +886,7 @@ def _render_report_configs(request, configs, domain, owner_id, couch_user, email
         return "", []
 
     for config in configs:
-        content, excel_file = config.get_report_content(lang, attach_excel=attach_excel)
+        content, excel_file = config.get_report_content(lang, attach_excel=attach_excel, couch_user=couch_user)
         if excel_file:
             excel_attachments.append({
                 'title': config.full_name + "." + format.extension,

--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -330,12 +330,15 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
     def owner(self):
         return CouchUser.get_by_user_id(self.owner_id)
 
-    def get_report_content(self, lang, attach_excel=False):
+    def get_report_content(self, lang, attach_excel=False, couch_user=None):
         """
         Get the report's HTML content as rendered by the static view format.
 
         """
         from corehq.apps.locations.middleware import LocationAccessMiddleware
+
+        if couch_user is None:
+            couch_user = self.owner
 
         try:
             if self.report is None:
@@ -359,8 +362,8 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
             )
 
         mock_request = HttpRequest()
-        mock_request.couch_user = self.owner
-        mock_request.user = self.owner.get_django_user()
+        mock_request.couch_user = couch_user
+        mock_request.user = couch_user.get_django_user()
         mock_request.domain = self.domain
         mock_request.couch_user.current_domain = self.domain
         mock_request.couch_user.language = lang

--- a/corehq/apps/saved_reports/tests/test_scheduled_reports.py
+++ b/corehq/apps/saved_reports/tests/test_scheduled_reports.py
@@ -201,7 +201,7 @@ class ScheduledReportSendingTest(TestCase):
         })
         report_config.save()
         report = ReportNotification(
-            hour=12, minute=None, day=30, interval='monthly', config_ids=[report_config._id]
+            domain=self.domain, hour=12, minute=None, day=30, interval='monthly', config_ids=[report_config._id]
         )
         report.save()
         report_text = get_scheduled_report_response(


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12234

## Feature Flag
None

## Product Description
For context see https://dimagi-dev.atlassian.net/browse/SAAS-12234.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

I don't think there are good tests for the parts of the code changed in this PR

### QA Plan

Manually tested in staging

### Safety story
The change itself is fairly superficial and easy to reason with. The major cases have been tested (again for more see the ticket).

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
