### PR TITLE
Add mobile UCRs for remote linked project spaces

### DIFF
--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -352,12 +352,12 @@ def update_linked_app(app, master_app_id_or_build, user_id):
     ):
         old_multimedia_ids = set([media_info.multimedia_id for path, media_info in app.multimedia_map.items()])
         report_map = get_static_report_mapping(master_build.domain, app['domain'])
-        if not app.domain_link.is_remote:
-            report_map.update({
-                c.report_meta.master_id: c._id
-                for c in get_report_configs_for_domain(app.domain)
-                if c.report_meta.master_id
-            })
+
+        report_map.update({
+            c.report_meta.master_id: c._id
+            for c in get_report_configs_for_domain(app.domain)
+            if c.report_meta.master_id
+        })
 
         try:
             app = overwrite_app(app, master_build, report_map)
@@ -365,7 +365,8 @@ def update_linked_app(app, master_app_id_or_build, user_id):
             raise AppLinkError(
                 _(
                     'This application uses mobile UCRs '
-                    'which are not available in the linked domain: {ucr_id}'
+                    'which are not available in the linked domain: {ucr_id}. '
+                    'Try linking these reports first and try again.'
                 ).format(ucr_id=str(e))
             )
 

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -7,7 +7,7 @@ from couchdbkit.exceptions import ResourceNotFound
 from lxml import etree
 from mock import patch
 
-from corehq.apps.app_manager.exceptions import AppEditingError
+from corehq.apps.app_manager.exceptions import AppEditingError, AppLinkError
 from corehq.apps.app_manager.models import (
     Application,
     LinkedApplication,
@@ -138,6 +138,17 @@ class TestLinkedApps(BaseLinkedAppsTest):
 
     def test_linked_reports_updated(self):
         # add a report on the master app
+        master_report, master_data_source = self._create_report_and_datasource()
+
+        # link report on master app to linked domain
+        link_info = create_linked_ucr(self.domain_link, master_report.get_id)
+
+        updated_app = update_linked_app(self.linked_app, self.master1, 'a-user-id')
+
+        # report config added with the linked report id updated in report config
+        self.assertEqual(updated_app.modules[0].report_configs[0].report_id, link_info.report.get_id)
+
+    def _create_report_and_datasource(self):
         master_data_source = get_sample_data_source()
         master_data_source.domain = self.domain
         master_data_source.save()
@@ -151,23 +162,30 @@ class TestLinkedApps(BaseLinkedAppsTest):
         master_reports_module.report_configs = [
             ReportAppConfig(report_id=master_report.get_id, header={'en': 'CommBugz'}),
         ]
+        return master_report, master_data_source
 
-        # link report on master app to linked domain
-        link_info = create_linked_ucr(self.domain_link, master_report.get_id)
-
-        updated_app = update_linked_app(self.linked_app, self.master1, 'a-user-id')
-
-        # report config added with the linked report id updated in report config
-        self.assertEqual(updated_app.modules[0].report_configs[0].report_id, link_info.report.get_id)
-
-    @patch('corehq.apps.app_manager.views.utils.get_report_configs_for_domain')
-    def test_linked_reports_not_updated_for_remote(self, get_report_configs_for_domain):
+    @patch('corehq.apps.linked_domain.ucr.remote_get_ucr_config')
+    def test_linked_reports_updated_for_remote(self, fake_ucr_getter):
         old_remote_base_url = self.domain_link.remote_base_url
         self.domain_link.remote_base_url = "http://my/app"
         self.domain_link.save()
 
-        update_linked_app(self.linked_app, self.master1, 'TestLinkedApps user')
-        get_report_configs_for_domain.assert_not_called()
+        master_report, master_data_source = self._create_report_and_datasource()
+
+        # Update app before linking report, should throw an error
+        with self.assertRaises(AppLinkError):
+            updated_app = update_linked_app(self.linked_app, self.master1, 'a-user-id')
+
+        # Link report, then pull app
+        fake_ucr_getter.return_value = {
+            "report": master_report,
+            "datasource": master_data_source,
+        }
+        link_info = create_linked_ucr(self.domain_link, master_report.get_id)
+        updated_app = update_linked_app(self.linked_app, self.master1, 'a-user-id')
+
+        # report config added with the linked report id updated in report config
+        self.assertEqual(updated_app.modules[0].report_configs[0].report_id, link_info.report.get_id)
 
         # reset for other tests
         self.domain_link.remote_base_url = old_remote_base_url

--- a/corehq/apps/linked_domain/tests/test_linked_userreports.py
+++ b/corehq/apps/linked_domain/tests/test_linked_userreports.py
@@ -132,23 +132,11 @@ class TestLinkedUCR(BaseLinkedAppsTest):
 
     @patch('corehq.apps.linked_domain.ucr.remote_get_ucr_config')
     def test_remote_link_ucr(self, fake_ucr_getter):
-        create_domain(self.domain)
-        self.addCleanup(delete_all_domains)
 
-        couch_user = WebUser.create(self.domain, "test", "foobar", None, None)
-        django_user = couch_user.get_django_user()
-        self.addCleanup(delete_all_users)
-
-        api_key, _ = HQApiKey.objects.get_or_create(user=django_user)
-        auth_headers = {'HTTP_AUTHORIZATION': 'apikey test:%s' % api_key.key}
-        self.domain_link.save()
-
-        url = reverse('linked_domain:ucr_config', args=[self.domain, self.report.get_id])
-        headers = auth_headers.copy()
-        headers[REMOTE_REQUESTER_HEADER] = self.domain_link.linked_domain
-        resp = self.client.get(url, **headers)
-
-        fake_ucr_getter.return_value = json.loads(resp.content)
+        fake_ucr_getter.return_value = {
+            "report": self.report,
+            "datasource": self.data_source,
+        }
 
         # Create
         linked_report_info = create_linked_ucr(self.domain_link, self.report.get_id)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SC-1474
I believe this should just work if the reports exist downstream, not sure why this was left out originally - @mkangia was this just because it was out of scope for what you were working on?

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Linked project spaces, mobile ucr

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
