### PR TITLE
Ensure All Worker Activity Report columns are visible

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1384,7 +1384,7 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
     num_avg_intervals = 3  # how many duration intervals we go back to calculate averages
     is_cacheable = True
 
-    fix_left_col = True
+    fix_left_col = False
     emailable = True
     exportable_all = True
 


### PR DESCRIPTION
## Summary
Initial ticket: [SAAS-96](https://dimagi-dev.atlassian.net/browse/SAAS-96). For the Worker Activity Report, depending on how you fiddle with the table's sorting options, the 2nd column can become partially hidden by the left-most column. 

I believe this was happening due to the report utilizing a fixed column -- from the [Data Tables documentation](https://datatables.net/extensions/fixedcolumns/): 
> any events attached to the DataTable need to also take into account the fixed tables.

I think what was happening here is that the table columns are sized to only the data available on the current 'page'. When the sorting options were changed, the new data would modify the column sizes, but those changes would not be reflected in the overlaid fixed column, resulting in part of the 2nd column being hidden.  As I saw no reason for this report to have a fixed column in the first place (it is meant for horizontally scrollable tables with many columns), the easy fix was to remove it.

The change is limited to a single line, in the single affected report (Worker Activity). It was introduced when the report was initially created, which leads me to believe that the author thought there was limited downside in turning fixed columns on, and one day this report might take advantage of it. However, from the docs again:
> It is important to state up front that utilising FixedColumns in your DataTable can significantly increase the complexity of the table and its use should not be undertaken lightly, particularly for complex tables. 

## Product Description
Should prevent parts of the worker activity report from being obscured.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

As this is purely a visual thing, there are no tests.

### QA Plan

No QA necessary

### Safety story

Images of the before/after on staging are attached to the JIRA ticket. The scope of this change is very isolated, however.

I tested and verified this locally. Additionally, I tried to shrink my browser in the belief that with a small enough window, I would see scrolling behavior that justified the fixed column, but that never occurred.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
