### PR TITLE
implement cursor based pagination

### DIFF
--- a/corehq/apps/api/resources/messaging_event/pagination.py
+++ b/corehq/apps/api/resources/messaging_event/pagination.py
@@ -39,7 +39,7 @@ def _get_objects(query, request_params, limit):
                 logger.debug(f"Skipping first object in API response: {last_id}")
                 return objects[1:]  # remove the first object since it was in the last page
 
-        logger.debug(f"Dropping last object in API response to keep page size consistent")
+        logger.debug("Dropping last object in API response to keep page size consistent")
         return objects[:-1]
 
     logger.debug("no cursor, returning normal page")

--- a/corehq/apps/api/resources/messaging_event/pagination.py
+++ b/corehq/apps/api/resources/messaging_event/pagination.py
@@ -1,0 +1,73 @@
+import logging
+from base64 import b64encode
+from urllib.parse import urlencode
+
+from corehq.apps.api.resources.messaging_event.serializers import serialize_event
+from corehq.apps.api.resources.messaging_event.utils import get_limit_offset
+from corehq.util import reverse
+
+LAST_OBJECT_ID = "last_object_id"
+
+logger = logging.getLogger(__name__)
+
+
+def get_paged_data(query, request_params):
+    limit = get_limit_offset("limit", request_params, 20, max_value=1000)
+    objects = _get_objects(query, request_params, limit)
+    return {
+        "objects": [serialize_event(event) for event in objects],
+        "meta": {
+            "limit": limit,
+            "next": _get_cursor(objects, request_params)
+        }
+    }
+
+
+def _get_objects(query, request_params, limit):
+    """Get the list of objects to return. For pages > 1 this will
+    skip the first object in the page if it was present in the previous
+    page (as encoded in the cursor)"""
+    if request_params.is_cursor:
+        objects = list(query[:limit + 1])
+        last_id = request_params.get(LAST_OBJECT_ID)
+        try:
+            last_id = int(last_id)
+        except ValueError:
+            logger.debug("invalid last_object_id: '{last_id}")
+        else:
+            if objects[0].id == last_id:
+                logger.debug(f"Skipping first object in API response: {last_id}")
+                return objects[1:]  # remove the first object since it was in the last page
+
+        logger.debug(f"Dropping last object in API response to keep page size consistent")
+        return objects[:-1]
+
+    logger.debug("no cursor, returning normal page")
+    return list(query[:limit])
+
+
+def _get_cursor(objects, request_params):
+    """Generate the 'cursor' parameter which includes all query params from the current
+    request excluding 'limit' as well as:
+      - filter parameter for the next page e.g. date.gte = last date
+      - ID of the last object in the current page to allow skipping it in the next page
+    """
+    if not objects:
+        return None
+
+    ascending_order = True
+    if "order_by" in request_params:
+        if request_params["order_by"].startswith("-"):
+            ascending_order = False
+
+    last_object = objects[-1]
+
+    filter_param = "date.gte" if ascending_order else "date.lte"
+    cursor_params = request_params.params.copy()
+    cursor_params.update({
+        filter_param: last_object.date.isoformat(),
+        LAST_OBJECT_ID: str(last_object.id)
+    })
+    encoded_params = urlencode(cursor_params)
+    next_params = {'cursor': b64encode(encoded_params.encode('utf-8'))}
+    return reverse('api_messaging_events', args=[request_params.domain], params=next_params)

--- a/corehq/apps/api/resources/messaging_event/utils.py
+++ b/corehq/apps/api/resources/messaging_event/utils.py
@@ -1,3 +1,7 @@
+from base64 import b64decode
+from collections import namedtuple
+
+from django.http import QueryDict
 from tastypie.exceptions import BadRequest
 
 
@@ -8,7 +12,7 @@ def get_limit_offset(param_name, request_data, default, max_value=None):
     except ValueError:
         raise BadRequest(f"Invalid {param_name} '{value}' provided. Please provide a positive integer.")
 
-    if value < 0:
+    if value <= 0:
         raise BadRequest(f"Invalid {param_name} '{value}' provided. Please provide a positive integer.")
 
     if max_value:
@@ -16,8 +20,13 @@ def get_limit_offset(param_name, request_data, default, max_value=None):
     return value
 
 
-def sort_query(query, request_data):
-    order_by = request_data.get("order_by")
+def sort_query(query, request_params):
+    """Always order by date and ID to ensure consistent result order
+    across requests.
+
+    This is required for the cursor pagination.
+    """
+    order_by = request_params.get("order_by")
 
     if not order_by:
         order_by_args = ["date", "id"]
@@ -27,3 +36,33 @@ def sort_query(query, request_data):
         order_by_args = [order_by, "id"]
 
     return query.order_by(*order_by_args)
+
+
+class CursorParams(namedtuple("CursorParams", "params, domain, is_cursor")):
+    def __getitem__(self, key):
+        return self.params[key]
+
+    def __contains__(self, key):
+        return key in self.params
+
+    def items(self):
+        return self.params.items()
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+
+def get_request_params(request):
+    """Get the query params from the request. If the request is using a cursor
+    decode the cursor and return those values as the query params.
+    :returns: CursorParams tuple"""
+    request_params = request.GET.dict()
+    if 'cursor' in request_params:
+        params_string = b64decode(request_params['cursor']).decode('utf-8')
+        return CursorParams(
+            QueryDict(params_string).dict(), request.domain, True
+        )
+    return CursorParams(request_params, request.domain, False)

--- a/corehq/apps/api/tests/test_messaging_event_api.py
+++ b/corehq/apps/api/tests/test_messaging_event_api.py
@@ -3,7 +3,6 @@ import urllib.parse
 from datetime import datetime, timedelta
 from urllib.parse import urlencode
 
-from django.http import QueryDict
 from django.urls import reverse
 
 from corehq.apps.api.tests.utils import APIResourceTest


### PR DESCRIPTION
PR into https://github.com/dimagi/commcare-hq/pull/29885
Redo of https://github.com/dimagi/commcare-hq/pull/29871

## Summary
This replaces the `offset` based pagination with `cursor` based pagination for the messaging-events API.