### PR TITLE
Added optional username param to run_all_managment_command

### DIFF
--- a/custom/covid/management/commands/run_all_management_command.py
+++ b/custom/covid/management/commands/run_all_management_command.py
@@ -9,8 +9,8 @@ from datetime import datetime
 DEVICE_ID = __name__ + ".run_all_management_command"
 
 
-def run_command(command, *args, location=None, inactive_location=None, output_file=None):
-    kwargs = {'output_file': output_file}
+def run_command(command, *args, location=None, inactive_location=None, username=None, output_file=None):
+    kwargs = {'username': username, 'output_file': output_file}
     try:
         if inactive_location is not None:
             kwargs['inactive_location'] = inactive_location
@@ -27,6 +27,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('csv_file')
         parser.add_argument('--only-inactive', action='store_true', default=False)
+        parser.add_argument('--username', type=str, default=None)
         parser.add_argument('--output-file', type=str, default=None)
 
     def handle(self, csv_file, **options):
@@ -44,6 +45,7 @@ class Command(BaseCommand):
                 locations['inactive'] = row['inactive_location_id']
                 location_ids[row['domain']] = locations
 
+        username = options["username"]
         output_file_name = options["output_file"]
         start_time = datetime.utcnow()
         if output_file_name:
@@ -60,7 +62,8 @@ class Command(BaseCommand):
         pool = Pool(20)
         if options["only_inactive"]:
             for domain in domains:
-                kwargs = {'inactive_location': location_ids[domain]['inactive'], 'output_file': output_file_name}
+                kwargs = {'inactive_location': location_ids[domain]['inactive'], 'username': username,
+                          'output_file': output_file_name}
                 if 'traveler' in location_ids[domain]['active']:
                     kwargs['location'] = location_ids[domain]['active']['traveler']
                 jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact',
@@ -69,16 +72,16 @@ class Command(BaseCommand):
             total_jobs.extend(jobs)
         else:
             for domain in domains:
-                kwargs = {'output_file': output_file_name}
+                kwargs = {'username': username, 'output_file': output_file_name}
                 if 'traveler' in location_ids[domain]['active']:
                     kwargs['location'] = location_ids[domain]['active']['traveler']
                 jobs.append(pool.spawn(run_command, 'update_case_index_relationship', domain, 'contact', **kwargs))
                 jobs.append(pool.spawn(run_command, 'add_hq_user_id_to_case', domain, 'checkin',
-                                       output_file=output_file_name))
+                                       username=username, output_file=output_file_name))
                 jobs.append(pool.spawn(run_command, 'update_owner_ids', domain, 'investigation',
-                                       output_file=output_file_name))
+                                       username=username, output_file=output_file_name))
                 jobs.append(pool.spawn(run_command, 'update_owner_ids', domain, 'checkin',
-                                       output_file=output_file_name))
+                                       username=username, output_file=output_file_name))
             pool.join()
             total_jobs.extend(jobs)
 
@@ -86,7 +89,7 @@ class Command(BaseCommand):
             second_pool = Pool(20)
             for domain in domains:
                 for location in location_ids[domain]['active'].values():
-                    kwargs = {'location': location, 'output_file': output_file_name}
+                    kwargs = {'location': location, 'username': username, 'output_file': output_file_name}
                     jobs.append(second_pool.spawn(run_command, 'add_assignment_cases', domain, 'patient',
                                                   **kwargs))
                     jobs.append(second_pool.spawn(run_command, 'add_assignment_cases', domain, 'contact',


### PR DESCRIPTION
## Summary
[https://dimagi-dev.atlassian.net/browse/USH-978](https://dimagi-dev.atlassian.net/browse/USH-978)
NJ is wanting the `--username` option to specify which user is submitting the case blocks so they can be excluded from data forwarding

## Product Description
This option was available for all the individual commands, so this just adds it as an option for running all at once

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
none for the run_all command, but username param is specified in the individual command tests

### QA Plan
not requesting QA

### Safety story
should be run on a test domain prior to the NJ casedb migration

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
