### PR TITLE
cursor pagination for messaging-event API

### DIFF
--- a/corehq/apps/api/resources/pagination.py
+++ b/corehq/apps/api/resources/pagination.py
@@ -1,4 +1,12 @@
+import logging
+from base64 import b64encode, b64decode
+from urllib.parse import urlencode
+
+from django.http import QueryDict
+from tastypie.exceptions import BadRequest
 from tastypie.paginator import Paginator
+
+logger = logging.getLogger(__name__)
 
 
 class NoCountingPaginator(Paginator):
@@ -60,3 +68,126 @@ class DoesNothingPaginatorCompat(Paginator):
             self.collection_name: self.objects,
             'meta': meta,
         }
+
+
+def make_cursor_paginator(get_cursor_params, get_object_id):
+    """Create a cursor paginator for a tastypie API.
+
+    The API must return consistently ordered results between requests:
+      e.g. order_by("date", "id")
+
+    The current implementation does not support use cases where all objects in the batch have
+    the same filter parameter value (see TestMessagingEventResource.test_cursor_stuck_in_loop).
+
+    :param get_cursor_params: A function that takes the last object in the batch
+        and returns filter parameters for that object. A second parameter is passed
+        to indicate the direction of sorting. e.g.
+
+        def get_cursor_params(object, ascending_order):
+            param = "date.gte" if ascending_order else "date.lte"
+            return {param: event.date.isoformat()}
+
+    :param get_object_id: Function to get the ID of an object. This must be formatted as it would
+        be in the cursor (urlencoded). e.g.
+
+        def get_object_id(object):
+            return str(object.id)
+    """
+
+    class _CursorPaginator(Paginator):
+        last_id_param = "last_object_id"
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            if "cursor" in self.request_data:
+                params_string = b64decode(self.request_data['cursor']).decode('utf-8')
+                self.cursor_params = QueryDict(params_string).dict()
+            else:
+                self.cursor_params = None
+
+        def page(self):
+            self.check_ordering()
+
+            limit = self.get_limit()
+            objects = self.get_objects(limit)
+            meta = {'limit': limit, 'next': self.get_cursor(limit, objects)}
+
+            return {
+                self.collection_name: objects,
+                'meta': meta,
+            }
+
+        def get_objects(self, limit):
+            """Get the list of objects to return. For pages > 1 this will
+            skip the first object in the page if it was present in the previous
+            page (as encoded in the cursor)"""
+            if self.cursor_params:
+                objects = list(self.get_slice(limit + 1, 0))
+                last_id = self.cursor_params.get(self.last_id_param, None)
+                if last_id and get_object_id(objects[0]) == last_id:
+                    logger.debug(f"Skipping first object in API response: {last_id}")
+                    objects = objects[1:]  # remove the first object since it was in the last page
+                else:
+                    logger.debug(f"Dropping last object in API response to keep page size consistent")
+                    objects = objects[:-1]
+            else:
+                logger.debug("no cursor, returning normal page")
+                objects = list(self.get_slice(limit, 0))
+
+            return objects
+
+        def check_ordering(self):
+            """Make sure the ordering is not changing between pages"""
+            if self.cursor_params and "order_by" in self.request_data:
+                request_order_by = self.request_data["order_by"]
+                cursor_order_by = self.cursor_params.get("order_by")
+                if request_order_by != cursor_order_by:
+                    raise BadRequest("Changing ordering during pagination is not supported")
+
+        def get_cursor(self, limit, objects):
+            """Generate the 'cursor' parameter which includes all query params from the current
+            request excluding 'limit' as well as:
+              - filter parameter for the next page e.g. date.gte = last date
+              - ID of the last object in the current page to allow skipping it in the next page
+            """
+            if self.resource_uri is None:
+                return None
+
+            if not objects:
+                return None
+
+            ascending_order = True
+            order_by = None
+            if "order_by" in self.request_data:
+                order_by = self.request_data["order_by"]
+                if order_by.startswith("-"):
+                    ascending_order = False
+
+            last_object = objects[-1]
+
+            cursor_params = get_cursor_params(last_object, ascending_order)
+            # add the ID of the last item so we can remove it from the next page if necessary
+            cursor_params[self.last_id_param] = get_object_id(last_object)
+
+            request_params = {}
+            for k, v in self.request_data.items():
+                if isinstance(v, str):
+                    request_params[k] = v.encode('utf-8')
+                else:
+                    request_params[k] = v
+
+            if 'limit' in request_params:
+                del request_params['limit']
+            request_params.update(cursor_params)
+            encoded_params = urlencode(request_params)
+
+            cursor = {'cursor': b64encode(encoded_params.encode('utf-8')), 'limit': limit}
+            if order_by:
+                cursor["order_by"] = order_by
+
+            return '%s?%s' % (
+                self.resource_uri,
+                urlencode(cursor)
+            )
+
+    return _CursorPaginator


### PR DESCRIPTION
## Summary
PR into https://github.com/dimagi/commcare-hq/pull/29869 that switches to cursor based pagination.

I'm not sure if this is really worth it. It is a lot more code. Opinions?

## Product Description
Cursor based pagination for new messaging-event API.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added

### QA Plan
I will QA on staging

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
