### PR TITLE
Small fixes and a big documentation update

### DIFF
--- a/corehq/apps/couch_sql_migration/README.md
+++ b/corehq/apps/couch_sql_migration/README.md
@@ -24,10 +24,10 @@ non-zero, proceed to setup and run migrations.
 
 The migration commands outlined in this document are typically run on a "limited
 release" on a machine in your CommCareHQ cluster, usually the `django_manage`
-machine. 8GB of RAM is recommended, although less may be necessary for small
-domains. It is also recommended to use a screen session so that network
+machine. 8GB of RAM is recommended, although small domains may require less.
+It is also recommended to use a tmux or screen session so that network
 disruptions between your workstation and the `django_manage` machine do not
-interrupt migration processes. Proceed to setup a limited release and screen
+interrupt migration processes. Proceed to setup a limited release and tmux or screen
 session:
 
 ```sh

--- a/corehq/apps/couch_sql_migration/README.md
+++ b/corehq/apps/couch_sql_migration/README.md
@@ -3,9 +3,71 @@
 The commands:
 
 ```sh
-./manage.py migrate_domain_from_couch_to_sql --help
+./manage.py couch_domain_report --help
 ./manage.py migrate_multiple_domains_from_couch_to_sql --help
+./manage.py migrate_domain_from_couch_to_sql --help
 ./manage.py couch_sql_diff --help
+```
+
+## Setup
+
+First, from a machine where you have `commcare-cloud` installed, check if there
+are any Couch domains that need to be migrated:
+
+```sh
+commcare-cloud <env> django-manage couch_domain_report
+```
+
+You can stop here if the total at the bottom of the report is zero. Your
+environment does not need to be migrated. On the other hand, if the total is
+non-zero, proceed to setup and run migrations.
+
+The migration commands outlined in this document are typically run on a "limited
+release" on a machine in your CommCareHQ cluster, usually the `django_manage`
+machine. 8GB of RAM is recommended, although less may be necessary for small
+domains. It is also recommended to use a screen session so that network
+disruptions between your workstation and the `django_manage` machine do not
+interrupt migration processes. Proceed to setup a limited release and screen
+session:
+
+```sh
+ENV=<your-env-name>
+
+commcare-cloud $ENV fab setup_limited_release:keep_days=30
+# make a note of the release directory path
+
+# start a screen session
+commcare-cloud $ENV ssh django_manage -t screen -S forms-migration
+
+# if the connection drops, use the following command to reconnect
+commcare-cloud $ENV ssh django_manage -t screen -x forms-migration
+
+# in the screen session
+sudo -iu cchq
+export RELEASE_PATH=...  # set to the limited release path created above
+export CCHQ_MIGRATION_STATE_DIR=~/forms-migration  # customize path as desired
+mkdir $CCHQ_MIGRATION_STATE_DIR
+cd $RELEASE_PATH
+source python_env-3.6/bin/activate
+```
+
+Continuing in the screen session, run the `couch_domain_report` command again
+with the `--output-dir=...` option.
+
+```sh
+./manage.py couch_domain_report --output-dir=$CCHQ_MIGRATION_STATE_DIR
+```
+
+Text files containing lists of domains will be created for various domain size
+categories. Additionally a `domains.csv` file is created with all domains to be
+migrated along with various statistics including an estimate of migration time.
+It may be useful to copy the CSV data into an Excel document to track progress,
+marking each row as it is completed. Migrations may be run in batches or
+individually for larger domains. For example, to migrate all domains that have
+no forms:
+
+```sh
+./manage.py migrate_multiple_domains_from_couch_to_sql --live $CCHQ_MIGRATION_STATE_DIR/no_forms.txt
 ```
 
 ## Migration status (`stats`)
@@ -20,8 +82,8 @@ progress, how many forms and cases have been migrated, diff counts, etc.
 
 In general it is unsafe to run multiple migration command processes on a domain
 simultaneously because the underlying state storage (a SQLite database) is not
-multi-process safe. Therefore, this should only be run when no other migration
-command is currently running.
+multi-process safe. Therefore, this (or any other command) should only be run
+when no other migration command is currently running on the domain.
 
 ### `stats` output columns
 
@@ -34,6 +96,121 @@ command is currently running.
 - **Changes**: number of documents with patchable differences between the Couch and
   SQL version. Diffs are put in this category if they are a result of a known
   difference between the Couch and SQL form processors.
+
+### Migrating domains
+
+One or more domains can be migrated (serially) with a single command.
+
+```sh
+./manage.py migrate_multiple_domains_from_couch_to_sql --live domain-list.txt
+# domain_list.txt must contain a single domain name to be migrated on each line
+```
+
+Alternate command syntax: list one or more domain(s) on the command line. Note
+the colon (`:`) before each domain name.
+
+```sh
+./manage.py migrate_multiple_domains_from_couch_to_sql --live :domain1:domain2...
+```
+
+There will be a very short period during each domain migration in which form
+submissions are disabled for the domain. It is short enough that end users are
+very unlikely to notice.
+
+At the end of each migration it will be committed if it is clean (if there are
+no unresolved diffs), and otherwise left in a "live" migrating state where diffs
+can be inspected and patched as needed. If the migration is not committed it
+must be finished and committed manually (see next section).
+
+## "Live" migration with minimal downtime
+
+A "live" migration can be done on a domain where the migration may take a long
+time. A few hopefully infrequently used operations will be disabled while the
+migration is in "live" (or `dry_run`) mode:
+
+- Edit forms (only available on Pro plans and above)
+- Delete or (un)archive form
+- Delete or (un)archive user
+
+Additionally, form submissions will be disabled for a short period at the end of
+the migration to finalize the migration and do some sanity checks to verify that
+the migration was successful. Other than these operations, the domain will be
+fully operational throughout the process.
+
+Starting or continuing a "live" migration:
+
+```sh
+./manage.py migrate_domain_from_couch_to_sql <domain> MIGRATE --live
+
+# inspect and patch diffs as necessary
+./manage.py couch_sql_diff <domain> show --select=<doc_type> [--changes]
+./manage.py migrate_domain_from_couch_to_sql <domain> MIGRATE --patch
+```
+
+These commands can be run repeatedly until all forms and cases have been
+migrated. Diffs may be inspected, patched, and repaired as needed.
+
+After the initial `MIGRATE --live` command is run the domain will remain in
+"live" migration state, regardless of whether the `--live` switch is used on
+subsequent `MIGRATE` commands, until `MIGRATE --finish` is run.
+
+It may be necessary to run `MIGRATE --finish` _before_ patching diffs if they
+affect cases that were modified within an hour of the most recent `--live`
+migration completion. Therefore it is a good idea to use `--finish` before
+patching diffs on active domains. This implies a longer period where form
+submissions are disabled. It is possible to `unfinish` (revert to "live" mode)
+if `--finish` is run, and then it is not possible to patch all diffs in a timely
+manner.
+
+```sh
+./manage.py migrate_domain_from_couch_to_sql <domain> unfinish
+```
+
+IMPORTANT: do not run multiple migration commands concurrently for a given
+domain. Wait for each command to complete before running the next. If necessary,
+a migration may be interrupted with a keyboard interrupt (^C, `SIGINT`). The
+migration will attempt a clean exit on receiving the first interrupt (this may
+take a few minutes). It will exit immedately on the second interrupt, but may be
+left in an unclean state and need to be `reset` to ensure complete migration. In
+general it is best to wait for clean exit.
+
+Diffs and changes of the following doc types are usually unimportant and may be
+ignored after initial inspection to verify they are unimportant:
+
+- CommCareCase-Deleted
+- XFormArchived
+- XFormDeprecated
+- XFormDuplicate
+- XFormError
+- XFormInstance-Deleted
+- HQSubmission
+- SubmissionErrorLog
+
+Full documents may be inspected by a superuser using the `raw_doc` view on the
+HQ website of the environment where the migration is being performed:
+
+`https://<site_name>/hq/admin/raw_doc/?id=<doc_id>`
+
+Additionally, after inspecting diffs of other doc types (XFormInstance,
+CommCareCase) most turn out to be unimportant. For example, the form or case may
+be very old or the diff may be insignificant such as a date format change. In
+most cases a record of CommCareCase diffs will be saved in a patch form (after
+running `--patch`) regardless of whether it could be patched or not, leaving an
+audit trail of differences between Couch and SQL cases. This can be verified by
+inspecting the last (SQL) form applied to the case after patching.
+
+When all diffs have been patched or otherwise resolved, these final commands
+must be run to finish and commit the migration. Form submissions will be
+disabled ("downtime" is instated) from the time when `MIGRATE --finish` starts
+until `COMMIT` is completed.
+
+```sh
+./manage.py migrate_domain_from_couch_to_sql <domain> MIGRATE --finish
+./manage.py migrate_domain_from_couch_to_sql <domain> COMMIT
+```
+
+After `COMMIT` has successfully run (and the prompt is acknowledged) the domain
+will be switched to use the SQL backend. This operation cannot be undone.
 
 ## Migrate a single domain with downtime
 
@@ -54,73 +231,6 @@ migration can be run at a later time.
 ./manage.py migrate_domain_from_couch_to_sql <domain> reset
 ```
 
-### Migrate multiple domains with downtime
-
-Multiple domains can be migrated (serially) with form submissions disabled
-while each migration is in progress. Each migration will be committed if it is
-clean, and otherwise reset.
-
-```sh
-./manage.py migrate_multiple_domains_from_couch_to_sql domain-list.txt
-```
-
-## "Live" migration with minimal downtime
-
-A "live" migration can be done on a large domain where the migration will take a
-long time. A few hopefully infrequently used operations will be disabled for the
-duration of the migration:
-
-- Edit forms (only available on Pro plans and above)
-- Delete or (un)archive form
-- Delete or (un)archive user
-
-Additionally, form submissions will be disabled for a short period (a few hours
-at most) at the end of the migration to finalize the migration and do some
-sanity checks to verify that everything was migrated as expected. Other than
-these operations, the domain will be fully operational throughout the process.
-
-IMPORTANT: Migration timelines and limited functionality expectations should be
-confirmed before a live migration is started on an active domain. Use the
-[support request template](#support-request-template) to initiate confirmation.
-
-Starting a "live" migration:
-
-```sh
-./manage.py migrate_domain_from_couch_to_sql <domain> stats
-./manage.py migrate_domain_from_couch_to_sql <domain> MIGRATE --live
-./manage.py migrate_domain_from_couch_to_sql <domain> MIGRATE --patch  # if necessary
-```
-
-These commands can be run repeatedly until all forms and cases have been
-migrated (except for any new forms submitted since one hour before the last
-form was migrated). Diffs may be inspected, patched, and repaired as needed.
-
-After the initial `MIGRATE --live` command is run the domain will remain in
-"live" migration state, regardless of whether the `--live` switch is used on
-subsequent `MIGRATE` commands, until `MIGRATE --finish` is run.
-
-When all not-freshly-submitted forms and cases have been migrated and diffs
-patched or otherwise resolved, these final commands must be run to finish and
-commit the migration. Form submissions will be disabled ("downtime" is instated)
-from the time when `MIGRATE --finish` starts until `COMMIT` is completed.
-
-```sh
-./manage.py migrate_domain_from_couch_to_sql <domain> MIGRATE --finish
-./manage.py migrate_domain_from_couch_to_sql <domain> COMMIT
-```
-
-### Live-migrate multiple domains
-
-Multiple live migrations can be started with a single command:
-
-```sh
-./manage.py migrate_multiple_domains_from_couch_to_sql --live domain-list.txt
-```
-
-Each live migration started this way can be inspected and patched as needed.
-The final `MIGRATE --finish` and `COMMIT` steps must be done individually for
-each domain.
-
 ## Patching case diffs
 
 The `MIGRATE --patch` command will patch case _diffs_ and _changes_ to make the
@@ -138,7 +248,7 @@ difference could not actually be patched. For example, `opened_by` cannot be
 patched because it is a calculated property based on the order in which forms
 were submitted. Once a case has been patched and there are no more unpatched
 differences its migration is considered to be complete with the patch form left
-as a persistent data trail.
+as a persistent audit trail.
 
 `MIGRATE --patch` is a convenience that performs the operations of a few other
 commands. Sometimes it is useful to run those commands individually to debug

--- a/corehq/apps/couch_sql_migration/README.md
+++ b/corehq/apps/couch_sql_migration/README.md
@@ -97,7 +97,7 @@ when no other migration command is currently running on the domain.
   SQL version. Diffs are put in this category if they are a result of a known
   difference between the Couch and SQL form processors.
 
-### Migrating domains
+## Migrating domains
 
 One or more domains can be migrated (serially) with a single command.
 


### PR DESCRIPTION
Review by commit.

- https://github.com/dimagi/commcare-hq/commit/0cdf345e9275994f425d7b2462b95b3f14df0476 - Recover from closed SQL connections in some places that were previously missed.
- https://github.com/dimagi/commcare-hq/commit/ca0ca53abee94725e996aef6a6792b66f666e250 - Update documentation in preparation for comms to third party hosters.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests added.

### QA Plan

No QA.

### Safety story

This only affects the forms and cases migration logic, which is only used by management commands.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
