### PR TITLE
Option to hide geocoder receive fields

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2083,6 +2083,7 @@ class CaseSearchProperty(DocumentSchema):
     input_ = StringProperty()
     default_value = StringProperty()
     hint = DictProperty()
+    hidden = BooleanProperty(default=False)
 
     # applicable when appearance is a receiver
     receiver_expression = StringProperty()

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -85,6 +85,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             hint: '',
             appearance: '',
             defaultValue: '',
+            hidden: false,
             receiverExpression: '',
             itemsetOptions: {},
         });
@@ -95,6 +96,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         self.hint = ko.observable(options.hint);
         self.appearance = ko.observable(options.appearance);
         self.defaultValue = ko.observable(options.defaultValue);
+        self.hidden = ko.observable(options.hidden);
         self.appearanceFinal = ko.computed(function () {
             var appearance = self.appearance();
             if (appearance === 'report_fixture' || appearance === 'lookup_table_fixture') {
@@ -144,7 +146,8 @@ hqDefine("app_manager/js/details/case_claim", function () {
         });
         self.itemset = itemsetModel(options.itemsetOptions, saveButton);
 
-        subscribeToSave(self, ['name', 'label', 'hint', 'appearance', 'defaultValue', 'receiverExpression'], saveButton);
+        subscribeToSave(self,
+            ['name', 'label', 'hint', 'appearance', 'defaultValue', 'hidden', 'receiverExpression'], saveButton);
 
         return self;
     };
@@ -255,6 +258,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                     hint: hint,
                     appearance: appearance,
                     defaultValue: searchProperties[i].default_value,
+                    hidden: searchProperties[i].hidden,
                     receiverExpression: searchProperties[i].receiver_expression,
                     itemsetOptions: {
                         instance_id: searchProperties[i].itemset.instance_id,
@@ -290,6 +294,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                         hint: p.hint(),
                         appearance: p.appearanceFinal(),
                         default_value: p.defaultValue(),
+                        hidden: p.hidden(),
                         receiver_expression: p.receiverExpression(),
                         fixture: ko.toJSON(p.itemset),
                     };

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -180,7 +180,8 @@ class RemoteRequestFactory(object):
             }
             if not prop.appearance or prop.itemset.nodeset:
                 kwargs['receive'] = prop.receiver_expression
-            kwargs['hidden'] = prop.hidden or False
+            if prop.hidden:
+                kwargs['hidden'] = prop.hidden
             if prop.appearance and self.app.enable_search_prompt_appearance:
                 if prop.appearance == 'address':
                     kwargs['input_'] = prop.appearance

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -180,6 +180,7 @@ class RemoteRequestFactory(object):
             }
             if not prop.appearance or prop.itemset.nodeset:
                 kwargs['receive'] = prop.receiver_expression
+            kwargs['hidden'] = prop.hidden or False
             if prop.appearance and self.app.enable_search_prompt_appearance:
                 if prop.appearance == 'address':
                     kwargs['input_'] = prop.appearance

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -524,6 +524,7 @@ class QueryPrompt(DisplayNode):
     key = StringField('@key')
     appearance = StringField('@appearance', required=False)
     receive = StringField('@receive', required=False)
+    hidden = SimpleBooleanField('@hidden', 'true', 'false', required=False)
     input_ = StringField('@input', required=False)
     default_value = StringField('@default', required=False)
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -127,6 +127,14 @@
                           <input class="form-control" type="text" data-bind="value: receiverExpression"/>
                         </div>
                       </div>
+                      <div class="form-group">
+                        <label class="control-label col-xs-12 col-sm-3">
+                          {% trans "Hide in Search Screen" %}
+                        </label>
+                        <div class="col-xs-12 col-sm-9">
+                          <input type="checkbox" data-bind="checked: hidden" />
+                        </div>
+                      </div>
                   </fieldset>
                 {% endif %}
                 <fieldset data-bind="visible: appearanceFinal() == 'fixture'">

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -439,6 +439,25 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         """
         self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
 
+    def test_prompt_hidden(self, *args):
+        """Setting the appearance to "address"
+        """
+        # Shouldn't be included for versions before 2.50
+        self.module.search_config.properties[0].hidden = True
+        suite = self.app.create_suite()
+        expected = """
+        <partial>
+          <prompt key="name" hidden="true">
+            <display>
+              <text>
+                <locale id="search_property.m0.name"/>
+              </text>
+            </display>
+          </prompt>
+        </partial>
+        """
+        self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
+
     def test_prompt_address_receiver_itemset(self, *args):
         """Setting the appearance to "address"
         """

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -953,6 +953,8 @@ def _update_search_properties(module, search_properties, lang='en'):
             ret['default_value'] = prop['default_value']
         if prop['hint']:
             ret['hint'] = hint
+        if prop['hidden']:
+            ret['hidden'] = prop['hidden']
         if prop.get('appearance', '') == 'fixture':
             ret['input_'] = 'select1'
             fixture_props = json.loads(prop['fixture'])

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -199,6 +199,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     $input.val(newValue).trigger('change');
                 }
             });
+            if (this.options.model.get('hidden') === 'true') {
+                this.$el.hide();
+            }
         },
     });
 


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/QA-3062

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Yes.

### QA Plan

https://dimagi-dev.atlassian.net/browse/QA-3062

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

If the users configured this option and then we have to roll it back, users might get the 'save' button activated in Case Search config screen.

- [x] This PR can be reverted after deploy with no further considerations 
