### PR TITLE
Bump radon from 4.5.0 to 5.0.1 in /requirements

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -218,12 +218,8 @@ faker==5.0.2
     # via -r base-requirements.in
 fixture==1.5.11
     # via -r dev-requirements.in
-flake8-polyfill==1.0.2
-    # via radon
 flake8==3.9.2
-    # via
-    #   -r dev-requirements.in
-    #   flake8-polyfill
+    # via -r dev-requirements.in
 flaky==3.7.0
     # via -r test-requirements.in
 freezegun==1.1.0
@@ -480,7 +476,7 @@ qrcode==4.0.4
     #   django-two-factor-auth
 quickcache==0.5.4
     # via -r base-requirements.in
-radon[flake8]==4.5.0
+radon==5.0.1
     # via -r test-requirements.in
 rcssmin==1.0.6
     # via django-compressor

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -11,4 +11,4 @@ requests-mock
 sqlalchemy-postgres-copy==0.5.0
 flaky==3.7.0
 freezegun~=1.1
-radon[flake8]  # flake8 extra needed due to bug in radon's dependency management
+radon>=5.0  # v5 no longer depends on flake8-polyfill

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -191,10 +191,6 @@ fakecouch==0.0.15
     # via -r test-requirements.in
 faker==5.0.2
     # via -r base-requirements.in
-flake8-polyfill==1.0.2
-    # via radon
-flake8==3.9.2
-    # via flake8-polyfill
 flaky==3.7.0
     # via -r test-requirements.in
 freezegun==1.1.0
@@ -227,7 +223,6 @@ idna==2.10
     #   requests
 importlib-metadata==3.4.0
     # via
-    #   flake8
     #   jsonschema
     #   pep517
 intervaltree==3.1.0
@@ -287,8 +282,6 @@ markupsafe==1.1.1
     # via
     #   jinja2
     #   mako
-mccabe==0.6.1
-    # via flake8
 mock==2.0.0
     # via -r base-requirements.in
 nose-exclude==0.5.0
@@ -339,14 +332,10 @@ py-kissmetrics==1.1.0
     # via -r base-requirements.in
 pycco==0.5.1
     # via -r base-requirements.in
-pycodestyle==2.7.0
-    # via flake8
 pycparser==2.20
     # via cffi
 pycryptodome==3.9.9
     # via -r base-requirements.in
-pyflakes==2.3.1
-    # via flake8
 pygithub==1.54.1
     # via -r base-requirements.in
 pygments==2.8.1
@@ -404,7 +393,7 @@ qrcode==4.0.4
     #   django-two-factor-auth
 quickcache==0.5.4
     # via -r base-requirements.in
-radon[flake8]==4.5.0
+radon==5.0.1
     # via -r test-requirements.in
 rcssmin==1.0.6
     # via django-compressor


### PR DESCRIPTION
## Summary

Jira: [SAAS-12210](https://dimagi-dev.atlassian.net/browse/SAAS-12210)

Followup to #29703 which was added to work around a radon dependency bug.  The issue in radon is resolved.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan

No QA.

### Safety story

Changelog and commits have been reviewed, this is a safe upgrade (also, "affected area" is very limited).

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
