### PR TITLE
Clear cache when set_toggle is called

### DIFF
--- a/corehq/apps/toggle_ui/tests.py
+++ b/corehq/apps/toggle_ui/tests.py
@@ -1,12 +1,14 @@
 import uuid
 from decimal import Decimal
+from mock import patch
 
-from django.test import TestCase
+from django.test import TestCase, SimpleTestCase
 
 from couchdbkit import ResourceNotFound
 
 from corehq.apps.toggle_ui.models import ToggleAudit
-from corehq.toggles import NAMESPACE_USER, NAMESPACE_DOMAIN
+from corehq.apps.toggle_ui.views import _clear_cache_for_toggle
+from corehq.toggles import NAMESPACE_USER, NAMESPACE_DOMAIN, NAMESPACE_OTHER, NAMESPACE_EMAIL_DOMAIN
 from toggle.models import Toggle
 
 from corehq.apps.toggle_ui.migration_helpers import move_toggles
@@ -86,3 +88,38 @@ class TestToggleAudit(TestCase):
         self.assertEqual(1, len(randomness))
         self.assertEqual(randomness[0].username, "username1")
         self.assertAlmostEqual(randomness[0].randomness, Decimal(0.001))
+
+
+class TestClearCacheForToggle(SimpleTestCase):
+
+    def test_clear_cache_for_domain_namespace(self):
+        with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock,\
+             patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock:
+            _clear_cache_for_toggle(NAMESPACE_DOMAIN, 'test-domain')
+            self.assertEqual(1, domain_mock.call_count)
+            self.assertEqual(0, user_mock.call_count)
+
+    def test_clear_cache_for_user_namespace(self):
+        with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock,\
+             patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock:
+            _clear_cache_for_toggle(NAMESPACE_USER, 'testuser')
+            self.assertEqual(0, domain_mock.call_count)
+            self.assertEqual(1, user_mock.call_count)
+
+    def test_clear_cache_for_other_namespace(self):
+        with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock,\
+             patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock:
+            _clear_cache_for_toggle(NAMESPACE_OTHER, 'testother')
+            self.assertEqual(0, domain_mock.call_count)
+            self.assertEqual(1, user_mock.call_count)
+
+    def test_clear_cache_for_email_namespace(self):
+        with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock,\
+             patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock:
+            _clear_cache_for_toggle(NAMESPACE_EMAIL_DOMAIN, 'testemaildomain')
+            self.assertEqual(0, domain_mock.call_count)
+            self.assertEqual(0, user_mock.call_count)
+
+    def test_clear_cache_raises_exception_for_colon_in_non_domain_namespaces(self):
+        with self.assertRaises(AssertionError):
+            _clear_cache_for_toggle(NAMESPACE_USER, 'testuser:test')

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -351,11 +351,10 @@ def set_toggle(request, toggle_slug):
     item = request.POST['item']
     enabled = request.POST['enabled'] == 'true'
     namespace = request.POST['namespace']
-    namespaced_entry = namespaced_item(item, namespace)
     if static_toggle.set(item=item, enabled=enabled, namespace=namespace):
         action = ToggleAudit.ACTION_ADD if enabled else ToggleAudit.ACTION_REMOVE
         ToggleAudit.objects.log_toggle_action(
-            toggle_slug, request.user.username, [namespaced_entry], action
+            toggle_slug, request.user.username, [namespaced_item(item, namespace)], action
         )
 
     if enabled:

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -243,16 +243,26 @@ def _call_save_fn_and_clear_cache(static_toggle, previously_enabled, currently_e
     for entry in changed_entries:
         enabled = entry in currently_enabled
         namespace, entry = parse_toggle(entry)
-        if namespace == NAMESPACE_DOMAIN:
-            domain = entry
-            if static_toggle.save_fn is not None:
-                static_toggle.save_fn(domain, enabled)
-            toggles_enabled_for_domain.clear(domain)
-        elif namespace != NAMESPACE_EMAIL_DOMAIN:
-            # these are sent down with no namespace
-            assert ':' not in entry, entry
-            username = entry
-            toggles_enabled_for_user.clear(username)
+        _call_save_fn_for_toggle(static_toggle, namespace, entry, enabled)
+        _clear_cache_for_toggle(namespace, entry)
+
+
+def _call_save_fn_for_toggle(static_toggle, namespace, entry, enabled):
+    if namespace == NAMESPACE_DOMAIN:
+        domain = entry
+        if static_toggle.save_fn is not None:
+            static_toggle.save_fn(domain, enabled)
+
+
+def _clear_cache_for_toggle(namespace, entry):
+    if namespace == NAMESPACE_DOMAIN:
+        domain = entry
+        toggles_enabled_for_domain.clear(domain)
+    elif namespace != NAMESPACE_EMAIL_DOMAIN:
+        # these are sent down with no namespace
+        assert ':' not in entry, entry
+        username = entry
+        toggles_enabled_for_user.clear(username)
 
 
 def _clear_caches_for_dynamic_toggle(static_toggle):
@@ -351,8 +361,6 @@ def set_toggle(request, toggle_slug):
     if enabled:
         _notify_on_change(static_toggle, [item], request.user.username)
 
-    currently_enabled = {namespaced_entry} if enabled else set()
-    previously_enabled = set() if enabled else {namespaced_entry}
-    _call_save_fn_and_clear_cache(static_toggle, previously_enabled, currently_enabled)
+    _clear_cache_for_toggle(namespace, item)
 
     return HttpResponse(json.dumps({'success': True}), content_type="application/json")


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Noticed while working on [this ticket](https://dimagi-dev.atlassian.net/browse/SAAS-12284).

Currently, the POST called from the [toggles UI](https://github.com/dimagi/commcare-hq/blob/31a966efd995bcb20ab5cc1d1a0ce2f0e4ca3bd5/corehq/apps/domain/static/domain/js/toggles.js#L52) when updating a feature flag does not clear cache. 

I separated the clear cache and save functionality into separate methods to ease in reuse without calling save multiple times (see commit by commit to better understand what I mean). 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests around clearing cache, but not around the larger `_call_save_fn_and_clear_cache` method. 
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None needed.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested. The intention of this PR is to add "one line" to clear cache on a method after a toggle is updated.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
