### PR TITLE
pass in type_code in check_blob_logs

### DIFF
--- a/corehq/blobs/management/commands/check_blob_logs.py
+++ b/corehq/blobs/management/commands/check_blob_logs.py
@@ -120,7 +120,7 @@ def check_blob(rec, old_db, new_db, migrate=False):
 
     if old_db.exists(key=key):
         if migrate:
-            with old_db.get(key=key) as content:
+            with old_db.get(key=key, type_code=CODES.maybe_compressed) as content:
                 new_db.copy_blob(content, key=key)
             action = "Migrated from"
         else:

--- a/corehq/blobs/migrate.py
+++ b/corehq/blobs/migrate.py
@@ -302,7 +302,7 @@ class BlobDbBackendCheckMigrator(BlobDbBackendMigrator):
         self.total_blobs += 1
         if not self.db.new_db.exists(key=meta.key):
             try:
-                content = self.db.old_db.get(key=meta.key)
+                content = self.db.old_db.get(key=meta.key, type_code=CODES.maybe_compressed)
             except NotFound:
                 self.save_backup(doc)
             else:


### PR DESCRIPTION
https://forum.dimagi.com/t/live-migration-from-s3-to-s3/8236

## Summary
Fix bug in blobdb management command `check_blob_logs`. Type code must be passed in to `db.get`.

Using `CODES.maybe_compressed` get's the raw content which can then be written to the new BlobDB.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Only impacts a manually run management command.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
