### PR TITLE
Add new case search labels placeholders

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2095,12 +2095,22 @@ class DefaultCaseSearchProperty(DocumentSchema):
     default_value = StringProperty()
 
 
+class CaseSearchLabel(DocumentSchema):
+    label = DictProperty(default={'en': 'Search All Cases'})
+
+
+class CaseSearchAgainLabel(DocumentSchema):
+    label = DictProperty(default={'en': 'Search Again'})
+
+
 class CaseSearch(DocumentSchema):
     """
     Properties and search command label
     """
     command_label = DictProperty(default={'en': 'Search All Cases'})
     again_label = DictProperty(default={'en': 'Search Again'})
+    search_label = SchemaProperty(CaseSearchLabel)
+    search_again_label = SchemaProperty(CaseSearchAgainLabel)
     properties = SchemaListProperty(CaseSearchProperty)
     auto_launch = BooleanProperty(default=False)        # if true, skip the casedb case list
     default_search = BooleanProperty(default=False)     # if true, skip the search fields screen

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -50,6 +50,8 @@ from corehq.apps.app_manager.models import (
     AdvancedModule,
     CaseListForm,
     CaseSearch,
+    CaseSearchAgainLabel,
+    CaseSearchLabel,
     CaseSearchProperty,
     DefaultCaseSearchProperty,
     DeleteModuleRecord,
@@ -1129,6 +1131,8 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
             module.search_config = CaseSearch(
                 command_label=command_label,
                 again_label=again_label,
+                search_label=CaseSearchLabel(label=command_label),
+                search_again_label=CaseSearchAgainLabel(label=again_label),
                 properties=properties,
                 default_relevant=bool(search_properties.get('search_default_relevant')),
                 additional_relevant=search_properties.get('search_additional_relevant', ''),

--- a/corehq/apps/translations/app_translations/upload_module.py
+++ b/corehq/apps/translations/app_translations/upload_module.py
@@ -90,9 +90,11 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
 
         if self.search_command_label:
             self._update_translation(self.search_command_label, self.module.search_config.command_label)
+            self.module.search_config.search_label.label = self.module.search_config.command_label
 
         if self.search_again_label:
             self._update_translation(self.search_again_label, self.module.search_config.again_label)
+            self.module.search_config.search_again_label.label = self.module.search_config.again_label
 
         self._update_case_search_labels(rows)
 

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -771,6 +771,21 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBaseWithApp):
             ]
         )
 
+    def test_new_labels_on_upload(self):
+        module = self.app.get_module(0)
+
+        # default values
+        self.assertEqual(module.search_config.search_label.label, {'en': 'Search All Cases'})
+        self.assertEqual(module.search_config.search_again_label.label, {'en': 'Search Again'})
+
+        self.upload_raw_excel_translations(self.multi_sheet_upload_headers, self.multi_sheet_upload_data)
+
+        # updated to be exactly as old labels
+        self.assertEqual(module.search_config.search_label.label,
+                         {'en': 'Find a Mother', 'fra': 'Mère!'})
+        self.assertEqual(module.search_config.search_again_label.label,
+                         {'en': 'Find Another Mother', 'fra': 'Mère! Encore!'})
+
 
 class BulkAppTranslationPartialsTest(BulkAppTranslationTestBase):
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This sets up things to be able to roll out https://github.com/dimagi/commcare-hq/pull/29735/files smoothly on production.
The new properties are set and are populated with values of old labels on any save (UI and bulk upload).

Once this is deployed, on prod
1. the [management command](https://github.com/dimagi/commcare-hq/pull/29735/files#diff-dac7d9d49e8e2ad772ac4e92690c22e94f98b0d51d3bf59de01080cc58aaed84) could be run at anytime in a private release
2. a fake run can then be done for production on the [migration](https://github.com/dimagi/commcare-hq/pull/29735/files#diff-8776ba8024442e4479536910a9665bd26a74429520c268a1e5ceeac9d561e745) before the next deploy

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USH_CASE_CLAIM_UPDATES` and `SYNC_SEARCH_CASE_CLAIM`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No UI changes

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Added test for changes to bulk upload and tested UI changes locally

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

This PR can be reverted if https://github.com/dimagi/commcare-hq/pull/29735 has not been deployed yet.
This PR would also be redundant after https://github.com/dimagi/commcare-hq/pull/29735 is merged.

