### PR TITLE
include shadow modules in case summary

### DIFF
--- a/corehq/apps/app_manager/app_schemas/app_case_metadata.py
+++ b/corehq/apps/app_manager/app_schemas/app_case_metadata.py
@@ -20,12 +20,9 @@ from corehq.apps.app_manager.app_schemas.case_properties import (
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.app_manager.models import (
     AdvancedForm,
-    AdvancedModule,
     Form,
     FormAction,
     FormActionCondition,
-    Module,
-    ShadowModule
 )
 from corehq.apps.app_manager.xform import VELLUM_TYPES
 from corehq.apps.data_dictionary.util import get_case_property_description_dict
@@ -53,7 +50,7 @@ class AppCaseMetadataBuilder(object):
 
     def _add_module_contributions(self):
         for module in self.app.get_modules():
-            if isinstance(module, (Module, AdvancedModule, ShadowModule)):
+            if hasattr(module, 'case_details'):
                 self._add_module_contribution(module)
 
     def _add_module_contribution(self, module):

--- a/corehq/apps/app_manager/app_schemas/app_case_metadata.py
+++ b/corehq/apps/app_manager/app_schemas/app_case_metadata.py
@@ -25,6 +25,7 @@ from corehq.apps.app_manager.models import (
     FormAction,
     FormActionCondition,
     Module,
+    ShadowModule
 )
 from corehq.apps.app_manager.xform import VELLUM_TYPES
 from corehq.apps.data_dictionary.util import get_case_property_description_dict
@@ -52,7 +53,7 @@ class AppCaseMetadataBuilder(object):
 
     def _add_module_contributions(self):
         for module in self.app.get_modules():
-            if isinstance(module, (Module, AdvancedModule)):
+            if isinstance(module, (Module, AdvancedModule, ShadowModule)):
                 self._add_module_contribution(module)
 
     def _add_module_contribution(self, module):


### PR DESCRIPTION
## Summary
[USH-804](https://dimagi-dev.atlassian.net/browse/USH-804)
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
[Shadow Modules](https://confluence.dimagi.com/display/ccinternal/Shadow+Modules+and+Forms)
<!-- If this is specific to a feature flag, which one? -->

## Product Description
In case summary, if a Shadow Module makes use of a property the Case Lists and Case Details columns will now display the Shadow Module associated with that property. (Previously Shadow Modules were being excluded)
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
none needed
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
This change should only affect the gathering and display of metadata for situations where Shadow Modules are in use. 
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
