### PR TITLE
Reminders: Fix session endpoint calculations

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -12,6 +12,7 @@ from corehq.apps.app_manager.suite_xml.xml_models import Instance
 
 
 class EntryInstances(PostProcessor):
+    """Adds instance declarations to the suite file"""
 
     def update_suite(self):
         for entry in self.suite.entries:

--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -69,14 +69,12 @@ class WorkflowHelper(PostProcessor):
 
     def get_frame_children(self, module, form=None, include_root_module=False):
         """
-        For a form return the list of stack frame children that are required
-        to navigate to that form; a mix of commands and datum declarations.
-
-        Given command may be a form (mX-fY) or case list menu item (mX-case-list).
+        For a form or module return the list of stack frame children that are required
+        to navigate there; a mix of commands and datum declarations.
 
         This is based on the following algorithm:
 
-        * Add the module the form is in to the stack (we'll call this `m`)
+        * Add the module (or form's module) to the stack (we'll call this `m`)
         * Walk through all forms in the module, determine what datum selections
           are present in all of the forms (this may be an empty set)
           * Basically if there are three forms that respectively load
@@ -85,6 +83,8 @@ class WorkflowHelper(PostProcessor):
             * f3: v1, v2
           * The longest common chain is v1, v2
         * Add a datum for each of those values to the stack
+
+        For forms:
         * Add the form "command id" for the <entry> to the stack
         * Add the remainder of the datums for the current form to the stack
         * For the three forms above, the stack entries for "last element" would be

--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -47,7 +47,15 @@ class WorkflowHelper(PostProcessor):
                 else:
                     stack_frames.extend(CaseListFormWorkflow(self).case_list_forms_frames(form))
 
-                self._create_workflow_stack(form_command, stack_frames)
+                frames = [_f for _f in [meta.to_frame() for meta in stack_frames if meta is not None] if _f]
+                if frames:
+
+                    entry = self._get_form_entry(form_command)
+                    if not entry.stack:
+                        entry.stack = Stack()
+
+                    for frame in frames:
+                        entry.stack.add_frame(frame)
 
     def get_frame_children(self, command, target_module, module_only=False, include_target_root=False):
         """
@@ -112,18 +120,6 @@ class WorkflowHelper(PostProcessor):
             frame_children.extend(remaining_datums)
 
         return frame_children
-
-    def _create_workflow_stack(self, form_command, frame_metas):
-        frames = [_f for _f in [meta.to_frame() for meta in frame_metas if meta is not None] if _f]
-        if not frames:
-            return
-
-        entry = self._get_form_entry(form_command)
-        if not entry.stack:
-            entry.stack = Stack()
-
-        for frame in frames:
-            entry.stack.add_frame(frame)
 
     def get_form_datums(self, form):
         """

--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -552,7 +552,7 @@ class StackFrameMeta(object):
 
         for child in children:
             if isinstance(child, CommandId):
-                frame.add_command(XPath.string(child.id))
+                frame.add_command(child.to_command())
             elif isinstance(child, StackDatum):
                 frame.add_datum(child)
             else:
@@ -577,6 +577,9 @@ class CommandId(object):
 
     def __repr__(self):
         return 'ModuleCommand(id={})'.format(self.id)
+
+    def to_command(self):
+        return XPath.string(self.id)
 
 
 @total_ordering

--- a/corehq/apps/app_manager/suite_xml/sections/endpoints.py
+++ b/corehq/apps/app_manager/suite_xml/sections/endpoints.py
@@ -29,28 +29,27 @@ class SessionEndpointContributor(SuiteContributorByModule):
     def get_module_contributions(self, module) -> List[SessionEndpoint]:
         endpoints = []
         if module.session_endpoint_id:
-            endpoints.append(self._get_module_endpoint(module))
+            endpoints.append(self._make_session_endpoint(module))
         for form in module.get_suite_forms():
             if form.session_endpoint_id:
-                endpoints.append(self._get_form_endpoint(form, module))
+                endpoints.append(self._make_session_endpoint(module, form))
         return endpoints
 
-    def _get_module_endpoint(self, module):
-        id_string = id_strings.case_list_command(module)
-        return self._make_session_endpoint(id_string, module, module.session_endpoint_id)
+    def _make_session_endpoint(self, module, form=None):
+        if form is not None:
+            endpoint_id = form.session_endpoint_id
+            id_string = id_strings.form_command(form)
+        else:
+            endpoint_id = module.session_endpoint_id
+            id_string = id_strings.case_list_command(module)
 
-    def _get_form_endpoint(self, form, module):
-        id_string = id_strings.form_command(form)
-        return self._make_session_endpoint(id_string, module, form.session_endpoint_id)
-
-    def _make_session_endpoint(self, id_string, module, endpoint_id):
         stack = Stack()
         frame = PushFrame()
         stack.add_frame(frame)
         frame.add_command(XPath.string(id_string))
         arguments = []
         helper = WorkflowHelper(self.suite, self.app, self.modules)
-        for child in helper.get_frame_children(id_string, module):
+        for child in helper.get_frame_children(module, form):
             if isinstance(child, WorkflowDatumMeta):
                 arguments.append(Argument(id=child.id))
                 frame.add_datum(

--- a/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
+++ b/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
@@ -95,9 +95,9 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
                         <push>
                             <command value="'m0'"/>
                             <command value="'m1'"/>
-                            <command value="'m1-f0'"/>
                             <datum id="parent_id" value="$parent_id"/>
                             <datum id="case_id" value="$case_id"/>
+                            <command value="'m1-f0'"/>
                         </push>
                     </stack>
                 </endpoint>
@@ -133,9 +133,9 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
                         <push>
                             <command value="'m0'"/>
                             <command value="'m1'"/>
-                            <command value="'m1-f0'"/>
                             <datum id="parent_id" value="$parent_id"/>
                             <datum id="case_id" value="$case_id"/>
+                            <command value="'m1-f0'"/>
                         </push>
                     </stack>
                 </endpoint>

--- a/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
+++ b/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
@@ -64,10 +64,10 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
                 <endpoint id="my_form">
                     <argument id="case_id"/>
                     <stack>
-                    <push>
-                        <command value="'m0-f0'"/>
-                        <datum id="case_id" value="$case_id"/>
-                    </push>
+                        <push>
+                            <command value="'m0-f0'"/>
+                            <datum id="case_id" value="$case_id"/>
+                        </push>
                     </stack>
                 </endpoint>
             </partial>
@@ -90,11 +90,11 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
                     <argument id="parent_id"/>
                     <argument id="case_id"/>
                     <stack>
-                    <push>
-                        <command value="'m1-f0'"/>
-                        <datum id="parent_id" value="$parent_id"/>
-                        <datum id="case_id" value="$case_id"/>
-                    </push>
+                        <push>
+                            <command value="'m1-f0'"/>
+                            <datum id="parent_id" value="$parent_id"/>
+                            <datum id="case_id" value="$case_id"/>
+                        </push>
                     </stack>
                 </endpoint>
             </partial>
@@ -125,11 +125,11 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
                     <argument id="parent_id"/>
                     <argument id="case_id"/>
                     <stack>
-                    <push>
-                        <command value="'m1-f0'"/>
-                        <datum id="parent_id" value="$parent_id"/>
-                        <datum id="case_id" value="$case_id"/>
-                    </push>
+                        <push>
+                            <command value="'m1-f0'"/>
+                            <datum id="parent_id" value="$parent_id"/>
+                            <datum id="case_id" value="$case_id"/>
+                        </push>
                     </stack>
                 </endpoint>
             </partial>
@@ -145,9 +145,9 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
             <partial>
                 <endpoint id="my_case_list">
                     <stack>
-                    <push>
-                        <command value="'m0-case-list'"/>
-                    </push>
+                        <push>
+                            <command value="'m0-case-list'"/>
+                        </push>
                     </stack>
                 </endpoint>
             </partial>
@@ -163,9 +163,9 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
             <partial>
                 <endpoint id="my_case_list">
                     <stack>
-                    <push>
-                        <command value="'m1-case-list'"/>
-                    </push>
+                        <push>
+                            <command value="'m1-case-list'"/>
+                        </push>
                     </stack>
                 </endpoint>
             </partial>

--- a/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
+++ b/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
@@ -45,6 +45,7 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
                 <endpoint id="my_form">
                     <stack>
                         <push>
+                            <command value="'m0'"/>
                             <command value="'m0-f0'"/>
                         </push>
                     </stack>
@@ -65,8 +66,9 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
                     <argument id="case_id"/>
                     <stack>
                         <push>
-                            <command value="'m0-f0'"/>
+                            <command value="'m0'"/>
                             <datum id="case_id" value="$case_id"/>
+                            <command value="'m0-f0'"/>
                         </push>
                     </stack>
                 </endpoint>
@@ -91,6 +93,8 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
                     <argument id="case_id"/>
                     <stack>
                         <push>
+                            <command value="'m0'"/>
+                            <command value="'m1'"/>
                             <command value="'m1-f0'"/>
                             <datum id="parent_id" value="$parent_id"/>
                             <datum id="case_id" value="$case_id"/>
@@ -117,6 +121,7 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
                 <endpoint id="my_form">
                     <stack>
                         <push>
+                            <command value="'m0'"/>
                             <command value="'m0-f0'"/>
                         </push>
                     </stack>
@@ -126,6 +131,8 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
                     <argument id="case_id"/>
                     <stack>
                         <push>
+                            <command value="'m0'"/>
+                            <command value="'m1'"/>
                             <command value="'m1-f0'"/>
                             <datum id="parent_id" value="$parent_id"/>
                             <datum id="case_id" value="$case_id"/>
@@ -138,7 +145,7 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
             "./endpoint",
         )
 
-    def test_case_list_session_endpoint_id(self):
+    def test_module_session_endpoint_id(self):
         self.module.session_endpoint_id = 'my_case_list'
         self.assertXmlPartialEqual(
             """
@@ -146,7 +153,7 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
                 <endpoint id="my_case_list">
                     <stack>
                         <push>
-                            <command value="'m0-case-list'"/>
+                            <command value="'m0'"/>
                         </push>
                     </stack>
                 </endpoint>
@@ -157,14 +164,15 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
         )
 
     def test_child_module_session_endpoint_id(self):
-        self.child_module.session_endpoint_id = 'my_case_list'
+        self.child_module.session_endpoint_id = 'my_child_module'
         self.assertXmlPartialEqual(
             """
             <partial>
-                <endpoint id="my_case_list">
+                <endpoint id="my_child_module">
                     <stack>
                         <push>
-                            <command value="'m1-case-list'"/>
+                            <command value="'m0'"/>
+                            <command value="'m1'"/>
                         </push>
                     </stack>
                 </endpoint>


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SC-1581
This PR is mostly a refactor of the end of form navigation code.  I did this while trying to better understand the code to be able to reuse it.  In the end, the session endpoints stuff doesn't need very much code at all, once I was able to figure out what to access and how.

## Feature Flag
Enable session endpoints

## Product Description
This should resolve some of the navigation issues with using session endpoints.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
This issue came up in QA

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Session endpoints is currently in QA, not yet released.  The end-of-form workflow changes shouldn't affect the suite file at all, and there's a pretty good test suite in `test_form_workflow.py` to verify that.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
