### PR TITLE
[SSO] Handle invitation acceptance for new SSO-enforced users 

### DIFF
--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -331,39 +331,48 @@ class DomainRegistrationForm(forms.Form):
 
 
 class BaseUserInvitationForm(NoAutocompleteMixin, forms.Form):
-    full_name = forms.CharField(label=_('Full Name'),
-                                max_length=User._meta.get_field('first_name').max_length +
-                                           User._meta.get_field('last_name').max_length + 1,
-                                widget=forms.TextInput(attrs={'class': 'form-control'}))
-    email = forms.EmailField(label=_('Email Address'),
-                             max_length=User._meta.get_field('email').max_length,
-                             widget=forms.TextInput(attrs={'class': 'form-control'}))
-    password = forms.CharField(label=_('Create Password'),
-                               widget=forms.PasswordInput(
-                                   render_value=False,
-                                   attrs={
-                                       'data-bind': "value: password, valueUpdate: 'input'",
-                                       'class': 'form-control',
-                                   }),
-                               help_text=mark_safe(  # nosec - no user input
-                               '<span data-bind="text: passwordHelp, css: color">'
-                               ))
+    full_name = forms.CharField(
+        label=_('Full Name'),
+        max_length=(User._meta.get_field('first_name').max_length +
+                    User._meta.get_field('last_name').max_length + 1),
+        widget=forms.TextInput(attrs={'class': 'form-control'})
+    )
+    email = forms.EmailField(
+        label=_('Email Address'),
+        max_length=User._meta.get_field('email').max_length,
+        widget=forms.TextInput(attrs={'class': 'form-control'})
+    )
+    password = forms.CharField(
+        label=_('Create Password'),
+        widget=forms.PasswordInput(
+            render_value=False,
+            attrs={
+               'data-bind': "value: password, valueUpdate: 'input'",
+               'class': 'form-control',
+            }
+        ),
+        help_text=mark_safe(  # nosec - no user input
+            '<span data-bind="text: passwordHelp, css: color">'
+        )
+    )
     if settings.ADD_CAPTCHA_FIELD_TO_FORMS:
         captcha = CaptchaField(label=_("Type the letters in the box"))
     # Must be set to False to have the clean_*() routine called
-    eula_confirmed = forms.BooleanField(required=False,
-                                        label="",
-                                        help_text=mark_safe_lazy(_(
-                                            """I have read and agree to Dimagi's
-                                                <a href="http://www.dimagi.com/terms/latest/privacy/"
-                                                    target="_blank">Privacy Policy</a>,
-                                                <a href="http://www.dimagi.com/terms/latest/tos/"
-                                                    target="_blank">Terms of Service</a>,
-                                                <a href="http://www.dimagi.com/terms/latest/ba/"
-                                                    target="_blank">Business Agreement</a>, and
-                                                <a href="http://www.dimagi.com/terms/latest/aup/"
-                                                    target="_blank">Acceptable Use Policy</a>.
-                                               """)))
+    eula_confirmed = forms.BooleanField(
+        required=False,
+        label="",
+        help_text=mark_safe_lazy(_(
+            """I have read and agree to Dimagi's
+                <a href="http://www.dimagi.com/terms/latest/privacy/"
+                    target="_blank">Privacy Policy</a>,
+                <a href="http://www.dimagi.com/terms/latest/tos/"
+                    target="_blank">Terms of Service</a>,
+                <a href="http://www.dimagi.com/terms/latest/ba/"
+                    target="_blank">Business Agreement</a>, and
+                <a href="http://www.dimagi.com/terms/latest/aup/"
+                    target="_blank">Acceptable Use Policy</a>.
+               """))
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -333,8 +333,8 @@ class DomainRegistrationForm(forms.Form):
 class BaseUserInvitationForm(NoAutocompleteMixin, forms.Form):
     full_name = forms.CharField(
         label=_('Full Name'),
-        max_length=(User._meta.get_field('first_name').max_length +
-                    User._meta.get_field('last_name').max_length + 1),
+        max_length=(User._meta.get_field('first_name').max_length
+                    + User._meta.get_field('last_name').max_length + 1),
         widget=forms.TextInput(attrs={'class': 'form-control'})
     )
     email = forms.EmailField(
@@ -347,8 +347,8 @@ class BaseUserInvitationForm(NoAutocompleteMixin, forms.Form):
         widget=forms.PasswordInput(
             render_value=False,
             attrs={
-               'data-bind': "value: password, valueUpdate: 'input'",
-               'class': 'form-control',
+                'data-bind': "value: password, valueUpdate: 'input'",
+                'class': 'form-control',
             }
         ),
         help_text=mark_safe(  # nosec - no user input

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -426,7 +426,9 @@ class WebUserInvitationForm(BaseUserInvitationForm):
             # sync django user
             duplicate.save()
         if User.objects.filter(username__iexact=data).count() > 0 or duplicate:
-            raise forms.ValidationError('Username already taken; please try another')
+            raise forms.ValidationError(_(
+                'Username already taken. Please try another or log in.'
+            ))
         return data
 
 

--- a/corehq/apps/users/templates/users/accept_invite.html
+++ b/corehq/apps/users/templates/users/accept_invite.html
@@ -41,7 +41,7 @@
                   {% else %}
                     <p class="lead">
                       {% blocktrans with user.username as username %}
-                        Would you liketo to accept the invitation
+                        Would you like to accept the invitation
                         to join the CommCare HQ {{ invite_type }}
                         <strong>{{ invite_to }}</strong> as <strong>{{ username }}</strong>?
                       {% endblocktrans %}

--- a/corehq/apps/users/templates/users/accept_invite.html
+++ b/corehq/apps/users/templates/users/accept_invite.html
@@ -89,18 +89,40 @@
               <h2>
                 {% blocktrans %}Create Account{% endblocktrans %}
               </h2>
+              {% if is_sso %}
+                <p class="help-block">
+                  {% blocktrans %}
+                    Your email is managed by {{ idp_name }}.
+                    You will be asked to authenticate with Single Sign-On
+                    in the next step.
+                  {% endblocktrans %}
+                </p>
+              {% else %}
               <p class="help-block">
                 {% blocktrans with invite_type|lower as invite_type_lower %}
                   To accept this {{ invite_type_lower }} invitation, you must create an account.
                 {% endblocktrans %}
               </p>
+              {% endif %}
               <form name="form" method="post" action="">
+                {% if is_sso %}
+                  <div class="form-group">
+                    <label class="control-label">{% trans "Username" %}</label>
+                    <p class="lead">
+                      {{ invited_user }}
+                    </p>
+                  </div>
+                {% endif %}
                 {% include 'users/partials/register_user_form_fields.html' %}
                 <div class="form-bubble-actions">
                   <button type="submit"
                           class="btn btn-lg btn-primary"
                           data-bind="enable: passwordSufficient">
-                    {% trans "Create Account" %}
+                    {% if is_sso %}
+                      {% trans "Continue to Single Sign-On" %}
+                    {% else %}
+                      {% trans "Create Account" %}
+                    {% endif %}
                   </button>
                 </div>
               </form>

--- a/corehq/apps/users/templates/users/accept_invite.html
+++ b/corehq/apps/users/templates/users/accept_invite.html
@@ -90,8 +90,8 @@
                 {% blocktrans %}Create Account{% endblocktrans %}
               </h2>
               <div class="help-block">
-                {% blocktrans %}
-                  To accept this {{ invite_type|lower }} invitation, you must create an account.
+                {% blocktrans with invite_type|lower as invite_type_lower %}
+                  To accept this {{ invite_type_lower }} invitation, you must create an account.
                 {% endblocktrans %}
               </div>
               <form name="form" method="post" action="">

--- a/corehq/apps/users/templates/users/accept_invite.html
+++ b/corehq/apps/users/templates/users/accept_invite.html
@@ -89,11 +89,11 @@
               <h2>
                 {% blocktrans %}Create Account{% endblocktrans %}
               </h2>
-              <div class="help-block">
+              <p class="help-block">
                 {% blocktrans with invite_type|lower as invite_type_lower %}
                   To accept this {{ invite_type_lower }} invitation, you must create an account.
                 {% endblocktrans %}
-              </div>
+              </p>
               <form name="form" method="post" action="">
                 {% include 'users/partials/register_user_form_fields.html' %}
                 <div class="form-bubble-actions">

--- a/corehq/apps/users/templates/users/accept_invite.html
+++ b/corehq/apps/users/templates/users/accept_invite.html
@@ -98,11 +98,11 @@
                   {% endblocktrans %}
                 </p>
               {% else %}
-              <p class="help-block">
-                {% blocktrans with invite_type|lower as invite_type_lower %}
-                  To accept this {{ invite_type_lower }} invitation, you must create an account.
-                {% endblocktrans %}
-              </p>
+                <p class="help-block">
+                  {% blocktrans with invite_type|lower as invite_type_lower %}
+                    To accept this {{ invite_type_lower }} invitation, you must create an account.
+                  {% endblocktrans %}
+                </p>
               {% endif %}
               <form name="form" method="post" action="">
                 {% if is_sso %}

--- a/corehq/apps/users/templates/users/partials/register_user_form_fields.html
+++ b/corehq/apps/users/templates/users/partials/register_user_form_fields.html
@@ -4,7 +4,7 @@
     {{ global_error }}
   </div>
 {% endfor %}
-<fieldset class="check-password">
+<fieldset {% if not is_sso %}class="check-password"{% endif %}>
   {% for field in form %}
     {% if field.is_hidden %}
       {{ field }}

--- a/corehq/apps/users/templates/users/partials/register_user_form_fields.html
+++ b/corehq/apps/users/templates/users/partials/register_user_form_fields.html
@@ -6,6 +6,9 @@
 {% endfor %}
 <fieldset class="check-password">
   {% for field in form %}
+    {% if field.is_hidden %}
+      {{ field }}
+    {% else %}
     <div class="form-group has-feedback{% if field.errors %} has-error{% endif %}">
       {% if field.label %}
         <label class="control-label" for="{{ field.id }}">{{ field.label }}</label>
@@ -22,5 +25,6 @@
         {% endfor %}
       </div>
     </div>
+    {% endif %}
   {% endfor %}
 </fieldset>

--- a/corehq/apps/users/templates/users/partials/register_user_form_fields.html
+++ b/corehq/apps/users/templates/users/partials/register_user_form_fields.html
@@ -7,7 +7,9 @@
 <fieldset class="check-password">
   {% for field in form %}
     <div class="form-group has-feedback{% if field.errors %} has-error{% endif %}">
-      <label class="control-label" for="{{ field.id }}">{{ field.label }}</label>
+      {% if field.label %}
+        <label class="control-label" for="{{ field.id }}">{{ field.label }}</label>
+      {% endif %}
       <div id="div_id_{{ field.name }}">
         {{ field }}
         {% if field.help_text %}

--- a/corehq/apps/users/templates/users/partials/register_user_form_fields.html
+++ b/corehq/apps/users/templates/users/partials/register_user_form_fields.html
@@ -10,14 +10,14 @@
       <label class="control-label" for="{{ field.id }}">{{ field.label }}</label>
       <div id="div_id_{{ field.name }}">
         {{ field }}
-        {% for error in field.errors %}
-          <p class="help-block">{{ error }}</p>
-        {% endfor %}
         {% if field.help_text %}
           <p class="help-block">
             {{ field.help_text }}
           </p>
         {% endif %}
+        {% for error in field.errors %}
+          <p class="help-block">{{ error }}</p>
+        {% endfor %}
       </div>
     </div>
   {% endfor %}

--- a/corehq/apps/users/templates/users/partials/register_user_form_fields.html
+++ b/corehq/apps/users/templates/users/partials/register_user_form_fields.html
@@ -9,22 +9,22 @@
     {% if field.is_hidden %}
       {{ field }}
     {% else %}
-    <div class="form-group has-feedback{% if field.errors %} has-error{% endif %}">
-      {% if field.label %}
-        <label class="control-label" for="{{ field.id }}">{{ field.label }}</label>
-      {% endif %}
-      <div id="div_id_{{ field.name }}">
-        {{ field }}
-        {% if field.help_text %}
-          <p class="help-block">
-            {{ field.help_text }}
-          </p>
+      <div class="form-group has-feedback{% if field.errors %} has-error{% endif %}">
+        {% if field.label %}
+          <label class="control-label" for="{{ field.id }}">{{ field.label }}</label>
         {% endif %}
-        {% for error in field.errors %}
-          <p class="help-block">{{ error }}</p>
-        {% endfor %}
+        <div id="div_id_{{ field.name }}">
+          {{ field }}
+          {% if field.help_text %}
+            <p class="help-block">
+              {{ field.help_text }}
+            </p>
+          {% endif %}
+          {% for error in field.errors %}
+            <p class="help-block">{{ error }}</p>
+          {% endfor %}
+        </div>
       </div>
-    </div>
     {% endif %}
   {% endfor %}
 </fieldset>

--- a/corehq/apps/users/views/web.py
+++ b/corehq/apps/users/views/web.py
@@ -162,8 +162,16 @@ class UserInvitationView(object):
                     return HttpResponseRedirect(self.redirect_to_on_success(invitation.email, invitation.domain))
             else:
                 if CouchUser.get_by_username(invitation.email):
-                    return HttpResponseRedirect(reverse("login") + '?next='
-                        + reverse('domain_accept_invitation', args=[invitation.domain, invitation.uuid]))
+                    login_url = reverse("login")
+                    accept_invitation_url = reverse(
+                        'domain_accept_invitation',
+                        args=[invitation.domain, invitation.uuid]
+                    )
+                    return HttpResponseRedirect(
+                        f"{login_url}"
+                        f"?next={accept_invitation_url}"
+                        f"&username={invitation.email}"
+                    )
                 form = WebUserInvitationForm(
                     initial={
                         'email': invitation.email,

--- a/corehq/apps/users/views/web.py
+++ b/corehq/apps/users/views/web.py
@@ -14,6 +14,7 @@ from django.utils.translation import ugettext_lazy
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.http import require_POST
 
+from corehq.apps.registration.models import AsyncSignupRequest
 from corehq.apps.sso.models import IdentityProvider
 from dimagi.utils.couch import CriticalSection
 
@@ -132,6 +133,11 @@ class UserInvitationView(object):
                 if form.is_valid():
                     # create the new user
                     invited_by_user = CouchUser.get_by_user_id(invitation.invited_by)
+
+                    if idp:
+                        signup_request = AsyncSignupRequest.create_from_invitation(invitation)
+                        return HttpResponseRedirect(idp.get_login_url(signup_request.username))
+
                     user = activate_new_user_via_reg_form(
                         form,
                         created_by=invited_by_user,


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SS-98

This ensures that users who are required to use SSO can accept invitations.

I also made some text changes, fixed typos, added translations, and cleaned up a little. There was more that needed cleanup (this view is really nonstandard!) but I have a lot of other work lined up that takes priority right now.

Review commit-by-commit. Super small easy to follow changes this way. ^_^

## Feature Flag
Not a pure feature flag, but this is only activated when `ENFORCE_SSO_LOGIN` is set to `True` in `localsettings`.

## Product Description
<img width="530" alt="Screen Shot 2021-06-09 at 4 59 36 PM" src="https://user-images.githubusercontent.com/716573/121437071-4b698680-c947-11eb-9c7c-1c93c8547e0c.png">


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
No automated test coverage for this.

### QA Plan
QA not needed for the `ENFORCE_SSO_LOGIN = False` setting (current default on production). QA will happen on staging for all of SSO shortly though.

### Safety story
This can be merged in prior to QA since the changes here were either super safe text / formatting cleanup changes or were isolated by the `ENFORCE_SSO_LOGIN` setting.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
