### PR TITLE
improve errors/docs when using Expression Columns

### DIFF
--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -1580,6 +1580,9 @@ column.
        }
    }
 
+**Expression columns cannot be used in aggregations or filters.**
+If you need to group by a derived value, then you must add that directly to your data source.
+
 The "aggregation" column property
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -542,6 +542,9 @@ class ExpressionColumn(BaseReportColumn):
             )
         ])
 
+    def get_query_column_ids(self):
+        raise InvalidQueryColumn(_("Expression Columns do not support group by, sorting, or querying."))
+
 
 class ChartSpec(JsonObject):
     type = StringProperty(required=True)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://sentry.io/organizations/dimagi/discover/commcarehq:17234330df0940269eddede442947201/?field=title&field=release&field=environment&field=user&field=timestamp&name=AttributeError%3A+%27ExpressionColumn%27+object+has+no+attribute+%27get_query_column_ids%27&project=136860&query=issue.id%3A2380146861&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

I'm unsure if this error actually gets shown to users but at a minimum it will be clearer in Sentry.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
UCR

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

None.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

In full transparency I didn't run this code. But the function was previously being called (and didn't exist so failed hard) and now it exists but just raises a clearer error. So I feel this is low risk.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
