### PR TITLE
refactor `redirect_to_default` view and add validation for landing page

### DIFF
--- a/corehq/apps/hqwebapp/tests/test_default_landing_page.py
+++ b/corehq/apps/hqwebapp/tests/test_default_landing_page.py
@@ -110,7 +110,7 @@ def test_web_user_landing_page(self, role, expected_urlname, enabled_toggle=None
     self.addCleanup(user.delete, deleted_by=None)
     self.client.login(username=user.username, password=self.global_password)
 
-    context = flag_enabled(enabled_toggle) if enabled_toggle else contextlib.suppress()
+    context = flag_enabled(enabled_toggle) if enabled_toggle else contextlib.suppress()  # noop context
     with context:
         response = self.client.get(reverse("domain_homepage", args=[self.domain]), follow=True)
     self.assertEqual(response.status_code, 200)
@@ -132,7 +132,7 @@ def test_mobile_worker_landing_page(self, role, expected_urlname, enabled_toggle
     self.addCleanup(user.delete, deleted_by=None)
     self.client.login(username=user.username, password=self.global_password)
 
-    context = flag_enabled(enabled_toggle) if enabled_toggle else contextlib.suppress()
+    context = flag_enabled(enabled_toggle) if enabled_toggle else contextlib.suppress()  # noop context
     with context:
         response = self.client.get(reverse("domain_homepage", args=[self.domain]), follow=True)
     self.assertEqual(response.status_code, 200)

--- a/corehq/apps/hqwebapp/tests/test_default_landing_page.py
+++ b/corehq/apps/hqwebapp/tests/test_default_landing_page.py
@@ -110,7 +110,7 @@ def test_web_user_landing_page(self, role, expected_urlname, enabled_toggle=None
     self.addCleanup(user.delete, deleted_by=None)
     self.client.login(username=user.username, password=self.global_password)
 
-    context = flag_enabled(enabled_toggle) if enabled_toggle else contextlib.nullcontext()
+    context = flag_enabled(enabled_toggle) if enabled_toggle else contextlib.suppress()
     with context:
         response = self.client.get(reverse("domain_homepage", args=[self.domain]), follow=True)
     self.assertEqual(response.status_code, 200)
@@ -132,7 +132,7 @@ def test_mobile_worker_landing_page(self, role, expected_urlname, enabled_toggle
     self.addCleanup(user.delete, deleted_by=None)
     self.client.login(username=user.username, password=self.global_password)
 
-    context = flag_enabled(enabled_toggle) if enabled_toggle else contextlib.nullcontext()
+    context = flag_enabled(enabled_toggle) if enabled_toggle else contextlib.suppress()
     with context:
         response = self.client.get(reverse("domain_homepage", args=[self.domain]), follow=True)
     self.assertEqual(response.status_code, 200)

--- a/corehq/apps/hqwebapp/tests/test_default_landing_page.py
+++ b/corehq/apps/hqwebapp/tests/test_default_landing_page.py
@@ -1,3 +1,5 @@
+import contextlib
+
 from django.test import Client, TestCase
 from django.urls import reverse
 
@@ -38,6 +40,11 @@ class TestDefaultLandingPages(TestCase):
             permissions=Permissions(access_web_apps=True),
         )
         cls.webapps_role.save()
+        cls.downloads_role = UserRole(
+            domain=cls.domain, name='webapps-role', default_landing_page='downloads',
+            permissions=Permissions.max(),
+        )
+        cls.downloads_role.save()
         cls.global_password = 'secret'
 
         # make an app because not having one changes the default dashboard redirect to the apps page
@@ -93,18 +100,21 @@ class TestDefaultLandingPages(TestCase):
     (None, DomainDashboardView.urlname),
     ('reports_role', "reports_home"),
     ('webapps_role', FormplayerMain.urlname),
+    ('downloads_role', DomainDashboardView.urlname),
+    ('downloads_role', 'download_data_files', 'DATA_FILE_DOWNLOAD'),
 ], TestDefaultLandingPages)
-def test_web_user_landing_page(self, role, expected_urlname, extra_url_args=None):
+def test_web_user_landing_page(self, role, expected_urlname, enabled_toggle=None):
     if role is not None:
         role = getattr(self, role)
-    extra_url_args = extra_url_args or []
     user = self._make_web_user('elodin@theuniversity.com', role=role)
     self.addCleanup(user.delete, deleted_by=None)
     self.client.login(username=user.username, password=self.global_password)
 
-    response = self.client.get(reverse("domain_homepage", args=[self.domain]), follow=True)
+    context = flag_enabled(enabled_toggle) if enabled_toggle else contextlib.nullcontext()
+    with context:
+        response = self.client.get(reverse("domain_homepage", args=[self.domain]), follow=True)
     self.assertEqual(response.status_code, 200)
-    self.assertEqual(reverse(expected_urlname, args=[self.domain] + extra_url_args),
+    self.assertEqual(reverse(expected_urlname, args=[self.domain]),
                      response.request['PATH_INFO'])
 
 
@@ -112,16 +122,19 @@ def test_web_user_landing_page(self, role, expected_urlname, extra_url_args=None
     (None, FormplayerMain.urlname),
     ('reports_role', "reports_home"),
     ('webapps_role', FormplayerMain.urlname),
+    ('downloads_role', FormplayerMain.urlname),
+    ('downloads_role', 'download_data_files', 'DATA_FILE_DOWNLOAD'),
 ], TestDefaultLandingPages)
-def test_mobile_worker_landing_page(self, role, expected_urlname, extra_url_args=None):
+def test_mobile_worker_landing_page(self, role, expected_urlname, enabled_toggle=None):
     if role is not None:
         role = getattr(self, role)
-    extra_url_args = extra_url_args or []
     user = self._make_commcare_user('kvothe', role=role)
     self.addCleanup(user.delete, deleted_by=None)
     self.client.login(username=user.username, password=self.global_password)
 
-    response = self.client.get(reverse("domain_homepage", args=[self.domain]), follow=True)
+    context = flag_enabled(enabled_toggle) if enabled_toggle else contextlib.nullcontext()
+    with context:
+        response = self.client.get(reverse("domain_homepage", args=[self.domain]), follow=True)
     self.assertEqual(response.status_code, 200)
-    self.assertEqual(reverse(expected_urlname, args=[self.domain] + extra_url_args),
+    self.assertEqual(reverse(expected_urlname, args=[self.domain]),
                      response.request['PATH_INFO'])

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -94,10 +94,7 @@ from corehq.apps.hqwebapp.utils import (
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.sms.event_handlers import handle_email_messaging_subevent
 from corehq.apps.users.event_handlers import handle_email_invite_message
-from corehq.apps.users.landing_pages import (
-    get_cloudcare_urlname,
-    get_redirect_url,
-)
+from corehq.apps.users.landing_pages import get_redirect_url
 from corehq.apps.users.models import CouchUser, Invitation
 from corehq.apps.users.util import format_username
 from corehq.form_processor.utils.general import should_use_sql_backend
@@ -249,7 +246,7 @@ def redirect_to_default(req, domain=None):
 
         if url is None:
             if couch_user.is_commcare_user():
-                url = reverse(get_cloudcare_urlname(domain_name), args=[domain_name])
+                url = reverse('formplayer_main', args=[domain_name])
             else:
                 url = reverse("dashboard_domain", args=[domain_name])
 

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -214,9 +214,10 @@ def redirect_to_default(req, domain=None):
     else:
         domains = Domain.active_for_user(req.user)
 
-    if 0 == len(domains) and not req.user.is_superuser:
+    if not domains and not req.user.is_superuser:
         return redirect('registration_domain')
-    elif 1 == len(domains):
+
+    if 1 == len(domains):
         from corehq.apps.users.models import DomainMembershipError
         if domains[0]:
             domain = domains[0].name

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -221,29 +221,32 @@ def redirect_to_default(req, domain=None):
         return HttpResponseRedirect(settings.DOMAIN_SELECT_URL)
 
     from corehq.apps.users.models import DomainMembershipError
-    if domains[0]:
-        domain = domains[0].name
-        couch_user = req.couch_user
-        try:
-            role = couch_user.get_role(domain)
-        except DomainMembershipError:
-            # commcare users without roles should always be denied access
-            if couch_user.is_commcare_user():
-                raise Http404()
-            else:
-                # web users without roles are redirected to the dashboard default
-                # view since some domains allow web users to request access if they
-                # don't have it
-                url = reverse("dashboard_domain", args=[domain])
-        else:
-            if role and role.default_landing_page:
-                url = get_redirect_url(role.default_landing_page, domain)
-            elif couch_user.is_commcare_user():
-                url = reverse(get_cloudcare_urlname(domain), args=[domain])
-            else:
-                url = reverse("dashboard_domain", args=[domain])
-    else:
+
+    domain = domains[0]
+    if not domain:
         raise Http404()
+
+    domain_name = domain.name
+    couch_user = req.couch_user
+    try:
+        role = couch_user.get_role(domain_name)
+    except DomainMembershipError:
+        # commcare users without roles should always be denied access
+        if couch_user.is_commcare_user():
+            raise Http404()
+        else:
+            # web users without roles are redirected to the dashboard default
+            # view since some domains allow web users to request access if they
+            # don't have it
+            url = reverse("dashboard_domain", args=[domain_name])
+    else:
+        if role and role.default_landing_page:
+            url = get_redirect_url(role.default_landing_page, domain_name)
+        elif couch_user.is_commcare_user():
+            url = reverse(get_cloudcare_urlname(domain_name), args=[domain_name])
+        else:
+            url = reverse("dashboard_domain", args=[domain_name])
+
     return HttpResponseRedirect(url)
 
 

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -199,48 +199,50 @@ def redirect_to_default(req, domain=None):
             url = reverse('domain_login', args=[domain])
         else:
             url = reverse('login')
-    elif domain and _two_factor_needed(domain, req):
+        return HttpResponseRedirect(url)
+
+    if domain and _two_factor_needed(domain, req):
         return TemplateResponse(
             request=req,
             template='two_factor/core/otp_required.html',
             status=403,
         )
-    else:
-        if domain:
-            domain = normalize_domain_name(domain)
-            domains = [Domain.get_by_name(domain)]
-        else:
-            domains = Domain.active_for_user(req.user)
 
-        if 0 == len(domains) and not req.user.is_superuser:
-            return redirect('registration_domain')
-        elif 1 == len(domains):
-            from corehq.apps.users.models import DomainMembershipError
-            if domains[0]:
-                domain = domains[0].name
-                couch_user = req.couch_user
-                try:
-                    role = couch_user.get_role(domain)
-                except DomainMembershipError:
-                    # commcare users without roles should always be denied access
-                    if couch_user.is_commcare_user():
-                        raise Http404()
-                    else:
-                        # web users without roles are redirected to the dashboard default
-                        # view since some domains allow web users to request access if they
-                        # don't have it
-                        url = reverse("dashboard_domain", args=[domain])
+    if domain:
+        domain = normalize_domain_name(domain)
+        domains = [Domain.get_by_name(domain)]
+    else:
+        domains = Domain.active_for_user(req.user)
+
+    if 0 == len(domains) and not req.user.is_superuser:
+        return redirect('registration_domain')
+    elif 1 == len(domains):
+        from corehq.apps.users.models import DomainMembershipError
+        if domains[0]:
+            domain = domains[0].name
+            couch_user = req.couch_user
+            try:
+                role = couch_user.get_role(domain)
+            except DomainMembershipError:
+                # commcare users without roles should always be denied access
+                if couch_user.is_commcare_user():
+                    raise Http404()
                 else:
-                    if role and role.default_landing_page:
-                        url = get_redirect_url(role.default_landing_page, domain)
-                    elif couch_user.is_commcare_user():
-                        url = reverse(get_cloudcare_urlname(domain), args=[domain])
-                    else:
-                        url = reverse("dashboard_domain", args=[domain])
+                    # web users without roles are redirected to the dashboard default
+                    # view since some domains allow web users to request access if they
+                    # don't have it
+                    url = reverse("dashboard_domain", args=[domain])
             else:
-                raise Http404()
+                if role and role.default_landing_page:
+                    url = get_redirect_url(role.default_landing_page, domain)
+                elif couch_user.is_commcare_user():
+                    url = reverse(get_cloudcare_urlname(domain), args=[domain])
+                else:
+                    url = reverse("dashboard_domain", args=[domain])
         else:
-            url = settings.DOMAIN_SELECT_URL
+            raise Http404()
+    else:
+        url = settings.DOMAIN_SELECT_URL
     return HttpResponseRedirect(url)
 
 

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -240,12 +240,18 @@ def redirect_to_default(req, domain=None):
             # don't have it
             url = reverse("dashboard_domain", args=[domain_name])
     else:
+        url = None
         if role and role.default_landing_page:
-            url = get_redirect_url(role.default_landing_page, domain_name)
-        elif couch_user.is_commcare_user():
-            url = reverse(get_cloudcare_urlname(domain_name), args=[domain_name])
-        else:
-            url = reverse("dashboard_domain", args=[domain_name])
+            try:
+                url = get_redirect_url(role.default_landing_page, domain_name)
+            except ValueError:
+                pass  # landing page no longer accessible to domain
+
+        if url is None:
+            if couch_user.is_commcare_user():
+                url = reverse(get_cloudcare_urlname(domain_name), args=[domain_name])
+            else:
+                url = reverse("dashboard_domain", args=[domain_name])
 
     return HttpResponseRedirect(url)
 

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -192,7 +192,7 @@ def not_found(request, template_name='404.html', exception=None):
 @always_allow_project_access
 def redirect_to_default(req, domain=None):
     if not req.user.is_authenticated:
-        if domain != None:
+        if domain is not None:
             url = reverse('domain_login', args=[domain])
         else:
             url = reverse('login')

--- a/corehq/apps/users/landing_pages.py
+++ b/corehq/apps/users/landing_pages.py
@@ -39,7 +39,7 @@ def get_landing_page(domain, landing_page_id):
     for landing_page in get_allowed_landing_pages(domain):
         if landing_page.id == landing_page_id:
             return landing_page
-    raise ValueError(_("No landing page found with id {}".format(landing_page_id)))
+    raise ValueError(_("No landing page found with id {page_id}").format(page_id=landing_page_id))
 
 
 def get_redirect_url(landing_page_id, domain):

--- a/corehq/apps/users/landing_pages.py
+++ b/corehq/apps/users/landing_pages.py
@@ -7,12 +7,7 @@ from django.utils.translation import ugettext_noop
 from corehq import toggles
 
 
-class LandingPage(namedtuple('LandingPage', ['id', 'name', 'urlname'])):
-
-    def get_urlname(self, domain):
-        if callable(self.urlname):
-            return self.urlname(domain)
-        return self.urlname
+LandingPage = namedtuple('LandingPage', ['id', 'name', 'urlname'])
 
 
 ALL_LANDING_PAGES = (
@@ -39,4 +34,4 @@ def get_landing_page(domain, landing_page_id):
 
 def get_redirect_url(landing_page_id, domain):
     page = get_landing_page(domain, landing_page_id)
-    return reverse(page.get_urlname(domain), args=[domain])
+    return reverse(page.urlname, args=[domain])

--- a/corehq/apps/users/landing_pages.py
+++ b/corehq/apps/users/landing_pages.py
@@ -15,14 +15,9 @@ class LandingPage(namedtuple('LandingPage', ['id', 'name', 'urlname'])):
         return self.urlname
 
 
-def get_cloudcare_urlname(domain):
-    from corehq.apps.cloudcare.views import FormplayerMain
-    return FormplayerMain.urlname
-
-
 ALL_LANDING_PAGES = (
     LandingPage('dashboard', ugettext_noop('Dashboard'), 'dashboard_default'),
-    LandingPage('webapps', ugettext_noop('Web Apps'), get_cloudcare_urlname),
+    LandingPage('webapps', ugettext_noop('Web Apps'), 'formplayer_main'),
     LandingPage('reports', ugettext_noop('Reports'), 'reports_home'),
     # Only allowed if toggles.DATA_FILE_DOWNLOAD.enabled(domain)
     LandingPage('downloads', ugettext_noop('Data File Downloads'), 'download_data_files'),

--- a/corehq/apps/users/landing_pages.py
+++ b/corehq/apps/users/landing_pages.py
@@ -35,13 +35,13 @@ def get_allowed_landing_pages(domain):
     return [page for page in ALL_LANDING_PAGES if page.id != 'downloads']
 
 
-def get_landing_page(id):
-    for landing_page in ALL_LANDING_PAGES:
-        if landing_page.id == id:
+def get_landing_page(domain, landing_page_id):
+    for landing_page in get_allowed_landing_pages(domain):
+        if landing_page.id == landing_page_id:
             return landing_page
-    raise ValueError(_("No landing page found with id {}".format(id)))
+    raise ValueError(_("No landing page found with id {}".format(landing_page_id)))
 
 
-def get_redirect_url(id, domain):
-    page = get_landing_page(id)
+def get_redirect_url(landing_page_id, domain):
+    page = get_landing_page(domain, landing_page_id)
     return reverse(page.get_urlname(domain), args=[domain])


### PR DESCRIPTION
This was something I noticed while working on the SQL role migration. It is 90% cleanup and 10% improvement in current behaviour.

## Summary
The first few commits are a pure refactor of the view to reduce the amount of nested if statements.

* daf69ca: handle ValueError that may be thrown by `get_redirect_url` if the value from the role is not valid
* 6c3bdba: check role value against list of allowed landing pages instead of all of them
* A few more clean up commits

I tried to keep the commmits small to make it easy to verify the change in each commit. Please review per commit (probably best with whitespace changes hidden [?w=1](https://github.com/dimagi/commcare-hq/pull/29824/files?w=1))

## Product description
Redirect the user to the default landing page if the one set in their role is no longer valid. Currently this only applies to the 'Data File Downloads' landing page which is enabled via a FF. Prior to this change if the FF was disabled any user with that landing page would receive a 404. Now they will be redirected to the default landing page.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Covered by existing tests (corehq/apps/hqwebapp/tests/test_default_landing_page.py). New tests added for data file download landing page.

### QA Plan
Tested locally:

* Non-domain login
* Domain specific login
* Web user with multiple domains
* Mobile user (single domain)
* Role with no landing page
* Role with landing page
* Role with 'Data File Downloads' as landing page when toggle enabled
* Role with 'Data File Downloads' as landing page when toggle disabled (correctly redirects to default landing page)

### Safety story
Other than the pure refactoring the only expected change here is that if a role has a default landing page set that is
no longer available to the domain then the user should be redirected to the default landing page.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
