### PR TITLE
prevent model.save from propagating to couch during populate command

### DIFF
--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -9,6 +9,7 @@ from django.db import transaction
 from corehq.dbaccessors.couchapps.all_docs import get_all_docs_with_doc_types, get_doc_count_by_type
 from corehq.util.couchdb_management import couch_config
 from corehq.util.django_migrations import skip_on_fresh_install
+from dimagi.utils.couch.migration import disable_sync_to_couch
 
 logger = logging.getLogger(__name__)
 
@@ -233,7 +234,7 @@ class PopulateSQLCommand(BaseCommand):
             self.doc_count,
             doc["_id"]
         ))
-        with transaction.atomic():
+        with transaction.atomic(), disable_sync_to_couch(self.sql_class()):
             model, created = self.update_or_create_sql_object(doc)
             action = "Creating" if created else "Updated"
             logger.info("{} model for doc with id {}".format(action, doc["_id"]))

--- a/corehq/apps/users/tests/test_migrate_roles_to_sql.py
+++ b/corehq/apps/users/tests/test_migrate_roles_to_sql.py
@@ -8,6 +8,7 @@ from corehq.apps.users.models import (
     SQLUserRole, SQLPermission
 )
 from corehq.apps.users.role_utils import get_custom_roles_for_domain
+from dimagi.utils.couch.migration import sync_to_couch_enabled
 
 
 class UserRoleCouchToSqlTests(TestCase):
@@ -237,7 +238,9 @@ class TestPopulateCommand(TestCase):
             role.delete()
 
     def test_command(self):
+        self.assertTrue(sync_to_couch_enabled(SQLUserRole))
         call_command("populate_user_role")
+        self.assertTrue(sync_to_couch_enabled(SQLUserRole))
         couch_roles = UserRole.by_domain(self.domain)
         self.assertEqual(len(couch_roles), len(self.roles))
         for role in couch_roles:

--- a/corehq/apps/users/tests/test_migrate_roles_to_sql.py
+++ b/corehq/apps/users/tests/test_migrate_roles_to_sql.py
@@ -211,6 +211,7 @@ class UserRoleCouchToSqlTests(TestCase):
 
 class TestPopulateCommand(TestCase):
     domain = 'test-populate-sql-roles'
+
     @classmethod
     def setUpClass(cls):
         role1 = UserRole.create(

--- a/corehq/ex-submodules/dimagi/utils/couch/migration.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/migration.py
@@ -13,6 +13,10 @@ _thread_local = threading.local()
 
 @contextmanager
 def disable_sync_to_couch(sql_class):
+    """Context manager used to disable syncing models from SQL
+    to Couch via `model.save`. This is necessary to prevent
+    syncs from happening when using functions like `Model.objects.create_or_update`
+    """
     if not hasattr(_thread_local, "disabled_models"):
         _thread_local.disabled_models = set()
 


### PR DESCRIPTION
## Summary
When calling `model.objects.update_or_create(...)` Django calls `.save` on the model. This save is then propagated to Couch via `SyncSQLToCouchMixin.save`. In cases where the SQL model is only partially populated on create this can result in the Couch model being updated with default / empty values.

In the specific case of the `UserRole` migration the initial SQL object is created without the `permissions` or 'assignable_by` values. This results in those fields being set to Null / empty values in the Couch model.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added

### QA plan
In addition to the tests I will do some targeted tests this on staging and India.

### Safety story
Changes to the management command only. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
