### PR TITLE
Multiple attempts with shorter timeouts

### DIFF
--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -11,7 +11,7 @@ from celery.schedules import crontab
 from celery.task import periodic_task, task
 from django.conf import settings
 from jinja2 import Template
-from requests import RequestException
+from requests import ReadTimeout, RequestException
 
 from casexml.apps.case.mock import CaseBlock
 from toggle.shortcuts import find_domains_with_toggle_enabled
@@ -46,8 +46,6 @@ from corehq.motech.requests import get_basic_requests
 from corehq.motech.utils import b64_aes_decrypt
 
 RowAndCase = namedtuple('RowAndCase', ['row', 'case'])
-# REQUEST_TIMEOUT is 5 minutes, but reports can take up to an hour
-REPORT_REQUEST_TIMEOUT = 60 * 60
 # The location metadata key that maps to its corresponding OpenMRS location UUID
 LOCATION_OPENMRS = 'openmrs_uuid'
 
@@ -78,8 +76,21 @@ def get_openmrs_patients(requests, importer, location=None):
     """
     endpoint = f'/ws/rest/v1/reportingrest/reportdata/{importer.report_uuid}'
     params = parse_params(importer.report_params, location)
-    response = requests.get(endpoint, params=params, raise_for_status=True,
-                            timeout=REPORT_REQUEST_TIMEOUT)
+
+    for minutes in (5, 10, 20, 40):
+        try:
+            response = requests.get(
+                endpoint,
+                params=params,
+                raise_for_status=True,
+                timeout=(5, minutes * 60),  # connection timeout, read timeout
+            )
+            break
+        except ReadTimeout:
+            if minutes < 40:
+                continue
+            else:
+                raise
     data = response.json()
     return data['dataSets'][0]['rows']  # e.g. ...
     #     [{u'familyName': u'Hornblower', u'givenName': u'Horatio', u'personId': 2},

--- a/corehq/motech/openmrs/tests/test_tasks.py
+++ b/corehq/motech/openmrs/tests/test_tasks.py
@@ -4,21 +4,26 @@ import logging
 from contextlib import contextmanager
 
 from django.conf import settings
+from django.test import SimpleTestCase
 
 import pytz
 from mock import patch
 from nose.tools import assert_raises_regexp
+from requests.exceptions import ConnectTimeout, ReadTimeout
 
 from corehq.apps.groups.models import Group
 from corehq.apps.locations.tests.util import LocationHierarchyTestCase
 from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.motech.auth import AuthManager
 from corehq.motech.exceptions import ConfigurationError
 from corehq.motech.openmrs.const import IMPORT_FREQUENCY_MONTHLY
 from corehq.motech.openmrs.models import OpenmrsImporter
 from corehq.motech.openmrs.tasks import (
     get_case_properties,
+    get_openmrs_patients,
     import_patients_with_importer,
 )
+from corehq.motech.requests import Requests
 from corehq.motech.views import ConnectionSettingsListView
 from corehq.util.view_utils import absolute_reverse
 
@@ -226,6 +231,79 @@ def test_get_importer_timezone(get_timezone_for_domain_mock):
         importer.timezone = "Africa/Maputo"
         timezone = importer.get_timezone()
         assert timezone == cat
+
+
+class TestTimeout(SimpleTestCase):
+
+    def setUp(self):
+        self.no_auth = AuthManager()
+
+    def test_timeout(self):
+        with patch.object(Requests, 'get') as request_get:
+            request_get.side_effect = ReadTimeout
+            requests = Requests(
+                TEST_DOMAIN,
+                'https://example.com/',
+                auth_manager=self.no_auth,
+                logger=lambda level, entry: None,
+            )
+            importer = Importer()
+
+            with self.assertRaises(ReadTimeout):
+                get_openmrs_patients(requests, importer)
+            self.assertEqual(request_get.call_count, 4)
+
+    def test_connection(self):
+        with patch.object(Requests, 'get') as request_get:
+            request_get.side_effect = ConnectTimeout
+            requests = Requests(
+                TEST_DOMAIN,
+                'https://example.com/',
+                auth_manager=self.no_auth,
+                logger=lambda level, entry: None,
+            )
+            importer = Importer()
+
+            with self.assertRaises(ConnectTimeout):
+                get_openmrs_patients(requests, importer)
+            self.assertEqual(request_get.call_count, 1)
+
+    def test_success(self):
+        with patch.object(Requests, 'get') as request_get:
+            request_get.side_effect = [
+                ReadTimeout,
+                ReadTimeout,
+                ReadTimeout,
+                Response(),
+            ]
+            requests = Requests(
+                TEST_DOMAIN,
+                'https://example.com/',
+                auth_manager=self.no_auth,
+                logger=lambda level, entry: None,
+            )
+            importer = Importer()
+
+            rows = get_openmrs_patients(requests, importer)
+            self.assertEqual(rows, [
+                {u'familyName': u'Hornblower', u'givenName': u'Horatio', u'personId': 2},
+                {u'familyName': u'Patient', u'givenName': u'John', u'personId': 3},
+            ])
+
+
+class Importer:
+    report_uuid = 'abc123'
+    report_params = {'foo': 'bar'}
+
+
+class Response:
+    data = {'dataSets': [{'rows': [
+        {u'familyName': u'Hornblower', u'givenName': u'Horatio', u'personId': 2},
+        {u'familyName': u'Patient', u'givenName': u'John', u'personId': 3},
+    ]}]}
+
+    def json(self):
+        return self.data
 
 
 class OwnerTests(LocationHierarchyTestCase):


### PR DESCRIPTION
## Summary

Context: [SC-1549](https://dimagi-dev.atlassian.net/browse/SC-1549)

Fixes a problem importing data from OpenMRS.

Testing shows that sending multiple requests with shorter timeouts succeeds where a single request with a longer timeout fails.

cc @avazirna

## Feature Flag

OpenMRS Integration


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Includes tests


### Safety story

* This change is only applicable to projects with the "OpenMRS Integration" toggle enabled, and an OpenMRS Importer configured.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
