### PR TITLE
Add action to "unfinish" forms & cases Couch to SQL migration

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -1466,7 +1466,7 @@ class MissingFormLoader:
 def get_main_forms_iteration_stop_date(statedb):
     resume_key = f"{statedb.domain}.XFormInstance.{statedb.unique_id}"
     itr = ResumableFunctionIterator(resume_key, None, None)
-    if itr.state.complete:
+    if getattr(itr.state, "complete", False):
         return None
     kwargs = itr.state.kwargs
     assert kwargs, f"migration state not found: {resume_key}"

--- a/corehq/apps/couch_sql_migration/missingdocs.py
+++ b/corehq/apps/couch_sql_migration/missingdocs.py
@@ -44,7 +44,7 @@ def find_missing_docs(domain, state_dir, live_migrate=False, resume=True, progre
     if live_migrate:
         log.info(f"stopping at {get_main_forms_iteration_stop_date(statedb)}")
     with statedb, stopper, ExitStack() as stop_it:
-        for entity in ["form", "case"]:
+        for entity in MissingIds.DOC_TYPES:
             missing_ids = MissingIds(
                 entity, statedb, stopper, resume=resume, progress=progress)
             stop_it.enter_context(missing_ids)
@@ -62,19 +62,31 @@ def recheck_missing_docs(domain, state_dir):
     statedb = open_state_db(domain, state_dir, readonly=False)
     counts = statedb.get_doc_counts()
     with statedb:
-        for entity in ["form", "case"]:
-            missing_ids = MissingIds(entity, statedb, None)
-            for doc_type in missing_ids.doc_types:
-                if doc_type not in counts or not counts[doc_type].missing:
-                    continue
-                log.info("Re-checking %s (%s)", doc_type, counts[doc_type].missing)
-                were_missing_ids = statedb.iter_missing_doc_ids(doc_type)
-                for doc_ids in chunked(were_missing_ids, 1000, set):
-                    missed = set(missing_ids.drop_sql_ids(doc_ids))
-                    dd_count(f"commcare.couchsqlmigration.{entity}.has_diff",
-                             value=len(missed))
-                    for doc_id in doc_ids - missed:
-                        statedb.doc_not_missing(doc_type, doc_id)
+        for missing_ids, doc_type in iter_missing_scanners(statedb):
+            if doc_type not in counts or not counts[doc_type].missing:
+                continue
+            log.info("Re-checking %s (%s)", doc_type, counts[doc_type].missing)
+            were_missing_ids = statedb.iter_missing_doc_ids(doc_type)
+            for doc_ids in chunked(were_missing_ids, 1000, set):
+                missed = set(missing_ids.drop_sql_ids(doc_ids))
+                dd_count(f"commcare.couchsqlmigration.{missing_ids.entity}.has_diff",
+                         value=len(missed))
+                for doc_id in doc_ids - missed:
+                    statedb.doc_not_missing(doc_type, doc_id)
+
+
+def discard_missing_docs_state(domain, state_dir):
+    statedb = open_state_db(domain, state_dir)
+    for missing_ids, doc_type in iter_missing_scanners(statedb):
+        resume_key, x = missing_ids.keys(doc_type)
+        missing_ids.discard_iteration_state(resume_key)
+
+
+def iter_missing_scanners(statedb):
+    for entity in MissingIds.DOC_TYPES:
+        missing_ids = MissingIds(entity, statedb, None)
+        for doc_type in missing_ids.doc_types:
+            yield missing_ids, doc_type
 
 
 @attr.s
@@ -136,11 +148,8 @@ class MissingIds:
         """
         if self.stopper.clean_break:
             return
-        assert doc_type in self.doc_types, \
-            f"'{doc_type}' is not a {self.entity} doc type"
+        resume_key, count_key = self.keys(doc_type)
         dd_type = f"find_{self.tag}_{self.entity}s"
-        count_key = f"{doc_type}.id.{self.tag}"
-        resume_key = f"{self.domain}.{count_key}.{self.statedb.unique_id}"
         if not self.resume:
             self.discard_iteration_state(resume_key)
             self.counter.pop(count_key)
@@ -155,6 +164,13 @@ class MissingIds:
                 yield from drop_if_not_missing(batch)
                 add_docs(len(batch))
         self._count_keys.add((doc_type, count_key))
+
+    def keys(self, doc_type):
+        assert doc_type in self.doc_types, \
+            f"'{doc_type}' is not a {self.entity} doc type"
+        count_key = f"{doc_type}.id.{self.tag}"
+        resume_key = f"{self.domain}.{count_key}.{self.statedb.unique_id}"
+        return resume_key, count_key
 
     def drop_sql_ids(self, couch_ids):
         """Filter the given couch ids, removing ids that are in SQL"""

--- a/corehq/apps/couch_sql_migration/staterebuilder.py
+++ b/corehq/apps/couch_sql_migration/staterebuilder.py
@@ -1,8 +1,6 @@
 import logging
 from functools import partial
 
-from django.db import connections
-
 from couchforms.models import XFormInstance
 from dimagi.utils.couch.database import iter_docs
 
@@ -67,7 +65,7 @@ def get_endkey_docid(domain, doc_type, migration_id):
     resume_key = "%s.%s.%s" % (domain, doc_type, migration_id)
     state = ResumableFunctionIterator(resume_key, None, None).state
     assert getattr(state, '_rev', None), "rebuild not necessary (no resume state)"
-    assert not state.complete, "iteration is complete"
+    assert not getattr(state, "complete", False), "iteration is complete"
     state_json = state.to_json()
     assert not state_json['args']
     kwargs = state_json['kwargs']

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -203,6 +203,22 @@ class BaseMigrationTestCase(TestCase, TestFileMixin):
                 self.fail("migration failed")
             assert not self.is_live_migration(), "live migration not finished"
 
+    def do_unfinish_migration(self):
+        if should_use_sql_backend(self.domain_name):
+            clear_local_domain_sql_backend_override(self.domain_name)
+        call_command('migrate_domain_from_couch_to_sql', self.domain_name, "unfinish")
+
+    def has_missing_docs_state(self):
+        from ..missingdocs import iter_missing_scanners
+        from corehq.util.pagination import ResumableFunctionIterator
+        statedb = open_state_db(self.domain_name, self.state_dir)
+        for missing_ids, doc_type in iter_missing_scanners(statedb):
+            resume_key, x = missing_ids.keys(doc_type)
+            itr = ResumableFunctionIterator(resume_key, None, None)
+            if itr.couch_db.doc_exist(itr.iteration_id):
+                return True
+        return False
+
     def is_live_migration(self):
         from corehq.apps.couch_sql_migration.progress import (
             MigrationStatus,
@@ -1314,6 +1330,24 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.do_migration(finish=True)
         self.assertEqual(self._get_form_ids(), {"one", "two"})
         self.assertEqual(self._get_form_ids("XFormArchived"), {"arch"})
+
+    def test_unfinish_migration(self):
+        self.submit_form(make_test_form("one"), timedelta(minutes=-97))
+        self.submit_form(make_test_form("two"))
+        with self.patch_migration_chunk_size(1):
+            self.do_migration(live=True, diffs=IGNORE)
+        self.assertEqual(self._get_form_ids(), {"one"})
+        msg = "cannot unfinish migration in dry_run state"
+        with self.assertRaises(CommandError, msg=msg):
+            self.do_unfinish_migration()
+        self.do_migration(finish=True, missing_docs="rebuild")
+        self.assertEqual(self._get_form_ids(), {"one", "two"})
+        self.assertTrue(self.has_missing_docs_state())
+        self.do_unfinish_migration()
+        self.assertFalse(self.has_missing_docs_state())
+        self.submit_form(make_test_form("three"))
+        self.do_migration(finish=True)
+        self.assertEqual(self._get_form_ids(), {"one", "two", "three"})
 
     def test_rebuild_state(self):
         def interrupt():

--- a/corehq/util/tests/test_pagination.py
+++ b/corehq/util/tests/test_pagination.py
@@ -54,6 +54,26 @@ class TestResumableFunctionIterator(SimpleTestCase):
         self.itr = self.get_iterator()
         self.assertEqual([item for item in self.itr], self.all_items[3:])
 
+    def test_resume_iteration_after_exhaustion(self):
+        itr = iter(self.itr)
+        self.assertEqual(list(itr), self.all_items)
+        # resume iteration
+        self.batches.append([8, 9])
+        self.itr = self.get_iterator()
+        self.assertEqual(list(self.itr), [8, 9])
+
+    def test_resume_iteration_after_legacy_completion(self):
+        itr = iter(self.itr)
+        self.assertEqual(list(itr), self.all_items)
+        state = self.itr.state
+        state.complete = True
+        state.args = state.kwargs = None
+        self.itr._save_state()
+        # attempt to resume yields no new items
+        self.batches.append([8, 9])
+        self.itr = self.get_iterator()
+        self.assertEqual(list(self.itr), [])
+
     def test_resume_iteration_after_complete_iteration(self):
         self.assertEqual(list(self.itr), self.all_items)
         # resume iteration


### PR DESCRIPTION
This allows the `migrate_multiple_domains_from_couch_to_sql` management command to patch cases at a better time in the migration, after form submissions have been suspended and all forms have been migrated, and then to revert to a "live" migrating state if there are differences that need to be reviewed before the migration can be committed.

Previously it was possible for a migration to be left in an incompleted state with form submissions suspended, which was bad because it required immediate action on active domains.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

A test has been added for the unfinish action as well as for the more primitive operation of resuming an iteration after "completion."

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
