### PR TITLE
fix --reusedb=flush

### DIFF
--- a/corehq/tests/nose.py
+++ b/corehq/tests/nose.py
@@ -16,22 +16,24 @@ import sys
 import threading
 from fnmatch import fnmatch
 
-from couchdbkit import ResourceNotFound
-from couchdbkit.ext.django import loading
-from django.core.management import call_command
-from django.test.utils import get_unique_databases_and_mirrors
-from mock import patch, Mock
-from nose.plugins import Plugin
-from nose.tools import nottest
 from django.conf import settings
+from django.core.management import call_command
 from django.db.backends.base.creation import TEST_DATABASE_PREFIX
 from django.db.utils import OperationalError
+from django.test.utils import get_unique_databases_and_mirrors
+
+from couchdbkit import ResourceNotFound
+from couchdbkit.ext.django import loading
 from django_nose.plugin import DatabaseContext
+from mock import Mock, patch
+from nose.plugins import Plugin
+from nose.tools import nottest
+
 from dimagi.utils.parsing import string_to_boolean
 
 from corehq.tests.noseplugins.cmdline_params import CmdLineParametersPlugin
 from corehq.util.couchdb_management import couch_config
-from corehq.util.test_utils import unit_testing_only, timelimit
+from corehq.util.test_utils import timelimit, unit_testing_only
 
 log = logging.getLogger(__name__)
 

--- a/corehq/tests/nose.py
+++ b/corehq/tests/nose.py
@@ -28,6 +28,7 @@ from django_nose.plugin import DatabaseContext
 from mock import Mock, patch
 from nose.plugins import Plugin
 from nose.tools import nottest
+from requests.exceptions import HTTPError
 
 from dimagi.utils.parsing import string_to_boolean
 
@@ -338,7 +339,7 @@ def flush_databases():
     for db in get_all_test_dbs():
         try:
             db.flush()
-        except ResourceNotFound:
+        except (ResourceNotFound, HTTPError):
             pass
     call_command('flush', interactive=False)
 


### PR DESCRIPTION
## Summary
There's been some chatter about the nuisance of test failures in `setUpClass` necessitating a full reset or manual deletions, so I wanted to see what the problem was with `--reusedb=flush`.  This was the only obvious thing I hit:
```
requests.exceptions.HTTPError: 404 Client Error: Object Not Found not_found Database does not exist. for url: http://localhost:5984/test_commcarehq__fluff-bihar/_all_docs?startkey=%22_design%22&endkey=%22_design%2F%5Cu9999%22&include_docs=true
```
That's fixed in this PR.  The other obvious potential pitfall is that flushing databases is pretty indiscriminate, so any bootstrapped data created in migrations will also be wiped.  We could delete the last line in `flush_databases`, which flushes SQL - that'd fix make sure the accounting bootstrap stuff is there, or we could do the flush and then run initial migrations.  That's slower, but I'd guess still faster than a full reset.  

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
Local tests only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
