### PR TITLE
Add more logging info when user is_superuser and is_staff is updated

### DIFF
--- a/corehq/apps/domain/management/commands/make_superuser.py
+++ b/corehq/apps/domain/management/commands/make_superuser.py
@@ -28,9 +28,9 @@ class Command(BaseCommand):
 
     @signalcommand
     def handle(self, username, **options):
-        if settings.IS_SAAS_ENVIRONMENT:
-            raise CommandError("""You cannot run this command in SaaS Enviornments.
-            Use https://www.commcarehq.org/hq/admin/superuser_management/ for granting superuser permissions""")
+            from dimagi.utils.web import get_site_domain
+            raise CommandError(f"""You cannot run this command in SaaS Enviornments.
+            Use https://{get_site_domain()}/hq/admin/superuser_management/ for granting superuser permissions""")
         from corehq.apps.users.models import WebUser
         try:
             validate_email(username)

--- a/corehq/apps/domain/management/commands/make_superuser.py
+++ b/corehq/apps/domain/management/commands/make_superuser.py
@@ -1,6 +1,7 @@
 import getpass
 import logging
 
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
 from email_validator import EmailSyntaxError, validate_email
@@ -27,6 +28,9 @@ class Command(BaseCommand):
 
     @signalcommand
     def handle(self, username, **options):
+        if settings.IS_SAAS_ENVIRONMENT:
+            raise CommandError("""You cannot run this command in SaaS Enviornments.
+            Use https://www.commcarehq.org/hq/admin/superuser_management/ for granting superuser permissions""")
         from corehq.apps.users.models import WebUser
         try:
             validate_email(username)

--- a/corehq/apps/domain/management/commands/make_superuser.py
+++ b/corehq/apps/domain/management/commands/make_superuser.py
@@ -28,6 +28,7 @@ class Command(BaseCommand):
 
     @signalcommand
     def handle(self, username, **options):
+        if settings.IS_SAAS_ENVIRONMENT or settings.IS_INDIA_ENVIRONMENT:
             from dimagi.utils.web import get_site_domain
             raise CommandError(f"""You cannot run this command in SaaS Enviornments.
             Use https://{get_site_domain()}/hq/admin/superuser_management/ for granting superuser permissions""")

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -97,12 +97,22 @@ class SuperuserManagement(UserAdministration):
             for user in users:
                 # save user object only if needed and just once
                 if user.is_superuser is not is_superuser:
+                    update_log = {
+                        'field': 'is_superuser',
+                        'previous': user.is_superuser,
+                        'current': is_superuser,
+                    }
                     user.is_superuser = is_superuser
-                    changed_fields.append('is_superuser')
+                    changed_fields.append(update_log)
 
                 if can_toggle_is_staff and user.is_staff is not is_staff:
+                    update_log = {
+                        'field': 'is_staff',
+                        'previous': user.is_staff,
+                        'current': is_staff,
+                    }
                     user.is_staff = is_staff
-                    changed_fields.append('is_staff')
+                    changed_fields.append(update_log)
 
                 if changed_fields:
                     user.save()

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -92,31 +92,21 @@ class SuperuserManagement(UserAdministration):
             users = form.cleaned_data['users']
             is_superuser = 'is_superuser' in form.cleaned_data['privileges']
             is_staff = 'is_staff' in form.cleaned_data['privileges']
-
-            changed_fields = []
+            changed_field_logs = []
             for user in users:
                 # save user object only if needed and just once
                 if user.is_superuser is not is_superuser:
-                    update_log = {
-                        'field': 'is_superuser',
-                        'previous': user.is_superuser,
-                        'current': is_superuser,
-                    }
                     user.is_superuser = is_superuser
-                    changed_fields.append(update_log)
+                    changed_field_logs.append(_("{} to {}".format("is_superuser", is_superuser)))
 
                 if can_toggle_is_staff and user.is_staff is not is_staff:
-                    update_log = {
-                        'field': 'is_staff',
-                        'previous': user.is_staff,
-                        'current': is_staff,
-                    }
                     user.is_staff = is_staff
-                    changed_fields.append(update_log)
+                    changed_field_logs.append(_("{} to {}".format("is_staff", is_staff)))
 
-                if changed_fields:
+                if changed_field_logs:
                     user.save()
-                    log_model_change(self.request.user, user, fields_changed=changed_fields)
+                    log_message = _("Changed: ") + _(" and ").join(changed_field_logs)
+                    log_model_change(self.request.user, user, message=log_message)
             messages.success(request, _("Successfully updated superuser permissions"))
 
         return self.get(request, *args, **kwargs)

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -97,15 +97,15 @@ class SuperuserManagement(UserAdministration):
                 # save user object only if needed and just once
                 if user.is_superuser is not is_superuser:
                     user.is_superuser = is_superuser
-                    changed_field_logs.append(_("{} to {}".format("is_superuser", is_superuser)))
+                    changed_field_logs.append(_(f"is_superuser to {is_superuser}"))
 
                 if can_toggle_is_staff and user.is_staff is not is_staff:
                     user.is_staff = is_staff
-                    changed_field_logs.append(_("{} to {}".format("is_staff", is_staff)))
+                    changed_field_logs.append(_(f"is_staff to {is_staff}"))
 
                 if changed_field_logs:
                     user.save()
-                    log_message = _("Changed: ") + _(" and ").join(changed_field_logs)
+                    log_message = _("Changed: ") + _(", ").join(changed_field_logs)
                     log_model_change(self.request.user, user, message=log_message)
             messages.success(request, _("Successfully updated superuser permissions"))
 

--- a/settings.py
+++ b/settings.py
@@ -1157,6 +1157,8 @@ _location = lambda x: os.path.join(FILEPATH, x)
 
 IS_SAAS_ENVIRONMENT = SERVER_ENVIRONMENT in ('production', 'staging')
 
+IS_INDIA_ENVIRONMENT = SERVER_ENVIRONMENT == 'india'
+
 if 'KAFKA_URL' in globals():
     import warnings
     warnings.warn(inspect.cleandoc("""KAFKA_URL is deprecated


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-11986
We needed certain things addressed in the logs
- Who: The user that was changed
- By whom: The user that initiated the changed
- When: the timestamp of the change
- Had what changed: some way to encode "is_staff was added" or "is_superuser was removed"

Out of which first three were already being logged and we were only logging the fields that were changed. The PR addresses the last point and adds previous and current values of the field to the logs.

<img width="1769" alt="Screenshot 2021-05-25 at 11 52 08 AM" src="https://user-images.githubusercontent.com/7694243/119451078-756d5700-bd52-11eb-9cab-581ac90f6efb.png">

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
