### PR TITLE
[SSO] remove single logout service

### DIFF
--- a/corehq/apps/sso/configuration.py
+++ b/corehq/apps/sso/configuration.py
@@ -14,10 +14,6 @@ def get_saml2_config(identity_provider):
             "url": url_helpers.get_saml_acs_url(identity_provider),
             "binding": OneLogin_Saml2_Constants.BINDING_HTTP_POST,
         },
-        "singleLogoutService": {
-            "url": url_helpers.get_saml_sls_url(identity_provider),
-            "binding": OneLogin_Saml2_Constants.BINDING_HTTP_REDIRECT,
-        },
         "attributeConsumingService": {
             "serviceName": "CommCare HQ",
             "serviceDescription": "SSO for CommCare HQ",

--- a/corehq/apps/sso/urls.py
+++ b/corehq/apps/sso/urls.py
@@ -5,8 +5,6 @@ from corehq.apps.sso.views.saml import (
     sso_saml_acs,
     sso_saml_login,
     sso_debug_user_data,
-    sso_saml_sls,
-    sso_saml_logout,
     sso_test_create_user,
 )
 
@@ -14,8 +12,6 @@ saml_urls = [
     url(r'^metadata/$', sso_saml_metadata, name='sso_saml_metadata'),
     url(r'^acs/$', sso_saml_acs, name='sso_saml_acs'),
     url(r'^debug/$', sso_debug_user_data, name='sso_debug_user_data'),
-    url(r'^sls/$', sso_saml_sls, name='sso_saml_sls'),
-    url(r'^logout/$', sso_saml_logout, name='sso_saml_logout'),
     url(r'^login/$', sso_saml_login, name='sso_saml_login'),
     url(r'^create/$', sso_test_create_user, name='sso_test_create_user'),
 ]

--- a/corehq/apps/sso/utils/url_helpers.py
+++ b/corehq/apps/sso/utils/url_helpers.py
@@ -15,10 +15,6 @@ def get_saml_login_url(identity_provider):
     return _get_full_sso_url("sso_saml_login", identity_provider)
 
 
-def get_saml_sls_url(identity_provider):
-    return _get_full_sso_url("sso_saml_sls", identity_provider)
-
-
 def get_dashboard_link(identity_provider):
     from corehq.apps.accounting.models import Subscription
     from corehq.apps.sso.views.enterprise_admin import EditIdentityProviderEnterpriseView

--- a/corehq/apps/sso/views/saml.py
+++ b/corehq/apps/sso/views/saml.py
@@ -157,48 +157,6 @@ def sso_debug_user_data(request, idp_slug):
 
 
 @use_saml2_auth
-def sso_saml_sls(request, idp_slug):
-    """
-    SLS stands for Single Logout Service. This view is responsible for
-    handling a logout response from the Identity Provider.
-    """
-    # todo these are placeholders for the json dump below
-    error_reason = None
-    success_slo = False
-    attributes = False
-    saml_user_data_present = False
-
-    request_id = request.session.get('LogoutRequestID')
-    url = request.saml2_auth.process_slo(
-        request_id=request_id,
-        delete_session_cb=lambda: request.session.flush()
-    )
-    errors = request.saml2_auth.get_errors()
-
-    if len(errors) == 0:
-        if url is not None:
-            return HttpResponseRedirect(url)
-        else:
-            success_slo = True
-    elif request.saml2_auth.get_settings().is_debug_active():
-        error_reason = request.saml2_auth.get_last_error_reason()
-
-    # todo what's below is a debugging placeholder
-    if 'samlUserdata' in request.session:
-        saml_user_data_present = True
-        if len(request.session['samlUserdata']) > 0:
-            attributes = request.session['samlUserdata'].items()
-
-    return HttpResponse(json.dumps({
-        "errors": errors,
-        "error_reason": error_reason,
-        "success_slo": success_slo,
-        "attributes": attributes,
-        "saml_user_data_present": saml_user_data_present,
-    }), 'text/json')
-
-
-@use_saml2_auth
 def sso_saml_login(request, idp_slug):
     """
     This view initiates a SAML 2.0 login request with the Identity Provider.
@@ -212,20 +170,6 @@ def sso_saml_login(request, idp_slug):
             # pre-populate username for Azure AD
             login_url = f'{login_url}&login_hint={username}'
     return HttpResponseRedirect(login_url)
-
-
-@use_saml2_auth
-def sso_saml_logout(request, idp_slug):
-    """
-    This view initiates a SAML 2.0 logout request with the Identity Provider.
-    """
-    return HttpResponseRedirect(request.saml2_auth.logout(
-        name_id=request.session.get('samlNameId'),
-        session_index=request.session.get('samlSessionIndex'),
-        nq=request.session.get('samlNameIdNameQualifier'),
-        name_id_format=request.session.get('samlNameIdFormat'),
-        spnq=request.session.get('samlNameIdSPNameQualifier')
-    ))
 
 
 @use_saml2_auth


### PR DESCRIPTION
## Summary
SAML SLS is optional. We only need it if we want to implement the ability to log the user out of Azure/IdP in addition to CommCare. In practice, only care about logging the user out of CommCare, which is sufficiently handled with the current logout process.

This change removes the option for Single Logout Service as it adds unnecessary complexity to the SAML2 setup.

## Feature Flag
Not behind a feature flag, but also in an area of the codebase that is not used / still under development.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
SSO has lots of tests. These views were never tested, however, as it was still a question as to whether they were necessary. Turns out they are not necessary.

### QA Plan
QA for SSO will happen in a larger batch prior to release

### Safety story
Very safe change. Does not affect any existing workflows.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
