### PR TITLE
Drop FHIRResourcePropertyAdmin

### DIFF
--- a/corehq/motech/fhir/admin.py
+++ b/corehq/motech/fhir/admin.py
@@ -5,43 +5,6 @@ from django.contrib import admin
 from corehq.motech.fhir.models import FHIRResourceType, FHIRResourceProperty
 
 
-def _domain(obj):
-    return obj.resource_type.domain
-
-
-def _case_property(obj):
-    case_type = obj.resource_type.case_type.name
-    if obj.case_property:
-        return f'{case_type}.{obj.case_property.name}'
-    if 'case_property' in obj.value_source_config:
-        return f"{case_type}.{obj.value_source_config['case_property']}"
-    return ''
-
-
-class FHIRResourcePropertyAdmin(admin.ModelAdmin):
-    model = FHIRResourceProperty
-    list_display = (
-        _domain,
-        'resource_type',
-        'value_source_jsonpath',
-        _case_property
-    )
-    list_display_links = (
-        _domain,
-        'resource_type',
-        'value_source_jsonpath',
-    )
-    list_filter = ('resource_type__domain',)
-    list_select_related = ('resource_type', 'resource_type__case_type')
-
-    readonly_fields = ('resource_type', 'case_property')
-
-    def has_add_permission(self, request):
-        # Domains are difficult to manage with this interface. Create
-        # using the Data Dictionary, and edit in Admin.
-        return False
-
-
 class FHIRResourcePropertyInline(admin.TabularInline):
     model = FHIRResourceProperty
     verbose_name_plural = 'FHIR resource properties'
@@ -87,4 +50,3 @@ class FHIRResourceTypeAdmin(admin.ModelAdmin):
 
 
 admin.site.register(FHIRResourceType, FHIRResourceTypeAdmin)
-admin.site.register(FHIRResourceProperty, FHIRResourcePropertyAdmin)


### PR DESCRIPTION
## Summary

Drops an unused (and pretty unusable) Admin model


## Feature Flag
FHIR Integration


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story

Only affects an Admin model for an unreleased feature


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
