### PR TITLE
[couch-to-sql roles] update various places in code to use SQL roles

### DIFF
--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -18,7 +18,6 @@ from corehq.apps.es.tests.utils import es_test
 from corehq.apps.users.analytics import update_analytics_indexes
 from corehq.apps.users.models import (
     CommCareUser,
-    UserRole,
     WebUser,
     UserRolePresets,
     SQLUserRole
@@ -401,7 +400,7 @@ class TestWebUserResource(APIResourceTest):
         self.assertEqual(response.content.decode('utf-8'), '{"error": "Invalid User Role \'App Editor\'"}')
 
     def test_create_with_custom_role(self):
-        new_user_role = UserRole.create(self.domain.name, 'awesomeness')
+        new_user_role = SQLUserRole.create(self.domain.name, 'awesomeness')
         user_json = deepcopy(self.default_user_json)
         user_json["role"] = new_user_role.name
         user_json["is_admin"] = False

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -41,7 +41,7 @@ from corehq.apps.users.dbaccessors import (
     get_mobile_user_count,
     get_web_user_count,
 )
-from corehq.apps.users.models import CouchUser, UserRole
+from corehq.apps.users.models import CouchUser, SQLUserRole
 from corehq.apps.users.util import WEIRD_USER_IDS
 from corehq.messaging.scheduling.util import domain_has_reminders
 from corehq.motech.repeaters.models import Repeater
@@ -446,7 +446,7 @@ def num_custom_roles(domain):
 
 
 def num_location_restricted_roles(domain):
-    roles = [r for r in UserRole.by_domain(domain)
+    roles = [r for r in SQLUserRole.objects.get_by_domain(domain)
              if not r.permissions.access_all_locations]
     return len(roles)
 

--- a/corehq/apps/domain/dbaccessors.py
+++ b/corehq/apps/domain/dbaccessors.py
@@ -78,7 +78,6 @@ def get_docs_in_domain_by_class(domain, doc_class, limit=None, skip=None):
         'CommCareCaseGroup',
         'HQGroupExportConfiguration',
         'Group',
-        'UserRole',
         'ReportConfiguration',
         'LinkedApplication',
     ]

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -24,7 +24,7 @@ from corehq.apps.users.dbaccessors import (
     get_mobile_user_count,
     get_web_user_count,
 )
-from corehq.apps.users.models import CouchUser, Invitation, UserRole
+from corehq.apps.users.models import CouchUser, Invitation
 from corehq.util.quickcache import quickcache
 
 

--- a/corehq/apps/ota/tests/test_app_aware_restore.py
+++ b/corehq/apps/ota/tests/test_app_aware_restore.py
@@ -25,8 +25,6 @@ from corehq.apps.userreports.tests.utils import (
     mock_datasource_config,
 )
 from corehq.apps.users.dbaccessors import delete_all_users
-from corehq.apps.users.models import Permissions, UserRole
-from corehq.util.test_utils import flag_enabled
 
 
 class AppAwareSyncTests(TestCase):

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -38,7 +38,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.tasks import send_html_email_async, send_mail_async
 from corehq.apps.registration.models import RegistrationRequest
 from corehq.apps.registration.tasks import send_domain_registration_email
-from corehq.apps.users.models import CouchUser, UserRole, WebUser
+from corehq.apps.users.models import CouchUser, WebUser
 from corehq.util.view_utils import absolute_reverse
 
 APPCUES_APP_SLUGS = ['health', 'agriculture', 'wash']

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -38,10 +38,10 @@ from corehq.apps.users.models import (
     CommCareUser,
     CouchUser,
     Invitation,
-    UserRole, InvitationStatus, DomainRequest,
+    SQLUserRole,
+    InvitationStatus
 )
 from corehq.apps.users.util import normalize_username, log_user_role_update
-from corehq.apps.users.views.utils import get_editable_role_choices
 from corehq.const import USER_CHANGE_VIA_BULK_IMPORTER
 from corehq.toggles import DOMAIN_PERMISSIONS_MIRROR
 
@@ -329,6 +329,8 @@ def check_modified_user_loc(location_ids, loc_id, assigned_loc_ids):
 
 def get_domain_info(domain, upload_domain, user_specs, domain_info_by_domain, upload_user=None, group_memoizer=None, is_web_upload=False):
     from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
+    from corehq.apps.users.views.utils import get_editable_role_choices
+
     domain_info = domain_info_by_domain.get(domain)
     if domain_info:
         return domain_info
@@ -360,7 +362,7 @@ def get_domain_info(domain, upload_domain, user_specs, domain_info_by_domain, up
             upload_domain=upload_domain,
         )
     else:
-        roles_by_name = {role.name: role for role in UserRole.by_domain(domain)}
+        roles_by_name = {role.name: role.get_qualified_id() for role in SQLUserRole.objects.get_by_domain(domain)}
         definition = CustomDataFieldsDefinition.get(domain, UserFieldsView.field_type)
         if definition:
             profiles_by_name = {
@@ -534,7 +536,7 @@ def create_or_update_users_and_groups(upload_domain, user_specs, upload_user, gr
                         user.reset_locations(location_ids, commit=False)
 
                 if role:
-                    role_qualified_id = domain_info.roles_by_name[role].get_qualified_id()
+                    role_qualified_id = domain_info.roles_by_name[role]
                     user_current_role = user.get_role(domain=domain)
                     log_role_update = not (user_current_role
                                         and user_current_role.get_qualified_id() == role_qualified_id)

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -21,7 +21,7 @@ from corehq.apps.user_importer.models import UserUploadRecord
 from corehq.apps.user_importer.tasks import import_users_and_groups
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import (
-    CommCareUser, DomainPermissionsMirror, UserRole, WebUser, Invitation
+    CommCareUser, DomainPermissionsMirror, SQLUserRole, WebUser, Invitation
 )
 from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
 from corehq.const import USER_CHANGE_VIA_BULK_IMPORTER
@@ -39,8 +39,8 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         cls.uploading_user = WebUser.create(cls.domain_name, "admin@xyz.com", 'password', None, None,
                                             is_superuser=True)
 
-        cls.role = UserRole.create(cls.domain.name, 'edit-apps')
-        cls.other_role = UserRole.create(cls.domain.name, 'admin')
+        cls.role = SQLUserRole.create(cls.domain.name, 'edit-apps')
+        cls.other_role = SQLUserRole.create(cls.domain.name, 'admin')
         cls.patcher = patch('corehq.apps.user_importer.tasks.UserUploadRecord')
         cls.patcher.start()
 
@@ -720,7 +720,7 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         )
         self.assertEqual(mock_send_activation_email.call_count, 1)
         self.assertEqual(self.user.get_role(self.domain_name).name, self.role.name)
-        self.assertEqual(Invitation.by_email('a@a.com')[0].role.split(":")[1], self.role._id)
+        self.assertEqual(Invitation.by_email('a@a.com')[0].role.split(":")[1], self.role.get_id)
 
         added_user_id = self.user._id
         import_users_and_groups(
@@ -870,9 +870,9 @@ class TestWebUserBulkUpload(TestCase, DomainSubscriptionMixin):
         cls.domain_name = 'mydomain'
         cls.domain = Domain.get_or_create_with_name(name=cls.domain_name)
         cls.other_domain = Domain.get_or_create_with_name(name='other-domain')
-        cls.role = UserRole.create(cls.domain.name, 'edit-apps')
-        cls.other_role = UserRole.create(cls.domain.name, 'admin')
-        cls.other_domain_role = UserRole.create(cls.other_domain.name, 'view-apps')
+        cls.role = SQLUserRole.create(cls.domain.name, 'edit-apps')
+        cls.other_role = SQLUserRole.create(cls.domain.name, 'admin')
+        cls.other_domain_role = SQLUserRole.create(cls.other_domain.name, 'view-apps')
         cls.patcher = patch('corehq.apps.user_importer.tasks.UserUploadRecord')
         cls.patcher.start()
 

--- a/corehq/apps/users/bulk_download.py
+++ b/corehq/apps/users/bulk_download.py
@@ -27,7 +27,7 @@ from corehq.apps.users.dbaccessors import (
     get_mobile_usernames_by_filters,
     get_web_users_by_filters,
 )
-from corehq.apps.users.models import UserRole
+from corehq.apps.users.models import SQLUserRole
 from corehq.util.workbook_json.excel import (
     alphanumeric_sort_key,
     flatten_json,
@@ -125,8 +125,8 @@ def get_user_role_name(domain_membership):
         role_name = ''
         if domain_membership.role_id:
             try:
-                role_name = UserRole.get(domain_membership.role_id).name
-            except ResourceNotFound:
+                role_name = SQLUserRole.objects.by_couch_id(domain_membership.role_id).name
+            except SQLUserRole.DoesNotExist:
                 role_name = ugettext('Unknown Role')
     return role_name
 

--- a/corehq/apps/users/dbaccessors.py
+++ b/corehq/apps/users/dbaccessors.py
@@ -4,7 +4,7 @@ from dimagi.utils.couch.database import iter_bulk_delete, iter_docs
 
 from corehq.apps.es import UserES
 from corehq.apps.locations.models import SQLLocation
-from corehq.apps.users.models import CommCareUser, CouchUser, Invitation, UserRole
+from corehq.apps.users.models import CommCareUser, CouchUser, Invitation, UserRole, SQLUserRole
 from corehq.pillows.utils import MOBILE_USER_TYPE, WEB_USER_TYPE
 from corehq.util.couch import stale_ok
 from corehq.util.quickcache import quickcache
@@ -158,7 +158,7 @@ def _get_invitations_by_filters(domain, user_filters, count_only=False):
         filters["email__icontains"] = search_string
     role_id = user_filters.get("role_id", None)
     if role_id:
-        role = UserRole.get(role_id)
+        role = SQLUserRole.objects.by_couch_id(role_id)
         filters["role"] = role.get_qualified_id()
 
     invitations = Invitation.by_domain(domain, **filters)

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -39,7 +39,7 @@ from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter
 from corehq.apps.sso.models import IdentityProvider
 from corehq.apps.sso.utils.request_helpers import is_request_using_sso
 from corehq.apps.users.dbaccessors import user_exists
-from corehq.apps.users.models import DomainPermissionsMirror, UserRole
+from corehq.apps.users.models import DomainPermissionsMirror, SQLUserRole
 from corehq.apps.users.util import (
     cc_user_domain,
     format_username,
@@ -1209,9 +1209,9 @@ class UserFilterForm(forms.Form):
         self.fields['location_id'].widget = LocationSelectWidget(self.domain)
         self.fields['location_id'].help_text = ExpandedMobileWorkerFilter.location_search_help
 
-        roles = UserRole.by_domain(self.domain)
+        roles = SQLUserRole.objects.get_by_domain(self.domain)
         self.fields['role_id'].choices = [('', _('All Roles'))] + [
-            (role._id, role.name or _('(No Name)')) for role in roles
+            (role.get_id, role.name or _('(No Name)')) for role in roles
         ]
 
         self.fields['domains'].choices = [('all_project_spaces', _('All Project Spaces'))] + \
@@ -1272,8 +1272,9 @@ class UserFilterForm(forms.Form):
         if not role_id:
             return None
 
-        role = UserRole.get(role_id)
-        if not role.domain == self.domain:
+        try:
+            SQLUserRole.objects.by_couch_id(role_id, domain=self.domain)
+        except SQLUserRole.DoesNotExist:
             raise forms.ValidationError(_("Invalid Role"))
         return role_id
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -3056,8 +3056,8 @@ class HQApiKey(models.Model):
     def role(self):
         if self.role_id:
             try:
-                return UserRole.get(self.role_id)
-            except ResourceNotFound:
+                return SQLUserRole.objects.by_couch_id(self.role_id)
+            except SQLUserRole.DoesNotExist:
                 logging.exception('no role with id %s found in domain %s' % (self.role_id, self.domain))
         elif self.domain:
             return CouchUser.from_django_user(self.user).get_domain_membership(self.domain).role

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2643,7 +2643,7 @@ class Invitation(models.Model):
     invited_on = models.DateTimeField()
     is_accepted = models.BooleanField(default=False)
     domain = models.CharField(max_length=255)
-    role = models.CharField(max_length=100, null=True)
+    role = models.CharField(max_length=100, null=True)  # role qualified ID
     program = models.CharField(max_length=126, null=True)   # couch id of a Program
     supply_point = models.CharField(max_length=126, null=True)  # couch id of a Location
 
@@ -2698,8 +2698,8 @@ class Invitation(models.Model):
             else:
                 role_id = self.role[len('user-role:'):]
                 try:
-                    return UserRole.get(role_id).name
-                except ResourceNotFound:
+                    return SQLUserRole.objects.by_couch_id(role_id).name
+                except SQLUserRole.DoesNotExist:
                     return _('Unknown Role')
         else:
             return None

--- a/corehq/apps/users/models_sql.py
+++ b/corehq/apps/users/models_sql.py
@@ -57,8 +57,12 @@ class UserRoleManager(models.Manager):
         # name is not unique so return all results
         return list(self.filter(domain=domain, name=name))
 
-    def by_couch_id(self, couch_id):
-        return SQLUserRole.objects.get(couch_id=couch_id)
+    def by_couch_id(self, couch_id, domain=None):
+        if domain:
+            query = SQLUserRole.objects.filter(domain=domain)
+        else:
+            query = SQLUserRole.objects
+        return query.get(couch_id=couch_id)
 
 
 class SQLUserRole(SyncSQLToCouchMixin, models.Model):

--- a/corehq/apps/users/tests/test_dbaccessors.py
+++ b/corehq/apps/users/tests/test_dbaccessors.py
@@ -27,7 +27,7 @@ from corehq.apps.users.dbaccessors import (
 from corehq.apps.users.models import (
     CommCareUser,
     Invitation,
-    UserRole,
+    SQLUserRole,
     WebUser,
 )
 from corehq.pillows.mappings.user_mapping import USER_INDEX
@@ -50,8 +50,8 @@ class AllCommCareUsersTest(TestCase):
         bootstrap_location_types(cls.ccdomain.name)
 
         initialize_domain_with_default_roles(cls.ccdomain.name)
-        cls.user_roles = UserRole.by_domain(cls.ccdomain.name)
-        cls.custom_role = UserRole.create(cls.ccdomain.name, "Custom Role")
+        cls.user_roles = SQLUserRole.objects.get_by_domain(cls.ccdomain.name)
+        cls.custom_role = SQLUserRole.create(cls.ccdomain.name, "Custom Role")
 
         cls.loc1 = make_loc('spain', domain=cls.ccdomain.name, type="district")
         cls.loc2 = make_loc('madagascar', domain=cls.ccdomain.name, type="district")
@@ -154,7 +154,7 @@ class AllCommCareUsersTest(TestCase):
         self.assertEqual(count_mobile_users_by_filters(self.ccdomain.name, filters), 0)
 
         # can search by role_id
-        filters = {'role_id': self.custom_role._id}
+        filters = {'role_id': self.custom_role.get_id}
         self.assertItemsEqual(
             usernames(get_mobile_users_by_filters(self.ccdomain.name, filters)),
             [self.ccuser_2.username]
@@ -188,7 +188,7 @@ class AllCommCareUsersTest(TestCase):
 
         self._assert_invitations({}, ["sergei_p@email.com", "sergei_r@email.com", "wolfgang@email.com"])
         self._assert_invitations({"search_string": "Sergei"}, ["sergei_p@email.com", "sergei_r@email.com"])
-        self._assert_invitations({"role_id": self.custom_role._id}, ["wolfgang@email.com"])
+        self._assert_invitations({"role_id": self.custom_role.get_id}, ["wolfgang@email.com"])
 
         for inv in invitations:
             inv.delete()

--- a/corehq/apps/users/tests/test_mirroring.py
+++ b/corehq/apps/users/tests/test_mirroring.py
@@ -12,7 +12,7 @@ from corehq.apps.users.models import (
     DomainPermissionsMirror,
     HQApiKey,
     Permissions,
-    UserRole,
+    SQLUserRole,
     WebUser,
 )
 
@@ -29,15 +29,25 @@ class DomainPermissionsMirrorTest(TestCase):
         create_domain('county')
 
         # Set up users
+        cls.master_role = SQLUserRole.create("state", "role1", permissions=Permissions(
+            view_web_users=True,
+            edit_web_users=False,
+            view_groups=True,
+            edit_groups=False,
+            edit_apps=True,  # needed for InternalFixtureResource
+            view_apps=True,
+        ))
         cls.web_user_admin = WebUser.create('state', 'emma', 'badpassword', None, None, email='e@aol.com',
                                             is_admin=True)
         cls.web_user_non_admin = WebUser.create('state', 'clementine', 'worsepassword', None, None,
                                                 email='c@aol.com')
+        cls.web_user_non_admin.set_role('state', cls.master_role.get_qualified_id())
+        cls.web_user_non_admin.save()
         cls.api_key, _ = HQApiKey.objects.get_or_create(user=WebUser.get_django_user(cls.web_user_non_admin))
+
 
     def setUp(self):
         patches = [
-            mock.patch.object(DomainMembership, 'role', self._master_role()),
             mock.patch.object(WebUser, 'has_permission', WebUser.has_permission.__wrapped__),
         ]
         for patch in patches:
@@ -45,24 +55,11 @@ class DomainPermissionsMirrorTest(TestCase):
             self.addCleanup(patch.stop)
 
     @classmethod
-    def _master_role(cls):
-        return UserRole(
-            domain='state',
-            permissions=Permissions(
-                view_web_users=True,
-                edit_web_users=False,
-                view_groups=True,
-                edit_groups=False,
-                edit_apps=True,     # needed for InternalFixtureResource
-                view_apps=True,
-            )
-        )
-
-    @classmethod
     def tearDownClass(cls):
         cls.web_user_admin.delete(deleted_by=None)
         cls.web_user_non_admin.delete(deleted_by=None)
         cls.api_key.delete()
+        cls.master_role.delete()
         Domain.get_by_name('county').delete()
         Domain.get_by_name('state').delete()
         cls.mirror.delete()
@@ -83,7 +80,7 @@ class DomainPermissionsMirrorTest(TestCase):
             self.assertTrue(self.web_user_non_admin.has_permission(domain, "view_groups"))
             self.assertFalse(self.web_user_non_admin.has_permission(domain, "edit_groups"))
 
-            # Admin's role is also self._master_role because of the patch, but is_admin gets checked first
+            # Admin's has no role but `is_admin` gives them access to everything
             self.assertTrue(self.web_user_admin.has_permission(domain, "view_groups"))
             self.assertTrue(self.web_user_admin.has_permission(domain, "edit_groups"))
 

--- a/corehq/apps/users/tests/test_user_role.py
+++ b/corehq/apps/users/tests/test_user_role.py
@@ -172,6 +172,15 @@ class RolesTests(TestCase):
         role_with_prefetch.set_permissions([])
         self.assertEqual(list(role_with_prefetch.get_permission_infos()), [])
 
+    def test_by_couch_id(self):
+        role = SQLUserRole.objects.by_couch_id(self.roles[0].get_id)
+        self.assertEqual(role.id, self.roles[0].id)
+
+        role = SQLUserRole.objects.by_couch_id(self.roles[0].get_id, domain=self.roles[0].domain)
+        self.assertEqual(role.id, self.roles[0].id)
+
+        with self.assertRaises(SQLUserRole.DoesNotExist):
+            SQLUserRole.objects.by_couch_id(self.roles[0].get_id, domain="other-domain")
 
 
 class TestRolePermissionsModel(TestCase):

--- a/corehq/apps/users/tests/test_web_user_download.py
+++ b/corehq/apps/users/tests/test_web_user_download.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es.tests.utils import es_test, populate_user_index
 from corehq.apps.users.bulk_download import parse_web_users
-from corehq.apps.users.models import Invitation, UserRole, WebUser
+from corehq.apps.users.models import Invitation, SQLUserRole, WebUser
 from corehq.pillows.mappings.user_mapping import USER_INDEX
 from corehq.util.elastic import ensure_index_deleted
 
@@ -20,8 +20,7 @@ class TestDownloadWebUsers(TestCase):
         cls.domain = 'old_shelf'
         cls.domain_obj = create_domain(cls.domain)
 
-        cls.role = UserRole(domain=cls.domain, name='App Editor')
-        cls.role.save()
+        cls.role = SQLUserRole.create(domain=cls.domain, name='App Editor')
         cls.qualified_role_id = cls.role.get_qualified_id()
 
         cls.user1 = WebUser.create(
@@ -59,8 +58,7 @@ class TestDownloadWebUsers(TestCase):
         cls.other_domain = 'new_shelf'
         cls.other_domain_obj = create_domain(cls.other_domain)
 
-        cls.other_role = UserRole(domain=cls.domain, name='User Admin')
-        cls.other_role.save()
+        cls.other_role = SQLUserRole.create(domain=cls.domain, name='User Admin')
 
         cls.user10 = WebUser.create(
             cls.other_domain_obj.name,

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -879,7 +879,7 @@ def delete_user_role(request, domain):
         return JsonResponse({})
     role_data = json.loads(request.body.decode('utf-8'))
     try:
-        role = SQLUserRole.objects.by_couch_id(role_data["_id"])
+        role = SQLUserRole.objects.by_couch_id(role_data["_id"], domain=domain)
     except SQLUserRole.DoesNotExist:
         return JsonResponse({})
     copy_id = role.couch_id


### PR DESCRIPTION
## Summary
PR on top of #29825

Updates a bunch of places that refer to couch roles. I tried to keep this to places that aren't related directly auth.

Areas impacted:
* Web User invitations
* Mobile user import
* Mobile user bulk download filtering
* Web user bulk download
* HQApiKey (`get_role` and `get_role_name`)
* Delete role

Review by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
All of these changes are covered by tests.

### QA Plan
In addition to being covered by unit tests I have tested this locally:
* bulk mobile user download / import
* bulk web user download
* web user invitations
* delete role

I was unable to test the changes to HQApiKey since there is no way to assign a role to an key via the UI. This functionality is well covered in unit tests.

## Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
