### PR TITLE
Fix select2 styleguide issue

### DIFF
--- a/corehq/apps/styleguide/templates/styleguide/examples/select2.html
+++ b/corehq/apps/styleguide/templates/styleguide/examples/select2.html
@@ -25,7 +25,7 @@
 
   <!-- Knockout binding: initialized by the koApplyBindings call below -->
   <div class="ko-model">
-    <select class="form-control" data-bind="options: letters, select2: {}, value: value"></select>
+    <select class="form-control" data-bind="select2: letters, value: value"></select>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Noticed while working on some UI ticket. Could be related to a recent version update, but the way this was previously being done resulted in an empty dropdown. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
UI change.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
