### PR TITLE
Replace Levenshtein library

### DIFF
--- a/corehq/motech/finders.py
+++ b/corehq/motech/finders.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from operator import eq
 
-from Levenshtein._levenshtein import distance
+from pyphonetics.distance_metrics import levenshtein_distance
 from couchdbkit.ext.django.schema import (
     DecimalProperty,
     ListProperty,
@@ -51,7 +51,7 @@ def le_levenshtein_percent(percent, string1, string2):
     """
     if not 0 <= percent < 1:
         raise ValueError('percent must be greater that or equal to 0 and less than 1')
-    dist = distance(string1, string2)
+    dist = levenshtein_distance(string1, string2)
     max_len = max(len(string1), len(string2))
     return dist / max_len <= percent
 

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -89,7 +89,7 @@ Pygments==2.8.1
 pygooglechart==0.4.0
 python-dateutil~=2.6
 python-imap==1.0.0
-python-levenshtein>=0.12.1
+pyphonetics==0.5.3
 python-magic~=0.4.22
 pytz>=2017.2
 PyYAML~=5.4.1

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -431,6 +431,8 @@ pyopenssl==20.0.1
     # via -r sso-requirements.in
 pyparsing==2.4.7
     # via packaging
+pyphonetics==0.5.3
+    # via -r base-requirements.in
 pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
@@ -448,8 +450,6 @@ python-dateutil==2.8.1
 python-editor==1.0.4
     # via alembic
 python-imap==1.0.0
-    # via -r base-requirements.in
-python-levenshtein==0.12.2
     # via -r base-requirements.in
 python-magic==0.4.22
     # via -r base-requirements.in
@@ -643,6 +643,8 @@ twilio==6.5.1
     # via -r base-requirements.in
 ua-parser==0.10.0
     # via user-agents
+unidecode==1.2.0
+    # via pyphonetics
 urllib3==1.26.5
     # via
     #   botocore
@@ -688,6 +690,5 @@ setuptools==50.3.0
     #   ipython
     #   jsonschema
     #   protobuf
-    #   python-levenshtein
     #   python-termstyle
     #   sphinx

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -332,6 +332,8 @@ pyjwt==1.7.1
     #   twilio
 pyparsing==2.4.7
     # via packaging
+pyphonetics==0.5.3
+    # via -r base-requirements.in
 pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
@@ -348,8 +350,6 @@ python-dateutil==2.8.1
 python-editor==1.0.4
     # via alembic
 python-imap==1.0.0
-    # via -r base-requirements.in
-python-levenshtein==0.12.2
     # via -r base-requirements.in
 python-magic==0.4.22
     # via -r base-requirements.in
@@ -502,6 +502,8 @@ typing-extensions==3.7.4.3
     # via importlib-metadata
 ua-parser==0.10.0
     # via user-agents
+unidecode==1.2.0
+    # via pyphonetics
 urllib3==1.26.5
     # via
     #   botocore
@@ -533,5 +535,4 @@ setuptools==53.0.0
     #   gunicorn
     #   jsonschema
     #   protobuf
-    #   python-levenshtein
     #   sphinx

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -355,6 +355,8 @@ pyopenssl==20.0.1
     #   -r prod-requirements.in
     #   -r sso-requirements.in
     #   ndg-httpsclient
+pyphonetics==0.5.3
+    # via -r base-requirements.in
 pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
@@ -371,8 +373,6 @@ python-dateutil==2.8.1
 python-editor==1.0.4
     # via alembic
 python-imap==1.0.0
-    # via -r base-requirements.in
-python-levenshtein==0.12.2
     # via -r base-requirements.in
 python-magic==0.4.22
     # via -r base-requirements.in
@@ -513,6 +513,8 @@ typing-extensions==3.7.4.3
     # via importlib-metadata
 ua-parser==0.10.0
     # via user-agents
+unidecode==1.2.0
+    # via pyphonetics
 urllib3==1.26.5
     # via
     #   botocore
@@ -553,4 +555,3 @@ setuptools==50.3.0
     #   ipython
     #   jsonschema
     #   protobuf
-    #   python-levenshtein

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -317,6 +317,8 @@ pyjwt==1.7.1
     #   twilio
 pyopenssl==20.0.1
     # via -r sso-requirements.in
+pyphonetics==0.5.3
+    # via -r base-requirements.in
 pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
@@ -333,8 +335,6 @@ python-dateutil==2.8.1
 python-editor==1.0.4
     # via alembic
 python-imap==1.0.0
-    # via -r base-requirements.in
-python-levenshtein==0.12.2
     # via -r base-requirements.in
 python-magic==0.4.22
     # via -r base-requirements.in
@@ -465,6 +465,8 @@ typing-extensions==3.7.4.3
     # via importlib-metadata
 ua-parser==0.10.0
     # via user-agents
+unidecode==1.2.0
+    # via pyphonetics
 urllib3==1.26.5
     # via
     #   botocore
@@ -498,4 +500,3 @@ setuptools==50.3.0
     #   gunicorn
     #   jsonschema
     #   protobuf
-    #   python-levenshtein

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -361,6 +361,8 @@ pyjwt==1.7.1
     #   twilio
 pyopenssl==20.0.1
     # via -r sso-requirements.in
+pyphonetics==0.5.3
+    # via -r base-requirements.in
 pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
@@ -378,8 +380,6 @@ python-dateutil==2.8.1
 python-editor==1.0.4
     # via alembic
 python-imap==1.0.0
-    # via -r base-requirements.in
-python-levenshtein==0.12.2
     # via -r base-requirements.in
 python-magic==0.4.22
     # via -r base-requirements.in
@@ -527,6 +527,8 @@ typing-extensions==3.7.4.3
     # via importlib-metadata
 ua-parser==0.10.0
     # via user-agents
+unidecode==1.2.0
+    # via pyphonetics
 urllib3==1.26.5
     # via
     #   botocore
@@ -564,4 +566,3 @@ setuptools==50.3.0
     #   gunicorn
     #   jsonschema
     #   protobuf
-    #   python-levenshtein


### PR DESCRIPTION
## Summary

Context: [SC-1457](https://dimagi-dev.atlassian.net/browse/SC-1457)

This small change swaps one Levenshtein library out for another. See Jira for more context.


## Feature Flag

"OpenMRS Integration" or "FHIR Integration"


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Automated test coverage

The change is covered by tests in `corehq/motech/openmrs/tests/test_finders.py`


### Safety story

The feature affected by this change is only used by one project.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
