### PR TITLE
Moved attributes up to ActionMixin

### DIFF
--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -743,14 +743,14 @@ class ActionMixin(OrderedXmlObject):
 
     stack = NodeField('stack', Stack)
     relevant = XPathField('@relevant')
+    auto_launch = StringField("@auto_launch")
+    redo_last = SimpleBooleanField("@redo_last", "true", "false")
 
 
 class Action(ActionMixin):
     """ For CC < 2.21 """
 
     display = NodeField('display', Display)
-    auto_launch = StringField("@auto_launch")
-    redo_last = SimpleBooleanField("@redo_last", "true", "false")
 
 
 class LocalizedAction(ActionMixin, TextOrDisplay):


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/QA-3076

Back in https://github.com/dimagi/commcare-hq/pull/29023 and https://github.com/dimagi/commcare-hq/pull/28788 I added these attributes to `Action`, not noticing that `LocalizedAction` existed, but it didn't matter because case search actions didn't use `LocalizedAction`.

When https://github.com/dimagi/commcare-hq/pull/29765 updates case search actions to use either `Action` or `LocalizedAction`, apps on CommCare 2.21+ stop supporting the case search workflows.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

This should be well-tested.

### QA Plan

Not requesting QA.

### Safety story
Change is simple, and automated test coverage here is good.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
