### PR TITLE
Drop WeasyPrint

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -51,7 +51,7 @@ Save those backups to somewhere you'll be able to access from the new environmen
 
 - Requirements of Python libraries, if they aren't already installed.
 
-      $ sudo apt install libpango1.0-0 libncurses-dev libxml2-dev libxmlsec1-dev libxmlsec1-openssl libxslt1-dev libpq-dev pkg-config
+      $ sudo apt install libncurses-dev libxml2-dev libxmlsec1-dev libxmlsec1-openssl libxslt1-dev libpq-dev pkg-config
 
 
 ##### macOS Notes
@@ -68,7 +68,6 @@ Save those backups to somewhere you'll be able to access from the new environmen
 - Additional requirements:
   - [Homebrew](https://brew.sh)
   - [libmagic](https://macappstore.org/libmagic) (available via homebrew)
-  - [pango](https://www.pango.org/) (available via homebrew)
   - libxmlsec1 (install with homebrew)
 
   

--- a/custom/apps/crs_reports/views.py
+++ b/custom/apps/crs_reports/views.py
@@ -12,7 +12,6 @@ from casexml.apps.case.templatetags.case_tags import case_inline_display
 from corehq.apps.users.models import CommCareUser
 from django.template.loader import get_template
 from django.http import HttpResponse
-# import weasyprint
 from custom.apps.crs_reports import MOTHER_POSTPARTUM_VISIT_FORM_XMLNS, BABY_POSTPARTUM_VISIT_FORM_XMLNS
 
 

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -116,7 +116,6 @@ tinys3==0.1.12
 tropo-webapi-python==0.1.3
 turn-python==0.0.1
 twilio==6.5.1
-WeasyPrint==51
 werkzeug==1.0.1
 xlrd==1.0.0
 xlwt==1.3.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -34,12 +34,6 @@ botocore==1.18.12
     # via
     #   boto3
     #   s3transfer
-cairocffi==1.1.0
-    # via
-    #   cairosvg
-    #   weasyprint
-cairosvg==2.5.1
-    # via weasyprint
 https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
     # via
     #   -r base-requirements.in
@@ -51,10 +45,8 @@ certifi==2020.6.20
     #   sentry-sdk
 cffi==1.14.3
     # via
-    #   cairocffi
     #   cryptography
     #   csiphash
-    #   weasyprint
 chardet==3.0.4
     # via
     #   ghdiff
@@ -85,10 +77,6 @@ cryptography==3.4.7
     #   pyopenssl
 csiphash==0.0.5
     # via -r base-requirements.in
-cssselect2==0.3.0
-    # via
-    #   cairosvg
-    #   weasyprint
 datadog==0.39.0
     # via -r base-requirements.in
 ddtrace==0.44.0
@@ -103,7 +91,6 @@ decorator==4.0.11
 defusedxml==0.5.0
     # via
     #   -r base-requirements.in
-    #   cairosvg
     #   python3-saml
 deprecated==1.2.10
     # via pygithub
@@ -272,8 +259,6 @@ gunicorn==20.0.4
     # via -r base-requirements.in
 hiredis==1.1.0
     # via -r base-requirements.in
-html5lib==1.1
-    # via weasyprint
 httpagentparser==1.9.0
     # via -r base-requirements.in
 idna==2.10
@@ -392,7 +377,6 @@ pickleshare==0.7.5
 pillow==8.1.2
     # via
     #   -r base-requirements.in
-    #   cairosvg
     #   django-simple-captcha
     #   reportlab
 pip-tools==6.1.0
@@ -449,8 +433,6 @@ pyopenssl==20.0.1
     # via -r sso-requirements.in
 pyparsing==2.4.7
     # via packaging
-pyphen==0.9.5
-    # via weasyprint
 pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
@@ -566,7 +548,6 @@ six==1.15.0
     #   eulxml
     #   fixture
     #   ghdiff
-    #   html5lib
     #   isodate
     #   jsonfield
     #   jsonobject
@@ -648,11 +629,6 @@ text-unidecode==1.3
     #   -r base-requirements.in
     #   faker
     #   python-slugify
-tinycss2==1.0.2
-    # via
-    #   cairosvg
-    #   cssselect2
-    #   weasyprint
 tinys3==0.1.12
     # via -r base-requirements.in
 toml==0.10.2
@@ -685,13 +661,6 @@ vine==1.3.0
     # via amqp
 wcwidth==0.2.5
     # via prompt-toolkit
-weasyprint==51
-    # via -r base-requirements.in
-webencodings==0.5.1
-    # via
-    #   cssselect2
-    #   html5lib
-    #   tinycss2
 werkzeug==1.0.1
     # via -r base-requirements.in
 wheel==0.36.2
@@ -716,8 +685,6 @@ pip==21.1.1
     # via pip-tools
 setuptools==50.3.0
     # via
-    #   cairocffi
-    #   cssselect2
     #   django-websocket-redis
     #   gunicorn
     #   ipython
@@ -726,5 +693,3 @@ setuptools==50.3.0
     #   python-levenshtein
     #   python-termstyle
     #   sphinx
-    #   tinycss2
-    #   weasyprint

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -30,12 +30,6 @@ botocore==1.18.12
     # via
     #   boto3
     #   s3transfer
-cairocffi==1.1.0
-    # via
-    #   cairosvg
-    #   weasyprint
-cairosvg==2.5.1
-    # via weasyprint
 https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
     # via
     #   -r base-requirements.in
@@ -47,10 +41,8 @@ certifi==2020.6.20
     #   sentry-sdk
 cffi==1.14.3
     # via
-    #   cairocffi
     #   cryptography
     #   csiphash
-    #   weasyprint
 chardet==3.0.4
     # via
     #   ghdiff
@@ -69,10 +61,6 @@ cryptography==3.4.7
     # via jwcrypto
 csiphash==0.0.5
     # via -r base-requirements.in
-cssselect2==0.3.0
-    # via
-    #   cairosvg
-    #   weasyprint
 datadog==0.39.0
     # via -r base-requirements.in
 ddtrace==0.44.0
@@ -83,9 +71,7 @@ decorator==4.0.11
     #   datadog
     #   jsonpath-ng
 defusedxml==0.5.0
-    # via
-    #   -r base-requirements.in
-    #   cairosvg
+    # via -r base-requirements.in
 deprecated==1.2.10
     # via pygithub
 diff-match-patch==20200713
@@ -224,8 +210,6 @@ gunicorn==20.0.4
     # via -r base-requirements.in
 hiredis==1.1.0
     # via -r base-requirements.in
-html5lib==1.1
-    # via weasyprint
 httpagentparser==1.9.0
     # via -r base-requirements.in
 idna==2.10
@@ -309,7 +293,6 @@ phonenumberslite==8.12.10
 pillow==8.1.2
     # via
     #   -r base-requirements.in
-    #   cairosvg
     #   django-simple-captcha
     #   reportlab
 ply==3.11
@@ -349,8 +332,6 @@ pyjwt==1.7.1
     #   twilio
 pyparsing==2.4.7
     # via packaging
-pyphen==0.9.5
-    # via weasyprint
 pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
@@ -448,7 +429,6 @@ six==1.15.0
     #   ethiopian-date-converter
     #   eulxml
     #   ghdiff
-    #   html5lib
     #   jsonfield
     #   jsonobject
     #   jsonobject-couchdbkit
@@ -510,11 +490,6 @@ text-unidecode==1.3
     # via
     #   -r base-requirements.in
     #   faker
-tinycss2==1.0.2
-    # via
-    #   cairosvg
-    #   cssselect2
-    #   weasyprint
 tinys3==0.1.12
     # via -r base-requirements.in
 tropo-webapi-python==0.1.3
@@ -540,13 +515,6 @@ user-agents==2.2.0
     # via django-user-agents
 vine==1.3.0
     # via amqp
-weasyprint==51
-    # via -r base-requirements.in
-webencodings==0.5.1
-    # via
-    #   cssselect2
-    #   html5lib
-    #   tinycss2
 werkzeug==1.0.1
     # via -r base-requirements.in
 wrapt==1.12.1
@@ -561,13 +529,9 @@ zipp==3.4.0
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==53.0.0
     # via
-    #   cairocffi
-    #   cssselect2
     #   django-websocket-redis
     #   gunicorn
     #   jsonschema
     #   protobuf
     #   python-levenshtein
     #   sphinx
-    #   tinycss2
-    #   weasyprint

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -30,12 +30,6 @@ botocore==1.18.12
     # via
     #   boto3
     #   s3transfer
-cairocffi==1.1.0
-    # via
-    #   cairosvg
-    #   weasyprint
-cairosvg==2.5.1
-    # via weasyprint
 https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
     # via
     #   -r base-requirements.in
@@ -49,10 +43,8 @@ certifi==2020.6.20
     #   sentry-sdk
 cffi==1.14.3
     # via
-    #   cairocffi
     #   cryptography
     #   csiphash
-    #   weasyprint
 chardet==3.0.4
     # via
     #   ghdiff
@@ -72,10 +64,6 @@ cryptography==3.4.7
     #   pyopenssl
 csiphash==0.0.5
     # via -r base-requirements.in
-cssselect2==0.3.0
-    # via
-    #   cairosvg
-    #   weasyprint
 datadog==0.39.0
     # via -r base-requirements.in
 ddtrace==0.44.0
@@ -90,7 +78,6 @@ decorator==4.0.11
 defusedxml==0.5.0
     # via
     #   -r base-requirements.in
-    #   cairosvg
     #   python3-saml
 deprecated==1.2.10
     # via pygithub
@@ -223,8 +210,6 @@ gunicorn==20.0.4
     # via -r base-requirements.in
 hiredis==1.1.0
     # via -r base-requirements.in
-html5lib==1.1
-    # via weasyprint
 httpagentparser==1.9.0
     # via -r base-requirements.in
 idna==2.10
@@ -320,7 +305,6 @@ pickleshare==0.7.5
 pillow==8.1.2
     # via
     #   -r base-requirements.in
-    #   cairosvg
     #   django-simple-captcha
     #   reportlab
 ply==3.11
@@ -371,8 +355,6 @@ pyopenssl==20.0.1
     #   -r prod-requirements.in
     #   -r sso-requirements.in
     #   ndg-httpsclient
-pyphen==0.9.5
-    # via weasyprint
 pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
@@ -472,7 +454,6 @@ six==1.15.0
     #   ethiopian-date-converter
     #   eulxml
     #   ghdiff
-    #   html5lib
     #   isodate
     #   jsonfield
     #   jsonobject
@@ -514,11 +495,6 @@ text-unidecode==1.3
     # via
     #   -r base-requirements.in
     #   faker
-tinycss2==1.0.2
-    # via
-    #   cairosvg
-    #   cssselect2
-    #   weasyprint
 tinys3==0.1.12
     # via -r base-requirements.in
 tornado==4.5.3
@@ -554,13 +530,6 @@ vine==1.3.0
     # via amqp
 wcwidth==0.2.5
     # via prompt-toolkit
-weasyprint==51
-    # via -r base-requirements.in
-webencodings==0.5.1
-    # via
-    #   cssselect2
-    #   html5lib
-    #   tinycss2
 werkzeug==1.0.1
     # via -r base-requirements.in
 wrapt==1.12.1
@@ -579,13 +548,9 @@ pip==21.1.1
     # via -r prod-requirements.in
 setuptools==50.3.0
     # via
-    #   cairocffi
-    #   cssselect2
     #   django-websocket-redis
     #   gunicorn
     #   ipython
     #   jsonschema
     #   protobuf
     #   python-levenshtein
-    #   tinycss2
-    #   weasyprint

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -26,12 +26,6 @@ botocore==1.18.12
     # via
     #   boto3
     #   s3transfer
-cairocffi==1.1.0
-    # via
-    #   cairosvg
-    #   weasyprint
-cairosvg==2.5.1
-    # via weasyprint
 https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
     # via
     #   -r base-requirements.in
@@ -43,10 +37,8 @@ certifi==2020.6.20
     #   sentry-sdk
 cffi==1.14.3
     # via
-    #   cairocffi
     #   cryptography
     #   csiphash
-    #   weasyprint
 chardet==3.0.4
     # via
     #   ghdiff
@@ -65,10 +57,6 @@ cryptography==3.4.7
     #   pyopenssl
 csiphash==0.0.5
     # via -r base-requirements.in
-cssselect2==0.3.0
-    # via
-    #   cairosvg
-    #   weasyprint
 datadog==0.39.0
     # via -r base-requirements.in
 ddtrace==0.44.0
@@ -81,7 +69,6 @@ decorator==4.0.11
 defusedxml==0.5.0
     # via
     #   -r base-requirements.in
-    #   cairosvg
     #   python3-saml
 deprecated==1.2.10
     # via pygithub
@@ -212,8 +199,6 @@ gunicorn==20.0.4
     # via -r base-requirements.in
 hiredis==1.1.0
     # via -r base-requirements.in
-html5lib==1.1
-    # via weasyprint
 httpagentparser==1.9.0
     # via -r base-requirements.in
 idna==2.10
@@ -294,7 +279,6 @@ phonenumberslite==8.12.10
 pillow==8.1.2
     # via
     #   -r base-requirements.in
-    #   cairosvg
     #   django-simple-captcha
     #   reportlab
 ply==3.11
@@ -333,8 +317,6 @@ pyjwt==1.7.1
     #   twilio
 pyopenssl==20.0.1
     # via -r sso-requirements.in
-pyphen==0.9.5
-    # via weasyprint
 pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
@@ -431,7 +413,6 @@ six==1.15.0
     #   ethiopian-date-converter
     #   eulxml
     #   ghdiff
-    #   html5lib
     #   isodate
     #   jsonfield
     #   jsonobject
@@ -472,11 +453,6 @@ text-unidecode==1.3
     # via
     #   -r base-requirements.in
     #   faker
-tinycss2==1.0.2
-    # via
-    #   cairosvg
-    #   cssselect2
-    #   weasyprint
 tinys3==0.1.12
     # via -r base-requirements.in
 tropo-webapi-python==0.1.3
@@ -502,13 +478,6 @@ user-agents==2.2.0
     # via django-user-agents
 vine==1.3.0
     # via amqp
-weasyprint==51
-    # via -r base-requirements.in
-webencodings==0.5.1
-    # via
-    #   cssselect2
-    #   html5lib
-    #   tinycss2
 werkzeug==1.0.1
     # via -r base-requirements.in
 wrapt==1.12.1
@@ -525,12 +494,8 @@ zipp==3.4.0
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==50.3.0
     # via
-    #   cairocffi
-    #   cssselect2
     #   django-websocket-redis
     #   gunicorn
     #   jsonschema
     #   protobuf
     #   python-levenshtein
-    #   tinycss2
-    #   weasyprint

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -28,12 +28,6 @@ botocore==1.18.12
     # via
     #   boto3
     #   s3transfer
-cairocffi==1.1.0
-    # via
-    #   cairosvg
-    #   weasyprint
-cairosvg==2.5.1
-    # via weasyprint
 https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
     # via
     #   -r base-requirements.in
@@ -45,10 +39,8 @@ certifi==2020.6.20
     #   sentry-sdk
 cffi==1.14.3
     # via
-    #   cairocffi
     #   cryptography
     #   csiphash
-    #   weasyprint
 chardet==3.0.4
     # via
     #   ghdiff
@@ -71,10 +63,6 @@ cryptography==3.4.7
     #   pyopenssl
 csiphash==0.0.5
     # via -r base-requirements.in
-cssselect2==0.3.0
-    # via
-    #   cairosvg
-    #   weasyprint
 datadog==0.39.0
     # via -r base-requirements.in
 ddtrace==0.44.0
@@ -87,7 +75,6 @@ decorator==4.0.11
 defusedxml==0.5.0
     # via
     #   -r base-requirements.in
-    #   cairosvg
     #   python3-saml
 deprecated==1.2.10
     # via pygithub
@@ -232,8 +219,6 @@ gunicorn==20.0.4
     # via -r base-requirements.in
 hiredis==1.1.0
     # via -r base-requirements.in
-html5lib==1.1
-    # via weasyprint
 httpagentparser==1.9.0
     # via -r base-requirements.in
 idna==2.10
@@ -330,7 +315,6 @@ phonenumberslite==8.12.10
 pillow==8.1.2
     # via
     #   -r base-requirements.in
-    #   cairosvg
     #   django-simple-captcha
     #   reportlab
 pip-tools==6.1.0
@@ -377,8 +361,6 @@ pyjwt==1.7.1
     #   twilio
 pyopenssl==20.0.1
     # via -r sso-requirements.in
-pyphen==0.9.5
-    # via weasyprint
 pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
@@ -481,7 +463,6 @@ six==1.15.0
     #   ethiopian-date-converter
     #   eulxml
     #   ghdiff
-    #   html5lib
     #   isodate
     #   jsonfield
     #   jsonobject
@@ -532,11 +513,6 @@ text-unidecode==1.3
     # via
     #   -r base-requirements.in
     #   faker
-tinycss2==1.0.2
-    # via
-    #   cairosvg
-    #   cssselect2
-    #   weasyprint
 tinys3==0.1.12
     # via -r base-requirements.in
 toml==0.10.2
@@ -564,13 +540,6 @@ user-agents==2.2.0
     # via django-user-agents
 vine==1.3.0
     # via amqp
-weasyprint==51
-    # via -r base-requirements.in
-webencodings==0.5.1
-    # via
-    #   cssselect2
-    #   html5lib
-    #   tinycss2
 werkzeug==1.0.1
     # via -r base-requirements.in
 wrapt==1.12.1
@@ -591,12 +560,8 @@ pip==21.1.1
     # via pip-tools
 setuptools==50.3.0
     # via
-    #   cairocffi
-    #   cssselect2
     #   django-websocket-redis
     #   gunicorn
     #   jsonschema
     #   protobuf
     #   python-levenshtein
-    #   tinycss2
-    #   weasyprint


### PR DESCRIPTION
## Summary

Remove `WeasyPrint` library from base-requirements.in.  Library seems unused ever since 0b31cff18856e312333f4586fe66fbc0e90dd372.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan

No QA.

### Safety story

All removed libraries (inventory and dependents) are not used anywhere in the codebase.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
