### PR TITLE
[User History] Track User delete

### DIFF
--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -44,7 +44,7 @@ class TestCreditLines(BaseInvoiceTestCase):
 
     def tearDown(self):
         for user in self.domain.all_users():
-            user.delete(deleted_by=None)
+            user.delete(self.domain.name, deleted_by=None)
         super(TestCreditLines, self).tearDown()
 
     def test_product_line_item_credits(self):
@@ -496,7 +496,7 @@ class TestUserSubscriptionChangeTransfers(BaseAccountingTest):
 
     def tearDown(self):
         for user in self.domain.all_users():
-            user.delete(deleted_by=None)
+            user.delete(self.domain.name, deleted_by=None)
         super(BaseAccountingTest, self).tearDown()
 
     @classmethod

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -102,16 +102,16 @@ class BaseCustomerInvoiceCase(BaseAccountingTest):
 
     def tearDown(self):
         for user in self.domain.all_users():
-            user.delete(deleted_by=None)
+            user.delete(self.domain.name, deleted_by=None)
 
         for user in self.domain2.all_users():
-            user.delete(deleted_by=None)
+            user.delete(self.domain2.name, deleted_by=None)
 
         for user in self.domain3.all_users():
-            user.delete(deleted_by=None)
+            user.delete(self.domain3.name, deleted_by=None)
 
         for user in self.domain_community.all_users():
-            user.delete(deleted_by=None)
+            user.delete(self.domain_community.name, deleted_by=None)
 
         if self.is_using_test_plans:
             utils.clear_plan_version_cache()

--- a/corehq/apps/accounting/tests/test_domain_user_history.py
+++ b/corehq/apps/accounting/tests/test_domain_user_history.py
@@ -23,7 +23,7 @@ class TestDomainUserHistory(BaseInvoiceTestCase):
 
     def tearDown(self):
         for user in self.domain.all_users():
-            user.delete(deleted_by=None)
+            user.delete(self.domain.name, deleted_by=None)
         super(TestDomainUserHistory, self).tearDown()
 
     def test_domain_user_history(self):

--- a/corehq/apps/accounting/tests/test_downgrades.py
+++ b/corehq/apps/accounting/tests/test_downgrades.py
@@ -91,7 +91,7 @@ class TestDowngrades(BaseAccountingTest):
     def tearDown(self):
         for domain in self.domains:
             for user in domain.all_users():
-                user.delete(deleted_by=None)
+                user.delete(domain.name, deleted_by=None)
             domain.delete()
         super(BaseAccountingTest, self).tearDown()
 

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -74,7 +74,7 @@ class BaseInvoiceTestCase(BaseAccountingTest):
 
     def tearDown(self):
         for user in self.domain.all_users():
-            user.delete(deleted_by=None)
+            user.delete(self.domain.name, deleted_by=None)
         super(BaseAccountingTest, self).tearDown()
 
     @classmethod

--- a/corehq/apps/analytics/tests/test_hubspot.py
+++ b/corehq/apps/analytics/tests/test_hubspot.py
@@ -182,9 +182,9 @@ class TestBlockedHubspotData(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.blocked_user.delete(None)
-        cls.blocked_by_email_user.delete(None)
-        cls.allowed_user.delete(None)
+        cls.blocked_user.delete(cls.blocked_domain.name, deleted_by=None)
+        cls.blocked_by_email_user.delete(cls.allowed_domain.name, deleted_by=None)
+        cls.allowed_user.delete(cls.allowed_domain.name, deleted_by=None)
         cls.blocked_domain.delete()
         cls.second_blocked_domain.delete()
         cls.allowed_domain.delete()

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -373,7 +373,8 @@ class WebUserResource(v0_1.WebUserResource):
             bundle.obj.save()
         except Exception:
             if bundle.obj._id:
-                bundle.obj.delete(deleted_by=bundle.request.user, deleted_via=USER_CHANGE_VIA_API)
+                bundle.obj.delete(bundle.request.domain, deleted_by=bundle.request.couch_user,
+                                  deleted_via=USER_CHANGE_VIA_API)
             else:
                 try:
                     django_user = bundle.obj.get_django_user()
@@ -381,8 +382,6 @@ class WebUserResource(v0_1.WebUserResource):
                     pass
                 else:
                     django_user.delete()
-                    log_model_change(bundle.request.user, django_user, message=f"deleted_via: {USER_CHANGE_VIA_API}",
-                                     action=ModelAction.DELETE)
             raise
         return bundle
 

--- a/corehq/apps/api/tests/core_api.py
+++ b/corehq/apps/api/tests/core_api.py
@@ -398,7 +398,7 @@ class TestSingleSignOnResource(APIResourceTest):
                                                  None, None)
 
     def tearDown(self):
-        self.commcare_user.delete(deleted_by=None)
+        self.commcare_user.delete(self.domain, deleted_by=None)
         super(TestSingleSignOnResource, self).tearDown()
 
     def test_web_user_success(self):
@@ -490,7 +490,7 @@ class TestApiKey(APIResourceTest):
         other_user = WebUser.create(self.domain.name, username, password, None, None)
         other_user.set_role(self.domain.name, 'admin')
         other_user.save()
-        self.addCleanup(other_user.delete, deleted_by=None)
+        self.addCleanup(other_user.delete, self.domain, deleted_by=None)
         django_user = WebUser.get_django_user(other_user)
         other_api_key, _ = HQApiKey.objects.get_or_create(user=django_user)
         self.addCleanup(other_api_key.delete)

--- a/corehq/apps/api/tests/test_auth.py
+++ b/corehq/apps/api/tests/test_auth.py
@@ -339,7 +339,7 @@ class RequirePermissionAuthenticationTest(AuthenticationTestBase):
         user = WebUser.create(self.domain, 'multi_domain_admin', '***', None, None, is_admin=True)
         user.add_domain_membership(project.name, is_admin=True)
         user.save()
-        self.addCleanup(lambda: user.delete(None))
+        self.addCleanup(user.delete, self.domain, deleted_by=None)
         unscoped_api_key, _ = HQApiKey.objects.get_or_create(
             user=WebUser.get_django_user(user),
             name='unscoped',

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -71,7 +71,7 @@ class TestCommCareUserResource(APIResourceTest):
 
         commcare_user = CommCareUser.create(domain=self.domain.name, username='fake_user', password='*****',
                                             created_by=None, created_via=None)
-        self.addCleanup(commcare_user.delete, deleted_by=None)
+        self.addCleanup(commcare_user.delete, self.domain, deleted_by=None)
         backend_id = commcare_user.get_id
         update_analytics_indexes()
 
@@ -99,7 +99,7 @@ class TestCommCareUserResource(APIResourceTest):
 
         commcare_user = CommCareUser.create(domain=self.domain.name, username='fake_user', password='*****',
                                             created_by=None, created_via=None)
-        self.addCleanup(commcare_user.delete, deleted_by=None)
+        self.addCleanup(commcare_user.delete, self.domain, deleted_by=None)
         backend_id = commcare_user._id
 
         response = self._assert_auth_get_resource(self.single_endpoint(backend_id))
@@ -151,7 +151,7 @@ class TestCommCareUserResource(APIResourceTest):
                                     content_type='application/json')
         self.assertEqual(response.status_code, 201)
         [user_back] = CommCareUser.by_domain(self.domain.name)
-        self.addCleanup(user_back.delete, deleted_by=None)
+        self.addCleanup(user_back.delete, self.domain, deleted_by=None)
         self.addCleanup(lambda: send_to_elasticsearch('users', user_back.to_json(), delete=True))
 
         self.assertEqual(user_back.username, "jdoe")
@@ -170,7 +170,7 @@ class TestCommCareUserResource(APIResourceTest):
         group = Group({"name": "test"})
         group.save()
 
-        self.addCleanup(user.delete, deleted_by=None)
+        self.addCleanup(user.delete, self.domain, deleted_by=None)
         self.addCleanup(group.delete)
 
         user_json = {
@@ -214,7 +214,7 @@ class TestCommCareUserResource(APIResourceTest):
 
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234",
                                    created_by=None, created_via=None)
-        self.addCleanup(user.delete, deleted_by=None)
+        self.addCleanup(user.delete, self.domain, deleted_by=None)
 
         user_json = {
             "first_name": "florence",
@@ -317,7 +317,7 @@ class TestWebUserResource(APIResourceTest):
         another_user = WebUser.create(self.domain.name, 'anotherguy', '***', None, None)
         another_user.set_role(self.domain.name, 'field-implementer')
         another_user.save()
-        self.addCleanup(another_user.delete, deleted_by=None)
+        self.addCleanup(another_user.delete, self.domain, deleted_by=None)
 
         response = self._assert_auth_get_resource(self.list_endpoint)
         self.assertEqual(response.status_code, 200)
@@ -424,7 +424,7 @@ class TestWebUserResource(APIResourceTest):
     def test_update(self):
         user = WebUser.create(domain=self.domain.name, username="test", password="qwer1234",
                               created_by=None, created_via=None)
-        self.addCleanup(user.delete, deleted_by=None)
+        self.addCleanup(user.delete, self.domain, deleted_by=None)
         user_json = deepcopy(self.default_user_json)
         user_json.pop('username')
         backend_id = user._id
@@ -442,7 +442,7 @@ class TestWebUserResource(APIResourceTest):
     def _delete_user(self, username):
         user = WebUser.get_by_username(username)
         if user:
-            user.delete(deleted_by=None)
+            user.delete(self.domain.name, deleted_by=None)
 
 
 class FakeUserES(object):

--- a/corehq/apps/api/tests/utils.py
+++ b/corehq/apps/api/tests/utils.py
@@ -103,7 +103,7 @@ class APIResourceTest(TestCase, metaclass=PatchMeta):
     @classmethod
     def tearDownClass(cls):
         cls.api_key.delete()
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
 
         for domain in Domain.get_all():
             Subscription._get_active_subscription_by_domain.clear(Subscription, domain.name)

--- a/corehq/apps/app_manager/tests/test_filters.py
+++ b/corehq/apps/app_manager/tests/test_filters.py
@@ -263,7 +263,7 @@ class AutoFilterTests(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.sheel.delete(deleted_by=None)
+        cls.sheel.delete(DOMAIN, deleted_by=None)
         cls.nyc.delete()
         cls.somerville.delete()
         cls.cambridge.delete()

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -75,7 +75,7 @@ class TestViews(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.project.name, deleted_by=None)
         cls.build.delete()
         cls.project.delete()
         super(TestViews, cls).tearDownClass()
@@ -330,7 +330,7 @@ class TestDownloadCaseSummaryViewByAPIKey(TestCase):
         # Set up the cls.web_user: set password and give access to the cls.domain.
         old_web_user = WebUser.get_by_username("test_user")
         if old_web_user:
-            old_web_user.delete(deleted_by=None)
+            old_web_user.delete(cls.domain.name, deleted_by=None)
         cls.web_user = WebUser.create(
             cls.domain.name, "test_user", "my_password", None, None, is_active=True
         )
@@ -352,7 +352,7 @@ class TestDownloadCaseSummaryViewByAPIKey(TestCase):
     def tearDownClass(cls):
         cls.app.delete()
         cls.web_user_api_key.delete()
-        cls.web_user.delete(deleted_by=None)
+        cls.web_user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
 
     def _encode_basic_credentials(self, username, password):

--- a/corehq/apps/app_manager/tests/views/test_paginate_releases.py
+++ b/corehq/apps/app_manager/tests/views/test_paginate_releases.py
@@ -47,7 +47,7 @@ class TestPaginateReleases(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         delete_es_index(APP_INDEX_INFO.index)
         super(TestPaginateReleases, cls).tearDownClass()

--- a/corehq/apps/auditcare/tests/test_auth.py
+++ b/corehq/apps/auditcare/tests/test_auth.py
@@ -28,7 +28,7 @@ class TestAccessAudit(AuditcareTest):
         # A Couch user is required for logout
         user = WebUser.create('', USERNAME, 'mockmock', None, None)
         user.save()
-        self.addCleanup(lambda: user.delete(None))
+        self.addCleanup(user.delete, '', deleted_by=None)
 
     def login(self, password='mockmock'):
         self.client.post(reverse('login'), {

--- a/corehq/apps/callcenter/tests/test_indicators.py
+++ b/corehq/apps/callcenter/tests/test_indicators.py
@@ -48,7 +48,7 @@ def create_domain_and_user(domain_name, username):
     domain = create_domain(domain_name)
     user = CommCareUser.get_by_username(username)
     if user:
-        user.delete(deleted_by=None)
+        user.delete(domain_name, deleted_by=None)
     user = CommCareUser.create(domain_name, username, '***', None, None)
 
     domain.call_center_config.enabled = True
@@ -177,10 +177,10 @@ class CallCenterTests(BaseCCTests):
     def tearDownClass(cls):
         clear_data(cls.aarohi_domain.name)
         clear_data(cls.cc_domain.name)
-        cls.cc_user.delete(deleted_by=None)
-        cls.cc_user_no_data.delete(deleted_by=None)
+        cls.cc_user.delete(cls.cc_domain.name, deleted_by=None)
+        cls.cc_user_no_data.delete(cls.cc_domain.name, deleted_by=None)
         cls.cc_domain.delete()
-        cls.aarohi_user.delete(deleted_by=None)
+        cls.aarohi_user.delete(cls.aarohi_domain.name, deleted_by=None)
         cls.aarohi_domain.delete()
         super(CallCenterTests, cls).tearDownClass()
 
@@ -619,7 +619,7 @@ class TestSavingToUCRDatabase(BaseCCTests):
     def tearDown(self):
         super(TestSavingToUCRDatabase, self).tearDown()
         clear_data(self.cc_domain.name)
-        self.cc_user.delete(deleted_by=None)
+        self.cc_user.delete(self.cc_domain.name, deleted_by=None)
         self.cc_domain.delete()
 
         connection_manager.dispose_engine('ucr')

--- a/corehq/apps/callcenter/tests/test_location_owners.py
+++ b/corehq/apps/callcenter/tests/test_location_owners.py
@@ -53,7 +53,7 @@ class CallCenterLocationOwnerTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
 
     def tearDown(self):

--- a/corehq/apps/callcenter/tests/test_owner_options_view.py
+++ b/corehq/apps/callcenter/tests/test_owner_options_view.py
@@ -85,7 +85,7 @@ class CallCenterLocationOwnerOptionsViewTest(TestCase):
     def tearDownClass(cls):
         super(CallCenterLocationOwnerOptionsViewTest, cls).tearDownClass()
         for user in cls.users:
-            user.delete(deleted_by=None)
+            user.delete(cls.domain.name, deleted_by=None)
         CALL_CENTER_LOCATION_OWNERS.set(cls.domain.name, False, NAMESPACE_DOMAIN)
         cls.domain.delete()
         ensure_index_deleted(USER_INDEX_INFO.index)

--- a/corehq/apps/callcenter/tests/test_utils.py
+++ b/corehq/apps/callcenter/tests/test_utils.py
@@ -67,7 +67,7 @@ class CallCenterUtilsTests(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         super(CallCenterUtilsTests, cls).tearDownClass()
 
@@ -85,7 +85,7 @@ class CallCenterUtilsTests(TestCase):
 
     def test_sync_full_name(self):
         other_user = CommCareUser.create(TEST_DOMAIN, 'user7', '***', None, None)
-        self.addCleanup(other_user.delete, deleted_by=None)
+        self.addCleanup(other_user.delete, self.domain.name, deleted_by=None)
         name = 'Ricky Bowwood'
         other_user.set_full_name(name)
         sync_call_center_user_case(other_user)
@@ -115,7 +115,7 @@ class CallCenterUtilsTests(TestCase):
 
     def test_sync_update_update(self):
         other_user = CommCareUser.create(TEST_DOMAIN, 'user2', '***', None, None)
-        self.addCleanup(other_user.delete, deleted_by=None)
+        self.addCleanup(other_user.delete, self.domain.name, deleted_by=None)
         sync_call_center_user_case(other_user)
         case = self._get_user_case(other_user._id)
         self.assertIsNotNone(case)
@@ -239,7 +239,7 @@ class CallCenterUtilsUsercaseTests(TestCase):
         self.user = CommCareUser.create(TEST_DOMAIN, 'user1', '***', None, None, commit=False)  # Don't commit yet
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain.name, deleted_by=None)
 
     @classmethod
     def tearDownClass(cls):
@@ -400,7 +400,7 @@ class CallCenterUtilsUsercaseTests(TestCase):
         self.assertEqual(2, len(old_user_case.xform_ids))
 
         new_user = CommCareUser.get_by_username(format_username('the_bunk', TEST_DOMAIN))
-        self.addCleanup(new_user.delete, deleted_by=None)
+        self.addCleanup(new_user.delete, self.domain.name, deleted_by=None)
         new_user_case = accessor.get_case_by_domain_hq_user_id(new_user._id, USERCASE_TYPE)
         self.assertEqual(new_user_case.owner_id, new_user.get_id)
         self.assertEqual(1, len(new_user_case.xform_ids))

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -52,7 +52,7 @@ class ImporterTest(TestCase):
         delete_all_cases()
 
     def tearDown(self):
-        self.couch_user.delete(deleted_by=None)
+        self.couch_user.delete(self.domain, deleted_by=None)
         self.domain_obj.delete()
         super(ImporterTest, self).tearDown()
 
@@ -577,7 +577,7 @@ class ImporterTest(TestCase):
 
     def test_user_can_access_location(self):
         with make_business_units(self.domain) as (inc, dsi, dsa), \
-                restrict_user_to_location(self, dsa):
+                restrict_user_to_location(self.domain, self, dsa):
             res = self.import_mock_file([
                 ['case_id', 'name', 'owner_id'],
                 ['', 'Leonard Nimoy', inc.location_id],
@@ -595,7 +595,7 @@ class ImporterTest(TestCase):
 
     def test_user_can_access_owner(self):
         with make_business_units(self.domain) as (inc, dsi, dsa), \
-                restrict_user_to_location(self, dsa):
+                restrict_user_to_location(self.domain, self, dsa):
             inc_owner = CommCareUser.create(self.domain, 'inc', 'pw', None, None, location=inc)
             dsi_owner = CommCareUser.create(self.domain, 'dsi', 'pw', None, None, location=dsi)
             dsa_owner = CommCareUser.create(self.domain, 'dsa', 'pw', None, None, location=dsa)
@@ -636,7 +636,7 @@ def make_worksheet_wrapper(*rows):
 
 
 @contextmanager
-def restrict_user_to_location(test_case, location):
+def restrict_user_to_location(domain, test_case, location):
     orig_user = test_case.couch_user
 
     restricted_user = WebUser.create(test_case.domain, "restricted", "s3cr3t", None, None)
@@ -647,7 +647,7 @@ def restrict_user_to_location(test_case, location):
         yield
     finally:
         test_case.couch_user = orig_user
-        restricted_user.delete(deleted_by=None)
+        restricted_user.delete(domain, deleted_by=None)
 
 
 @contextmanager
@@ -670,4 +670,4 @@ def get_commcare_user(domain_name):
     try:
         yield user
     finally:
-        user.delete(deleted_by=None)
+        user.delete(domain_name, deleted_by=None)

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -24,6 +24,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.es import AppES, CaseES, CaseSearchES, FormES, GroupES, UserES
 from corehq.apps.hqwebapp.tasks import mail_admins_async
 from corehq.apps.users.models import WebUser
+from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.form_processor.backends.sql.dbaccessors import (
     CaseReindexAccessor,
     FormReindexAccessor,
@@ -253,7 +254,7 @@ def delete_web_user():
         ]:
             web_user = WebUser.get_by_username(username)
             if web_user:
-                web_user.delete(deleted_by=None, deleted_via=__name__)
+                web_user.delete(None, deleted_by=SYSTEM_USER_ID, deleted_via=__name__)
 
 
 def _get_missing_domains():

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -254,7 +254,7 @@ def delete_web_user():
         ]:
             web_user = WebUser.get_by_username(username)
             if web_user:
-                web_user.delete(None, deleted_by=SYSTEM_USER_ID, deleted_via=__name__)
+                web_user.delete(None, deleted_by=SYSTEM_USER_ID, deleted_via=__name__ + '.delete_web_user')
 
 
 def _get_missing_domains():

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -36,7 +36,7 @@ class ReadableQuestionsAPITest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain, deleted_by=None)
         cls.project.delete()
         super(ReadableQuestionsAPITest, cls).tearDownClass()
 

--- a/corehq/apps/commtrack/tests/test_fixture.py
+++ b/corehq/apps/commtrack/tests/test_fixture.py
@@ -155,7 +155,7 @@ class FixtureTest(TestCase, TestXmlMixin):
 
         # test restore with different user
         user2 = create_restore_user(self.domain, username='user2')
-        self.addCleanup(user2._couch_user.delete, deleted_by=None)
+        self.addCleanup(user2._couch_user.delete, self.domain, deleted_by=None)
         fixture_xml = self.generate_product_fixture_xml(user2)
         index_schema, fixture = call_fixture_generator(product_fixture_generator, user2)
 
@@ -259,7 +259,7 @@ class FixtureTest(TestCase, TestXmlMixin):
 
         # test restore with different user
         user2 = create_restore_user(self.domain, username='user2')
-        self.addCleanup(user2._couch_user.delete, deleted_by=None)
+        self.addCleanup(user2._couch_user.delete, self.domain, deleted_by=None)
         program_xml = self.generate_program_xml(program_list, user2)
         fixture = call_fixture_generator(program_fixture_generator, user2)
 

--- a/corehq/apps/commtrack/tests/test_locations.py
+++ b/corehq/apps/commtrack/tests/test_locations.py
@@ -44,7 +44,7 @@ class LocationsTest(TestCase):
         self.user.set_location(self.loc)
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
         SQLLocation.objects.all().delete()
         super(LocationsTest, self).tearDown()
 

--- a/corehq/apps/custom_data_fields/tests/test_profiles.py
+++ b/corehq/apps/custom_data_fields/tests/test_profiles.py
@@ -100,7 +100,7 @@ class TestCustomDataFieldsProfile(TestCase):
         user = CommCareUser.create(self.domain, 'pentagon', '*****', None, None, metadata={
             PROFILE_SLUG: self.profile5.id,
         })
-        self.addCleanup(user.delete, deleted_by=None)
+        self.addCleanup(user.delete, self.domain, deleted_by=None)
         send_to_elasticsearch('users', transform_user_for_elasticsearch(user.to_json()))
         self.es.indices.refresh(USER_INDEX)
 

--- a/corehq/apps/data_dictionary/tests/test_view.py
+++ b/corehq/apps/data_dictionary/tests/test_view.py
@@ -27,7 +27,7 @@ class UpdateCasePropertyViewTest(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.case_type_obj.delete()
-        cls.couch_user.delete(deleted_by=None)
+        cls.couch_user.delete(cls.domain_name, deleted_by=None)
         cls.domain.delete()
         super(UpdateCasePropertyViewTest, cls).tearDownClass()
 

--- a/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
+++ b/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
@@ -108,7 +108,7 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain, deleted_by=None)
         cls.domain_obj.delete()
         super(CaseRuleSchedulingIntegrationTest, cls).tearDownClass()
 

--- a/corehq/apps/data_interfaces/tests/test_xform_management.py
+++ b/corehq/apps/data_interfaces/tests/test_xform_management.py
@@ -23,7 +23,7 @@ class XFormManagementTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.web_user.delete(deleted_by=None)
+        cls.web_user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
 
     def test_get_xform_ids__sanity_check(self):

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -137,7 +137,7 @@ def _delete_web_user_membership(domain_name):
     for web_user in list(active_web_users) + list(inactive_web_users):
         web_user.delete_domain_membership(domain_name)
         if settings.UNIT_TESTING and not web_user.domain_memberships:
-            web_user.delete(deleted_by=None)
+            web_user.delete(domain_name, deleted_by=None)
         else:
             web_user.save()
 

--- a/corehq/apps/domain/tests/test_domain_transfer.py
+++ b/corehq/apps/domain/tests/test_domain_transfer.py
@@ -39,9 +39,9 @@ class BaseDomainTest(TestCase):
         self.muggle.save()
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
         self.domain.delete()
-        self.muggle.delete(deleted_by=None)
+        self.muggle.delete(self.domain, deleted_by=None)
         self.another_domain.delete()
 
 
@@ -148,7 +148,7 @@ class TestTransferDomainViews(BaseDomainTest):
 
     def tearDown(self):
         self.transfer.delete()
-        self.rando.delete(deleted_by=None)
+        self.rando.delete(self.domain, deleted_by=None)
         super(TestTransferDomainViews, self).tearDown()
 
     def test_permissions_for_activation(self):

--- a/corehq/apps/domain/tests/test_password_reset.py
+++ b/corehq/apps/domain/tests/test_password_reset.py
@@ -25,7 +25,7 @@ class PasswordResetTest(TestCase):
     def test_web_user_lookup(self):
         email = 'web-user@example.com'
         web_user = WebUser.create(self.domain, email, 's3cr3t', None, None)
-        self.addCleanup(web_user.delete, deleted_by=None)
+        self.addCleanup(web_user.delete, self.domain, deleted_by=None)
         results = list(get_active_users_by_email(email))
         self.assertEqual(1, len(results))
         self.assertEqual(web_user.username, results[0].username)
@@ -33,13 +33,13 @@ class PasswordResetTest(TestCase):
     def test_web_user_by_email(self):
         email = 'web-user-email@example.com'
         web_user = WebUser.create(self.domain, 'web-user2@example.com', 's3cr3t', None, None, email=email)
-        self.addCleanup(web_user.delete, deleted_by=None)
+        self.addCleanup(web_user.delete, self.domain, deleted_by=None)
         self.assertEqual(0, len(list(get_active_users_by_email(email))))
 
     def test_mobile_worker_excluded(self):
         email = 'mw-excluded@example.com'
         mobile_worker = CommCareUser.create(self.domain, 'mw-excluded', 's3cr3t', None, None, email=email)
-        self.addCleanup(mobile_worker.delete, deleted_by=None)
+        self.addCleanup(mobile_worker.delete, self.domain, deleted_by=None)
         results = list(get_active_users_by_email(email))
         self.assertEqual(0, len(results))
 
@@ -47,7 +47,7 @@ class PasswordResetTest(TestCase):
     def test_mobile_worker_included_with_flag(self):
         email = 'mw-included@example.com'
         mobile_worker = CommCareUser.create(self.domain, 'mw-included', 's3cr3t', None, None, email=email)
-        self.addCleanup(mobile_worker.delete, deleted_by=None)
+        self.addCleanup(mobile_worker.delete, self.domain, deleted_by=None)
         results = list(get_active_users_by_email(email))
         self.assertEqual(1, len(results))
         self.assertEqual(mobile_worker.username, results[0].username)

--- a/corehq/apps/domain/tests/test_views.py
+++ b/corehq/apps/domain/tests/test_views.py
@@ -41,7 +41,7 @@ class TestDomainViews(TestCase, DomainSubscriptionMixin):
 
     def tearDown(self):
         self.teardown_subscriptions()
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain.name, deleted_by=None)
         self.domain.delete()
         clear_plan_version_cache()
         super().tearDown()

--- a/corehq/apps/dropbox/tests/test_dropbox_upload_helper.py
+++ b/corehq/apps/dropbox/tests/test_dropbox_upload_helper.py
@@ -20,7 +20,7 @@ class DropboxUploadHelperTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         super(DropboxUploadHelperTest, cls).tearDownClass()
 

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -325,9 +325,9 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
             created_via=None,
             email='webuser@example.com',
         )
-        self.addCleanup(ccuser_1.delete, deleted_by=None)
-        self.addCleanup(ccuser_2.delete, deleted_by=None)
-        self.addCleanup(web_user.delete, deleted_by=None)
+        self.addCleanup(ccuser_1.delete, self.domain_name, deleted_by=None)
+        self.addCleanup(ccuser_2.delete, self.domain_name, deleted_by=None)
+        self.addCleanup(web_user.delete, self.domain_name, deleted_by=None)
 
         self._dump_and_load(expected_object_counts)
 
@@ -354,7 +354,7 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
             email='email@example.com',
             uuid='428d454aa9abc74e1964e16d3565d6b6'  # match ID in devicelog.xml
         )
-        self.addCleanup(user.delete, deleted_by=None)
+        self.addCleanup(user.delete, self.domain_name, deleted_by=None)
 
         with open('corehq/ex-submodules/couchforms/tests/data/devicelogs/devicelog.xml', 'rb') as f:
             xml = f.read()
@@ -382,7 +382,7 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
             email='email@example.com',
             uuid=user_id
         )
-        self.addCleanup(user.delete, deleted_by=None)
+        self.addCleanup(user.delete, self.domain_name, deleted_by=None)
 
         DemoUserRestore(
             demo_user_id=user_id,

--- a/corehq/apps/enterprise/tests/test_decorators.py
+++ b/corehq/apps/enterprise/tests/test_decorators.py
@@ -57,8 +57,8 @@ class TestRequireEnterpriseAdminDecorator(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.enterprise_admin.delete(None)
-        cls.other_domain_user.delete(None)
+        cls.enterprise_admin.delete(cls.domain.name, deleted_by=None)
+        cls.other_domain_user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         cls.account.delete()
         super().tearDownClass()

--- a/corehq/apps/enterprise/tests/test_enterprise_tasks.py
+++ b/corehq/apps/enterprise/tests/test_enterprise_tasks.py
@@ -26,7 +26,7 @@ class TestEmailEnterpriseReport(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.billing_account.delete()
-        cls.couch_user.delete(deleted_by=None)
+        cls.couch_user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         super(TestEmailEnterpriseReport, cls).tearDownClass()
 

--- a/corehq/apps/export/tests/test_export_views.py
+++ b/corehq/apps/export/tests/test_export_views.py
@@ -61,7 +61,7 @@ class ViewTestCase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         super(ViewTestCase, cls).tearDownClass()
 

--- a/corehq/apps/fixtures/tests/test_fixture_data.py
+++ b/corehq/apps/fixtures/tests/test_fixture_data.py
@@ -113,7 +113,7 @@ class FixtureDataTest(TestCase):
     def tearDown(self):
         self.data_type.delete()
         self.data_item.delete()
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
         self.fixture_ownership.delete()
         delete_all_users()
         delete_all_fixture_data_types()
@@ -399,7 +399,7 @@ class TestFixtureOrdering(TestCase):
         for data_item in cls.data_items:
             data_item.delete()
         cls.data_type.delete()
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain, deleted_by=None)
         super(TestFixtureOrdering, cls).tearDownClass()
 
     def test_fixture_order(self):

--- a/corehq/apps/groups/tests/test_groups.py
+++ b/corehq/apps/groups/tests/test_groups.py
@@ -32,7 +32,7 @@ class GroupTest(TestCase):
     @classmethod
     def tearDownClass(cls):
         for user in CommCareUser.all():
-            user.delete(deleted_by=None)
+            user.delete(DOMAIN, deleted_by=None)
         super(GroupTest, cls).tearDownClass()
 
     def testGetUsers(self):

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -48,7 +48,7 @@ class TestCaseAPI(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.web_user.delete(deleted_by=None)
+        cls.web_user.delete(cls.domain, deleted_by=None)
         cls.domain_obj.delete()
         super().tearDownClass()
 

--- a/corehq/apps/hqcase/tests/test_explode_cases.py
+++ b/corehq/apps/hqcase/tests/test_explode_cases.py
@@ -46,7 +46,7 @@ class ExplodeCasesDbTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         super(ExplodeCasesDbTest, cls).tearDownClass()
 

--- a/corehq/apps/hqcase/tests/test_get_case.py
+++ b/corehq/apps/hqcase/tests/test_get_case.py
@@ -23,7 +23,7 @@ class GetCaseTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         super(GetCaseTest, cls).tearDownClass()
 
     def setUp(self):

--- a/corehq/apps/hqcase/tests/test_loadtest_users.py
+++ b/corehq/apps/hqcase/tests/test_loadtest_users.py
@@ -32,7 +32,7 @@ class LoadtestUserTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         super(LoadtestUserTest, cls).tearDownClass()
 

--- a/corehq/apps/hqcase/tests/test_object_cache.py
+++ b/corehq/apps/hqcase/tests/test_object_cache.py
@@ -53,7 +53,7 @@ class CaseObjectCacheTest(BaseCaseMultimediaTest):
         self.interface = FormProcessorInterface(TEST_DOMAIN_NAME)
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain.name, deleted_by=None)
         self.domain.delete()
         super(CaseObjectCacheTest, self).tearDown()
 

--- a/corehq/apps/hqwebapp/session_details_endpoint/tests.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/tests.py
@@ -47,7 +47,7 @@ class SessionDetailsViewTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.couch_user.delete(deleted_by=None)
+        cls.couch_user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         super(SessionDetailsViewTest, cls).tearDownClass()
 

--- a/corehq/apps/hqwebapp/tests/test_csrf_middleware.py
+++ b/corehq/apps/hqwebapp/tests/test_csrf_middleware.py
@@ -22,7 +22,7 @@ class TestCSRF(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         super(TestCSRF, cls).tearDownClass()
 

--- a/corehq/apps/hqwebapp/tests/test_default_landing_page.py
+++ b/corehq/apps/hqwebapp/tests/test_default_landing_page.py
@@ -75,7 +75,7 @@ class TestDefaultLandingPages(TestCase):
 
     def test_no_role_cant_access(self):
         user = self._make_web_user('elodin@theuniversity.com')
-        self.addCleanup(user.delete, deleted_by=None)
+        self.addCleanup(user.delete, self.domain, deleted_by=None)
         user.delete_domain_membership(self.domain)
         user.save()
         self.client.login(username=user.username, password=self.global_password)
@@ -84,9 +84,9 @@ class TestDefaultLandingPages(TestCase):
 
     def test_formplayer_default_override(self):
         web_user = self._make_web_user('elodin@theuniversity.com', role=self.webapps_role)
-        self.addCleanup(web_user.delete, deleted_by=None)
+        self.addCleanup(web_user.delete, self.domain, deleted_by=None)
         mobile_worker = self._make_commcare_user('kvothe')
-        self.addCleanup(mobile_worker.delete, deleted_by=None)
+        self.addCleanup(mobile_worker.delete, self.domain, deleted_by=None)
         for user in [web_user, mobile_worker]:
             self.client.login(username=user.username, password=self.global_password)
 
@@ -107,7 +107,7 @@ def test_web_user_landing_page(self, role, expected_urlname, enabled_toggle=None
     if role is not None:
         role = getattr(self, role)
     user = self._make_web_user('elodin@theuniversity.com', role=role)
-    self.addCleanup(user.delete, deleted_by=None)
+    self.addCleanup(user.delete, self.domain, deleted_by=None)
     self.client.login(username=user.username, password=self.global_password)
 
     context = flag_enabled(enabled_toggle) if enabled_toggle else contextlib.suppress()  # noop context
@@ -129,7 +129,7 @@ def test_mobile_worker_landing_page(self, role, expected_urlname, enabled_toggle
     if role is not None:
         role = getattr(self, role)
     user = self._make_commcare_user('kvothe', role=role)
-    self.addCleanup(user.delete, deleted_by=None)
+    self.addCleanup(user.delete, self.domain, deleted_by=None)
     self.client.login(username=user.username, password=self.global_password)
 
     context = flag_enabled(enabled_toggle) if enabled_toggle else contextlib.suppress()  # noop context

--- a/corehq/apps/hqwebapp/tests/test_doc_info.py
+++ b/corehq/apps/hqwebapp/tests/test_doc_info.py
@@ -24,12 +24,12 @@ class TestDocInfo(TestCase):
 
     def test_couch_user(self):
         user = CommCareUser.create(self.domain, format_username("lilly", self.domain), "123", None, None)
-        self.addCleanup(lambda: user.delete(None))
+        self.addCleanup(user.delete, self.domain, deleted_by=None)
         self._test_doc(user.user_id, "CommCareUser")
 
     def test_web_user(self):
         user = WebUser.create(self.domain, "marias@email.com", "123", None, None)
-        self.addCleanup(lambda: user.delete(None))
+        self.addCleanup(user.delete, self.domain, deleted_by=None)
         self._test_doc(user.user_id, "WebUser")
 
     def test_location(self):

--- a/corehq/apps/hqwebapp/tests/test_password_lockout.py
+++ b/corehq/apps/hqwebapp/tests/test_password_lockout.py
@@ -14,7 +14,7 @@ class PasswordLockoutTest(TestCase):
         self.user = WebUser.create(self.domain.name, self.username, self.password, None, None)
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain.name, deleted_by=None)
         self.domain.delete()
 
     def test_login_lockout(self):

--- a/corehq/apps/hqwebapp/tests/test_timeout_middleware.py
+++ b/corehq/apps/hqwebapp/tests/test_timeout_middleware.py
@@ -48,7 +48,7 @@ class TestTimeout(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.insecure_domain.name, deleted_by=None)
         cls.insecure_domain.delete()
         cls.secure_domain1.delete()
         cls.secure_domain2.delete()

--- a/corehq/apps/linked_domain/tests/test_linked_case_claim.py
+++ b/corehq/apps/linked_domain/tests/test_linked_case_claim.py
@@ -69,7 +69,7 @@ class TestRemoteLinkedCaseClaim(BaseLinkedCaseClaimTest):
 
     @classmethod
     def tearDownClass(cls):
-        cls.couch_user.delete(deleted_by=None)
+        cls.couch_user.delete(cls.domain, deleted_by=None)
         cls.api_key.delete()
         super(TestRemoteLinkedCaseClaim, cls).tearDownClass()
 

--- a/corehq/apps/linked_domain/tests/test_remote_auth.py
+++ b/corehq/apps/linked_domain/tests/test_remote_auth.py
@@ -32,7 +32,7 @@ class RemoteAuthTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.couch_user.delete(deleted_by=None)
+        cls.couch_user.delete(cls.domain.name, deleted_by=None)
         cls.api_key.delete()
         cls.domain_link.delete()
         cls.domain.delete()

--- a/corehq/apps/locations/tests/test_bulk_management.py
+++ b/corehq/apps/locations/tests/test_bulk_management.py
@@ -296,7 +296,7 @@ class TestTreeValidator(UploadTestUtils, TestCase):
         self.user = WebUser.create(self.domain, 'username', 'password', None, None)
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
         self.domain_obj.delete()
         super(TestTreeValidator, self).tearDown()
 
@@ -451,7 +451,7 @@ class TestBulkManagementNoInitialLocs(UploadTestUtils, TestCase):
         self.user = WebUser.create(self.domain, 'username', 'password', None, None)
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
         self.domain_obj.delete()
         super(TestBulkManagementNoInitialLocs, self).tearDown()
 
@@ -728,7 +728,7 @@ class TestBulkManagementWithInitialLocs(UploadTestUtils, LocationHierarchyPerTes
         self.user = WebUser.create(self.domain, 'username', 'password', None, None)
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
         super(TestBulkManagementWithInitialLocs, self).tearDown()
 
     @property
@@ -1116,7 +1116,7 @@ class TestRestrictedUserUpload(UploadTestUtils, LocationHierarchyPerTest):
         restrict_user_by_location(self.domain, self.user)
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
         super(TestRestrictedUserUpload, self).tearDown()
 
     def test_only_additions(self):

--- a/corehq/apps/locations/tests/test_dbaccessors.py
+++ b/corehq/apps/locations/tests/test_dbaccessors.py
@@ -66,7 +66,7 @@ class TestUsersByLocation(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.george.delete(deleted_by=None)
+        cls.george.delete(cls.domain, deleted_by=None)
         cls.domain_obj.delete()
         ensure_index_deleted(USER_INDEX)
         super(TestUsersByLocation, cls).tearDownClass()
@@ -109,7 +109,7 @@ class TestUsersByLocation(TestCase):
             [u._id for u in users],
             [self.varys._id, self.tyrion._id, self.daenerys._id, self.george._id]
         )
-        other_user.delete(deleted_by=None)
+        other_user.delete(self.domain, deleted_by=None)
 
     def test_generate_user_ids_from_primary_location_ids_from_couch(self):
         self.assertItemsEqual(

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -127,7 +127,7 @@ class LocationFixturesTest(LocationHierarchyTestCase, FixtureHasLocationsMixin):
         self.user = create_restore_user(self.domain, 'user', '123')
 
     def tearDown(self):
-        self.user._couch_user.delete(deleted_by=None)
+        self.user._couch_user.delete(self.domain, deleted_by=None)
         for lt in self.location_types.values():
             lt.expand_to = None
             lt._expand_from_root = False
@@ -446,7 +446,7 @@ class LocationFixturesDataTest(LocationHierarchyTestCase, FixtureHasLocationsMix
     @classmethod
     def tearDownClass(cls):
         cls.loc_fields.delete()
-        cls.user._couch_user.delete(deleted_by=None)
+        cls.user._couch_user.delete(cls.domain, deleted_by=None)
         super(LocationFixturesDataTest, cls).tearDownClass()
 
     def test_utility_method(self):

--- a/corehq/apps/locations/tests/test_location_types.py
+++ b/corehq/apps/locations/tests/test_location_types.py
@@ -81,7 +81,7 @@ class TestLocationTypeOwnership(TestCase):
         super(TestLocationTypeOwnership, cls).tearDownClass()
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
 
     def test_no_case_sharing(self):
         no_case_sharing_type = make_loc_type('no-case-sharing', domain=self.domain)

--- a/corehq/apps/locations/tests/test_permissions.py
+++ b/corehq/apps/locations/tests/test_permissions.py
@@ -171,7 +171,7 @@ class TestAccessRestrictions(LocationHierarchyTestCase):
     @classmethod
     def tearDownClass(cls):
         UserESFake.reset_docs()
-        cls.suffolk_user.delete(deleted_by=None)
+        cls.suffolk_user.delete(cls.domain, deleted_by=None)
         delete_all_users()
         super(TestAccessRestrictions, cls).tearDownClass()
 

--- a/corehq/apps/locations/tests/test_views.py
+++ b/corehq/apps/locations/tests/test_views.py
@@ -47,7 +47,7 @@ class LocationTypesViewTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.couch_user.delete(deleted_by=None)
+        cls.couch_user.delete(cls.domain, deleted_by=None)
         cls.project.delete()
         super(LocationTypesViewTest, cls).tearDownClass()
 

--- a/corehq/apps/mobile_auth/tests.py
+++ b/corehq/apps/mobile_auth/tests.py
@@ -24,7 +24,7 @@ class MobileAuthTest(TestCase):
         self.user_id = self.commcare_user.get_id
 
     def tearDown(self):
-        self.commcare_user.delete(deleted_by=None)
+        self.commcare_user.delete(self.domain_name, deleted_by=None)
 
     @staticmethod
     def format_datetime_no_usec(dt):

--- a/corehq/apps/ota/tests/test_claim.py
+++ b/corehq/apps/ota/tests/test_claim.py
@@ -36,7 +36,7 @@ class CaseClaimTests(TestCase):
         self.create_case()
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain.name, deleted_by=None)
         self.domain.delete()
         super(CaseClaimTests, self).tearDown()
 

--- a/corehq/apps/ota/tests/test_digest_restore.py
+++ b/corehq/apps/ota/tests/test_digest_restore.py
@@ -34,8 +34,8 @@ class DigestOtaRestoreTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.commcare_user.delete(deleted_by=None)
-        cls.web_user.delete(deleted_by=None)
+        cls.commcare_user.delete(cls.domain, deleted_by=None)
+        cls.web_user.delete(cls.domain, deleted_by=None)
         delete_all_domains()
         super(DigestOtaRestoreTest, cls).tearDownClass()
 

--- a/corehq/apps/ota/tests/test_formplayer_restore.py
+++ b/corehq/apps/ota/tests/test_formplayer_restore.py
@@ -30,7 +30,7 @@ class FormplayerRestoreTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.commcare_user.delete(deleted_by=None)
+        cls.commcare_user.delete(cls.domain, deleted_by=None)
         delete_all_domains()
         super(FormplayerRestoreTest, cls).tearDownClass()
 

--- a/corehq/apps/ota/tests/test_restore_user_check.py
+++ b/corehq/apps/ota/tests/test_restore_user_check.py
@@ -39,7 +39,7 @@ class UserCheckSyncTests(TestCase):
 
         original_user = CommCareUser.create(self.domain, username, password, None, None)
         original_user_id = original_user.user_id
-        original_user.delete(deleted_by=None)
+        original_user.delete(self.domain, deleted_by=None)
 
         # user deleted so can't auth
         self._assert_restore_response_code(401, auth_header)

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -330,7 +330,7 @@ class CaseClaimEndpointTests(TestCase):
 
     def tearDown(self):
         ensure_index_deleted(CASE_SEARCH_INDEX)
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain.name, deleted_by=None)
         self.domain.delete()
         cache = get_redis_default_cache()
         cache.clear()

--- a/corehq/apps/receiverwrapper/tests/test_auth.py
+++ b/corehq/apps/receiverwrapper/tests/test_auth.py
@@ -265,7 +265,7 @@ class AuthCouchOnlyTest(TestCase, AuthTestMixin, _AuthTestsCouchOnly):
         super(AuthCouchOnlyTest, self)._set_up_auth_test()
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
         super(AuthCouchOnlyTest, self).tearDown()
 
 
@@ -283,7 +283,7 @@ class InsecureAuthCouchOnlyTest(TestCase, AuthTestMixin, _AuthTestsCouchOnly):
         super(InsecureAuthCouchOnlyTest, self)._set_up_auth_test()
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
         super(InsecureAuthCouchOnlyTest, self).tearDown()
 
 
@@ -301,7 +301,7 @@ class AuthTest(TestCase, AuthTestMixin, _AuthTestsBothBackends):
         super(AuthTest, self)._set_up_auth_test()
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
         super(AuthTest, self).tearDown()
 
 
@@ -319,7 +319,7 @@ class InsecureAuthTest(TestCase, AuthTestMixin, _AuthTestsBothBackends):
         super(InsecureAuthTest, self)._set_up_auth_test()
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
         super(InsecureAuthTest, self).tearDown()
 
 

--- a/corehq/apps/receiverwrapper/tests/test_submissions.py
+++ b/corehq/apps/receiverwrapper/tests/test_submissions.py
@@ -39,7 +39,7 @@ class BaseSubmissionTest(TestCase):
     def tearDown(self):
         FormProcessorTestUtils.delete_all_xforms(self.domain.name)
         FormProcessorTestUtils.delete_all_cases(self.domain.name)
-        self.couch_user.delete(deleted_by=None)
+        self.couch_user.delete(self.domain, deleted_by=None)
         self.domain.delete()
         super(BaseSubmissionTest, self).tearDown()
 

--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -56,7 +56,7 @@ class SubmissionErrorTest(TestCase, TestFileMixin):
 
     @classmethod
     def tearDownClass(cls):
-        cls.couch_user.delete(deleted_by=None)
+        cls.couch_user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         super(SubmissionErrorTest, cls).tearDownClass()
 

--- a/corehq/apps/reminders/tests/test_util.py
+++ b/corehq/apps/reminders/tests/test_util.py
@@ -8,7 +8,8 @@ from corehq.apps.users.models import CommCareUser
 class ReminderUtilTest(TestCase):
 
     def setUp(self):
-        self.user = CommCareUser.create('test', 'test', 'test', None, None)
+        self.domain = 'test'
+        self.user = CommCareUser.create(self.domain, 'test', 'test', None, None)
 
     def test_get_two_way_number_for_recipient(self):
         self.assertIsNone(get_two_way_number_for_recipient(self.user))
@@ -39,4 +40,4 @@ class ReminderUtilTest(TestCase):
 
     def tearDown(self):
         delete_domain_phone_numbers('test')
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)

--- a/corehq/apps/reports/tests/test_cache.py
+++ b/corehq/apps/reports/tests/test_cache.py
@@ -55,8 +55,8 @@ class ReportCacheTest(TestCase):
         self.web_user2 = WebUser.create(self.domain, 'w2', 'secret', None, None)
 
     def tearDown(self):
-        self.web_user1.delete(deleted_by=None)
-        self.web_user2.delete(deleted_by=None)
+        self.web_user1.delete(self.domain, deleted_by=None)
+        self.web_user2.delete(self.domain, deleted_by=None)
         self.test_domain.delete()
         super(ReportCacheTest, self).tearDown()
 

--- a/corehq/apps/reports/tests/test_case_export.py
+++ b/corehq/apps/reports/tests/test_case_export.py
@@ -13,11 +13,12 @@ def _mock_case(owner, user):
 
 
 class CaseExportTest(TestCase):
+    domain = 'case-export-test'
 
     def setUp(self):
         super(CaseExportTest, self).setUp()
         for user in CommCareUser.all():
-            user.delete(deleted_by=None)
+            user.delete(self.domain, deleted_by=None)
 
     def testUserFilters(self):
         self.assertTrue(case_users_filter(_mock_case('owner', 'user'), ['owner']))
@@ -31,15 +32,14 @@ class CaseExportTest(TestCase):
         self.assertFalse(case_users_filter(_mock_case('owner', 'user'), ['rando', 'stranger', 'ghost']))
 
     def testGroupFilters(self):
-        domain = 'case-export-test'
-        active_user = CommCareUser.create(domain=domain, username='activeguy', password='secret',
+        active_user = CommCareUser.create(domain=self.domain, username='activeguy', password='secret',
                                           created_by=None, created_via=None)
-        inactive_user = CommCareUser.create(domain=domain, username='inactivegal', password='secret',
+        inactive_user = CommCareUser.create(domain=self.domain, username='inactivegal', password='secret',
                                             created_by=None, created_via=None)
         inactive_user.is_active = False
         inactive_user.save()
 
-        group = Group(domain=domain, name='group', users=[active_user._id, inactive_user._id])
+        group = Group(domain=self.domain, name='group', users=[active_user._id, inactive_user._id])
         group.save()
 
         # no matter what the group should match on ownerid (but not user id)

--- a/corehq/apps/reports/tests/test_case_list_report.py
+++ b/corehq/apps/reports/tests/test_case_list_report.py
@@ -40,7 +40,7 @@ class TestCaseListReport(TestCase):
         for user in dummy_user_list:
             user_obj = CouchUser.get_by_username(user['username'])
             if user_obj:
-                user_obj.delete('')
+                user_obj.delete(cls.domain, deleted_by=None)
         cls.user_list = []
         for user in dummy_user_list:
             user_obj = CommCareUser.create(**user) if user['doc_type'] == 'CommcareUser'\
@@ -72,7 +72,7 @@ class TestCaseListReport(TestCase):
         ensure_index_deleted(USER_INDEX)
         ensure_index_deleted(CASE_INDEX)
         for user in cls.user_list:
-            user.delete(deleted_by='')
+            user.delete(cls.domain, deleted_by=None)
         super().tearDownClass()
 
     @classmethod

--- a/corehq/apps/reports/tests/test_export_response.py
+++ b/corehq/apps/reports/tests/test_export_response.py
@@ -26,7 +26,7 @@ class ExportResponseTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.couch_user.delete(deleted_by=None)
+        cls.couch_user.delete(cls.domain, deleted_by=None)
         cls.domain_obj.delete()
         super().tearDownClass()
 

--- a/corehq/apps/reports/tests/test_filters.py
+++ b/corehq/apps/reports/tests/test_filters.py
@@ -259,7 +259,7 @@ class TestEMWFilterOutput(TestCase):
     def tearDownClass(cls):
         ensure_index_deleted(USER_INDEX)
         for user in cls.user_list:
-            user.delete(deleted_by='')
+            user.delete(cls.domain, deleted_by=None)
         super().tearDownClass()
 
     def _send_users_to_es(self):

--- a/corehq/apps/reports/tests/test_message_log_report.py
+++ b/corehq/apps/reports/tests/test_message_log_report.py
@@ -59,7 +59,7 @@ class MessageLogReportTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.couch_user.delete(deleted_by=None)
+        cls.couch_user.delete(cls.domain, deleted_by=None)
         cls.domain_obj.delete()
         super(MessageLogReportTest, cls).tearDownClass()
 

--- a/corehq/apps/reports/tests/test_phone_number_report.py
+++ b/corehq/apps/reports/tests/test_phone_number_report.py
@@ -24,7 +24,7 @@ class PhoneNumberReportTestCase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.couch_user.delete(deleted_by=None)
+        cls.couch_user.delete(cls.domain_name, deleted_by=None)
         cls.domain.delete()
         super(PhoneNumberReportTestCase, cls).tearDownClass()
 

--- a/corehq/apps/reports/tests/test_sql_reports.py
+++ b/corehq/apps/reports/tests/test_sql_reports.py
@@ -33,7 +33,7 @@ class BaseReportTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.couch_user.delete(deleted_by=None)
+        cls.couch_user.delete(DOMAIN, deleted_by=None)
         Session.remove()
         super(BaseReportTest, cls).tearDownClass()
 

--- a/corehq/apps/sms/tests/test_chat.py
+++ b/corehq/apps/sms/tests/test_chat.py
@@ -191,8 +191,8 @@ class ChatHistoryTestCase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.contact3.delete(deleted_by=None)
-        cls.chat_user.delete(deleted_by=None)
+        cls.contact3.delete(cls.domain, deleted_by=None)
+        cls.chat_user.delete(cls.domain, deleted_by=None)
         cls.domain_obj.delete()
         super(ChatHistoryTestCase, cls).tearDownClass()
 

--- a/corehq/apps/sms/tests/test_queueing.py
+++ b/corehq/apps/sms/tests/test_queueing.py
@@ -76,7 +76,7 @@ class QueueingTestCase(BaseSMSTest):
         SMS.objects.filter(domain=self.domain).delete()
 
     def tearDown(self):
-        self.contact.delete(deleted_by=None)
+        self.contact.delete(self.domain, deleted_by=None)
         self.backend.delete()
         self.backend_mapping.delete()
 

--- a/corehq/apps/sms/tests/test_util.py
+++ b/corehq/apps/sms/tests/test_util.py
@@ -25,7 +25,7 @@ class UtilTestCase(TestCase):
         self.user = CommCareUser.create(self.domain, 'test-user', '123', None, None)
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
 
     def testCleanPhoneNumber(self):
         phone_number = "  324 23-23421241"

--- a/corehq/apps/sms/tests/test_views.py
+++ b/corehq/apps/sms/tests/test_views.py
@@ -113,7 +113,7 @@ def normal_user():
     try:
         yield
     finally:
-        user.delete(deleted_by=None)
+        user.delete(DOMAIN_NAME, deleted_by=None)
 
 
 @contextmanager
@@ -125,7 +125,7 @@ def domain_admin():
     try:
         yield
     finally:
-        user.delete(deleted_by=None)
+        user.delete(DOMAIN_NAME, deleted_by=None)
 
 
 @contextmanager
@@ -140,4 +140,4 @@ def superuser():
     try:
         yield
     finally:
-        user.delete(deleted_by=None)
+        user.delete(DOMAIN_NAME, deleted_by=None)

--- a/corehq/apps/sms/tests/util.py
+++ b/corehq/apps/sms/tests/util.py
@@ -322,7 +322,7 @@ class TouchformsTestCase(LiveServerTestCase, DomainSubscriptionMixin):
     def tearDown(self):
         delete_domain_phone_numbers(self.domain)
         for user in self.users:
-            user.delete(deleted_by=None)
+            user.delete(self.domain, deleted_by=None)
         for app in self.apps:
             app.delete()
         for keyword in self.keywords:

--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -48,7 +48,7 @@ class TestSsoBackend(TestCase):
     def tearDownClass(cls):
         AuthenticatedEmailDomain.objects.all().delete()
         IdentityProvider.objects.all().delete()
-        cls.user.delete(None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
 
         # cleanup "new" users
         for username in [
@@ -60,7 +60,7 @@ class TestSsoBackend(TestCase):
         ]:
             web_user = WebUser.get_by_username(username)
             if web_user:
-                web_user.delete(None)
+                web_user.delete(cls.domain.name, deleted_by=None)
 
         cls.domain.delete()
         cls.account.delete()

--- a/corehq/apps/sso/tests/test_forms.py
+++ b/corehq/apps/sso/tests/test_forms.py
@@ -35,7 +35,7 @@ class BaseSSOFormTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.accounting_admin.delete(None)
+        cls.accounting_admin.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         cls.account.delete()
         super().tearDownClass()

--- a/corehq/apps/sso/tests/test_request_helpers.py
+++ b/corehq/apps/sso/tests/test_request_helpers.py
@@ -130,8 +130,8 @@ class TestIsRequestBlockedFromViewingDomainDueToSso(TestCase):
     def tearDownClass(cls):
         AuthenticatedEmailDomain.objects.all().delete()
         IdentityProvider.objects.all().delete()
-        cls.user_without_idp.delete(None)
-        cls.user.delete(None)
+        cls.user_without_idp.delete(cls.external_domain.name, deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         cls.domain_created_by_user.delete()
         cls.external_domain.delete()
         cls.domain.delete()

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1267,7 +1267,7 @@ class TestGetCaseSharingGroupsExpression(TestCase):
         for group in Group.by_domain(self.second_domain):
             group.delete()
         for user in CommCareUser.all():
-            user.delete(deleted_by=None)
+            user.delete(self.domain, deleted_by=None)
         super(TestGetCaseSharingGroupsExpression, self).tearDown()
 
     @run_with_all_backends
@@ -1332,7 +1332,7 @@ class TestGetReportingGroupsExpression(TestCase):
         for group in Group.by_domain(self.second_domain):
             group.delete()
         for user in CommCareUser.all():
-            user.delete(deleted_by=None)
+            user.delete(self.domain, deleted_by=None)
         super(TestGetReportingGroupsExpression, self).tearDown()
 
     @run_with_all_backends

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -247,7 +247,7 @@ class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
             web_user.set_role(domain.name, user_role.get_qualified_id())
             web_user.current_domain = domain.name
             web_user.save()
-            self.addCleanup(web_user.delete, deleted_by=None)
+            self.addCleanup(web_user.delete, domain.name, deleted_by=None)
 
             request = HttpRequest()
             request.can_access_all_locations = True

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1171,6 +1171,8 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         return session_data
 
     def delete(self, deleted_by_domain, deleted_by, deleted_via=None):
+        if not deleted_by and not settings.UNIT_TESTING:
+            raise ValueError("Missing deleted_by")
         self.clear_quickcache_for_user()
         try:
             user = self.get_django_user()

--- a/corehq/apps/users/tests/case_utils.py
+++ b/corehq/apps/users/tests/case_utils.py
@@ -15,7 +15,7 @@ class CaseUtilsTestCase(TestCase):
     def test_get_wrapped_user(self):
         user = CommCareUser.create(self.domain, 'wrapped-user-test', 'password', None, None)
         user.save()
-        self.addCleanup(user.delete, deleted_by=None)
+        self.addCleanup(user.delete, self.domain, deleted_by=None)
         wrapped = get_wrapped_owner(user._id)
         self.assertTrue(isinstance(wrapped, CommCareUser))
 
@@ -29,7 +29,7 @@ class CaseUtilsTestCase(TestCase):
     def test_owned_by_user(self):
         user = CommCareUser.create(self.domain, 'owned-user-test', 'password', None, None)
         user.save()
-        self.addCleanup(user.delete, deleted_by=None)
+        self.addCleanup(user.delete, self.domain, deleted_by=None)
         owners = get_owning_users(user._id)
         self.assertEqual(1, len(owners))
         self.assertEqual(owners[0]._id, user._id)
@@ -40,7 +40,7 @@ class CaseUtilsTestCase(TestCase):
         for i in range(5):
             user = CommCareUser.create(self.domain, 'owned-group-test-user-%s' % i, 'password', None, None)
             user.save()
-            self.addCleanup(user.delete, deleted_by=None)
+            self.addCleanup(user.delete, self.domain, deleted_by=None)
             ids.append(user._id)
 
         group = Group(domain=self.domain, name='owned-group-test-group', users=ids)

--- a/corehq/apps/users/tests/create.py
+++ b/corehq/apps/users/tests/create.py
@@ -23,7 +23,7 @@ class CreateTestCase(TestCase):
         domain_obj = create_domain(domain)
         self.addCleanup(domain_obj.delete)
         couch_user = WebUser.create(domain, username, password, None, None, email=email)
-        self.addCleanup(couch_user.delete, deleted_by=None)
+        self.addCleanup(couch_user.delete, domain, deleted_by=None)
 
         self.assertEqual(couch_user.domains, [domain])
         self.assertEqual(couch_user.email, email)
@@ -47,7 +47,7 @@ class CreateTestCase(TestCase):
         self.addCleanup(domain2.delete)
         self.addCleanup(domain1.delete)
         couch_user = WebUser.create(None, username, password, None, None, email=email)
-        self.addCleanup(couch_user.delete, deleted_by=None)
+        self.addCleanup(couch_user.delete, domain1, deleted_by=None)
         self.assertEqual(couch_user.username, username)
         self.assertEqual(couch_user.email, email)
         couch_user.add_domain_membership('domain1')
@@ -63,8 +63,8 @@ class TestDomainMemberships(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.webuser.delete(deleted_by=None)
-        cls.webuser2.delete(deleted_by=None)
+        cls.webuser.delete(cls.domain, deleted_by=None)
+        cls.webuser2.delete(cls.domain, deleted_by=None)
         cls.project.delete()
         super(TestDomainMemberships, cls).tearDownClass()
 

--- a/corehq/apps/users/tests/phone_users.py
+++ b/corehq/apps/users/tests/phone_users.py
@@ -22,7 +22,7 @@ class PhoneUsersTestCase(TestCase):
     def tearDown(self):
         user = WebUser.get_by_username(self.username)
         if user:
-            user.delete(deleted_by=None)
+            user.delete(self.domain, deleted_by=None)
 
         domain_obj = Domain.get_by_name(self.domain)
         if domain_obj:
@@ -54,7 +54,7 @@ class PhoneUsersTestCase(TestCase):
         self.assertEqual(self.couch_user.default_phone_number, '789')
 
     def testPhoneUsersViewLastCommCareUsername(self):
-        self.couch_user.delete(deleted_by=None)
+        self.couch_user.delete(self.domain, deleted_by=None)
         phone_user_count = CouchUser.phone_users_by_domain(self.domain).count()
         self.assertEqual(phone_user_count, 0)
 

--- a/corehq/apps/users/tests/sync.py
+++ b/corehq/apps/users/tests/sync.py
@@ -42,7 +42,7 @@ class SyncWebUserTestCase(TestCase):
         self.assertEqual(len(self.web_user.first_name), 50)
 
     def tearDown(self):
-        WebUser.get_by_user_id(self.web_user.user_id).delete(deleted_by=None)
+        WebUser.get_by_user_id(self.web_user.user_id).delete(self.domain_obj.name, deleted_by=None)
         self.domain_obj.delete()
         super().tearDown()
 
@@ -91,6 +91,6 @@ class SyncCommCareUserTestCase(TestCase):
         self.commcare_user.save()
 
     def tearDown(self):
-        CommCareUser.get_by_user_id(self.commcare_user.user_id).delete(deleted_by=None)
+        CommCareUser.get_by_user_id(self.commcare_user.user_id).delete(self.domain, deleted_by=None)
         self.domain_obj.delete()
         super(SyncCommCareUserTestCase, self).tearDown()

--- a/corehq/apps/users/tests/test_confirm_account.py
+++ b/corehq/apps/users/tests/test_confirm_account.py
@@ -40,7 +40,7 @@ class TestAccountConfirmation(TestCase):
         super().tearDownClass()
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
 
     def test_confirm_account(self):
 

--- a/corehq/apps/users/tests/test_confirm_account_view.py
+++ b/corehq/apps/users/tests/test_confirm_account_view.py
@@ -32,7 +32,7 @@ class TestMobileWorkerConfirmAccountView(TestCase):
         self.url = reverse('commcare_user_confirm_account', args=[self.domain, self.user.get_id])
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
 
     @flag_enabled('TWO_STAGE_USER_PROVISIONING')
     def test_expected_workflow(self):

--- a/corehq/apps/users/tests/test_create_mobile_workers.py
+++ b/corehq/apps/users/tests/test_create_mobile_workers.py
@@ -30,7 +30,7 @@ class TestCreateMobileWorkers(TestCase):
             first_name='Mobile',
             last_name='Worker',
         )
-        self.addCleanup(user.delete, deleted_by=None)
+        self.addCleanup(user.delete, self.domain, deleted_by=None)
         self.assertEqual(self.domain, user.domain)
         self.assertEqual('mw1', user.username)
         self.assertEqual('mw1@example.com', user.email)
@@ -56,7 +56,7 @@ class TestCreateMobileWorkers(TestCase):
             email='mw1@example.com',
             is_account_confirmed=False,
         )
-        self.addCleanup(user.delete, deleted_by=None)
+        self.addCleanup(user.delete, self.domain, deleted_by=None)
         self.assertEqual(False, user.is_active)
         self.assertEqual(False, user.is_account_confirmed)
         # confirm user can't login

--- a/corehq/apps/users/tests/test_dbaccessors.py
+++ b/corehq/apps/users/tests/test_dbaccessors.py
@@ -237,7 +237,7 @@ class AllCommCareUsersTest(TestCase):
             [user.username for user in
              get_all_commcare_users_by_domain(self.ccdomain.name)]
         )
-        deleted_user.delete(deleted_by=None)
+        deleted_user.delete(self.ccdomain.name, deleted_by=None)
 
     def test_get_user_docs_by_username(self):
         users = [self.ccuser_1, self.web_user, self.ccuser_other_domain]

--- a/corehq/apps/users/tests/test_download.py
+++ b/corehq/apps/users/tests/test_download.py
@@ -91,9 +91,9 @@ class TestDownloadMobileWorkers(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user1.delete(deleted_by=None)
-        cls.user2.delete(deleted_by=None)
-        cls.user3.delete(deleted_by=None)
+        cls.user1.delete(cls.domain_obj.name, deleted_by=None)
+        cls.user2.delete(cls.domain_obj.name, deleted_by=None)
+        cls.user3.delete(cls.other_domain_obj.name, deleted_by=None)
         cls.domain_obj.delete()
         cls.other_domain_obj.delete()
         cls.definition.delete()

--- a/corehq/apps/users/tests/test_download_with_profile.py
+++ b/corehq/apps/users/tests/test_download_with_profile.py
@@ -75,8 +75,8 @@ class TestDownloadMobileWorkersWithProfile(TestCase, DomainSubscriptionMixin):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user1.delete(deleted_by=None)
-        cls.user2.delete(deleted_by=None)
+        cls.user1.delete(cls.domain, deleted_by=None)
+        cls.user2.delete(cls.domain, deleted_by=None)
         cls.domain_obj.delete()
         cls.definition.delete()
         cls.teardown_subscriptions()

--- a/corehq/apps/users/tests/test_location_assignment.py
+++ b/corehq/apps/users/tests/test_location_assignment.py
@@ -44,7 +44,7 @@ class CCUserLocationAssignmentTest(TestCase):
         )
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
         super(CCUserLocationAssignmentTest, self).tearDown()
 
     def test_set_location(self):
@@ -119,7 +119,7 @@ class CCUserLocationAssignmentTest(TestCase):
         self.assertEqual(saved_user.get_sql_location(self.domain), None)
 
     def test_create_with_location(self):
-        self.addCleanup(self.user.delete, deleted_by=None)
+        self.addCleanup(self.user.delete, self.domain, deleted_by=None)
         self.user = CommCareUser.create(
             domain=self.domain,
             username='cc2',
@@ -180,7 +180,7 @@ class WebUserLocationAssignmentTest(TestCase):
         )
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
         super(WebUserLocationAssignmentTest, self).tearDown()
 
     def test_set_location(self):

--- a/corehq/apps/users/tests/test_log_user_change.py
+++ b/corehq/apps/users/tests/test_log_user_change.py
@@ -108,7 +108,7 @@ class TestLogUserChange(TestCase):
         new_user_id = new_user.get_id
 
         # domain less delete action by non-system user
-        with self.assertRaisesMessage(ValueError, "Please pass domain"):
+        with self.assertRaisesMessage(ValueError, "missing 'domain' argument'"):
             new_user.delete(None, deleted_by=self.web_user, deleted_via=__name__)
 
         # domain less delete action by SYSTEM_USER_ID

--- a/corehq/apps/users/tests/test_log_user_change.py
+++ b/corehq/apps/users/tests/test_log_user_change.py
@@ -76,14 +76,15 @@ class TestLogUserChange(TestCase):
 
         self.commcare_user.phone_numbers = restore_phone_numbers_to
 
+    @override_settings(UNIT_TESTING=False)
+    def test_delete_missing_deleted_by(self):
+        with self.assertRaisesMessage(ValueError, "Missing deleted_by"):
+            self.commcare_user.delete(self.domain, deleted_by=None)
+
     def test_delete(self):
         user_to_delete = CommCareUser.create(self.domain, f'delete@{self.domain}.commcarehq.org', '******',
                                              created_by=None, created_via=None)
         user_to_delete_id = user_to_delete.get_id
-
-        with override_settings(UNIT_TESTING=False):
-            with self.assertRaisesMessage(ValueError, "Missing deleted_by"):
-                user_to_delete.delete(self.domain, deleted_by=None)
 
         user_to_delete.delete(self.domain, deleted_by=self.web_user, deleted_via=USER_CHANGE_VIA_WEB)
 

--- a/corehq/apps/users/tests/test_log_user_change.py
+++ b/corehq/apps/users/tests/test_log_user_change.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser, UserHistory, WebUser
@@ -89,6 +89,10 @@ class TestLogUserChange(TestCase):
         user_to_delete = CommCareUser.create(self.domain, f'delete@{self.domain}.commcarehq.org', '******',
                                              created_by=None, created_via=None)
         user_to_delete_id = user_to_delete.get_id
+
+        with override_settings(UNIT_TESTING=False):
+            with self.assertRaisesMessage(ValueError, "Missing deleted_by"):
+                user_to_delete.delete(self.domain, deleted_by=None)
 
         user_to_delete.delete(self.domain, deleted_by=self.web_user, deleted_via=USER_CHANGE_VIA_WEB)
 

--- a/corehq/apps/users/tests/test_log_user_change.py
+++ b/corehq/apps/users/tests/test_log_user_change.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser, UserHistory, WebUser
-from corehq.apps.users.util import log_user_change, SYSTEM_USER_ID
+from corehq.apps.users.util import SYSTEM_USER_ID, log_user_change
 from corehq.const import USER_CHANGE_VIA_BULK_IMPORTER, USER_CHANGE_VIA_WEB
 from corehq.util.model_log import ModelAction
 

--- a/corehq/apps/users/tests/test_mirroring.py
+++ b/corehq/apps/users/tests/test_mirroring.py
@@ -23,6 +23,7 @@ class DomainPermissionsMirrorTest(TestCase):
         super().setUpClass()
 
         # Set up domains
+        cls.domain = 'state'
         cls.mirror = DomainPermissionsMirror(source='state', mirror='county')
         cls.mirror.save()
         create_domain('state')
@@ -60,8 +61,8 @@ class DomainPermissionsMirrorTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.web_user_admin.delete(deleted_by=None)
-        cls.web_user_non_admin.delete(deleted_by=None)
+        cls.web_user_admin.delete(cls.domain, deleted_by=None)
+        cls.web_user_non_admin.delete(cls.domain, deleted_by=None)
         cls.api_key.delete()
         Domain.get_by_name('county').delete()
         Domain.get_by_name('state').delete()

--- a/corehq/apps/users/tests/test_user_model.py
+++ b/corehq/apps/users/tests/test_user_model.py
@@ -176,7 +176,7 @@ class UserModelTest(TestCase):
         })
 
         definition.delete()
-        web_user.delete(deleted_by=None)
+        web_user.delete(self.domain, deleted_by=None)
 
     @patch('corehq.apps.users.models.toggles.MOBILE_LOGIN_LOCKOUT.enabled')
     def test_commcare_user_is_locked_only_with_toggle(self, mock_lockout_enabled_for_domain):

--- a/corehq/apps/users/tests/test_util.py
+++ b/corehq/apps/users/tests/test_util.py
@@ -17,12 +17,13 @@ class TestUsernameToUserID(TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestUsernameToUserID, cls).setUpClass()
-        cls.user = CommCareUser.create('scale-domain', 'scale', 'dude', None, None)
+        cls.domain = 'scale-domain'
+        cls.user = CommCareUser.create(cls.domain, 'scale', 'dude', None, None)
         cache.clear()
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain, deleted_by=None)
         cache.clear()
         super(TestUsernameToUserID, cls).tearDownClass()
 
@@ -39,12 +40,13 @@ class TestUserIdToUsernameToUserName(TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestUserIdToUsernameToUserName, cls).setUpClass()
-        cls.user_without_name = CommCareUser.create('test-domain', 'no_name', 'a_secret', None, None)
-        cls.user_with_first_name = CommCareUser.create('test-domain', 'first_name', 'a_secret', None, None,
+        cls.domain = 'test-domain'
+        cls.user_without_name = CommCareUser.create(cls.domain, 'no_name', 'a_secret', None, None)
+        cls.user_with_first_name = CommCareUser.create(cls.domain, 'first_name', 'a_secret', None, None,
                                                        first_name='Alice')
-        cls.user_with_last_name = CommCareUser.create('test-domain', 'last_name', 'a_secret', None, None,
+        cls.user_with_last_name = CommCareUser.create(cls.domain, 'last_name', 'a_secret', None, None,
                                                       last_name='Jones')
-        cls.user_with_full_name = CommCareUser.create('test-domain', 'full_name', 'a_secret', None, None,
+        cls.user_with_full_name = CommCareUser.create(cls.domain, 'full_name', 'a_secret', None, None,
                                                       first_name='Alice', last_name='Jones')
         cls.users = [
             cls.user_without_name,
@@ -57,7 +59,7 @@ class TestUserIdToUsernameToUserName(TestCase):
     @classmethod
     def tearDownClass(cls):
         for user in cls.users:
-            user.delete(deleted_by=None)
+            user.delete(cls.domain, deleted_by=None)
         cache.clear()
         super(TestUserIdToUsernameToUserName, cls).tearDownClass()
 

--- a/corehq/apps/users/tests/test_web_user_download.py
+++ b/corehq/apps/users/tests/test_web_user_download.py
@@ -104,10 +104,10 @@ class TestDownloadWebUsers(TestCase):
     @classmethod
     def tearDownClass(cls):
         ensure_index_deleted(USER_INDEX)
-        cls.user1.delete(deleted_by=None)
-        cls.user2.delete(deleted_by=None)
-        cls.user10.delete(deleted_by=None)
-        cls.user11.delete(deleted_by=None)
+        cls.user1.delete(cls.domain_obj.name, deleted_by=None)
+        cls.user2.delete(cls.domain_obj.name, deleted_by=None)
+        cls.user10.delete(cls.other_domain_obj.name, deleted_by=None)
+        cls.user11.delete(cls.other_domain_obj.name, deleted_by=None)
         cls.invited_user.delete()
         cls.other_invited_user.delete()
         cls.domain_obj.delete()

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -340,7 +340,7 @@ def log_user_change(domain, couch_user, changed_by_user, changed_via=None,
 
     :param domain: domain where the update was initiated
     :param couch_user: user being changed
-    :param changed_by_user: user making the change
+    :param changed_by_user: user making the change or SYSTEM_USER_ID
     :param changed_via: changed via medium i.e API/Web
     :param message: Optional Message text
     :param fields_changed: dict of user fields that have changed with their current value
@@ -349,7 +349,7 @@ def log_user_change(domain, couch_user, changed_by_user, changed_via=None,
     from corehq.apps.users.models import UserHistory
 
     # domain is essential to filter changes done in a domain
-    if not domain:
+    if not domain and changed_by_user != SYSTEM_USER_ID:
         raise ValueError("Please pass domain")
 
     # for an update, there should always be fields that have changed
@@ -360,7 +360,7 @@ def log_user_change(domain, couch_user, changed_by_user, changed_via=None,
         domain=domain,
         user_type=couch_user.doc_type,
         user_id=couch_user.get_id,
-        by_user_id=changed_by_user.get_id,
+        by_user_id=SYSTEM_USER_ID if changed_by_user == SYSTEM_USER_ID else changed_by_user.get_id,
         details={
             'changes': _get_changed_details(couch_user, action, fields_changed),
             'changed_via': changed_via,

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1264,7 +1264,8 @@ class DeleteCommCareUsers(BaseManageCommCareUserView, UsernameUploadMixin):
         deleted_count = 0
         for user_id, doc in user_docs_by_id.items():
             if user_id not in user_ids_with_forms:
-                CommCareUser.wrap(doc).delete(deleted_by=request.user, deleted_via=USER_CHANGE_VIA_BULK_IMPORTER)
+                CommCareUser.wrap(doc).delete(request.domain, deleted_by=request.couch_user,
+                                              deleted_via=USER_CHANGE_VIA_BULK_IMPORTER)
                 deleted_count += 1
         if deleted_count:
             messages.success(request, f"{deleted_count} user(s) deleted.")

--- a/corehq/apps/zapier/tests/test_create_update_cases_from_zapier.py
+++ b/corehq/apps/zapier/tests/test_create_update_cases_from_zapier.py
@@ -40,7 +40,7 @@ class TestZapierCreateCaseAction(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain, deleted_by=None)
         cls.domain_object.delete()
         FormProcessorTestUtils.delete_all_cases()
         super(TestZapierCreateCaseAction, cls).tearDownClass()

--- a/corehq/apps/zapier/tests/test_zapier_forwarding.py
+++ b/corehq/apps/zapier/tests/test_zapier_forwarding.py
@@ -30,7 +30,7 @@ class TestZapierCaseForwarding(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.web_user.delete(deleted_by=None)
+        cls.web_user.delete(cls.domain, deleted_by=None)
         cls.domain_object.delete()
         delete_all_repeaters()
         super(TestZapierCaseForwarding, cls).tearDownClass()

--- a/corehq/apps/zapier/tests/test_zapier_hooks.py
+++ b/corehq/apps/zapier/tests/test_zapier_hooks.py
@@ -87,7 +87,7 @@ class TestZapierIntegration(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.web_user.delete(deleted_by=None)
+        cls.web_user.delete(cls.domain, deleted_by=None)
         cls.application.delete()
         cls.domain_object.delete()
         delete_all_repeaters()

--- a/corehq/blobs/tests/test_migrate_metadata.py
+++ b/corehq/blobs/tests/test_migrate_metadata.py
@@ -63,13 +63,14 @@ class TestMigrateBackend(TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestMigrateBackend, cls).setUpClass()
-        cls.user = mod.CommCareUser(username="testuser", domain="test")
+        cls.domain = "test"
+        cls.user = mod.CommCareUser(username="testuser", domain=cls.domain)
         cls.user.save()
         assert cls.user._id, cls.user
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain, deleted_by=None)
         super(TestMigrateBackend, cls).tearDownClass()
 
     def CaseUploadFileMeta_save(self, obj, key):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_synclog_pillow.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_synclog_pillow.py
@@ -40,7 +40,7 @@ class SyncLogPillowTest(TestCase):
     @classmethod
     def tearDownClass(cls):
         delete_all_sync_logs()
-        cls.ccuser.delete(deleted_by=None)
+        cls.ccuser.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         super(SyncLogPillowTest, cls).tearDownClass()
 

--- a/corehq/ex-submodules/pillowtop/tests/test_form_submission_metadata_tracker_processor.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_form_submission_metadata_tracker_processor.py
@@ -35,7 +35,7 @@ class MarkLatestSubmissionTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain, deleted_by=None)
         super(MarkLatestSubmissionTest, cls).tearDownClass()
 
     def test_mark_latest_submission_basic(self):

--- a/corehq/ex-submodules/soil/tests/test_download_base.py
+++ b/corehq/ex-submodules/soil/tests/test_download_base.py
@@ -60,7 +60,7 @@ class TestAuthenticatedDownloadBase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.couch_user.delete(deleted_by=None)
+        cls.couch_user.delete(cls.domain, deleted_by=None)
         cls.domain_obj.delete()
 
         super(TestAuthenticatedDownloadBase, cls).tearDownClass()

--- a/corehq/ex-submodules/toggle/tests.py
+++ b/corehq/ex-submodules/toggle/tests.py
@@ -353,8 +353,8 @@ class NamespaceTests(TestCase):
     def tearDownClass(cls):
         cls.domain.delete()
         cls.second_domain.delete()
-        cls.user.delete(deleted_by='admin')
-        cls.second_user.delete(deleted_by='admin')
+        cls.user.delete(cls.domain.name, deleted_by=None)
+        cls.second_user.delete(cls.domain.name, deleted_by=None)
 
     def test_email_domain_namespace(self):
         email_domain_toggle = StaticToggle(

--- a/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
+++ b/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
@@ -126,7 +126,7 @@ class TestBulkConditionalAlerts(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain, deleted_by=None)
         cls.domain_obj.delete()
         super(TestBulkConditionalAlerts, cls).tearDownClass()
 

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -704,9 +704,9 @@ class SchedulingRecipientTest(TestCase):
         user1 = CommCareUser.create(self.domain, uuid.uuid4().hex, 'abc', None, None)
         user2 = CommCareUser.create(self.domain, uuid.uuid4().hex, 'abc', None, None)
         user3 = CommCareUser.create(self.domain, uuid.uuid4().hex, 'abc', None, None)
-        self.addCleanup(user1.delete, deleted_by=None)
-        self.addCleanup(user2.delete, deleted_by=None)
-        self.addCleanup(user3.delete, deleted_by=None)
+        self.addCleanup(user1.delete, self.domain, deleted_by=None)
+        self.addCleanup(user2.delete, self.domain, deleted_by=None)
+        self.addCleanup(user3.delete, self.domain, deleted_by=None)
 
         self.assertIsNone(user1.memoized_usercase)
         self.assertIsNone(Content.get_two_way_entry_or_phone_number(user1))
@@ -757,9 +757,9 @@ class SchedulingRecipientTest(TestCase):
         user1 = CommCareUser.create(self.domain, uuid.uuid4().hex, 'abc', None, None)
         user2 = CommCareUser.create(self.domain, uuid.uuid4().hex, 'abc', None, None)
         user3 = CommCareUser.create(self.domain, uuid.uuid4().hex, 'abc', None, None)
-        self.addCleanup(user1.delete, deleted_by=None)
-        self.addCleanup(user2.delete, deleted_by=None)
-        self.addCleanup(user3.delete, deleted_by=None)
+        self.addCleanup(user1.delete, self.domain, deleted_by=None)
+        self.addCleanup(user2.delete, self.domain, deleted_by=None)
+        self.addCleanup(user3.delete, self.domain, deleted_by=None)
 
         self.assertIsNone(user1.memoized_usercase)
         self.assertIsNone(Content.get_two_way_entry_or_phone_number(user1))
@@ -808,9 +808,9 @@ class SchedulingRecipientTest(TestCase):
             user1 = CommCareUser.create(self.domain, uuid.uuid4().hex, 'abc', None, None)
             user2 = CommCareUser.create(self.domain, uuid.uuid4().hex, 'abc', None, None)
             user3 = CommCareUser.create(self.domain, uuid.uuid4().hex, 'abc', None, None)
-            self.addCleanup(user1.delete, deleted_by=None)
-            self.addCleanup(user2.delete, deleted_by=None)
-            self.addCleanup(user3.delete, deleted_by=None)
+            self.addCleanup(user1.delete, self.domain, deleted_by=None)
+            self.addCleanup(user2.delete, self.domain, deleted_by=None)
+            self.addCleanup(user3.delete, self.domain, deleted_by=None)
 
             self.assertIsNone(user1.memoized_usercase)
             self.assertIsNone(Content.get_two_way_entry_or_phone_number(user1))
@@ -840,7 +840,7 @@ class SchedulingRecipientTest(TestCase):
     @run_with_all_backends
     def test_phone_number_preference(self):
         user = CommCareUser.create(self.domain, uuid.uuid4().hex, 'abc', None, None)
-        self.addCleanup(user.delete, deleted_by=None)
+        self.addCleanup(user.delete, self.domain, deleted_by=None)
 
         user.add_phone_number('12345')
         user.add_phone_number('23456')

--- a/corehq/messaging/scheduling/tests/test_templating.py
+++ b/corehq/messaging/scheduling/tests/test_templating.py
@@ -61,8 +61,8 @@ class TemplatingTestCase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.mobile_user.delete(deleted_by=None)
-        cls.web_user.delete(deleted_by=None)
+        cls.mobile_user.delete(cls.domain, deleted_by=None)
+        cls.web_user.delete(cls.domain, deleted_by=None)
         cls.group.delete()
         cls.location.delete()
         cls.location_type.delete()

--- a/corehq/messaging/smsbackends/starfish/tests/test_incoming.py
+++ b/corehq/messaging/smsbackends/starfish/tests/test_incoming.py
@@ -28,7 +28,7 @@ class IncomingTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.couch_user.delete(deleted_by=None)
+        cls.couch_user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         cls.backend.delete()
         super(IncomingTest, cls).tearDownClass()

--- a/corehq/messaging/smsbackends/trumpia/tests/test_incoming.py
+++ b/corehq/messaging/smsbackends/trumpia/tests/test_incoming.py
@@ -28,7 +28,7 @@ class IncomingTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.couch_user.delete(deleted_by=None)
+        cls.couch_user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         cls.backend.delete()
         super(IncomingTest, cls).tearDownClass()

--- a/corehq/messaging/smsbackends/unicel/tests/test_create_from_request.py
+++ b/corehq/messaging/smsbackends/unicel/tests/test_create_from_request.py
@@ -44,7 +44,7 @@ class IncomingPostTest(TestCase):
         self.message_utf_hex = '0939093F0928094D092609400020091509300924093E00200939094800200907093800200938092E092F00200915093E092E002009390948003F'
 
     def tearDown(self):
-        self.couch_user.delete(deleted_by=None)
+        self.couch_user.delete(self.domain.name, deleted_by=None)
         self.domain.delete()
         super().tearDown()
 

--- a/corehq/motech/dhis2/tests/test_events_helpers.py
+++ b/corehq/motech/dhis2/tests/test_events_helpers.py
@@ -39,7 +39,7 @@ class TestDhis2EventsHelpers(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         cls.location.delete()
         cls.domain.delete()
         super().tearDownClass()

--- a/corehq/motech/dhis2/tests/test_views.py
+++ b/corehq/motech/dhis2/tests/test_views.py
@@ -66,7 +66,7 @@ class BaseViewTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         cls.connection_setting.delete()
         cls.dataset_map.delete()

--- a/corehq/motech/fhir/tests/test_fhir_views.py
+++ b/corehq/motech/fhir/tests/test_fhir_views.py
@@ -50,7 +50,7 @@ class BaseFHIRViewTest(TestCase):
     @classmethod
     def tearDownClass(cls):
         delete_all_cases()
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain_obj.name, deleted_by=None)
         cls.domain_obj.delete()
         super().tearDownClass()
 

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -301,7 +301,7 @@ class AllowedToForwardTests(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.owner.delete(deleted_by=None)
+        cls.owner.delete(DOMAIN, deleted_by=None)
         super(AllowedToForwardTests, cls).tearDownClass()
 
     def test_update_from_openmrs(self):

--- a/corehq/motech/openmrs/tests/test_tasks.py
+++ b/corehq/motech/openmrs/tests/test_tasks.py
@@ -272,8 +272,8 @@ class OwnerTests(LocationHierarchyTestCase):
     def tearDownClass(cls):
         cls.bad_group.delete()
         cls.group.delete()
-        cls.mobile_worker.delete(deleted_by=None)
-        cls.web_user.delete(deleted_by=None)
+        cls.mobile_worker.delete(cls.domain, deleted_by=None)
+        cls.web_user.delete(cls.domain, deleted_by=None)
         super().tearDownClass()
 
     def test_location_owner(self):

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -860,7 +860,7 @@ class UserRepeaterTest(TestCase, DomainSubscriptionMixin):
             None,
             None,
         )
-        self.addCleanup(user.delete, deleted_by=None)
+        self.addCleanup(user.delete, self.domain, deleted_by=None)
         return user
 
     def test_trigger(self):

--- a/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
+++ b/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
@@ -84,5 +84,5 @@ class GetNUsersForRateLimitingTest(TestCase, DomainSubscriptionMixin):
                                        password='123', created_by=None, created_via=None)
             user.is_active = True
             user.save()
-            self.addCleanup(user.delete, deleted_by=None)
+            self.addCleanup(user.delete, domain, deleted_by=None)
         assert CommCareUser.total_by_domain(domain, is_active=True) == n_users

--- a/corehq/tests/test_middleware.py
+++ b/corehq/tests/test_middleware.py
@@ -157,7 +157,7 @@ class TestLogLongRequestMiddlewareReports(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         super().tearDownClass()
 

--- a/custom/abt/tests/test_custom_recipients.py
+++ b/custom/abt/tests/test_custom_recipients.py
@@ -46,7 +46,7 @@ class CustomRecipientTest(TestCase):
         self.user.set_location(self.child_location)
 
     def tearDown(self):
-        self.user.delete(deleted_by=None)
+        self.user.delete(self.domain, deleted_by=None)
         self.child_location.delete()
         self.parent_location.delete()
         self.child_location_type.delete()

--- a/custom/champ/tests/utils.py
+++ b/custom/champ/tests/utils.py
@@ -41,7 +41,7 @@ class ChampTestCase(TestCase, DomainSubscriptionMixin):
     @classmethod
     def tearDownClass(cls):
         cls.teardown_subscriptions()
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         clear_plan_version_cache()
         super().tearDownClass()
 

--- a/custom/intrahealth/tests/reports/util.py
+++ b/custom/intrahealth/tests/reports/util.py
@@ -197,6 +197,6 @@ class ReportTestCase(TestCase):
             cls.recouvrement_table.drop(connection, checkfirst=True)
             cls.livraison_table.drop(connection, checkfirst=True)
         cls.engine.dispose()
-        cls.web_user.delete(deleted_by=None)
+        cls.web_user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         super(ReportTestCase, cls).tearDownClass()

--- a/custom/intrahealth/tests/test_utils.py
+++ b/custom/intrahealth/tests/test_utils.py
@@ -80,7 +80,7 @@ class IntraHealthTestCase(TestCase):
             cls.couverture_table.drop(connection, checkfirst=True)
 
         cls.engine.dispose()
-        cls.mobile_worker.delete(deleted_by=None)
+        cls.mobile_worker.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         delete_all_xforms()
         super(IntraHealthTestCase, cls).tearDownClass()

--- a/custom/intrahealth/tests/utils.py
+++ b/custom/intrahealth/tests/utils.py
@@ -38,7 +38,7 @@ class YeksiTestCase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         super().tearDownClass()
 
 

--- a/custom/nic_compliance/tests/test_password_validation.py
+++ b/custom/nic_compliance/tests/test_password_validation.py
@@ -16,7 +16,7 @@ class TestUsedPasswordsRestriction(TestCase):
         self.user = self.web_user.get_django_user()
 
     def tearDown(self):
-        self.web_user.delete(deleted_by=None)
+        self.web_user.delete(self.domain.name, deleted_by=None)
         self.domain.delete()
 
     def test_used_password_reset(self):

--- a/custom/ucla/tests.py
+++ b/custom/ucla/tests.py
@@ -43,7 +43,7 @@ class TestUCLACustomHandler(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.schedule.delete()
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         super(TestUCLACustomHandler, cls).tearDownClass()
 

--- a/testapps/test_pillowtop/tests/test_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_xform_pillow.py
@@ -68,7 +68,7 @@ class XFormPillowTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by=None)
+        cls.user.delete(cls.domain, deleted_by=None)
         super().tearDownClass()
 
     @run_with_all_backends


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
:fish: / :fish: 
Builds on the [base setup](https://github.com/dimagi/commcare-hq/pull/29887) to track user deletion.
This PR also adds a way to skip passing domain for deletions done by system admins where there is no domain.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No UI changes.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
same as base PR

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This was first run of master to run tests and only after a [green build](https://travis-ci.com/github/dimagi/commcare-hq/builds/228648661), base was changed to mk/user-history/base

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
same as base PR
