### PR TITLE
[ERM UI] Add search and pagination to pull release content tab

### DIFF
--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -33,8 +33,8 @@ class DomainLink(models.Model):
 
     # used for linking across remote instances of HQ
     remote_base_url = models.CharField(max_length=255, null=True, blank=True,
-                                       help_text=_("should be the full link with the trailing /. "
-                                                   "Example: https://www.commcarehq.org/"))
+                                       help_text=_("should be the full link without the trailing /. "
+                                                   "Example: https://www.commcarehq.org"))
     remote_username = models.CharField(max_length=255, null=True, blank=True)
     remote_api_key = models.CharField(max_length=255, null=True, blank=True)
 
@@ -42,14 +42,24 @@ class DomainLink(models.Model):
     all_objects = models.Manager()
 
     @property
-    def qualified_master(self):
+    def upstream_url(self):
         if self.is_remote:
             return '{}{}'.format(
                 self.remote_base_url,
                 reverse('domain_homepage', args=[self.master_domain])
             )
         else:
-            return self.master_domain
+            return reverse('domain_links', args=[self.master_domain])
+
+    @property
+    def downstream_url(self):
+        if self.is_remote:
+            return '{}{}'.format(
+                self.remote_base_url,
+                reverse('domain_homepage', args=[self.linked_domain])
+            )
+        else:
+            return reverse('domain_links', args=[self.linked_domain])
 
     @property
     def remote_details(self):

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -17,7 +17,7 @@ hqDefine("linked_domain/js/domain_links", [
     var _private = {};
     _private.RMI = function () {};
 
-    var ModelStatus = function (data) {
+    var LinkedDataViewModel = function (data) {
         var self = {};
         self.type = data.type;
         self.name = data.name;
@@ -58,7 +58,6 @@ hqDefine("linked_domain/js/domain_links", [
 
     var DomainLinksViewModel = function (data) {
         var self = {};
-        self.addDownstreamDomainModal = AddDownstreamDomainModal(self, data.available_domains);
         self.domain = data.domain;
         self.master_link = data.master_link;
         if (self.master_link) {
@@ -69,13 +68,25 @@ hqDefine("linked_domain/js/domain_links", [
             }
         }
 
+        // setup add downstream domain modal view model
+        var addDownstreamDomainData = {
+            parent: self,
+            availableDomains: data.available_domains
+        };
+        self.addDownstreamDomainViewModel = AddDownstreamDomainViewModel(addDownstreamDomainData);
+
+        // setup pull release content view model
+        var pullReleaseContentData = {
+            parent: self,
+            linkedDataViewModels: _.map(data.model_status, LinkedDataViewModel),
+            canUpdate: data.can_update,
+            upstreamDomain: self.master_link ? self.master_link.master_domain : null,
+            upstreamURL: self.master_link ? self.master_href : null
+        };
+        self.pullReleaseContentViewModel = PullReleaseContentViewModel(pullReleaseContentData);
+
         // General data
         self.domain_links = ko.observableArray(_.map(data.linked_domains, DomainLink));
-
-        // Pull Content Tab
-        self.model_status = _.map(data.model_status, ModelStatus);
-        self.can_update = data.can_update;
-        self.models = data.models;
 
         // Manage Downstream Domains Tab
         // search box
@@ -114,9 +125,9 @@ hqDefine("linked_domain/js/domain_links", [
                 "linked_domain": link.linked_domain(),
             }).done(function () {
                 self.domain_links.remove(link);
-                var availableDomains = self.addDownstreamDomainModal.availableDomains();
+                var availableDomains = self.addDownstreamDomainViewModel.availableDomains();
                 availableDomains.push(link.linked_domain());
-                self.addDownstreamDomainModal.availableDomains(availableDomains.sort());
+                self.addDownstreamDomainViewModel.availableDomains(availableDomains.sort());
                 self.goToPage(self.currentPage);
             }).fail(function () {
                 alertUser.alert_user(gettext('Something unexpected happened.\n' +
@@ -166,10 +177,52 @@ hqDefine("linked_domain/js/domain_links", [
         return self;
     };
 
-    var AddDownstreamDomainModal = function (manageDomainsViewModel, availableDomains) {
+    var PullReleaseContentViewModel = function (data) {
+        // Pull Content Tab
+        self.parent = data.parent;
+        self.linkedDataViewModels = data.linkedDataViewModels;
+        self.can_update = data.canUpdate;
+        self.upstreamDomain = data.upstreamDomain;
+        self.upstreamURL = data.upstreamURL;
+
+        // search box
+        self.query = ko.observable();
+        self.filteredLinkedDataViewModels = ko.observableArray([]);
+        self.matchesQuery = function (linkedDataViewModel) {
+            return !self.query() || linkedDataViewModel.name.toLowerCase().indexOf(self.query().toLowerCase()) !== -1;
+        };
+        self.filter = function () {
+            self.filteredLinkedDataViewModels(_.filter(self.linkedDataViewModels, self.matchesQuery));
+            self.goToPage(1);
+        };
+
+        // pagination
+        self.paginatedLinkedDataViewModels = ko.observableArray([]);
+        self.itemsPerPage = ko.observable(5);
+        self.totalItems = ko.computed(function () {
+            return self.query() ? self.filteredLinkedDataViewModels().length : self.linkedDataViewModels.length;
+        });
+        self.currentPage = 1;
+
+        self.goToPage = function (page) {
+            self.currentPage = page;
+            self.paginatedLinkedDataViewModels.removeAll();
+            var skip = (self.currentPage - 1) * self.itemsPerPage();
+            var visibleLinkedDataViewModels = self.query() ? self.filteredLinkedDataViewModels() : self.linkedDataViewModels;
+            self.paginatedLinkedDataViewModels(visibleLinkedDataViewModels.slice(skip, skip + self.itemsPerPage()));
+        };
+
+        self.onPaginationLoad = function () {
+            self.goToPage(1);
+        };
+
+        return self;
+    };
+
+    var AddDownstreamDomainViewModel = function (data) {
         var self = {};
-        self.parent = manageDomainsViewModel;
-        self.availableDomains = ko.observableArray(availableDomains.sort());
+        self.parent = data.parent;
+        self.availableDomains = ko.observableArray(data.availableDomains.sort());
         self.value = ko.observable();
 
         self.addDownstreamDomain = function (viewModel) {
@@ -203,7 +256,7 @@ hqDefine("linked_domain/js/domain_links", [
 
         var model = DomainLinksViewModel(view_data);
         if ($("#ko-tabs-pull-content").length) {
-            $("#ko-tabs-pull-content").koApplyBindings(model);
+            $("#ko-tabs-pull-content").koApplyBindings(model.pullReleaseContentViewModel);
         }
         if ($("#ko-tabs-push-content").length) {
             $("#ko-tabs-push-content").koApplyBindings(model);
@@ -213,7 +266,7 @@ hqDefine("linked_domain/js/domain_links", [
         }
 
         if ($("#new-downstream-domain-modal").length) {
-            $("#new-downstream-domain-modal").koApplyBindings(model.addDownstreamDomainModal);
+            $("#new-downstream-domain-modal").koApplyBindings(model.addDownstreamDomainViewModel);
         }
 
     });

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -162,8 +162,8 @@ hqDefine("linked_domain/js/domain_links", [
         self.is_remote = link.is_remote;
         self.master_domain = link.master_domain;
         self.lastUpdate = link.last_update;
-        self.upstreamURL = link.upstream_url;
-        self.downstreamURL = link.downstream_url;
+        self.upstreamUrl = link.upstream_url;
+        self.downstreamUrl = link.downstream_url;
         return self;
     };
 

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -70,7 +70,6 @@ hqDefine("linked_domain/js/domain_links", [
         var pullReleaseContentData = {
             parent: self,
             linkedDataViewModels: _.map(data.model_status, LinkedDataViewModel),
-            canUpdate: data.can_update,
             upstreamLink: data.master_link,
         };
         self.pullReleaseContentViewModel = PullReleaseContentViewModel(pullReleaseContentData);
@@ -172,7 +171,6 @@ hqDefine("linked_domain/js/domain_links", [
         // Pull Content Tab
         self.parent = data.parent;
         self.linkedDataViewModels = data.linkedDataViewModels;
-        self.can_update = data.canUpdate;
         self.upstreamLink = data.upstreamLink;
         if (self.upstreamLink) {
             if (self.upstreamLink.is_remote) {

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -62,7 +62,7 @@ hqDefine("linked_domain/js/domain_links", [
         // setup add downstream domain modal view model
         var addDownstreamDomainData = {
             parent: self,
-            availableDomains: data.available_domains
+            availableDomains: data.available_domains,
         };
         self.addDownstreamDomainViewModel = AddDownstreamDomainViewModel(addDownstreamDomainData);
 
@@ -71,7 +71,7 @@ hqDefine("linked_domain/js/domain_links", [
             parent: self,
             linkedDataViewModels: _.map(data.model_status, LinkedDataViewModel),
             canUpdate: data.can_update,
-            upstreamLink: data.master_link
+            upstreamLink: data.master_link,
         };
         self.pullReleaseContentViewModel = PullReleaseContentViewModel(pullReleaseContentData);
 

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -66,13 +66,17 @@ hqDefine("linked_domain/js/domain_links", [
         };
         self.addDownstreamDomainViewModel = AddDownstreamDomainViewModel(addDownstreamDomainData);
 
-        // setup pull release content view model
-        var pullReleaseContentData = {
-            parent: self,
-            linkedDataViewModels: _.map(data.model_status, LinkedDataViewModel),
-            upstreamLink: data.master_link,
-        };
-        self.pullReleaseContentViewModel = PullReleaseContentViewModel(pullReleaseContentData);
+        // can only pull content if a link with an upstream domain exists
+        var pullReleaseContentData = null;
+        if (data.master_link) {
+            pullReleaseContentData = {
+                parent: self,
+                linkedDataViewModels: _.map(data.model_status, LinkedDataViewModel),
+                domainLink: DomainLink(data.master_link),
+            };
+            self.pullReleaseContentViewModel = PullReleaseContentViewModel(pullReleaseContentData);
+        }
+
 
         // General data
         self.domain = data.domain;
@@ -157,13 +161,9 @@ hqDefine("linked_domain/js/domain_links", [
         self.linked_domain = ko.observable(link.linked_domain);
         self.is_remote = link.is_remote;
         self.master_domain = link.master_domain;
-        self.remote_base_url = ko.observable(link.remote_base_url);
         self.lastUpdate = link.last_update;
-        if (self.is_remote) {
-            self.domain_link = self.linked_domain;
-        } else {
-            self.domain_link = initialPageData.reverse('domain_links', self.linked_domain());
-        }
+        self.upstreamURL = link.upstream_url;
+        self.downstreamURL = link.downstream_url;
         return self;
     };
 
@@ -171,15 +171,7 @@ hqDefine("linked_domain/js/domain_links", [
         // Pull Content Tab
         self.parent = data.parent;
         self.linkedDataViewModels = data.linkedDataViewModels;
-        self.upstreamLink = data.upstreamLink;
-        if (self.upstreamLink) {
-            if (self.upstreamLink.is_remote) {
-                self.upstreamURL = self.upstreamLink.master_domain;
-            } else {
-                self.upstreamURL = initialPageData.reverse('domain_links', self.upstreamLink.master_domain);
-            }
-        }
-        self.upstreamDomain = self.upstreamLink ? self.upstreamLink.master_domain : null;
+        self.domainLink = data.domainLink;
 
         // search box
         self.query = ko.observable();

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -58,15 +58,6 @@ hqDefine("linked_domain/js/domain_links", [
 
     var DomainLinksViewModel = function (data) {
         var self = {};
-        self.domain = data.domain;
-        self.master_link = data.master_link;
-        if (self.master_link) {
-            if (self.master_link.is_remote) {
-                self.master_href = self.master_link.master_domain;
-            } else {
-                self.master_href = initialPageData.reverse('domain_links', self.master_link.master_domain);
-            }
-        }
 
         // setup add downstream domain modal view model
         var addDownstreamDomainData = {
@@ -80,12 +71,12 @@ hqDefine("linked_domain/js/domain_links", [
             parent: self,
             linkedDataViewModels: _.map(data.model_status, LinkedDataViewModel),
             canUpdate: data.can_update,
-            upstreamDomain: self.master_link ? self.master_link.master_domain : null,
-            upstreamURL: self.master_link ? self.master_href : null
+            upstreamLink: data.master_link
         };
         self.pullReleaseContentViewModel = PullReleaseContentViewModel(pullReleaseContentData);
 
         // General data
+        self.domain = data.domain;
         self.domain_links = ko.observableArray(_.map(data.linked_domains, DomainLink));
 
         // Manage Downstream Domains Tab
@@ -182,8 +173,15 @@ hqDefine("linked_domain/js/domain_links", [
         self.parent = data.parent;
         self.linkedDataViewModels = data.linkedDataViewModels;
         self.can_update = data.canUpdate;
-        self.upstreamDomain = data.upstreamDomain;
-        self.upstreamURL = data.upstreamURL;
+        self.upstreamLink = data.upstreamLink;
+        if (self.upstreamLink) {
+            if (self.upstreamLink.is_remote) {
+                self.upstreamURL = self.upstreamLink.master_domain;
+            } else {
+                self.upstreamURL = initialPageData.reverse('domain_links', self.upstreamLink.master_domain);
+            }
+        }
+        self.upstreamDomain = self.upstreamLink ? self.upstreamLink.master_domain : null;
 
         // search box
         self.query = ko.observable();

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -7,7 +7,6 @@
 {% block page_content %}
   {% initial_page_data 'view_data' view_data %}
   {% registerurl 'linked_domain:domain_link_rmi' domain %}
-  {% registerurl 'domain_links' '---' %}
   {% registerurl 'app_settings' domain '---' %}
 
   {% if not is_master_domain and not is_linked_domain %}

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/manage_downstream_domains_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/manage_downstream_domains_tab.html
@@ -40,7 +40,7 @@
           </thead>
           <tbody data-bind="foreach: paginatedDomainLinks">
           <tr>
-            <td><a data-bind="attr: {'href': domain_link}, text: linked_domain"></a></td>
+            <td><a data-bind="attr: {'href': downstreamURL}, text: linked_domain"></a></td>
             <td data-bind="text: lastUpdate"></td>
             <td>
               <button type="button" class="btn btn-danger" data-toggle="modal" data-bind="attr: {'data-target': '#remove-link-modal-' + $index()}">

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/manage_downstream_domains_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/manage_downstream_domains_tab.html
@@ -40,7 +40,7 @@
           </thead>
           <tbody data-bind="foreach: paginatedDomainLinks">
           <tr>
-            <td><a data-bind="attr: {'href': downstreamURL}, text: linked_domain"></a></td>
+            <td><a data-bind="attr: {'href': downstreamUrl}, text: linked_domain"></a></td>
             <td data-bind="text: lastUpdate"></td>
             <td>
               <button type="button" class="btn btn-danger" data-toggle="modal" data-bind="attr: {'data-target': '#remove-link-modal-' + $index()}">

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
@@ -2,10 +2,10 @@
 {% load i18n %}
 
 <div id="ko-tabs-pull-content" class="ko-template">
-  <div data-bind="if: master_link">
+  <div data-bind="if: upstreamDomain">
     <p>
       {% blocktrans %}
-        This project is linked to the upstream project <a data-bind="attr: {'href': master_href}, text: master_link.master_domain"></a>.<br/>
+        This project is linked to the upstream project <a data-bind="attr: {'href': upstreamURL}, text: upstreamDomain"></a>.<br/>
         The following items below are synced from the upstream project.<br/>
         <a href="#" target="_blank">Learn more</a> about Linked Projects.
       {% endblocktrans %}
@@ -16,6 +16,11 @@
         <h3 class="panel-title">{% trans 'Linked Data Models' %}</h3>
       </div>
       <div class="panel-body">
+        <search-box data-apply-bindings="false"
+          params="value: query,
+                  action: filter,
+                  immediate: true,
+                  placeholder: '{% trans_html_attr "Search Data Models..." %}'"></search-box>
         <table class="table table-striped table-hover">
           <thead>
           <tr>
@@ -24,7 +29,7 @@
             <th class="col-sm-5"></th>
           </tr>
           </thead>
-          <tbody data-bind="foreach: model_status">
+          <tbody data-bind="foreach: paginatedLinkedDataViewModels">
           <tr>
             <td data-bind="text: name"></td>
             <td data-bind="text: lastUpdate"></td>
@@ -47,7 +52,7 @@
                       </h4>
                       <p>
                         {% blocktrans %}
-                          This will pull <b data-bind="text: name"></b> from the upstream project <b data-bind="text: $parent.master_link.master_domain"></b>, overwriting the existing <b data-bind="text: name"></b>.<br/>
+                          This will pull <b data-bind="text: name"></b> from the upstream project <b data-bind="text: $root.upstreamDomain"></b>, overwriting the existing <b data-bind="text: name"></b>.<br/>
                           <a href="#" target="_blank">Learn more</a> about pulling content from an upstream project into a downstream project.
                         {% endblocktrans %}
                       </p>
@@ -74,6 +79,11 @@
           </tr>
           </tbody>
         </table>
+        <pagination data-apply-bindings="false"
+          params="goToPage: goToPage,
+                  perPage: itemsPerPage,
+                  totalItems: totalItems,
+                  onLoad: onPaginationLoad"></pagination>
       </div>
     </div>
   </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 <div id="ko-tabs-pull-content" class="ko-template">
-  <div data-bind="if: upstreamDomain">
+  <div data-bind="if: upstreamLink">
     <p>
       {% blocktrans %}
         This project is linked to the upstream project <a data-bind="attr: {'href': upstreamURL}, text: upstreamDomain"></a>.<br/>

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
@@ -2,10 +2,10 @@
 {% load i18n %}
 
 <div id="ko-tabs-pull-content" class="ko-template">
-  <div data-bind="if: upstreamLink">
+  <div data-bind="if: domainLink">
     <p>
       {% blocktrans %}
-        This project is linked to the upstream project <a data-bind="attr: {'href': upstreamURL}, text: upstreamDomain"></a>.<br/>
+        This project is linked to the upstream project <a data-bind="attr: {'href': domainLink.upstreamURL}, text: domainLink.master_domain"></a>.<br/>
         The data models below can be synced with the existing data models in the upstream project.<br/>
         <a href="#" target="_blank">Learn more</a> about syncing data between linked projects.
       {% endblocktrans %}

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
@@ -5,7 +5,7 @@
   <div data-bind="if: domainLink">
     <p>
       {% blocktrans %}
-        This project is linked to the upstream project <a data-bind="attr: {'href': domainLink.upstreamURL}, text: domainLink.master_domain"></a>.<br/>
+        This project is linked to the upstream project <a data-bind="attr: {'href': domainLink.upstreamUrl}, text: domainLink.master_domain"></a>.<br/>
         The data models below can be synced with the existing data models in the upstream project.<br/>
         <a href="#" target="_blank">Learn more</a> about syncing data between linked projects.
       {% endblocktrans %}

--- a/corehq/apps/linked_domain/tests/test_domain_link_methods.py
+++ b/corehq/apps/linked_domain/tests/test_domain_link_methods.py
@@ -4,19 +4,19 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.linked_domain.models import DomainLink
 
 
-class DomainLinkURLsTest(TestCase):
+class DomainLinkUrlsTest(TestCase):
 
     domain = 'domain-link-tests'
 
     @classmethod
     def setUpClass(cls):
-        super(DomainLinkURLsTest, cls).setUpClass()
+        super(DomainLinkUrlsTest, cls).setUpClass()
         cls.downstream = create_domain('downstream-domain')
         cls.upstream = create_domain('upstream-domain')
 
     @classmethod
     def tearDownClass(cls):
-        super(DomainLinkURLsTest, cls).tearDownClass()
+        super(DomainLinkUrlsTest, cls).tearDownClass()
         cls.downstream.delete()
         cls.upstream.delete()
 

--- a/corehq/apps/linked_domain/tests/test_domain_link_methods.py
+++ b/corehq/apps/linked_domain/tests/test_domain_link_methods.py
@@ -1,0 +1,53 @@
+from django.test import TestCase
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.linked_domain.models import DomainLink
+
+
+class DomainLinkURLsTest(TestCase):
+
+    domain = 'domain-link-tests'
+
+    @classmethod
+    def setUpClass(cls):
+        super(DomainLinkURLsTest, cls).setUpClass()
+        cls.downstream = create_domain('downstream-domain')
+        cls.upstream = create_domain('upstream-domain')
+
+    @classmethod
+    def tearDownClass(cls):
+        super(DomainLinkURLsTest, cls).tearDownClass()
+        cls.downstream.delete()
+        cls.upstream.delete()
+
+    def test_upstream_url(self):
+        domain_link = DomainLink.link_domains(linked_domain=self.downstream.name, master_domain=self.upstream.name)
+        self.addCleanup(domain_link.delete)
+
+        expected_upstream_url = '/a/upstream-domain/settings/project/domain_links/'
+        self.assertEqual(expected_upstream_url, domain_link.upstream_url)
+
+    def test_remote_upstream_url(self):
+        domain_link = DomainLink.link_domains(linked_domain=self.downstream.name, master_domain=self.upstream.name)
+        domain_link.remote_base_url = 'test.base.url'
+        domain_link.save()
+        self.addCleanup(domain_link.delete)
+
+        expected_upstream_url = 'test.base.url/a/upstream-domain/'
+        self.assertEqual(expected_upstream_url, domain_link.upstream_url)
+
+    def test_downstream_url(self):
+        domain_link = DomainLink.link_domains(linked_domain=self.downstream.name, master_domain=self.upstream.name)
+        self.addCleanup(domain_link.delete)
+
+        expected_downstream_url = '/a/downstream-domain/settings/project/domain_links/'
+        self.assertEqual(expected_downstream_url, domain_link.downstream_url)
+
+    def test_remote_downstream_url(self):
+        domain_link = DomainLink.link_domains(linked_domain=self.downstream.name, master_domain=self.upstream.name)
+        domain_link.remote_base_url = 'test.base.url'
+        domain_link.save()
+        self.addCleanup(domain_link.delete)
+
+        expected_downstream_url = 'test.base.url/a/downstream-domain/'
+        self.assertEqual(expected_downstream_url, domain_link.downstream_url)

--- a/corehq/apps/linked_domain/view_helpers.py
+++ b/corehq/apps/linked_domain/view_helpers.py
@@ -35,8 +35,9 @@ from corehq.util.timezones.utils import get_timezone_for_request
 def build_domain_link_view_model(link, timezone):
     return {
         'linked_domain': link.linked_domain,
-        'master_domain': link.qualified_master,
-        'remote_base_url': link.remote_base_url,
+        'master_domain': link.master_domain,
+        'upstream_url': link.upstream_url,
+        'downstream_url': link.downstream_url,
         'is_remote': link.is_remote,
         'last_update': server_to_user_time(link.last_pull, timezone) if link.last_pull else _('Never'),
     }


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-148)

Intended on just implementing pagination, but decided it was easier to just do the whole kit and caboodle which means I also implemented the search box. I also pulled the data for this tab into its own view model and did some renaming. Apologies for some verbose variable names. If that irks you feel free to offer some suggestions! 

![Screen Shot 2021-06-09 at 11 42 21 AM](https://user-images.githubusercontent.com/15785053/121388575-953b7800-c919-11eb-8a10-d4448a243843.png)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
UI changes.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will run through QA on parent branch.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
