### PR TITLE
Migrate user APIs to use SQL role

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -268,14 +268,14 @@ class CommCareUserResource(v0_1.CommCareUserResource):
             bundle.obj.save()
         except Exception:
             if bundle.obj._id:
-                bundle.obj.retire(deleted_by=request.user, deleted_via=USER_CHANGE_VIA_API)
+                bundle.obj.retire(deleted_by=bundle.request.user, deleted_via=USER_CHANGE_VIA_API)
             try:
                 django_user = bundle.obj.get_django_user()
             except User.DoesNotExist:
                 pass
             else:
                 django_user.delete()
-                log_model_change(request.user, django_user, message=f"deleted_via: {USER_CHANGE_VIA_API}",
+                log_model_change(bundle.request.user, django_user, message=f"deleted_via: {USER_CHANGE_VIA_API}",
                                  action=ModelAction.DELETE)
         return bundle
 

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -277,6 +277,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
                 django_user.delete()
                 log_model_change(bundle.request.user, django_user, message=f"deleted_via: {USER_CHANGE_VIA_API}",
                                  action=ModelAction.DELETE)
+            raise
         return bundle
 
     def obj_update(self, bundle, **kwargs):

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -79,8 +79,9 @@ from corehq.apps.users.models import (
     CommCareUser,
     CouchUser,
     Permissions,
-    UserRole,
-    WebUser, UserRolePresets,
+    SQLUserRole,
+    UserRolePresets,
+    WebUser,
 )
 from corehq.apps.users.role_utils import get_all_role_names_for_domain
 from corehq.apps.users.util import raw_username
@@ -115,9 +116,9 @@ def user_es_call(domain, q, fields, size, start_at):
 
 def _set_role_for_bundle(kwargs, bundle):
     # check for roles associated with the domain
-    domain_roles = UserRole.by_domain_and_name(kwargs['domain'], bundle.data.get('role'))
+    domain_roles = SQLUserRole.objects.by_domain_and_name(kwargs['domain'], bundle.data.get('role'))
     if domain_roles:
-        qualified_role_id = domain_roles[0].get_qualified_id()
+        qualified_role_id = domain_roles[0].get_qualified_id()  # roles may not be unique by name
         bundle.obj.set_role(kwargs['domain'], qualified_role_id)
     else:
         # check for preset roles and now create them for the domain

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -80,7 +80,7 @@ from corehq.apps.users.models import (
     CouchUser,
     Permissions,
     UserRole,
-    WebUser,
+    WebUser, UserRolePresets,
 )
 from corehq.apps.users.role_utils import get_all_role_names_for_domain
 from corehq.apps.users.util import raw_username
@@ -121,7 +121,7 @@ def _set_role_for_bundle(kwargs, bundle):
         bundle.obj.set_role(kwargs['domain'], qualified_role_id)
     else:
         # check for preset roles and now create them for the domain
-        preset_role_id = UserRole.get_preset_role_id(bundle.data.get('role'))
+        preset_role_id = UserRolePresets.get_preset_role_id(bundle.data.get('role'))
         if preset_role_id:
             bundle.obj.set_role(kwargs['domain'], preset_role_id)
 

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -326,7 +326,7 @@ class WebUserResource(v0_1.WebUserResource):
                 if not details.get('role', None):
                     raise BadRequest("Please assign role for non admin user")
                 elif self._invalid_user_role(request, details):
-                    raise BadRequest("Invalid User Role %s" % details.get('role', None))
+                    raise BadRequest(f"Invalid User Role '{details.get('role')}'")
 
         return super(WebUserResource, self).dispatch(request_type, request, **kwargs)
 

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -253,7 +253,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
                     should_save = True
         return should_save
 
-    def obj_create(self, bundle, request=None, **kwargs):
+    def obj_create(self, bundle, **kwargs):
         try:
             bundle.obj = CommCareUser.create(
                 domain=kwargs['domain'],
@@ -351,7 +351,7 @@ class WebUserResource(v0_1.WebUserResource):
                     should_save = True
         return should_save
 
-    def obj_create(self, bundle, request=None, **kwargs):
+    def obj_create(self, bundle, **kwargs):
         self._validate(bundle)
         try:
             self._meta.domain = kwargs['domain']

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -21,6 +21,7 @@ from corehq.apps.users.models import (
     UserRole,
     WebUser,
 )
+from corehq.apps.users.role_utils import init_domain_with_presets
 from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
 from corehq.elastic import send_to_elasticsearch
 from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
@@ -273,6 +274,11 @@ class TestWebUserResource(APIResourceTest):
         ],
         "role": "Admin"
     }
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        init_domain_with_presets(cls.domain.name)
 
     def _check_user_data(self, user, json_user):
         self.assertEqual(user._id, json_user['id'])

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -417,7 +417,7 @@ class TestWebUserResource(APIResourceTest):
                                                    content_type='application/json',
                                                    failure_code=400)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content.decode('utf-8'), '{"error": "Invalid User Role Jack of all trades"}')
+        self.assertEqual(response.content.decode('utf-8'), '{"error": "Invalid User Role \'Jack of all trades\'"}')
 
     def test_create_with_missing_non_admin_role(self):
         user_json = deepcopy(self.default_user_json)

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -412,10 +412,7 @@ class TestWebUserResource(APIResourceTest):
         user_json = deepcopy(self.default_user_json)
         user_json['is_admin'] = False
         user_json["role"] = 'Jack of all trades'
-        response = self._assert_auth_post_resource(self.list_endpoint,
-                                                   json.dumps(user_json),
-                                                   content_type='application/json',
-                                                   failure_code=400)
+        response = self._assert_auth_post_resource(self.list_endpoint, json.dumps(user_json))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content.decode('utf-8'), '{"error": "Invalid User Role \'Jack of all trades\'"}')
 

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -401,10 +401,7 @@ class TestWebUserResource(APIResourceTest):
     def test_create_with_invalid_admin_role(self):
         user_json = deepcopy(self.default_user_json)
         user_json["role"] = 'Jack of all trades'
-        response = self._assert_auth_post_resource(self.list_endpoint,
-                                                   json.dumps(user_json),
-                                                   content_type='application/json',
-                                                   failure_code=400)
+        response = self._assert_auth_post_resource(self.list_endpoint, json.dumps(user_json))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content.decode('utf-8'), '{"error": "An admin can have only one role : Admin"}')
 
@@ -420,10 +417,7 @@ class TestWebUserResource(APIResourceTest):
         user_json = deepcopy(self.default_user_json)
         user_json['is_admin'] = False
         user_json.pop("role")
-        response = self._assert_auth_post_resource(self.list_endpoint,
-                                                   json.dumps(user_json),
-                                                   content_type='application/json',
-                                                   failure_code=400)
+        response = self._assert_auth_post_resource(self.list_endpoint, json.dumps(user_json))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content.decode('utf-8'), '{"error": "Please assign role for non admin user"}')
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1175,7 +1175,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             user = self.get_django_user()
             user.delete()
             if deleted_by:
-                log_model_change(user, deleted_by, message=f"deleted_via: {deleted_via}",
+                log_model_change(deleted_by, user, message=f"deleted_via: {deleted_via}",
                                  action=ModelAction.DELETE)
         except User.DoesNotExist:
             pass

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -380,10 +380,6 @@ class UserRole(SyncCouchToSQLMixin, QuickCachedDocumentMixin, Document):
         role.save()
         return role
 
-    @classmethod
-    def get_preset_role_id(cls, name):
-        return UserRolePresets.get_preset_role_id(name)
-
     @property
     def has_users_assigned(self):
         from corehq.apps.es.users import UserES

--- a/corehq/apps/users/models_sql.py
+++ b/corehq/apps/users/models_sql.py
@@ -46,6 +46,10 @@ class StaticRole:
 
 class UserRoleManager(models.Manager):
 
+    def by_domain_and_name(self, domain, name):
+        # name is not unique so return all results
+        return list(self.filter(domain=domain, name=name))
+
     def by_couch_id(self, couch_id):
         return SQLUserRole.objects.get(couch_id=couch_id)
 

--- a/corehq/apps/users/role_utils.py
+++ b/corehq/apps/users/role_utils.py
@@ -52,7 +52,3 @@ def init_domain_with_presets(domain):
         get_or_create_role_with_permissions(
             domain, role_name, UserRolePresets.get_permissions(role_name)
         )
-
-
-def get_all_role_names_for_domain(domain_name):
-    return set([role.name for role in UserRole.by_domain(domain_name)])

--- a/corehq/apps/users/role_utils.py
+++ b/corehq/apps/users/role_utils.py
@@ -55,6 +55,4 @@ def init_domain_with_presets(domain):
 
 
 def get_all_role_names_for_domain(domain_name):
-    presets = set(UserRolePresets.NAME_ID_MAP.keys())
-    custom = set([role.name for role in UserRole.by_domain(domain_name)])
-    return presets | custom
+    return set([role.name for role in UserRole.by_domain(domain_name)])


### PR DESCRIPTION
## Summary
This ended up being much more refactoring than I had anticipated.

When I started looking at the code I found it was doing a number of things that were not great:
* validating roles against a static list instead of what's in the DB
* doing validation prior to doing permissions checks
* broken error handling

Thankfully the test coverage is quite good so I was able to refactor this in safety.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Existing

### Safety story
Changes to WebUser create / update API that are well tested in code.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
