### PR TITLE
"storedBy" is a valid property

### DIFF
--- a/corehq/motech/dhis2/schema.py
+++ b/corehq/motech/dhis2/schema.py
@@ -174,6 +174,7 @@ def get_tracked_entity_schema() -> dict:
         "orgUnit": id_schema,
         SchemaOptional("programOwners"): [object],
         SchemaOptional("relationships"): [relationship_schema],
+        SchemaOptional("storedBy"): str,
         SchemaOptional("trackedEntityInstance"): id_schema,
         "trackedEntityType": id_schema,
     }

--- a/corehq/motech/dhis2/tests/data/tracked_entity_instance_1.json
+++ b/corehq/motech/dhis2/tests/data/tracked_entity_instance_1.json
@@ -1,0 +1,153 @@
+{
+    "created": "2021-06-04T04:49:57.499",
+    "orgUnit": "COOtUCVYxqj",
+    "createdAtClient": "2021-06-04T04:49:57.499",
+    "trackedEntityInstance": "V5hmMGzvEWO",
+    "lastUpdated": "2021-06-04T04:49:57.500",
+    "trackedEntityType": "ga0BXNqarm1",
+    "lastUpdatedAtClient": "2021-06-04T04:49:57.499",
+    "storedBy": "commcare_hq",
+    "inactive": false,
+    "deleted": false,
+    "featureType": "NONE",
+    "programOwners": [
+        {
+            "ownerOrgUnit": "fUp11y6nggB",
+            "program": "tK2Uc9BH4Ri",
+            "trackedEntityInstance": "B5Wv376I7i0"
+        }
+    ],
+    "enrollments": [
+        {
+            "storedBy": "commcare_hq",
+            "created": "2021-06-04T04:49:57.520",
+            "orgUnit": "yk9g9piNzoe",
+            "createdAtClient": "2021-06-04T04:49:57.522",
+            "program": "c26pFwsredE",
+            "trackedEntityInstance": "ZimXHxBjye1",
+            "enrollment": "MLbzfikIiX6",
+            "lastUpdated": "2021-06-04T04:49:57.522",
+            "trackedEntityType": "YDh6otVtcg1",
+            "lastUpdatedAtClient": "2021-06-04T04:49:57.522",
+            "orgUnitName": "chia narwhal celiac shoreditch",
+            "enrollmentDate": "2021-06-04T04:49:57.520",
+            "deleted": false,
+            "incidentDate": "2021-06-04T04:49:57.520",
+            "status": "ACTIVE",
+            "notes": [],
+            "relationships": [],
+            "attributes": [],
+            "events": [
+                {
+                    "storedBy": "commcare_hq",
+                    "dueDate": "2021-06-04T04:49:57.562",
+                    "program": "XhJ4T2K5jrJ",
+                    "event": "C9Rz0Zf62kF",
+                    "programStage": "Yu6Vtb8rWaW",
+                    "orgUnit": "KLRJaFagekQ",
+                    "trackedEntityInstance": "hZZHzRNCqy7",
+                    "enrollment": "eQQ6dvOEhea",
+                    "enrollmentStatus": "ACTIVE",
+                    "status": "COMPLETED",
+                    "orgUnitName": "chia narwhal celiac shoreditch",
+                    "eventDate": "2021-06-04T00:00:00.000",
+                    "attributeCategoryOptions": "B0wLTvutblc",
+                    "lastUpdated": "2021-06-04T04:49:57.562",
+                    "created": "2021-06-04T04:49:57.562",
+                    "completedDate": "2021-06-04T04:49:57.562",
+                    "deleted": false,
+                    "attributeOptionCombo": "TOCh6WqfCM9",
+                    "dataValues": [
+                        {
+                            "lastUpdated": "2021-06-04T04:49:57.562",
+                            "created": "2021-06-04T04:49:57.562",
+                            "dataElement": "ULRM783C0PL",
+                            "value": "b03469f4-0912-4479-bd81-090dedd655c7",
+                            "providedElsewhere": false
+                        },
+                        {
+                            "lastUpdated": "2021-06-04T04:49:57.562",
+                            "created": "2021-06-04T04:49:57.562",
+                            "dataElement": "xLNHCxpBqVC",
+                            "value": "hospital_c1_m1",
+                            "providedElsewhere": false
+                        },
+                        {
+                            "lastUpdated": "2021-06-04T04:49:57.562",
+                            "created": "2021-06-04T04:49:57.562",
+                            "dataElement": "wZDU8aqM84D",
+                            "value": "2021-06-03",
+                            "providedElsewhere": false
+                        }
+                    ],
+                    "notes": [],
+                    "relationships": []
+                },
+                {
+                    "program": "x1AMWb6IUTF",
+                    "programStage": "k3GlgTudj9P",
+                    "orgUnit": "TilZcFMgGDG",
+                    "eventDate": "2021-06-04",
+                    "status": "COMPLETED",
+                    "dataValues": [
+                        {
+                            "dataElement": "FnjMAphmZmR",
+                            "value": "6203bf68-b5bf-4cef-946f-32fc0a7c2db3"
+                        },
+                        {
+                            "dataElement": "if1DucDHSB8",
+                            "value": "2021-06-04"
+                        },
+                        {
+                            "dataElement": "URLLtgn3qOQ",
+                            "value": "fixie echo park kinfolk flannel"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "relationships": [],
+    "attributes": [
+        {
+            "attribute": "RFSPyNDnRzV",
+            "value": null
+        },
+        {
+            "attribute": "EMezjpdF0J0",
+            "value": null
+        },
+        {
+            "attribute": "dcOMS3RZtuo",
+            "value": "40"
+        },
+        {
+            "attribute": "KvNGELEYQAf",
+            "value": " La croix PBR&B butcher everyday carry four"
+        },
+        {
+            "attribute": "bsdrcuoY75E",
+            "value": "b1153361-0b6f-4e6f-b2e1-12d945f14f76"
+        },
+        {
+            "attribute": "JnAFnRiOH0d",
+            "value": "3 wolf moon semiotics"
+        },
+        {
+            "attribute": "gNKEWVV8Tjw",
+            "value": "2"
+        },
+        {
+            "attribute": "XJMMpH9MgDa",
+            "value": "5"
+        },
+        {
+            "attribute": "Pe091MHLyUT",
+            "value": "32d28c9e-3ddc-4bf0-8430-d5b4104e10ee"
+        },
+        {
+            "attribute": "aKQIBMcRlZF",
+            "value": "2021-06-03"
+        }
+    ]
+}

--- a/corehq/motech/dhis2/tests/test_schema.py
+++ b/corehq/motech/dhis2/tests/test_schema.py
@@ -1,4 +1,21 @@
 import doctest
+import json
+
+from schema import Schema
+
+from django.conf import settings
+
+from corehq.motech.dhis2.schema import get_tracked_entity_schema
+
+DATA_DIR = settings.BASE_DIR + '/corehq/motech/dhis2/tests/data/'
+
+
+def test_tracked_entity_instance_1():
+    filename = DATA_DIR + 'tracked_entity_instance_1.json'
+    with open(filename) as fp:
+        doc = json.load(fp)
+    schema = get_tracked_entity_schema()
+    Schema(schema).validate(doc)
 
 
 def test_doctests():


### PR DESCRIPTION
## Summary

CommCare validates outgoing API calls to DHIS2 for Tracked Entity and Anonymous Events integrations. 

This change adds the "storedBy" property for Tracked Entity Instances. It also adds a test for the document that was failing validation.


## Feature Flag

DHIS2 Integration


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Includes test


### Safety story

Code change is a test. Non-code change updates a schema definition.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
