### PR TITLE
Improve docker scripts and env documentation

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -133,10 +133,13 @@ ENV Vars
 
 * JS_SETUP=[yes|**no**]
   * Run `yarn` installs
-* TEST=[javascript|python|python-sharded]
-  * javascript: extra setup and config for JS tests. Also only run JS tests
-  * python: default tests
-  * python-sharded: configure django for sharded setup and only run subset of tests
+* TEST=[javascript|**python**|python-sharded|python-sharded-and-javascript]
+  * `javascript`: extra setup and config for JS tests. Also only run JS tests
+  * `python`: default tests
+  * `python-sharded`: configure django for sharded setup and only run subset of
+    tests
+  * `python-sharded-and-javascript`: combines `python-sharded` and `javascript`.
+    Also sends static analysis to datadog if job is travis "cron" event.
 * NOSE_DIVIDED_WE_RUN
   * used to only run a subset of tests
   * see .travis.yml for exact options

--- a/docker/README.md
+++ b/docker/README.md
@@ -129,9 +129,9 @@ script:
 ```
 
 ENV Vars
-~~~~~~~~
+--------
 
-* JS_SETUP=yes
+* JS_SETUP=[yes|**no**]
   * Run `yarn` installs
 * TEST=[javascript|python|python-sharded]
   * javascript: extra setup and config for JS tests. Also only run JS tests
@@ -141,6 +141,21 @@ ENV Vars
   * used to only run a subset of tests
   * see .travis.yml for exact options
 * REUSE_DB
-  * Same as normal REUSE_DB
- 
+  * Same as normal `REUSE_DB`
+* DOCKER_HQ_OVERLAY=[**none**|overlayfs|**aufs**]
+  * `none`: mounts commcare-hq directory in docker container read/write for
+    direct access.  This is the default when not specified with Travis jobs.
+  * `overlayfs`: mounts commcare-hq directory in docker container read-only and
+    uses it as the "lowerdir" in an `overlayfs` mount to insulate the host OS
+    data from being modified by the container.
+  * `aufs`: [deprecated] same behavior as `overlayfs`, only using Docker's `aufs`
+    overlay engine instead of `overlayfs`. This is the default when not
+    specified with non-Travis jobs.
+* DOCKER_HQ_OVERLAYFS_CHMOD=[yes|**no**]
+  * Perform a recursive chmod on the commcare-hq overlay to ensure read access
+    for cchq user.
+* DOCKER_HQ_OVERLAYFS_METACOPY=[on|**off**]
+  * Set the `metacopy=on` mount option for the overlayfs mount (performance
+    optimization, has security implications).
+
 See .travis.yml for env variable options used on travis.

--- a/docker/README.md
+++ b/docker/README.md
@@ -147,13 +147,13 @@ ENV Vars
   * Same as normal `REUSE_DB`
 * DOCKER_HQ_OVERLAY=[**none**|overlayfs|**aufs**]
   * `none`: mounts commcare-hq directory in docker container read/write for
-    direct access.  This is the default when not specified with Travis jobs.
+    direct access.  This is the default when running in Travis.
   * `overlayfs`: mounts commcare-hq directory in docker container read-only and
     uses it as the "lowerdir" in an `overlayfs` mount to insulate the host OS
     data from being modified by the container.
   * `aufs`: [deprecated] same behavior as `overlayfs`, only using Docker's `aufs`
-    overlay engine instead of `overlayfs`. This is the default when not
-    specified with non-Travis jobs.
+    overlay engine instead of `overlayfs`. This is the default when not running
+    in Travis.
 * DOCKER_HQ_OVERLAYFS_CHMOD=[yes|**no**]
   * Perform a recursive chmod on the commcare-hq overlay to ensure read access
     for cchq user.

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -220,7 +220,7 @@ else
             # is an expensive operation and some container ecosystems (travis
             # perhaps?) may not require it. I suspect this is the reason local
             # testing was not working for many people in the past.
-            logmsg INFO -n "chmod'ing commcare-hq overlay... "
+            logmsg -n INFO "chmod'ing commcare-hq overlay... "
             now=$(date +%s)
             # add world-read (and world-x for dirs and existing-x files)
             chmod -R o+rX commcare-hq

--- a/docker/wait.sh
+++ b/docker/wait.sh
@@ -4,12 +4,14 @@
 set -e
 
 if [ -n "$1" ]; then
+    # always use argv if provided
     SERVICES="$1"
-else [ -n "DEPENDENT_SERVICES" ]
+elif [ -n "$DEPENDENT_SERVICES" ]; then
+    # otherwise use DEPENDENT_SERVICES (if present)
     SERVICES="$DEPENDENT_SERVICES"
-fi
-if [ -z "$SERVICES" ]; then
-    exit 0
+else
+    echo "ERROR: No services to wait for!"
+    exit 1
 fi
 
 echo "Waiting for services: $SERVICES"

--- a/docker/wait.sh
+++ b/docker/wait.sh
@@ -3,6 +3,14 @@
 
 set -e
 
+if [ -f /mnt/commcare-hq-ro/scripts/bash-utils.sh ]; then
+    source /mnt/commcare-hq-ro/scripts/bash-utils.sh # provides logmsg
+else
+    # if bash-utils.sh is not where we expect it, stub out logmsg (allows this
+    # script to be used outside the docker environment).
+    function logmsg { echo "$@"; }
+fi
+
 if [ -n "$1" ]; then
     # always use argv if provided
     SERVICES="$1"
@@ -10,31 +18,31 @@ elif [ -n "$DEPENDENT_SERVICES" ]; then
     # otherwise use DEPENDENT_SERVICES (if present)
     SERVICES="$DEPENDENT_SERVICES"
 else
-    echo "ERROR: No services to wait for!"
+    logmsg ERROR "No services to wait for!"
     exit 1
 fi
 
-echo "Waiting for services: $SERVICES"
+logmsg INFO "Waiting for services: $SERVICES"
 
 for service in $SERVICES; do
     svc=$(echo $service | cut -d : -f 1)
     port=$(echo $service | cut -d : -f 2)
 
-    echo -n "Waiting for TCP connection to $svc:$port..."
+    logmsg -n INFO "Waiting for TCP connection to $svc:$port..."
 
     counter=0
     while ! { exec 6<>/dev/tcp/${svc}/${port}; } 2>/dev/null
     do
-      echo -n .
+      echo -n . >&2  # append dot to most recent log line
       sleep 1
       let counter=counter+1
       if [ $counter -gt 90 ]; then
-        echo "TIMEOUT"
+        echo " TIMEOUT" >&2  # finalize log line
         exit 1
       fi
     done
 
-    echo "$svc ok"
+    echo " $svc ok" >&2  # finalize log line
 done
 
-echo "Services ready!"
+logmsg INFO "Services ready!"

--- a/scripts/bash-utils.sh
+++ b/scripts/bash-utils.sh
@@ -1,20 +1,19 @@
 
 function logmsg {
-    # USAGE: logmsg LEVELNAME [-n] [MESSAGE ...]
+    # USAGE: logmsg [-n] LEVELNAME [MESSAGE ...]
     #
     # Write a log message to stderr.
     # LEVELNAME  log level name (for colorization). Resulting message will be
     #            colorized (if stderr is a TTY) for common level names.
-    #        -n  Do not write a trailing newline (must be *immediately after*
-    #            LEVELNAME)
+    #        -n  Do not write a trailing newline (must be *very first* argument)
     local echo_args=( -e )
-    local script=$(basename "$0")
-    local levelname="$1"
-    shift
     if [ "x${1}" == "x-n" ]; then
         shift
         echo_args+=( -n )
     fi
+    local script=$(basename "$0")
+    local levelname="$1"
+    shift
     local msg="$*"
     local ccode=''
     local reset=''

--- a/scripts/docker
+++ b/scripts/docker
@@ -11,7 +11,7 @@ function usage() {
             echo "OPTIONS are passed to the selected test runner."
             echo ""
             echo "Set TEST environment variable to select a test runner:"
-            echo "  TEST=python|python-sharded|javascript"
+            echo "  TEST=python|python-sharded|javascript|python-sharded-and-javascript"
             echo ""
             echo "The default is python."
             echo ""


### PR DESCRIPTION
## Summary

This change is a followup of to #29779 which includes improvements and documentation including:

- fix syntax error and improve logging and timing in docker/wait.sh
- add documentation for new (as of #29779) env vars in docker/README.md
- add documentation for existing functionality missing in docker/README.md
- remove code duplication in docker/run.sh
- fix testing python module inconsistency when using docker overlay


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan

No QA.

### Safety story

Tested locally without any issues. This change does not introduce any docker or testing "command changes", and is fully backward-compatible.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
