### PR TITLE
add commit reference to populate_user_role migration

### DIFF
--- a/corehq/apps/users/management/commands/populate_user_role.py
+++ b/corehq/apps/users/management/commands/populate_user_role.py
@@ -3,7 +3,6 @@ from corehq.apps.users.models import UserRole, Permissions
 from corehq.apps.users.models_sql import (
     migrate_role_assignable_by_to_sql,
     migrate_role_permissions_to_sql,
-    SQLUserRole,
 )
 
 
@@ -23,7 +22,7 @@ class Command(PopulateSQLCommand):
 
     @classmethod
     def commit_adding_migration(cls):
-        return "TODO: add once the PR adding this file is merged"
+        return "4f5a5ef0a9b5ef9873a9b2dce5646d7aa881c416"
 
     @classmethod
     def diff_couch_and_sql(cls, couch, sql):


### PR DESCRIPTION
## Summary
Add commit ref to `populate_user_role` command.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Text update to existing management command.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
