### PR TITLE
remove ES_ENV_SETTINGS from HQ

### DIFF
--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -26,16 +26,6 @@ ANALYZERS = {
     }
 }
 
-REMOVE_SETTING = None
-
-ES_ENV_SETTINGS = {
-    'icds': {
-        'hqusers': {
-            "number_of_replicas": 1,
-        },
-    },
-}
-
 XFORM_HQ_INDEX_NAME = "xforms"
 CASE_HQ_INDEX_NAME = "hqcases"
 USER_HQ_INDEX_NAME = "hqusers"
@@ -102,15 +92,9 @@ class ElasticsearchIndexInfo(jsonobject.JsonObject):
             ES_INDEX_SETTINGS.get(settings.SERVER_ENVIRONMENT, {}).get(self.hq_index_name, {})
         )
 
-        overrides = copy(ES_ENV_SETTINGS)
         if settings.ES_SETTINGS is not None:
-            overrides.update({settings.SERVER_ENVIRONMENT: settings.ES_SETTINGS})
-
-        for hq_index_name in ['default', self.hq_index_name]:
-            for key, value in overrides.get(settings.SERVER_ENVIRONMENT, {}).get(hq_index_name, {}).items():
-                if value is REMOVE_SETTING:
-                    del meta_settings['settings'][key]
-                else:
+            for hq_index_name in ['default', self.hq_index_name]:
+                for key, value in settings.ES_SETTINGS.get(hq_index_name, {}).items():
                     meta_settings['settings'][key] = value
 
         return meta_settings

--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -71,6 +71,10 @@ ES_INDEX_SETTINGS = {
     },
 }
 
+# Allow removing settings from defaults by setting
+# the value to None in settings.ES_SETTINGS
+REMOVE_SETTING = None
+
 
 class ElasticsearchIndexInfo(jsonobject.JsonObject):
     index = jsonobject.StringProperty(required=True)
@@ -95,7 +99,10 @@ class ElasticsearchIndexInfo(jsonobject.JsonObject):
         if settings.ES_SETTINGS is not None:
             for hq_index_name in ['default', self.hq_index_name]:
                 for key, value in settings.ES_SETTINGS.get(hq_index_name, {}).items():
-                    meta_settings['settings'][key] = value
+                    if value is REMOVE_SETTING:
+                        del meta_settings['settings'][key]
+                    else:
+                        meta_settings['settings'][key] = value
 
         return meta_settings
 


### PR DESCRIPTION
## Summary
commcare-cloud always sets localsettings.ES_SETTINGS so the values hard coded
here always get overridden.

You can still set env specific settings in the `ES_INDEX_SETTINGS` dict. These will get overridden by values from localsettings if they exist.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
