### PR TITLE
Support Encounter and Immunization

### DIFF
--- a/corehq/motech/fhir/const.py
+++ b/corehq/motech/fhir/const.py
@@ -32,8 +32,10 @@ FHIR_DATA_TYPES = (
     FHIR_DATA_TYPE_LIST_OF_STRING,
 )
 
-SUPPORTED_FHIR_RESOURCE_TYPES = [
-    'Patient',
+SUPPORTED_FHIR_RESOURCE_TYPES = (
     'DiagnosticReport',
-    'Observation'
-]
+    'Encounter',
+    'Immunization',
+    'Observation',
+    'Patient',
+)

--- a/corehq/motech/fhir/tests/test_validators.py
+++ b/corehq/motech/fhir/tests/test_validators.py
@@ -21,6 +21,7 @@ class TestValidateSupportedFHIRTypes(SimpleTestCase):
         except ValidationError as e:
             self.assertEqual(
                 e.message_dict['name'],
-                ['Unsupported FHIR Resource type Random. '
-                 'Please choose from Patient, DiagnosticReport, Observation']
+                ['Unsupported FHIR Resource type Random. Please choose from '
+                 'DiagnosticReport, Encounter, Immunization, Observation, '
+                 'Patient']
             )


### PR DESCRIPTION
## Summary

Small change to allow the Data Dictionary to support mapping case types to FHIR "Encounter" and "Immunization" resource types.

![image](https://user-images.githubusercontent.com/708421/121860808-82e68300-ccf9-11eb-861c-f4ff78a1a64b.png)

Required for the Community Health CoP and EmptyBoxes projects respectively.


## Feature Flag

"FHIR Integration"


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story

* Non-code change
* Only applicable to a feature that is not yet released.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
