### PR TITLE
[SSO] Catch SAML configuration errors in a friendlier way

### DIFF
--- a/corehq/apps/sso/decorators.py
+++ b/corehq/apps/sso/decorators.py
@@ -1,11 +1,17 @@
+import logging
 from functools import wraps
 
 from django.http import Http404
+from django.shortcuts import render
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
+from onelogin.saml2.errors import OneLogin_Saml2_Error
 
 from corehq.apps.sso.models import IdentityProvider
 from corehq.apps.sso.configuration import get_saml2_config
 from corehq.apps.sso.utils.request_helpers import get_request_data
+from corehq.apps.sso.utils.url_helpers import get_documentation_url
+
+logger = logging.getLogger(__name__)
 
 
 def identity_provider_required(view_func):
@@ -21,9 +27,36 @@ def use_saml2_auth(view_func):
     def _inner(request, idp_slug, *args, **kwargs):
         request.idp = _get_idp_or_404(idp_slug)
         request.saml2_request_data = get_request_data(request)
-        request.saml2_auth = OneLogin_Saml2_Auth(
-            request.saml2_request_data, get_saml2_config(request.idp)
-        )
+        try:
+            request.saml2_auth = OneLogin_Saml2_Auth(
+                request.saml2_request_data, get_saml2_config(request.idp)
+            )
+        except OneLogin_Saml2_Error as e:
+            if (request.idp.is_active
+                    and e.code != OneLogin_Saml2_Error.REDIRECT_INVALID_URL):
+                logger.error(
+                    f"An active Identity Provider {idp_slug} appears to have "
+                    f"an SSO configuration issue. Please look into this "
+                    f"immediately! {str(e)}"
+                )
+            elif e.code not in [
+                OneLogin_Saml2_Error.SETTINGS_INVALID,
+                OneLogin_Saml2_Error.CERT_NOT_FOUND,
+                OneLogin_Saml2_Error.REDIRECT_INVALID_URL
+            ]:
+                logger.error(
+                    f"An inactive Identity Provider {idp_slug} appears to have "
+                    f"an SSO configuration issue. Please take note of this "
+                    f"error if an Enterprise Admin reaches out for support: "
+                    f"error code {e.code}, {str(e)}"
+                )
+            return render(request, 'sso/config_errors.html', {
+                'idp_is_active': request.idp.is_active,
+                'idp_name': request.idp.name,
+                'error': e,
+                'docs_link': get_documentation_url(request.idp),
+            })
+
         return view_func(request, idp_slug, *args, **kwargs)
     return _inner
 

--- a/corehq/apps/sso/templates/sso/config_errors.html
+++ b/corehq/apps/sso/templates/sso/config_errors.html
@@ -1,0 +1,94 @@
+{% extends login_template %}
+{% load i18n %}
+
+{% block title %}{% trans "Single Sign-On is misconfigured" %}{% endblock title %}
+
+{% block login-content %}
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-xs-12">
+        <div class="reg-form-container sign-in-container">
+          <div class="form-bubble form-bubble-lg">
+            <h2>
+              {% blocktrans %}
+                Single Sign-On
+              {% endblocktrans %}
+            </h2>
+
+            {% if request.idp.is_active %}
+              <p class="lead">
+                {% blocktrans with request.idp.is_active as idp_name %}
+                  It looks like there is an issue with {{ idp_name }}'s configuration.
+                {% endblocktrans %}
+              </p>
+              <p>
+                {% blocktrans %}
+                  We have been alerted of this issue and are working with your
+                  account manager to resolve this problem. Thank you for your
+                  patience!
+                {% endblocktrans %}
+              </p>
+            {% else %}
+              {% if error.code == e.SETTINGS_INVALID %}
+                <p class="lead">
+                  {% blocktrans %}
+                    It looks like your setup is not complete.
+                  {% endblocktrans %}
+                </p>
+                <p>
+                  {% blocktrans %}
+                    Information seems to be missing from your SSO configuration.
+                    Please review the <a href="{{ docs_link }}">documentation</a>
+                    for setting up SSO.
+                  {% endblocktrans %}
+                </p>
+              {% elif error.code == e.CERT_NOT_FOUND %}
+                <p class="lead">
+                  {% blocktrans %}
+                    It looks like we are missing your certificate.
+                  {% endblocktrans %}
+                </p>
+                <p>
+                  {% blocktrans %}
+                    It looks like your x509 certificate is missing from your
+                    SSO setup.  Please review the
+                    <a href="{{ docs_link }}">documentation</a>
+                    for setting up SSO.
+                  {% endblocktrans %}
+                </p>
+              {% elif error.code == e.REDIRECT_INVALID_URL %}
+                <p class="lead">
+                  {% blocktrans %}
+                    Your Redirect URL is invalid.
+                  {% endblocktrans %}
+                </p>
+                <p>
+                  {% blocktrans %}
+                    The redirect URL you have specified is not valid. Please
+                    remove the text after "next=" in the url to temporarily
+                    resolve this issue. If the issue persists, please contact
+                    support so we can find a permanent solution.
+                  {% endblocktrans %}
+                </p>
+              {% else %}
+                <p class="lead">
+                  {% blocktrans %}
+                    It looks like there is an issue with your SSO configuration.
+                  {% endblocktrans %}
+                </p>
+                <p>
+                  {% blocktrans with e.code as error_code %}
+                    The error code is "{{ error_code }}". Please reach out to
+                    your support contact with this information so we can
+                    assist with this issue.
+                  {% endblocktrans %}
+                </p>
+              {% endif %}
+            {% endif %}
+
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/corehq/apps/sso/templates/sso/config_errors.html
+++ b/corehq/apps/sso/templates/sso/config_errors.html
@@ -15,7 +15,21 @@
               {% endblocktrans %}
             </h2>
 
-            {% if request.idp.is_active %}
+            {% if error.code == error.REDIRECT_INVALID_URL %}
+              <p class="lead">
+                {% blocktrans %}
+                  Your Redirect URL is invalid.
+                {% endblocktrans %}
+              </p>
+              <p>
+                {% blocktrans %}
+                  The redirect URL you have specified is not valid. Please
+                  remove the text after "next=" in the url to temporarily
+                  resolve this issue. If the issue persists, please contact
+                  support so we can find a permanent solution.
+                {% endblocktrans %}
+              </p>
+            {% elif request.idp.is_active %}
               <p class="lead">
                 {% blocktrans with request.idp.is_active as idp_name %}
                   It looks like there is an issue with {{ idp_name }}'s configuration.
@@ -54,20 +68,6 @@
                     SSO setup.  Please review the
                     <a href="{{ docs_link }}">documentation</a>
                     for setting up SSO.
-                  {% endblocktrans %}
-                </p>
-              {% elif error.code == error.REDIRECT_INVALID_URL %}
-                <p class="lead">
-                  {% blocktrans %}
-                    Your Redirect URL is invalid.
-                  {% endblocktrans %}
-                </p>
-                <p>
-                  {% blocktrans %}
-                    The redirect URL you have specified is not valid. Please
-                    remove the text after "next=" in the url to temporarily
-                    resolve this issue. If the issue persists, please contact
-                    support so we can find a permanent solution.
                   {% endblocktrans %}
                 </p>
               {% else %}

--- a/corehq/apps/sso/templates/sso/config_errors.html
+++ b/corehq/apps/sso/templates/sso/config_errors.html
@@ -37,9 +37,8 @@
               </p>
               <p>
                 {% blocktrans %}
-                  We have been alerted of this issue and are working with your
-                  account manager to resolve this problem. Thank you for your
-                  patience!
+                  Please reach out to support so we can quickly resolve this
+                  problem. Thank you!
                 {% endblocktrans %}
               </p>
             {% else %}

--- a/corehq/apps/sso/templates/sso/config_errors.html
+++ b/corehq/apps/sso/templates/sso/config_errors.html
@@ -29,7 +29,7 @@
                 {% endblocktrans %}
               </p>
             {% else %}
-              {% if error.code == e.SETTINGS_INVALID %}
+              {% if error.code == error.SETTINGS_INVALID %}
                 <p class="lead">
                   {% blocktrans %}
                     It looks like your setup is not complete.
@@ -42,7 +42,7 @@
                     for setting up SSO.
                   {% endblocktrans %}
                 </p>
-              {% elif error.code == e.CERT_NOT_FOUND %}
+              {% elif error.code == error.CERT_NOT_FOUND %}
                 <p class="lead">
                   {% blocktrans %}
                     It looks like we are missing your certificate.
@@ -56,7 +56,7 @@
                     for setting up SSO.
                   {% endblocktrans %}
                 </p>
-              {% elif error.code == e.REDIRECT_INVALID_URL %}
+              {% elif error.code == error.REDIRECT_INVALID_URL %}
                 <p class="lead">
                   {% blocktrans %}
                     Your Redirect URL is invalid.
@@ -77,7 +77,7 @@
                   {% endblocktrans %}
                 </p>
                 <p>
-                  {% blocktrans with e.code as error_code %}
+                  {% blocktrans with error.code as error_code %}
                     The error code is "{{ error_code }}". Please reach out to
                     your support contact with this information so we can
                     assist with this issue.

--- a/corehq/apps/sso/utils/url_helpers.py
+++ b/corehq/apps/sso/utils/url_helpers.py
@@ -15,6 +15,11 @@ def get_saml_login_url(identity_provider):
     return _get_full_sso_url("sso_saml_login", identity_provider)
 
 
+def get_documentation_url(identity_provider):
+    # todo update documentation URL (will change depending on IdP)
+    return '#'
+
+
 def get_dashboard_link(identity_provider):
     from corehq.apps.accounting.models import Subscription
     from corehq.apps.sso.views.enterprise_admin import EditIdentityProviderEnterpriseView

--- a/corehq/apps/sso/views/saml.py
+++ b/corehq/apps/sso/views/saml.py
@@ -30,6 +30,7 @@ from corehq.apps.sso.utils.session_helpers import (
     get_sso_username_from_session,
     prepare_session_with_sso_username,
 )
+from corehq.apps.sso.utils.url_helpers import get_documentation_url
 from corehq.apps.users.models import Invitation
 
 
@@ -77,7 +78,7 @@ def sso_saml_acs(request, idp_slug):
         return render(request, error_template, {
             'saml_error_reason': request.saml2_auth.get_last_error_reason() or errors[0],
             'idp_type': "Azure AD",  # we will update this later,
-            'docs_link': '#tbd',  # we will update this later,
+            'docs_link': get_documentation_url(request.idp),
         })
 
     if not request.saml2_auth.is_authenticated():


### PR DESCRIPTION
## Summary
Just noticed that a brand new (but misconfigured) inactive identity provider was throwing a 500 when it shouldn't be failing that hard. This makes changes to catch SSO configuration issues and display useful error messages to the user and log actual errors only when it is absolutely necessary.

## Screenshots

### bad redirect URL
![Screen Shot 2021-06-04 at 10 35 18 AM](https://user-images.githubusercontent.com/716573/120829889-87ee4a00-c523-11eb-8733-ffbe47d5e6da.png)

### any non-reply URL error for active IdP
![Screen Shot 2021-06-04 at 10 38 36 AM](https://user-images.githubusercontent.com/716573/120829807-7147f300-c523-11eb-9eae-2ede2ea4ba3e.png)

### bad configuration error for inactive IdP
![Screen Shot 2021-06-04 at 10 32 11 AM](https://user-images.githubusercontent.com/716573/120830022-b0764400-c523-11eb-80b1-7adf5cb82361.png)

### missing certificate error for inactive IdP
![Screen Shot 2021-06-04 at 10 34 27 AM](https://user-images.githubusercontent.com/716573/120830120-c7b53180-c523-11eb-822c-8582348d26c8.png)

### a general error for an inactive IdP
![Screen Shot 2021-06-04 at 10 42 07 AM](https://user-images.githubusercontent.com/716573/120830201-def41f00-c523-11eb-8df9-e3d73fc18ad9.png)


## Feature Flag
No feature flag needed. Still actively in development and not part of any primary workflows.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
front end not tested

### QA Plan
QA will happen when SSO work is fully complete

### Safety story
This code is not actively in use on production / still in active development.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
