### PR TITLE
[ERM UI] Add search box to Linked Projects page

### DIFF
--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -92,7 +92,7 @@ hqDefine("linked_domain/js/domain_links", [
         self.paginatedDomainLinks = ko.observableArray([]);
         self.itemsPerPage = ko.observable(5);
         self.totalItems = ko.computed(function () {
-           return self.query() ? self.filteredDomainLinks().length : self.domain_links().length;
+            return self.query() ? self.filteredDomainLinks().length : self.domain_links().length;
         });
         self.currentPage = 1;
 

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -5,7 +5,7 @@ hqDefine("linked_domain/js/domain_links", [
     'knockout',
     'hqwebapp/js/alert_user',
     'hqwebapp/js/multiselect_utils',
-    'hqwebapp/js/components.ko', // for pagination
+    'hqwebapp/js/components.ko', // for pagination and search box
     'hqwebapp/js/select2_knockout_bindings.ko',     // selects2 for fields
 ], function (
     RMI,
@@ -68,18 +68,31 @@ hqDefine("linked_domain/js/domain_links", [
             }
         }
 
+        // General data
         self.domain_links = ko.observableArray(_.map(data.linked_domains, DomainLink));
 
-        // pull content
+        // Pull Content Tab
         self.model_status = _.map(data.model_status, ModelStatus);
         self.can_update = data.can_update;
         self.models = data.models;
 
-        // manage downstream domains tab
+        // Manage Downstream Domains Tab
+        // search box
+        self.query = ko.observable();
+        self.filteredDomainLinks = ko.observableArray([]);
+        self.matchesQuery = function (domainLink) {
+            return !self.query() || domainLink.linked_domain().toLowerCase().indexOf(self.query().toLowerCase()) !== -1;
+        };
+        self.filter = function () {
+            self.filteredDomainLinks(_.filter(self.domain_links(), self.matchesQuery));
+            self.goToPage(1);
+        };
+
+        // pagination
         self.paginatedDomainLinks = ko.observableArray([]);
         self.itemsPerPage = ko.observable(5);
         self.totalItems = ko.computed(function () {
-            return self.domain_links().length;
+           return self.query() ? self.filteredDomainLinks().length : self.domain_links().length;
         });
         self.currentPage = 1;
 
@@ -87,7 +100,8 @@ hqDefine("linked_domain/js/domain_links", [
             self.currentPage = page;
             self.paginatedDomainLinks.removeAll();
             var skip = (self.currentPage - 1) * self.itemsPerPage();
-            self.paginatedDomainLinks(self.domain_links().slice(skip, skip + self.itemsPerPage()));
+            var visibleDomains = self.query() ? self.filteredDomainLinks() : self.domain_links();
+            self.paginatedDomainLinks(visibleDomains.slice(skip, skip + self.itemsPerPage()));
         };
 
         self.onPaginationLoad = function () {
@@ -106,7 +120,7 @@ hqDefine("linked_domain/js/domain_links", [
             });
         };
 
-        // push content tab
+        // Push Content Tab
         self.domainsToRelease = ko.observableArray();
         self.modelsToRelease = ko.observableArray();
         self.buildAppsOnRelease = ko.observable(false);

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -101,6 +101,11 @@
               <h3 class="panel-title">{% trans 'Downstream Projects' %}</h3>
             </div>
           <div class="panel-body">
+            <search-box data-apply-bindings="false"
+                      params="value: query,
+                              action: filter,
+                              immediate: true,
+                              placeholder: '{% trans_html_attr "Search Downstream Projects..." %}'"></search-box>
             <div data-bind="if: domain_links().length">
               <table class="table table-striped table-hover" id="linked-domains-table">
                 <thead>

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -100,56 +100,57 @@
             <div class="panel-heading">
               <h3 class="panel-title">{% trans 'Downstream Projects' %}</h3>
             </div>
-          <div class="panel-body">
-            <search-box data-apply-bindings="false"
-                      params="value: query,
-                              action: filter,
-                              immediate: true,
-                              placeholder: '{% trans_html_attr "Search Downstream Projects..." %}'"></search-box>
-            <div data-bind="if: domain_links().length">
-              <table class="table table-striped table-hover" id="linked-domains-table">
-                <thead>
-                <tr>
-                  <th>{% trans "Project Name" %}</th>
-                  <th>{% trans "Last Updated" %} ({{ timezone }})</th>
-                  <th></th>
-                </tr>
-                </thead>
-                <tbody data-bind="foreach: paginatedDomainLinks">
-                <tr>
-                  <td><a data-bind="attr: {'href': domain_link}, text: linked_domain"></a></td>
-                  <td data-bind="text: lastUpdate"></td>
-                  <td>
-                    <button type="button" class="btn btn-danger" data-toggle="modal" data-bind="attr: {'data-target': '#remove-link-modal-' + $index()}">
-                      <i class="fa fa-trash"></i>
-                      {% trans 'Remove Link' %}
-                    </button>
-                    <div class="modal fade" tabindex="-1" role="dialog" data-bind="attr: {'id': 'remove-link-modal-' + $index()}">
-                      <div class="modal-dialog" role="document">
-                        <div class="modal-content">
-                          <div class="modal-header">
-                            <button type="button" class="close" data-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>
-                            <h4 class="modal-title">{% trans 'Remove Project Link' %}</h4>
-                          </div>
-                          <div class="modal-body">
-                            <p>{% trans 'Are you sure you want to remove the link between projects?' %}</p>
-                          </div>
-                          <div class="modal-footer">
-                            <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
-                            <button type="button" class="btn btn-danger" data-bind="click: $root.deleteLink.bind($data)" data-dismiss="modal">{% trans 'Remove' %}</button>
-                          </div>
-                        </div><!-- /.modal-content -->
-                      </div><!-- /.modal-dialog -->
-                    </div><!-- /.modal -->
-                  </td>
-                </tr>
-                </tbody>
-              </table>
-              <pagination data-apply-bindings="false"
-                params="goToPage: goToPage,
-                        perPage: itemsPerPage,
-                        totalItems: totalItems,
-                        onLoad: onPaginationLoad"></pagination>
+            <div class="panel-body">
+              <search-box data-apply-bindings="false"
+                        params="value: query,
+                                action: filter,
+                                immediate: true,
+                                placeholder: '{% trans_html_attr "Search Downstream Projects..." %}'"></search-box>
+              <div data-bind="if: domain_links().length">
+                <table class="table table-striped table-hover" id="linked-domains-table">
+                  <thead>
+                  <tr>
+                    <th>{% trans "Project Name" %}</th>
+                    <th>{% trans "Last Updated" %} ({{ timezone }})</th>
+                    <th></th>
+                  </tr>
+                  </thead>
+                  <tbody data-bind="foreach: paginatedDomainLinks">
+                  <tr>
+                    <td><a data-bind="attr: {'href': domain_link}, text: linked_domain"></a></td>
+                    <td data-bind="text: lastUpdate"></td>
+                    <td>
+                      <button type="button" class="btn btn-danger" data-toggle="modal" data-bind="attr: {'data-target': '#remove-link-modal-' + $index()}">
+                        <i class="fa fa-trash"></i>
+                        {% trans 'Remove Link' %}
+                      </button>
+                      <div class="modal fade" tabindex="-1" role="dialog" data-bind="attr: {'id': 'remove-link-modal-' + $index()}">
+                        <div class="modal-dialog" role="document">
+                          <div class="modal-content">
+                            <div class="modal-header">
+                              <button type="button" class="close" data-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>
+                              <h4 class="modal-title">{% trans 'Remove Project Link' %}</h4>
+                            </div>
+                            <div class="modal-body">
+                              <p>{% trans 'Are you sure you want to remove the link between projects?' %}</p>
+                            </div>
+                            <div class="modal-footer">
+                              <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
+                              <button type="button" class="btn btn-danger" data-bind="click: $root.deleteLink.bind($data)" data-dismiss="modal">{% trans 'Remove' %}</button>
+                            </div>
+                          </div><!-- /.modal-content -->
+                        </div><!-- /.modal-dialog -->
+                      </div><!-- /.modal -->
+                    </td>
+                  </tr>
+                  </tbody>
+                </table>
+                <pagination data-apply-bindings="false"
+                  params="goToPage: goToPage,
+                          perPage: itemsPerPage,
+                          totalItems: totalItems,
+                          onLoad: onPaginationLoad"></pagination>
+              </div>
             </div>
           </div>
         </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -95,50 +95,57 @@
               <i class="fa fa-plus"></i> {% trans "Add Downstream Project" %}
             </button>
           {% endif %}
-          <div data-bind="if: domain_links().length">
-            <table class="table table-striped table-hover" id="linked-domains-table">
-              <thead>
-              <tr>
-                <th>{% trans "Project Name" %}</th>
-                <th>{% trans "Last Updated" %} ({{ timezone }})</th>
-                <th></th>
-              </tr>
-              </thead>
-              <tbody data-bind="foreach: paginatedDomainLinks">
-              <tr>
-                <td><a data-bind="attr: {'href': domain_link}, text: linked_domain"></a></td>
-                <td data-bind="text: lastUpdate"></td>
-                <td>
-                  <button type="button" class="btn btn-danger" data-toggle="modal" data-bind="attr: {'data-target': '#remove-link-modal-' + $index()}">
-                    <i class="fa fa-trash"></i>
-                    {% trans 'Remove Link' %}
-                  </button>
-                  <div class="modal fade" tabindex="-1" role="dialog" data-bind="attr: {'id': 'remove-link-modal-' + $index()}">
-                    <div class="modal-dialog" role="document">
-                      <div class="modal-content">
-                        <div class="modal-header">
-                          <button type="button" class="close" data-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>
-                          <h4 class="modal-title">{% trans 'Remove Project Link' %}</h4>
-                        </div>
-                        <div class="modal-body">
-                          <p>{% trans 'Are you sure you want to remove the link between projects?' %}</p>
-                        </div>
-                        <div class="modal-footer">
-                          <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
-                          <button type="button" class="btn btn-danger" data-bind="click: $root.deleteLink.bind($data)" data-dismiss="modal">{% trans 'Remove' %}</button>
-                        </div>
-                      </div><!-- /.modal-content -->
-                    </div><!-- /.modal-dialog -->
-                  </div><!-- /.modal -->
-                </td>
-              </tr>
-              </tbody>
-            </table>
-            <pagination data-apply-bindings="false"
-              params="goToPage: goToPage,
-                      perPage: itemsPerPage,
-                      totalItems: totalItems,
-                      onLoad: onPaginationLoad"></pagination>
+          <div class="spacer"></div>
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h3 class="panel-title">{% trans 'Downstream Projects' %}</h3>
+            </div>
+          <div class="panel-body">
+            <div data-bind="if: domain_links().length">
+              <table class="table table-striped table-hover" id="linked-domains-table">
+                <thead>
+                <tr>
+                  <th>{% trans "Project Name" %}</th>
+                  <th>{% trans "Last Updated" %} ({{ timezone }})</th>
+                  <th></th>
+                </tr>
+                </thead>
+                <tbody data-bind="foreach: paginatedDomainLinks">
+                <tr>
+                  <td><a data-bind="attr: {'href': domain_link}, text: linked_domain"></a></td>
+                  <td data-bind="text: lastUpdate"></td>
+                  <td>
+                    <button type="button" class="btn btn-danger" data-toggle="modal" data-bind="attr: {'data-target': '#remove-link-modal-' + $index()}">
+                      <i class="fa fa-trash"></i>
+                      {% trans 'Remove Link' %}
+                    </button>
+                    <div class="modal fade" tabindex="-1" role="dialog" data-bind="attr: {'id': 'remove-link-modal-' + $index()}">
+                      <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                          <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>
+                            <h4 class="modal-title">{% trans 'Remove Project Link' %}</h4>
+                          </div>
+                          <div class="modal-body">
+                            <p>{% trans 'Are you sure you want to remove the link between projects?' %}</p>
+                          </div>
+                          <div class="modal-footer">
+                            <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
+                            <button type="button" class="btn btn-danger" data-bind="click: $root.deleteLink.bind($data)" data-dismiss="modal">{% trans 'Remove' %}</button>
+                          </div>
+                        </div><!-- /.modal-content -->
+                      </div><!-- /.modal-dialog -->
+                    </div><!-- /.modal -->
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+              <pagination data-apply-bindings="false"
+                params="goToPage: goToPage,
+                        perPage: itemsPerPage,
+                        totalItems: totalItems,
+                        onLoad: onPaginationLoad"></pagination>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-103)

Another UI change in a series of PRs aimed at improving the Linked Projects UI. This PR includes the following:

**1st commit** - wrap the downstream domains table in a panel element for aesthetics
**2nd commit** - add a search box to filter downstream domains

![Screen Shot 2021-06-03 at 2 20 35 PM](https://user-images.githubusercontent.com/15785053/120700298-7d7a7480-c47f-11eb-8150-b70d7db76f0c.png)
![Screen Shot 2021-06-03 at 2 20 45 PM](https://user-images.githubusercontent.com/15785053/120700312-81a69200-c47f-11eb-9aaf-bbb992c5c1a3.png)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Adds a search box to the Linked Projects page to allow users to filter linked project spaces.
## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
UI changes only.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will run through QA on parent branch.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested. No intention of merging this PR directly into master.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
