### PR TITLE
DHIS2 UI: response message format

### DIFF
--- a/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
+++ b/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
@@ -11,7 +11,7 @@ hqDefine("dhis2/js/dataset_map", [
 ) {
     $(function () {
         var $sendNowResult = $('#send-now-result');
-        var $remoteLogsLink = $('#remote-logs')
+        var $remoteLogsLink = $('#remote-logs');
         $remoteLogsLink.hide();
 
         var handleSuccess = function (response) {
@@ -22,8 +22,8 @@ hqDefine("dhis2/js/dataset_map", [
                 $sendNowResult.addClass("text-danger");
             }
             $sendNowResult.text(gettext('DHIS2 response: ') + response.text);
-            if (resp.responseJSON) {
-                $remoteLogsLink.attr('href', resp.responseJSON['log_url']);
+            if (response.responseJSON) {
+                $remoteLogsLink.attr('href', response.responseJSON['log_url']);
                 $remoteLogsLink.show();
             }
         };

--- a/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
+++ b/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
@@ -10,8 +10,7 @@ hqDefine("dhis2/js/dataset_map", [
     initialPageData
 ) {
     $(function () {
-        var $sendNowResult = $('#send-now-result');
-        var $remoteLogsLink = $('#remote-logs');
+        var $sendNowResult = $('#send-now-result'), $remoteLogsLink = $('#remote-logs');
         $remoteLogsLink.hide();
 
         var handleSuccess = function (response) {

--- a/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
+++ b/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
@@ -11,6 +11,8 @@ hqDefine("dhis2/js/dataset_map", [
 ) {
     $(function () {
         var $sendNowResult = $('#send-now-result');
+        var $remoteLogsLink = $('#remote-logs')
+        $remoteLogsLink.hide();
 
         var handleSuccess = function (response) {
             $sendNowResult.removeClass("hide text-danger text-success");
@@ -20,6 +22,10 @@ hqDefine("dhis2/js/dataset_map", [
                 $sendNowResult.addClass("text-danger");
             }
             $sendNowResult.text(gettext('DHIS2 response: ') + response.text);
+            if (resp.responseJSON) {
+                $remoteLogsLink.attr('href', resp.responseJSON['log_url']);
+                $remoteLogsLink.show();
+            }
         };
 
         var handleFailure = function (resp) {
@@ -30,6 +36,11 @@ hqDefine("dhis2/js/dataset_map", [
                 gettext('CommCare HQ was unable to send the DataSet: ')
                 + (resp.responseJSON ? resp.responseJSON['error'] : resp.statusText)
             );
+
+            if (resp.responseJSON) {
+                $remoteLogsLink.attr('href', resp.responseJSON['log_url']);
+                $remoteLogsLink.show();
+            }
         };
 
         sendNow = function (dataSetMapId) {
@@ -39,6 +50,5 @@ hqDefine("dhis2/js/dataset_map", [
                 error: handleFailure,
             });
         };
-
     });
 });

--- a/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
+++ b/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
@@ -10,7 +10,8 @@ hqDefine("dhis2/js/dataset_map", [
     initialPageData
 ) {
     $(function () {
-        var $sendNowResult = $('#send-now-result'), $remoteLogsLink = $('#remote-logs');
+        var $sendNowResult = $('#send-now-result'),
+            $remoteLogsLink = $('#remote-logs');
         $remoteLogsLink.hide();
 
         var handleSuccess = function (response) {

--- a/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
+++ b/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
@@ -22,8 +22,8 @@ hqDefine("dhis2/js/dataset_map", [
                 $sendNowResult.addClass("text-danger");
             }
             $sendNowResult.text(gettext('DHIS2 response: ') + response.text);
-            if (response.responseJSON) {
-                $remoteLogsLink.attr('href', response.responseJSON['log_url']);
+            if (response.log_url) {
+                $remoteLogsLink.attr('href', response.log_url);
                 $remoteLogsLink.show();
             }
         };
@@ -36,7 +36,6 @@ hqDefine("dhis2/js/dataset_map", [
                 gettext('CommCare HQ was unable to send the DataSet: ')
                 + (resp.responseJSON ? resp.responseJSON['error'] : resp.statusText)
             );
-
             if (resp.responseJSON) {
                 $remoteLogsLink.attr('href', resp.responseJSON['log_url']);
                 $remoteLogsLink.show();

--- a/corehq/motech/dhis2/tasks.py
+++ b/corehq/motech/dhis2/tasks.py
@@ -98,7 +98,7 @@ def send_dataset(
                 'error': _('There was an error retrieving some UCR data. '
                            'Try contacting support to help resolve this issue.'),
                 'text': None,
-                'log_url': response_log_url
+                'log_url': response_log_url,
             }
 
         except Exception as err:
@@ -111,12 +111,12 @@ def send_dataset(
                 'error': str(err),
                 'status_code': response.status_code if response else None,
                 'text': text,
-                'log_url': response_log_url
+                'log_url': response_log_url,
             }
         else:
             return {
                 'success': True,
                 'status_code': response.status_code,
                 'text': pformat_json(response.text),
-                'log_url': response_log_url
+                'log_url': response_log_url,
             }

--- a/corehq/motech/dhis2/templates/dhis2/dataset_map_list.html
+++ b/corehq/motech/dhis2/templates/dhis2/dataset_map_list.html
@@ -29,7 +29,7 @@
   <div class="col-xs-12 col-sm-8 col-md-8 col-lg-6">
     <div id="send-now-result"
          class="text-success hide"></div>
-    <a id="remote-logs" data-bind="attr: {href: hrefUrl}">View log</a>
+    <a id="remote-logs" href="">View log</a>
   </div>
 {% endblock %}
 

--- a/corehq/motech/dhis2/templates/dhis2/dataset_map_list.html
+++ b/corehq/motech/dhis2/templates/dhis2/dataset_map_list.html
@@ -29,7 +29,7 @@
   <div class="col-xs-12 col-sm-8 col-md-8 col-lg-6">
     <div id="send-now-result"
          class="text-success hide"></div>
-    <a id="remote-logs" href="">View log</a>
+    <a id="remote-logs" href="#">View log</a>
   </div>
 {% endblock %}
 

--- a/corehq/motech/dhis2/templates/dhis2/dataset_map_list.html
+++ b/corehq/motech/dhis2/templates/dhis2/dataset_map_list.html
@@ -96,4 +96,5 @@
     <td data-bind="text: ucr"></td>
     <td>{% trans 'Deleted' %}</td>
   </script>
+
 {% endblock %}

--- a/corehq/motech/dhis2/templates/dhis2/dataset_map_list.html
+++ b/corehq/motech/dhis2/templates/dhis2/dataset_map_list.html
@@ -29,7 +29,7 @@
   <div class="col-xs-12 col-sm-8 col-md-8 col-lg-6">
     <div id="send-now-result"
          class="text-success hide"></div>
-    <a id="remote-logs" href="#">View log</a>
+    <a id="remote-logs" href="#">{% trans "View log" %}</a>
   </div>
 {% endblock %}
 

--- a/corehq/motech/dhis2/templates/dhis2/dataset_map_list.html
+++ b/corehq/motech/dhis2/templates/dhis2/dataset_map_list.html
@@ -29,6 +29,7 @@
   <div class="col-xs-12 col-sm-8 col-md-8 col-lg-6">
     <div id="send-now-result"
          class="text-success hide"></div>
+    <a id="remote-logs" data-bind="attr: {href: hrefUrl}">View log</a>
   </div>
 {% endblock %}
 

--- a/corehq/motech/dhis2/views.py
+++ b/corehq/motech/dhis2/views.py
@@ -364,12 +364,7 @@ class DataSetMapUpdateView(BaseUpdateView, BaseProjectSettingsView,
 def send_dataset_now(request, domain, pk):
     dataset_map = SQLDataSetMap.objects.get(domain=domain, pk=pk)
     send_date = datetime.utcnow().date()
-
-    result = send_dataset(
-        dataset_map,
-        send_date,
-        log_resource_url=reverse('motech_log_list_view', args=[domain])
-    )
+    result = send_dataset(dataset_map, send_date)
     return JsonResponse(result, status=result['status_code'] or 500)
 
 

--- a/corehq/motech/dhis2/views.py
+++ b/corehq/motech/dhis2/views.py
@@ -364,7 +364,12 @@ class DataSetMapUpdateView(BaseUpdateView, BaseProjectSettingsView,
 def send_dataset_now(request, domain, pk):
     dataset_map = SQLDataSetMap.objects.get(domain=domain, pk=pk)
     send_date = datetime.utcnow().date()
-    result = send_dataset(dataset_map, send_date)
+
+    result = send_dataset(
+        dataset_map,
+        send_date,
+        log_resource_url=reverse('motech_log_list_view', args=[domain])
+    )
     return JsonResponse(result, status=result['status_code'] or 500)
 
 


### PR DESCRIPTION
## Summary
See [ticket](https://dimagi-dev.atlassian.net/browse/SC-1453)

- Fix request response message formatting.
- Add "View Log" link so user can view the full log.

## Feature Flag
DHIS2

## Product Description
- Response formatted better
- Added a link to request logs when request response is shown on screen

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] This PR can be reverted after deploy with no further considerations 
