### PR TITLE
[User History] Track User retire/unretire

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -268,15 +268,14 @@ class CommCareUserResource(v0_1.CommCareUserResource):
             bundle.obj.save()
         except Exception:
             if bundle.obj._id:
-                bundle.obj.retire(deleted_by=bundle.request.user, deleted_via=USER_CHANGE_VIA_API)
+                bundle.obj.retire(bundle.request.domain, deleted_by=bundle.request.couch_user,
+                                  deleted_via=USER_CHANGE_VIA_API)
             try:
                 django_user = bundle.obj.get_django_user()
             except User.DoesNotExist:
                 pass
             else:
                 django_user.delete()
-                log_model_change(bundle.request.user, django_user, message=f"deleted_via: {USER_CHANGE_VIA_API}",
-                                 action=ModelAction.DELETE)
             raise
         return bundle
 
@@ -293,7 +292,8 @@ class CommCareUserResource(v0_1.CommCareUserResource):
     def obj_delete(self, bundle, **kwargs):
         user = CommCareUser.get(kwargs['pk'])
         if user:
-            user.retire(deleted_by=bundle.request.user, deleted_via=USER_CHANGE_VIA_API)
+            user.retire(bundle.request.domain, deleted_by=bundle.request.couch_user,
+                        deleted_via=USER_CHANGE_VIA_API)
         return ImmediateHttpResponse(response=http.HttpAccepted())
 
 

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -1137,19 +1137,19 @@ class MigrationTestCase(BaseMigrationTestCase):
         with self.assertRaises(NotAllowed):
             user.retire(self.domain_name, deleted_by=None)
         with self.assertRaises(NotAllowed):
-            user.unretire(unretired_by=None)
+            user.unretire(self.domain_name, unretired_by=None)
 
         clear_local_domain_sql_backend_override(self.domain_name)
         self.assert_backend("couch")
         with self.assertRaises(NotAllowed):
             user.retire(self.domain_name, deleted_by=None)
         with self.assertRaises(NotAllowed):
-            user.unretire(unretired_by=None)
+            user.unretire(self.domain_name, unretired_by=None)
 
         self.do_migration(finish=True)
         self.do_migration(COMMIT)
         user.retire(self.domain_name, deleted_by=None)
-        user.unretire(unretired_by=None)
+        user.unretire(self.domain_name, unretired_by=None)
 
     def test_delete_cases_during_migration(self):
         from corehq.apps.hqcase.tasks import delete_exploded_cases

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -1135,20 +1135,20 @@ class MigrationTestCase(BaseMigrationTestCase):
             self.do_migration(live=True, diffs=IGNORE)
         self.assert_backend("sql")
         with self.assertRaises(NotAllowed):
-            user.retire(deleted_by=None)
+            user.retire(self.domain_name, deleted_by=None)
         with self.assertRaises(NotAllowed):
             user.unretire(unretired_by=None)
 
         clear_local_domain_sql_backend_override(self.domain_name)
         self.assert_backend("couch")
         with self.assertRaises(NotAllowed):
-            user.retire(deleted_by=None)
+            user.retire(self.domain_name, deleted_by=None)
         with self.assertRaises(NotAllowed):
             user.unretire(unretired_by=None)
 
         self.do_migration(finish=True)
         self.do_migration(COMMIT)
-        user.retire(deleted_by=None)
+        user.retire(self.domain_name, deleted_by=None)
         user.unretire(unretired_by=None)
 
     def test_delete_cases_during_migration(self):

--- a/corehq/apps/groups/tests/test_groups.py
+++ b/corehq/apps/groups/tests/test_groups.py
@@ -23,7 +23,7 @@ class GroupTest(TestCase):
         cls.inactive_user.save()
         cls.deleted_user = CommCareUser.create(domain=DOMAIN, username='goner', password='secret',
                                                created_by=None, created_via=None)
-        cls.deleted_user.retire(deleted_by=None)
+        cls.deleted_user.retire(DOMAIN, deleted_by=None)
 
     def tearDown(self):
         for group in Group.by_domain(DOMAIN):

--- a/corehq/apps/sms/tests/test_phone_numbers.py
+++ b/corehq/apps/sms/tests/test_phone_numbers.py
@@ -751,7 +751,7 @@ class TestUserPhoneNumberSync(TestCase):
         self.assertEqual(PhoneNumber.by_domain(self.domain).count(), 2)
         self.assertPhoneEntries(self.mobile_worker2, ['9990002'])
 
-        self.mobile_worker1.retire(deleted_by=None)
+        self.mobile_worker1.retire(self.domain, deleted_by=None)
         self.assertEqual(PhoneNumber.by_domain(self.domain).count(), 1)
         self.assertPhoneEntries(self.mobile_worker2, ['9990002'])
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1842,6 +1842,9 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         - It will not restore reminders for cases
         """
         NotAllowed.check(self.domain)
+        if not unretired_by and not settings.UNIT_TESTING:
+            raise ValueError("Missing unretired_by")
+
         by_username = self.get_db().view('users/by_username', key=self.username, reduce=False).first()
         if by_username and by_username['id'] != self._id:
             return False, "A user with the same username already exists in the system"
@@ -1868,6 +1871,9 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
 
     def retire(self, retired_by_domain, deleted_by, deleted_via=None):
         NotAllowed.check(self.domain)
+        if not deleted_by and not settings.UNIT_TESTING:
+            raise ValueError("Missing deleted_by")
+
         suffix = DELETED_SUFFIX
         deletion_id = uuid4().hex
         deletion_date = datetime.utcnow()

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1833,7 +1833,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         owner_ids.extend([g._id for g in self.get_case_sharing_groups()])
         return owner_ids
 
-    def unretire(self, unretired_by, unretired_via=None):
+    def unretire(self, unretired_by_domain, unretired_by, unretired_via=None):
         """
         This un-deletes a user, but does not fully restore the state to
         how it previously was. Using this has these caveats:
@@ -1857,10 +1857,12 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         undelete_system_forms.delay(self.domain, set(deleted_form_ids), set(deleted_case_ids))
         self.save()
         if unretired_by:
-            log_model_change(
+            log_user_change(
+                unretired_by_domain,
+                self,
                 unretired_by,
-                self.get_django_user(use_primary_db=True),
-                message=f"unretired_via: {unretired_via}",
+                changed_via=unretired_via,
+                action=ModelAction.CREATE,
             )
         return True, None
 

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -160,7 +160,7 @@ class RetireUserTestCase(TestCase):
         self.assertTrue(form_2.is_deleted)
 
         # Both forms should be undeleted on `unretire()`
-        self.commcare_user.unretire(unretired_by=None)
+        self.commcare_user.unretire(self.domain, unretired_by=None)
         form_1 = FormAccessors(self.domain).get_form(xform_1.form_id)
         self.assertFalse(form_1.is_deleted)
         form_2 = FormAccessors(self.domain).get_form(xform_2.form_id)

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -1,9 +1,7 @@
 import uuid
 from xml.etree import cElementTree as ElementTree
 
-from django.contrib.admin.models import LogEntry
-from django.test import TestCase
-from django.utils.encoding import force_text
+from django.test import TestCase, override_settings
 
 import mock
 
@@ -65,6 +63,9 @@ class RetireUserTestCase(TestCase):
         super(RetireUserTestCase, self).tearDown()
 
     def test_retire(self):
+        with override_settings(UNIT_TESTING=False):
+            with self.assertRaisesMessage(ValueError, "Missing deleted_by"):
+                self.commcare_user.retire(self.domain, deleted_by=None)
         deleted_via = "Test test"
 
         self.commcare_user.retire(self.domain, deleted_by=self.other_user, deleted_via=deleted_via)
@@ -97,6 +98,10 @@ class RetireUserTestCase(TestCase):
         self.assertEqual(len(cases), 3)
         form = FormAccessors(self.domain).get_form(xform.form_id)
         self.assertTrue(form.is_deleted)
+
+        with override_settings(UNIT_TESTING=False):
+            with self.assertRaisesMessage(ValueError, "Missing unretired_by"):
+                self.commcare_user.unretire(self.domain, unretired_by=None)
 
         self.assertEqual(
             UserHistory.objects.filter(

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -92,7 +92,7 @@ class RetireUserTestCase(TestCase):
             ).as_text())
         xform = submit_case_blocks(caseblocks, self.domain, user_id=owner_id)[0]
 
-        self.commcare_user.retire(deleted_by=None)
+        self.commcare_user.retire(self.domain, deleted_by=None)
         cases = CaseAccessors(self.domain).get_cases(case_ids)
         self.assertTrue(all([c.is_deleted for c in cases]))
         self.assertEqual(len(cases), 3)
@@ -146,7 +146,7 @@ class RetireUserTestCase(TestCase):
         xform_2 = submit_case_blocks(caseblocks[1:], self.domain, user_id=SYSTEM_USER_ID)[0]
 
         # Both forms should be deleted on `retire()`
-        self.commcare_user.retire(deleted_by=None)
+        self.commcare_user.retire(self.domain, deleted_by=None)
         form_1 = FormAccessors(self.domain).get_form(xform_1.form_id)
         self.assertTrue(form_1.is_deleted)
         form_2 = FormAccessors(self.domain).get_form(xform_2.form_id)
@@ -213,7 +213,7 @@ class RetireUserTestCase(TestCase):
         casexml = ElementTree.tostring(caseblock.as_xml(), encoding='utf-8').decode('utf-8')
         submit_case_blocks(casexml, self.domain, user_id=self.other_user._id)
 
-        self.other_user.retire(deleted_by=None)
+        self.other_user.retire(self.domain, deleted_by=None)
 
         detail = UserArchivedRebuild(user_id=self.other_user.user_id)
         rebuild_case.assert_called_once_with(self.domain, case_id, detail)
@@ -233,7 +233,7 @@ class RetireUserTestCase(TestCase):
         casexml = ElementTree.tostring(caseblock.as_xml(), encoding='utf-8').decode('utf-8')
         submit_case_blocks(casexml, self.domain, user_id=self.commcare_user._id)
 
-        self.other_user.retire(deleted_by=None)
+        self.other_user.retire(self.domain, deleted_by=None)
 
         self.assertEqual(rebuild_case.call_count, 0)
 
@@ -253,7 +253,7 @@ class RetireUserTestCase(TestCase):
         casexmls = [ElementTree.tostring(caseblock.as_xml(), encoding='utf-8').decode('utf-8') for caseblock in caseblocks]
         submit_case_blocks(casexmls, self.domain, user_id=self.other_user._id)
 
-        self.other_user.retire(deleted_by=None)
+        self.other_user.retire(self.domain, deleted_by=None)
 
         detail = UserArchivedRebuild(user_id=self.other_user.user_id)
         expected_call_args = [mock.call(self.domain, case_id, detail) for case_id in case_ids]
@@ -283,7 +283,7 @@ class RetireUserTestCase(TestCase):
             )
             submit_case_blocks(caseblock.as_text(), self.domain, user_id=self.other_user._id)
 
-        self.other_user.retire(deleted_by=None)
+        self.other_user.retire(self.domain, deleted_by=None)
 
         detail = UserArchivedRebuild(user_id=self.other_user.user_id)
         expected_call_args = [mock.call(self.domain, case_id, detail) for case_id in case_ids[1:]]
@@ -314,7 +314,7 @@ class RetireUserTestCase(TestCase):
         usercase = self.commcare_user.get_usercase()
         self.assertEqual(2, len(usercase.xform_ids))
 
-        self.commcare_user.retire(deleted_by=None)
+        self.commcare_user.retire(self.domain, deleted_by=None)
 
         for form_id in usercase.xform_ids:
             self.assertTrue(FormAccessors(self.domain).get_form(form_id).is_deleted)
@@ -347,12 +347,12 @@ class RetireUserTestCase(TestCase):
             ).as_text()
         ], self.domain, user_id=self.other_user._id)
 
-        self.commcare_user.retire(deleted_by=None)
+        self.commcare_user.retire(self.domain, deleted_by=None)
 
         self.assertTrue(FormAccessors(self.domain).get_form(xform.form_id).is_deleted)
         self.assertFalse(FormAccessors(self.domain).get_form(double_case_xform.form_id).is_deleted)
 
         # When the other user is deleted then the form should get deleted since it no-longer touches
         # any 'live' cases.
-        self.other_user.retire(deleted_by=None)
+        self.other_user.retire(self.domain, deleted_by=None)
         self.assertTrue(FormAccessors(self.domain).get_form(double_case_xform.form_id).is_deleted)

--- a/corehq/apps/users/tests/sync.py
+++ b/corehq/apps/users/tests/sync.py
@@ -84,7 +84,7 @@ class SyncCommCareUserTestCase(TestCase):
         self.assertEqual(len(self.commcare_user.first_name), 50)
 
     def test_retire(self):
-        self.commcare_user.retire(deleted_by=None)
+        self.commcare_user.retire(self.domain, deleted_by=None)
         self.assertEqual(User.objects.filter(username=self.commcare_user.username).count(), 0)
 
         self.commcare_user = CommCareUser.create(self.domain, self.username, self.password, None, None)

--- a/corehq/apps/users/tests/test_dbaccessors.py
+++ b/corehq/apps/users/tests/test_dbaccessors.py
@@ -103,7 +103,7 @@ class AllCommCareUsersTest(TestCase):
             created_via=None,
             email='retired_user_email@example.com',
         )
-        cls.retired_user.retire(deleted_by=None)
+        cls.retired_user.retire(cls.ccdomain.name, deleted_by=None)
 
     @classmethod
     def tearDownClass(cls):
@@ -231,7 +231,7 @@ class AllCommCareUsersTest(TestCase):
             created_via=None,
             email='deleted_email@example.com',
         )
-        deleted_user.retire(deleted_by=None)
+        deleted_user.retire(self.ccdomain.name, deleted_by=None)
         self.assertNotIn(
             deleted_user.username,
             [user.username for user in

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -457,7 +457,8 @@ def force_user_412(request, domain, user_id):
 @require_POST
 def restore_commcare_user(request, domain, user_id):
     user = CommCareUser.get_by_user_id(user_id, domain)
-    success, message = user.unretire(unretired_by=request.user, unretired_via=USER_CHANGE_VIA_WEB)
+    success, message = user.unretire(request.domain, unretired_by=request.couch_user,
+                                     unretired_via=USER_CHANGE_VIA_WEB)
     if success:
         messages.success(request, "User %s and all their submissions have been restored" % user.username)
     else:

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -428,7 +428,7 @@ def delete_commcare_user(request, domain, user_id):
         messages.error(request, _("This is a location user. You must delete the "
                        "corresponding location before you can delete this user."))
         return HttpResponseRedirect(reverse(EditCommCareUserView.urlname, args=[domain, user_id]))
-    user.retire(deleted_by=request.user, deleted_via=USER_CHANGE_VIA_WEB)
+    user.retire(request.domain, deleted_by=request.couch_user, deleted_via=USER_CHANGE_VIA_WEB)
     messages.success(request, "User %s has been deleted. All their submissions and cases will be permanently deleted in the next few minutes" % user.username)
     return HttpResponseRedirect(reverse(MobileWorkerListView.urlname, args=[domain]))
 

--- a/testapps/test_pillowtop/tests/test_user_pillow.py
+++ b/testapps/test_pillowtop/tests/test_user_pillow.py
@@ -58,7 +58,7 @@ class UserPillowTest(UserPillowTestBase):
     def test_kafka_user_pillow_deletion(self):
         user = self._make_and_test_user_kafka_pillow('test-kafka-user_deletion')
         # soft delete
-        user.retire(deleted_by=None)
+        user.retire(TEST_DOMAIN, deleted_by=None)
 
         # send to kafka
         since = get_topic_offset(topics.COMMCARE_USER)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
:fish: / :fish: 
Builds on the [base setup](https://github.com/dimagi/commcare-hq/pull/29887) to track user retire/unretire for mobile workers, which is triggered when a mobile user is deleted/restored.
A "retire" is treated like a "Delete" action and "unretire" as "Create".

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No UI changes.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
same as base PR

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This was first run of master to run tests and only after a [green build](https://travis-ci.com/github/dimagi/commcare-hq/builds/228646860), base was changed to mk/user-history/base

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
same as base PR
