### PR TITLE
Tighten access controls on saved report views

### DIFF
--- a/corehq/apps/reports/lookup.py
+++ b/corehq/apps/reports/lookup.py
@@ -1,0 +1,55 @@
+from corehq.apps.domain.models import Domain
+from corehq.apps.domain.utils import get_custom_domain_module
+
+
+class ReportLookup:
+    def __init__(self, report_type):
+        self.report_type = report_type
+
+    def get_reports(self, domain=None):
+        attr_name = self.report_type
+        from corehq import reports
+        if domain:
+            domain_obj = Domain.get_by_name(domain)
+        else:
+            domain_obj = None
+
+        def process(reports):
+            if callable(reports):
+                reports = reports(domain_obj) if domain_obj else tuple()
+            return tuple(reports)
+
+        corehq_reports = process(getattr(reports, attr_name, ()))
+
+        module_name = get_custom_domain_module(domain)
+        if module_name is None:
+            custom_reports = ()
+        else:
+            module = __import__(module_name, fromlist=['reports'])
+            if hasattr(module, 'reports'):
+                reports = getattr(module, 'reports')
+                custom_reports = process(getattr(reports, attr_name, ()))
+            else:
+                custom_reports = ()
+
+        return corehq_reports + custom_reports
+
+    def get_report(self, domain, slug):
+        for name, group in self.get_reports(domain):
+            for report in group:
+                if report.slug == slug:
+                    return report
+
+        return None
+
+
+# TODO: Relying on hard-coded paths like this makes our code brittle.
+# If we do stick with this approach, this should likely be a method on each report,
+# so that reports can determine their own naming conventions.
+# However, a better fix would be to populate a report repository on startup that links
+# report paths to report slugs, and thus allows us to store slugs, not paths, within user permissions
+def get_full_report_name(report):
+    if not report:
+        return ''
+
+    return report.__module__ + '.' + report.__name__

--- a/corehq/apps/reports/lookup.py
+++ b/corehq/apps/reports/lookup.py
@@ -34,6 +34,9 @@ class ReportLookup:
 
         return corehq_reports + custom_reports
 
+    # NOTE: This is largely duplicated in ReportDispatcher.get_report
+    # This should be the primary way that we resolve slugs into report objects,
+    # and we should look into removing the logic from report dispatcher when possible
     def get_report(self, domain, slug):
         for name, group in self.get_reports(domain):
             for report in group:

--- a/corehq/apps/reports/tests/test_dispatcher.py
+++ b/corehq/apps/reports/tests/test_dispatcher.py
@@ -1,0 +1,72 @@
+from django.test import SimpleTestCase, TestCase
+from corehq.apps.domain.shortcuts import create_domain
+
+from ..dispatcher import ProjectReportDispatcher, AdminReportDispatcher, DomainReportDispatcher
+
+
+class ProjectReportDispatcherTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.domain = 'test-domain'
+        cls.domain_obj = create_domain(cls.domain)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_obj.delete()
+
+    def test_no_domain_has_no_reports(self):
+        reports = list(ProjectReportDispatcher.get_reports(None))
+        self.assertEqual(reports, [])
+
+    def test_new_domain_contains_core_reports(self):
+        reports = list(ProjectReportDispatcher.get_reports('test-domain'))
+        monitor_worker_reports = reports[0]
+        inspect_data_reports = reports[1]
+        manage_deployment_reports = reports[2]
+        messaging_reports = reports[3]
+
+        self.assertEqual(monitor_worker_reports[0], 'Monitor Workers')
+        self.assertEqual(inspect_data_reports[0], 'Inspect Data')
+        self.assertEqual(manage_deployment_reports[0], 'Manage Deployments')
+        self.assertEqual(messaging_reports[0], 'Messaging')
+
+    def test_get_report_returns_none_if_not_found(self):
+        report = ProjectReportDispatcher.get_report('test-domain', 'bad-report')
+        self.assertIsNone(report)
+
+    def test_get_report_returns_found_report(self):
+        report = ProjectReportDispatcher.get_report('test-domain', 'worker_activity')
+        self.assertEqual(report.slug, 'worker_activity')
+
+
+class AdminReportDispatcherTests(SimpleTestCase):
+    def test_get_reports_returns_all_admin_reports(self):
+        report_groups = list(AdminReportDispatcher.get_reports(None))
+
+        self.assertEqual(len(report_groups), 1)
+        name, domain_stat_reports = report_groups[0]
+        self.assertEqual(name, 'Domain Stats')
+        report_names = {report.slug for report in domain_stat_reports}
+        self.assertEqual(report_names, {
+            'user_list_report',
+            'user_audit_report',
+            'device_log_soft_asserts',
+            'deploy_history_report',
+            'phone_number_report'
+        })
+
+
+class DomainReportDispatcherTests(SimpleTestCase):
+    def test_get_reports_returns_correct_report_names(self):
+        report_groups = list(DomainReportDispatcher.get_reports(None))
+
+        self.assertEqual(len(report_groups), 1)
+        name, project_settings_reports = report_groups[0]
+        self.assertEqual(name, 'Project Settings')
+        report_names = {report.slug for report in project_settings_reports}
+        self.assertEqual(report_names, {
+            'incremental_export_logs',
+            'couch_repeat_record_report',
+            'project_link_report',
+            'repeat_record_report'
+        })

--- a/corehq/apps/reports/tests/test_views.py
+++ b/corehq/apps/reports/tests/test_views.py
@@ -1,0 +1,578 @@
+import io
+
+from urllib.parse import urlencode
+from couchdbkit import ResourceNotFound
+from django.http.response import Http404
+from django.core.exceptions import PermissionDenied
+from django.test import TestCase, RequestFactory
+from unittest.mock import patch
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import Permissions, UserRole, WebUser
+from corehq.apps.saved_reports.models import ReportConfig, ReportNotification
+from corehq.blobs import get_blob_db
+import unittest
+
+from .. import views
+
+REPORT_NAME_LOOKUP = {
+    'worker_activity': 'corehq.apps.reports.standard.monitoring.WorkerActivityReport'
+}
+
+
+class TestEmailReport(TestCase):
+    ARG_INDEX = 0
+    RECIPIENT_INDEX = 0
+
+    @patch.object(views, 'send_email_report')
+    def test_user_can_send_email(self, mock_send_email):
+        self._set_user_report_access(REPORT_NAME_LOOKUP['worker_activity'])
+        response = self.email_report(report_name='worker_activity')
+        mock_send_email.delay.assert_called_once()
+        self.assertEqual(response.status_code, 200)
+
+    @patch.object(views, 'send_email_report')
+    def test_email_is_sent_to_recipient_list(self, mock_send_email):
+        # NOTE: It appears the email form is broken and will only accept a single email
+        # so that's all that is being tested here
+        self.request = self._create_request(params={'recipient_emails': 'user1@test.com'})
+        self.email_report()
+
+        self.assertEqual(
+            mock_send_email.delay.call_args[self.ARG_INDEX][self.RECIPIENT_INDEX],
+            {'user1@test.com'}
+        )
+
+    @patch.object(views, 'send_email_report')
+    def test_owner_flag_adds_owner_email_to_recipient_list(self, mock_send_email):
+        # Setup creates a user with email address 'test_user@dimagi.com'
+        self.request = self._create_request(params={
+            'recipient_emails': 'user1@test.com',
+            'send_to_owner': True
+        })
+        self.email_report()
+
+        self.assertEqual(
+            mock_send_email.delay.call_args[self.ARG_INDEX][self.RECIPIENT_INDEX],
+            {'test_user@dimagi.com', 'user1@test.com'}
+        )
+
+    def test_invalid_form_returns_bad_request(self):
+        invalid_form_params = {}
+        self.request = self._create_request(params=invalid_form_params)
+        response = self.email_report()
+        self.assertEqual(response.status_code, 400)
+
+    def test_invalid_slug_returns_404(self):
+        with self.assertRaises(Http404):
+            self.email_report(report_name='nonexistant_report')
+
+    def test_when_user_cannot_view_report_receives_404(self):
+        self._set_user_report_access('not_this_report')
+        with self.assertRaises(Http404):
+            self.email_report(report_name='worker_activity')
+
+# ################ Helpers / Setup
+    def email_report(self, domain=None, report_name='worker_activity'):
+        domain = domain or self.domain
+        return views.email_report(self.request, domain, report_name, once=True)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'test-domain'
+        cls.domain_obj = create_domain(cls.domain)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+
+        self.reports_role = UserRole.create(self.domain, 'Test Role', permissions=Permissions(
+            view_report_list=[REPORT_NAME_LOOKUP['worker_activity']]
+        ))
+
+        self.user = WebUser.create(self.domain,
+            'test_user@dimagi.com',
+            'test_password',
+            None,
+            None,
+            role_id=self.reports_role._id)
+
+        self.user.is_authenticated = True
+        self.request = self._create_request()
+
+    def tearDown(self):
+        self.user.delete(deleted_by=None)
+        self.reports_role.delete()
+
+        super().tearDown()
+
+    def _create_request(self, params=None):
+        if params is None:
+            params = {'send_to_owner': True}
+
+        params = urlencode(params)
+
+        base_url = f'/a/{self.domain}/emailReport'
+        url = f'{base_url}?{params}'
+        request = RequestFactory().get(url)
+        request.user = self.user
+        return request
+
+    def _set_user_report_access(self, *report_names):
+        self.reports_role.permissions = Permissions(view_report_list=list(report_names))
+        self.reports_role.save()
+
+
+class TestDeleteConfig(TestCase):
+    def test_invalid_config_id_returns_404(self):
+        with self.assertRaises(Http404):
+            self.delete_config(config_id='nonexistant_config_id')
+
+    def test_mismatched_domains_returns_404(self):
+        report = self._create_saved_report(domain='not_your_domain')
+
+        with self.assertRaises(Http404):
+            self.delete_config(domain=self.domain, config_id=report._id)
+
+    def test_non_owner_cannot_delete_saved_report(self):
+        report = self._create_saved_report(user_id='not_you')
+
+        with self.assertRaises(Http404):
+            self.delete_config(config_id=report._id)
+
+    def test_can_delete_saved_report(self):
+        report = self._create_saved_report(domain=self.domain, user_id=self.user._id)
+
+        response = self.delete_config(self.domain, report._id)
+        self.assertEqual(response.status_code, 200)
+
+        with self.assertRaises(ResourceNotFound):
+            ReportConfig.get(report._id)
+
+# ############ Helper / Setup
+    def delete_config(self, domain=None, config_id='test'):
+        domain = domain or self.domain
+        return views.delete_config(self.request, domain, config_id)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'test-domain'
+        cls.domain_obj = create_domain(cls.domain)
+        cls.user = WebUser.create(cls.domain, 'test_user', 'test_password', None, None)
+        cls.user.is_authenticated = True
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete(deleted_by=None)
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        self.request = self._create_request()
+
+    def _create_request(self):
+        url = f'/a/{self.domain}/deleteConfig'
+        request = RequestFactory().delete(url)
+        request.user = self.user
+        return request
+
+    def _create_saved_report(self, domain=None, user_id=None):
+        config = ReportConfig(
+            domain=domain or self.domain,
+            owner_id=user_id or self.user._id,
+            name='Test',
+            description='Test Saved Report',
+            report_slug='worker_activity',
+            report_type='project_report'
+        )
+        config.save()
+        self.addCleanup(config.delete)
+
+        return config
+
+
+class TestDeleteScheduledReport(TestCase):
+    def test_invalid_report_redirects_to_home(self):
+        response = self.delete_scheduled_report(report_id='invalid_report_id')
+        self.assertEqual(response.status_code, 302)
+
+    def test_mismatched_domains_returns_404(self):
+        report = self._create_report(domain='not_your_domain')
+
+        with self.assertRaises(Http404):
+            self.delete_scheduled_report(domain=self.domain, report_id=report._id)
+
+    def test_user_without_permissions_cannot_delete_report(self):
+        report = self._create_report(owner_id='not_you')
+
+        with self.assertRaises(Http404):
+            self.delete_scheduled_report(user=self.user, report_id=report._id)
+
+    @patch.object(views.messages, 'success')
+    def test_owner_can_delete_report(self, mock_success):
+        report = self._create_report(owner_id=self.user._id)
+
+        response = self.delete_scheduled_report(user=self.user, report_id=report._id)
+        self.assertEqual(response.status_code, 302)
+        with self.assertRaises(ResourceNotFound):
+            ReportNotification.get(report._id)
+
+    @patch.object(views.messages, 'success')
+    def test_domain_admin_can_delete_report(self, mock_success):
+        domain_admin = self._create_user(username='domain_admin', is_admin=True)
+        report = self._create_report(owner_id=self.user._id)
+
+        response = self.delete_scheduled_report(user=domain_admin, report_id=report._id)
+        self.assertEqual(response.status_code, 302)
+        with self.assertRaises(ResourceNotFound):
+            ReportNotification.get(report._id)
+
+# ################## Helpers / Setup
+    def delete_scheduled_report(self, user=None, domain=None, report_id='test_report'):
+        if user:
+            self.request.user = user
+
+        domain = domain or self.domain
+        return views.delete_scheduled_report(self.request, domain, report_id)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'test-domain'
+        cls.domain_obj = create_domain(cls.domain)
+
+        cls.user = WebUser.create(cls.domain, 'test_user', 'test_password', None, None)
+        cls.user.is_authenticated = True
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete(deleted_by=None)
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        self.request = self._create_request()
+
+    def _create_user(self, username='test_user', is_admin=False):
+        user = WebUser.create(self.domain, username, 'test_password', None, None, is_admin=is_admin)
+        user.is_authenticated = True
+
+        self.addCleanup(user.delete, deleted_by=None)
+        return user
+
+    def _create_request(self):
+        url = f'/a/{self.domain}/delete_scheduled_report'
+        request = RequestFactory().post(url)
+        request.user = self.user
+        return request
+
+    def _create_report(self, domain=None, owner_id=None):
+        domain = domain or self.domain
+        owner_id = owner_id or self.user._id
+        report = ReportNotification(domain=domain, owner_id=owner_id)
+        report.save()
+        self.addCleanup(report.delete)
+        return report
+
+
+class TestSendTestScheduledReport(TestCase):
+    def test_invalid_report_raises_404(self):
+        with self.assertRaises(Http404):
+            self.send_scheduled_report('invalid_report_id')
+
+    def test_mismatched_domains_returns_404(self):
+        report = self._create_saved_report(domain='not_your_domain')
+
+        with self.assertRaises(Http404):
+            self.send_scheduled_report(report._id, domain=self.domain)
+
+    @patch.object(views.messages, 'success')
+    def test_owner_can_send_report(self, mock_success):
+        report = self._create_saved_report(owner_id=self.user._id)
+
+        response = self.send_scheduled_report(report._id, user=self.user)
+        self.assertEqual(response.status_code, 302)
+
+    @patch.object(views.messages, 'success')
+    def test_domain_admin_can_send_report(self, mock_success):
+        domain_admin = self._create_user(username='domain-admin', is_admin=True)
+
+        report = self._create_saved_report(owner_id=self.user._id)
+
+        response = self.send_scheduled_report(report._id, user=domain_admin)
+        self.assertEqual(response.status_code, 302)
+
+# ############## Helpers / Setup
+    def send_scheduled_report(self, report_id, domain=None, user=None):
+        if user:
+            self.request.user = user
+
+        domain = domain or self.domain
+        return views.send_test_scheduled_report(self.request, domain, report_id)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'test-domain'
+        cls.domain_obj = create_domain(cls.domain)
+
+        cls.user = WebUser.create(cls.domain, 'test_user', 'test_password', None, None)
+        cls.user.is_authenticated = True
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete(deleted_by=None)
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        self.request = self._create_request()
+
+    def _create_user(self, username='test_user', is_admin=False):
+        user = WebUser.create(self.domain, username, 'test_password', None, None, is_admin=is_admin)
+        user.is_authenticated = True
+
+        self.addCleanup(user.delete, deleted_by=None)
+        return user
+
+    def _create_request(self):
+        url = f'/a/{self.domain}/sendScheduledReport'
+        request = RequestFactory().get(url)
+        request.user = self.user
+        return request
+
+    def _create_saved_report(self, domain=None, owner_id=None):
+        domain = domain or self.domain
+        owner_id = owner_id or self.user._id
+        report = ReportNotification(domain=domain, owner_id=owner_id)
+        report.save()
+
+        self.addCleanup(report.delete)
+        return report
+
+
+class TestExportReport(TestCase):
+    def test_invalid_hash_returns_404(self):
+        response = self.retrieve_exported_report(export_id='invalid_export_hash')
+        self.assertEqual(response.status_code, 404)
+
+    def test_mismatched_domain_returns_404(self):
+        self._generate_report(domain='not_your_domain')
+
+        with self.assertRaises(Http404):
+            self.retrieve_exported_report(domain=self.domain)
+
+    def test_user_lacking_permissions_returns_error(self):
+        self._generate_report(report_name='my_report')
+        self._set_user_report_access('not_this_report')
+
+        with self.assertRaises(PermissionDenied):
+            self.retrieve_exported_report()
+
+    def test_authorized_user_can_retrieve_report(self):
+        self._generate_report(report_name='my_report', content=b'Some File')
+        self._set_user_report_access('my_report')
+
+        response = self.retrieve_exported_report()
+        self.assertEqual(response.content, b'Some File')
+
+    def retrieve_exported_report(self, export_id=None, domain=None):
+        if not export_id:
+            export_id = self.export_id
+
+        if not domain:
+            domain = self.domain
+
+        return views.export_report(self.request, domain, export_id, 'xlsx')
+
+# ################ Helpers / Setup
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'test-domain'
+        cls.domain_obj = create_domain(cls.domain)
+
+        cls.db = get_blob_db()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+
+        # Create a basic role for the user
+        self.reports_role = UserRole.create(self.domain, 'Test Role', permissions=Permissions(
+            view_report_list=[]
+        ))
+
+        self.user = WebUser.create(self.domain,
+            'test_user',
+            'test_password',
+            None,
+            None,
+            role_id=self.reports_role._id)
+
+        self.user.is_authenticated = True
+        self.request = self._create_request()
+
+        self.export_id = 'export_id'
+
+    def tearDown(self):
+        self.user.delete(deleted_by=None)
+        self.reports_role.delete()
+        super().tearDown()
+
+    def _create_request(self):
+        url = f'/a/{self.domain}/exportReport'
+        request = RequestFactory().get(url)
+        request.user = self.user
+        return request
+
+    def _set_user_report_access(self, *report_names):
+        # NOTE: user permissions get cached, so if these permissions
+        # were changed between checks, the cache would need to be cleared
+        self.reports_role.permissions = Permissions(view_report_list=list(report_names))
+        self.reports_role.save()
+
+    def _generate_report(self, export_id=None, report_name='test_report', domain=None, content=b'Some File'):
+        export_id = export_id or self.export_id
+        domain = domain or self.domain
+        file = io.BytesIO(content)
+        self.db.put(file,
+            domain=domain,
+            name='MyTestExport',
+            parent_id=export_id,
+            key=export_id,
+            type_code=1,
+            timeout=300,
+            properties={'report_class': report_name})
+        self.addCleanup(self.db.delete, export_id)
+
+
+class TestViewScheduledReport(TestCase):
+    def test_missing_report_returns_404(self):
+        with self.assertRaises(Http404):
+            self.view_scheduled_report('nonexistant_id')
+
+    def test_mismatched_domains_returns_404(self):
+        report = self._create_scheduled_report(domain='not_your_domain')
+
+        with self.assertRaises(Http404):
+            self.view_scheduled_report(report._id, domain=self.domain)
+
+    def test_user_with_no_report_access_receives_404(self):
+        self._set_user_report_access()  # Ensure the user has access to no reports
+        # User should be unable to view even his own report
+        scheduled_report = self._create_scheduled_report(owner_id=self.user._id)
+
+        with self.assertRaises(Http404):
+            self.view_scheduled_report(scheduled_report._id)
+
+    def test_user_without_scheduled_report_access_recieves_404(self):
+        scheduled_report = self._create_scheduled_report(owner_id='not_you')
+
+        with self.assertRaises(Http404):
+            self.view_scheduled_report(scheduled_report._id)
+
+    def test_user_without_permissions_receives_error_message(self):
+        saved_report = self._create_saved_report(user_id='not_you')
+        scheduled_report = self._create_scheduled_report(config_ids=[saved_report._id])
+
+        with self.assertRaises(Http404):
+            self.view_scheduled_report(scheduled_report._id)
+
+    @unittest.skip
+    def test_can_view_scheduled_report(self):
+        # TODO: Likely need to look into `send_to_elasticsarch`, especially in some existing
+        # tests, to figure out how to populate elasticsearch so that the resulting report
+        # can be generated
+        saved_report = self._create_saved_report(slug='worker_activity')
+        scheduled_report = self._create_scheduled_report(config_ids=[saved_report._id])
+
+        self._set_user_report_access(REPORT_NAME_LOOKUP['worker_activity'])
+
+        response = self.view_scheduled_report(scheduled_report._id)
+        self.assertEqual(response.status_code, 200)
+
+# ################### Helpers / Setup
+
+    def view_scheduled_report(self, report_id, domain=None):
+        domain = domain or self.domain
+        return views.view_scheduled_report(self.request, domain, report_id)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'test-domain'
+        cls.domain_obj = create_domain(cls.domain)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        self.reports_role = UserRole.create(self.domain, 'Test Role', permissions=Permissions(
+            view_report_list=[]
+        ))
+        self.user = WebUser.create(self.domain,
+            'test_user',
+            'test_password',
+            None,
+            None,
+            role_id=self.reports_role._id)
+        self.user.is_authenticated = True
+        self.request = self._create_request()
+
+    def tearDown(self):
+        self.user.delete(deleted_by=None)
+        self.reports_role.delete()
+        super().tearDown()
+
+    def _create_request(self):
+        url = f'/a/{self.domain}/view_scheduled_report'
+        request = RequestFactory().get(url)
+        request.user = self.user
+        return request
+
+    def _create_saved_report(self, domain=None, user_id=None, slug='worker_activity'):
+        config = ReportConfig(
+            domain=domain or self.domain,
+            owner_id=user_id or self.user._id,
+            name='Test',
+            description='Test Saved Report',
+            report_slug=slug,
+            report_type='project_report'
+        )
+        config.save()
+        self.addCleanup(config.delete)
+
+        return config
+
+    def _create_scheduled_report(self, domain=None, owner_id=None, config_ids=['fake']):
+        domain = domain or self.domain
+        owner_id = owner_id or self.user._id
+        report = ReportNotification(domain=domain, owner_id=owner_id, config_ids=config_ids)
+        report.save()
+
+        self.addCleanup(report.delete)
+
+        return report
+
+    def _set_user_report_access(self, *report_names):
+        # NOTE: user permissions get cached, so if these permissions
+        # were changed between checks, the cache would need to be cleared
+        self.reports_role.permissions = Permissions(view_report_list=list(report_names))
+        self.reports_role.save()

--- a/corehq/apps/reports/tests/test_views.py
+++ b/corehq/apps/reports/tests/test_views.py
@@ -198,7 +198,7 @@ class TestDeleteConfig(TestCase):
 
 
 class TestDeleteScheduledReport(TestCase):
-    def test_invalid_report_redirects_to_home(self):
+    def test_invalid_report_redirects(self):
         response = self.delete_scheduled_report(report_id='invalid_report_id')
         self.assertEqual(response.status_code, 302)
 

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -120,7 +120,7 @@ urlpatterns = [
     # once off email
     url(r"^email_onceoff/(?P<report_slug>[\w_]+)/$", email_report, kwargs=dict(once=True), name='email_report'),
     url(r"^custom/email_onceoff/(?P<report_slug>[\w_]+)/$", email_report,
-        kwargs=dict(dispatcher_klass=CustomProjectReportDispatcher, once=True), name='email_onceoff'),
+        kwargs=dict(dispatcher_class=CustomProjectReportDispatcher, once=True), name='email_onceoff'),
 
     # Saved reports
     url(r"^configs$", AddSavedReportConfigView.as_view(), name=AddSavedReportConfigView.name),

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -120,7 +120,7 @@ urlpatterns = [
     # once off email
     url(r"^email_onceoff/(?P<report_slug>[\w_]+)/$", email_report, kwargs=dict(once=True), name='email_report'),
     url(r"^custom/email_onceoff/(?P<report_slug>[\w_]+)/$", email_report,
-        kwargs=dict(report_type=CustomProjectReportDispatcher.prefix, once=True), name='email_onceoff'),
+        kwargs=dict(dispatcher_klass=CustomProjectReportDispatcher, once=True), name='email_onceoff'),
 
     # Saved reports
     url(r"^configs$", AddSavedReportConfigView.as_view(), name=AddSavedReportConfigView.name),

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -165,6 +165,7 @@ from no_exceptions.exceptions import Http403
 
 from .dispatcher import ProjectReportDispatcher
 from .forms import SavedReportConfigForm
+from .lookup import ReportLookup, get_full_report_name
 from .standard import ProjectReport, inspect
 from .standard.cases.basic import CaseListReport
 
@@ -298,14 +299,11 @@ class MySavedReportsView(BaseProjectReportSectionView):
                                                         include_docs=True, startkey=key, endkey=key + [{}])
         user = self.request.couch_user
         user_email = user.get_email()
-        is_admin = user.is_domain_admin(self.domain)
         for scheduled_report in all_scheduled_reports:
             if not _is_valid(scheduled_report) or user_email == scheduled_report.owner_email:
                 continue
             self._adjust_report_day_and_time(scheduled_report)
-            if is_admin:
-                ret.append(scheduled_report)
-            elif user_email in scheduled_report.all_recipient_emails:
+            if scheduled_report.can_be_viewed_by(user):
                 ret.append(scheduled_report)
         return sorted(ret, key=self._report_sort_key())
 
@@ -468,12 +466,15 @@ class AddSavedReportConfigView(View):
 
 @login_and_domain_required
 @datespan_default
-def email_report(request, domain, report_slug, report_type=ProjectReportDispatcher.prefix, once=False):
+def email_report(request, domain, report_slug, dispatcher_klass=ProjectReportDispatcher, once=False):
     from .forms import EmailReportForm
 
     form = EmailReportForm(request.GET)
     if not form.is_valid():
         return HttpResponseBadRequest()
+
+    if not _can_email_report(report_slug, request, dispatcher_klass, domain):
+        raise Http404()
 
     recipient_emails = set(form.cleaned_data['recipient_emails'])
     if form.cleaned_data['send_to_owner']:
@@ -481,24 +482,49 @@ def email_report(request, domain, report_slug, report_type=ProjectReportDispatch
 
     request_data = request_as_dict(request)
 
+    report_type = dispatcher_klass.prefix
     send_email_report.delay(recipient_emails, domain, report_slug, report_type,
                             request_data, once, form.cleaned_data)
     return HttpResponse()
+
+
+def _can_email_report(report_slug, request, dispatcher_klass, domain):
+    dispatcher = dispatcher_klass()
+    lookup = ReportLookup(dispatcher.map_name)
+    report = lookup.get_report(domain, report_slug)
+    if not report:
+        return False
+
+    report_name = get_full_report_name(report)
+    if not dispatcher.permissions_check(report_name, request, domain):
+        return False
+
+    return True
 
 
 @login_and_domain_required
 @require_http_methods(['DELETE'])
 def delete_config(request, domain, config_id):
     try:
-        config = ReportConfig.get(config_id)
+        saved_report = ReportConfig.get(config_id)
     except ResourceNotFound:
         raise Http404()
 
-    config.delete()
+    if not _can_delete_saved_report(saved_report, request.couch_user, domain):
+        raise Http404()
+
+    saved_report.delete()
     ProjectReportsTab.clear_dropdown_cache(domain, request.couch_user)
 
     touch_saved_reports_views(request.couch_user, domain)
     return HttpResponse()
+
+
+def _can_delete_saved_report(report, user, domain):
+    if domain != report.domain:
+        return False
+
+    return user._id == report.owner_id
 
 
 def normalize_hour(hour):
@@ -798,21 +824,33 @@ class ReportNotificationUnsubscribeView(TemplateView):
 def delete_scheduled_report(request, domain, scheduled_report_id):
     user = request.couch_user
     try:
-        rep = ReportNotification.get(scheduled_report_id)
+        scheduled_report = ReportNotification.get(scheduled_report_id)
     except ResourceNotFound:
         # was probably already deleted by a fast-clicker.
         pass
     else:
-        if user._id != rep.owner._id and not user.is_domain_admin(domain):
-            return HttpResponseBadRequest()
+        if not _can_delete_scheduled_report(scheduled_report, user, domain):
+            raise Http404()
 
-        rep.delete()
+        scheduled_report.delete()
         messages.success(request, "Scheduled report deleted!")
     return HttpResponseRedirect(reverse("reports_home", args=(domain,)))
 
 
+def _can_delete_scheduled_report(report, user, domain):
+    if report.domain != domain:
+        return False
+
+    if user._id != report.owner_id and not user.is_domain_admin(domain):
+        return False
+
+    return True
+
+
 @login_and_domain_required
 def send_test_scheduled_report(request, domain, scheduled_report_id):
+    if not _can_send_test_report(scheduled_report_id, request.couch_user, domain):
+        raise Http404()
 
     try:
         send_delayed_report(scheduled_report_id)
@@ -826,6 +864,21 @@ def send_test_scheduled_report(request, domain, scheduled_report_id):
     return HttpResponseRedirect(reverse("reports_home", args=(domain,)))
 
 
+def _can_send_test_report(report_id, user, domain):
+    try:
+        report = ReportNotification.get(report_id)
+    except ResourceNotFound:
+        return False
+
+    if report.domain != domain:
+        return False
+
+    if user._id != report.owner._id and not user.is_domain_admin(domain):
+        return False
+
+    return True
+
+
 def get_scheduled_report_response(couch_user, domain, scheduled_report_id,
                                   email=True, attach_excel=False,
                                   send_only_active=False, request=None):
@@ -837,6 +890,17 @@ def get_scheduled_report_response(couch_user, domain, scheduled_report_id,
     be sent.
     """
     # todo: clean up this API?
+    domain_obj = Domain.get_by_name(domain)
+    if not user_can_view_reports(domain_obj, couch_user):
+        raise Http404
+
+    scheduled_report = ReportNotification.get_report(scheduled_report_id)
+    if not scheduled_report:
+        raise Http404
+
+    if not (scheduled_report.domain == domain and scheduled_report.can_be_viewed_by(couch_user)):
+        raise Http404
+
     from django.http import HttpRequest
     if not request:
         request = HttpRequest()
@@ -844,19 +908,16 @@ def get_scheduled_report_response(couch_user, domain, scheduled_report_id,
         request.user = couch_user.get_django_user()
         request.domain = domain
         request.couch_user.current_domain = domain
-    notification = ReportNotification.get(scheduled_report_id)
-    if notification.doc_type != 'ReportNotification' or notification.domain != domain:
-        raise Http404
 
     return _render_report_configs(
         request,
-        notification.configs,
-        notification.domain,
-        notification.owner_id,
+        scheduled_report.configs,
+        scheduled_report.domain,
+        scheduled_report.owner_id,
         couch_user,
         email,
         attach_excel=attach_excel,
-        lang=notification.language,
+        lang=scheduled_report.language,
         send_only_active=send_only_active,
     )
 
@@ -2079,6 +2140,9 @@ def _is_location_safe_report_class(view_fn, request, domain, export_hash, format
     return report_class_is_location_safe(meta.properties["report_class"])
 
 
+# TODO: This should be renamed to better convey what the function does.
+# Export suggests that this is exporting data, but this is actually the function
+# that retrieves the data that was previously exported.
 @conditionally_location_safe(_is_location_safe_report_class)
 @login_and_domain_required
 @require_GET
@@ -2091,6 +2155,10 @@ def export_report(request, domain, export_hash, format):
         meta = db.metadb.get(parent_id=export_hash, key=export_hash)
     except models.BlobMeta.DoesNotExist:
         return report_not_found
+
+    if domain != meta.domain:
+        raise Http404()
+
     report_class = meta.properties["report_class"]
 
     try:
@@ -2098,7 +2166,7 @@ def export_report(request, domain, export_hash, format):
     except NotFound:
         return report_not_found
     with report_file:
-        if not request.couch_user.has_permission(domain, 'view_report', data=report_class):
+        if not request.couch_user.has_permission(meta.domain, 'view_report', data=report_class):
             raise PermissionDenied()
         if format in Format.VALID_FORMATS:
             file = ContentFile(report_file.read())

--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -777,6 +777,12 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
         if start_date != self.start_date and start_date < datetime.today().date():
             raise ValidationError("You can not specify a start date in the past.")
 
+    def can_be_viewed_by(self, user):
+        if ((user._id == self.owner_id)
+                or (user.is_domain_admin(self.domain)
+                or (user.get_email() in self.all_recipient_emails))):
+            return True
+
 
 class ScheduledReportsCheckpoint(models.Model):
     """

--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -6,6 +6,7 @@ import logging
 import uuid
 from collections import defaultdict, namedtuple
 from datetime import datetime
+from couchdbkit.exceptions import ResourceNotFound
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -530,6 +531,18 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
             return False
         except AttributeError:
             return True
+
+    @classmethod
+    def get_report(cls, report_id):
+        try:
+            notification = ReportNotification.get(report_id)
+        except ResourceNotFound:
+            notification = None
+        else:
+            if notification.doc_type != 'ReportNotification':
+                notification = None
+
+        return notification
 
     @classmethod
     def by_domain_and_owner(cls, domain, owner_id, stale=True, **kwargs):

--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -791,10 +791,9 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
             raise ValidationError("You can not specify a start date in the past.")
 
     def can_be_viewed_by(self, user):
-        if ((user._id == self.owner_id)
+        return ((user._id == self.owner_id)
                 or (user.is_domain_admin(self.domain)
-                or (user.get_email() in self.all_recipient_emails))):
-            return True
+                or (user.get_email() in self.all_recipient_emails)))
 
 
 class ScheduledReportsCheckpoint(models.Model):

--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -559,10 +559,6 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
     @property
     @memoized
     def all_recipient_emails(self):
-        # handle old documents
-        if not self.owner_id:
-            return frozenset([self.owner.get_email()])
-
         emails = frozenset(self.recipient_emails)
         if self.send_to_owner and self.owner_email:
             emails |= {self.owner_email}

--- a/corehq/apps/saved_reports/tests/test_models.py
+++ b/corehq/apps/saved_reports/tests/test_models.py
@@ -1,0 +1,34 @@
+from django.test import SimpleTestCase
+from unittest.mock import create_autospec
+from corehq.apps.users.models import WebUser
+from ..models import ReportNotification
+
+
+class TestReportNotification(SimpleTestCase):
+    def test_unauthorized_user_cannot_view_report(self):
+        report = ReportNotification(owner_id='5', domain='test_domain', recipient_emails=[])
+        bad_user = self._create_user(id='3', is_domain_admin=False)
+        self.assertFalse(report.can_be_viewed_by(bad_user))
+
+    def test_owner_can_view_report(self):
+        report = ReportNotification(owner_id='5', domain='test_domain', recipient_emails=[])
+        owner = self._create_user(id='5')
+        self.assertTrue(report.can_be_viewed_by(owner))
+
+    def test_domain_admin_can_view_report(self):
+        report = ReportNotification(owner_id='5', domain='test_domain', recipient_emails=[])
+        domain_admin = self._create_user(is_domain_admin=True)
+        self.assertTrue(report.can_be_viewed_by(domain_admin))
+
+    def test_subscribed_user_can_view_report(self):
+        report = ReportNotification(owner_id='5', domain='test_domain', recipient_emails=['test@dimagi.com'])
+        subscribed_user = self._create_user(email='test@dimagi.com')
+        self.assertTrue(report.can_be_viewed_by(subscribed_user))
+
+    def _create_user(self, id='100', email='not-included', is_domain_admin=False):
+        user_template = WebUser(domain='test_domain', username='test_user')
+        user = create_autospec(user_template, spec_set=True, _id=id)
+        user.is_domain_admin = lambda domain: is_domain_admin
+        user.get_email = lambda: email
+
+        return user

--- a/corehq/util/elastic.py
+++ b/corehq/util/elastic.py
@@ -3,6 +3,7 @@ from corehq.util.es.elasticsearch import NotFoundError
 
 from corehq.util.test_utils import unit_testing_only, trap_extra_setup
 from pillowtop.es_utils import initialize_index_and_mapping
+from unittest import SkipTest
 
 TEST_ES_PREFIX = 'test_'
 
@@ -36,6 +37,17 @@ def delete_es_index(es_index):
         es.indices.delete(index=es_index)
     else:
         raise DeleteProductionESIndex('You cannot delete a production index in tests!!')
+
+
+@unit_testing_only
+def ensure_active_es():
+    """Only return an ES instance if it is connectable"""
+    from corehq.elastic import get_es_new
+    es = get_es_new()
+    if not es.ping():
+        raise SkipTest('Cannot connect to Elasticsearch')
+
+    return es
 
 
 class DeleteProductionESIndex(Exception):

--- a/corehq/util/view_utils.py
+++ b/corehq/util/view_utils.py
@@ -164,6 +164,10 @@ def request_as_dict(request):
             Dict containing the request data
     """
 
+    # This is a parameter that is provided by middleware that may or may not exist
+    can_access_all_locations = (request.can_access_all_locations
+        if hasattr(request, 'can_access_all_locations') else False)
+
     request_data = dict(
         GET=request.GET if request.method == 'GET' else request.POST,
         META=dict(
@@ -172,7 +176,7 @@ def request_as_dict(request):
         ),
         datespan=request.datespan,
         couch_user=None,
-        can_access_all_locations=request.can_access_all_locations
+        can_access_all_locations=can_access_all_locations
     )
 
     try:

--- a/corehq/util/view_utils.py
+++ b/corehq/util/view_utils.py
@@ -165,8 +165,7 @@ def request_as_dict(request):
     """
 
     # This is a parameter that is provided by middleware that may or may not exist
-    can_access_all_locations = (request.can_access_all_locations
-        if hasattr(request, 'can_access_all_locations') else False)
+    can_access_all_locations = getattr(request, 'can_access_all_locations', False)
 
     request_data = dict(
         GET=request.GET if request.method == 'GET' else request.POST,


### PR DESCRIPTION
## Summary
Background ticket: https://dimagi-dev.atlassian.net/browse/SAAS-12244

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

All modified report views are now covered by test suites in _reports/tests/test_views.py_.  Changes to the dispatchers are covered in _reports/tests/test_dispatcher.py_, and scheduled report model changes are tested in _savedreports/tests/models.py_

Because of the way viewing a scheduled report currently works (i.e. it needs to generate the full report), the happy path case is currently skipped.

### QA Plan

The integration/unit tests cover a lot, but I'd still like to verify that the changes do not break any custom projects' reports, if we have QA tests for that. Verifying that creating and accessing saved and scheduled reports would be great.

### Safety story
Local testing was performed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
