### PR TITLE
 remove uses of deprecated json_response from users app

### DIFF
--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -10,7 +10,6 @@ from crispy_forms.utils import render_crispy_form
 
 from corehq.apps.sso.models import IdentityProvider
 from corehq.apps.sso.utils.user_helpers import get_email_domain_from_username
-from dimagi.utils.web import json_response
 from django.contrib import messages
 from django.http import (
     Http404,
@@ -26,6 +25,8 @@ from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
+
+from corehq.util.json import CommCareJSONEncoder
 from soil import DownloadBase
 from soil.exceptions import TaskFailedError
 from soil.util import expose_cached_download, get_download_context
@@ -816,7 +817,7 @@ def undo_remove_web_user(request, domain, record_id):
 @require_POST
 def post_user_role(request, domain):
     if not domain_has_privilege(domain, privileges.ROLE_BASED_ACCESS):
-        return json_response({})
+        return JsonResponse({})
     role_data = json.loads(request.body.decode('utf-8'))
     role_data = dict(
         (p, role_data[p])
@@ -870,24 +871,25 @@ def post_user_role(request, domain):
         role.permissions.edit_users_in_locations = False
 
     role.save()
-    role.__setattr__('hasUsersAssigned', role.has_users_assigned)
-    return json_response(role)
+    response_data = role.to_json()
+    response_data['hasUsersAssigned'] = role.has_users_assigned
+    return JsonResponse(response_data)
 
 
 @domain_admin_required
 @require_POST
 def delete_user_role(request, domain):
     if not domain_has_privilege(domain, privileges.ROLE_BASED_ACCESS):
-        return json_response({})
+        return JsonResponse({})
     role_data = json.loads(request.body.decode('utf-8'))
     try:
         role = UserRole.get(role_data["_id"])
     except ResourceNotFound:
-        return json_response({})
+        return JsonResponse({})
     copy_id = role._id
     role.delete()
     # return removed id in order to remove it from UI
-    return json_response({"_id": copy_id})
+    return JsonResponse({"_id": copy_id})
 
 
 @always_allow_project_access
@@ -895,7 +897,7 @@ def delete_user_role(request, domain):
 @require_can_edit_web_users
 def delete_request(request, domain):
     DomainRequest.objects.get(id=request.POST['id']).delete()
-    return json_response({'status': 'ok'})
+    return JsonResponse({'status': 'ok'})
 
 
 @always_allow_project_access

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -26,7 +26,6 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
-from corehq.util.json import CommCareJSONEncoder
 from soil import DownloadBase
 from soil.exceptions import TaskFailedError
 from soil.util import expose_cached_download, get_download_context

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -34,7 +34,6 @@ from memoized import memoized
 from casexml.apps.phone.models import SyncLogSQL
 from couchexport.models import Format
 from couchexport.writers import Excel2007ExportWriter
-from dimagi.utils.web import json_response
 from soil import DownloadBase
 from soil.exceptions import TaskFailedError
 from soil.util import expose_cached_download, get_download_context
@@ -834,11 +833,11 @@ def _modify_user_status(request, domain, user_id, is_active):
     user = CommCareUser.get_by_user_id(user_id, domain)
     if (not _can_edit_workers_location(request.couch_user, user)
             or (is_active and not can_add_extra_mobile_workers(request))):
-        return json_response({
+        return JsonResponse({
             'error': _("No Permission."),
         })
     if not is_active and user.user_location_id:
-        return json_response({
+        return JsonResponse({
             'error': _("This is a location user, archive or delete the "
                        "corresponding location to deactivate it."),
         })
@@ -847,7 +846,7 @@ def _modify_user_status(request, domain, user_id, is_active):
     change_message = "Activated User" if is_active else "Deactivated User"
     log_model_change(request.user, user.get_django_user(), message=change_message,
                      action=ModelAction.UPDATE)
-    return json_response({
+    return JsonResponse({
         'success': True,
     })
 
@@ -918,7 +917,7 @@ def paginate_mobile_workers(request, domain):
             'status': _status_string(user),
         })
 
-    return json_response({
+    return JsonResponse({
         'users': users,
         'total': users_data.total,
     })
@@ -1313,7 +1312,7 @@ def count_users(request, domain):
     user_count = 0
     for domain in user_filters['domains']:
         user_count += get_commcare_users_by_filters(domain, user_filters, count_only=True)
-    return json_response({
+    return JsonResponse({
         'count': user_count
     })
 

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1,9 +1,9 @@
 import io
 import json
 import re
-from datetime import datetime
 
-from django.conf import settings
+from braces.views import JsonRequestResponseMixin
+from couchdbkit import ResourceNotFound
 from django.contrib import messages
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.core.exceptions import ValidationError
@@ -23,21 +23,12 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop
 from django.views.decorators.http import require_GET, require_POST
 from django.views.generic import TemplateView, View
-
-from braces.views import JsonRequestResponseMixin
-from couchdbkit import ResourceNotFound
 from django_prbac.exceptions import PermissionDenied
 from django_prbac.utils import has_privilege
 from djng.views.mixins import JSONResponseMixin, allow_remote_invocation
 from memoized import memoized
 
 from casexml.apps.phone.models import SyncLogSQL
-from couchexport.models import Format
-from couchexport.writers import Excel2007ExportWriter
-from soil import DownloadBase
-from soil.exceptions import TaskFailedError
-from soil.util import expose_cached_download, get_download_context
-
 from corehq import privileges
 from corehq.apps.accounting.async_handlers import Select2BillingInfoHandler
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
@@ -71,9 +62,6 @@ from corehq.apps.locations.permissions import (
 from corehq.apps.ota.utils import demo_restore_date_created, turn_off_demo_mode
 from corehq.apps.registration.forms import MobileWorkerAccountConfirmationForm
 from corehq.apps.sms.verify import initiate_sms_verification_workflow
-from corehq.apps.user_importer.importer import UserUploadError, check_headers
-from corehq.apps.user_importer.models import UserUploadRecord
-from corehq.apps.user_importer.tasks import import_users_and_groups, parallel_user_import
 from corehq.apps.users.account_confirmation import (
     send_account_confirmation_if_necessary,
 )
@@ -121,8 +109,7 @@ from corehq.const import (
 )
 from corehq.toggles import (
     FILTERED_BULK_USER_DOWNLOAD,
-    TWO_STAGE_USER_PROVISIONING,
-    PARALLEL_USER_IMPORTS
+    TWO_STAGE_USER_PROVISIONING
 )
 from corehq.util import get_document_or_404
 from corehq.util.dates import iso_string_to_datetime
@@ -133,7 +120,11 @@ from corehq.util.workbook_json.excel import (
     WorksheetNotFound,
     get_workbook,
 )
-
+from couchexport.models import Format
+from couchexport.writers import Excel2007ExportWriter
+from soil import DownloadBase
+from soil.exceptions import TaskFailedError
+from soil.util import get_download_context
 from .custom_data_fields import UserFieldsView
 
 BULK_MOBILE_HELP_SITE = ("https://confluence.dimagi.com/display/commcarepublic"

--- a/corehq/apps/users/views/web.py
+++ b/corehq/apps/users/views/web.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.contrib.auth import authenticate, login
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import ValidationError
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -14,7 +14,6 @@ from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.http import require_POST
 
 from dimagi.utils.couch import CriticalSection
-from dimagi.utils.web import json_response
 
 from corehq.apps.accounting.decorators import always_allow_project_access
 from corehq.apps.analytics.tasks import (
@@ -193,12 +192,12 @@ def reinvite_web_user(request, domain):
     try:
         invitation = Invitation.objects.get(uuid=uuid)
     except Invitation.DoesNotExist:
-        return json_response({'response': _("Error while attempting resend"), 'status': 'error'})
+        return JsonResponse({'response': _("Error while attempting resend"), 'status': 'error'})
 
     invitation.invited_on = datetime.utcnow()
     invitation.save()
     invitation.send_activation_email()
-    return json_response({'response': _("Invitation resent"), 'status': 'ok'})
+    return JsonResponse({'response': _("Invitation resent"), 'status': 'ok'})
 
 
 @always_allow_project_access
@@ -208,7 +207,7 @@ def delete_invitation(request, domain):
     uuid = request.POST['uuid']
     invitation = Invitation.objects.get(uuid=uuid)
     invitation.delete()
-    return json_response({'status': 'ok'})
+    return JsonResponse({'status': 'ok'})
 
 
 @method_decorator(always_allow_project_access, name='dispatch')


### PR DESCRIPTION
## Summary
remove uses of deprecated json_response from users app

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
not covered

### QA Plan
Reviewed all changes and tested views locally, particularly where more than simple data is being passed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
