### PR TITLE
set corresponding display on Detail instead of None

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2477,7 +2477,18 @@ class Module(ModuleBase, ModuleDetailsMixin):
 
     @classmethod
     def new_module(cls, name, lang):
-        detail = Detail(
+        short_detail = Detail(
+            display='short',
+            columns=[DetailColumn(
+                format='plain',
+                header={(lang or 'en'): _("Name")},
+                field='name',
+                model='case',
+                hasAutocomplete=True,
+            )]
+        )
+        long_detail = Detail(
+            display='long',
             columns=[DetailColumn(
                 format='plain',
                 header={(lang or 'en'): _("Name")},
@@ -2491,8 +2502,8 @@ class Module(ModuleBase, ModuleDetailsMixin):
             forms=[],
             case_type='',
             case_details=DetailPair(
-                short=Detail(detail.to_json()),
-                long=Detail(detail.to_json()),
+                short=Detail(short_detail.to_json()),
+                long=Detail(long_detail.to_json()),
             ),
         )
         module.get_or_create_unique_id()
@@ -2980,7 +2991,17 @@ class AdvancedModule(ModuleBase):
 
     @classmethod
     def new_module(cls, name, lang):
-        detail = Detail(
+        short_detail = Detail(
+            display='short',
+            columns=[DetailColumn(
+                format='plain',
+                header={(lang or 'en'): _("Name")},
+                field='name',
+                model='case',
+            )]
+        )
+        long_detail = Detail(
+            display='long',
             columns=[DetailColumn(
                 format='plain',
                 header={(lang or 'en'): _("Name")},
@@ -2994,8 +3015,8 @@ class AdvancedModule(ModuleBase):
             forms=[],
             case_type='',
             case_details=DetailPair(
-                short=Detail(detail.to_json()),
-                long=Detail(detail.to_json()),
+                short=Detail(short_detail.to_json()),
+                long=Detail(long_detail.to_json()),
             ),
             product_details=DetailPair(
                 short=Detail(
@@ -3775,7 +3796,17 @@ class ShadowModule(ModuleBase, ModuleDetailsMixin):
     @classmethod
     def new_module(cls, name, lang, shadow_module_version=2):
         lang = lang or 'en'
-        detail = Detail(
+        short_detail = Detail(
+            display='short',
+            columns=[DetailColumn(
+                format='plain',
+                header={(lang or 'en'): _("Name")},
+                field='name',
+                model='case',
+            )]
+        )
+        long_detail = Detail(
+            display='long',
             columns=[DetailColumn(
                 format='plain',
                 header={(lang or 'en'): _("Name")},
@@ -3786,8 +3817,8 @@ class ShadowModule(ModuleBase, ModuleDetailsMixin):
         module = ShadowModule(
             name={(lang or 'en'): name or _("Untitled Menu")},
             case_details=DetailPair(
-                short=Detail(detail.to_json()),
-                long=Detail(detail.to_json()),
+                short=Detail(short_detail.to_json()),
+                long=Detail(long_detail.to_json()),
             ),
             shadow_module_version=shadow_module_version,
         )

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-advanced-autoload.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-advanced-autoload.xml
@@ -41,6 +41,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m0_case_long">
@@ -79,6 +84,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
       <display>

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-advanced.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-advanced.xml
@@ -41,6 +41,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m0_case_long">
@@ -79,6 +84,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
       <display>

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-multiple-references.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-multiple-references.xml
@@ -47,6 +47,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
       <display>
@@ -99,6 +104,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m1_case_long">
@@ -137,6 +147,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
       <display>

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-advanced.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-advanced.xml
@@ -47,6 +47,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m0_case_long">
@@ -85,6 +90,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m1_case_long">
@@ -123,6 +133,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
         <display>

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-basic.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-basic.xml
@@ -47,6 +47,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m0_case_long">
@@ -85,6 +90,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <field>
       <header>
@@ -135,6 +145,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
         <display>

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-submodule-advanced-rename-var.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-submodule-advanced-rename-var.xml
@@ -53,6 +53,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m0_case_long">
@@ -91,6 +96,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m1_case_long">
@@ -129,6 +139,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
         <display>
@@ -179,6 +194,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
         <display>

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-submodule-advanced.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-submodule-advanced.xml
@@ -53,6 +53,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m0_case_long">
@@ -91,6 +96,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m1_case_long">
@@ -129,6 +139,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
         <display>
@@ -179,6 +194,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
         <display>

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-submodule-basic.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-submodule-basic.xml
@@ -53,6 +53,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m0_case_long">
@@ -91,6 +96,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m1_case_long">
@@ -129,6 +139,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
         <display>
@@ -179,6 +194,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
         <display>

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-submodule-mixed.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-submodule-mixed.xml
@@ -53,6 +53,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m0_case_long">
@@ -91,6 +96,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m1_case_long">
@@ -129,6 +139,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
         <display>
@@ -179,6 +194,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
         <display>

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-usercase.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-usercase.xml
@@ -41,6 +41,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
       <display>
@@ -94,6 +99,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m1_case_long">

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite.xml
@@ -41,6 +41,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
       <display>
@@ -94,6 +99,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m1_case_long">

--- a/corehq/apps/app_manager/tests/data/case_list_form/case_list_form_end_of_form_case_list.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case_list_form_end_of_form_case_list.xml
@@ -41,6 +41,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
       <display>
@@ -93,6 +98,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m1_case_long">

--- a/corehq/apps/app_manager/tests/data/case_list_form/source_requires_case_target_doesnt.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/source_requires_case_target_doesnt.xml
@@ -53,6 +53,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m0_case_long">
@@ -91,6 +96,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
       <display>
@@ -143,6 +153,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m2_case_long">
@@ -181,6 +196,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action>
       <display>

--- a/corehq/apps/app_manager/tests/data/suite/fixture-to-case-selection-localization.xml
+++ b/corehq/apps/app_manager/tests/data/suite/fixture-to-case-selection-localization.xml
@@ -35,6 +35,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m0_case_long">

--- a/corehq/apps/app_manager/tests/data/suite/fixture-to-case-selection-parent-child.xml
+++ b/corehq/apps/app_manager/tests/data/suite/fixture-to-case-selection-parent-child.xml
@@ -41,6 +41,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m0_case_long">
@@ -94,6 +99,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m1_case_long">

--- a/corehq/apps/app_manager/tests/data/suite/fixture-to-case-selection-with-form-filtering.xml
+++ b/corehq/apps/app_manager/tests/data/suite/fixture-to-case-selection-with-form-filtering.xml
@@ -35,6 +35,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m0_case_long">

--- a/corehq/apps/app_manager/tests/data/suite/fixture-to-case-selection.xml
+++ b/corehq/apps/app_manager/tests/data/suite/fixture-to-case-selection.xml
@@ -35,6 +35,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
   </detail>
   <detail id="m0_case_long">

--- a/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
@@ -16,6 +16,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <field>
       <header>
@@ -127,6 +132,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <field>
       <header>
@@ -238,6 +248,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action auto_launch="false()" redo_last="false">
       <display>
@@ -289,6 +304,11 @@
           <xpath function="case_name"/>
         </text>
       </template>
+      <sort direction="ascending" order="1" type="string">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
     </field>
     <action auto_launch="false()" redo_last="true">
       <display>

--- a/corehq/apps/app_manager/tests/test_apps.py
+++ b/corehq/apps/app_manager/tests/test_apps.py
@@ -9,6 +9,7 @@ from mock import patch
 
 from corehq.apps.app_manager.dbaccessors import get_app, get_build_ids
 from corehq.apps.app_manager.models import (
+    AdvancedModule,
     Application,
     ApplicationBase,
     DetailColumn,
@@ -16,7 +17,8 @@ from corehq.apps.app_manager.models import (
     Module,
     ReportAppConfig,
     ReportModule,
-    import_app, ShadowModule, AdvancedModule,
+    ShadowModule,
+    import_app,
 )
 from corehq.apps.app_manager.tasks import (
     autogenerate_build,
@@ -387,16 +389,16 @@ class AppManagerTest(TestCase, TestXmlMixin):
         self.app = Application.new_app(self.domain, "Untitled Application")
 
         module = self.app.add_module(Module.new_module("Untitled Module", None))
-        self.assertIsNone(module.case_details['short'].display)
-        self.assertIsNone(module.case_details['long'].display)
+        self.assertEqual(module.case_details['short'].display, 'short')
+        self.assertEqual(module.case_details['long'].display, 'long')
 
         module = self.app.add_module(ShadowModule.new_module("Report Module", None))
-        self.assertIsNone(module.case_details['short'].display)
-        self.assertIsNone(module.case_details['long'].display)
+        self.assertEqual(module.case_details['short'].display, 'short')
+        self.assertEqual(module.case_details['long'].display, 'long')
 
         module = self.app.add_module(AdvancedModule.new_module("Advanced Module", None))
-        self.assertIsNone(module.case_details['short'].display)
-        self.assertIsNone(module.case_details['long'].display)
+        self.assertEqual(module.case_details['short'].display, 'short')
+        self.assertEqual(module.case_details['long'].display, 'long')
 
         # on wrap
         app = Application.wrap(self.app.to_json())

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -563,6 +563,11 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
 
         icon_mapping_spec = """
         <partial>
+          <template width="0">
+            <text>
+              <xpath function="if(gender = 'male' and age &lt;= 21, $h{key1_varname}, if(gender = 'female' and age &lt;= 21, $h{key2_varname}, if(gender = 'male' and age &gt; 21, $h{key3_varname}, if(gender = 'female' and age &gt; 21, $h{key4_varname}, ''))))"/>
+            </text>
+          </template>
           <template>
             <text>
               <xpath function="if(gender = 'male' and age &lt;= 21, $h{key1_varname}, if(gender = 'female' and age &lt;= 21, $h{key2_varname}, if(gender = 'male' and age &gt; 21, $h{key3_varname}, if(gender = 'female' and age &gt; 21, $h{key4_varname}, ''))))">
@@ -634,6 +639,11 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
 
         icon_mapping_spec = """
         <partial>
+          <template width="0">
+            <text>
+              <xpath function="if(if(gender = 'male', 'boy', 'girl') = 'boy', 0, if(if(gender = 'male', 'boy', 'girl') = 'girl', 1, ''))"/>
+            </text>
+          </template>
           <template>
             <text>
               <xpath function="if(if(gender = 'male', 'boy', 'girl') = 'boy', $kboy, if(if(gender = 'male', 'boy', 'girl') = 'girl', $kgirl, ''))">


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Display on Detail for new modules was set to None. But on wrap/save it's set to 'short'/'long' accordingly.
This would lead to conditions like `detail.display == 'short'` to fail like [here](https://github.com/dimagi/commcare-hq/blob/9a515556b81847a1cda39e612db8e12383e3b2d5/corehq/apps/app_manager/detail_screen.py#L161), in tests where apps are not saved, or wrapped before testing.
https://github.com/dimagi/commcare-hq/pull/29784/files added sort nodes by default, so most test updates are from that change.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
On environments, apps are always saved, so display is set correctly, So, it's only in tests where apps are not saved/wrapped, the effect of the change in "new_module" would be visible.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
