### PR TITLE
Fix html escaping in error message shown in form archive

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1937,20 +1937,26 @@ def archive_form(request, domain, instance_id):
 
 
 def _get_cases_with_forms_message(domain, cases_with_other_forms, case_id_from_request):
-    def _get_case_link(case_id, name):
-        if case_id == case_id_from_request:
-            return _("%(case_name)s (this case)") % {'case_name': name}
-        else:
-            return '<a href="{}#!history">{}</a>'.format(reverse('case_data', args=[domain, case_id]), name)
+    def _get_all_case_links():
+        all_case_links = []
+        for case_id, case_name in cases_with_other_forms.items():
+            if case_id == case_id_from_request:
+                all_case_links.append(_(
+                    format_html(f'{case_name}s (this case)')
+                ))
+            else:
+                all_case_links.append(_(
+                    format_html(
+                        f'<a href=\"{reverse("case_data", args=[domain, case_id])}#!history\">{case_name}</a>'
+                    )
+                ))
+        return all_case_links
 
-    case_links = ', '.join([
-        _get_case_link(case_id, name)
-        for case_id, name in cases_with_other_forms.items()
-    ])
+    case_links = ", ".join(_get_all_case_links())
+
     msg = _("""Form cannot be archived as it creates cases that are updated by other forms.
         All other forms for these cases must be archived first:""")
-    notify_msg = format_html("""{} {}""".format(msg, case_links))
-    return notify_msg
+    return format_html(f"{msg} {case_links}")
 
 
 def _get_cases_with_other_forms(domain, xform):

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -22,7 +22,7 @@ from django.http import (
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
-from django.utils.html import format_html
+from django.utils.html import format_html, format_html_join
 from django.utils.translation import get_language
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
@@ -1941,22 +1941,22 @@ def _get_cases_with_forms_message(domain, cases_with_other_forms, case_id_from_r
         all_case_links = []
         for case_id, case_name in cases_with_other_forms.items():
             if case_id == case_id_from_request:
-                all_case_links.append(_(
-                    format_html(f'{case_name}s (this case)')
-                ))
+                all_case_links.append([(
+                    format_html(_("{}s (this case)"), case_name)
+                )])
             else:
-                all_case_links.append(_(
-                    format_html(
-                        f'<a href=\"{reverse("case_data", args=[domain, case_id])}#!history\">{case_name}</a>'
-                    )
-                ))
+                all_case_links.append([format_html(_(
+                    '<a href="{}#!history">{}</a>'),
+                    reverse("case_data", args=[domain, case_id]),
+                    case_name
+                )])
         return all_case_links
 
-    case_links = ", ".join(_get_all_case_links())
+    case_links = format_html_join(", ", "{}", _get_all_case_links())
 
     msg = _("""Form cannot be archived as it creates cases that are updated by other forms.
         All other forms for these cases must be archived first:""")
-    return format_html(f"{msg} {case_links}")
+    return format_html("{} {}", msg, case_links)
 
 
 def _get_cases_with_other_forms(domain, xform):

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1941,12 +1941,13 @@ def _get_cases_with_forms_message(domain, cases_with_other_forms, case_id_from_r
         all_case_links = []
         for case_id, case_name in cases_with_other_forms.items():
             if case_id == case_id_from_request:
-                all_case_links.append(
-                    format_html(_("{} (this case)"), case_name)
-                )
+                all_case_links.append(format_html(
+                    _("{} (this case)"),
+                    case_name
+                ))
             else:
-                all_case_links.append(format_html(_(
-                    '<a href="{}#!history">{}</a>'),
+                all_case_links.append(format_html(
+                    '<a href="{}#!history">{}</a>',
                     reverse("case_data", args=[domain, case_id]),
                     case_name
                 ))

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -23,7 +23,6 @@ from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
 from django.utils.html import format_html
-from django.utils.safestring import mark_safe
 from django.utils.translation import get_language
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
@@ -1950,7 +1949,7 @@ def _get_cases_with_forms_message(domain, cases_with_other_forms, case_id_from_r
     ])
     msg = _("""Form cannot be archived as it creates cases that are updated by other forms.
         All other forms for these cases must be archived first:""")
-    notify_msg = mark_safe("""{} {}""".format(msg, case_links))
+    notify_msg = format_html("""{} {}""".format(msg, case_links))
     return notify_msg
 
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -23,6 +23,7 @@ from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.utils.translation import get_language
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
@@ -1949,7 +1950,7 @@ def _get_cases_with_forms_message(domain, cases_with_other_forms, case_id_from_r
     ])
     msg = _("""Form cannot be archived as it creates cases that are updated by other forms.
         All other forms for these cases must be archived first:""")
-    notify_msg = """{} {}""".format(msg, case_links)
+    notify_msg = mark_safe("""{} {}""".format(msg, case_links))
     return notify_msg
 
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1941,18 +1941,18 @@ def _get_cases_with_forms_message(domain, cases_with_other_forms, case_id_from_r
         all_case_links = []
         for case_id, case_name in cases_with_other_forms.items():
             if case_id == case_id_from_request:
-                all_case_links.append([(
-                    format_html(_("{}s (this case)"), case_name)
-                )])
+                all_case_links.append(
+                    format_html(_("{} (this case)"), case_name)
+                )
             else:
-                all_case_links.append([format_html(_(
+                all_case_links.append(format_html(_(
                     '<a href="{}#!history">{}</a>'),
                     reverse("case_data", args=[domain, case_id]),
                     case_name
-                )])
+                ))
         return all_case_links
 
-    case_links = format_html_join(", ", "{}", _get_all_case_links())
+    case_links = format_html_join(", ", "{}", ((link,) for link in _get_all_case_links()))
 
     msg = _("""Form cannot be archived as it creates cases that are updated by other forms.
         All other forms for these cases must be archived first:""")


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12185

When users try to archive a registration form which affected many cases then the error message that was shown to the user spitted out raw HTML to the user. This PR addresses that.
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
A minor change and have been tested on local.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
