### PR TITLE
populate couch to sql command: add --domains flag and progress output

### DIFF
--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -1,4 +1,6 @@
+import datetime
 import logging
+import os
 import sys
 import traceback
 
@@ -14,10 +16,9 @@ from corehq.dbaccessors.couchapps.all_docs import (
 )
 from corehq.util.couchdb_management import couch_config
 from corehq.util.django_migrations import skip_on_fresh_install
+from corehq.util.log import with_progress_bar
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.couch.migration import disable_sync_to_couch
-
-logger = logging.getLogger(__name__)
 
 
 class PopulateSQLCommand(BaseCommand):
@@ -194,71 +195,82 @@ class PopulateSQLCommand(BaseCommand):
         parser.add_argument(
             '--domains',
             nargs='+',
-            help="""Only migrate documents in the specified domains""",
+            help="Only migrate documents in the specified domains",
+        )
+        parser.add_argument(
+            '--log-path',
+            help="File path to write logs to. If not provided a default will be used."
         )
 
     def handle(self, **options):
+        log_path = options.get("log_path")
         verify_only = options.get("verify_only", False)
         skip_verify = options.get("skip_verify", False)
+
+        if not log_path:
+            date = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H-%M-%S')
+            command_name = self.__class__.__module__.split('.')[-1]
+            log_path = f"{command_name}_{date}.log"
+
+        if os.path.exists(log_path):
+            raise CommandError(f"Log file already exists: {log_path}")
 
         if verify_only and skip_verify:
             raise CommandError("verify_only and skip_verify are mutually exclusive")
 
         self.diff_count = 0
-        self.doc_index = 0
+        doc_index = 0
 
         domains = options["domains"]
         if domains:
-            self.doc_count = sum(self._get_couch_doc_count_for_domain(domain) for domain in domains)
+            doc_count = sum(self._get_couch_doc_count_for_domain(domain) for domain in domains)
             sql_doc_count = self._get_sql_doc_count_for_domains(domains)
             docs = self._iter_couch_docs_for_domains(domains)
         else:
-            self.doc_count = get_doc_count_by_type(self.couch_db(), self.couch_doc_type())
+            doc_count = get_doc_count_by_type(self.couch_db(), self.couch_doc_type())
             sql_doc_count = self.sql_class().objects.count()
             docs = get_all_docs_with_doc_types(self.couch_db(), [self.couch_doc_type()])
 
-        logger.info("Found {} {} docs and {} {} models".format(
-            self.doc_count,
+        print(f"\n\nDetailed log output file: {log_path}")
+        print("Found {} {} docs and {} {} models".format(
+            doc_count,
             self.couch_doc_type(),
             sql_doc_count,
             self.sql_class().__name__,
         ))
 
-        for doc in docs:
-            self.doc_index += 1
-            if not verify_only:
-                self._migrate_doc(doc)
-            if not skip_verify:
-                self._verify_doc(doc, exit=not verify_only)
+        with open(log_path, 'w') as logfile:
+            for doc in with_progress_bar(docs, length=doc_count, oneline=False):
+                doc_index += 1
+                if not verify_only:
+                    self._migrate_doc(doc, logfile)
+                if not skip_verify:
+                    self._verify_doc(doc, logfile, exit=not verify_only)
+                if doc_index % 1000 == 0:
+                    print(f"Diff count: {self.diff_count}")
 
-        logger.info(f"Processed {self.doc_index} documents")
+        print(f"Processed {doc_index} documents")
         if not skip_verify:
-            logger.info(f"Found {self.diff_count} differences")
+            print(f"Found {self.diff_count} differences")
 
-    def _verify_doc(self, doc, exit=True):
+    def _verify_doc(self, doc, logfile, exit=True):
         try:
             couch_id_name = getattr(self.sql_class(), '_migration_couch_id_name', 'couch_id')
             obj = self.sql_class().objects.get(**{couch_id_name: doc["_id"]})
             diff = self.get_diff_as_string(doc, obj)
             if diff:
-                logger.info(f"Doc {getattr(obj, couch_id_name)} has differences:\n{diff}")
+                logfile.write(f"Doc {getattr(obj, couch_id_name)} has differences:\n{diff}\n")
                 self.diff_count += 1
                 if exit:
-                    sys.exit(1)
+                    raise CommandError(f"Doc verification failed for '{getattr(obj, couch_id_name)}'. Exiting.")
         except self.sql_class().DoesNotExist:
             pass    # ignore, the difference in total object count has already been displayed
 
-    def _migrate_doc(self, doc):
-        logger.info("Looking at {} doc #{} of {} with id {}".format(
-            self.couch_doc_type(),
-            self.doc_index,
-            self.doc_count,
-            doc["_id"]
-        ))
+    def _migrate_doc(self, doc, logfile):
         with transaction.atomic(), disable_sync_to_couch(self.sql_class()):
             model, created = self.update_or_create_sql_object(doc)
             action = "Creating" if created else "Updated"
-            logger.info("{} model for doc with id {}".format(action, doc["_id"]))
+            logfile.write(f"{action} model for {self.couch_doc_type()} with id {doc['_id']}\n")
 
     def _get_couch_doc_count_for_domain(self, domain):
         return get_doc_count_by_domain_type(self.couch_db(), domain, self.couch_doc_type())
@@ -268,7 +280,7 @@ class PopulateSQLCommand(BaseCommand):
 
     def _iter_couch_docs_for_domains(self, domains):
         for domain in domains:
-            logger.info(f"Processing data for domain: {domain}")
+            print(f"Processing data for domain: {domain}")
             doc_id_iter = iterate_doc_ids_in_domain_by_type(
                 domain, self.couch_doc_type(), database=self.couch_db()
             )

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -223,7 +223,7 @@ class PopulateSQLCommand(BaseCommand):
 
         domains = options["domains"]
         if domains:
-            doc_count = sum(self._get_couch_doc_count_for_domain(domain) for domain in domains)
+            doc_count = self._get_couch_doc_count_for_domains(domains)
             sql_doc_count = self._get_sql_doc_count_for_domains(domains)
             docs = self._iter_couch_docs_for_domains(domains)
         else:
@@ -272,8 +272,11 @@ class PopulateSQLCommand(BaseCommand):
             action = "Creating" if created else "Updated"
             logfile.write(f"{action} model for {self.couch_doc_type()} with id {doc['_id']}\n")
 
-    def _get_couch_doc_count_for_domain(self, domain):
-        return get_doc_count_by_domain_type(self.couch_db(), domain, self.couch_doc_type())
+    def _get_couch_doc_count_for_domains(self, domains):
+        return sum(
+            get_doc_count_by_domain_type(self.couch_db(), domain, self.couch_doc_type())
+            for domain in domains
+        )
 
     def _get_sql_doc_count_for_domains(self, domains):
         return self.sql_class().objects.filter(domain__in=domains).count()

--- a/corehq/motech/dhis2/tests/test_models.py
+++ b/corehq/motech/dhis2/tests/test_models.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -217,7 +217,7 @@ class GetInfoForColumnsTests(TestCase):
             }]
         })
         self.dataset_map.save()
-        call_command('populate_sqldatasetmap')
+        call_command('populate_sqldatasetmap', log_path=f"sqldatasetmap_{datetime.utcnow().isoformat()}.log")
         self.sqldataset_map = SQLDataSetMap.objects.get(
             domain=self.domain,
             couch_id=self.dataset_map._id,

--- a/docs/couch_to_sql_models.rst
+++ b/docs/couch_to_sql_models.rst
@@ -98,6 +98,8 @@ sync mixins. `Example of tests for sync and migration code <https://github.com/d
 The migration command has a ``--verify`` option that will find any differences in the couch data vs the sql data.
 
 Once this PR is deployed - later, after the whole shebang has been QAed - you'll run the migration command in any environments where it's likely to take more than a trivial amount of time.
+If the model is tied to domains you should initially migrate a few selected domains using ``--domains X Y Z`` and manually
+verify that the migration worked as expected before running it for all the data.
 
 PR 2: Verify migration and read from SQL
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
The goal here was to make it easier to run the command for selected domains in order to give the user more scope for testing the command before final rollout. The progress output also makes it easier to see the progress and the log data is persisted to disk for reference so it doesn't get lost in the console.

* Adds a `--domains` option to the command to allow migrating only specific domains. This is useful for spot checking prior to running on all data.
* Write detailed log output to a file and only show progress info in the console.

Can be reviewed by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
None for this specifically though there are other tests for usages of this in specific migrations.

### QA Plan
Tested locally and used when running the command on `india`

### Safety story
This only affects management commands.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
