### PR TITLE
Cs/sc 1335 dataset workflow

### DIFF
--- a/corehq/motech/dhis2/forms.py
+++ b/corehq/motech/dhis2/forms.py
@@ -62,8 +62,11 @@ class DataSetMapForm(forms.ModelForm):
                     'Week periods use the format yyyyWn (e.g. "2004W10" for '
                     'week 10, 2004). Month periods use the format yyyyMM '
                     '(e.g. "200403" for March 2004). Quarter periods use the '
-                    'format yyyyQn (e.g. "2004Q1" for January-March 2004).'),
-        required=True,
+                    'format yyyyQn (e.g. "2004Q1" for January-March 2004). '
+                    'If the UCR has a date filter then leave the field blank to '
+                    'filter the UCR by the date range of the previous '
+                    'period.'),
+        required=False,
     )
     attribute_option_combo_id = forms.CharField(
         label=_('AttributeOptionComboID'),

--- a/corehq/motech/dhis2/forms.py
+++ b/corehq/motech/dhis2/forms.py
@@ -238,7 +238,7 @@ def add_initial_properties(instance, kwargs_initial):
 
 def ucr_has_field(ucr: ReportConfiguration, field):
     for column in ucr.report_columns:
-        if column.display == field:
+        if column.column_id == field:
             return True
     return False
 
@@ -338,7 +338,6 @@ class DataValueMapCreateForm(DataValueMapBaseForm):
 
 
 class DataValueMapUpdateForm(DataValueMapBaseForm):
-
     id = forms.CharField(widget=forms.HiddenInput())
 
     class Meta:

--- a/corehq/motech/dhis2/forms.py
+++ b/corehq/motech/dhis2/forms.py
@@ -26,6 +26,8 @@ from .const import (
     SEND_FREQUENCY_WEEKLY,
 )
 from .models import SQLDataSetMap, SQLDataValueMap
+from corehq.apps.userreports.models import ReportConfiguration
+from corehq.util.couch import get_document_or_not_found
 
 
 class DataSetMapForm(forms.ModelForm):
@@ -45,38 +47,23 @@ class DataSetMapForm(forms.ModelForm):
     )
     data_set_id = forms.CharField(
         label=_('DataSetID'),
-        help_text=_('The DHIS2 DataSet ID to which this UCR adds value'),
+        help_text=_('The DHIS2 DataSet ID to which this DataSet adds value.'),
         validators=[RegexValidator(DHIS2_UID_RE, DHIS2_UID_MESSAGE)],
         required=True,
     )
     org_unit_id = forms.CharField(
-        label=_('OrgUnitID¹'),
-        validators=[RegexValidator(DHIS2_UID_RE, DHIS2_UID_MESSAGE)],
-        required=False,
-    )
-    org_unit_column = forms.CharField(
-        label=_('OrgUnitID column¹'),
-        help_text=_('¹ Please set either a fixed value for "OrgUnitID", or '
-                    'specify an "OrgUnitID column" where a DHIS2 Organisation '
-                    'Unit ID will be found.'),
-        required=False,
+        label=_('OrgUnitID'),
+        required=True,
+        help_text=_('The UCR column name specifying the OrgUnitID or a static OrgUnitID.'),
     )
     period = forms.CharField(
-        label=_('Period²'),
-        help_text=_('Week periods use the format yyyyWn (e.g. "2004W10" for '
+        label=_('Period'),
+        help_text=_('The UCR column name specifying the Period or a static Period. '
+                    'Week periods use the format yyyyWn (e.g. "2004W10" for '
                     'week 10, 2004). Month periods use the format yyyyMM '
                     '(e.g. "200403" for March 2004). Quarter periods use the '
                     'format yyyyQn (e.g. "2004Q1" for January-March 2004).'),
-        required=False,
-    )
-    period_column = forms.CharField(
-        label=_('Period column²'),
-        help_text=_('² Please set a fixed value for "Period", or specify a '
-                    '"Period column" where a period will be found, or if the '
-                    'UCR has a date filter then leave both fields blank to '
-                    'filter the UCR by the date range of the previous '
-                    'period.'),
-        required=False,
+        required=True,
     )
     attribute_option_combo_id = forms.CharField(
         label=_('AttributeOptionComboID'),
@@ -107,6 +94,7 @@ class DataSetMapForm(forms.ModelForm):
 
     def __init__(self, domain, *args, **kwargs):
         from corehq.motech.dhis2.views import DataSetMapListView
+        kwargs['initial'] = add_initial_properties(kwargs.get('instance'), kwargs.get('initial'))
 
         super().__init__(*args, **kwargs)
         self.domain = domain
@@ -124,9 +112,7 @@ class DataSetMapForm(forms.ModelForm):
                 crispy.Field('day_to_send'),
                 crispy.Field('data_set_id'),
                 crispy.Field('org_unit_id'),
-                crispy.Field('org_unit_column'),
                 crispy.Field('period'),
-                crispy.Field('period_column'),
                 crispy.Field('attribute_option_combo_id'),
                 crispy.Field('complete_date', css_class='date-picker'),
             ),
@@ -154,33 +140,6 @@ class DataSetMapForm(forms.ModelForm):
     def clean(self):
         cleaned_data = super().clean()
 
-        if not (
-            cleaned_data.get('org_unit_id')
-            or cleaned_data.get('org_unit_column')
-        ):
-            self.add_error('org_unit_column', _(
-                'Either "OrgUnitID" or "OrgUnitID column" is required.'
-            ))
-
-        if (
-            cleaned_data.get('org_unit_id')
-            and cleaned_data.get('org_unit_column')
-        ):
-            self.add_error('org_unit_column', _(
-                'Either "OrgUnitID" or "OrgUnitID column" is required, but '
-                'not both.'
-            ))
-
-        if (
-            cleaned_data.get('period')
-            and cleaned_data.get('period_column')
-        ):
-            self.add_error('period_column', _(
-                'Either "Period" or "Period column" is required, but not '
-                'both. Alternatively, leave both fields blank to use the '
-                "UCR's date filter."
-            ))
-
         if (
             cleaned_data.get('frequency') == SEND_FREQUENCY_WEEKLY
             and not _int_in_range(cleaned_data.get('day_to_send'), 1, 7)
@@ -198,31 +157,90 @@ class DataSetMapForm(forms.ModelForm):
                 'from 1 to 28).'
             ))
 
+        ucr_id = cleaned_data.get('ucr_id')
+        ucr = None
+        if ucr_id:
+            ucr = get_document_or_not_found(ReportConfiguration, self.domain, ucr_id)
+
+        if cleaned_data.get('org_unit_id'):
+            org_unit_id = cleaned_data.get('org_unit_id')
+
+            # Check if the user input corresponds to one of the UCR's columns
+            # If so, populate 'org_unit_column', else 'org_unit_id'
+            if ucr_has_field(ucr, org_unit_id):
+                # Save user period input appropriately as period_column
+                cleaned_data['org_unit_column'] = cleaned_data['org_unit_id']
+                cleaned_data['org_unit_id'] = None
+
+            else:
+                try:
+                    org_unit_validator = RegexValidator(DHIS2_UID_RE, DHIS2_UID_MESSAGE)
+                    org_unit_validator(org_unit_id)
+                    # Ensure org_unit_column and org_unit_id is not both saved
+                    if cleaned_data['org_unit_column']:
+                        cleaned_data['org_unit_column'] = None
+
+                except ValidationError:
+                    self.add_error('org_unit_id', org_unit_validator.message)
+
         if cleaned_data.get('period'):
-            period_validators = {
-                SEND_FREQUENCY_WEEKLY: RegexValidator(r'^\d{4}W\d{1,2}$', _(
-                    '"Frequency" is set to "Weekly". Please enter a valid '
-                    'week period in the format yyyyWn (e.g. "2004W10" for '
-                    'week 10, 2004).'
-                )),
-                SEND_FREQUENCY_MONTHLY: RegexValidator(r'^\d{6}$', _(
-                    '"Frequency" is set to "Monthly". Please enter a valid '
-                    'month period in the format yyyyMM (e.g. "200403" for '
-                    'March 2004).'
-                )),
-                SEND_FREQUENCY_QUARTERLY: RegexValidator(r'^\d{4}Q\d$', _(
-                    '"Frequency" is set to "Quarterly". Please enter a valid '
-                    'quarter period in the format yyyyQn (e.g. "2004Q1" for '
-                    'January-March 2004).'
-                )),
-            }
-            validate_period = period_validators[cleaned_data.get('frequency')]
-            try:
-                validate_period(cleaned_data.get('period'))
-            except ValidationError:
-                self.add_error('period', validate_period.message)
+            period = cleaned_data.get('period')
+
+            # Check if the user input corresponds to one of the UCR's columns
+            # If so, populate 'period_column', else 'period'
+            if ucr_has_field(ucr, period):
+                # Save user period input appropriately as period_column
+                cleaned_data['period_column'] = cleaned_data['period']
+                cleaned_data['period'] = None
+
+            else:
+                period_validators = {
+                    SEND_FREQUENCY_WEEKLY: RegexValidator(r'^\d{4}W\d{1,2}$', _(
+                        '"Frequency" is set to "Weekly". Please enter a valid '
+                        'week period in the format yyyyWn (e.g. "2004W10" for '
+                        'week 10, 2004).'
+                    )),
+                    SEND_FREQUENCY_MONTHLY: RegexValidator(r'^\d{6}$', _(
+                        '"Frequency" is set to "Monthly". Please enter a valid '
+                        'month period in the format yyyyMM (e.g. "200403" for '
+                        'March 2004).'
+                    )),
+                    SEND_FREQUENCY_QUARTERLY: RegexValidator(r'^\d{4}Q\d$', _(
+                        '"Frequency" is set to "Quarterly". Please enter a valid '
+                        'quarter period in the format yyyyQn (e.g. "2004Q1" for '
+                        'January-March 2004).'
+                    )),
+                }
+                validate_period = period_validators[cleaned_data.get('frequency')]
+                try:
+                    validate_period(cleaned_data.get('period'))
+
+                    # Ensure period column and period is not both saved
+                    if cleaned_data['period_column'] is not None:
+                        cleaned_data['period_column'] = None
+
+                except ValidationError:
+                    self.add_error('period', validate_period.message)
 
         return self.cleaned_data
+
+
+def add_initial_properties(instance, kwargs_initial):
+    if instance is not None:
+        if instance.period_column:
+            kwargs_initial['period'] = instance.period_column
+
+        if instance.org_unit_column:
+            kwargs_initial['org_unit_id'] = instance.org_unit_column
+
+    return kwargs_initial
+
+
+def ucr_has_field(ucr: ReportConfiguration, field):
+    for column in ucr.report_columns:
+        if column.display == field:
+            return True
+    return False
 
 
 def get_connection_settings_field(domain):

--- a/corehq/motech/dhis2/forms.py
+++ b/corehq/motech/dhis2/forms.py
@@ -45,10 +45,9 @@ class DataSetMapForm(forms.ModelForm):
     )
     data_set_id = forms.CharField(
         label=_('DataSetID'),
-        help_text=_('Set DataSetID if this UCR adds values to an existing '
-                    'DHIS2 DataSet'),
+        help_text=_('The DHIS2 DataSet ID to which this UCR adds value'),
         validators=[RegexValidator(DHIS2_UID_RE, DHIS2_UID_MESSAGE)],
-        required=False,
+        required=True,
     )
     org_unit_id = forms.CharField(
         label=_('OrgUnitID¹'),

--- a/corehq/motech/dhis2/forms.py
+++ b/corehq/motech/dhis2/forms.py
@@ -240,10 +240,7 @@ def add_initial_properties(instance, kwargs_initial):
 
 
 def ucr_has_field(ucr: ReportConfiguration, field):
-    for column in ucr.report_columns:
-        if column.column_id == field:
-            return True
-    return False
+    return any(c.column_id == field for c in ucr.report_columns)
 
 
 def get_connection_settings_field(domain):

--- a/corehq/motech/dhis2/forms.py
+++ b/corehq/motech/dhis2/forms.py
@@ -47,7 +47,7 @@ class DataSetMapForm(forms.ModelForm):
     )
     data_set_id = forms.CharField(
         label=_('DataSetID'),
-        help_text=_('The DHIS2 DataSet ID to which this DataSet adds value.'),
+        help_text=_('The DHIS2 ID of this DataSet'),
         validators=[RegexValidator(DHIS2_UID_RE, DHIS2_UID_MESSAGE)],
         required=True,
     )

--- a/corehq/motech/dhis2/forms.py
+++ b/corehq/motech/dhis2/forms.py
@@ -198,17 +198,17 @@ class DataSetMapForm(forms.ModelForm):
                     SEND_FREQUENCY_WEEKLY: RegexValidator(r'^\d{4}W\d{1,2}$', _(
                         '"Frequency" is set to "Weekly". Please enter a valid '
                         'week period in the format yyyyWn (e.g. "2004W10" for '
-                        'week 10, 2004).'
+                        'week 10, 2004), or enter a valid column.'
                     )),
                     SEND_FREQUENCY_MONTHLY: RegexValidator(r'^\d{6}$', _(
                         '"Frequency" is set to "Monthly". Please enter a valid '
                         'month period in the format yyyyMM (e.g. "200403" for '
-                        'March 2004).'
+                        'March 2004), or enter a valid column.'
                     )),
                     SEND_FREQUENCY_QUARTERLY: RegexValidator(r'^\d{4}Q\d$', _(
                         '"Frequency" is set to "Quarterly". Please enter a valid '
                         'quarter period in the format yyyyQn (e.g. "2004Q1" for '
-                        'January-March 2004).'
+                        'January-March 2004), or enter a valid column.'
                     )),
                 }
                 validate_period = period_validators[cleaned_data.get('frequency')]

--- a/corehq/motech/dhis2/models.py
+++ b/corehq/motech/dhis2/models.py
@@ -320,7 +320,7 @@ def group_dataset_datavalues(
     )
 
 
-def group_data_by_keys(data: List[dict], keys: list):
+def _group_data_by_keys(data: List[dict], keys: list):
     from collections import defaultdict
     datasets_dict = defaultdict(lambda: [])
     for row in data:
@@ -342,7 +342,7 @@ def get_grouped_datavalues_sets(
 ) -> List[dict]:
 
     datasets = []
-    for grouped_key, grouped_value in group_data_by_keys(data_list, group_by_keys).items():
+    for grouped_key, grouped_value in _group_data_by_keys(data_list, group_by_keys).items():
         dataset = copy.deepcopy(template_dataset)
 
         for key, key_value in zip(group_by_keys, grouped_key):

--- a/corehq/motech/dhis2/models.py
+++ b/corehq/motech/dhis2/models.py
@@ -228,10 +228,10 @@ def get_datavalues(
     return datavalues
 
 
-def get_dataset(
+def parse_dataset_for_request(
     dataset_map: Union[DataSetMap, SQLDataSetMap],
     send_date: date
-) -> dict:
+) -> list:
     if not dataset_map.ucr:
         raise ValueError(f'UCR not found for {dataset_map!r}')
     date_filter = get_date_filter(dataset_map.ucr)
@@ -255,27 +255,23 @@ def get_dataset(
     if dataset_map.attribute_option_combo_id:
         dataset['attributeOptionCombo'] = dataset_map.attribute_option_combo_id
 
-    datasets = process_complete_date(dataset_map, dataset, datavalues_list)
+    if dataset_map.complete_date:
+        dataset['completeDate'] = str(dataset_map.complete_date)
+        datavalues_sets = group_dataset_datavalues(dataset, datavalues_list)
+    else:
+        datavalues_sets = dataset
 
-    return datasets
+    return datavalues_sets
 
 
-def process_complete_date(
-    dataset_map: Union[DataSetMap, SQLDataSetMap],
+def group_dataset_datavalues(
     dataset,
     datavalues_list
 ) -> list:
     """
-        This function evaluates a few cases regarding the 'completeDate':
-        1)
-            Evaluation: 'completeDate' is not specified
-            Considerations: None
-            Process: None
-            Response: return `dataset` as a list
-        2)
-            Evaluation: 'completeDate' is specified
+        This function evaluates a few cases regarding the 'period' and 'orgUnit':
             Considerations:
-                 In this case the 'period' and 'orgUnit' must be on specified on the same level as the 'completeDate',
+                 The 'period' and 'orgUnit' must be on specified on the same level as the 'completeDate',
                  thus the payload MUST be in the following format:
                     {
                         "completeDate": <completeDate>,
@@ -283,58 +279,56 @@ def process_complete_date(
                         "period": <period>,
                         "dataValues": [...]
                     }
+
+                Since 'completeDate' is specified directly on the `dataset` dictionary, we look there.
                 Several cases should be considered:
-                A) 'orgUnit' and 'period' is static, i.e. already on same level as 'completeDate'
-                B) 'orgUnit' is static and 'period' is dynamic, i.e. 'period' is specified in datavalues_list
-                C) 'period' is static and 'orgUnit' is dynamic, i.e. 'period' is specified in datavalues_list
-                D) both 'period' and 'orgUnit' is dynamic
-
-            Process:
-                A) No further processing, simply add 'dataValues' to dataset and return dataset as is.
-                B) Go through 'datavalues_list' and group by 'period' so that a list of items can be constructed
+                A) 'orgUnit' and 'period' is static, i.e. already on same level as 'completeDate'.
+                    - No further processing, simply add 'dataValues' to dataset and return dataset as is.
+                B) 'orgUnit' is static and 'period' is dynamic, i.e. 'period' is specified in `datavalues_list`.
+                    - Go through 'datavalues_list' and group by 'period' so that a list of items can be constructed
                     such that 'period' sits on the same level as 'completeDate'
-                C) Same as B), except 'period' is not 'orgUnit'.
-                D) Same as B and C, except both 'orgUnit' and 'period' should be considered.
+                C) 'period' is static and 'orgUnit' is dynamic, i.e. 'period' is specified in `datavalues_list`.
+                    - Same as B), except 'period' is not 'orgUnit'.
+                D) both 'period' and 'orgUnit' is dynamic.
+                    - Same as B and C, except both 'orgUnit' and 'period' should be considered.
 
-            Return: list of items, where each item corresponds to the format specified in "Considerations"
+            Return:
+                A list of grouped 'datavalues_sets', where each 'set' corresponds to the format
+                specified in "Considerations" above.
     """
-    if dataset_map.complete_date:
-        dataset['completeDate'] = str(dataset_map.complete_date)
-
-        if dataset.get('orgUnit') and dataset.get('period'):
-            dataset['dataValues'] = datavalues_list
-            return [dataset]
-
-        group_by = None
-        if dataset.get('orgUnit') and not dataset.get('period'):
-            # Group datavalues_list by period and apply dataset_template
-            group_by = ['period']
-
-        if dataset.get('period') and not dataset.get('orgUnit'):
-            # Group by orgUnit
-            group_by = ['orgUnit']
-
-        if not dataset.get('orgUnit') and not dataset.get('period'):
-            # Group by orgUnit and period
-            group_by = ['orgUnit', 'period']
-
-        grouped_datasets = get_grouped_datasets_with_template(
-            group_by=group_by,
-            template_dataset=dataset,
-            data_list=datavalues_list
-        )
-        return grouped_datasets
-
-    else:
+    if dataset.get('orgUnit') and dataset.get('period'):
+        dataset['dataValues'] = datavalues_list
         return [dataset]
 
+    group_by_items = []
+    if dataset.get('orgUnit') and not dataset.get('period'):
+        # Need to group datavalues_list by period
+        group_by_items = ['period']
 
-def get_grouped_datasets_with_template(group_by, template_dataset, data_list):
+    if dataset.get('period') and not dataset.get('orgUnit'):
+        # Need to group datavalues_list by orgUnit
+        group_by_items = ['orgUnit']
+
+    if not dataset.get('orgUnit') and not dataset.get('period'):
+        # Need to group datavalues_list by orgUnit and period
+        group_by_items = ['orgUnit', 'period']
+
+    return get_grouped_datavalues_sets(
+        group_by=group_by_items,
+        template_dataset=dataset,
+        data_list=datavalues_list
+    )
+
+
+def get_grouped_datavalues_sets(group_by, template_dataset, data_list):
+    """
+        'group_by' will mostly be a list containing just 1 item, but in one instance it contains 2 items, thus
+        all list operations concerning the 'group_by' argument would take a very short time to execute.
+    """
     def get_grouped_data(data, group_by_keys):
         data_list_temp = copy.deepcopy(data)
 
         while len(data_list_temp) > 0:
-            # group_by_keys will be at most 2 items
             group_by_values_ = [data_list_temp[0][group_by_key] for group_by_key in group_by_keys]
 
             grouped_data = []

--- a/corehq/motech/dhis2/models.py
+++ b/corehq/motech/dhis2/models.py
@@ -233,7 +233,7 @@ def get_dataset(
     send_date: date
 ) -> dict:
     if not dataset_map.ucr:
-        raise ValueError('UCR not found for {dataset_map!r}')
+        raise ValueError(f'UCR not found for {dataset_map!r}')
     date_filter = get_date_filter(dataset_map.ucr)
     date_range = get_date_range(dataset_map.frequency, send_date)
     ucr_data = get_ucr_data(dataset_map.ucr, date_filter, date_range)

--- a/corehq/motech/dhis2/models.py
+++ b/corehq/motech/dhis2/models.py
@@ -364,31 +364,6 @@ def get_grouped_datasets_with_template(group_by, template_dataset, data_list):
 
     return datasets
 
-# def get_grouped_datasets_with_template(template={}, group_by='', data_list=[]):
-#     def get_items_from_list_with_key_value(key, value, datalist):
-#         relevant_items = []
-#         for data_item in datalist:
-#             if data_item[key] == value:
-#                 data_item.pop(key)
-#                 relevant_items.append(data_item)
-#                 datalist.remove(data_item)
-#
-#         return relevant_items
-#
-#     data_list_copy = copy.deepcopy(data_list)
-#     elements_to_group_by = set([data_list_item[group_by] for data_list_item in data_list_copy])
-#
-#     grouped_data_list = []
-#     for group_by_element in elements_to_group_by:
-#         grouped_data_template = copy.deepcopy(template)
-#
-#         grouped_data_template[group_by] = group_by_element
-#         grouped_data_template['dataValues'] = get_items_from_list_with_key_value(group_by, group_by_element, data_list_copy)
-#
-#         grouped_data_list.append(grouped_data_template)
-#
-#     return grouped_data_list
-
 
 def get_date_range(frequency: str, send_date: date) -> DateSpan:
     if frequency == SEND_FREQUENCY_WEEKLY:

--- a/corehq/motech/dhis2/models.py
+++ b/corehq/motech/dhis2/models.py
@@ -259,6 +259,7 @@ def parse_dataset_for_request(
         dataset['completeDate'] = str(dataset_map.complete_date)
         datavalues_sets = group_dataset_datavalues(dataset, datavalues_list)
     else:
+        dataset['dataValues'] = datavalues_list
         datavalues_sets = [dataset]
 
     return datavalues_sets

--- a/corehq/motech/dhis2/models.py
+++ b/corehq/motech/dhis2/models.py
@@ -1,3 +1,4 @@
+import copy
 from datetime import date, timedelta
 from itertools import chain
 from typing import Dict, List, Optional, Union
@@ -238,9 +239,10 @@ def get_dataset(
     ucr_data = get_ucr_data(dataset_map.ucr, date_filter, date_range)
 
     datavalues = (get_datavalues(dataset_map, row) for row in ucr_data)  # one UCR row may have many DataValues
-    dataset = {
-        'dataValues': list(chain.from_iterable(datavalues))  # get a single list of DataValues
-    }
+    datavalues_list = list(chain.from_iterable(datavalues))  # get a single list of DataValues
+
+    dataset = {}
+
     if dataset_map.data_set_id:
         dataset['dataSet'] = dataset_map.data_set_id
     if dataset_map.org_unit_id:
@@ -252,9 +254,140 @@ def get_dataset(
                                        date_range.startdate)
     if dataset_map.attribute_option_combo_id:
         dataset['attributeOptionCombo'] = dataset_map.attribute_option_combo_id
+
+    datasets = process_complete_date(dataset_map, dataset, datavalues_list)
+
+    return datasets
+
+
+def process_complete_date(
+    dataset_map: Union[DataSetMap, SQLDataSetMap],
+    dataset,
+    datavalues_list
+) -> list:
+    """
+        This function evaluates a few cases regarding the 'completeDate':
+        1)
+            Evaluation: 'completeDate' is not specified
+            Considerations: None
+            Process: None
+            Response: return `dataset` as a list
+        2)
+            Evaluation: 'completeDate' is specified
+            Considerations:
+                 In this case the 'period' and 'orgUnit' must be on specified on the same level as the 'completeDate',
+                 thus the payload MUST be in the following format:
+                    {
+                        "completeDate": <completeDate>,
+                        "orgUnit": <orgUnit>,
+                        "period": <period>,
+                        "dataValues": [...]
+                    }
+                Several cases should be considered:
+                A) 'orgUnit' and 'period' is static, i.e. already on same level as 'completeDate'
+                B) 'orgUnit' is static and 'period' is dynamic, i.e. 'period' is specified in datavalues_list
+                C) 'period' is static and 'orgUnit' is dynamic, i.e. 'period' is specified in datavalues_list
+                D) both 'period' and 'orgUnit' is dynamic
+
+            Process:
+                A) No further processing, simply add 'dataValues' to dataset and return dataset as is.
+                B) Go through 'datavalues_list' and group by 'period' so that a list of items can be constructed
+                    such that 'period' sits on the same level as 'completeDate'
+                C) Same as B), except 'period' is not 'orgUnit'.
+                D) Same as B and C, except both 'orgUnit' and 'period' should be considered.
+
+            Return: list of items, where each item corresponds to the format specified in "Considerations"
+    """
     if dataset_map.complete_date:
         dataset['completeDate'] = str(dataset_map.complete_date)
-    return dataset
+
+        if dataset.get('orgUnit') and dataset.get('period'):
+            dataset['dataValues'] = datavalues_list
+            return [dataset]
+
+        group_by = None
+        if dataset.get('orgUnit') and not dataset.get('period'):
+            # Group datavalues_list by period and apply dataset_template
+            group_by = ['period']
+
+        if dataset.get('period') and not dataset.get('orgUnit'):
+            # Group by orgUnit
+            group_by = ['orgUnit']
+
+        if not dataset.get('orgUnit') and not dataset.get('period'):
+            # Group by orgUnit and period
+            group_by = ['orgUnit', 'period']
+
+        grouped_datasets = get_grouped_datasets_with_template(
+            group_by=group_by,
+            template_dataset=dataset,
+            data_list=datavalues_list
+        )
+        return grouped_datasets
+
+    else:
+        return [dataset]
+
+
+def get_grouped_datasets_with_template(group_by, template_dataset, data_list):
+    def get_grouped_data(data, group_by_keys):
+        data_list_temp = copy.deepcopy(data)
+
+        while len(data_list_temp) > 0:
+            # group_by_keys will be at most 2 items
+            group_by_values_ = [data_list_temp[0][group_by_key] for group_by_key in group_by_keys]
+
+            grouped_data = []
+            iterable_data_list = copy.deepcopy(data_list_temp)
+
+            for data_item in data_list_temp:
+                data_item_key_values = [data_item[group_by_key] for group_by_key in group_by_keys]
+
+                if sorted(data_item_key_values) == sorted(group_by_values_):
+                    iterable_data_list.remove(data_item)
+                    [data_item.pop(group_by_key) for group_by_key in group_by_keys]
+                    grouped_data.append(data_item)
+
+            data_list_temp = copy.deepcopy(iterable_data_list)
+            yield [{'group_by_values': group_by_values_, 'grouped_datavalues': grouped_data}]
+
+    datasets = []
+    for grouped_result in chain.from_iterable(get_grouped_data(data_list, group_by)):
+        grouped_data_set = copy.deepcopy(template_dataset)
+
+        group_by_values = grouped_result['group_by_values']
+        for key, value in zip(group_by, group_by_values):
+            grouped_data_set[key] = value
+
+        grouped_data_set['dataValues'] = grouped_result['grouped_datavalues']
+        datasets.append(grouped_data_set)
+
+    return datasets
+
+# def get_grouped_datasets_with_template(template={}, group_by='', data_list=[]):
+#     def get_items_from_list_with_key_value(key, value, datalist):
+#         relevant_items = []
+#         for data_item in datalist:
+#             if data_item[key] == value:
+#                 data_item.pop(key)
+#                 relevant_items.append(data_item)
+#                 datalist.remove(data_item)
+#
+#         return relevant_items
+#
+#     data_list_copy = copy.deepcopy(data_list)
+#     elements_to_group_by = set([data_list_item[group_by] for data_list_item in data_list_copy])
+#
+#     grouped_data_list = []
+#     for group_by_element in elements_to_group_by:
+#         grouped_data_template = copy.deepcopy(template)
+#
+#         grouped_data_template[group_by] = group_by_element
+#         grouped_data_template['dataValues'] = get_items_from_list_with_key_value(group_by, group_by_element, data_list_copy)
+#
+#         grouped_data_list.append(grouped_data_template)
+#
+#     return grouped_data_list
 
 
 def get_date_range(frequency: str, send_date: date) -> DateSpan:

--- a/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
+++ b/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
@@ -33,8 +33,7 @@ hqDefine("dhis2/js/dataset_map", [
                 .removeClass("hide text-success")
                 .addClass("text-danger");
             $sendNowResult.text(
-                gettext('CommCare HQ was unable to send the DataSet: ')
-                + (resp.responseJSON ? resp.responseJSON['error'] : resp.statusText)
+                gettext('CommCare HQ was unable to send the DataSet: Error occurred')
             );
             if (resp.responseJSON) {
                 $remoteLogsLink.attr('href', resp.responseJSON['log_url']);

--- a/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
+++ b/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
@@ -33,7 +33,8 @@ hqDefine("dhis2/js/dataset_map", [
                 .removeClass("hide text-success")
                 .addClass("text-danger");
             $sendNowResult.text(
-                gettext('CommCare HQ was unable to send the DataSet: Error occurred')
+                gettext('CommCare HQ was unable to send the DataSet: ')
+                + (resp.responseJSON ? resp.responseJSON['error'] : resp.statusText)
             );
             if (resp.responseJSON) {
                 $remoteLogsLink.attr('href', resp.responseJSON['log_url']);

--- a/corehq/motech/dhis2/tasks.py
+++ b/corehq/motech/dhis2/tasks.py
@@ -15,6 +15,8 @@ from corehq.motech.dhis2.models import (
     should_send_on_date,
 )
 from corehq.util.view_utils import reverse
+from corehq.privileges import DATA_FORWARDING
+from corehq.apps.domain.models import Domain
 
 
 @periodic_task(
@@ -23,7 +25,7 @@ from corehq.util.view_utils import reverse
 )
 def send_datasets_for_all_domains():
     for domain in find_domains_with_toggle_enabled(toggles.DHIS2_INTEGRATION):
-        send_datasets.delay(domain)
+        send_datasets.delay(domain) if _data_forwarding_privilege(domain) else None
 
 
 @task(serializer='pickle', queue='background_queue')
@@ -33,6 +35,10 @@ def send_datasets(domain_name, send_now=False, send_date=None):
     for dataset_map in SQLDataSetMap.objects.filter(domain=domain_name).all():
         if send_now or should_send_on_date(dataset_map, send_date):
             send_dataset(dataset_map, send_date)
+
+
+def _data_forwarding_privilege(domain_name):
+    return Domain.get_by_name(domain_name).has_privilege(DATA_FORWARDING)
 
 
 def send_dataset(

--- a/corehq/motech/dhis2/tasks.py
+++ b/corehq/motech/dhis2/tasks.py
@@ -107,18 +107,19 @@ def send_dataset(
         except Exception as err:
             requests.notify_error(message=str(err),
                                   details=traceback.format_exc())
+            text = pformat_json(response.text if response else None)
 
             return {
                 'success': False,
                 'error': str(err),
                 'status_code': response.status_code if response else None,
-                'text': _('Could not send data, DHIS2 reported an issue.'),
+                'text': text,
                 'log_url': response_log_url,
             }
         else:
             return {
                 'success': True,
-                'status_code': response.status_code if response else None,
-                'text': _('Successfully send to DHIS2'),
+                'status_code': response.status_code,
+                'text': pformat_json(response.text),
                 'log_url': response_log_url,
             }

--- a/corehq/motech/dhis2/tasks.py
+++ b/corehq/motech/dhis2/tasks.py
@@ -11,7 +11,7 @@ from toggle.shortcuts import find_domains_with_toggle_enabled
 from corehq import toggles
 from corehq.motech.dhis2.models import (
     SQLDataSetMap,
-    get_dataset,
+    parse_dataset_for_request,
     should_send_on_date,
 )
 from corehq.util.view_utils import reverse
@@ -86,12 +86,11 @@ def send_dataset(
 
     with dataset_map.connection_settings.get_requests(payload_id) as requests:
         try:
-            datasets = get_dataset(dataset_map, send_date)
+            datavalues_sets = parse_dataset_for_request(dataset_map, send_date)
 
-            # Consider other way of sending? This is brute forcing
-            for dataset in datasets:
-                requests.post('/api/dataValueSets', json=dataset,
-                                         raise_for_status=True)
+            for datavalues_set in datavalues_sets:
+                requests.post('/api/dataValueSets', json=datavalues_set,
+                              raise_for_status=True)
 
         except DatabaseError as db_err:
             requests.notify_error(message=str(db_err),

--- a/corehq/motech/dhis2/tasks.py
+++ b/corehq/motech/dhis2/tasks.py
@@ -11,7 +11,7 @@ from toggle.shortcuts import find_domains_with_toggle_enabled
 from corehq import toggles
 from corehq.motech.dhis2.models import (
     SQLDataSetMap,
-    get_dataset,
+    parse_dataset_for_request,
     should_send_on_date,
 )
 from corehq.util.view_utils import reverse
@@ -85,13 +85,13 @@ def send_dataset(
     )
 
     with dataset_map.connection_settings.get_requests(payload_id) as requests:
+        response = None
         try:
-            datasets = get_dataset(dataset_map, send_date)
+            datavalues_sets = parse_dataset_for_request(dataset_map, send_date)
 
-            # Consider other way of sending? This is brute forcing
-            for dataset in datasets:
-                requests.post('/api/dataValueSets', json=dataset,
-                                         raise_for_status=True)
+            for datavalues_set in datavalues_sets:
+                response = requests.post('/api/dataValueSets', json=datavalues_set,
+                              raise_for_status=True)
 
         except DatabaseError as db_err:
             requests.notify_error(message=str(db_err),
@@ -111,14 +111,14 @@ def send_dataset(
             return {
                 'success': False,
                 'error': str(err),
-                'status_code': None,
+                'status_code': response.status_code if response else None,
                 'text': _('Could not send data, DHIS2 reported an issue.'),
                 'log_url': response_log_url,
             }
         else:
             return {
                 'success': True,
-                'status_code': None,
+                'status_code': response.status_code if response else None,
                 'text': _('Successfully send to DHIS2'),
                 'log_url': response_log_url,
             }

--- a/corehq/motech/dhis2/tests/test_models.py
+++ b/corehq/motech/dhis2/tests/test_models.py
@@ -24,7 +24,8 @@ from ..models import (
     get_previous_week,
     get_quarter_start_month,
     should_send_on_date,
-    get_grouped_datavalues_sets
+    get_grouped_datavalues_sets,
+    _group_data_by_keys,
 )
 
 
@@ -293,6 +294,53 @@ class TestDifferentDataSetMaps(TestCase):
 
 class TestGetGroupedDatasets(TestCase):
 
+    def test_group_data_by_keys(self):
+        data_list = [
+            {'dataElement': 'dataElementID1', 'period': '202102', 'value': 90456},
+            {'dataElement': 'dataElementID2', 'period': '202103', 'value': 90456},
+            {'dataElement': 'dataElementID3', 'period': '202104', 'value': 135},
+            {'dataElement': 'dataElementID4', 'period': '202105', 'value': 90333},
+            {'dataElement': 'dataElementID5', 'period': '202106', 'value': 90333},
+            {'dataElement': 'dataElementID6', 'period': '202103', 'value': 90456},
+            {'dataElement': 'dataElementID7', 'period': '202102', 'value': 90210}
+        ]
+        num_unique_periods = 5
+        result = _group_data_by_keys(data_list, ['period'])
+
+        self.assertEqual(len(result), num_unique_periods)
+        for key_value, key_grouped in result.items():
+            if key_value == ('202102',):
+                self.assertEqual(
+                    key_grouped,
+                    [
+                        {'dataElement': 'dataElementID1', 'value': 90456},
+                        {'dataElement': 'dataElementID7', 'value': 90210}
+                    ]
+                )
+            elif key_value == ('202103',):
+                self.assertEqual(
+                    key_grouped,
+                    [
+                        {'dataElement': 'dataElementID2', 'value': 90456},
+                        {'dataElement': 'dataElementID6', 'value': 90456}
+                    ]
+                )
+            elif key_value == ('202104',):
+                self.assertEqual(
+                    key_grouped,
+                    [{'dataElement': 'dataElementID3', 'value': 135}]
+                )
+            elif key_value == ('202105',):
+                self.assertEqual(
+                    key_grouped,
+                    [{'dataElement': 'dataElementID4', 'value': 90333}]
+                )
+            else:
+                self.assertEqual(
+                    key_grouped,
+                    [{'dataElement': 'dataElementID5', 'value': 90333}]
+                )
+
     def test_group_by_period(self):
         template_dataset = {'dataSet': 'p1UpPrpg1QX', 'orgUnit': 'g8dWMTyEZGZ'}
 
@@ -307,7 +355,7 @@ class TestGetGroupedDatasets(TestCase):
         ]
 
         grouped_result = get_grouped_datavalues_sets(
-            group_by=['period'],
+            group_by_keys=['period'],
             template_dataset=template_dataset,
             data_list=data_list
         )
@@ -350,7 +398,7 @@ class TestGetGroupedDatasets(TestCase):
         ]
 
         grouped_result = get_grouped_datavalues_sets(
-            group_by=['orgUnit'],
+            group_by_keys=['orgUnit'],
             template_dataset=template_dataset,
             data_list=data_list
         )
@@ -387,7 +435,7 @@ class TestGetGroupedDatasets(TestCase):
         ]
 
         grouped_result = get_grouped_datavalues_sets(
-            group_by=['orgUnit', 'period'],
+            group_by_keys=['orgUnit', 'period'],
             template_dataset=template_dataset,
             data_list=data_list
         )

--- a/corehq/motech/dhis2/tests/test_models.py
+++ b/corehq/motech/dhis2/tests/test_models.py
@@ -24,6 +24,7 @@ from ..models import (
     get_previous_week,
     get_quarter_start_month,
     should_send_on_date,
+    get_grouped_datasets_with_template
 )
 
 
@@ -288,3 +289,120 @@ class TestDifferentDataSetMaps(TestCase):
             'is_org_unit': False,
             'is_period': False,
         }})
+
+
+class TestGetGroupedDatasets(TestCase):
+
+    def test_group_by_period(self):
+        template_dataset = {'dataSet': 'p1UpPrpg1QX', 'orgUnit': 'g8dWMTyEZGZ'}
+
+        data_list = [
+            {'dataElement': 'dataElementID1', 'period': '202102', 'value': 90456},
+            {'dataElement': 'dataElementID2', 'period': '202103', 'value': 90456},
+            {'dataElement': 'dataElementID3', 'period': '202104', 'value': 135},
+            {'dataElement': 'dataElementID4', 'period': '202105', 'value': 90333},
+            {'dataElement': 'dataElementID5', 'period': '202106', 'value': 90333},
+            {'dataElement': 'dataElementID6', 'period': '202103', 'value': 90456},
+            {'dataElement': 'dataElementID7', 'period': '202102', 'value': 90210}
+        ]
+
+        grouped_result = get_grouped_datasets_with_template(
+            group_by=['period'],
+            template_dataset=template_dataset,
+            data_list=data_list
+        )
+
+        expected_results = {
+            '202102': [
+                {'dataElement': 'dataElementID1', 'value': 90456},
+                {'dataElement': 'dataElementID7', 'value': 90210}
+            ],
+            '202103': [
+                {'dataElement': 'dataElementID2', 'value': 90456},
+                {'dataElement': 'dataElementID6', 'value': 90456}
+            ],
+            '202104': [
+                {'dataElement': 'dataElementID3', 'value': 135}
+            ],
+            '202105': [
+                {'dataElement': 'dataElementID4', 'value': 90333}
+            ],
+            '202106': [
+                {'dataElement': 'dataElementID5', 'value': 90333}
+            ]
+        }
+
+        self.assertEqual(len(grouped_result), 5)
+
+        for res in grouped_result:
+            self.assertIn('period', res)
+            self.assertIn('dataValues', res)
+            self.assertEqual(expected_results[res['period']], res['dataValues'])
+
+    def test_group_by_orgUnit(self):
+        template_dataset = {'dataSet': 'p1UpPrpg1QX', 'period': '202104'}
+
+        data_list = [
+            {'dataElement': 'dataElementID1', 'orgUnit': 'orgUnit1', 'value': 90456},
+            {'dataElement': 'dataElementID2', 'orgUnit': 'orgUnit1', 'value': 90456},
+            {'dataElement': 'dataElementID3', 'orgUnit': 'orgUnit2', 'value': 135},
+            {'dataElement': 'dataElementID4', 'orgUnit': 'orgUnit3', 'value': 135}
+        ]
+
+        grouped_result = get_grouped_datasets_with_template(
+            group_by=['orgUnit'],
+            template_dataset=template_dataset,
+            data_list=data_list
+        )
+
+        expected_results = {
+            'orgUnit1': [
+                {'dataElement': 'dataElementID1', 'value': 90456},
+                {'dataElement': 'dataElementID2', 'value': 90456}
+            ],
+            'orgUnit2': [
+                {'dataElement': 'dataElementID3', 'value': 135}
+            ],
+            'orgUnit3': [
+                {'dataElement': 'dataElementID4', 'value': 135}
+            ]
+        }
+
+        self.assertEqual(len(grouped_result), 3)
+
+        for res in grouped_result:
+            self.assertIn('orgUnit', res)
+            self.assertIn('dataValues', res)
+            self.assertEqual(expected_results[res['orgUnit']], res['dataValues'])
+
+    def test_group_by_orgUnit_and_period(self):
+        template_dataset = {'dataSet': 'p1UpPrpg1QX'}
+
+        data_list = [
+            {'dataElement': 'dataElementID1', 'orgUnit': 'orgUnit1', 'period': '202101', 'value': 90456},
+            {'dataElement': 'dataElementID2', 'orgUnit': 'orgUnit1', 'period': '202101', 'value': 90456},
+            {'dataElement': 'dataElementID3', 'orgUnit': 'orgUnit1', 'period': '202102', 'value': 90456},
+            {'dataElement': 'dataElementID4', 'orgUnit': 'orgUnit2', 'period': '202102', 'value': 135},
+            {'dataElement': 'dataElementID5', 'orgUnit': 'orgUnit3', 'period': '202103', 'value': 135}
+        ]
+
+        grouped_result = get_grouped_datasets_with_template(
+            group_by=['orgUnit', 'period'],
+            template_dataset=template_dataset,
+            data_list=data_list
+        )
+
+        expected_results = [
+            {'dataElement': 'dataElementID1', 'value': 90456},
+            {'dataElement': 'dataElementID2', 'value': 90456}
+        ]
+
+        self.assertEqual(len(grouped_result), 4)
+
+        result_of_interest = None
+        for result in grouped_result:
+            if result.get('orgUnit') == 'orgUnit1' and result.get('period') == '202101':
+                result_of_interest = result
+                break
+
+        self.assertEqual(result_of_interest.get('dataValues'), expected_results)

--- a/corehq/motech/dhis2/tests/test_models.py
+++ b/corehq/motech/dhis2/tests/test_models.py
@@ -24,7 +24,7 @@ from ..models import (
     get_previous_week,
     get_quarter_start_month,
     should_send_on_date,
-    get_grouped_datasets_with_template
+    get_grouped_datavalues_sets
 )
 
 
@@ -306,7 +306,7 @@ class TestGetGroupedDatasets(TestCase):
             {'dataElement': 'dataElementID7', 'period': '202102', 'value': 90210}
         ]
 
-        grouped_result = get_grouped_datasets_with_template(
+        grouped_result = get_grouped_datavalues_sets(
             group_by=['period'],
             template_dataset=template_dataset,
             data_list=data_list
@@ -349,7 +349,7 @@ class TestGetGroupedDatasets(TestCase):
             {'dataElement': 'dataElementID4', 'orgUnit': 'orgUnit3', 'value': 135}
         ]
 
-        grouped_result = get_grouped_datasets_with_template(
+        grouped_result = get_grouped_datavalues_sets(
             group_by=['orgUnit'],
             template_dataset=template_dataset,
             data_list=data_list
@@ -386,7 +386,7 @@ class TestGetGroupedDatasets(TestCase):
             {'dataElement': 'dataElementID5', 'orgUnit': 'orgUnit3', 'period': '202103', 'value': 135}
         ]
 
-        grouped_result = get_grouped_datasets_with_template(
+        grouped_result = get_grouped_datavalues_sets(
             group_by=['orgUnit', 'period'],
             template_dataset=template_dataset,
             data_list=data_list


### PR DESCRIPTION
## Summary
(See AE feedback and comments [here](https://docs.google.com/document/d/1eO3uBUURnHg8HGAZSvi3je_3fVKKEBRvDh44_BoAY2I/edit#))

### Changes
#### UI
OrgUnitID and Period now only has one input which accepts either a static value or a UCR column value. Upon submission the BE checks if the column exists in the UCR, otherwise it expects it to be a static DHIS2 ID and the appropriate validation will be performed as per DHIS2 ID criteria.

#### BE
When the user has submitted a CompleteDate, the BE checks 4 things:

If Period and OrgUnitID is static, use the payload as parsed like before.
If Period is static and OrgUnitID is dynamic (ie column), group by org_unit_column as to fit [this](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/data.html#webapi_sending_data_values) payload structure
If OrgUnitID is static and Period is dynamic (ie column), group by period_column as to fit [this](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/data.html#webapi_sending_data_values) payload structure
If both Period and OrgUnitID is dynamic, (ie columns), group by both Period and OrgUnitID as to fit [this](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/data.html#webapi_sending_data_values) payload structure.

Other notes: This implementation might not be the most optimized piece of code ever written, _but_ the fact is that this code will run silently in the background and does not need to be highly optimized.

## Feature Flag
DHIS2

## Product Description
On the Add/Edit DataSet Map form view:
- DataSetId field made a requirement
- Removed the `Period Column` and `OrgUnit Column` input fields. The BE will take the input and compare it with the UCR's columns; if no matching column is found, assume it's an ID and do the DHIS2 ID validation.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Unit tests

### QA Plan
This has been tested on staging by myself, although it's awaiting QA also.

- [x] This PR can be reverted after deploy with no further considerations 
