### PR TITLE
Hardcode values in get_sql_start_time

### DIFF
--- a/corehq/apps/auditcare/tests/test_export.py
+++ b/corehq/apps/auditcare/tests/test_export.py
@@ -183,7 +183,7 @@ class TestNavigationEventsQueries(AuditcareTest):
                 write_export_from_all_log_events(csvfile, start=start, end=end)
             with open(filename, encoding="utf-8") as fh:
                 def key(row):
-                    return row["Date"], row["Type"]
+                    return row["Date"], row["Type"], row["User"]
                 rows = DictReader(fh)
                 items = sorted([unpack(r) for r in rows], key=key)
                 expected_items = [

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -160,16 +160,15 @@ def iter_couch_audit_events(params, chunksize=10000):
 
 def get_fixed_start_date_for_sql():
     # reemove after auditcare migration is done
-    if settings.SERVER_ENVIRONMENT == 'production':
-        return datetime(2021, 3, 24, 6, 17, 21, 988840)
-    elif settings.SERVER_ENVIRONMENT == 'india':
-        return datetime(2021, 3, 23, 21, 52, 25, 476894)
-    elif settings.SERVER_ENVIRONMENT == 'staging':
-        return datetime(2021, 3, 20, 11, 50, 2, 921916)
-    elif settings.SERVER_ENVIRONMENT == 'swiss':
-        return datetime(2021, 3, 25, 8, 22, 53, 179334)
-    else:
-        return None
+    return FIXED_START_DATES.get(settings.SERVER_ENVIRONMENT)
+
+
+FIXED_START_DATES = {
+    'production': datetime(2021, 3, 24, 6, 17, 21, 988840),
+    'india': datetime(2021, 3, 23, 21, 52, 25, 476894),
+    'staging': datetime(2021, 3, 20, 11, 50, 2, 921916),
+    'swiss': datetime(2021, 3, 25, 8, 22, 53, 179334),
+}
 
 
 def determine_sql_start_date(start_date):

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -166,7 +166,18 @@ def get_sql_start_date():
     all auditcare data in Couch will be obsolete and/or archived before
     SQL data. It should be removed when the data in Couch is no longer
     relevant.
+
+    NOTE the output is being hardcoded for the time historical auditcare events are copied to SQL
     """
+    if settings.SERVER_ENVIRONMENT == 'production':
+        return datetime(2021, 3, 24, 6, 17, 21, 988840)
+    elif settings.SERVER_ENVIRONMENT == 'india':
+        return datetime(2021, 3, 23, 21, 52, 25, 476894)
+    elif settings.SERVER_ENVIRONMENT == 'staging':
+        return datetime(2021, 3, 20, 11, 50, 2, 921916)
+    elif settings.SERVER_ENVIRONMENT == 'swiss':
+        return datetime(2021, 3, 25, 8, 22, 53, 179334)
+
     manager = NavigationEventAudit.objects
     row = manager.order_by("event_date").values("event_date")[:1].first()
     return row["event_date"] if row else None

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -1,18 +1,20 @@
 import csv
-from datetime import timedelta
+from datetime import datetime, timedelta
 from itertools import chain
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.db.models import ForeignKey
 
 import attr
 from couchdbkit.ext.django.loading import get_db
-from django.contrib.auth.models import User
-from django.db.models import ForeignKey
+
+from dimagi.utils.couch.database import iter_docs
+from dimagi.utils.parsing import string_to_datetime
 
 from corehq.apps.domain.utils import get_domain_from_url
 from corehq.apps.users.models import WebUser
 from corehq.util.models import ForeignValue
-
-from dimagi.utils.couch.database import iter_docs
-from dimagi.utils.parsing import string_to_datetime
 
 from ..models import AccessAudit, NavigationEventAudit
 

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -183,15 +183,9 @@ def get_sql_start_date():
 
     NOTE the output is being hardcoded for the time historical auditcare events are copied to SQL
     """
-    if settings.SERVER_ENVIRONMENT == 'production':
-        return datetime(2021, 3, 24, 6, 17, 21, 988840)
-    elif settings.SERVER_ENVIRONMENT == 'india':
-        return datetime(2021, 3, 23, 21, 52, 25, 476894)
-    elif settings.SERVER_ENVIRONMENT == 'staging':
-        return datetime(2021, 3, 20, 11, 50, 2, 921916)
-    elif settings.SERVER_ENVIRONMENT == 'swiss':
-        return datetime(2021, 3, 25, 8, 22, 53, 179334)
-
+    fixed_sql_start = get_fixed_start_date_for_sql()
+    if fixed_sql_start:
+        return fixed_sql_start
     manager = NavigationEventAudit.objects
     row = manager.order_by("event_date").values("event_date")[:1].first()
     return row["event_date"] if row else None

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -21,7 +21,8 @@ from ..models import AccessAudit, NavigationEventAudit
 
 def navigation_events_by_user(user, start_date=None, end_date=None):
     params = {"user": user, "start_date": start_date, "end_date": end_date}
-    where = get_date_range_where(start_date, end_date)
+    sql_start_date = determine_sql_start_date(start_date)
+    where = get_date_range_where(sql_start_date, end_date)
     query = NavigationEventAudit.objects.filter(user=user, **where)
     return chain(
         iter_couch_audit_events(params),
@@ -54,7 +55,8 @@ def get_users_to_export(username, domain):
 
 def get_all_log_events(start_date=None, end_date=None):
     params = {"start_date": start_date, "end_date": end_date}
-    where = get_date_range_where(start_date, end_date)
+    sql_start_date = determine_sql_start_date(start_date)
+    where = get_date_range_where(sql_start_date, end_date)
     return chain(
         iter_couch_audit_events(params),
         AuditWindowQuery(AccessAudit.objects.filter(**where)),

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -156,6 +156,20 @@ def iter_couch_audit_events(params, chunksize=10000):
         yield CouchAuditEvent(doc)
 
 
+def get_fixed_start_date_for_sql():
+    # reemove after auditcare migration is done
+    if settings.SERVER_ENVIRONMENT == 'production':
+        return datetime(2021, 3, 24, 6, 17, 21, 988840)
+    elif settings.SERVER_ENVIRONMENT == 'india':
+        return datetime(2021, 3, 23, 21, 52, 25, 476894)
+    elif settings.SERVER_ENVIRONMENT == 'staging':
+        return datetime(2021, 3, 20, 11, 50, 2, 921916)
+    elif settings.SERVER_ENVIRONMENT == 'swiss':
+        return datetime(2021, 3, 25, 8, 22, 53, 179334)
+    else:
+        return None
+
+
 def get_sql_start_date():
     """Get the date of the first SQL auditcare record
 

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -170,6 +170,14 @@ def get_fixed_start_date_for_sql():
         return None
 
 
+def determine_sql_start_date(start_date):
+    fixed_start_date = get_fixed_start_date_for_sql()
+    if fixed_start_date and start_date < fixed_start_date:
+        return fixed_start_date
+    else:
+        return start_date
+
+
 def get_sql_start_date():
     """Get the date of the first SQL auditcare record
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
A part of https://dimagi-dev.atlassian.net/browse/SAAS-12241
Currently while preparing the auditcare reports we figure out whether we need to query couch based on the date range provided. If the value of the timestamp is less than the oldest record's timestamp in SQL then we query couch as well to prepare the record.
Now as we are planning to migrate older auditcare event logs to SQL then we might have a condition that can lead to missing records in the generated reports. 
So we would be hardcoding the timestamp of the oldest record for production, staging, India, swiss till the time migration would be in progress.
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
