### PR TITLE
Updated nodeset child case type dropdown to clear custom expression o…

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/detail_tab_nodeset.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/detail_tab_nodeset.js
@@ -35,6 +35,7 @@ hqDefine('app_manager/js/details/detail_tab_nodeset', function () {
         });
         self.nodesetCaseType.subscribe(function () {
             self.fire('change');
+            self.nodeset("");
         });
 
         return self;


### PR DESCRIPTION
…n change

## Summary
Minor followup for https://github.com/dimagi/commcare-hq/pull/29671

Because the app build code checks the nodeset custom expression before the nodeset case type [here](https://github.com/dimagi/commcare-hq/blob/db7bcf407dcb66d56ee5603ee62ccdd0fae1eeeb/corehq/apps/app_manager/suite_xml/sections/details.py#L224-L233), the UI needs to clear 

## Feature Flag
Associate a nodeset with a case detail tab

## Product Description
Probably don't need to announce, as this fixes a bug that has only been live for a few hours.

Previously, if you set a custom expression and then changed to use a case type, the app would keep using the custom expression.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None at the UI level.

### QA Plan

Not requesting QA.

### Safety story
Tested locally that expression disappears on selecting a case type, and that I can still save either a case type or a custom expression.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
