### PR TITLE
Initial WIP on adding date validation to case importer

### DIFF
--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -14,6 +14,7 @@ from dimagi.utils.logging import notify_exception
 from soil.progress import TaskProgressManager
 
 from corehq.apps.case_importer.exceptions import CaseRowError
+from corehq.apps.data_dictionary.util import validated_fields
 from corehq.apps.export.tasks import add_inferred_export_properties
 from corehq.apps.groups.models import Group
 from corehq.apps.hqcase.utils import CASEBLOCK_CHUNKSIZE, submit_case_blocks
@@ -80,6 +81,8 @@ class _Importer(object):
         self.uncreated_external_ids = set()
         self._unsubmitted_caseblocks = []
         self.multi_domain = multi_domain
+        self.validated_fields = validated_fields(domain, config.case_type)
+        self.field_map = self._create_field_map()
 
     def do_import(self, spreadsheet):
         with TaskProgressManager(self.task, src="case_importer") as progress_manager:
@@ -102,8 +105,8 @@ class _Importer(object):
             return self.results.to_json()
 
     def import_row(self, row_num, raw_row):
-        search_id = _parse_search_id(self.config, raw_row)
-        fields_to_update = _populate_updated_fields(self.config, raw_row)
+        search_id = self._parse_search_id(raw_row)
+        fields_to_update = self._populate_updated_fields(raw_row)
         if not any(fields_to_update.values()):
             # if the row was blank, just skip it, no errors
             return
@@ -194,6 +197,104 @@ class _Importer(object):
             self.user.user_id,
             device_id=__name__ + ".do_import",
         )
+
+    def _parse_search_id(self, row):
+        """ Find and convert the search id in an Excel row """
+
+        # Find index of user specified search column
+        search_column = self.config.search_column
+        search_id = row[search_column] or ''
+
+        try:
+            # if the spreadsheet gives a number, strip any decimals off
+            # float(x) is more lenient in conversion from string so both
+            # are used
+            search_id = int(float(search_id))
+        except (ValueError, TypeError, OverflowError):
+            # if it's not a number that's okay too
+            pass
+
+        return _convert_field_value(search_id)
+
+    def _populate_updated_fields(self, row):
+        """
+        Returns a dict map of fields that were marked to be updated
+        due to the import. This can be then used to pass to the CaseBlock
+        to trigger updates.
+        """
+        field_map = self.field_map
+        fields_to_update = {}
+        for key in field_map:
+            try:
+                update_value = row[key]
+            except Exception:
+                continue
+
+            if 'field_name' in field_map[key]:
+                update_field_name = field_map[key]['field_name'].strip()
+            else:
+                # nothing was selected so don't add this value
+                continue
+
+            if update_field_name in RESERVED_FIELDS:
+                if update_field_name == 'parent_ref':
+                    raise exceptions.InvalidCustomFieldNameException(
+                        _('Field name "{}" is deprecated. Please use "parent_identifier" instead.'))
+                else:
+                    raise exceptions.InvalidCustomFieldNameException(
+                        _('Field name "{}" is reserved').format(update_field_name))
+
+            if isinstance(update_value, str) and update_value.strip() == SCALAR_NEVER_WAS:
+                # If we find any instances of blanks ('---'), convert them to an
+                # actual blank value without performing any data type validation.
+                # This is to be consistent with how the case export works.
+                update_value = ''
+            elif update_value is not None:
+                update_value = _convert_field_value(update_value)
+
+            # NOTE: new inserted validation here
+            if update_field_name in self.validated_fields:
+                case_property = self.validated_fields[update_field_name]
+                if not case_property.valid_value(update_value):
+                    # note: probably want to accumulate full list of invalid
+                    # columns for this row and raise and exception with that
+                    # full set of info rather than bailing out on first one
+                    # as we're currently doing here.
+                    if case_property.data_type == 'date':
+                        raise exceptions.InvalidDate(update_field_name)
+                    # else select type would be handled here, when that's added
+
+            fields_to_update[update_field_name] = update_value
+
+        return fields_to_update
+
+    def _create_field_map(self):
+        config = self.config
+        excel_fields = config.excel_fields
+        case_fields = config.case_fields
+        custom_fields = config.custom_fields
+
+        field_map = {}
+        for i, field in enumerate(excel_fields):
+            if field:
+                field_map[field] = {}
+
+                if case_fields[i]:
+                    field_map[field]['field_name'] = case_fields[i]
+                elif custom_fields[i]:
+                    # if we have configured this field for external_id populate external_id instead
+                    # of the default property name from the column
+                    if config.search_field == EXTERNAL_ID and field == config.search_column:
+                        field_map[field]['field_name'] = EXTERNAL_ID
+                    else:
+                        field_map[field]['field_name'] = custom_fields[i]
+        # hack: make sure the external_id column ends up in the field_map if the user
+        # didn't explicitly put it there
+        if config.search_column not in field_map and config.search_field == EXTERNAL_ID:
+            field_map[config.search_column] = {
+                'field_name': EXTERNAL_ID
+            }
+        return field_map
 
 
 class _TimedAndThrottledImporter(_Importer):
@@ -399,34 +500,6 @@ def _log_case_lookup(domain):
     case_load_counter("case_importer", domain)
 
 
-def _convert_custom_fields_to_struct(config):
-    excel_fields = config.excel_fields
-    case_fields = config.case_fields
-    custom_fields = config.custom_fields
-
-    field_map = {}
-    for i, field in enumerate(excel_fields):
-        if field:
-            field_map[field] = {}
-
-            if case_fields[i]:
-                field_map[field]['field_name'] = case_fields[i]
-            elif custom_fields[i]:
-                # if we have configured this field for external_id populate external_id instead
-                # of the default property name from the column
-                if config.search_field == EXTERNAL_ID and field == config.search_column:
-                    field_map[field]['field_name'] = EXTERNAL_ID
-                else:
-                    field_map[field]['field_name'] = custom_fields[i]
-    # hack: make sure the external_id column ends up in the field_map if the user
-    # didn't explicitly put it there
-    if config.search_column not in field_map and config.search_field == EXTERNAL_ID:
-        field_map[config.search_column] = {
-            'field_name': EXTERNAL_ID
-        }
-    return field_map
-
-
 class _ImportResults(object):
     CREATED = 'created'
     UPDATED = 'updated'
@@ -475,66 +548,6 @@ class _ImportResults(object):
 def _convert_field_value(value):
     # coerce to string unless it's a unicode string then we want that
     return value if isinstance(value, str) else str(value)
-
-
-def _parse_search_id(config, row):
-    """ Find and convert the search id in an Excel row """
-
-    # Find index of user specified search column
-    search_column = config.search_column
-    search_id = row[search_column] or ''
-
-    try:
-        # if the spreadsheet gives a number, strip any decimals off
-        # float(x) is more lenient in conversion from string so both
-        # are used
-        search_id = int(float(search_id))
-    except (ValueError, TypeError, OverflowError):
-        # if it's not a number that's okay too
-        pass
-
-    return _convert_field_value(search_id)
-
-
-def _populate_updated_fields(config, row):
-    """
-    Returns a dict map of fields that were marked to be updated
-    due to the import. This can be then used to pass to the CaseBlock
-    to trigger updates.
-    """
-    field_map = _convert_custom_fields_to_struct(config)
-    fields_to_update = {}
-    for key in field_map:
-        try:
-            update_value = row[key]
-        except Exception:
-            continue
-
-        if 'field_name' in field_map[key]:
-            update_field_name = field_map[key]['field_name'].strip()
-        else:
-            # nothing was selected so don't add this value
-            continue
-
-        if update_field_name in RESERVED_FIELDS:
-            if update_field_name == 'parent_ref':
-                raise exceptions.InvalidCustomFieldNameException(
-                    _('Field name "{}" is deprecated. Please use "parent_identifier" instead.'))
-            else:
-                raise exceptions.InvalidCustomFieldNameException(
-                    _('Field name "{}" is reserved').format(update_field_name))
-
-        if isinstance(update_value, str) and update_value.strip() == SCALAR_NEVER_WAS:
-            # If we find any instances of blanks ('---'), convert them to an
-            # actual blank value without performing any data type validation.
-            # This is to be consistent with how the case export works.
-            update_value = ''
-        elif update_value is not None:
-            update_value = _convert_field_value(update_value)
-
-        fields_to_update[update_field_name] = update_value
-
-    return fields_to_update
 
 
 class _OwnerAccessor(object):

--- a/corehq/apps/data_dictionary/models.py
+++ b/corehq/apps/data_dictionary/models.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.db import models
 from django.utils.translation import ugettext as _
 
@@ -91,3 +93,11 @@ class CaseProperty(models.Model):
         from .util import get_data_dict_props_by_case_type
         get_data_dict_props_by_case_type.clear(self.case_type.domain)
         return super(CaseProperty, self).save(*args, **kwargs)
+
+    def valid_value(self, value):
+        if self.data_type == 'date':
+            try:
+                datetime.strptime(value, '%Y-%m-%d')
+            except ValueError:
+                return False
+        return True

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -173,3 +173,13 @@ def get_data_dict_props_by_case_type(domain):
 def get_data_dict_case_types(domain):
     case_types = CaseType.objects.filter(domain=domain).values_list('name', flat=True)
     return set(case_types)
+
+
+def validated_fields(domain, case_type_name):
+    filter_kwargs = {
+        'case_type__domain': domain,
+        'case_type__name': case_type_name,
+        'data_type__in': ['date', 'select'],
+    }
+    props = CaseProperty.objects.filter(**filter_kwargs)
+    return {prop.name: prop for prop in props}


### PR DESCRIPTION
Intended to generate discussion on approach of starting by hooking into existing validation structure in case importer, which is a bit different than what had been envisioned (adding an explicit validation step).

(A large amount of the code changes here are simply moving independent functions (unused elsewhere, so far as I can see) into methods on the `_Importer` class to allow for computation of the field map and validated fields once per import rather than once per row.)

## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [ ] Risk label is set correctly
- [ ] All migrations are backwards compatible and won't block deploy
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
