### PR TITLE
[ERM UI] Add pagination to linked/downstream projects tab

### DIFF
--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -5,6 +5,7 @@ hqDefine("linked_domain/js/domain_links", [
     'knockout',
     'hqwebapp/js/alert_user',
     'hqwebapp/js/multiselect_utils',
+    'hqwebapp/js/components.ko', // for pagination
 ], function (
     RMI,
     initialPageData,
@@ -66,26 +67,42 @@ hqDefine("linked_domain/js/domain_links", [
             }
         }
 
+        self.domain_links = ko.observableArray(_.map(data.linked_domains, function (link) {
+            return DomainLink(link);
+        }));
+
+        // pull content
+        self.model_status = _.map(data.model_status, ModelStatus);
         self.can_update = data.can_update;
         self.models = data.models;
 
-        self.model_status = _.map(data.model_status, ModelStatus);
+        // manage downstream domains tab
+        self.paginated_domain_links = ko.observableArray([]);
+        self.itemsPerPage = ko.observable(5);
+        self.totalItems = ko.observable(self.domain_links.length);
 
-        self.linked_domains = ko.observableArray(_.map(data.linked_domains, function (link) {
-            return DomainLink(link);
-        }));
+        self.goToPage = function (page) {
+            self.paginated_domain_links.removeAll();
+            var skip = (page - 1) * self.itemsPerPage()
+            self.paginated_domain_links = self.domain_links.slice(skip, skip + self.itemsPerPage())
+        };
+
+        self.onPaginationLoad = function () {
+            self.goToPage(1);
+        };
 
         self.deleteLink = function (link) {
             _private.RMI("delete_domain_link", {
                 "linked_domain": link.linked_domain(),
             }).done(function () {
-                self.linked_domains.remove(link);
+                self.domain_links.remove(link);
             }).fail(function () {
                 alertUser.alert_user(gettext('Something unexpected happened.\n' +
                     'Please try again, or report an issue if the problem persists.'), 'danger');
             });
         };
 
+        // push content tab
         self.domainsToRelease = ko.observableArray();
         self.modelsToRelease = ko.observableArray();
         self.buildAppsOnRelease = ko.observable(false);
@@ -93,6 +110,7 @@ hqDefine("linked_domain/js/domain_links", [
         self.enableReleaseButton = ko.computed(function () {
             return self.domainsToRelease().length && self.modelsToRelease().length && !self.releaseInProgress();
         });
+
         self.createRelease = function () {
             self.releaseInProgress(true);
             _private.RMI("create_release", {
@@ -139,6 +157,14 @@ hqDefine("linked_domain/js/domain_links", [
         setRMI(initialPageData.reverse('linked_domain:domain_link_rmi'), csrfToken);
 
         var model = DomainLinksViewModel(view_data);
-        $("#domain_links").koApplyBindings(model);
+        if ($("#ko-tabs-pull-content").length) {
+            $("#ko-tabs-pull-content").koApplyBindings(model);
+        }
+        if ($("#ko-tabs-push-content").length) {
+            $("#ko-tabs-push-content").koApplyBindings(model);
+        }
+        if ($("#ko-tabs-manage-downstream").length) {
+            $("#ko-tabs-manage-downstream").koApplyBindings(model);
+        }
     });
 });

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -79,7 +79,7 @@ hqDefine("linked_domain/js/domain_links", [
         // manage downstream domains tab
         self.paginated_domain_links = ko.observableArray([]);
         self.itemsPerPage = ko.observable(5);
-        self.totalItems = ko.observable(self.domain_links.length);
+        self.totalItems = ko.observable(self.domain_links().length);
 
         self.goToPage = function (page) {
             self.paginated_domain_links.removeAll();

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -67,9 +67,7 @@ hqDefine("linked_domain/js/domain_links", [
             }
         }
 
-        self.domain_links = _.map(data.linked_domains, function (link) {
-            return DomainLink(link);
-        });
+        self.domain_links = ko.observableArray(_.map(data.linked_domains, DomainLink));
 
         // pull content
         self.model_status = _.map(data.model_status, ModelStatus);
@@ -80,7 +78,7 @@ hqDefine("linked_domain/js/domain_links", [
         self.paginatedDomainLinks = ko.observableArray([]);
         self.itemsPerPage = ko.observable(5);
         self.totalItems = ko.computed(function () {
-            return self.domain_links.length;
+            return self.domain_links().length;
         });
         self.currentPage = 1;
 
@@ -99,9 +97,7 @@ hqDefine("linked_domain/js/domain_links", [
             _private.RMI("delete_domain_link", {
                 "linked_domain": link.linked_domain(),
             }).done(function () {
-                self.domain_links = self.domain_links.filter(function (item) {
-                    return item !== link;
-                });
+                self.domain_links.remove(link);
                 self.goToPage(self.currentPage);
             }).fail(function () {
                 alertUser.alert_user(gettext('Something unexpected happened.\n' +

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -79,12 +79,16 @@ hqDefine("linked_domain/js/domain_links", [
         // manage downstream domains tab
         self.paginated_domain_links = ko.observableArray([]);
         self.itemsPerPage = ko.observable(5);
-        self.totalItems = ko.observable(self.domain_links().length);
+        self.totalItems = ko.computed(function () {
+            return self.domain_links().length;
+        });
+        self.currentPage = 1;
 
         self.goToPage = function (page) {
+            self.currentPage = page;
             self.paginated_domain_links.removeAll();
-            var skip = (page - 1) * self.itemsPerPage()
-            self.paginated_domain_links = self.domain_links.slice(skip, skip + self.itemsPerPage())
+            var skip = (self.currentPage - 1) * self.itemsPerPage();
+            self.paginated_domain_links(self.domain_links().slice(skip, skip + self.itemsPerPage()));
         };
 
         self.onPaginationLoad = function () {
@@ -96,6 +100,7 @@ hqDefine("linked_domain/js/domain_links", [
                 "linked_domain": link.linked_domain(),
             }).done(function () {
                 self.domain_links.remove(link);
+                self.goToPage(self.currentPage);
             }).fail(function () {
                 alertUser.alert_user(gettext('Something unexpected happened.\n' +
                     'Please try again, or report an issue if the problem persists.'), 'danger');

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -99,7 +99,7 @@ hqDefine("linked_domain/js/domain_links", [
             _private.RMI("delete_domain_link", {
                 "linked_domain": link.linked_domain(),
             }).done(function () {
-                self.domain_links = self.domain_links.filter(function(item) {
+                self.domain_links = self.domain_links.filter(function (item) {
                     return item !== link;
                 });
                 self.goToPage(self.currentPage);

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -20,7 +20,7 @@ hqDefine("linked_domain/js/domain_links", [
         var self = {};
         self.type = data.type;
         self.name = data.name;
-        self.last_update = ko.observable(data.last_update);
+        self.lastUpdate = ko.observable(data.last_update);
         self.detail = data.detail;
         self.showUpdate = ko.observable(data.can_update);
         self.update_url = null;
@@ -42,7 +42,7 @@ hqDefine("linked_domain/js/domain_links", [
                 if (data.error) {
                     self.error(data.error);
                 } else {
-                    self.last_update(data.last_update);
+                    self.lastUpdate(data.last_update);
                     self.hasSuccess(true);
                 }
                 self.showSpinner(false);
@@ -67,9 +67,9 @@ hqDefine("linked_domain/js/domain_links", [
             }
         }
 
-        self.domain_links = ko.observableArray(_.map(data.linked_domains, function (link) {
+        self.domain_links = _.map(data.linked_domains, function (link) {
             return DomainLink(link);
-        }));
+        });
 
         // pull content
         self.model_status = _.map(data.model_status, ModelStatus);
@@ -77,18 +77,18 @@ hqDefine("linked_domain/js/domain_links", [
         self.models = data.models;
 
         // manage downstream domains tab
-        self.paginated_domain_links = ko.observableArray([]);
+        self.paginatedDomainLinks = ko.observableArray([]);
         self.itemsPerPage = ko.observable(5);
         self.totalItems = ko.computed(function () {
-            return self.domain_links().length;
+            return self.domain_links.length;
         });
         self.currentPage = 1;
 
         self.goToPage = function (page) {
             self.currentPage = page;
-            self.paginated_domain_links.removeAll();
+            self.paginatedDomainLinks.removeAll();
             var skip = (self.currentPage - 1) * self.itemsPerPage();
-            self.paginated_domain_links(self.domain_links().slice(skip, skip + self.itemsPerPage()));
+            self.paginatedDomainLinks(self.domain_links.slice(skip, skip + self.itemsPerPage()));
         };
 
         self.onPaginationLoad = function () {
@@ -99,7 +99,9 @@ hqDefine("linked_domain/js/domain_links", [
             _private.RMI("delete_domain_link", {
                 "linked_domain": link.linked_domain(),
             }).done(function () {
-                self.domain_links.remove(link);
+                self.domain_links = self.domain_links.filter(function(item) {
+                    return item !== link;
+                });
                 self.goToPage(self.currentPage);
             }).fail(function () {
                 alertUser.alert_user(gettext('Something unexpected happened.\n' +
@@ -140,7 +142,7 @@ hqDefine("linked_domain/js/domain_links", [
         self.is_remote = link.is_remote;
         self.master_domain = link.master_domain;
         self.remote_base_url = ko.observable(link.remote_base_url);
-        self.last_update = link.last_update;
+        self.lastUpdate = link.last_update;
         if (self.is_remote) {
             self.domain_link = self.linked_domain;
         } else {

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -52,7 +52,7 @@
                   <tbody data-bind="foreach: model_status">
                   <tr>
                     <td data-bind="text: name"></td>
-                    <td data-bind="text: last_update"></td>
+                    <td data-bind="text: lastUpdate"></td>
                     <td data-bind="css: {'has-error': error}">
                       <button class="btn btn-danger" data-bind="visible: showUpdate() && !update_url, click: update">
                         {% trans "Overwrite" %}
@@ -79,7 +79,7 @@
       {% endif %}
       <div class="tab-pane fade{% if not is_linked_domain %} in active{% endif %}" id="tabs-manage-downstream">
         <div id="ko-tabs-manage-downstream" class="ko-template">
-          <div data-bind="if: domain_links().length">
+          <div data-bind="if: domain_links.length">
             <table class="table table-striped table-hover" id="linked-domains-table">
               <thead>
               <tr>
@@ -88,10 +88,10 @@
                 <th></th>
               </tr>
               </thead>
-              <tbody data-bind="foreach: paginated_domain_links">
+              <tbody data-bind="foreach: paginatedDomainLinks">
               <tr>
                 <td><a data-bind="attr: {'href': domain_link}, text: linked_domain"></a></td>
-                <td data-bind="text: last_update"></td>
+                <td data-bind="text: lastUpdate"></td>
                 <td>
                   <button type="button" class="btn btn-danger" data-toggle="modal" data-bind="attr: {'data-target': '#remove-link-modal-' + $index()}">
                     <i class="fa fa-trash"></i>
@@ -101,7 +101,7 @@
                     <div class="modal-dialog" role="document">
                       <div class="modal-content">
                         <div class="modal-header">
-                          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                          <button type="button" class="close" data-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>
                           <h4 class="modal-title">{% trans 'Remove Project Link' %}</h4>
                         </div>
                         <div class="modal-body">
@@ -109,7 +109,7 @@
                         </div>
                         <div class="modal-footer">
                           <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
-                          <button type="button" class="btn btn-primary" data-bind="click: $root.deleteLink.bind($data)" data-dismiss="modal">{% trans 'Remove' %}</button>
+                          <button type="button" class="btn btn-danger" data-bind="click: $root.deleteLink.bind($data)" data-dismiss="modal">{% trans 'Remove' %}</button>
                         </div>
                       </div><!-- /.modal-content -->
                     </div><!-- /.modal-dialog -->
@@ -122,7 +122,6 @@
               params="goToPage: goToPage,
                       perPage: itemsPerPage,
                       totalItems: totalItems,
-                      slug: 'linked-domains-table',
                       onLoad: onPaginationLoad"></pagination>
           </div>
         </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -23,144 +23,156 @@
     {% endcomment %}
     <ul class="nav nav-tabs sticky-tabs">
       {% if is_linked_domain %}
-        <li class="active"><a data-toggle="tab" href="#tabs-master">{% trans "Project Link" %}</a></li>
+        <li class="active"><a data-toggle="tab" href="#tabs-pull-content">{% trans "Project Link" %}</a></li>
       {% endif %}
-      <li{% if not is_linked_domain %} class="active"{% endif %}><a data-toggle="tab" href="#tabs-linked">{% trans "Projects linked to this one" %}</a></li>
-      <li><a data-toggle="tab" href="#tabs-release">{% trans "Release Content" %}</a></li>
+      <li{% if not is_linked_domain %} class="active"{% endif %}><a data-toggle="tab" href="#tabs-manage-downstream">{% trans "Projects linked to this one" %}</a></li>
+      <li><a data-toggle="tab" href="#tabs-push-content">{% trans "Release Content" %}</a></li>
     </ul>
     <div class="spacer"></div>
   {% elif is_linked_domain %}
     <h2>{% trans "Project Link" %}</h2>  {# header for the only tab that will be displayed #}
   {% endif %}
 
-  <div id="domain_links" class="ko-template">
+  <div id="domain_links">
     <div class="tab-content">
       {% if is_linked_domain %}
-        <div class="tab-pane fade in active" id="tabs-master">
-          <div data-bind="if: master_link">
-            <p>{% trans "This project is linked to " %}<a data-bind="attr: {'href': master_href}, text: master_link.master_domain"></a></p>
-            <div>
-              <table class="table table-striped table-hover">
-                <thead>
-                <tr>
-                  <th class="col-sm-5">{% trans "Linked Model" %}</th>
-                  <th class="col-sm-2">{% trans "Last Updated" %} ({{ timezone }})</th>
-                  <th class="col-sm-5"></th>
-                </tr>
-                </thead>
-                <tbody data-bind="foreach: model_status">
-                <tr>
-                  <td data-bind="text: name"></td>
-                  <td data-bind="text: last_update"></td>
-                  <td data-bind="css: {'has-error': error}">
-                    <button class="btn btn-danger" data-bind="visible: showUpdate() && !update_url, click: update">
-                      {% trans "Overwrite" %}
-                    </button>
-                    <button class="btn btn-default disabled" data-bind="visible: showSpinner">
-                      <i class="fa fa-spinner"></i>
-                    </button>
-                    <button class="btn btn-success disabled" data-bind="visible: hasSuccess">
-                      <i class="fa fa-check"></i> {% trans "Success" %}
-                    </button>
-                    <button class="btn btn-danger disabled" data-bind="visible: error">
-                      <i class="fa fa-times"></i> {% trans "Error" %}
-                    </button>
-                    <span class="help-block" data-bind="visible: error, text: error"></span>
-                    <a data-bind="visible: showUpdate && update_url, attr: {href: update_url}">{% trans "Go to update page" %}</a>
-                  </td>
-                </tr>
-                </tbody>
-              </table>
+        <div class="tab-pane fade in active" id="tabs-pull-content">
+          <div id="ko-tabs-pull-content" class="ko-template">
+            <div data-bind="if: master_link">
+              <p>{% trans "This project is linked to " %}<a data-bind="attr: {'href': master_href}, text: master_link.master_domain"></a></p>
+              <div>
+                <table class="table table-striped table-hover">
+                  <thead>
+                  <tr>
+                    <th class="col-sm-5">{% trans "Linked Model" %}</th>
+                    <th class="col-sm-2">{% trans "Last Updated" %} ({{ timezone }})</th>
+                    <th class="col-sm-5"></th>
+                  </tr>
+                  </thead>
+                  <tbody data-bind="foreach: model_status">
+                  <tr>
+                    <td data-bind="text: name"></td>
+                    <td data-bind="text: last_update"></td>
+                    <td data-bind="css: {'has-error': error}">
+                      <button class="btn btn-danger" data-bind="visible: showUpdate() && !update_url, click: update">
+                        {% trans "Overwrite" %}
+                      </button>
+                      <button class="btn btn-default disabled" data-bind="visible: showSpinner">
+                        <i class="fa fa-spinner"></i>
+                      </button>
+                      <button class="btn btn-success disabled" data-bind="visible: hasSuccess">
+                        <i class="fa fa-check"></i> {% trans "Success" %}
+                      </button>
+                      <button class="btn btn-danger disabled" data-bind="visible: error">
+                        <i class="fa fa-times"></i> {% trans "Error" %}
+                      </button>
+                      <span class="help-block" data-bind="visible: error, text: error"></span>
+                      <a data-bind="visible: showUpdate && update_url, attr: {href: update_url}">{% trans "Go to update page" %}</a>
+                    </td>
+                  </tr>
+                  </tbody>
+                </table>
+              </div>
             </div>
           </div>
         </div>
       {% endif %}
-      <div class="tab-pane fade{% if not is_linked_domain %} in active{% endif %}" id="tabs-linked">
-        <div data-bind="if: linked_domains().length">
-          <table class="table table-striped table-hover">
-            <thead>
-            <tr>
-              <th>{% trans "Project Name" %}</th>
-              <th>{% trans "Last Updated" %} ({{ timezone }})</th>
-              <th></th>
-            </tr>
-            </thead>
-            <tbody data-bind="foreach: linked_domains">
-            <tr>
-              <td><a data-bind="attr: {'href': domain_link}, text: linked_domain"></a></td>
-              <td data-bind="text: last_update"></td>
-              <td>
-                <button type="button" class="btn btn-danger" data-bind="click: $root.deleteLink.bind($data)">
-                  <i class="fa fa-trash"></i>
-                  {% trans 'Delete Link' %}
-                </button>
-              </td>
-            </tr>
-            </tbody>
-          </table>
+      <div class="tab-pane fade{% if not is_linked_domain %} in active{% endif %}" id="tabs-manage-downstream">
+        <div id="ko-tabs-manage-downstream" class="ko-template">
+          <div data-bind="if: domain_links().length">
+            <table class="table table-striped table-hover" id="linked-domains-table">
+              <thead>
+              <tr>
+                <th>{% trans "Project Name" %}</th>
+                <th>{% trans "Last Updated" %} ({{ timezone }})</th>
+                <th></th>
+              </tr>
+              </thead>
+              <tbody data-bind="foreach: domain_links">
+              <tr>
+                <td><a data-bind="attr: {'href': domain_link}, text: linked_domain"></a></td>
+                <td data-bind="text: last_update"></td>
+                <td>
+                  <button type="button" class="btn btn-danger" data-bind="click: $root.deleteLink.bind($data)">
+                    <i class="fa fa-trash"></i>
+                    {% trans 'Delete Link' %}
+                  </button>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+            <pagination data-apply-bindings="false"
+              params="goToPage: goToPage,
+                      perPage: itemsPerPage,
+                      totalItems: totalItems,
+                      slug: 'linked-domains-table',
+                      onLoad: onPaginationLoad"></pagination>
+          </div>
         </div>
       </div>
-      <div class="tab-pane fade" id="tabs-release">
-        <form class="form-horizontal">
-          <div class="form-group">
-            <label class="col-sm-3 col-md-2 control-label">
-              {% trans "Models" %}
-            </label>
-            <div class="col-sm-9 col-md-10 controls">
-              <select multiple class="form-control"
-                      data-bind="selectedOptions: modelsToRelease,
-                                 multiselect: {
-                                     selectableHeaderTitle: '{% trans_html_attr "All content" %}',
-                                     selectedHeaderTitle: '{% trans_html_attr "Content to release" %}',
-                                     searchItemTitle: '{% trans_html_attr "Search content" %}',
-                                }">
-                {% for model in view_data.master_model_status %}
-                  <option value="{% html_attr model %}">{{ model.name }}</option>
-                {% endfor %}
-              </select>
-            </div>
-          </div>
-          <div class="form-group">
-            <label class="col-sm-3 col-md-2 control-label">
-              {% trans "Projects" %}
-            </label>
-            <div class="col-sm-9 col-md-10 controls">
-              <select multiple class="form-control"
-                      data-bind="selectedOptions: domainsToRelease,
-                                 multiselect: {
-                                     selectableHeaderTitle: '{% trans_html_attr "All projects" %}',
-                                     selectedHeaderTitle: '{% trans_html_attr "Projects to release to" %}',
-                                     searchItemTitle: '{% trans_html_attr "Search projects" %}',
-                                }">
-                {% for link in view_data.linked_domains %}
-                  {% if not linked_domain.is_remote %}
-                    <option value="{{ link.linked_domain }}">{{ link.linked_domain }}</option>
-                  {% endif %}
-                {% endfor %}
-              </select>
-            </div>
-          </div>
-          <div class="form-group">
-            <label class="col-sm-3 col-md-2 control-label" for="build-apps">
-              {% trans "Create and release new build for apps" %}
-            </label>
-            <div class="col-sm-9 col-md-10 controls">
-              <div class="checkbox">
-                <label>
-                  <input type="checkbox" data-bind="checked: buildAppsOnRelease" />
-                </label>
+      <div class="tab-pane fade" id="tabs-push-content">
+        <div id="ko-tabs-push-content" class="ko-template">
+          <form class="form-horizontal">
+            <div class="form-group">
+              <label class="col-sm-3 col-md-2 control-label">
+                {% trans "Models" %}
+              </label>
+              <div class="col-sm-9 col-md-10 controls">
+                <select multiple class="form-control"
+                        data-bind="selectedOptions: modelsToRelease,
+                                   multiselect: {
+                                       selectableHeaderTitle: '{% trans_html_attr "All content" %}',
+                                       selectedHeaderTitle: '{% trans_html_attr "Content to release" %}',
+                                       searchItemTitle: '{% trans_html_attr "Search content" %}',
+                                  }">
+                  {% for model in view_data.master_model_status %}
+                    <option value="{% html_attr model %}">{{ model.name }}</option>
+                  {% endfor %}
+                </select>
               </div>
             </div>
-          </div>
-          <div class="form-actions">
-            <div class="col-sm-offset-3 col-md-offset-2 controls col-sm-9 col-md-8 col-lg-6">
-              <button type="button" class="btn btn-primary" data-bind="click: createRelease, enable: enableReleaseButton">
-                <i class="fa fa-refresh fa-spin icon-refresh icon-spin" data-bind="visible: releaseInProgress"></i>
-                {% trans "Create Release" %}
-              </button>
+            <div class="form-group">
+              <label class="col-sm-3 col-md-2 control-label">
+                {% trans "Projects" %}
+              </label>
+              <div class="col-sm-9 col-md-10 controls">
+                <select multiple class="form-control"
+                        data-bind="selectedOptions: domainsToRelease,
+                                   multiselect: {
+                                       selectableHeaderTitle: '{% trans_html_attr "All projects" %}',
+                                       selectedHeaderTitle: '{% trans_html_attr "Projects to release to" %}',
+                                       searchItemTitle: '{% trans_html_attr "Search projects" %}',
+                                  }">
+                  {% for link in view_data.linked_domains %}
+                    {% if not linked_domain.is_remote %}
+                      <option value="{{ link.linked_domain }}">{{ link.linked_domain }}</option>
+                    {% endif %}
+                  {% endfor %}
+                </select>
+              </div>
             </div>
-          </div>
-        </form>
+            <div class="form-group">
+              <label class="col-sm-3 col-md-2 control-label" for="build-apps">
+                {% trans "Create and release new build for apps" %}
+              </label>
+              <div class="col-sm-9 col-md-10 controls">
+                <div class="checkbox">
+                  <label>
+                    <input type="checkbox" data-bind="checked: buildAppsOnRelease" />
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div class="form-actions">
+              <div class="col-sm-offset-3 col-md-offset-2 controls col-sm-9 col-md-8 col-lg-6">
+                <button type="button" class="btn btn-primary" data-bind="click: createRelease, enable: enableReleaseButton">
+                  <i class="fa fa-refresh fa-spin icon-refresh icon-spin" data-bind="visible: releaseInProgress"></i>
+                  {% trans "Create Release" %}
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
       </div>
     </div>
   </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -102,10 +102,10 @@
                       <div class="modal-content">
                         <div class="modal-header">
                           <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                          <h4 class="modal-title">{% trans 'Remove Link' %}</h4>
+                          <h4 class="modal-title">{% trans 'Remove Project Link' %}</h4>
                         </div>
                         <div class="modal-body">
-                          <p>Are you sure you want to remove the link between domains?</p>
+                          <p>{% trans 'Are you sure you want to remove the link between projects?' %}</p>
                         </div>
                         <div class="modal-footer">
                           <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -95,7 +95,7 @@
                 <td>
                   <button type="button" class="btn btn-danger" data-bind="click: $root.deleteLink.bind($data)">
                     <i class="fa fa-trash"></i>
-                    {% trans 'Delete Link' %}
+                    {% trans 'Remove Link' %}
                   </button>
                 </td>
               </tr>

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -88,15 +88,32 @@
                 <th></th>
               </tr>
               </thead>
-              <tbody data-bind="foreach: domain_links">
+              <tbody data-bind="foreach: paginated_domain_links">
               <tr>
                 <td><a data-bind="attr: {'href': domain_link}, text: linked_domain"></a></td>
                 <td data-bind="text: last_update"></td>
                 <td>
-                  <button type="button" class="btn btn-danger" data-bind="click: $root.deleteLink.bind($data)">
+                  <button type="button" class="btn btn-danger" data-toggle="modal" data-bind="attr: {'data-target': '#remove-link-modal-' + $index()}">
                     <i class="fa fa-trash"></i>
                     {% trans 'Remove Link' %}
                   </button>
+                  <div class="modal fade" tabindex="-1" role="dialog" data-bind="attr: {'id': 'remove-link-modal-' + $index()}">
+                    <div class="modal-dialog" role="document">
+                      <div class="modal-content">
+                        <div class="modal-header">
+                          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                          <h4 class="modal-title">{% trans 'Remove Link' %}</h4>
+                        </div>
+                        <div class="modal-body">
+                          <p>Are you sure you want to remove the link between domains?</p>
+                        </div>
+                        <div class="modal-footer">
+                          <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
+                          <button type="button" class="btn btn-primary" data-bind="click: $root.deleteLink.bind($data)" data-dismiss="modal">{% trans 'Remove' %}</button>
+                        </div>
+                      </div><!-- /.modal-content -->
+                    </div><!-- /.modal-dialog -->
+                  </div><!-- /.modal -->
                 </td>
               </tr>
               </tbody>

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -79,7 +79,7 @@
       {% endif %}
       <div class="tab-pane fade{% if not is_linked_domain %} in active{% endif %}" id="tabs-manage-downstream">
         <div id="ko-tabs-manage-downstream" class="ko-template">
-          <div data-bind="if: domain_links.length">
+          <div data-bind="if: domain_links().length">
             <table class="table table-striped table-hover" id="linked-domains-table">
               <thead>
               <tr>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SS-103

This is the first PR in a series of PRs that will make subtle changes/additions to the Linked Projects UI. This PR accomplishes the following: 
- adds pagination to the downstream/linked projects table
- adds confirmation modal when removing domain links

![Screen Shot 2021-05-31 at 11 11 47 AM](https://user-images.githubusercontent.com/15785053/120213410-28312f80-c201-11eb-9373-1323952bbe20.png)
![Screen Shot 2021-05-31 at 11 12 14 AM](https://user-images.githubusercontent.com/15785053/120213416-2bc4b680-c201-11eb-97fc-f45ddbf72df4.png)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
UI changes.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will run all UI changes through QA when complete.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
