### PR TITLE
Fix docstring

### DIFF
--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -4,7 +4,7 @@ ROOT = 'root'
 
 
 def _format_to_regex(pattern):
-    """
+    r"""
     convert a format string with %s and %d to a regex
 
     %s => .*
@@ -14,13 +14,13 @@ def _format_to_regex(pattern):
     everything else gets `re.escape`d
 
     >>> import re
-    >>> format = '%shello %%sam %s, you are %d years old.'
-    >>> regex = _format_to_regex(format)
-    >>> print regex
+    >>> format_ = '%shello %%sam %s, you are %d years old.'
+    >>> regex = _format_to_regex(format_)
+    >>> print(regex)
     .*hello\ %sam\ .*\,\ you\ are\ [0-9]+\ years\ old\.
-    >>> bool(re.match(regex, format % ("Oh ", "i am", 6)))
+    >>> bool(re.match(regex, format_ % ("Oh ", "i am", 6)))
     True
-    >>> bool(re.match(regex, format))
+    >>> bool(re.match(regex, format_))
     False
 
     """

--- a/corehq/apps/app_manager/tests/test_id_strings.py
+++ b/corehq/apps/app_manager/tests/test_id_strings.py
@@ -1,0 +1,8 @@
+import doctest
+from nose.tools import assert_equal
+from corehq.apps.app_manager import id_strings
+
+
+def test_doctests():
+    results = doctest.testmod(id_strings)
+    assert_equal(results.failed, 0)


### PR DESCRIPTION
## Summary

Addresses deprecation warning:

    corehq/apps/app_manager/id_strings.py:26: DeprecationWarning: invalid escape sequence \
      """


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Tests doctest


### Safety story

Non-code change (excl. test). Just fixes a doctest and resolves a deprecation warning.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
