### PR TITLE
Removed ES6 from login.js

### DIFF
--- a/corehq/apps/registration/static/registration/js/login.js
+++ b/corehq/apps/registration/static/registration/js/login.js
@@ -21,8 +21,8 @@ hqDefine('registration/js/login', [
         });
 
         // populate username field if set in the query string
-        const urlParams = new URLSearchParams(window.location.search);
-        const username = urlParams.get('username');
+        var urlParams = new URLSearchParams(window.location.search);
+        var username = urlParams.get('username');
         if (username) {
             var usernameElt = document.getElementById('id_auth-username');
             if (usernameElt) {
@@ -31,8 +31,8 @@ hqDefine('registration/js/login', [
         }
 
         if (initialPageData.get('enforce_sso_login')) {
-            let $passwordField = $('#id_auth-password');
-            let loginController = userLoginForm.loginController({
+            var $passwordField = $('#id_auth-password');
+            var loginController = userLoginForm.loginController({
                 initialUsername: $('#id_auth-username').val(),
                 passwordField: $passwordField,
                 passwordFormGroup: $passwordField.closest('.form-group'),


### PR DESCRIPTION
## Summary

This code isn't getting minified because the uglifier can't handle ES6.

It might not be a big deal to update the build process to accept ES6, I added it to the js pod agenda doc.

```
[185.19.29.53] out: Uglify file: /home/cchq/www/swiss/releases/2021-06-01_14.42/staticfiles/users/js/bundle.js
[185.19.29.53] out: Error: Cannot uglify file: /home/cchq/www/swiss/releases/2021-06-01_14.42/staticfiles/users/js/bundle.js. Skipping it. Error is:
[185.19.29.53] out: SyntaxError: Unexpected token: name (loginController)
[185.19.29.53] out:
[185.19.29.53] out: If the source uses ES2015 or later syntax, please pass "optimize: 'none'" to r.js and use an ES2015+ compatible minifier after running r.js. The included UglifyJS only un
derstands ES5 or earlier syntax.
```

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None?

### QA Plan

Not requesting QA.

### Safety story
Registration UI is risky, but this is a very straightforward change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
