### PR TITLE
Revert "ensure cache clearing for IdentityProvider does not fail hard"

### DIFF
--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -332,12 +332,8 @@ def clear_caches_when_subscription_status_changes(sender, instance, **kwargs):
     :param instance: Subscription - the instance being saved/deleted
     :param kwargs:
     """
-    try:
-        for identity_provider in IdentityProvider.objects.filter(owner=instance.account):
-            identity_provider.clear_domain_caches(instance.subscriber.domain)
-    except BillingAccount.DoesNotExist:
-        # for community subscriptions that might not have a BillingAccount set up
-        pass
+    for identity_provider in IdentityProvider.objects.filter(owner=instance.account):
+        identity_provider.clear_domain_caches(instance.subscriber.domain)
 
 
 class AuthenticatedEmailDomain(models.Model):


### PR DESCRIPTION
Reverts dimagi/commcare-hq#29917

It turned out my tests had a deeper issue, they weren't creating subscriptions properly (fixed in https://github.com/dimagi/commcare-hq/pull/29864/commits/21f1b16fe7eb047349ad461e8c6611f681f75039). So I'm inclined to revert this, since I don't think this code is causing any real problems.