### PR TITLE
Revert "static admin and default roles"

### DIFF
--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -10,7 +10,7 @@ from corehq.apps.registration.models import AsyncSignupRequest
 from corehq.apps.sso.models import IdentityProvider, AuthenticatedEmailDomain
 from corehq.apps.sso.tests import generator
 from corehq.apps.sso.tests.generator import create_request_session
-from corehq.apps.users.models import WebUser, Invitation, StaticRole
+from corehq.apps.users.models import WebUser, Invitation, UserRole
 
 
 class TestSsoBackend(TestCase):
@@ -260,7 +260,7 @@ class TestSsoBackend(TestCase):
         invitation should add the user to the invited project
         space and accept the invitation
         """
-        admin_role = StaticRole.domain_admin(self.domain.name)
+        admin_role = UserRole.admin_role(self.domain.name)
         invitation = Invitation(
             domain=self.domain.name,
             email='isa@vaultwax.com',
@@ -342,7 +342,7 @@ class TestSsoBackend(TestCase):
         user data from a registration form and/or the samlUserdata are all
         properly saved to the User model.
         """
-        admin_role = StaticRole.domain_admin(domain=self.domain.name)
+        admin_role = UserRole.admin_role(domain=self.domain.name)
         existing_user = WebUser.create(
             None, 'exist@vaultwax.com', 'testpwd', None, None
         )

--- a/corehq/apps/users/models_sql.py
+++ b/corehq/apps/users/models_sql.py
@@ -1,43 +1,9 @@
-import attr
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
 from corehq.apps.users.landing_pages import ALL_LANDING_PAGES
 from corehq.util.models import ForeignValue, foreign_value_init
 from dimagi.utils.couch.migration import SyncSQLToCouchMixin
-
-
-@attr.s(frozen=True)
-class StaticRole:
-    domain = attr.ib()
-    name = attr.ib()
-    permissions = attr.ib()
-    default_landing_page = None
-    is_non_admin_editable = False
-    is_archived = False
-    upstream_id = None
-    couch_id = None
-    assignable_by = []
-
-    @classmethod
-    def domain_admin(cls, domain):
-        from corehq.apps.users.models import Permissions
-        return StaticRole(domain, "Admin", Permissions.max())
-
-    @classmethod
-    def domain_default(cls, domain):
-        from corehq.apps.users.models import Permissions
-        return StaticRole(domain, None, Permissions())
-
-    def get_qualified_id(self):
-        return self.name.lower() if self.name else None
-
-    @property
-    def get_id(self):
-        return None
-
-    def to_json(self):
-        return role_to_dict(self)
 
 
 class UserRoleManager(models.Manager):
@@ -99,9 +65,6 @@ class SQLUserRole(SyncSQLToCouchMixin, models.Model):
 
     def get_qualified_id(self):
         return 'user-role:%s' % self.get_id
-
-    def to_json(self):
-        return role_to_dict(self)
 
     def set_permissions(self, permission_infos):
         permissions_by_name = {
@@ -235,14 +198,3 @@ def migrate_role_assignable_by_to_sql(couch_role, sql_role):
                 assignable_by_mapping[couch_id] = assignable_by_sql_role.id
 
     sql_role.set_assignable_by(list(assignable_by_mapping.values()))
-
-
-def role_to_dict(role):
-    data = {}
-    for field in SQLUserRole._migration_get_fields():
-        data[field] = getattr(role, field)
-    data["permissions"] = role.permissions.to_json()
-    data["assignable_by"] = role.assignable_by
-    if role.couch_id:
-        data["_id"] = role.couch_id
-    return data

--- a/corehq/apps/users/tests/test_user_role.py
+++ b/corehq/apps/users/tests/test_user_role.py
@@ -1,13 +1,11 @@
 from django.db import IntegrityError
 from django.db.transaction import atomic
-from django.test import TestCase, SimpleTestCase
+from django.test import TestCase
 
 from corehq.apps.users.models import (
     Permissions,
-    SQLUserRole, SQLPermission, RolePermission, RoleAssignableBy, PermissionInfo, UserRole,
-    StaticRole
+    SQLUserRole, SQLPermission, RolePermission, RoleAssignableBy, PermissionInfo
 )
-from corehq.apps.users.tests.test_migrate_roles_to_sql import _drop_couch_only_fields
 
 
 class RolesTests(TestCase):
@@ -167,20 +165,3 @@ class TestRolePermissionsModel(TestCase):
                 RolePermission(permission=Permissions.edit_data.name, allow_all=True),
                 RolePermission(permission=Permissions.edit_data.name, allow_all=False),
             ], bulk=False)
-
-
-class TestStaticRoles(SimpleTestCase):
-    domain = "static-role-test"
-
-    def test_static_role_default(self):
-        static_dict = StaticRole.domain_default(self.domain).to_json()
-        couch_dict = UserRole(domain=self.domain, name=None, permissions=Permissions()).to_json()
-        _drop_couch_only_fields(couch_dict)
-        self.assertDictEqual(couch_dict, static_dict)
-
-    def test_static_role_admin(self):
-        static_admin_role = StaticRole.domain_admin(self.domain)
-        couch_dict = UserRole(domain=self.domain, name="Admin", permissions=Permissions.max()).to_json()
-        _drop_couch_only_fields(couch_dict)
-        self.assertDictEqual(couch_dict, static_admin_role.to_json())
-        self.assertEqual(static_admin_role.get_qualified_id(), "admin")

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -100,7 +100,6 @@ from corehq.apps.users.models import (
     DomainRemovalRecord,
     DomainRequest,
     Invitation,
-    StaticRole,
     UserRole,
     WebUser,
 )
@@ -500,7 +499,7 @@ class BaseRoleAccessView(BaseUserSettingsView):
     @property
     @memoized
     def user_roles(self):
-        user_roles = [StaticRole.domain_admin(self.domain)]
+        user_roles = [UserRole.admin_role(self.domain)]
         user_roles.extend(sorted(
             UserRole.by_domain(self.domain),
             key=lambda role: role.name if role.name else '\uFFFF'
@@ -658,7 +657,7 @@ class ListRolesView(BaseRoleAccessView):
             'user_roles': self.user_roles,
             'non_admin_roles': self.user_roles[1:],
             'can_edit_roles': self.can_edit_roles,
-            'default_role': StaticRole.domain_default(self.domain),
+            'default_role': UserRole.get_default(),
             'report_list': get_possible_reports(self.domain),
             'is_domain_admin': self.couch_user.is_domain_admin,
             'domain_object': self.domain_object,

--- a/corehq/apps/users/views/utils.py
+++ b/corehq/apps/users/views/utils.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 
 from corehq.apps.users.models import (
     DomainMembershipError,
-    StaticRole,
     UserRole,
 )
 
@@ -31,7 +30,7 @@ def get_editable_role_choices(domain, couch_user, allow_admin_role, use_qualifie
             if role.accessible_by_non_admin_role(user_role_id)
         ]
     elif allow_admin_role:
-        roles = [StaticRole.domain_admin(domain)] + roles
+        roles = [UserRole.admin_role(domain)] + roles
     return [role_to_choice(role) for role in roles]
 
 


### PR DESCRIPTION
Reverts dimagi/commcare-hq#29763

It looks like tests never ran on this because it was originally a PR into another PR and was then switched to master.

```
======================================================================
ERROR: corehq.apps.domain.tests.test_domain_transfer:TestTransferDomainIntegration.test_basic_workflow
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/commcare-hq-ro/corehq/apps/domain/tests/test_domain_transfer.py", line 227, in test_basic_workflow
    resp = self.client.get(reverse(TransferDomainView.urlname, args=[self.domain.name]))
...
  File "/mnt/commcare-hq-ro/corehq/tabs/templatetags/menu_tags.py", line 96, in render
    role_rev = user_role._rev if user_role else None
AttributeError: 'StaticRole' object has no attribute '_rev'
```