### PR TITLE
Remove modernize

### DIFF
--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -7,7 +7,6 @@ django-extensions
 ipython==7.16.1
 wheel==0.36.2
 transifex-client==0.14.2
-modernize
 gnureadline==8.0.0
 git-build-branch
 

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -342,8 +342,6 @@ mccabe==0.6.1
     # via flake8
 mock==2.0.0
     # via -r base-requirements.in
-modernize==0.7
-    # via -r dev-requirements.in
 nose-exclude==0.5.0
     # via -r test-requirements.in
 nose==1.3.7


### PR DESCRIPTION
Remove dev requirement that is no longer needed since we're on Python 3.

Doing this instead of https://github.com/dimagi/commcare-hq/pull/29839

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
