### PR TITLE
Use SQL backend by default

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -638,7 +638,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
         return domain
 
     @classmethod
-    def get_or_create_with_name(cls, name, is_active=False, secure_submissions=True, use_sql_backend=False):
+    def get_or_create_with_name(cls, name, is_active=False, secure_submissions=True, use_sql_backend=True):
         result = cls.view("domain/domains", key=name, reduce=False, include_docs=True).first()
         if result:
             return result

--- a/corehq/apps/domain/shortcuts.py
+++ b/corehq/apps/domain/shortcuts.py
@@ -3,7 +3,7 @@ Shortcuts for working with domains and users.
 """
 
 
-def create_domain(name, active=True, use_sql_backend=False):
+def create_domain(name, active=True, use_sql_backend=True):
     """Create domain without secure submissions for tests"""
     return Domain.get_or_create_with_name(name=name, is_active=active,
                                           secure_submissions=False, use_sql_backend=use_sql_backend)


### PR DESCRIPTION
Change domain creation functions to use SQL backend by default. User-facing domain creation has defaulted to using the SQL backend since https://github.com/dimagi/commcare-hq/commit/b6fe86f8ea2d1b287bb375908720a549307c0c64 was merged. However, I have observed that somehow a small number of new Couch domains have been created on production since then. I don't know how that happened, but hopefully this will close the loophole.

Initially opening for tests, and planning to push updates as necessary to resolve failures.

## Safety Assurance

- [ ] Risk label is set correctly
- [ ] All migrations are backwards compatible and won't block deploy
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

No QA.

### Safety story

This change should have no user-facing effects. All new domains created by users should already use the SQL backend by default.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
