### PR TITLE
added parsing for the last_accessed date arg

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2680,7 +2680,6 @@ class DomainRemovalRecord(DeleteRecord):
         user = WebUser.get_by_user_id(self.user_id)
         user.domain_memberships.append(self.domain_membership)
         user.domains.append(self.domain)
-        #user.add_domain_membership(**self.domain_membership._doc)
         user.save()
 
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -508,6 +508,8 @@ class _AuthorizableMixin(IsMemberOfMixin):
         return domain_membership
 
     def add_domain_membership(self, domain, timezone=None, **kwargs):
+        if kwargs.get('last_accessed'):
+            kwargs['last_accessed'] = datetime.strptime(kwargs['last_accessed'], '%Y-%m-%d').date()
         for d in self.domain_memberships:
             if d.domain == domain:
                 if domain not in self.domains:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -508,8 +508,6 @@ class _AuthorizableMixin(IsMemberOfMixin):
         return domain_membership
 
     def add_domain_membership(self, domain, timezone=None, **kwargs):
-        if kwargs.get('last_accessed'):
-            kwargs['last_accessed'] = datetime.strptime(kwargs['last_accessed'], '%Y-%m-%d').date()
         for d in self.domain_memberships:
             if d.domain == domain:
                 if domain not in self.domains:
@@ -2680,7 +2678,9 @@ class DomainRemovalRecord(DeleteRecord):
 
     def undo(self):
         user = WebUser.get_by_user_id(self.user_id)
-        user.add_domain_membership(**self.domain_membership._doc)
+        user.domain_memberships.append(self.domain_membership)
+        user.domains.append(self.domain)
+        #user.add_domain_membership(**self.domain_membership._doc)
         user.save()
 
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
a user was getting a 500 error on trying to undo removals for web users, and once you refresh the page, the web user is removed. Undo option was broken. It turns out the bug was with the last_accessed variable in the kwargs of add_domain_membership. I fixed this by just adding a parse for the variable.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Users can now remove web users. Whoo!

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below
It fixes a bug

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

I tested the fix locally and will test it on staging.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested it locally. It worked! Will test on staging

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
