### PR TITLE
[ERM UI] Update text to display which domain is being removed

### DIFF
--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -132,7 +132,17 @@
                               <h4 class="modal-title">{% trans 'Remove Project Link' %}</h4>
                             </div>
                             <div class="modal-body">
-                              <p>{% trans 'Are you sure you want to remove the link between projects?' %}</p>
+                              <h4>
+                                {% blocktrans %}
+                                  Are you sure you want to remove the downstream link to <b data-bind="text: linked_domain"></b>?
+                                {% endblocktrans %}
+                              </h4>
+                              <p>
+                                {% blocktrans %}
+                                  Removing the link will also remove links between upstream and downstream data models.<br/>
+                                  <a href="#" target="_blank">Learn more</a> about what happens when downstream project links are removed.
+                                {% endblocktrans %}
+                              </p>
                             </div>
                             <div class="modal-footer">
                               <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Minor text update to the remove project link modal. @biyeun in the figma mockups, you have the text "Removing the link will also remove [set of things that will happen]." I assume what you had in mind was a list of data models that would change as a result of this action? If so, I can work on that more but was not sure how helpful/necessary that is here. If we link to documentation as well it seems the user could be knowledgeable enough to know what will happen, but that assumes they read the documentation. Just curious to hear any thoughts on why we should or shouldn't include that list (if that is what you had in mind). 

<img width="622" alt="Screen Shot 2021-06-08 at 11 54 03 AM" src="https://user-images.githubusercontent.com/15785053/121253673-65d42f00-c877-11eb-8cda-c1308f1b0b61.png">

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Text change.
## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
UI change.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Text change, but will run through QA on parent branch.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
