### PR TITLE
Web apps: Fixed in-form language change for dropdowns

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -535,11 +535,6 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
             }));
         });
 
-        self.options.subscribe(function () {
-            // Clear answer if options change
-            self.rawAnswer(undefined);
-        });
-
         self.additionalSelect2Options = function () {
             return {};
         };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entrycontrols_full_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entrycontrols_full_spec.js
@@ -84,25 +84,23 @@ describe('Entries', function () {
         assert.isTrue(spy.calledTwice);
     });
 
-    it('Should clear Dropdown on options change', function () {
+    it('Should retain Dropdown value on options change', function () {
+        // This behavior is necessary for changing the in-form language
         var entry,
             question;
         questionJSON.datatype = Const.SELECT;
         questionJSON.style = { raw: Const.MINIMAL };
-        questionJSON.choices = ['a', 'b'];
+        questionJSON.choices = ['one', 'two'];
         question = UI.Question(questionJSON);
 
         entry = question.entry;
         assert.isTrue(entry instanceof Controls.DropdownEntry);
 
-        entry.rawAnswer(2);     // 'b'
+        entry.rawAnswer(2);     // 'two'
         assert.equal(entry.answer(), 2);
 
-        question.choices(['b', 'c', 'd']);
-        assert.equal(entry.answer(), Const.NO_ANSWER);
-
-        question.choices(['e', 'f']);
-        assert.equal(entry.answer(), Const.NO_ANSWER);
+        question.choices(['un', 'deux']);
+        assert.equal(entry.answer(), 2);
     });
 
     it('Should return FloatEntry', function () {
@@ -144,25 +142,23 @@ describe('Entries', function () {
         assert.equal(entry.answer(), Const.NO_ANSWER);
     });
 
-    it('Should clear Combobox on options change', function () {
+    it('Should retain Combobox value on options change', function () {
+        // This behavior is necessary for changing the in-form language
         var entry,
             question;
         questionJSON.datatype = Const.SELECT;
         questionJSON.style = { raw: Const.COMBOBOX };
-        questionJSON.choices = ['a', 'b'];
+        questionJSON.choices = ['one', 'two'];
         question = UI.Question(questionJSON);
 
         entry = question.entry;
         assert.isTrue(entry instanceof Controls.ComboboxEntry);
 
-        entry.rawAnswer(2);     // 'b'
+        entry.rawAnswer(2);     // 'two'
         assert.equal(entry.answer(), 2);
 
-        question.choices(['b', 'c', 'd']);
-        assert.equal(entry.answer(), Const.NO_ANSWER);
-
-        question.choices(['e', 'f']);
-        assert.equal(entry.answer(), Const.NO_ANSWER);
+        question.choices(['moja', 'mbili', 'tatu']);
+        assert.equal(entry.answer(), 2);
     });
 
     it('Should properly filter combobox', function () {


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SUPPORT-9538

This behavior was [added deliberately](https://github.com/dimagi/commcare-hq/commit/c39f408f2a8f5f49ce4d686aa238700dfcf2757f), but it wasn't compatible with the [language changer](https://github.com/dimagi/commcare-hq/pull/28463). My memory is that there isn't a use case for options changing within a form other than the language changer.

## Feature Flag
USH: Allow user to change form language in web apps

## Product Description
Previously, when a user changed the language in a form, dropdown questions would get cleared.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

PR updates tests.

### QA Plan

No QA.

### Safety story
Usually web apps UI changes should be QAed, but this one is quite small in scope.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
