### PR TITLE
Removed unpopulated select toggle attrs from HTML

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/select_toggle.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/select_toggle.js
@@ -34,6 +34,13 @@ hqDefine('hqwebapp/js/components/select_toggle', [
             self.name = params.name || '';
             self.id = params.id || '';
             self.disabled = params.disabled || false;
+            self.htmlAttrs = {};
+            if (self.name) {
+                self.htmlAttrs.name = self.name;
+            }
+            if (self.id) {
+                self.htmlAttrs.id = self.id;
+            }
 
             // Data
             self.value = ko.isObservable(params.value) ? params.value : ko.observable(params.value);

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/ko_select_toggle.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/ko_select_toggle.html
@@ -1,6 +1,6 @@
 <script type="text/html" id="ko-select-toggle">
   <div class="ko-select-toggle">
-    <select class="hide" data-bind="foreach: options, attr: {name: name, id: id}, value: value">
+    <select class="hide" data-bind="foreach: options, attr: htmlAttrs, value: value">
       <option data-bind="value: $data.id,
                                text: $data.text,
                                attr: {selected: $data.selected}"></option>


### PR DESCRIPTION
## Summary
Minor, this is just to reduce the warnings that clutter the console when multiple elements have blank ids:
![Screen Shot 2021-05-28 at 7 32 00 PM](https://user-images.githubusercontent.com/1486591/120050484-77057c00-bfeb-11eb-8666-f74495dfa625.png)


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No

### QA Plan

None

### Safety story
Minor, smoke tested widget locally.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
