### PR TITLE
validate HTTP_Referer before redirecting.

### DIFF
--- a/corehq/apps/groups/views.py
+++ b/corehq/apps/groups/views.py
@@ -9,6 +9,7 @@ from django.views.decorators.http import require_POST
 from dimagi.utils.couch import CriticalSection
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.couch.undo import DELETED_SUFFIX
+from dimagi.utils.web import get_url_base
 
 from corehq.apps.groups.models import DeleteGroupRecord, Group
 from corehq.apps.users.decorators import require_permission
@@ -30,8 +31,7 @@ def add_group(request, domain):
             "please give it a name first"
         ))
         redirection_url = request.META['HTTP_REFERER']
-
-        if not is_url_or_host_banned(redirection_url):
+        if not redirection_url.startswith(get_url_base()):
             messages.warning(request, _(
                 "We sensed a fishy redirection URL in your Request. "
                 "Therefore, redirected you here as we care about your security."


### PR DESCRIPTION
Verify the redirection URL before redirecting. When the Referrer is not verified, redirect to the home page.
https://dimagi-dev.atlassian.net/browse/SAAS-12249


The motive of this PR:
1. Share the list of places HTTP_REFERER is being used without validation.
2. Verify If the fix mentioned in the PR looks good
3. I can think about how to do it modularly. But, Can this fix be applied to other places as well especially from a usage perspective because I am not sure if there is any URL out of these which we expect to redirect to unknown HOST.


This a draft PR to gather people's points of view on this issue and the resolution.

right now we are redirecting to HTTP_REFERRER on the following pages without any validation of the destination URL:
1. Add Group: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/groups/views.py#L31
2. Update Group: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/groups/views.py#L137
3. Send SMS: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/sms/views.py#L359
4. Unarchive FOrm: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/reports/views.py#L2002
5.  Archive Form: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/reports/views.py#L1936
6. Location Update: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/locations/views.py#L105
7. Dropbox upload: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/views.py#L560
8. Dropbox Logout: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/views.py#L504
9. Base Export: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/export/views/new.py#L211
10. Deactivate Domain Transfer: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/domain/views/internal.py#L428
11. Import App: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/views/apps.py#L640
12. Move Child Module after parent: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/views/apps.py#L979
13. Adjust Invoice Summary: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/accounting/views.py#L967
14. Sending Subscriber Email: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/accounting/emails.py#L27


If HTTP_REFERER is validated, then redirect as shown below:
<img width="1440" alt="Screenshot 2021-05-31 at 1 18 41 PM" src="https://user-images.githubusercontent.com/21310920/120179702-8ae9f180-c228-11eb-89cf-d7a631846263.png">

If HTTP_REFERER is not validated, then redirect to home page with warning:
<img width="1440" alt="Screenshot 2021-05-31 at 1 18 23 PM" src="https://user-images.githubusercontent.com/21310920/120179811-a7862980-c228-11eb-827a-e09592353e30.png">



