### PR TITLE
[SSO] Improve Add Project / Domain-less New User Page

### DIFF
--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -18,7 +18,7 @@
       {% trans 'Accept All Invitations' %}
     </a>
   </div>
-  <p/>
+  <div class="spacer"></div>
 
   <div class="panel panel-info" data-bind="visible: invitationLinks().length">
     <div class="panel-heading ">
@@ -27,8 +27,8 @@
       </h3>
     </div>
     <div class="panel-body">
-      <ul class="list-unstyled" data-bind="foreach: invitationLinks">
-        <li style="padding-bottom: 6px;">
+      <ul class="list-invitations" data-bind="foreach: invitationLinks">
+        <li>
           <a data-bind="attr: {href: url}" class="btn btn-default btn-xs">
             <i class='fa fa-envelope'>
             </i>

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/list.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/list.less
@@ -10,3 +10,17 @@
     .border-bottom-radius(5px);
   }
 }
+
+.list-invitations {
+  padding-left: 0;
+  list-style: none;
+
+  li {
+    list-style: none;
+    padding: 3px 0;
+
+    > .btn {
+      margin-right: 10px;
+    }
+  }
+}

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -296,6 +296,10 @@ class DomainRegistrationForm(forms.Form):
                 'placeholder': _('My CommCare Project'),
             }
         ),
+        help_text=_(
+            "Important: This will be used to create a project URL, and you "
+            "will not be able to change it in the future."
+        ),
     )
 
     def __init__(self, *args, **kwargs):

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -287,9 +287,16 @@ class DomainRegistrationForm(forms.Form):
     max_name_length = 25
 
     org = forms.CharField(widget=forms.HiddenInput(), required=False)
-    hr_name = forms.CharField(label=_('Project Name'), max_length=max_name_length,
-                                      widget=forms.TextInput(attrs={'class': 'form-control',
-                                        'placeholder': _('My CommCare Project')}))
+    hr_name = forms.CharField(
+        label=_('Project Name'),
+        max_length=max_name_length,
+        widget=forms.TextInput(
+            attrs={
+                'class': 'form-control',
+                'placeholder': _('My CommCare Project'),
+            }
+        ),
+    )
 
     def __init__(self, *args, **kwargs):
         super(DomainRegistrationForm, self).__init__(*args, **kwargs)

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -306,8 +306,8 @@ class DomainRegistrationForm(forms.Form):
         super(DomainRegistrationForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_class = "form-horizontal"
-        self.helper.label_class = 'col-sm-3 col-md-4 col-lg-2'
-        self.helper.field_class = 'col-sm-6 col-md-5 col-lg-3'
+        self.helper.label_class = 'col-sm-3 col-md-3 col-lg-2'
+        self.helper.field_class = 'col-sm-6 col-md-5 col-lg-4'
         self.helper.layout = crispy.Layout(
             'hr_name',
             'org',

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -315,7 +315,7 @@ class DomainRegistrationForm(forms.Form):
                 twbscrispy.StrictButton(
                     _("Create Project"),
                     type="submit",
-                    css_class="btn btn-primary btn-lg disable-on-submit",
+                    css_class="btn btn-primary disable-on-submit",
                 )
             )
         )

--- a/corehq/apps/registration/templates/registration/domain_request.html
+++ b/corehq/apps/registration/templates/registration/domain_request.html
@@ -111,8 +111,8 @@
             </p>
             <p>
               {% blocktrans %}
-                <a href="#tbd">Learn more about CommCare Enterprise</a> if you would like to link project spaces
-                together under one account.
+                <a href="https://dimagi.com/commcare/enterprise/" target="_blank">Learn more about CommCare Enterprise</a>
+                if you would like to link project spaces together under one account.
               {% endblocktrans %}
             </p>
           </div>

--- a/corehq/apps/registration/templates/registration/domain_request.html
+++ b/corehq/apps/registration/templates/registration/domain_request.html
@@ -7,47 +7,121 @@
 
 {% block content %}
   <div class="container">
-    <h1>
+    <div class="page-header">
       {% if is_new_user %}
-        {% blocktrans %}
-          Welcome to CommCare HQ!
-        {% endblocktrans %}
+        <h1>
+          {% blocktrans with request.couch_user.first_name as first_name %}
+            Welcome to CommCare HQ, {{ first_name }}!
+          {% endblocktrans %}
+        </h1>
+        <p class="lead">
+          {% if invitation_links %}
+            {% blocktrans %}
+              Please accept an invitation or create your own project space to start using CommCare.
+            {% endblocktrans %}
+          {% else %}
+            {% blocktrans %}
+              Before you can view any of your own data from CommCare, you will need
+              to create a project space.
+            {% endblocktrans %}
+          {% endif %}
+        </p>
       {% else %}
-        {% blocktrans %}
-          Create a New Project Space
-        {% endblocktrans %}
+        <h1>
+          {% blocktrans with request.couch_user.first_name as first_name %}
+            Let's add a new project, {{ first_name }}.
+          {% endblocktrans %}
+        </h1>
+        <p class="lead">
+          {% if invitation_links %}
+            {% blocktrans %}
+              Please accept an invitation or create your own project space.
+            {% endblocktrans %}
+          {% else %}
+            {% blocktrans %}
+              Create a project space below as a separate sandbox for new
+              applications, users, and form submissions.
+            {% endblocktrans %}
+          {% endif %}
+        </p>
       {% endif %}
-    </h1>
-    <div class="help-block">
-      Please create a name for your project.
-      This will be used to create a project URL, and you will not be able to change it in the future.
     </div>
 
-    {% block registration-content %}
-      <div>
-        {% if is_new_user %}
-          <p>
-            {% blocktrans with request.couch_user.first_name as first_name %}
-              Congratulations, {{ first_name }}&mdash;you've successfully joined CommCare HQ.
-            {% endblocktrans %}
-          </p>
-          <p>
-            {% blocktrans %}
-              Your CommCare HQ project will contain all form submissions from your CommCare
-              mobile applications, as well as tools that help you easily create, deploy, and monitor
-              your applications and workers.
-            {% endblocktrans %}
-          </p>
-          <p>
-            {% blocktrans %}
-              Before you can view any of your own data from CommCare, you will need to create a
-              project space.
-            {% endblocktrans %}
-          </p>
+    {% if invitation_links %}
+      <div class="panel panel-modern-gray">
+        <div class="panel-heading">
+          <h4 class="panel-title panel-title-nolink">
+            {% trans "My Invitations" %}
+          </h4>
+        </div>
+        <div class="panel-body">
+          {% if show_multiple_invites %}
+            <p>
+              <a class="btn btn-primary"
+                 href="{% url "accept_all_invitations" %}">
+                <i class="fa fa-envelope"></i>
+                {% trans 'Accept All Invitations' %}
+              </a>
+            </p>
+            <div class="spacer"></div>
+            <p>
+              {% blocktrans %}
+                You have been invited to the following project spaces:
+              {% endblocktrans %}
+            </p>
+          {% endif %}
+          <ul class="list-invitations">
+            {% for invitation in invitation_links %}
+              <li>
+                <a href="{{ invitation.url }}"
+                   class="btn btn-default btn-xs">
+                  <i class='fa fa-envelope'>
+                  </i>
+                  {% trans "Accept" %}
+                </a>
+                {{ invitation.domain }}
+              </li>
+            {% endfor %}
+          </ul>
+
+        </div>
+      </div>
+    {% endif %}
+    <div class="panel panel-modern-gray">
+      <div class="panel-heading">
+        <h4 class="panel-title panel-title-nolink">
+          {% trans "Create a New Project Space" %}
+        </h4>
+      </div>
+      <div class="panel-body">
+        <p>
+          {% blocktrans %}
+            Your project space contains all form submissions from your CommCare
+            mobile applications and tools to help you easily create, deploy, and monitor
+            your applications and workers.
+          {% endblocktrans %}
+        </p>
+
+        {% if not is_new_user %}
+          <div class="alert alert-info">
+            <p>
+              {% blocktrans %}
+                <strong>Please note:</strong> This project space will not immediately become a part of existing subscriptions.
+              {% endblocktrans %}
+            </p>
+            <p>
+              {% blocktrans %}
+                <a href="#tbd">Learn more about CommCare Enterprise</a> if you would like to link project spaces
+                together under one account.
+              {% endblocktrans %}
+            </p>
+          </div>
+        {% else %}
+          <div class="spacer"></div>
         {% endif %}
+
         {% crispy form %}
       </div>
-    {% endblock %}
+    </div>
   </div>
-
 {% endblock %}


### PR DESCRIPTION
## Summary
This is addresses the use case for a new user clicking on the CommCare app icon on their Azure dashboard and never going through the sign-up workflow. The way SSO is set up this action will properly create the user's account on HQ (tied to their Azure email), but the user will end up on the "Add Project" view as soon as they login because they will have no domain memberships.

To improve this workflow, I've ensured that domain invitations are also listed on this page and that the organization and styling of the page are a little friendlier to digest for new and existing users.

## Feature Flag
This isn't under the `ENTERPRISE_SSO` and can be separately QA'd from SSO, as it's also improving the overall user experience for non-SSO users who visit the Add Project page.

## Product Description
Pictures are best to describe the changes. I'm also plopping this PR on staging.

### Newly created user with no domain invites or memberships
<img width="1666" alt="Screen Shot 2021-05-25 at 1 26 43 PM" src="https://user-images.githubusercontent.com/716573/119564325-4664de80-bd6e-11eb-8c91-8adc35c1fff5.png">

### Newly created user with one invite and no domain memberships
<img width="1672" alt="Screen Shot 2021-05-25 at 1 30 25 PM" src="https://user-images.githubusercontent.com/716573/119564379-58468180-bd6e-11eb-8ef6-75549763c371.png">

### Newly created user with multiple invites and no domain memberships
<img width="1675" alt="Screen Shot 2021-05-25 at 4 14 12 PM" src="https://user-images.githubusercontent.com/716573/119564439-698f8e00-bd6e-11eb-9e0a-2a85b2ad1b42.png">

### Existing user with invitations who clicks on Add Project
<img width="1674" alt="Screen Shot 2021-05-25 at 4 14 46 PM" src="https://user-images.githubusercontent.com/716573/119564498-7a400400-bd6e-11eb-951b-026e6f3013c8.png">

### Existing user without invitations who clicks on Add Project
<img width="1653" alt="Screen Shot 2021-05-25 at 4 35 13 PM" src="https://user-images.githubusercontent.com/716573/119564824-d145d900-bd6e-11eb-8ba4-5c4c6d61d715.png">

### Just want to highlight this little upsell
<img width="625" alt="Screen Shot 2021-05-25 at 4 15 15 PM" src="https://user-images.githubusercontent.com/716573/119564873-ddca3180-bd6e-11eb-958a-768487a0cc19.png">


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
No tests for this view

### QA Plan
This will either be QA'd individually or as part of the whole SSO push. Not 100% sure yet.

### Safety story
Going through QA, but fairly confident in the changes. Mostly needing UAT.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
