### PR TITLE
Added HQ dev FAQ

### DIFF
--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -11,9 +11,9 @@ to mark your local project as a test project and grant access to all features.
 
 ## Common Problems
 + I created local forms and/or cases, but I don't see them in reports.
-   + ElasticSearch data is out of date. See [#ElasticSearch](#ElasticSearch)
+   + ElasticSearch data is out of date. See [ElasticSearch](https://github.com/dimagi/commcare-hq/blob/master/DEV_FAQ.md#elasticsearch) below.
 + I created local cases, but some other part of HQ that filters by case type doesn't show my case types.
-   + ElasticSearch data is out of date. See [#ElasticSearch](#ElasticSearch)
+   + ElasticSearch data is out of date. See [ElasticSearch](https://github.com/dimagi/commcare-hq/blob/master/DEV_FAQ.md#elasticsearch) below.
 + My local downloads/uploads aren't working
    + Look back over the [celery setup](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP.md#running-commcare-hq).
    + Many background tasks on HQ will run fine locally, if you don't run celery but do have `CELERY_TASK_ALWAYS_EAGER=True` in local settings, but some do require celery (typically those that have a task and also a polling job, which is how most downloads and uploads work).
@@ -21,7 +21,7 @@ to mark your local project as a test project and grant access to all features.
    + Double check that your browser isn't caching. In Chrome, this is Dev Tools > Settings > Preferences > Network and check "Disable cache (while DevTools is open)"
    + Double check that you're editing the source file, under `corehq/apps/<app_name>/static`, not a file in `staticfiles`
 + Web Apps and/or App Preview aren't working at all
-   + Formplayer isn't running properly. See [#Formplayer](#Formplayer)
+   + Formplayer isn't running properly. See [Formplayer](https://github.com/dimagi/commcare-hq/blob/master/DEV_FAQ.md#formplayer) below.
 + My web server is throwing a slew of web socket errors
    + It happens, try restarting.
 

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -6,7 +6,7 @@ is set up and you've started working on a significant code change.
 ## General Advice
 
 - Use the developers section of the [Dimagi Forum](https://forum.dimagi.com/) for help with issues.
-- Some features are limited to specific software plans. Visit Project Settings > Internal Subscription Management
+- Some features are limited to specific software plans. Use the `make_domain_enterprise_level` command
 to mark your local project as a test project and grant access to all features.
 
 ## Common Problems

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -59,11 +59,12 @@ As described in the [dev setup guide](https://github.com/dimagi/commcare-hq/blob
 use `run_ptop` to keep ES continually up to date.
 
 Alternatively, you can run `ptop_reindexer_v2` as needed to sync individual indexes. `ptop_reindexer_v2` works on one index at a time.
-Running it without any arguments will list the available indexes. The indexes you're most likely to need are `sql-form` and `sql-case`,
-which will populate form-based can case-based reports and exports (excepting the Case List Explorer and Explore Case Data reports, which
-use the `case_search` index). Depending on what you're working on, you may also want `user`, `group`,
-`sms` (messaging reports and exports), or `case_search` (Case List Explorer, Explore Case Data). You do not want `case` or `form`, which are
-only used on legacy domains that store forms and cases in CouchDB.
+Running it without any arguments will list the available indexes. The indexes you're most likely to use:
++ `sql-form` and `sql-case` populate form-based and case-based reports and exports
++ `user` and `group` may be useful, depending on what you're working on
++ `case_search` populates the Case list Explorer and Explore Case Data reports, as well as the case search/claim feature
++ `sms` populates messaging reports and SMS exports
++ You do **not** care about `case` or `form`, which are only used on legacy domains that store forms and cases in CouchDB.
 
 ## Formplayer
 

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -29,4 +29,17 @@ to mark your local project as a test project and grant access to all features.
 + Running Tests TODO pull from DEV_SETUP
 + Generating Sample Data
 + ElasticSearch TODO pull from document
-+ Formplayer TODO pull from document
+
+# Formplayer
+
+You can run formplayer either in Docker or as a standalone service. It's simpler to run via Docker.
+If you're doing formplayer development, you'll need to run it as a separate service.
+
+When troubleshooting formplayer in docker, use standard docker commands to view logs: `docker logs <formplayer_container_name>`
+
+Formplayer expects HQ to be running on port 8000. If you run HQ on a different port, you'll need to modify settings and run formplayer outside of docker.
+
+If you run formplayer as a separate service, make sure you're not acciddentally also running it in Docker - HQ's Docker script's `up` command will start it.
+
+See the [Formplayer README](https://github.com/dimagi/formplayer/blob/master/README.md)
+and [Formplayer setup for HQ](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP.md#formplayer).

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -1,16 +1,15 @@
-Developer FAQ
--------------
+# Developer FAQ
 
 This is a starting point for troubleshooting issues that frequently occur once your local environment
 is set up and you've started working on a singnificant code change.
 
-# General Advice
+## General Advice
 
 - Use the developers section of the [Dimagi Forum](https://forum.dimagi.com/) for help with issues.
 - Some features are limited to specific software plans. Visit Project Settings > Internal Subscription Management
 to mark your local project as a test project and grant access to all features.
 
-# Common Problems
+## Common Problems
 + I created local forms and/or cases, but I don't see them in reports.
    + ElasticSearch data is out of date. See [#ElasticSearch](#ElasticSearch)
 + I created local cases, but some other part of HQ that filters by case type doesn't show my case types.
@@ -26,29 +25,29 @@ to mark your local project as a test project and grant access to all features.
 + My web server is throwing a slew of web socket errors
    + It happens, try restarting.
 
-# Generating Sample Data
+## Generating Sample Data
 
-## SMS
+### SMS
 
 Check out the `generate_fake_sms_data` command.
 
-## Applications
+### Applications
 
 If you have an application on commcarehq.org, follow [these instructions](https://confluence.dimagi.com/display/commcarepublic/Copying+an+Application+between+Projects+or+Servers) to copy it to your local environment.
 
 There are also [three template apps](https://github.com/dimagi/commcare-hq/tree/master/corehq/apps/app_manager/static/app_manager/template_apps) checked into the codebase.
 You can run [load_app_from_slug](https://github.com/dimagi/commcare-hq/blob/6021df8639dc0053c8dbdbb8690993be708776c5/corehq/apps/app_manager/views/apps.py#L510) in a django shell to import one of these apps. Note that you may wish to only run the first few lins of `load_app_from_slug` if you don't care about your app having multimedia.
 
-## Cases
+### Cases
 
 The easiest way to add cases locally is generally to use your local case importer. [Docs](https://confluence.dimagi.com/display/commcarepublic/Importing+Cases+Using+Excel)
 for this are extensive, but at its most basic, you can just upload a single-column file with a bunch of case names to create cases.
 
-## Cases + App + Data Dictionary
+### Cases + App + Data Dictionary
 
 The `create_case_fixtures` command will add a sample app, a data dictionary, and a set of relevant cases.
 
-# ElasticSearch
+## ElasticSearch
 
 ElasticSearch is the data source for reports, exports, and an assortment of parts of other features.
 Most issues with data not appearing locally, if you've already done something to create that data, are issues with ElasticSearch.
@@ -66,7 +65,7 @@ use the `case_search` index). Depending on what you're working on, you may also 
 `sms` (messaging reports and exports), or `case_search` (Case List Explorer, Explore Case Data). You do not want `case` or `form`, which are
 only used on legacy domains that store forms and cases in CouchDB.
 
-# Formplayer
+## Formplayer
 
 You can run formplayer either in Docker or as a standalone service. It's simpler to run via Docker.
 If you're doing formplayer development, you'll need to run it as a separate service.

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -4,17 +4,29 @@ Developer FAQ
 This is a starting point for troubleshooting issues that frequently occur once your local environment
 is set up and you've started working on a singnificant code change.
 
-TODO: make these links and/or answers
-+ I created local forms and/or cases, but I don't see them in reports.
-+ I created local cases, but some other part of HQ that filters by case type doesn't show my case types.
-+ My local downloads/uploads aren't working
-+ My JS/LESS changes aren't showing up (caching, staticfiles)
-+ Web Apps and/or App Preview aren't working at all
-+ My local app doesn't appear in Web Apps
-+ My web server is throwing a slew of web socket errors
+# General Advice
 
-+ General advice: TODO: give yourself a test subscription, use commcare-devs for advice
+- Use the developers section of the [Dimagi Forum](https://forum.dimagi.com/) for help with issues.
+- Some features are limited to specific software plans. Visit Project Settings > Internal Subscription Management
+to mark your local project as a test project and grant access to all features.
+
+# Common Problems
++ I created local forms and/or cases, but I don't see them in reports.
+   + ElasticSearch data is out of date. See [#ElasticSearch](#ElasticSearch)
++ I created local cases, but some other part of HQ that filters by case type doesn't show my case types.
+   + ElasticSearch data is out of date. See [#ElasticSearch](#ElasticSearch)
++ My local downloads/uploads aren't working
+   + Look back over the [celery setup](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP.md#running-commcare-hq).
+   + Many background tasks on HQ will run fine locally, if you don't run celery but do have `CELERY_TASK_ALWAYS_EAGER=True` in local settings, but some do require celery (typically those that have a task and also a polling job, which is how most downloads and uploads work).
++ My JS/LESS changes aren't showing up (caching, staticfiles)
+   + Double check that your browser isn't caching. In Chrome, this is Dev Tools > Settings > Preferences > Network and check "Disable cache (while DevTools is open)"
+   + Double check that you're editing the source file, under `corehq/apps/<app_name>/static`, not a file in `staticfiles`
++ Web Apps and/or App Preview aren't working at all
+   + Formplayer isn't running properly. See [#Formplayer](#Formplayer)
++ My web server is throwing a slew of web socket errors
+   + It happens, try restarting.
+
 + Running Tests TODO pull from DEV_SETUP
-+ Generating test data
-+ Keeping ElasticSearch up to date TODO pull from document
-+ Troubleshooting Formplayer TODO pull from document
++ Generating Sample Data
++ ElasticSearch TODO pull from document
++ Formplayer TODO pull from document

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -1,5 +1,8 @@
-Common issues
+Developer FAQ
 -------------
+
+This is a starting point for troubleshooting issues that frequently occur once your local environment
+is set up and you've started working on a singnificant code change.
 
 + If you have an authentication error running `./manage.py migrate` the first
   time, open `pg_hba.conf` (`/etc/postgresql/9.1/main/pg_hba.conf` on Ubuntu)

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -26,8 +26,6 @@ to mark your local project as a test project and grant access to all features.
 + My web server is throwing a slew of web socket errors
    + It happens, try restarting.
 
-+ Running Tests TODO pull from DEV_SETUP
-
 # Generating Sample Data
 
 ## SMS

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -18,26 +18,3 @@ TODO: make these links and/or answers
 + Generating test data
 + Keeping ElasticSearch up to date TODO pull from document
 + Troubleshooting Formplayer TODO pull from document
-
-
-
-
-TODO: move this back into DEV_SETUP
-+ If you have an authentication error running `./manage.py migrate` the first
-  time, open `pg_hba.conf` (`/etc/postgresql/9.1/main/pg_hba.conf` on Ubuntu)
-  and change the line "local all all peer" to "local all all md5".
-
-+ When running `./manage.py sync_couch_views`:
-   + First time running `sync_couch_views`
-      + 401 error related to nonexistent database:
-         $ curl -X PUT http://localhost:5984/commcarehq  # create the database
-         $ curl -X PUT http://localhost:5984/_config/admins/commcarehq -d '"commcarehq"' . # add admin user
-      + Error stemming from any Python modules: the issue may be that your virtualenv is relying on the `site-packages` directory of your local Python installation for some of its requirements. (Creating your virtualenv with the `--no-site-packages` flag should prevent this, but it seems that it does not always work). You can check if this is the case by running `pip show {name-of-module-that-is-erroring}`. This will show the location that your virtualenv is pulling that module from; if the location is somewhere other than the path to your virtualenv, then something is wrong. The easiest solution to this is to remove any conflicting modules from the location that your virtualenv is pulling them from (as long as you use virtualenvs for all of your Python projects, this won't cause you any issues).
-    + If you encounter an error stemming from an Incompatible Library Version of libxml2.2.dylib on Mac OS X, try running the following commands:
-
-            $ brew install libxml2
-	        $ brew install libxslt
-	        $ brew link libxml2 --force
-	        $ brew link libxslt --force
-
-	+ If you encounter an authorization error related to CouchDB, try going to your `localsettings.py` file and change `COUCH_PASSWORD` to an empty string.

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -1,7 +1,7 @@
 # Developer FAQ
 
 This is a starting point for troubleshooting issues that frequently occur once your local environment
-is set up and you've started working on a singnificant code change.
+is set up and you've started working on a significant code change.
 
 ## General Advice
 
@@ -10,20 +10,33 @@ is set up and you've started working on a singnificant code change.
 to mark your local project as a test project and grant access to all features.
 
 ## Common Problems
-+ I created local forms and/or cases, but I don't see them in reports.
-   + ElasticSearch data is out of date. See [ElasticSearch](https://github.com/dimagi/commcare-hq/blob/master/DEV_FAQ.md#elasticsearch) below.
-+ I created local cases, but some other part of HQ that filters by case type doesn't show my case types.
-   + ElasticSearch data is out of date. See [ElasticSearch](https://github.com/dimagi/commcare-hq/blob/master/DEV_FAQ.md#elasticsearch) below.
-+ My local downloads/uploads aren't working
-   + Look back over the [celery setup](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP.md#running-commcare-hq).
-   + Many background tasks on HQ will run fine locally, if you don't run celery but do have `CELERY_TASK_ALWAYS_EAGER=True` in local settings, but some do require celery (typically those that have a task and also a polling job, which is how most downloads and uploads work).
-+ My JS/LESS changes aren't showing up (caching, staticfiles)
-   + Double check that your browser isn't caching. In Chrome, this is Dev Tools > Settings > Preferences > Network and check "Disable cache (while DevTools is open)"
-   + Double check that you're editing the source file, under `corehq/apps/<app_name>/static`, not a file in `staticfiles`
-+ Web Apps and/or App Preview aren't working at all
-   + Formplayer isn't running properly. See [Formplayer](https://github.com/dimagi/commcare-hq/blob/master/DEV_FAQ.md#formplayer) below.
-+ My web server is throwing a slew of web socket errors
-   + It happens, try restarting.
+> I created local forms and/or cases, but I don't see them in reports.
+
+ElasticSearch data is out of date. See [ElasticSearch](https://github.com/dimagi/commcare-hq/blob/master/DEV_FAQ.md#elasticsearch) below.
+
+> I created local cases, but some other part of HQ that filters by case type doesn't show my case types.
+
+ElasticSearch data is out of date. See [ElasticSearch](https://github.com/dimagi/commcare-hq/blob/master/DEV_FAQ.md#elasticsearch) below.
+
+> My local downloads/uploads aren't working
+
+Look back over the [celery setup](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP.md#running-commcare-hq).
+
+Many background tasks on HQ will run fine locally, if you don't run celery but do have `CELERY_TASK_ALWAYS_EAGER=True` in local settings, but some do require celery (typically those that have a task and also a polling job, which is how most downloads and uploads work).
+
+> My JS/LESS changes aren't showing up (caching, staticfiles)
+
+Double check that your browser isn't caching. In Chrome, this is Dev Tools > Settings > Preferences > Network and check "Disable cache (while DevTools is open)"
+
+Also double check that you're editing the source file, under `corehq/apps/<app_name>/static`, not a file in `staticfiles`
+
+> Web Apps and/or App Preview aren't working at all
+
+Formplayer isn't running properly. See [Formplayer](https://github.com/dimagi/commcare-hq/blob/master/DEV_FAQ.md#formplayer) below.
+
+> My web server is throwing a slew of web socket errors
+
+It happens, try restarting.
 
 ## Generating Sample Data
 

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -4,6 +4,25 @@ Developer FAQ
 This is a starting point for troubleshooting issues that frequently occur once your local environment
 is set up and you've started working on a singnificant code change.
 
+TODO: make these links and/or answers
++ I created local forms and/or cases, but I don't see them in reports.
++ I created local cases, but some other part of HQ that filters by case type doesn't show my case types.
++ My local downloads/uploads aren't working
++ My JS/LESS changes aren't showing up (caching, staticfiles)
++ Web Apps and/or App Preview aren't working at all
++ My local app doesn't appear in Web Apps
++ My web server is throwing a slew of web socket errors
+
++ General advice: TODO: give yourself a test subscription, use commcare-devs for advice
++ Running Tests TODO pull from DEV_SETUP
++ Generating test data
++ Keeping ElasticSearch up to date TODO pull from document
++ Troubleshooting Formplayer TODO pull from document
+
+
+
+
+TODO: move this back into DEV_SETUP
 + If you have an authentication error running `./manage.py migrate` the first
   time, open `pg_hba.conf` (`/etc/postgresql/9.1/main/pg_hba.conf` on Ubuntu)
   and change the line "local all all peer" to "local all all md5".

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -27,8 +27,46 @@ to mark your local project as a test project and grant access to all features.
    + It happens, try restarting.
 
 + Running Tests TODO pull from DEV_SETUP
-+ Generating Sample Data
-+ ElasticSearch TODO pull from document
+
+# Generating Sample Data
+
+## SMS
+
+Check out the `generate_fake_sms_data` command.
+
+## Applications
+
+If you have an application on commcarehq.org, follow [these instructions](https://confluence.dimagi.com/display/commcarepublic/Copying+an+Application+between+Projects+or+Servers) to copy it to your local environment.
+
+There are also [three template apps](https://github.com/dimagi/commcare-hq/tree/master/corehq/apps/app_manager/static/app_manager/template_apps) checked into the codebase.
+You can run [load_app_from_slug](https://github.com/dimagi/commcare-hq/blob/6021df8639dc0053c8dbdbb8690993be708776c5/corehq/apps/app_manager/views/apps.py#L510) in a django shell to import one of these apps. Note that you may wish to only run the first few lins of `load_app_from_slug` if you don't care about your app having multimedia.
+
+## Cases
+
+The easiest way to add cases locally is generally to use your local case importer. [Docs](https://confluence.dimagi.com/display/commcarepublic/Importing+Cases+Using+Excel)
+for this are extensive, but at its most basic, you can just upload a single-column file with a bunch of case names to create cases.
+
+## Cases + App + Data Dictionary
+
+The `create_case_fixtures` command will add a sample app, a data dictionary, and a set of relevant cases.
+
+# ElasticSearch
+
+ElasticSearch is the data source for reports, exports, and an assortment of parts of other features.
+Most issues with data not appearing locally, if you've already done something to create that data, are issues with ElasticSearch.
+
+You can run ElasticSearch continuously, mimicking a production environment, or on an as-needed basis. Either one of these can be simpler,
+depending on how much you're working with ES data.
+
+As described in the [dev setup guide](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP.md#running-commcare-hq), you can
+use `run_ptop` to keep ES continually up to date.
+
+Alternatively, you can run `ptop_reindexer_v2` as needed to sync individual indexes. `ptop_reindexer_v2` works on one index at a time.
+Running it without any arguments will list the available indexes. The indexes you're most likely to need are `sql-form` and `sql-case`,
+which will populate form-based can case-based reports and exports (excepting the Case List Explorer and Explore Case Data reports, which
+use the `case_search` index). Depending on what you're working on, you may also want `user`, `group`,
+`sms` (messaging reports and exports), or `case_search` (Case List Explorer, Explore Case Data). You do not want `case` or `form`, which are
+only used on legacy domains that store forms and cases in CouchDB.
 
 # Formplayer
 

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -9,8 +9,8 @@ commcare-cloud](https://dimagi.github.io/commcare-cloud/)
 These instructions are for Mac or Linux computers. For Windows, consider using
 an Ubuntu virtual machine.
 
-Common issues and their solutions can be found at the end
-of this document.
+Once your environment is up and running, bookmark the [dev FAQ](https://github.com/dimagi/commcare-hq/blob/master/DEV_FAQ.md)
+for common issues encountered in day-to-day HQ development.
 
 ### (Optional) Copying data from an existing HQ install
 
@@ -620,7 +620,3 @@ run the Python tests when saving py files as follows:
 ### Sniffer Installation instructions
 https://github.com/jeffh/sniffer/
 (recommended to install pywatchman or macfsevents for this to actually be worthwhile otherwise it takes a long time to see the change)
-
-## Other links
-
-+ [Common Issues](https://github.com/dimagi/commcare-hq/blob/master/COMMON_ISSUES.md)

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -277,7 +277,7 @@ If you previously created backups of another HQ install's data, you can now copy
 
 
 
-### Set up your Django environment
+### Initial Database Population
 
 Before running any of the commands below, you should have all of the following
 running: CouchDB, Redis, and Elasticsearch.
@@ -288,11 +288,32 @@ Populate your database:
     $ ./manage.py sync_couch_views
     $ ./manage.py create_kafka_topics
     $ env CCHQ_IS_FRESH_INSTALL=1 ./manage.py migrate --noinput
-    $ ./manage.py compilejsi18n
 
 You should run `./manage.py migrate` frequently, but only use the environment
 variable CCHQ_IS_FRESH_INSTALL during your initial setup.  It is used to skip a
 few tricky migrations that aren't necessary for new installs.
+
+#### Troubleshooting
+
+If you have an authentication error running `./manage.py migrate` the first
+time, open `pg_hba.conf` (`/etc/postgresql/9.1/main/pg_hba.conf` on Ubuntu)
+and change the line "local all all peer" to "local all all md5".
+
+If you have trouble with your first run of `./manage.py sync_couch_views`:
++ 401 error related to nonexistent database:
+   $ curl -X PUT http://localhost:5984/commcarehq  # create the database
+   $ curl -X PUT http://localhost:5984/_config/admins/commcarehq -d '"commcarehq"' . # add admin user
++ Error stemming from any Python modules: the issue may be that your virtualenv is relying on the `site-packages` directory of your local Python installation for some of its requirements. (Creating your virtualenv with the `--no-site-packages` flag should prevent this, but it seems that it does not always work). You can check if this is the case by running `pip show {name-of-module-that-is-erroring}`. This will show the location that your virtualenv is pulling that module from; if the location is somewhere other than the path to your virtualenv, then something is wrong. The easiest solution to this is to remove any conflicting modules from the location that your virtualenv is pulling them from (as long as you use virtualenvs for all of your Python projects, this won't cause you any issues).
+
++ If you encounter an error stemming from an Incompatible Library Version of libxml2.2.dylib on Mac OS X, try running the following commands:
+   $ brew install libxml2
+   $ brew install libxslt
+   $ brew link libxml2 --force
+   $ brew link libxslt --force
+
++ If you encounter an authorization error related to CouchDB, try going to your `localsettings.py` file and change `COUCH_PASSWORD` to an empty string.
+
+### ElasticSearch Setup
 
 To set up elasticsearch indexes run the following:
 

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -301,15 +301,20 @@ and change the line "local all all peer" to "local all all md5".
 
 If you have trouble with your first run of `./manage.py sync_couch_views`:
 + 401 error related to nonexistent database:
-   $ curl -X PUT http://localhost:5984/commcarehq  # create the database
-   $ curl -X PUT http://localhost:5984/_config/admins/commcarehq -d '"commcarehq"' . # add admin user
+```
+$ curl -X PUT http://localhost:5984/commcarehq  # create the database
+$ curl -X PUT http://localhost:5984/_config/admins/commcarehq -d '"commcarehq"' . # add admin user
+```
+
 + Error stemming from any Python modules: the issue may be that your virtualenv is relying on the `site-packages` directory of your local Python installation for some of its requirements. (Creating your virtualenv with the `--no-site-packages` flag should prevent this, but it seems that it does not always work). You can check if this is the case by running `pip show {name-of-module-that-is-erroring}`. This will show the location that your virtualenv is pulling that module from; if the location is somewhere other than the path to your virtualenv, then something is wrong. The easiest solution to this is to remove any conflicting modules from the location that your virtualenv is pulling them from (as long as you use virtualenvs for all of your Python projects, this won't cause you any issues).
 
 + If you encounter an error stemming from an Incompatible Library Version of libxml2.2.dylib on Mac OS X, try running the following commands:
-   $ brew install libxml2
-   $ brew install libxslt
-   $ brew link libxml2 --force
-   $ brew link libxslt --force
+```
+$ brew install libxml2
+$ brew install libxslt
+$ brew link libxml2 --force
+$ brew link libxslt --force
+```
 
 + If you encounter an authorization error related to CouchDB, try going to your `localsettings.py` file and change `COUCH_PASSWORD` to an empty string.
 

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -498,9 +498,11 @@ you can follow the instructions in the [pipes repository](https://github.com/dim
 Running Tests
 -------------
 
-To run the standard tests for CommCare HQ, simply run
+To run the standard tests for CommCare HQ, run
 
     $ ./manage.py test
+
+These may not all pass in a local environment. It's often more practical, and faster, to just run tests for the django app where you're working.
 
 To run a particular test or subset of tests
 


### PR DESCRIPTION
Docs only.

Based on https://docs.google.com/document/d/1LrosfV6tuTOhiwOsZ5BUxU5UruSZPMLtQsQ9WVtjMWs/edit and related conversations. This is a little duplicative but hopefully not very. The main point is to have a document separate from the dev setup guide, which is still fairly long, for the kinds of issues that you don't typically run into until you're a few days/weeks past initial setup, and to frame these issues in the ways new devs tend to describe them.