### PR TITLE
Removed unnecessary tearDown

### DIFF
--- a/corehq/apps/app_manager/tests/test_apps.py
+++ b/corehq/apps/app_manager/tests/test_apps.py
@@ -84,10 +84,6 @@ class AppManagerTest(TestCase, TestXmlMixin):
             )
         self.app.save()
 
-    def tearDown(self):
-        DomainLink.all_objects.all().delete()
-        super().tearDown()
-
     def test_last_modified(self):
         lm = self.app.last_modified
         self.app.save()


### PR DESCRIPTION
## Summary
This isn't necessary, and there's another `tearDown` defined on line 113.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan

None

### Safety story
Minor change to test code.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
