### PR TITLE
vellum:cfdf7bfea80fac5268e1d9dba8bde60a6832c88e manifest.txt

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/vellum/manifest.txt
+++ b/corehq/apps/app_manager/static/app_manager/js/vellum/manifest.txt
@@ -1,0 +1,1277 @@
+├─ @bracken/require-less@0.1.6
+│  └─ less@2
+├─ @types/node@14.14.22
+├─ @types/yauzl@2.9.1
+│  └─ @types/node@*
+├─ abbrev@1.1.1
+├─ accepts@1.3.7
+│  ├─ mime-types@~2.1.24
+│  └─ negotiator@0.6.2
+├─ agent-base@5.1.1
+├─ ajv@6.12.6
+│  ├─ fast-deep-equal@^3.1.1
+│  ├─ fast-json-stable-stringify@^2.0.0
+│  ├─ json-schema-traverse@^0.4.1
+│  └─ uri-js@^4.2.2
+├─ ansi-colors@3.2.3
+├─ ansi-regex@4.1.0
+├─ ansi-styles@3.2.1
+│  └─ color-convert@^1.9.0
+├─ anymatch@3.1.1
+│  ├─ normalize-path@^3.0.0
+│  └─ picomatch@^2.0.4
+├─ argparse@1.0.10
+│  └─ sprintf-js@~1.0.2
+├─ args@5.0.1
+│  ├─ camelcase@5.0.0
+│  ├─ chalk@2.4.2
+│  ├─ leven@2.1.0
+│  └─ mri@1.1.4
+├─ arr-diff@4.0.0
+├─ arr-flatten@1.1.0
+├─ arr-union@3.1.0
+├─ array-each@1.0.1
+├─ array-slice@1.1.0
+├─ array-unique@0.3.2
+├─ asap@2.0.6
+├─ asn1@0.2.4
+│  └─ safer-buffer@~2.1.0
+├─ assert-plus@1.0.0
+├─ assertion-error@1.1.0
+├─ assign-symbols@1.0.0
+├─ async@1.5.2
+├─ asynckit@0.4.0
+├─ At.js@1.5.3
+├─ atob@2.1.2
+├─ aws-sign2@0.7.0
+├─ aws4@1.11.0
+├─ balanced-match@1.0.0
+├─ base@0.11.2
+│  ├─ cache-base@^1.0.1
+│  ├─ class-utils@^0.3.5
+│  ├─ component-emitter@^1.2.1
+│  ├─ define-property@^1.0.0
+│  ├─ define-property@1.0.0
+│  │  └─ is-descriptor@^1.0.0
+│  ├─ isobject@^3.0.1
+│  ├─ mixin-deep@^1.2.0
+│  └─ pascalcase@^0.1.1
+├─ base64-js@1.5.1
+├─ basic-auth@1.1.0
+├─ batch@0.6.1
+├─ bcrypt-pbkdf@1.0.2
+│  └─ tweetnacl@^0.14.3
+├─ biginteger@1.0.3
+├─ binary-extensions@2.2.0
+├─ bl@4.0.3
+│  ├─ buffer@^5.5.0
+│  ├─ inherits@^2.0.4
+│  └─ readable-stream@^3.4.0
+├─ body@5.1.0
+│  ├─ continuable-cache@^0.3.1
+│  ├─ error@^7.0.0
+│  ├─ raw-body@~1.1.0
+│  └─ safe-json-parse@~1.0.1
+├─ bootstrap@3.4.1
+├─ brace-expansion@1.1.11
+│  ├─ balanced-match@^1.0.0
+│  └─ concat-map@0.0.1
+├─ braces@3.0.2
+│  └─ fill-range@^7.0.1
+├─ browser-stdout@1.3.1
+├─ buffer-crc32@0.2.13
+├─ buffer@5.7.1
+│  ├─ base64-js@^1.3.1
+│  └─ ieee754@^1.1.13
+├─ bytes@1.0.0
+├─ cache-base@1.0.1
+│  ├─ collection-visit@^1.0.0
+│  ├─ component-emitter@^1.2.1
+│  ├─ get-value@^2.0.6
+│  ├─ has-value@^1.0.0
+│  ├─ isobject@^3.0.1
+│  ├─ set-value@^2.0.0
+│  ├─ to-object-path@^0.3.0
+│  ├─ union-value@^1.0.0
+│  └─ unset-value@^1.0.0
+├─ call-bind@1.0.2
+│  ├─ function-bind@^1.1.1
+│  └─ get-intrinsic@^1.0.2
+├─ camelcase@5.0.0
+├─ Caret.js@0.3.1
+│  ├─ grunt-legacy-log-utils@2.0.1
+│  │  ├─ chalk@~2.4.1
+│  │  └─ lodash@~4.17.10
+│  ├─ grunt-legacy-log@2.0.0
+│  │  ├─ colors@~1.1.2
+│  │  ├─ grunt-legacy-log-utils@~2.0.0
+│  │  ├─ hooker@~0.2.3
+│  │  └─ lodash@~4.17.5
+│  ├─ grunt-legacy-util@1.1.1
+│  │  ├─ async@~1.5.2
+│  │  ├─ exit@~0.1.1
+│  │  ├─ getobject@~0.1.0
+│  │  ├─ hooker@~0.2.3
+│  │  ├─ lodash@~4.17.10
+│  │  ├─ underscore.string@~3.3.4
+│  │  └─ which@~1.3.0
+│  ├─ grunt@~0.4.1
+│  ├─ grunt@1.2.0
+│  │  ├─ dateformat@~3.0.3
+│  │  ├─ eventemitter2@~0.4.13
+│  │  ├─ exit@~0.1.2
+│  │  ├─ findup-sync@~0.3.0
+│  │  ├─ glob@~7.1.6
+│  │  ├─ grunt-cli@~1.3.2
+│  │  ├─ grunt-known-options@~1.1.0
+│  │  ├─ grunt-legacy-log@~2.0.0
+│  │  ├─ grunt-legacy-util@~1.1.1
+│  │  ├─ iconv-lite@~0.4.13
+│  │  ├─ js-yaml@~3.14.0
+│  │  ├─ minimatch@~3.0.4
+│  │  ├─ mkdirp@~1.0.4
+│  │  ├─ nopt@~3.0.6
+│  │  ├─ path-is-absolute@~2.0.0
+│  │  └─ rimraf@~3.0.2
+│  ├─ mkdirp@1.0.4
+│  └─ path-is-absolute@2.0.0
+├─ caseless@0.12.0
+├─ chai@4.2.0
+│  ├─ assertion-error@^1.1.0
+│  ├─ check-error@^1.0.2
+│  ├─ deep-eql@^3.0.1
+│  ├─ get-func-name@^2.0.0
+│  ├─ pathval@^1.1.0
+│  └─ type-detect@^4.0.5
+├─ chalk@2.4.2
+│  ├─ ansi-styles@^3.2.1
+│  ├─ escape-string-regexp@^1.0.5
+│  ├─ supports-color@^5.3.0
+│  └─ supports-color@5.5.0
+│     └─ has-flag@^3.0.0
+├─ check-error@1.0.2
+├─ chokidar@3.3.0
+│  ├─ anymatch@~3.1.1
+│  ├─ braces@~3.0.2
+│  ├─ fsevents@~2.1.1
+│  ├─ glob-parent@~5.1.0
+│  ├─ is-binary-path@~2.1.0
+│  ├─ is-glob@~4.0.1
+│  ├─ normalize-path@~3.0.0
+│  └─ readdirp@~3.2.0
+├─ chownr@1.1.4
+├─ class-utils@0.3.6
+│  ├─ arr-union@^3.1.0
+│  ├─ define-property@^0.2.5
+│  ├─ isobject@^3.0.0
+│  └─ static-extend@^0.1.1
+├─ cli@1.0.1
+│  ├─ exit@0.1.2
+│  └─ glob@^7.1.1
+├─ cliui@5.0.0
+│  ├─ string-width@^3.1.0
+│  ├─ strip-ansi@^5.2.0
+│  └─ wrap-ansi@^5.1.0
+├─ codemirror@5.30.0
+├─ collection-visit@1.0.0
+│  ├─ map-visit@^1.0.0
+│  └─ object-visit@^1.0.0
+├─ color-convert@1.9.3
+│  └─ color-name@1.1.3
+├─ color-name@1.1.3
+├─ colors@1.1.2
+├─ combined-stream@1.0.8
+│  └─ delayed-stream@~1.0.0
+├─ component-emitter@1.3.0
+├─ concat-map@0.0.1
+├─ connect-livereload@0.5.4
+├─ connect@3.7.0
+│  ├─ debug@2.6.9
+│  ├─ finalhandler@1.1.2
+│  ├─ parseurl@~1.3.3
+│  └─ utils-merge@1.0.1
+├─ console-browserify@1.1.0
+│  └─ date-now@^0.1.4
+├─ continuable-cache@0.3.1
+├─ copy-descriptor@0.1.1
+├─ core-util-is@1.0.2
+├─ corser@2.0.1
+├─ css-tree@1.1.2
+│  ├─ mdn-data@2.0.14
+│  ├─ source-map@^0.6.1
+│  └─ source-map@0.6.1
+├─ csso@4.2.0
+│  └─ css-tree@^1.1.2
+├─ dashdash@1.14.1
+│  └─ assert-plus@^1.0.0
+├─ date-now@0.1.4
+├─ dateformat@3.0.3
+├─ debug@2.6.9
+│  ├─ ms@2.0.0
+│  └─ ms@2.0.0
+├─ decamelize@1.2.0
+├─ decode-uri-component@0.2.0
+├─ deep-eql@3.0.1
+│  └─ type-detect@^4.0.0
+├─ define-properties@1.1.3
+│  └─ object-keys@^1.0.12
+├─ define-property@0.2.5
+│  ├─ is-accessor-descriptor@0.1.6
+│  │  ├─ kind-of@^3.0.2
+│  │  └─ kind-of@3.2.2
+│  │     └─ is-buffer@^1.1.5
+│  ├─ is-data-descriptor@0.1.4
+│  │  ├─ kind-of@^3.0.2
+│  │  └─ kind-of@3.2.2
+│  │     └─ is-buffer@^1.1.5
+│  ├─ is-descriptor@^0.1.0
+│  ├─ is-descriptor@0.1.6
+│  │  ├─ is-accessor-descriptor@^0.1.6
+│  │  ├─ is-data-descriptor@^0.1.4
+│  │  └─ kind-of@^5.0.0
+│  └─ kind-of@5.1.0
+├─ delayed-stream@1.0.0
+├─ depd@1.1.2
+├─ destroy@1.0.4
+├─ detect-file@1.0.0
+├─ diff@3.5.0
+├─ dom-serializer@0.2.2
+│  ├─ domelementtype@^2.0.1
+│  ├─ domelementtype@2.1.0
+│  └─ entities@^2.0.0
+├─ domelementtype@1.3.1
+├─ domhandler@2.3.0
+│  └─ domelementtype@1
+├─ domutils@1.5.1
+│  ├─ dom-serializer@0
+│  └─ domelementtype@1
+├─ ecc-jsbn@0.1.2
+│  ├─ jsbn@~0.1.0
+│  └─ safer-buffer@^2.1.0
+├─ ecstatic@3.3.2
+│  ├─ he@^1.1.1
+│  ├─ mime@^1.6.0
+│  ├─ minimist@^1.1.0
+│  └─ url-join@^2.0.5
+├─ ee-first@1.1.1
+├─ emoji-regex@7.0.3
+├─ encodeurl@1.0.2
+├─ end-of-stream@1.4.4
+│  └─ once@^1.4.0
+├─ entities@2.1.0
+├─ equivalent-xml-js@0.0.0
+├─ errno@0.1.8
+│  └─ prr@~1.0.1
+├─ error@7.2.1
+│  └─ string-template@~0.2.1
+├─ es-abstract@1.18.0-next.2
+│  ├─ call-bind@^1.0.2
+│  ├─ es-to-primitive@^1.2.1
+│  ├─ function-bind@^1.1.1
+│  ├─ get-intrinsic@^1.0.2
+│  ├─ has-symbols@^1.0.1
+│  ├─ has@^1.0.3
+│  ├─ is-callable@^1.2.2
+│  ├─ is-negative-zero@^2.0.1
+│  ├─ is-regex@^1.1.1
+│  ├─ object-inspect@^1.9.0
+│  ├─ object-keys@^1.1.1
+│  ├─ object.assign@^4.1.2
+│  ├─ object.assign@4.1.2
+│  │  ├─ call-bind@^1.0.0
+│  │  ├─ define-properties@^1.1.3
+│  │  ├─ has-symbols@^1.0.1
+│  │  └─ object-keys@^1.1.1
+│  ├─ string.prototype.trimend@^1.0.3
+│  └─ string.prototype.trimstart@^1.0.3
+├─ es-to-primitive@1.2.1
+│  ├─ is-callable@^1.1.4
+│  ├─ is-date-object@^1.0.1
+│  └─ is-symbol@^1.0.2
+├─ escape-html@1.0.3
+├─ escape-string-regexp@1.0.5
+├─ esprima@4.0.1
+├─ etag@1.8.1
+├─ eventemitter2@0.4.14
+├─ eventemitter3@4.0.7
+├─ exit@0.1.2
+├─ expand-brackets@2.1.4
+│  ├─ debug@^2.3.3
+│  ├─ define-property@^0.2.5
+│  ├─ extend-shallow@^2.0.1
+│  ├─ posix-character-classes@^0.1.0
+│  ├─ regex-not@^1.0.0
+│  ├─ snapdragon@^0.8.1
+│  └─ to-regex@^3.0.1
+├─ expand-tilde@2.0.2
+│  └─ homedir-polyfill@^1.0.1
+├─ extend-shallow@2.0.1
+│  └─ is-extendable@^0.1.0
+├─ extend@3.0.2
+├─ extglob@2.0.4
+│  ├─ array-unique@^0.3.2
+│  ├─ define-property@^1.0.0
+│  ├─ define-property@1.0.0
+│  │  └─ is-descriptor@^1.0.0
+│  ├─ expand-brackets@^2.1.4
+│  ├─ extend-shallow@^2.0.1
+│  ├─ fragment-cache@^0.2.1
+│  ├─ regex-not@^1.0.0
+│  ├─ snapdragon@^0.8.1
+│  └─ to-regex@^3.0.1
+├─ extract-zip@2.0.1
+│  ├─ @types/yauzl@^2.9.1
+│  ├─ debug@^4.1.1
+│  ├─ debug@4.3.1
+│  │  └─ ms@2.1.2
+│  ├─ get-stream@^5.1.0
+│  ├─ ms@2.1.2
+│  └─ yauzl@^2.10.0
+├─ extsprintf@1.3.0
+├─ fast-deep-equal@3.1.3
+├─ fast-json-stable-stringify@2.1.0
+├─ faye-websocket@0.10.0
+│  └─ websocket-driver@>=0.5.1
+├─ fd-slicer@1.1.0
+│  └─ pend@~1.2.0
+├─ fill-range@7.0.1
+│  └─ to-regex-range@^5.0.1
+├─ finalhandler@1.1.2
+│  ├─ debug@2.6.9
+│  ├─ encodeurl@~1.0.2
+│  ├─ escape-html@~1.0.3
+│  ├─ on-finished@~2.3.0
+│  ├─ parseurl@~1.3.3
+│  ├─ statuses@~1.5.0
+│  └─ unpipe@~1.0.0
+├─ find-up@3.0.0
+│  └─ locate-path@^3.0.0
+├─ findup-sync@0.3.0
+│  ├─ glob@~5.0.0
+│  └─ glob@5.0.15
+│     ├─ inflight@^1.0.4
+│     ├─ inherits@2
+│     ├─ minimatch@2 || 3
+│     ├─ once@^1.3.0
+│     └─ path-is-absolute@^1.0.0
+├─ fined@1.2.0
+│  ├─ expand-tilde@^2.0.2
+│  ├─ is-plain-object@^2.0.3
+│  ├─ object.defaults@^1.1.0
+│  ├─ object.pick@^1.2.0
+│  └─ parse-filepath@^1.0.1
+├─ flagged-respawn@1.0.1
+├─ flat@4.1.1
+│  ├─ is-buffer@~2.0.3
+│  └─ is-buffer@2.0.5
+├─ follow-redirects@1.13.1
+├─ for-in@1.0.2
+├─ for-own@1.0.0
+│  └─ for-in@^1.0.1
+├─ forever-agent@0.6.1
+├─ form-data@2.3.3
+│  ├─ asynckit@^0.4.0
+│  ├─ combined-stream@^1.0.6
+│  └─ mime-types@^2.1.12
+├─ fragment-cache@0.2.1
+│  └─ map-cache@^0.2.2
+├─ fresh@0.5.2
+├─ fs-constants@1.0.0
+├─ fs.realpath@1.0.0
+├─ fsevents@2.1.3
+├─ function-bind@1.1.1
+├─ fuse.js@2.7.4
+├─ gaze@1.1.3
+│  └─ globule@^1.0.0
+├─ get-caller-file@2.0.5
+├─ get-func-name@2.0.0
+├─ get-intrinsic@1.0.2
+│  ├─ function-bind@^1.1.1
+│  ├─ has-symbols@^1.0.1
+│  └─ has@^1.0.3
+├─ get-stream@5.2.0
+│  └─ pump@^3.0.0
+├─ get-value@2.0.6
+├─ getobject@0.1.0
+├─ getpass@0.1.7
+│  └─ assert-plus@^1.0.0
+├─ glob-parent@5.1.1
+│  └─ is-glob@^4.0.1
+├─ glob@7.1.6
+│  ├─ fs.realpath@^1.0.0
+│  ├─ inflight@^1.0.4
+│  ├─ inherits@2
+│  ├─ minimatch@^3.0.4
+│  ├─ once@^1.3.0
+│  └─ path-is-absolute@^1.0.0
+├─ global-modules@1.0.0
+│  ├─ global-prefix@^1.0.1
+│  ├─ is-windows@^1.0.1
+│  └─ resolve-dir@^1.0.0
+├─ global-prefix@1.0.2
+│  ├─ expand-tilde@^2.0.2
+│  ├─ homedir-polyfill@^1.0.1
+│  ├─ ini@^1.3.4
+│  ├─ is-windows@^1.0.1
+│  └─ which@^1.2.14
+├─ globule@1.3.2
+│  ├─ glob@~7.1.1
+│  ├─ lodash@~4.17.10
+│  └─ minimatch@~3.0.2
+├─ graceful-fs@4.2.4
+├─ growl@1.10.5
+├─ grunt-cli@1.3.2
+│  ├─ grunt-known-options@~1.1.0
+│  ├─ interpret@~1.1.0
+│  ├─ liftoff@~2.5.0
+│  ├─ nopt@~4.0.1
+│  ├─ nopt@4.0.3
+│  │  ├─ abbrev@1
+│  │  └─ osenv@^0.1.4
+│  └─ v8flags@~3.1.1
+├─ grunt-contrib-connect@1.0.2
+│  ├─ async@^1.5.2
+│  ├─ connect-livereload@^0.5.0
+│  ├─ connect@^3.4.0
+│  ├─ http2@^3.3.4
+│  ├─ morgan@^1.6.1
+│  ├─ opn@^4.0.0
+│  ├─ portscanner@^1.0.0
+│  ├─ serve-index@^1.7.1
+│  └─ serve-static@^1.10.0
+├─ grunt-contrib-jshint@2.1.0
+│  ├─ chalk@^2.4.2
+│  ├─ hooker@^0.2.3
+│  └─ jshint@~2.10.2
+├─ grunt-contrib-watch@1.1.0
+│  ├─ async@^2.6.0
+│  ├─ async@2.6.3
+│  │  └─ lodash@^4.17.14
+│  ├─ gaze@^1.1.0
+│  ├─ lodash@^4.17.10
+│  └─ tiny-lr@^1.1.1
+├─ grunt-known-options@1.1.1
+├─ grunt-legacy-log-utils@2.1.0
+│  ├─ ansi-styles@4.3.0
+│  │  └─ color-convert@^2.0.1
+│  ├─ chalk@~4.1.0
+│  ├─ chalk@4.1.0
+│  │  ├─ ansi-styles@^4.1.0
+│  │  └─ supports-color@^7.1.0
+│  ├─ color-convert@2.0.1
+│  │  └─ color-name@~1.1.4
+│  ├─ color-name@1.1.4
+│  ├─ has-flag@4.0.0
+│  ├─ lodash@~4.17.19
+│  └─ supports-color@7.2.0
+│     └─ has-flag@^4.0.0
+├─ grunt-legacy-log@3.0.0
+│  ├─ colors@~1.1.2
+│  ├─ grunt-legacy-log-utils@~2.1.0
+│  ├─ hooker@~0.2.3
+│  └─ lodash@~4.17.19
+├─ grunt-legacy-util@2.0.0
+│  ├─ async@~1.5.2
+│  ├─ exit@~0.1.1
+│  ├─ getobject@~0.1.0
+│  ├─ hooker@~0.2.3
+│  ├─ lodash@~4.17.20
+│  ├─ underscore.string@~3.3.5
+│  └─ which@~1.3.0
+├─ grunt@1.3.0
+│  ├─ dateformat@~3.0.3
+│  ├─ eventemitter2@~0.4.13
+│  ├─ exit@~0.1.2
+│  ├─ findup-sync@~0.3.0
+│  ├─ glob@~7.1.6
+│  ├─ grunt-cli@~1.3.2
+│  ├─ grunt-known-options@~1.1.0
+│  ├─ grunt-legacy-log@~3.0.0
+│  ├─ grunt-legacy-util@~2.0.0
+│  ├─ iconv-lite@~0.4.13
+│  ├─ js-yaml@~3.14.0
+│  ├─ minimatch@~3.0.4
+│  ├─ mkdirp@~1.0.4
+│  ├─ mkdirp@1.0.4
+│  ├─ nopt@~3.0.6
+│  └─ rimraf@~3.0.2
+├─ har-schema@2.0.0
+├─ har-validator@5.1.5
+│  ├─ ajv@^6.12.3
+│  └─ har-schema@^2.0.0
+├─ has-flag@3.0.0
+├─ has-symbols@1.0.1
+├─ has-value@1.0.0
+│  ├─ get-value@^2.0.6
+│  ├─ has-values@^1.0.0
+│  └─ isobject@^3.0.0
+├─ has-values@1.0.0
+│  ├─ is-number@^3.0.0
+│  ├─ kind-of@^4.0.0
+│  └─ kind-of@4.0.0
+│     └─ is-buffer@^1.1.5
+├─ has@1.0.3
+│  └─ function-bind@^1.1.1
+├─ he@1.2.0
+├─ homedir-polyfill@1.0.3
+│  └─ parse-passwd@^1.0.0
+├─ hooker@0.2.3
+├─ htmlparser2@3.8.3
+│  ├─ domelementtype@1
+│  ├─ domhandler@2.3
+│  ├─ domutils@1.5
+│  ├─ entities@1.0
+│  ├─ entities@1.0.0
+│  ├─ readable-stream@1.1
+│  └─ readable-stream@1.1.13
+│     ├─ core-util-is@~1.0.0
+│     ├─ inherits@~2.0.1
+│     ├─ isarray@0.0.1
+│     └─ string_decoder@~0.10.x
+├─ http-errors@1.6.3
+│  ├─ depd@~1.1.2
+│  ├─ inherits@2.0.3
+│  ├─ inherits@2.0.3
+│  ├─ setprototypeof@1.1.0
+│  └─ statuses@>= 1.4.0 < 2
+├─ http-parser-js@0.5.3
+├─ http-proxy@1.18.1
+│  ├─ eventemitter3@^4.0.0
+│  ├─ follow-redirects@^1.0.0
+│  └─ requires-port@^1.0.0
+├─ http-server@0.12.3
+│  ├─ basic-auth@^1.0.3
+│  ├─ colors@^1.4.0
+│  ├─ colors@1.4.0
+│  ├─ corser@^2.0.1
+│  ├─ ecstatic@^3.3.2
+│  ├─ http-proxy@^1.18.0
+│  ├─ minimist@^1.2.5
+│  ├─ opener@^1.5.1
+│  ├─ portfinder@^1.0.25
+│  ├─ secure-compare@3.0.1
+│  └─ union@~0.5.0
+├─ http-signature@1.2.0
+│  ├─ assert-plus@^1.0.0
+│  ├─ jsprim@^1.2.2
+│  └─ sshpk@^1.7.0
+├─ http2@3.3.7
+├─ https-proxy-agent@4.0.0
+│  ├─ agent-base@5
+│  ├─ debug@4
+│  ├─ debug@4.3.1
+│  │  └─ ms@2.1.2
+│  └─ ms@2.1.2
+├─ iconv-lite@0.4.24
+│  └─ safer-buffer@>= 2.1.2 < 3
+├─ ieee754@1.2.1
+├─ image-size@0.5.5
+├─ inflight@1.0.6
+│  ├─ once@^1.3.0
+│  └─ wrappy@1
+├─ inherits@2.0.4
+├─ ini@1.3.8
+├─ interpret@1.1.0
+├─ is-absolute@1.0.0
+│  ├─ is-relative@^1.0.0
+│  └─ is-windows@^1.0.1
+├─ is-accessor-descriptor@1.0.0
+│  ├─ kind-of@^6.0.0
+│  └─ kind-of@6.0.3
+├─ is-binary-path@2.1.0
+│  └─ binary-extensions@^2.0.0
+├─ is-buffer@1.1.6
+├─ is-callable@1.2.2
+├─ is-core-module@2.2.0
+│  └─ has@^1.0.3
+├─ is-data-descriptor@1.0.0
+│  ├─ kind-of@^6.0.0
+│  └─ kind-of@6.0.3
+├─ is-date-object@1.0.2
+├─ is-descriptor@1.0.2
+│  ├─ is-accessor-descriptor@^1.0.0
+│  ├─ is-data-descriptor@^1.0.0
+│  ├─ kind-of@^6.0.2
+│  └─ kind-of@6.0.3
+├─ is-extendable@0.1.1
+├─ is-extglob@2.1.1
+├─ is-fullwidth-code-point@2.0.0
+├─ is-glob@4.0.1
+│  └─ is-extglob@^2.1.1
+├─ is-negative-zero@2.0.1
+├─ is-number@3.0.0
+│  └─ kind-of@^3.0.2
+├─ is-plain-object@2.0.4
+│  └─ isobject@^3.0.1
+├─ is-regex@1.1.1
+│  └─ has-symbols@^1.0.1
+├─ is-relative@1.0.0
+│  └─ is-unc-path@^1.0.0
+├─ is-symbol@1.0.3
+│  └─ has-symbols@^1.0.1
+├─ is-typedarray@1.0.0
+├─ is-unc-path@1.0.0
+│  └─ unc-path-regex@^0.1.2
+├─ is-windows@1.0.2
+├─ isarray@0.0.1
+├─ isexe@2.0.0
+├─ isobject@3.0.1
+├─ isstream@0.1.2
+├─ jquery@3.5.1
+├─ js-yaml@3.14.1
+│  ├─ argparse@^1.0.7
+│  └─ esprima@^4.0.0
+├─ jsbn@0.1.1
+├─ jsdiff@0.0.0
+├─ jshint@2.12.0
+│  ├─ cli@~1.0.0
+│  ├─ console-browserify@1.1.x
+│  ├─ exit@0.1.x
+│  ├─ htmlparser2@3.8.x
+│  ├─ lodash@~4.17.19
+│  ├─ minimatch@~3.0.2
+│  ├─ shelljs@0.3.x
+│  └─ strip-json-comments@1.0.x
+├─ json-schema-traverse@0.4.1
+├─ json-schema@0.2.3
+├─ json-stringify-safe@5.0.1
+├─ jsprim@1.4.1
+│  ├─ assert-plus@1.0.0
+│  ├─ extsprintf@1.3.0
+│  ├─ json-schema@0.2.3
+│  └─ verror@1.10.0
+├─ jstree-actions@0.2.1
+├─ jstree@3.3.11
+│  └─ jquery@>=1.9.1
+├─ kind-of@3.2.2
+│  └─ is-buffer@^1.1.5
+├─ langcodes@0.0.0
+├─ less@2.7.3
+│  ├─ errno@^0.1.1
+│  ├─ graceful-fs@^4.1.2
+│  ├─ image-size@~0.5.0
+│  ├─ mime@^1.2.11
+│  ├─ mkdirp@^0.5.0
+│  ├─ promise@^7.1.1
+│  ├─ request@2.81.0
+│  └─ source-map@^0.5.3
+├─ leven@2.1.0
+├─ liftoff@2.5.0
+│  ├─ extend@^3.0.0
+│  ├─ findup-sync@^2.0.0
+│  ├─ findup-sync@2.0.0
+│  │  ├─ detect-file@^1.0.0
+│  │  ├─ is-glob@^3.1.0
+│  │  ├─ micromatch@^3.0.4
+│  │  └─ resolve-dir@^1.0.1
+│  ├─ fined@^1.0.1
+│  ├─ flagged-respawn@^1.0.0
+│  ├─ is-glob@3.1.0
+│  │  └─ is-extglob@^2.1.0
+│  ├─ is-plain-object@^2.0.4
+│  ├─ object.map@^1.0.0
+│  ├─ rechoir@^0.6.2
+│  └─ resolve@^1.1.7
+├─ linkify-it@3.0.2
+│  └─ uc.micro@^1.0.1
+├─ livereload-js@2.4.0
+├─ locate-path@3.0.0
+│  ├─ p-locate@^3.0.0
+│  └─ path-exists@^3.0.0
+├─ lodash@4.17.20
+├─ log-symbols@3.0.0
+│  └─ chalk@^2.4.2
+├─ make-iterator@1.0.1
+│  ├─ kind-of@^6.0.2
+│  └─ kind-of@6.0.3
+├─ map-cache@0.2.2
+├─ map-visit@1.0.0
+│  └─ object-visit@^1.0.0
+├─ markdown-it@12.0.4
+│  ├─ argparse@^2.0.1
+│  ├─ argparse@2.0.1
+│  ├─ entities@~2.1.0
+│  ├─ linkify-it@^3.0.1
+│  ├─ mdurl@^1.0.1
+│  └─ uc.micro@^1.0.5
+├─ mdn-data@2.0.14
+├─ mdurl@1.0.1
+├─ MediaUploader@0.0.0
+├─ micromatch@3.1.10
+│  ├─ arr-diff@^4.0.0
+│  ├─ array-unique@^0.3.2
+│  ├─ braces@^2.3.1
+│  ├─ braces@2.3.2
+│  │  ├─ arr-flatten@^1.1.0
+│  │  ├─ array-unique@^0.3.2
+│  │  ├─ extend-shallow@^2.0.1
+│  │  ├─ extend-shallow@2.0.1
+│  │  │  └─ is-extendable@^0.1.0
+│  │  ├─ fill-range@^4.0.0
+│  │  ├─ is-extendable@0.1.1
+│  │  ├─ isobject@^3.0.1
+│  │  ├─ repeat-element@^1.1.2
+│  │  ├─ snapdragon-node@^2.0.1
+│  │  ├─ snapdragon@^0.8.1
+│  │  ├─ split-string@^3.0.2
+│  │  └─ to-regex@^3.0.1
+│  ├─ define-property@^2.0.2
+│  ├─ define-property@2.0.2
+│  │  ├─ is-descriptor@^1.0.2
+│  │  └─ isobject@^3.0.1
+│  ├─ extend-shallow@^3.0.2
+│  ├─ extend-shallow@3.0.2
+│  │  ├─ assign-symbols@^1.0.0
+│  │  └─ is-extendable@^1.0.1
+│  ├─ extglob@^2.0.4
+│  ├─ fill-range@4.0.0
+│  │  ├─ extend-shallow@^2.0.1
+│  │  ├─ extend-shallow@2.0.1
+│  │  │  └─ is-extendable@^0.1.0
+│  │  ├─ is-extendable@0.1.1
+│  │  ├─ is-number@^3.0.0
+│  │  ├─ repeat-string@^1.6.1
+│  │  └─ to-regex-range@^2.1.0
+│  ├─ fragment-cache@^0.2.1
+│  ├─ is-extendable@1.0.1
+│  │  └─ is-plain-object@^2.0.4
+│  ├─ kind-of@^6.0.2
+│  ├─ kind-of@6.0.3
+│  ├─ nanomatch@^1.2.9
+│  ├─ object.pick@^1.3.0
+│  ├─ regex-not@^1.0.0
+│  ├─ snapdragon@^0.8.1
+│  ├─ to-regex-range@2.1.1
+│  │  ├─ is-number@^3.0.0
+│  │  └─ repeat-string@^1.6.1
+│  └─ to-regex@^3.0.2
+├─ mime-db@1.45.0
+├─ mime-types@2.1.28
+│  └─ mime-db@1.45.0
+├─ mime@1.6.0
+├─ minimatch@3.0.4
+│  └─ brace-expansion@^1.1.7
+├─ minimist@1.2.5
+├─ mitt@2.1.0
+├─ mixin-deep@1.3.2
+│  ├─ for-in@^1.0.2
+│  ├─ is-extendable@^1.0.1
+│  └─ is-extendable@1.0.1
+│     └─ is-plain-object@^2.0.4
+├─ mkdirp-classic@0.5.3
+├─ mkdirp@0.5.5
+│  └─ minimist@^1.2.5
+├─ mocha-headless-chrome@3.1.0
+│  ├─ args@^5.0.1
+│  ├─ mkdirp@^1.0.4
+│  ├─ mkdirp@1.0.4
+│  └─ puppeteer@^4.0.0
+├─ mocha@7.2.0
+│  ├─ ansi-colors@3.2.3
+│  ├─ browser-stdout@1.3.1
+│  ├─ chokidar@3.3.0
+│  ├─ debug@3.2.6
+│  ├─ debug@3.2.6
+│  │  ├─ ms@^2.1.1
+│  │  └─ ms@2.1.3
+│  ├─ diff@3.5.0
+│  ├─ escape-string-regexp@1.0.5
+│  ├─ find-up@3.0.0
+│  ├─ glob@7.1.3
+│  ├─ glob@7.1.3
+│  │  ├─ fs.realpath@^1.0.0
+│  │  ├─ inflight@^1.0.4
+│  │  ├─ inherits@2
+│  │  ├─ minimatch@^3.0.4
+│  │  ├─ once@^1.3.0
+│  │  └─ path-is-absolute@^1.0.0
+│  ├─ growl@1.10.5
+│  ├─ he@1.2.0
+│  ├─ js-yaml@3.13.1
+│  ├─ js-yaml@3.13.1
+│  │  ├─ argparse@^1.0.7
+│  │  └─ esprima@^4.0.0
+│  ├─ log-symbols@3.0.0
+│  ├─ minimatch@3.0.4
+│  ├─ mkdirp@0.5.5
+│  ├─ ms@2.1.1
+│  ├─ node-environment-flags@1.0.6
+│  ├─ object.assign@4.1.0
+│  ├─ strip-json-comments@2.0.1
+│  ├─ strip-json-comments@2.0.1
+│  ├─ supports-color@6.0.0
+│  ├─ which@1.3.1
+│  ├─ wide-align@1.1.3
+│  ├─ yargs-parser@13.1.2
+│  ├─ yargs-unparser@1.6.0
+│  └─ yargs@13.3.2
+├─ morgan@1.10.0
+│  ├─ basic-auth@~2.0.1
+│  ├─ basic-auth@2.0.1
+│  │  └─ safe-buffer@5.1.2
+│  ├─ debug@2.6.9
+│  ├─ depd@~2.0.0
+│  ├─ depd@2.0.0
+│  ├─ on-finished@~2.3.0
+│  ├─ on-headers@~1.0.2
+│  └─ safe-buffer@5.1.2
+├─ mri@1.1.4
+├─ ms@2.1.1
+├─ nanomatch@1.2.13
+│  ├─ arr-diff@^4.0.0
+│  ├─ array-unique@^0.3.2
+│  ├─ define-property@^2.0.2
+│  ├─ define-property@2.0.2
+│  │  ├─ is-descriptor@^1.0.2
+│  │  └─ isobject@^3.0.1
+│  ├─ extend-shallow@^3.0.2
+│  ├─ extend-shallow@3.0.2
+│  │  ├─ assign-symbols@^1.0.0
+│  │  └─ is-extendable@^1.0.1
+│  ├─ fragment-cache@^0.2.1
+│  ├─ is-extendable@1.0.1
+│  │  └─ is-plain-object@^2.0.4
+│  ├─ is-windows@^1.0.2
+│  ├─ kind-of@^6.0.2
+│  ├─ kind-of@6.0.3
+│  ├─ object.pick@^1.3.0
+│  ├─ regex-not@^1.0.0
+│  ├─ snapdragon@^0.8.1
+│  └─ to-regex@^3.0.1
+├─ negotiator@0.6.2
+├─ node-environment-flags@1.0.6
+│  ├─ object.getownpropertydescriptors@^2.0.3
+│  └─ semver@^5.7.0
+├─ nopt@3.0.6
+│  └─ abbrev@1
+├─ normalize-path@3.0.0
+├─ oauth-sign@0.9.0
+├─ object-assign@4.1.1
+├─ object-copy@0.1.0
+│  ├─ copy-descriptor@^0.1.0
+│  ├─ define-property@^0.2.5
+│  └─ kind-of@^3.0.3
+├─ object-inspect@1.9.0
+├─ object-keys@1.1.1
+├─ object-visit@1.0.1
+│  └─ isobject@^3.0.0
+├─ object.assign@4.1.0
+│  ├─ define-properties@^1.1.2
+│  ├─ function-bind@^1.1.1
+│  ├─ has-symbols@^1.0.0
+│  └─ object-keys@^1.0.11
+├─ object.defaults@1.1.0
+│  ├─ array-each@^1.0.1
+│  ├─ array-slice@^1.0.0
+│  ├─ for-own@^1.0.0
+│  └─ isobject@^3.0.0
+├─ object.getownpropertydescriptors@2.1.1
+│  ├─ call-bind@^1.0.0
+│  ├─ define-properties@^1.1.3
+│  └─ es-abstract@^1.18.0-next.1
+├─ object.map@1.0.1
+│  ├─ for-own@^1.0.0
+│  └─ make-iterator@^1.0.0
+├─ object.pick@1.3.0
+│  └─ isobject@^3.0.1
+├─ on-finished@2.3.0
+│  └─ ee-first@1.1.1
+├─ on-headers@1.0.2
+├─ once@1.4.0
+│  └─ wrappy@1
+├─ opener@1.5.2
+├─ opn@4.0.2
+│  ├─ object-assign@^4.0.1
+│  └─ pinkie-promise@^2.0.0
+├─ os-homedir@1.0.2
+├─ os-tmpdir@1.0.2
+├─ osenv@0.1.5
+│  ├─ os-homedir@^1.0.0
+│  └─ os-tmpdir@^1.0.0
+├─ p-limit@2.3.0
+│  └─ p-try@^2.0.0
+├─ p-locate@3.0.0
+│  └─ p-limit@^2.0.0
+├─ p-try@2.2.0
+├─ parse-filepath@1.0.2
+│  ├─ is-absolute@^1.0.0
+│  ├─ map-cache@^0.2.0
+│  └─ path-root@^0.1.1
+├─ parse-passwd@1.0.0
+├─ parseurl@1.3.3
+├─ pascalcase@0.1.1
+├─ path-exists@3.0.0
+├─ path-is-absolute@1.0.1
+├─ path-parse@1.0.6
+├─ path-root-regex@0.1.2
+├─ path-root@0.1.1
+│  └─ path-root-regex@^0.1.0
+├─ pathval@1.1.0
+├─ pend@1.2.0
+├─ performance-now@2.1.0
+├─ picomatch@2.2.2
+├─ pinkie-promise@2.0.1
+│  └─ pinkie@^2.0.0
+├─ pinkie@2.0.4
+├─ portfinder@1.0.28
+│  ├─ async@^2.6.2
+│  ├─ async@2.6.3
+│  │  └─ lodash@^4.17.14
+│  ├─ debug@^3.1.1
+│  ├─ debug@3.2.7
+│  │  └─ ms@^2.1.1
+│  ├─ mkdirp@^0.5.5
+│  └─ ms@2.1.3
+├─ portscanner@1.2.0
+│  └─ async@1.5.2
+├─ posix-character-classes@0.1.1
+├─ progress@2.0.3
+├─ promise@7.3.1
+│  └─ asap@~2.0.3
+├─ proxy-from-env@1.1.0
+├─ prr@1.0.1
+├─ psl@1.8.0
+├─ pump@3.0.0
+│  ├─ end-of-stream@^1.1.0
+│  └─ once@^1.3.1
+├─ punycode@2.1.1
+├─ puppeteer@4.0.1
+│  ├─ debug@^4.1.0
+│  ├─ debug@4.3.1
+│  │  └─ ms@2.1.2
+│  ├─ extract-zip@^2.0.0
+│  ├─ https-proxy-agent@^4.0.0
+│  ├─ mime@^2.0.3
+│  ├─ mitt@^2.0.1
+│  ├─ ms@2.1.2
+│  ├─ progress@^2.0.1
+│  ├─ proxy-from-env@^1.0.0
+│  ├─ rimraf@^3.0.2
+│  ├─ tar-fs@^2.0.0
+│  ├─ unbzip2-stream@^1.3.3
+│  └─ ws@^7.2.3
+├─ qs@6.9.6
+├─ range-parser@1.2.1
+├─ raw-body@1.1.7
+│  ├─ bytes@1
+│  └─ string_decoder@0.10
+├─ readable-stream@3.6.0
+│  ├─ inherits@^2.0.3
+│  ├─ string_decoder@^1.1.1
+│  ├─ string_decoder@1.3.0
+│  │  └─ safe-buffer@~5.2.0
+│  └─ util-deprecate@^1.0.1
+├─ readdirp@3.2.0
+│  └─ picomatch@^2.0.4
+├─ rechoir@0.6.2
+│  └─ resolve@^1.1.6
+├─ regex-not@1.0.2
+│  ├─ extend-shallow@^3.0.2
+│  ├─ extend-shallow@3.0.2
+│  │  ├─ assign-symbols@^1.0.0
+│  │  └─ is-extendable@^1.0.1
+│  ├─ is-extendable@1.0.1
+│  │  └─ is-plain-object@^2.0.4
+│  └─ safe-regex@^1.1.0
+├─ repeat-element@1.1.3
+├─ repeat-string@1.6.1
+├─ request@2.88.2
+│  ├─ aws-sign2@~0.7.0
+│  ├─ aws4@^1.8.0
+│  ├─ caseless@~0.12.0
+│  ├─ combined-stream@~1.0.6
+│  ├─ extend@~3.0.2
+│  ├─ forever-agent@~0.6.1
+│  ├─ form-data@~2.3.2
+│  ├─ har-validator@~5.1.3
+│  ├─ http-signature@~1.2.0
+│  ├─ is-typedarray@~1.0.0
+│  ├─ isstream@~0.1.2
+│  ├─ json-stringify-safe@~5.0.1
+│  ├─ mime-types@~2.1.19
+│  ├─ oauth-sign@~0.9.0
+│  ├─ performance-now@^2.1.0
+│  ├─ qs@~6.5.2
+│  ├─ safe-buffer@^5.1.2
+│  ├─ tough-cookie@~2.5.0
+│  ├─ tunnel-agent@^0.6.0
+│  └─ uuid@^3.3.2
+├─ require-css@0.1.10
+├─ require-directory@2.1.1
+├─ require-main-filename@2.0.0
+├─ requirejs-plugins@1.0.2
+├─ requirejs-text@2.0.15
+├─ requirejs-undertemplate@0.0.4
+│  ├─ requirejs-text@~2.0.12
+│  ├─ requirejs@~2.2.0
+│  ├─ requirejs@2.2.0
+│  ├─ underscore@^1.8.3
+│  └─ underscore@1.12.0
+├─ requirejs@2.3.6
+├─ requires-port@1.0.0
+├─ resolve-dir@1.0.1
+│  ├─ expand-tilde@^2.0.0
+│  └─ global-modules@^1.0.0
+├─ resolve-url@0.2.1
+├─ resolve@1.19.0
+│  ├─ is-core-module@^2.1.0
+│  └─ path-parse@^1.0.6
+├─ ret@0.1.15
+├─ rimraf@3.0.2
+│  └─ glob@^7.1.3
+├─ safe-buffer@5.2.1
+├─ safe-json-parse@1.0.1
+├─ safe-regex@1.1.0
+│  └─ ret@~0.1.10
+├─ safer-buffer@2.1.2
+├─ secure-compare@3.0.1
+├─ semver@5.7.1
+├─ send@0.17.1
+│  ├─ debug@2.6.9
+│  ├─ depd@~1.1.2
+│  ├─ destroy@~1.0.4
+│  ├─ encodeurl@~1.0.2
+│  ├─ escape-html@~1.0.3
+│  ├─ etag@~1.8.1
+│  ├─ fresh@0.5.2
+│  ├─ http-errors@~1.7.2
+│  ├─ http-errors@1.7.3
+│  │  ├─ depd@~1.1.2
+│  │  ├─ inherits@2.0.4
+│  │  ├─ setprototypeof@1.1.1
+│  │  ├─ statuses@>= 1.5.0 < 2
+│  │  └─ toidentifier@1.0.0
+│  ├─ mime@1.6.0
+│  ├─ ms@2.1.1
+│  ├─ on-finished@~2.3.0
+│  ├─ range-parser@~1.2.1
+│  ├─ setprototypeof@1.1.1
+│  └─ statuses@~1.5.0
+├─ serve-index@1.9.1
+│  ├─ accepts@~1.3.4
+│  ├─ batch@0.6.1
+│  ├─ debug@2.6.9
+│  ├─ escape-html@~1.0.3
+│  ├─ http-errors@~1.6.2
+│  ├─ mime-types@~2.1.17
+│  └─ parseurl@~1.3.2
+├─ serve-static@1.14.1
+│  ├─ encodeurl@~1.0.2
+│  ├─ escape-html@~1.0.3
+│  ├─ parseurl@~1.3.3
+│  └─ send@0.17.1
+├─ set-blocking@2.0.0
+├─ set-value@2.0.1
+│  ├─ extend-shallow@^2.0.1
+│  ├─ is-extendable@^0.1.1
+│  ├─ is-plain-object@^2.0.3
+│  └─ split-string@^3.0.1
+├─ setprototypeof@1.1.0
+├─ shelljs@0.3.0
+├─ snapdragon-node@2.1.1
+│  ├─ define-property@^1.0.0
+│  ├─ define-property@1.0.0
+│  │  └─ is-descriptor@^1.0.0
+│  ├─ isobject@^3.0.0
+│  └─ snapdragon-util@^3.0.1
+├─ snapdragon-util@3.0.1
+│  └─ kind-of@^3.2.0
+├─ snapdragon@0.8.2
+│  ├─ base@^0.11.1
+│  ├─ debug@^2.2.0
+│  ├─ define-property@^0.2.5
+│  ├─ extend-shallow@^2.0.1
+│  ├─ map-cache@^0.2.2
+│  ├─ source-map-resolve@^0.5.0
+│  ├─ source-map@^0.5.6
+│  └─ use@^3.1.0
+├─ source-map-resolve@0.5.3
+│  ├─ atob@^2.1.2
+│  ├─ decode-uri-component@^0.2.0
+│  ├─ resolve-url@^0.2.1
+│  ├─ source-map-url@^0.4.0
+│  └─ urix@^0.1.0
+├─ source-map-url@0.4.0
+├─ source-map@0.5.7
+├─ split-string@3.1.0
+│  ├─ extend-shallow@^3.0.0
+│  ├─ extend-shallow@3.0.2
+│  │  ├─ assign-symbols@^1.0.0
+│  │  └─ is-extendable@^1.0.1
+│  └─ is-extendable@1.0.1
+│     └─ is-plain-object@^2.0.4
+├─ sprintf-js@1.0.3
+├─ sshpk@1.16.1
+│  ├─ asn1@~0.2.3
+│  ├─ assert-plus@^1.0.0
+│  ├─ bcrypt-pbkdf@^1.0.0
+│  ├─ dashdash@^1.12.0
+│  ├─ ecc-jsbn@~0.1.1
+│  ├─ getpass@^0.1.1
+│  ├─ jsbn@~0.1.0
+│  ├─ safer-buffer@^2.0.2
+│  └─ tweetnacl@~0.14.0
+├─ static-extend@0.1.2
+│  ├─ define-property@^0.2.5
+│  └─ object-copy@^0.1.0
+├─ statuses@1.5.0
+├─ string_decoder@0.10.31
+├─ string-template@0.2.1
+├─ string-width@3.1.0
+│  ├─ emoji-regex@^7.0.1
+│  ├─ is-fullwidth-code-point@^2.0.0
+│  └─ strip-ansi@^5.1.0
+├─ string.prototype.trimend@1.0.3
+│  ├─ call-bind@^1.0.0
+│  └─ define-properties@^1.1.3
+├─ string.prototype.trimstart@1.0.3
+│  ├─ call-bind@^1.0.0
+│  └─ define-properties@^1.1.3
+├─ strip-ansi@5.2.0
+│  └─ ansi-regex@^4.1.0
+├─ strip-json-comments@1.0.4
+├─ supports-color@6.0.0
+│  └─ has-flag@^3.0.0
+├─ tar-fs@2.1.1
+│  ├─ chownr@^1.1.1
+│  ├─ mkdirp-classic@^0.5.2
+│  ├─ pump@^3.0.0
+│  └─ tar-stream@^2.1.4
+├─ tar-stream@2.2.0
+│  ├─ bl@^4.0.3
+│  ├─ end-of-stream@^1.4.1
+│  ├─ fs-constants@^1.0.0
+│  ├─ inherits@^2.0.3
+│  └─ readable-stream@^3.1.1
+├─ through@2.3.8
+├─ tiny-lr@1.1.1
+│  ├─ body@^5.1.0
+│  ├─ debug@^3.1.0
+│  ├─ debug@3.2.7
+│  │  └─ ms@^2.1.1
+│  ├─ faye-websocket@~0.10.0
+│  ├─ livereload-js@^2.3.0
+│  ├─ ms@2.1.3
+│  ├─ object-assign@^4.1.0
+│  └─ qs@^6.4.0
+├─ to-object-path@0.3.0
+│  └─ kind-of@^3.0.2
+├─ to-regex-range@5.0.1
+│  ├─ is-number@^7.0.0
+│  └─ is-number@7.0.0
+├─ to-regex@3.0.2
+│  ├─ define-property@^2.0.2
+│  ├─ define-property@2.0.2
+│  │  ├─ is-descriptor@^1.0.2
+│  │  └─ isobject@^3.0.1
+│  ├─ extend-shallow@^3.0.2
+│  ├─ extend-shallow@3.0.2
+│  │  ├─ assign-symbols@^1.0.0
+│  │  └─ is-extendable@^1.0.1
+│  ├─ is-extendable@1.0.1
+│  │  └─ is-plain-object@^2.0.4
+│  ├─ regex-not@^1.0.2
+│  └─ safe-regex@^1.1.0
+├─ toidentifier@1.0.0
+├─ tough-cookie@2.5.0
+│  ├─ psl@^1.1.28
+│  └─ punycode@^2.1.1
+├─ tunnel-agent@0.6.0
+│  └─ safe-buffer@^5.0.1
+├─ tweetnacl@0.14.5
+├─ type-detect@4.0.8
+├─ uc.micro@1.0.6
+├─ unbzip2-stream@1.4.3
+│  ├─ buffer@^5.2.1
+│  └─ through@^2.3.8
+├─ unc-path-regex@0.1.2
+├─ underscore.string@3.3.5
+│  ├─ sprintf-js@^1.0.3
+│  ├─ sprintf-js@1.1.2
+│  └─ util-deprecate@^1.0.2
+├─ underscore@1.8.3
+├─ union-value@1.0.1
+│  ├─ arr-union@^3.1.0
+│  ├─ get-value@^2.0.6
+│  ├─ is-extendable@^0.1.1
+│  └─ set-value@^2.0.1
+├─ union@0.5.0
+│  └─ qs@^6.4.0
+├─ unpipe@1.0.0
+├─ unset-value@1.0.0
+│  ├─ has-value@^0.3.1
+│  ├─ has-value@0.3.1
+│  │  ├─ get-value@^2.0.3
+│  │  ├─ has-values@^0.1.4
+│  │  ├─ isobject@^2.0.0
+│  │  └─ isobject@2.1.0
+│  │     └─ isarray@1.0.0
+│  ├─ has-values@0.1.4
+│  ├─ isarray@1.0.0
+│  └─ isobject@^3.0.0
+├─ uri-js@4.4.1
+│  └─ punycode@^2.1.0
+├─ urix@0.1.0
+├─ url-join@2.0.5
+├─ use@3.1.1
+├─ util-deprecate@1.0.2
+├─ utils-merge@1.0.1
+├─ uuid@3.4.0
+├─ v8flags@3.1.3
+│  └─ homedir-polyfill@^1.0.1
+├─ verror@1.10.0
+│  ├─ assert-plus@^1.0.0
+│  ├─ core-util-is@1.0.2
+│  ├─ extsprintf@^1.2.0
+│  └─ extsprintf@1.4.0
+├─ websocket-driver@0.7.4
+│  ├─ http-parser-js@>=0.5.1
+│  ├─ safe-buffer@>=5.1.0
+│  └─ websocket-extensions@>=0.1.1
+├─ websocket-extensions@0.1.4
+├─ which-module@2.0.0
+├─ which@1.3.1
+│  └─ isexe@^2.0.0
+├─ wide-align@1.1.3
+│  ├─ ansi-regex@3.0.0
+│  ├─ string-width@^1.0.2 || 2
+│  ├─ string-width@2.1.1
+│  │  ├─ is-fullwidth-code-point@^2.0.0
+│  │  └─ strip-ansi@^4.0.0
+│  └─ strip-ansi@4.0.0
+│     └─ ansi-regex@^3.0.0
+├─ wrap-ansi@5.1.0
+│  ├─ ansi-styles@^3.2.0
+│  ├─ string-width@^3.0.0
+│  └─ strip-ansi@^5.0.0
+├─ wrappy@1.0.2
+├─ ws@7.4.2
+├─ XMLWriter@1.1.0
+├─ xpath@0.0.4
+│  └─ biginteger@^1.0.3
+├─ xrayquire@0.1.1
+├─ y18n@4.0.1
+├─ yargs-parser@13.1.2
+│  ├─ camelcase@^5.0.0
+│  ├─ camelcase@5.3.1
+│  └─ decamelize@^1.2.0
+├─ yargs-unparser@1.6.0
+│  ├─ flat@^4.1.0
+│  ├─ lodash@^4.17.15
+│  └─ yargs@^13.3.0
+├─ yargs@13.3.2
+│  ├─ cliui@^5.0.0
+│  ├─ find-up@^3.0.0
+│  ├─ get-caller-file@^2.0.1
+│  ├─ require-directory@^2.1.1
+│  ├─ require-main-filename@^2.0.0
+│  ├─ set-blocking@^2.0.0
+│  ├─ string-width@^3.0.0
+│  ├─ which-module@^2.0.0
+│  ├─ y18n@^4.0.0
+│  └─ yargs-parser@^13.1.2
+├─ yarn@1.22.10
+└─ yauzl@2.10.0
+   ├─ buffer-crc32@~0.2.3
+   └─ fd-slicer@~1.1.0
+Done in 0.47s.


### PR DESCRIPTION
This is approximate because it was built using the version of vellum that is currently on master, but the resulting main-components.js file, which is not included in this commit, is slightly different. Ideally it would be exactly the same; I'm not sure why it changed. In any case, this is better than what we had before (nothing), and at least a good starting point for tracking what libraries are changing when vellum is updated.

See also https://github.com/dimagi/Vellum/pull/1012

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No test coverage.

### QA Plan

No QA.

### Safety story

It's just a text file containing versions of libraries bundled in vellum.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
