### PR TITLE
[case import] prefix _ with `$root` when referencing _ in html knockout

### DIFF
--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
@@ -15,7 +15,7 @@
                   "></search-box>
     </div>
   </h2>
-  <!--ko if: state() == states.SUCCESS && !_.isEmpty(case_uploads())-->
+  <!--ko if: state() == states.SUCCESS && !$root._.isEmpty(case_uploads())-->
   <table class="table table-striped">
     <tr>
       <th class="col-md-1">{% trans "Status" %}</th>
@@ -34,10 +34,10 @@
     <tr>
       <td class="col-md-1">
         <!--ko if: task_status().state == $root.states.SUCCESS && task_status().result-->
-        <!--ko if: _.isEmpty(task_status().result.errors)-->
+        <!--ko if: $root._.isEmpty(task_status().result.errors)-->
         <span class="label label-success">{% trans "Success" %}</span>
         <!--/ko-->
-        <!--ko if: !_.isEmpty(task_status().result.errors)-->
+        <!--ko if: !$root._.isEmpty(task_status().result.errors)-->
         <span class="label label-warning">{% trans "Success with warnings" %}</span>
         <!--/ko-->
         <!--/ko-->
@@ -125,7 +125,7 @@
                       totalItems: totalItems,
                       showSpinner: showPaginationSpinner"></pagination>
   <!--/ko-->
-  <!--ko if: state() === states.SUCCESS && _.isEmpty(case_uploads())-->
+  <!--ko if: state() === states.SUCCESS && $root._.isEmpty(case_uploads())-->
   <div class="alert alert-info">
     {% trans "No recent uploads found." %}
   </div>

--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
@@ -26,7 +26,7 @@
   </p>
   <!--/ko-->
 </div>
-<!--ko if: !_.isEmpty(result.errors)-->
+<!--ko if: !$root._.isEmpty(result.errors)-->
 <div class="alert alert-warning">
   <ul class="list-unstyled">
     <!--ko foreach: result.errors-->
@@ -55,7 +55,7 @@
   <p>{% trans "Unable to retrieve details" %}</p>
 </div>
 <!--/ko-->
-<!--ko if: state === $root.states.FAILED && result && !_.isEmpty(result.errors)-->
+<!--ko if: state === $root.states.FAILED && result && !$root._.isEmpty(result.errors)-->
 <div class="alert alert-warning">
   <ul class="list-unstyled">
     <!--ko foreach: result.errors-->


### PR DESCRIPTION
Fixes https://dimagi-dev.atlassian.net/browse/SAAS-12283 which was caused by https://github.com/dimagi/commcare-hq/pull/29676

## Summary
quick fix to ensure `_` is always prefixed by `$root`

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story
This is a hotfix

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
