### PR TITLE
remove es6 syntax

### DIFF
--- a/corehq/apps/registration/static/registration/js/user_login_form.js
+++ b/corehq/apps/registration/static/registration/js/user_login_form.js
@@ -1,5 +1,6 @@
 hqDefine('registration/js/user_login_form', [
     'jquery',
+    'underscore',
     'knockout',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/assert_properties',
@@ -7,6 +8,7 @@ hqDefine('registration/js/user_login_form', [
     'hqwebapp/js/knockout_bindings.ko',
 ], function (
     $,
+    _,
     ko,
     initialPageData,
     assertProperties,
@@ -56,7 +58,10 @@ hqDefine('registration/js/user_login_form', [
          * or "Continue to <IdentityProvider>".
          * @param {boolean} expandPasswordField - (optional) if this is true, auto expand password field
          */
-        self.updateContinueText = function (expandPasswordField = false) {
+        self.updateContinueText = function (expandPasswordField) {
+            if (_.isUndefined(expandPasswordField)) {
+                expandPasswordField = false;
+            }
             self.continueTextPromise = $.post(self.checkSsoLoginStatusUrl, {
                 username: self.authUsername(),
             }, function (data) {


### PR DESCRIPTION
## Summary
this was causing the requirejs build to fail on the registration bundle. Tested locally to make sure it didn't cause any further issues and all looks ✅ 

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
Did a thorough local test. This code also isn't run on production at all as it requires `ENFORCE_SSO_LOGIN` to be enabled in `localsettings`

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
