### PR TITLE
Mixed Type  Case Lists and Case Search

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2125,6 +2125,7 @@ class CaseSearch(DocumentSchema):
     search_button_display_condition = StringProperty()
     default_properties = SchemaListProperty(DefaultCaseSearchProperty)
     blacklisted_owner_ids_expression = StringProperty()
+    additional_case_types = ListProperty(str)
 
     @property
     def case_session_var(self):
@@ -2211,7 +2212,6 @@ class ModuleBase(IndexedSchema, ModuleMediaMixin, NavMenuItemMediaMixin, Comment
     case_type = StringProperty()
     case_list_form = SchemaProperty(CaseListForm)
     module_filter = StringProperty()
-    additional_case_types = ListProperty(str)
     put_in_root = BooleanProperty(default=False)
     root_module_id = StringProperty()
     fixture_select = SchemaProperty(FixtureSelect)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2211,6 +2211,7 @@ class ModuleBase(IndexedSchema, ModuleMediaMixin, NavMenuItemMediaMixin, Comment
     case_type = StringProperty()
     case_list_form = SchemaProperty(CaseListForm)
     module_filter = StringProperty()
+    additional_case_types = ListProperty(str)
     put_in_root = BooleanProperty(default=False)
     root_module_id = StringProperty()
     fixture_select = SchemaProperty(FixtureSelect)

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -96,9 +96,16 @@ class EntriesHelper(object):
         return xpath
 
     @staticmethod
-    def get_nodeset_xpath(case_type, filter_xpath=''):
-        return "instance('casedb')/casedb/case[@case_type='{case_type}'][@status='open']{filter_xpath}".format(
-            case_type=case_type,
+    def get_nodeset_xpath(case_type, filter_xpath='', additional_types=None):
+        if additional_types:
+            case_type_filter = " or ".join([
+                "@case_type='{case_type}'".format(case_type=case_type)
+                for case_type in set(additional_types).union({case_type})
+            ])
+        else:
+            case_type_filter = "@case_type='{case_type}'".format(case_type=case_type)
+        return "instance('casedb')/casedb/case[{case_type_filter}][@status='open']{filter_xpath}".format(
+            case_type_filter=case_type_filter,
             filter_xpath=filter_xpath,
         )
 
@@ -445,7 +452,8 @@ class EntriesHelper(object):
             datums.append(FormDatumMeta(
                 datum=SessionDatum(
                     id=datum['session_var'],
-                    nodeset=(EntriesHelper.get_nodeset_xpath(datum['case_type'], filter_xpath=filter_xpath)
+                    nodeset=(EntriesHelper.get_nodeset_xpath(datum['case_type'], filter_xpath=filter_xpath,
+                             additional_types=datum['module'].search_config.additional_case_types)
                              + parent_filter + fixture_select_filter),
                     value="./@case_id",
                     detail_select=self.details_helper.get_detail_id_safe(detail_module, 'case_short'),

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -132,7 +132,7 @@ class RemoteRequestFactory(object):
 
         nodeset = CaseTypeXpath(self.module.case_type).case(instance_name=RESULTS_INSTANCE)
         if toggles.USH_CASE_CLAIM_UPDATES.enabled(self.app.domain):
-            additional_types = list(set(self.module.additional_case_types) - {self.module.case_type})
+            additional_types = list(set(self.module.search_config.additional_case_types) - {self.module.case_type})
             if additional_types:
                 nodeset = CaseTypeXpath(self.module.case_type).cases(
                     additional_types, instance_name=RESULTS_INSTANCE)
@@ -154,7 +154,7 @@ class RemoteRequestFactory(object):
                 ref="'{}'".format(self.module.case_type)
             ),
         ]
-        additional_types = list(set(self.module.additional_case_types) - {self.module.case_type})
+        additional_types = list(set(self.module.search_config.additional_case_types) - {self.module.case_type})
         for type in additional_types:
             default_query_datums.append(
                 QueryData(

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -131,8 +131,13 @@ class RemoteRequestFactory(object):
             long_detail_id = 'search_long'
 
         nodeset = CaseTypeXpath(self.module.case_type).case(instance_name=RESULTS_INSTANCE)
-        if self.module.search_config.search_filter and toggles.USH_CASE_CLAIM_UPDATES.enabled(self.app.domain):
-            nodeset = f"{nodeset}[{interpolate_xpath(self.module.search_config.search_filter)}]"
+        if toggles.USH_CASE_CLAIM_UPDATES.enabled(self.app.domain):
+            additional_types = list(set(self.module.additional_case_types) - {self.module.case_type})
+            if additional_types:
+                nodeset = CaseTypeXpath(self.module.case_type).cases(
+                    additional_types, instance_name=RESULTS_INSTANCE)
+            if self.module.search_config.search_filter:
+                nodeset = f"{nodeset}[{interpolate_xpath(self.module.search_config.search_filter)}]"
 
         return [SessionDatum(
             id=self.module.search_config.case_session_var,

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -154,6 +154,14 @@ class RemoteRequestFactory(object):
                 ref="'{}'".format(self.module.case_type)
             ),
         ]
+        additional_types = list(set(self.module.additional_case_types) - {self.module.case_type})
+        for type in additional_types:
+            default_query_datums.append(
+                QueryData(
+                    key='case_type',
+                    ref="'{}'".format(type)
+                )
+            )
         extra_query_datums = [
             QueryData(key="{}".format(c.property), ref="{}".format(c.defaultValue))
             for c in self.module.search_config.default_properties

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_case_type.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_case_type.html
@@ -5,10 +5,17 @@
 <div class="form-group" id="case_type_form_group">
   <label class="{% css_label_class %} control-label">
     {% trans "Case Type" %}
+    {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
+    <span class="hq-help-template"
+          data-title="{% trans "Case Type" %}"
+          data-content="{% trans "The name for the type of case you are tracking (e.g. “pregnancy,” “farm,” “household,” etc.). All cases you register in this case list will be this type of case. Other case lists with the same case type will use the same set of case(s)." %}"
+    ></span>
+    {% else %}
     <span class="hq-help-template"
           data-title="{% trans "Case Type" %}"
           data-content="{% trans "The name for the type of case you are tracking (e.g. &quot;pregnancy&quot;, &quot;farm&quot;, &quot;household&quot;, etc.). All cases you register in this case list will be this type of case, and only cases of this type will show in the case list. Other case lists with the same case type will use the same set of cases." %}"
     ></span>
+    {% endif %}
   </label>
   <div class="{% css_field_class %}">
     <input class="code form-control" type="text" id="case_type" name="case_type" value="{{ module.case_type }}" />

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -66,7 +66,7 @@
               <div class="{% css_field_class %}">
                 <select name='additional_case_types' class='form-control multiselect-caselist' multiple="multiple" >
                   {% for case_type in case_types %}
-                    <option value="{{ case_type }}" {% if case_type in  module.additional_case_types %}selected{% endif %}>{{ case_type }}</option>
+                    <option value="{{ case_type }}" {% if case_type in  module.search_config.additional_case_types %}selected{% endif %}>{{ case_type }}</option>
                   {% endfor %}
                 </select>
               </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -69,7 +69,6 @@
                     <option value="{{ case_type }}" {% if case_type in  module.additional_case_types %}selected{% endif %}>{{ case_type }}</option>
                   {% endfor %}
                 </select>
-                <input name="detail_type" type="hidden" value="{{ detail_type }}" />
               </div>
             </div>
             {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -49,28 +49,29 @@
           <div class="panel-body">
             {% if not module.is_surveys and module.module_type != 'shadow' %}
               {% include "app_manager/partials/modules/module_view_case_type.html" %}
-            {% endif %}
 
-            {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
-            <div class="form-group">
-              <label class="{% css_label_class %} control-label">
-                 {% trans "Case List and Case Search Types" %}
-                <span class="hq-help-template"
-                      data-title="{% trans "Case List and Case Search Types" %}"
-                      data-content="{% blocktrans %}
-                             Cases of these types will be displayed in Case List and Case Search screens.
-                             <a href='https://confluence.dimagi.com/display/ccinternal/Case+Search+and+Claim'>(More Information)</span>
-                             {% endblocktrans %}">
-                </span>
-              </label>
-              <div class="{% css_field_class %}">
-                <select name='additional_case_types' class='form-control multiselect-caselist' multiple="multiple" >
-                  {% for case_type in case_types %}
-                    <option value="{{ case_type }}" {% if case_type in  module.search_config.additional_case_types %}selected{% endif %}>{{ case_type }}</option>
-                  {% endfor %}
-                </select>
+              {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
+              <div class="form-group">
+                <label class="{% css_label_class %} control-label">
+                  {% trans "Case List and Case Search Types" %}
+                  <span class="hq-help-template"
+                        data-title="{% trans "Case List and Case Search Types" %}"
+                        data-content="{% blocktrans %}
+                             Cases of these types will be displayed in Case List  and Case Search screens.
+                             <a target='_blank'
+                             href='https://confluence.dimagi.com/display/ccinternal/Case+Search+and+Claim'>(More   Information)</a>
+                              {% endblocktrans %}">
+                  </span>
+                </label>
+                <div class="{% css_field_class %}">
+                <select name='additional_case_types' class='form-control  multiselect-caselist' multiple="multiple" >
+                    {% for case_type in case_types %}
+                    <option value="{{ case_type }}" {% if case_type in  module.search_config.additional_case_types %}selected{% endif   %}>{{ case_type }}</option>
+                    {% endfor %}
+                  </select>
+                </div>
               </div>
-            </div>
+              {% endif %}
             {% endif %}
 
             {% if child_module_enabled and not module.is_training_module%}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -51,6 +51,29 @@
               {% include "app_manager/partials/modules/module_view_case_type.html" %}
             {% endif %}
 
+            {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
+            <div class="form-group">
+              <label class="{% css_label_class %} control-label">
+                 {% trans "Case List and Case Search Types" %}
+                <span class="hq-help-template"
+                      data-title="{% trans "Case List and Case Search Types" %}"
+                      data-content="{% blocktrans %}
+                             Cases of these types will be displayed in Case List and Case Search screens.
+                             <a href='https://confluence.dimagi.com/display/ccinternal/Case+Search+and+Claim'>(More Information)</span>
+                             {% endblocktrans %}">
+                </span>
+              </label>
+              <div class="{% css_field_class %}">
+                <select name='additional_case_types' class='form-control multiselect-caselist' multiple="multiple" >
+                  {% for case_type in case_types %}
+                    <option value="{{ case_type }}" {% if case_type in  module.additional_case_types %}selected{% endif %}>{{ case_type }}</option>
+                  {% endfor %}
+                </select>
+                <input name="detail_type" type="hidden" value="{{ detail_type }}" />
+              </div>
+            </div>
+            {% endif %}
+
             {% if child_module_enabled and not module.is_training_module%}
               <div class="form-group">
                 <label class="{% css_label_class %} control-label">

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -205,7 +205,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
     def test_additional_types(self, *args):
         another_case_type = "another_case_type"
-        self.module.additional_case_types = [another_case_type]
+        self.module.search_config.additional_case_types = [another_case_type]
         suite_xml = self.app.create_suite()
         suite = parse_normalize(suite_xml, to_string=False)
         ref_path = './remote-request[1]/session/datum/@nodeset'

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -202,6 +202,24 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             suite.xpath(ref_path)[0]
         )
 
+    @flag_enabled('USH_CASE_CLAIM_UPDATES')
+    def test_additional_types(self, *args):
+        another_case_type = "another_case_type"
+        self.module.additional_case_types = [another_case_type]
+        suite = self.app.create_suite()
+        suite = parse_normalize(suite, to_string=False)
+        ref_path = './remote-request[1]/session/datum/@nodeset'
+        self.assertEqual(
+            "instance('{}')/{}/case[@case_type='{}' or @case_type='{}'][{}]".format(
+                RESULTS_INSTANCE,
+                RESULTS_INSTANCE,
+                self.module.case_type,
+                another_case_type,
+                self.module.search_config.search_filter
+            ),
+            suite.xpath(ref_path)[0]
+        )
+
     def test_case_search_action_relevant_condition(self, *args):
         condition = "'foo' = 'bar'"
         self.module.search_config.search_button_display_condition = condition

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -206,8 +206,8 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     def test_additional_types(self, *args):
         another_case_type = "another_case_type"
         self.module.additional_case_types = [another_case_type]
-        suite = self.app.create_suite()
-        suite = parse_normalize(suite, to_string=False)
+        suite_xml = self.app.create_suite()
+        suite = parse_normalize(suite_xml, to_string=False)
         ref_path = './remote-request[1]/session/datum/@nodeset'
         self.assertEqual(
             "instance('{}')/{}/case[@case_type='{}' or @case_type='{}'][{}]".format(
@@ -218,6 +218,16 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 self.module.search_config.search_filter
             ),
             suite.xpath(ref_path)[0]
+        )
+        self.assertXmlPartialEqual(
+            """
+            <partial>
+              <data key="case_type" ref="'case'"/>
+              <data key="case_type" ref="'another_case_type'"/>
+            </partial>
+            """,
+            suite_xml,
+            "./remote-request[1]/session/query/data[@key='case_type']"
         )
 
     def test_case_search_action_relevant_condition(self, *args):

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1137,7 +1137,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
                 search_label=CaseSearchLabel(label=command_label),
                 search_again_label=CaseSearchAgainLabel(label=again_label),
                 properties=properties,
-                additional_case_types=module.additional_case_types,
+                additional_case_types=module.search_config.additional_case_types,
                 default_relevant=bool(search_properties.get('search_default_relevant')),
                 additional_relevant=search_properties.get('search_additional_relevant', ''),
                 auto_launch=bool(search_properties.get('auto_launch')),

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -114,7 +114,7 @@ from corehq.apps.hqmedia.models import (
 from corehq.apps.hqmedia.views import ProcessDetailPrintTemplateUploadView
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.reports.analytics.esaccessors import (
-    get_case_types_for_domain_es, get_case_types_for_domain
+    get_case_types_for_domain_es
 )
 from corehq.apps.reports.daterange import get_simple_dateranges
 from corehq.apps.userreports.models import (
@@ -198,7 +198,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
         'case_list_form_options': _case_list_form_options(app, module, lang),
         'valid_parents_for_child_module': _get_valid_parents_for_child_module(app, module),
         'shadow_parent': _get_shadow_parent(app, module),
-        'case_types': get_case_types_for_domain(app.domain),
+        'case_types': {m.case_type for m in app.modules if m.case_type},
         'session_endpoints_enabled': toggles.SESSION_ENDPOINTS.enabled(app.domain),
         'js_options': {
             'fixture_columns_by_type': _get_fixture_columns_by_type(app.domain),

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1137,6 +1137,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
                 search_label=CaseSearchLabel(label=command_label),
                 search_again_label=CaseSearchAgainLabel(label=again_label),
                 properties=properties,
+                additional_case_types=module.additional_case_types,
                 default_relevant=bool(search_properties.get('search_default_relevant')),
                 additional_relevant=search_properties.get('search_additional_relevant', ''),
                 auto_launch=bool(search_properties.get('auto_launch')),

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -687,7 +687,7 @@ def edit_module_attr(request, domain, app_id, module_unique_id, attr):
             track_workflow(request.couch_user.username, "User orphaned a child module")
 
     if should_edit('additional_case_types'):
-        module.additional_case_types = list(set(request.POST.getlist('additional_case_types')))
+        module.search_config.additional_case_types = list(set(request.POST.getlist('additional_case_types')))
 
     if should_edit('excl_form_ids') and isinstance(module, ShadowModule):
         excl = request.POST.getlist('excl_form_ids')

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -114,7 +114,7 @@ from corehq.apps.hqmedia.models import (
 from corehq.apps.hqmedia.views import ProcessDetailPrintTemplateUploadView
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.reports.analytics.esaccessors import (
-    get_case_types_for_domain_es,
+    get_case_types_for_domain_es, get_case_types_for_domain
 )
 from corehq.apps.reports.daterange import get_simple_dateranges
 from corehq.apps.userreports.models import (
@@ -198,6 +198,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
         'case_list_form_options': _case_list_form_options(app, module, lang),
         'valid_parents_for_child_module': _get_valid_parents_for_child_module(app, module),
         'shadow_parent': _get_shadow_parent(app, module),
+        'case_types': get_case_types_for_domain(app.domain),
         'session_endpoints_enabled': toggles.SESSION_ENDPOINTS.enabled(app.domain),
         'js_options': {
             'fixture_columns_by_type': _get_fixture_columns_by_type(app.domain),
@@ -529,6 +530,7 @@ def edit_module_attr(request, domain, app_id, module_unique_id, attr):
         'case_list_form_use_default_audio_for_all': None,
         "case_list_post_form_workflow": None,
         "case_type": None,
+        "additional_case_types": [],
         'comment': None,
         "display_separately": None,
         "has_schedule": None,
@@ -683,6 +685,9 @@ def edit_module_attr(request, domain, app_id, module_unique_id, attr):
             track_workflow(request.couch_user.username, "User associated module with a parent")
         elif old_root and not module['root_module_id']:
             track_workflow(request.couch_user.username, "User orphaned a child module")
+
+    if should_edit('additional_case_types'):
+        module.additional_case_types = list(set(request.POST.getlist('additional_case_types')))
 
     if should_edit('excl_form_ids') and isinstance(module, ShadowModule):
         excl = request.POST.getlist('excl_form_ids')

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -218,9 +218,9 @@ class CaseTypeXpath(CaseSelectionXPath):
         quoted = CaseTypeXpath("'{}'".format(self))
         return super(CaseTypeXpath, quoted).case(instance_name, case_name)
 
-    def cases(self, additional_types=[], instance_name='casedb', case_name='case'):
+    def cases(self, additional_types, instance_name='casedb', case_name='case'):
         quoted = CaseTypeXpath("'{}'".format(self))
-        selector = "{sel}={self}".format(sel=self.selector, self=quoted)
+        selector = "{sel}={quoted}".format(sel=self.selector, quoted=quoted)
         for type in additional_types:
             quoted = CaseTypeXpath("'{}'".format(type))
             selector = "{selector} or {sel}={quoted}".format(selector=selector, sel=self.selector, quoted=quoted)

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -218,6 +218,16 @@ class CaseTypeXpath(CaseSelectionXPath):
         quoted = CaseTypeXpath("'{}'".format(self))
         return super(CaseTypeXpath, quoted).case(instance_name, case_name)
 
+    def cases(self, additional_types=[], instance_name='casedb', case_name='case'):
+        quoted = CaseTypeXpath("'{}'".format(self))
+        selector = "{sel}={self}".format(sel=self.selector, self=quoted)
+        for type in additional_types:
+            quoted = CaseTypeXpath("'{}'".format(type))
+            selector = "{selector} or {sel}={quoted}".format(selector=selector, sel=self.selector, quoted=quoted)
+        return CaseXPath("instance('{inst}')/{inst}/{case}[{sel}]".format(
+            inst=instance_name, case=case_name, sel=selector
+        ))
+
 
 class UsercaseXPath(XPath):
 

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -129,7 +129,7 @@ class CaseSearchCriteria(object):
                 self.search_es = self.search_es.case_property_query(key, value, fuzzy=(key in fuzzies))
 
 
-def get_related_cases(domain, app_id, case_type, cases):
+def get_related_cases(domain, app_id, case_types, cases):
     """
     Fetch related cases that are necessary to display any related-case
     properties in the app requesting this case search.
@@ -140,8 +140,14 @@ def get_related_cases(domain, app_id, case_type, cases):
         return []
 
     app = get_app_cached(domain, app_id)
-    paths = get_related_case_relationships(app, case_type)
-    child_case_types = get_child_case_types(app, case_type)
+    paths = [
+        rel for rels in [get_related_case_relationships(app, case_type) for case_type in case_types]
+        for rel in rels
+    ]
+    child_case_types = [
+        _type for types in [get_child_case_types(app, case_type) for case_type in case_types]
+        for _type in types
+    ]
 
     results = []
     if paths:

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -507,7 +507,7 @@ class TestCaseSearchLookups(TestCase):
 
     def test_multiple_case_types(self):
         cases = [
-            {'_id': 'c1', 'case_type': 'song', 'description': 'New York New York'},
+            {'_id': 'c1', 'case_type': 'song', 'description': 'New York'},
             {'_id': 'c2', 'case_type': 'song', 'description': 'Another Song'},
             {'_id': 'c3', 'case_type': 'show', 'description': 'New York'},
             {'_id': 'c4', 'case_type': 'show', 'description': 'Boston'},

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -442,7 +442,7 @@ class TestCaseSearchLookups(TestCase):
                 {'_id': 'c3', 'dob': date(2020, 3, 3)},
                 {'_id': 'c4', 'dob': date(2020, 3, 4)},
             ],
-            CaseSearchCriteria(self.domain, self.case_type, {'dob': '__range__2020-03-02__2020-03-03'}).search_es,
+            CaseSearchCriteria(self.domain, [self.case_type], {'dob': '__range__2020-03-02__2020-03-03'}).search_es,
             None,
             ['c2', 'c3']
         )

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -505,6 +505,23 @@ class TestCaseSearchLookups(TestCase):
         self._assert_related_case_ids(cases, {"host", "parent"}, {"c2", "c4"})
         self._assert_related_case_ids(cases, {"host", "parent/parent"}, {"c4", "c1"})
 
+    def test_multiple_case_types(self):
+        cases = [
+            {'_id': 'c1', 'case_type': 'song', 'description': 'New York New York'},
+            {'_id': 'c2', 'case_type': 'song', 'description': 'Another Song'},
+            {'_id': 'c3', 'case_type': 'show', 'description': 'New York'},
+            {'_id': 'c4', 'case_type': 'show', 'description': 'Boston'},
+        ]
+        config, _ = CaseSearchConfig.objects.get_or_create(pk=self.domain, enabled=True)
+        self._assert_query_runs_correctly(
+            self.domain,
+            cases,
+            CaseSearchCriteria(self.domain, ['show', 'song'], {'description': 'New York'}).search_es,
+            None,
+            ['c1', 'c3']
+        )
+        config.delete()
+
     def _assert_related_case_ids(self, cases, paths, ids):
         results = get_related_case_results(self.domain, cases, paths)
         self.assertEqual(ids, {result['_id'] for result in results})

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -63,7 +63,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
                 "bool": {
                     "filter": [
                         {'term': {'domain.exact': 'swashbucklers'}},
-                        {"term": {"type.exact": "case_type"}},
+                        {"terms": {"type.exact": ["case_type"]}},
                         {"term": {"closed": False}},
                         {
                             "bool": {
@@ -159,7 +159,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
                 "bool": {
                     "filter": [
                         {'term': {'domain.exact': 'swashbucklers'}},
-                        {"term": {"type.exact": "case_type"}},
+                        {"terms": {"type.exact": ["case_type"]}},
                         {"term": {"closed": False}},
                         {"match_all": {}}
                     ],

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -107,7 +107,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
         }
 
         self.checkQuery(
-            CaseSearchCriteria(DOMAIN, 'case_type', criteria).search_es,
+            CaseSearchCriteria(DOMAIN, ['case_type'], criteria).search_es,
             expected
         )
 
@@ -298,7 +298,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
             "size": CASE_SEARCH_MAX_RESULTS
         }
         self.checkQuery(
-            CaseSearchCriteria(DOMAIN, 'case_type', criteria).search_es,
+            CaseSearchCriteria(DOMAIN, ['case_type'], criteria).search_es,
             expected,
             validate_query=False
         )

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -104,6 +104,7 @@ def app_aware_search(request, domain, app_id):
     """
     criteria = request.GET.dict()
     try:
+        # could be a list or a single string
         case_type = criteria.pop('case_type')
     except KeyError:
         return HttpResponse('Search request must specify case type', status=400)

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -102,7 +102,7 @@ def app_aware_search(request, domain, app_id):
     Accepts search criteria as GET params, e.g. "https://www.commcarehq.org/a/domain/phone/search/?a=b&c=d"
     Returns results as a fixture with the same structure as a casedb instance.
     """
-    criteria = request.GET.dict()
+    criteria = {k: v[0] if len(v) == 1 else v for k, v in request.GET.lists()}
     try:
         # could be a list or a single string
         case_type = criteria.pop('case_type')

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -106,11 +106,12 @@ def app_aware_search(request, domain, app_id):
     try:
         # could be a list or a single string
         case_type = criteria.pop('case_type')
+        case_types = case_type if isinstance(case_type, list) else [case_type]
     except KeyError:
         return HttpResponse('Search request must specify case type', status=400)
 
     try:
-        case_search_criteria = CaseSearchCriteria(domain, case_type, criteria)
+        case_search_criteria = CaseSearchCriteria(domain, case_types, criteria)
     except TooManyRelatedCasesError:
         return HttpResponse(_('Search has too many results. Please try a more specific search.'), status=400)
     except CaseFilterError as e:
@@ -132,7 +133,7 @@ def app_aware_search(request, domain, app_id):
     # Even if it's a SQL domain, we just need to render the hits as cases, so CommCareCase.wrap will be fine
     cases = [CommCareCase.wrap(flatten_result(result, include_score=True)) for result in hits]
     if app_id:
-        cases.extend(get_related_cases(domain, app_id, case_type, cases))
+        cases.extend(get_related_cases(domain, app_id, case_types, cases))
 
     fixtures = CaseDBFixture(cases).fixture
     return HttpResponse(fixtures, content_type="text/xml; charset=utf-8")


### PR DESCRIPTION
## Summary
[Design doc](https://www.google.com/url?sa=t&rct=j&esrc=s&source=appssearch&uact=8&cd=0&cad=rja&q&sig2=VhlHNC5xOgbQcTwgqwmGDw&ved=0ahUKEwjIpqaU4ozxAhXOgKwCHSy5DQ44ABABKAAwAA&url=https://drive.google.com/a/dimagi.com/open?id%3D1-r6VCViy-cAwlpLIDN_Er7RGcWB0JKb5o821OI74qTM%26usp%3Dchrome_omnibox&usg=AOvVaw1mSc8FlhaiBdtCAdHj9YCF). Ticket https://dimagi-dev.atlassian.net/browse/USH-1014

This adds an option to select multiple case-types to be displayed under Case List and Case Search screens. When the option is enabled cases of multiple types will be displayed in the case-list and case search results.

<img width="844" alt="Screenshot 2021-06-15 at 3 39 52 PM" src="https://user-images.githubusercontent.com/829142/122035294-f4a0f880-cdef-11eb-9b7e-7d934f761f9b.png">


## Feature Flag
USH_CASE_CLAIM_UPDATES

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-3135

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
