### PR TITLE
tweak DET schema flag UI

### DIFF
--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -167,21 +167,22 @@
                        id="det-config-checkbox"
                        data-bind="checked: show_det_config_download,
                                   attr: { disabled: !{{ has_api_access|JSON }}}" />
-                <strong>{% trans "Generate a Data Export Tool config file?" %}</strong><br/>
-                {% blocktrans %}
-                  Checking this will add a button to download a configuration file
-                  for the <a href="https://confluence.dimagi.com/display/commcarepublic/CommCare+Data+Export+Tool" target="_blank">
-                  CommCare Data Export Tool</a> for the export.
-                {% endblocktrans %}
+                {% trans "Generate a Data Export Tool config file?" %}
               </label>
-              {% if not has_api_access %}
-                <span class="hq-help-template"
-                      data-content='{% blocktrans %}
-                                      The Data Export Tool requires API access, which is only available on the Pro Plan or higher.
-                                      Click <a href="{{ software_plan_url }}">here</a> to manage the software plan for your project.
-                                    {% endblocktrans %}'
-                  ></span>
-              {% endif %}
+              {% trans "Download a Data Export Tool configuration file for this export" as det_help %}
+              <span class="hq-help-template"
+                    data-content='{% blocktrans %}
+                                    <p>Checking this will add a button to download a configuration file
+                                       for the <a href="https://confluence.dimagi.com/display/commcarepublic/CommCare+Data+Export+Tool" target="_blank">
+                                       CommCare Data Export Tool</a> for the export.</p>
+                                   {% endblocktrans %}
+                                   {% if not has_api_access %}
+                                   {% blocktrans %}
+                                    <p>The Data Export Tool requires API access, which is only available on the Pro Plan or higher.
+                                       Click <a href="{{ software_plan_url }}">here</a> to manage the software plan for your project.</p>
+                                  {% endblocktrans %}
+                                  {% endif %}'
+                ></span>
             </div>
             {% if export_instance.type == 'form' %}
               <div class="checkbox"

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -165,7 +165,8 @@
               <label>
                 <input type="checkbox"
                        id="det-config-checkbox"
-                       data-bind="checked: show_det_config_download" />
+                       data-bind="checked: show_det_config_download,
+                                  attr: { disabled: !{{ has_api_access|JSON }}}" />
                 <strong>{% trans "Generate a Data Export Tool config file?" %}</strong><br/>
                 {% blocktrans %}
                   Checking this will add a button to download a configuration file
@@ -173,9 +174,15 @@
                   CommCare Data Export Tool</a> for the export.
                 {% endblocktrans %}
               </label>
+              {% if not has_api_access %}
+                <span class="hq-help-template"
+                      data-content='{% blocktrans %}
+                                      The Data Export Tool requires API access, which is only available on the Pro Plan or higher.
+                                      Click <a href="{{ software_plan_url }}">here</a> to manage the software plan for your project.
+                                    {% endblocktrans %}'
+                  ></span>
+              {% endif %}
             </div>
-
-
             {% if export_instance.type == 'form' %}
               <div class="checkbox"
                    {% if not request|toggle_enabled:'SUPPORT' %}data-bind="visible: initiallyIncludeErrors"{% endif %}>

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -52,7 +52,7 @@ from corehq.apps.export.views.utils import (
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.settings.views import BaseProjectDataView
 from corehq.apps.users.models import WebUser
-from corehq.privileges import DAILY_SAVED_EXPORT, EXCEL_DASHBOARD
+from corehq.privileges import DAILY_SAVED_EXPORT, EXCEL_DASHBOARD, API_ACCESS
 
 
 class BaseExportView(BaseProjectDataView):
@@ -126,6 +126,7 @@ class BaseExportView(BaseProjectDataView):
             'allow_deid': allow_deid,
             'has_excel_dashboard_access': domain_has_privilege(self.domain, EXCEL_DASHBOARD),
             'has_daily_saved_export_access': domain_has_privilege(self.domain, DAILY_SAVED_EXPORT),
+            'has_api_access': domain_has_privilege(self.domain, API_ACCESS),
             'can_edit': self.export_instance.can_edit(self.request.couch_user),
             'has_other_owner': owner_id and owner_id != self.request.couch_user.user_id,
             'owner_name': WebUser.get_by_user_id(owner_id).username if owner_id else None,


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Minor UI changes to the [DET config file UI](https://github.com/dimagi/commcare-hq/pull/29746/)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

1. Disables the checkbox for projects that don't have permission to use APIs
2. Puts all the help text behind a bubble, and changes the help text depending on whether or not you have access 

Option with inline help removed:

![image](https://user-images.githubusercontent.com/66555/119354953-f4a45180-bca4-11eb-89c5-26bc9e335f6c.png)

Popup:

![image](https://user-images.githubusercontent.com/66555/119355084-20bfd280-bca5-11eb-9036-cc8069b5d4a5.png)

The second paragraph only appears if you don't have access. (sorry about the big screencap, my screenshot snipper is finicky with the popups)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

Just a minor UI change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

None.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Not recommending QA.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested locally. Low impact.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
