### PR TITLE
[ERM UI] Fix remove link modal bug

### DIFF
--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -126,6 +126,13 @@ hqDefine("linked_domain/js/domain_links", [
             }).fail(function () {
                 alertUser.alert_user(gettext('Something unexpected happened.\n' +
                     'Please try again, or report an issue if the problem persists.'), 'danger');
+            }).always(function () {
+                // fix for b3
+                $('body').removeClass('modal-open');
+                var $modalBackdrop = $('.modal-backdrop');
+                if ($modalBackdrop) {
+                    $modalBackdrop.remove();
+                }
             });
         };
 

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -68,7 +68,7 @@
           <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
           <button type="button" class="btn btn-primary" data-dismiss="modal" data-bind="click: addDownstreamDomain">{% trans 'Add' %}</button>
         </div>
-      </div><!-- /.modal-content -->
-    </div><!-- /.modal-dialog -->
-  </div><!-- /.modal -->
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/manage_downstream_domains_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/manage_downstream_domains_tab.html
@@ -71,9 +71,9 @@
                       <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
                       <button type="button" class="btn btn-danger" data-bind="click: $root.deleteLink.bind($data)" data-dismiss="modal">{% trans 'Remove' %}</button>
                     </div>
-                  </div><!-- /.modal-content -->
-                </div><!-- /.modal-dialog -->
-              </div><!-- /.modal -->
+                  </div>
+                </div>
+              </div>
             </td>
           </tr>
           </tbody>

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
@@ -61,9 +61,9 @@
                       <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
                       <button type="button" class="btn btn-primary" data-bind="click: update" data-dismiss="modal">{% trans 'Sync & Overwrite' %}</button>
                     </div>
-                  </div><!-- /.modal-content -->
-                </div><!-- /.modal-dialog -->
-              </div><!-- /.modal -->
+                  </div>
+                </div>
+              </div>
               <button class="btn btn-default disabled" data-bind="visible: showSpinner">
                 <i class="fa fa-spinner"></i>
               </button>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
There is an issue with this modal in particular where the backdrop is not removed after the modal is dismissed. At first I thought it was an implementation error, but with the `data-dismiss="modal"` class added to the button, bootstrap should handle the rest. This appears to be [a known issue](https://github.com/twbs/bootstrap/issues/16320) that has not been fixed in bootstrap 3. I also removed the modal comments because some posts said bootstrap was easily confused by them. Sounds questionable but I did so anyway. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
UI change.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will run through QA on parent branch.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
