### PR TITLE
FHIRImporter Admin

### DIFF
--- a/corehq/motech/fhir/admin.py
+++ b/corehq/motech/fhir/admin.py
@@ -8,6 +8,7 @@ from corehq.motech.fhir.models import (
     FHIRImporterResourceType,
     FHIRResourceProperty,
     FHIRResourceType,
+    JSONPathToResourceType,
 )
 
 
@@ -96,6 +97,26 @@ class FHIRImporterResourceTypeAdmin(admin.ModelAdmin):
         return obj.fhir_importer.domain
 
 
+class JSONPathToResourceTypeAdmin(admin.ModelAdmin):
+    model = JSONPathToResourceType
+    list_display = (
+        'domain',
+        'resource_type',
+        'related_resource_type',
+    )
+    list_display_links = (
+        'domain',
+        'resource_type',
+        'related_resource_type',
+    )
+    list_filter = ('resource_type__fhir_importer__domain',)
+    list_select_related = ('resource_type__fhir_importer',)
+
+    def domain(self, obj):
+        return obj.resource_type.domain
+
+
 admin.site.register(FHIRResourceType, FHIRResourceTypeAdmin)
 admin.site.register(FHIRImporter, FHIRImporterAdmin)
 admin.site.register(FHIRImporterResourceType, FHIRImporterResourceTypeAdmin)
+admin.site.register(JSONPathToResourceType, JSONPathToResourceTypeAdmin)

--- a/corehq/motech/fhir/admin.py
+++ b/corehq/motech/fhir/admin.py
@@ -2,7 +2,13 @@ import json
 
 from django.contrib import admin
 
-from corehq.motech.fhir.models import FHIRResourceType, FHIRResourceProperty
+from corehq.motech.fhir.models import (
+    FHIRImporter,
+    FHIRImporterResourceProperty,
+    FHIRImporterResourceType,
+    FHIRResourceProperty,
+    FHIRResourceType,
+)
 
 
 class FHIRResourcePropertyInline(admin.TabularInline):
@@ -49,4 +55,47 @@ class FHIRResourceTypeAdmin(admin.ModelAdmin):
         return False
 
 
+class FHIRImporterAdmin(admin.ModelAdmin):
+    list_display = (
+        'domain',
+        'connection_settings',
+        'frequency',
+    )
+    list_display_links = (
+        'domain',
+        'connection_settings',
+        'frequency',
+    )
+    list_filter = ('domain',)
+    list_select_related = ('connection_settings',)
+
+
+class FHIRImporterResourcePropertyInline(admin.TabularInline):
+    model = FHIRImporterResourceProperty
+    verbose_name_plural = 'FHIR Importer resource properties'
+    fields = ('value_source_config',)
+
+
+class FHIRImporterResourceTypeAdmin(admin.ModelAdmin):
+    model = FHIRImporterResourceType
+    list_display = (
+        'domain',
+        'name',
+        'case_type',
+    )
+    list_display_links = (
+        'domain',
+        'name',
+        'case_type',
+    )
+    list_filter = ('fhir_importer__domain',)
+    list_select_related = ('fhir_importer',)
+    inlines = [FHIRImporterResourcePropertyInline]
+
+    def domain(self, obj):
+        return obj.fhir_importer.domain
+
+
 admin.site.register(FHIRResourceType, FHIRResourceTypeAdmin)
+admin.site.register(FHIRImporter, FHIRImporterAdmin)
+admin.site.register(FHIRImporterResourceType, FHIRImporterResourceTypeAdmin)

--- a/corehq/motech/fhir/migrations/0008_blank_search_params.py
+++ b/corehq/motech/fhir/migrations/0008_blank_search_params.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fhir', '0007_fhirimporterresourceproperty'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='fhirimporterresourcetype',
+            name='search_params',
+            field=jsonfield.fields.JSONField(blank=True, default=dict),
+        ),
+    ]

--- a/corehq/motech/fhir/models.py
+++ b/corehq/motech/fhir/models.py
@@ -371,6 +371,9 @@ class FHIRImporterResourceType(models.Model):
     import_related_only = models.BooleanField(default=False)
     search_params = JSONField(default=dict, blank=True)
 
+    def __str__(self):
+        return self.name
+
     @property
     def domain(self):
         return self.fhir_importer.domain
@@ -433,6 +436,13 @@ class JSONPathToResourceType(models.Model):
         FHIRImporterResourceType,
         on_delete=models.CASCADE,
     )
+
+    def __str__(self):
+        jsonpath = self.jsonpath
+        if jsonpath.startswith('$.'):
+            jsonpath = jsonpath[2:]
+        return (f'{self.resource_type.name}.{jsonpath} → '
+                f'{self.related_resource_type.name}')
 
 
 class FHIRImporterResourceProperty(models.Model):

--- a/corehq/motech/fhir/models.py
+++ b/corehq/motech/fhir/models.py
@@ -330,6 +330,9 @@ class FHIRImporter(models.Model):
             models.Index(fields=['frequency']),
         ]
 
+    def __str__(self):
+        return f'{self.connection_settings} ({self.frequency})'
+
 
 class FHIRImporterResourceType(models.Model):
     """
@@ -366,7 +369,7 @@ class FHIRImporterResourceType(models.Model):
     case_type = models.ForeignKey(CaseType, on_delete=models.CASCADE)
 
     import_related_only = models.BooleanField(default=False)
-    search_params = JSONField(default=dict)
+    search_params = JSONField(default=dict, blank=True)
 
     @property
     def domain(self):


### PR DESCRIPTION
## Summary

Only the "FHIRImporter Admin models" commit is unique.

Adds Admin models for managing FHIRImporters.

Follows up PR #29844 

The "Drop FHIRResourcePropertyAdmin" commit is cherry-picked from PR #29846


## Feature Flag

FHIR Integration


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story

These models are only accessible to superusers.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
