### PR TITLE
Management command to add app_id to existing linked reports

### DIFF
--- a/corehq/apps/linked_domain/management/commands/add_app_id_to_linked_reports.py
+++ b/corehq/apps/linked_domain/management/commands/add_app_id_to_linked_reports.py
@@ -1,0 +1,50 @@
+from django.core.management import BaseCommand, CommandError
+
+from corehq.apps.linked_domain.applications import get_downstream_app_id
+from corehq.apps.linked_domain.models import DomainLink
+from corehq.apps.userreports.dbaccessors import get_report_configs_for_domain
+from corehq.apps.userreports.models import DataSourceConfiguration, ReportConfiguration
+
+
+def migrate_linked_reports(upstream_domain=None):
+    if upstream_domain:
+        domain_links = DomainLink.objects.filter(master_domain=upstream_domain)
+    else:
+        domain_links = DomainLink.objects.filter(deleted=False)
+
+    for domain_link in domain_links:
+        reports = get_report_configs_for_domain(domain_link.linked_domain)
+        for report in reports:
+            if report.report_meta.master_id and not report.config.meta.build.app_id:
+                upstream_report = ReportConfiguration.get(report.report_meta.master_id)
+                upstream_datasource = DataSourceConfiguration.get(upstream_report.config_id)
+                downstream_app_id = get_downstream_app_id(
+                    domain_link.linked_domain,
+                    upstream_datasource.meta.build.app_id,
+                )
+                if not downstream_app_id:
+                    # just as a backup in case upstream_app_id is not set but family_id is
+                    downstream_app_id = get_downstream_app_id(
+                        domain_link.linked_domain,
+                        upstream_datasource.meta.build.app_id,
+                        use_upstream_app_id=False
+                    )
+                if not downstream_app_id:
+                    raise CommandError(f"Could not find downstream_app_id for upstream app"
+                                       f" {upstream_datasource.meta.build.app_id} "
+                                       f"in downstream domain {domain_link.linked_domain}")
+
+                report.config.meta.build.app_id = downstream_app_id
+                report.config.save()
+
+
+class Command(BaseCommand):
+    """
+    Searches for existing linked reports that do not contain an app_id, and adds the app_id
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument('upstream_domain', nargs='?')
+
+    def handle(self, upstream_domain, **options):
+        migrate_linked_reports(upstream_domain)

--- a/corehq/apps/linked_domain/management/commands/add_app_id_to_linked_reports.py
+++ b/corehq/apps/linked_domain/management/commands/add_app_id_to_linked_reports.py
@@ -35,6 +35,9 @@ def migrate_linked_reports(upstream_domain=None):
                         upstream_datasource.meta.build.app_id,
                         use_upstream_app_id=False
                     )
+                    if downstream_app_id:
+                        logger.info(f"Needed to use family_id to find downstream app {downstream_app_id}")
+
                 if not downstream_app_id:
                     logger.warning(f"Could not find downstream_app_id for upstream app"
                                    f" {upstream_datasource.meta.build.app_id} "

--- a/corehq/apps/linked_domain/tests/test_add_app_id_command.py
+++ b/corehq/apps/linked_domain/tests/test_add_app_id_command.py
@@ -1,0 +1,91 @@
+from django.core.management import CommandError
+from django.test.testcases import TestCase
+
+from corehq.apps.app_manager.models import Application, LinkedApplication
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.linked_domain.management.commands.add_app_id_to_linked_reports import migrate_linked_reports
+from corehq.apps.linked_domain.models import DomainLink
+from corehq.apps.linked_domain.tests.test_view_helpers import _create_report
+from corehq.apps.userreports.models import ReportConfiguration
+
+
+class TestAddAppIdToLinkedReports(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestAddAppIdToLinkedReports, cls).setUpClass()
+        cls.upstream_domain_obj = create_domain('test-upstream')
+        cls.upstream_domain = cls.upstream_domain_obj.name
+        cls.downstream_domain_obj = create_domain('test-downstream')
+        cls.downstream_domain = cls.downstream_domain_obj.name
+        cls.domain_link = DomainLink.link_domains(cls.downstream_domain, cls.upstream_domain)
+
+        cls.original_app = Application.new_app(cls.upstream_domain, "Original Application")
+        cls.original_app.linked_whitelist = [cls.downstream_domain]
+        cls.original_app.save()
+
+        cls.linked_app = LinkedApplication.new_app(cls.downstream_domain, "Linked Application")
+        cls.linked_app.upstream_app_id = cls.original_app._id
+        cls.linked_app.family_id = cls.original_app._id
+        cls.linked_app.save()
+
+        cls.original_report = _create_report(cls.upstream_domain, app_id=cls.original_app._id)
+        # intentionally do not pass app_id into create method, as this is the scenario this migration is used in
+        cls.linked_report = _create_report(cls.downstream_domain, upstream_id=cls.original_report._id)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.original_report.delete()
+        cls.linked_report.delete()
+        cls.linked_app.delete()
+        cls.original_app.delete()
+        cls.domain_link.delete()
+        cls.upstream_domain_obj.delete()
+        cls.downstream_domain_obj.delete()
+        super(TestAddAppIdToLinkedReports, cls).tearDownClass()
+
+    def test_app_id_for_linked_reports_updates_given_upstream_app_id(self):
+        self.linked_report.config.meta.build.app_id = None
+        self.linked_report.save()
+        self.assertIsNone(self.linked_report.config.meta.build.app_id)
+        self.linked_app.family_id = None
+        self.linked_app.upstream_app_id = self.original_app._id
+        self.linked_app.save()
+
+        migrate_linked_reports()
+        # refetch
+        actual_report = ReportConfiguration.get(self.linked_report._id)
+        self.assertEqual(self.linked_app._id, actual_report.config.meta.build.app_id)
+
+    def test_app_id_for_linked_reports_updates_given_family_id(self):
+        self.linked_report.config.meta.build.app_id = None
+        self.linked_report.save()
+        self.assertIsNone(self.linked_report.config.meta.build.app_id)
+        self.linked_app.family_id = self.original_app._id
+        self.linked_app.upstream_app_id = None
+        self.linked_app.save()
+
+        migrate_linked_reports()
+        # refetch
+        actual_report = ReportConfiguration.get(self.linked_report._id)
+        self.assertEqual(self.linked_app._id, actual_report.config.meta.build.app_id)
+
+    def test_app_id_for_linked_reports_raises_error(self):
+        self.linked_report.config.meta.build.app_id = None
+        self.linked_report.save()
+        self.assertIsNone(self.linked_report.config.meta.build.app_id)
+        self.linked_app.family_id = None
+        self.linked_app.upstream_app_id = None
+        self.linked_app.save()
+
+        with self.assertRaises(CommandError):
+            migrate_linked_reports()
+
+    def test_linked_report_with_app_id_is_not_updated(self):
+        self.linked_report.config.meta.build.app_id = self.linked_app._id
+        self.linked_report.save()
+        self.assertEqual(self.linked_app._id, self.linked_report.config.meta.build.app_id)
+        migrate_linked_reports()
+        # refetch
+        actual_report = ReportConfiguration.get(self.linked_report._id)
+        self.assertEqual(self.linked_app._id, actual_report.config.meta.build.app_id)

--- a/corehq/apps/linked_domain/tests/test_add_app_id_command.py
+++ b/corehq/apps/linked_domain/tests/test_add_app_id_command.py
@@ -1,4 +1,3 @@
-from django.core.management import CommandError
 from django.test.testcases import TestCase
 
 from corehq.apps.app_manager.models import Application, LinkedApplication

--- a/corehq/apps/linked_domain/tests/test_view_helpers.py
+++ b/corehq/apps/linked_domain/tests/test_view_helpers.py
@@ -35,12 +35,13 @@ from corehq.apps.userreports.models import (
 from corehq.util.test_utils import flag_enabled
 
 
-def _create_report(domain, title="report", upstream_id=None, should_save=True):
+def _create_report(domain, title="report", upstream_id=None, should_save=True, app_id=None):
     data_source = DataSourceConfiguration(
         domain=domain,
         table_id=uuid.uuid4().hex,
         referenced_doc_type='XFormInstance',
     )
+    data_source.meta.build.app_id = app_id
     data_source.save()
     report = ReportConfiguration(
         domain=domain,


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Followup to [this PR](https://github.com/dimagi/commcare-hq/pull/29751), which set the `app_id`on the linked report upon creation. This PR migrates existing linked reports to have their `app_id` set to the linked application the report is based off of. This is so when domains are unlinked, the linked reports can become editable in the downstream domain. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added test to cover various scenarios.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA plan.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested and wrote automated tests for this command.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
