### PR TITLE
[ERM UI] Create domain link RMI

### DIFF
--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -82,17 +82,24 @@ class DomainLink(models.Model):
     @classmethod
     def link_domains(cls, linked_domain, master_domain, remote_details=None):
         existing_links = cls.all_objects.filter(linked_domain=linked_domain)
-        active_links_with_other_domains = [l for l in existing_links
-                                           if not l.deleted and l.master_domain != master_domain]
+        active_links_with_other_domains = [
+            domain_link for domain_link in existing_links
+            if not domain_link.deleted and domain_link.master_domain != master_domain
+        ]
         if active_links_with_other_domains:
-            raise DomainLinkError('Domain "{}" is already linked to a different domain ({}).'.format(
-                linked_domain, active_links_with_other_domains[0].master_domain
-            ))
+            already_linked_domain = active_links_with_other_domains[0].master_domain
+            raise DomainLinkError(
+                _(f'{linked_domain} is already a downstream project space of {already_linked_domain}.')
+            )
 
-        deleted_existing_links = [l for l in existing_links
-                                  if l.deleted and l.master_domain == master_domain]
-        active_links_with_this_domain = [l for l in existing_links
-                                         if not l.deleted and l.master_domain == master_domain]
+        deleted_existing_links = [
+            domain_link for domain_link in existing_links
+            if domain_link.deleted and domain_link.master_domain == master_domain
+        ]
+        active_links_with_this_domain = [
+            domain_link for domain_link in existing_links
+            if not domain_link.deleted and domain_link.master_domain == master_domain
+        ]
 
         if deleted_existing_links:
             # if there was a deleted link, just undelete it

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -173,18 +173,18 @@ hqDefine("linked_domain/js/domain_links", [
         self.value = ko.observable();
 
         self.addDownstreamDomain = function (viewModel) {
-            // TODO: make rmi call to create domain link
-            var domainLinkResponse = {"linked_domain": viewModel.value(),
-                "is_remote": false,
-                "master_domain": self.parent.domain,
-                "remote_base_url": "",
-                "last_update": ""};
-            self.parent.domain_links.unshift(DomainLink(domainLinkResponse));
-            self.availableDomains(_.filter(self.availableDomains(), function (item) {
-                return item !== viewModel.value();
-            }));
-            self.value(null);
-            self.parent.goToPage(1);
+            _private.RMI("create_domain_link", {
+              "downstream_domain": viewModel.value(),
+            }).done(function (data) {
+                self.availableDomains(_.filter(self.availableDomains(), function (item) {
+                    return item !== viewModel.value();
+                }));
+                self.value(null);
+                self.parent.domain_links.unshift(DomainLink(data.response));
+                self.parent.goToPage(1);
+            }).fail(function () {
+                alertUser.alert_user(gettext('Unable to link domains.\nPlease try again, or report an issue if the problem persists.'), 'danger');
+            });
         };
         return self;
     };

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -175,15 +175,19 @@ hqDefine("linked_domain/js/domain_links", [
         self.addDownstreamDomain = function (viewModel) {
             _private.RMI("create_domain_link", {
                 "downstream_domain": viewModel.value(),
-            }).done(function (data) {
-                self.availableDomains(_.filter(self.availableDomains(), function (item) {
-                    return item !== viewModel.value();
-                }));
-                self.value(null);
-                self.parent.domain_links.unshift(DomainLink(data.response));
-                self.parent.goToPage(1);
+            }).done(function (response) {
+                if (response.success) {
+                    self.availableDomains(_.filter(self.availableDomains(), function (item) {
+                        return item !== viewModel.value();
+                    }));
+                    self.value(null);
+                    self.parent.domain_links.unshift(DomainLink(response.domain_link));
+                    self.parent.goToPage(1);
+                } else {
+                    alertUser.alert_user(gettext('Unable to link project spaces. ' + response.message + '\nYou must remove the existing link before creating this new link.'), 'danger');
+                }
             }).fail(function () {
-                alertUser.alert_user(gettext('Unable to link domains.\nPlease try again, or report an issue if the problem persists.'), 'danger');
+                alertUser.alert_user(gettext('Unable to link project spaces.\nPlease try again, or report an issue if the problem persists.'), 'danger');
             });
         };
         return self;

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -184,7 +184,10 @@ hqDefine("linked_domain/js/domain_links", [
                     self.parent.domain_links.unshift(DomainLink(response.domain_link));
                     self.parent.goToPage(1);
                 } else {
-                    alertUser.alert_user(gettext('Unable to link project spaces. ' + response.message + '\nYou must remove the existing link before creating this new link.'), 'danger');
+                    var errorMessage = _.template(
+                        gettext('Unable to link project spaces. <%- error %>\nYou must remove the existing link before creating this new link.')
+                    )({error: response.message});
+                    alertUser.alert_user(errorMessage, 'danger');
                 }
             }).fail(function () {
                 alertUser.alert_user(gettext('Unable to link project spaces.\nPlease try again, or report an issue if the problem persists.'), 'danger');

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -174,7 +174,7 @@ hqDefine("linked_domain/js/domain_links", [
 
         self.addDownstreamDomain = function (viewModel) {
             _private.RMI("create_domain_link", {
-              "downstream_domain": viewModel.value(),
+                "downstream_domain": viewModel.value(),
             }).done(function (data) {
                 self.availableDomains(_.filter(self.availableDomains(), function (item) {
                     return item !== viewModel.value();

--- a/corehq/apps/linked_domain/view_helpers.py
+++ b/corehq/apps/linked_domain/view_helpers.py
@@ -32,6 +32,16 @@ from corehq.apps.userreports.models import ReportConfiguration
 from corehq.util.timezones.utils import get_timezone_for_request
 
 
+def link_context(link, timezone):
+    return {
+        'linked_domain': link.linked_domain,
+        'master_domain': link.qualified_master,
+        'remote_base_url': link.remote_base_url,
+        'is_remote': link.is_remote,
+        'last_update': server_to_user_time(link.last_pull, timezone) if link.last_pull else 'Never',
+    }
+
+
 def get_apps(domain):
     master_list = {}
     linked_list = {}

--- a/corehq/apps/linked_domain/view_helpers.py
+++ b/corehq/apps/linked_domain/view_helpers.py
@@ -32,13 +32,13 @@ from corehq.apps.userreports.models import ReportConfiguration
 from corehq.util.timezones.utils import get_timezone_for_request
 
 
-def link_context(link, timezone):
+def build_domain_link_view_model(link, timezone):
     return {
         'linked_domain': link.linked_domain,
         'master_domain': link.qualified_master,
         'remote_base_url': link.remote_base_url,
         'is_remote': link.is_remote,
-        'last_update': server_to_user_time(link.last_pull, timezone) if link.last_pull else 'Never',
+        'last_update': server_to_user_time(link.last_pull, timezone) if link.last_pull else _('Never'),
     }
 
 

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -86,7 +86,7 @@ from corehq.apps.linked_domain.view_helpers import (
     get_apps,
     get_fixtures,
     get_keywords,
-    get_reports, link_context,
+    get_reports, build_domain_link_view_model,
 )
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
 from corehq.apps.reports.dispatcher import DomainReportDispatcher
@@ -237,7 +237,7 @@ class DomainLinkView(BaseAdminProjectSettingsView):
         """
         timezone = get_timezone_for_request()
         master_link = get_domain_master_link(self.domain)
-        linked_domains = [link_context(link, timezone) for link in get_linked_domains(self.domain)]
+        linked_domains = [build_domain_link_view_model(link, timezone) for link in get_linked_domains(self.domain)]
         master_apps, linked_apps = get_apps(self.domain)
         master_fixtures, linked_fixtures = get_fixtures(self.domain, master_link)
         master_reports, linked_reports = get_reports(self.domain)
@@ -261,7 +261,7 @@ class DomainLinkView(BaseAdminProjectSettingsView):
             'is_erm_ff_enabled': ERM_DEVELOPMENT.enabled(self.domain),
             'view_data': {
                 'available_domains': available_domains_to_link,
-                'master_link': link_context(master_link, timezone) if master_link else None,
+                'master_link': build_domain_link_view_model(master_link, timezone) if master_link else None,
                 'model_status': sorted(view_models_to_pull, key=lambda m: m['name']),
                 'master_model_status': sorted(view_models_to_push, key=lambda m: m['name']),
                 'linked_domains': sorted(linked_domains, key=lambda d: d['linked_domain']),
@@ -341,13 +341,13 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
         except DomainLinkError as e:
             return {
                 'success': False,
-                'message': str(e),
+                'message': str(e)
             }
 
         timezone = get_timezone_for_request()
         return {
             'success': True,
-            'response': link_context(domain_link, timezone.localize(datetime.utcnow()).tzname())
+            'domain_link': build_domain_link_view_model(domain_link, timezone.localize(datetime.utcnow()).tzname())
         }
 
 

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -81,12 +81,13 @@ from corehq.apps.linked_domain.util import (
     server_to_user_time,
 )
 from corehq.apps.linked_domain.view_helpers import (
+    build_domain_link_view_model,
     build_pullable_view_models_from_data_models,
     build_view_models_from_data_models,
     get_apps,
     get_fixtures,
     get_keywords,
-    get_reports, build_domain_link_view_model,
+    get_reports,
 )
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
 from corehq.apps.reports.dispatcher import DomainReportDispatcher

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -347,7 +347,7 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
         timezone = get_timezone_for_request()
         return {
             'success': True,
-            'domain_link': build_domain_link_view_model(domain_link, timezone.localize(datetime.utcnow()).tzname())
+            'domain_link': build_domain_link_view_model(domain_link, timezone)
         }
 
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-147)

This PR handles making the RMI call from the frontend to create a domain link. The `DomainLink` object itself is quite simple, so this should be sufficient to start linking data models.

I was planning on displaying the `DomainLinkError` exception on the frontend, but thought twice about it from a security perspective. The state it is in right now doesn't make sense, as I would either use the message or not send it in the response at all. Any thoughts?

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will run through QA on parent branch.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested on both a newly created link and a reinstated link (one that has been removed but still exists). 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
