### PR TITLE
[SSO] actually redirect to the next/RelayState URL when it's passed to SSO login

### DIFF
--- a/corehq/apps/registration/static/registration/js/login.js
+++ b/corehq/apps/registration/static/registration/js/login.js
@@ -36,6 +36,7 @@ hqDefine('registration/js/login', [
                 initialUsername: $('#id_auth-username').val(),
                 passwordField: $passwordField,
                 passwordFormGroup: $passwordField.closest('.form-group'),
+                nextUrl: urlParams.get('next'),
             });
             $('#user-login-form').koApplyBindings(loginController);
             loginController.init();

--- a/corehq/apps/registration/static/registration/js/user_login_form.js
+++ b/corehq/apps/registration/static/registration/js/user_login_form.js
@@ -19,10 +19,12 @@ hqDefine('registration/js/user_login_form', [
             'initialUsername',
             'passwordField',
             'passwordFormGroup',
+            'nextUrl',
         ]);
         let self = {};
 
         self.checkSsoLoginStatusUrl = initialPageData.reverse('check_sso_login_status');
+        self.nextUrl = options.nextUrl;
         self.passwordField = options.passwordField;
         self.passwordFormGroup = options.passwordFormGroup;
         self.passwordFormGroup.hide();
@@ -118,8 +120,12 @@ hqDefine('registration/js/user_login_form', [
             self.proceedToNextStep();
         };
 
-        self.continueToSsoLogin = function (sso_url) {
-            window.location = sso_url;
+        self.continueToSsoLogin = function (ssoUrl) {
+            if (self.nextUrl) {
+                // note ssoUrl already contains ?username=foo
+                ssoUrl = ssoUrl + "&next=" + self.nextUrl;
+            }
+            window.location = ssoUrl;
         };
 
         self.continueToPasswordLogin = function () {

--- a/corehq/apps/registration/static/registration/js/user_login_form.js
+++ b/corehq/apps/registration/static/registration/js/user_login_form.js
@@ -14,14 +14,14 @@ hqDefine('registration/js/user_login_form', [
 ) {
     'use strict';
 
-    let loginController = function (options) {
+    var loginController = function (options) {
         assertProperties.assertRequired(options, [
             'initialUsername',
             'passwordField',
             'passwordFormGroup',
             'nextUrl',
         ]);
-        let self = {};
+        var self = {};
 
         self.checkSsoLoginStatusUrl = initialPageData.reverse('check_sso_login_status');
         self.nextUrl = options.nextUrl;

--- a/corehq/apps/sso/views/saml.py
+++ b/corehq/apps/sso/views/saml.py
@@ -152,7 +152,7 @@ def sso_saml_login(request, idp_slug):
     """
     This view initiates a SAML 2.0 login request with the Identity Provider.
     """
-    login_url = request.saml2_auth.login()
+    login_url = request.saml2_auth.login(return_to=request.GET.get('next'))
     username = get_sso_username_from_session(request) or request.GET.get('username')
     if username:
         # verify that the stored user data actually the current IdP

--- a/corehq/apps/sso/views/saml.py
+++ b/corehq/apps/sso/views/saml.py
@@ -14,6 +14,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.utils.translation import ugettext as _
 from onelogin.saml2.errors import OneLogin_Saml2_Error
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
+from onelogin.saml2.utils import OneLogin_Saml2_Utils
 
 from corehq.apps.domain.decorators import login_required
 from corehq.apps.domain.exceptions import NameUnavailableException
@@ -30,6 +31,7 @@ from corehq.apps.sso.utils.session_helpers import (
     get_sso_username_from_session,
     prepare_session_with_sso_username,
 )
+from corehq.apps.sso.utils.url_helpers import get_saml_login_url
 from corehq.apps.users.models import Invitation
 
 
@@ -122,6 +124,17 @@ def sso_saml_acs(request, idp_slug):
                 )
 
         AsyncSignupRequest.clear_data_for_username(user.username)
+
+        relay_state = request.saml2_request_data['post_data'].get('RelayState')
+        if relay_state not in [
+            OneLogin_Saml2_Utils.get_self_url(request.saml2_request_data),
+            get_saml_login_url(request.idp),
+        ]:
+            # redirect to next=<relay_state>
+            return HttpResponseRedirect(
+                request.saml2_auth.redirect_to(relay_state)
+            )
+
         return redirect("homepage")
 
     return render(request, error_template, {


### PR DESCRIPTION
## Summary
This ensures SSO login respects the `next` parameter when it's passed to it. An essential change to ensure that the functionality for the session timeout screen works.

## Feature Flag
Not hidden behind a feature flag as this code is still unused / in active development

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
no coverage here, mostly js changes

### QA Plan
QA will happen for SSO likely starting next week-ish (or the week following)

### Safety story
this can be merged into master as this is still actively in development and not part of anyone's workflow.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
