### PR TITLE
[couch-to-sql roles] update linked domains to use SQL roles

### DIFF
--- a/corehq/apps/linked_domain/local_accessors.py
+++ b/corehq/apps/linked_domain/local_accessors.py
@@ -7,7 +7,7 @@ from corehq.apps.fixtures.dbaccessors import get_fixture_data_type_by_tag, get_f
 from corehq.apps.linked_domain.util import _clean_json
 from corehq.apps.locations.views import LocationFieldsView
 from corehq.apps.products.views import ProductFieldsView
-from corehq.apps.users.models import UserRole
+from corehq.apps.users.models import SQLUserRole
 from corehq.apps.users.views.mobile import UserFieldsView
 from corehq.apps.integration.models import DialerSettings, GaenOtpServerSettings, HmacCalloutSettings
 
@@ -56,7 +56,7 @@ def get_user_roles(domain):
     def _to_json(role):
         return _clean_json(role.to_json())
 
-    return [_to_json(role) for role in UserRole.by_domain(domain)]
+    return [_to_json(role) for role in SQLUserRole.objects.get_by_domain(domain)]
 
 
 def get_data_dictionary(domain):

--- a/corehq/apps/linked_domain/tests/test_update_roles.py
+++ b/corehq/apps/linked_domain/tests/test_update_roles.py
@@ -74,7 +74,7 @@ class TestUpdateRoles(BaseLinkedAppsTest):
 
         # create role in linked domain with upstream_id and name not matching upstream name
         SQLUserRole.create(
-            self.linked_domain, 'id_test', Permissions(edit_web_users=True, view_locations=True),
+            self.linked_domain, 'id_test', Permissions(edit_web_users=False, view_locations=True),
             upstream_id=self.other_role.get_id
         )
 

--- a/corehq/apps/linked_domain/tests/test_update_roles.py
+++ b/corehq/apps/linked_domain/tests/test_update_roles.py
@@ -9,37 +9,25 @@ from corehq.apps.linked_domain.tests.test_linked_apps import BaseLinkedAppsTest
 from corehq.apps.linked_domain.updates import update_user_roles
 from corehq.apps.linked_domain.util import _clean_json
 from corehq.apps.userreports.util import get_ucr_class_name
-from corehq.apps.users.models import Permissions, UserRole
+from corehq.apps.users.models import Permissions, SQLUserRole
 
 
 class TestUpdateRoles(BaseLinkedAppsTest):
     @classmethod
     def setUpClass(cls):
         super(TestUpdateRoles, cls).setUpClass()
-        cls.role = UserRole(
-            domain=cls.domain,
-            name='test',
-            permissions=Permissions(
-                edit_data=True,
-                edit_reports=True,
-                view_report_list=[
-                    'corehq.reports.DynamicReportmaster_report_id'
-                ]
-            ),
-            is_non_admin_editable=True,
+        permissions = Permissions(
+            edit_data=True,
+            edit_reports=True,
+            view_report_list=[
+                'corehq.reports.DynamicReportmaster_report_id'
+            ]
         )
-        cls.role.save()
-
-        cls.other_role = UserRole(
-            domain=cls.domain,
-            name='other_test',
-            permissions=Permissions(
-                edit_web_users=True,
-                view_locations=True,
-            ),
-            assignable_by=[cls.role.get_id],
+        cls.role = SQLUserRole.create(cls.domain, 'test', permissions, is_non_admin_editable=True)
+        cls.other_role = SQLUserRole.create(
+            cls.domain, 'other_test', Permissions(edit_web_users=True, view_locations=True)
         )
-        cls.other_role.save()
+        cls.other_role.set_assignable_by([cls.role.id])
 
     @classmethod
     def tearDownClass(cls):
@@ -48,18 +36,18 @@ class TestUpdateRoles(BaseLinkedAppsTest):
         super(TestUpdateRoles, cls).tearDownClass()
 
     def tearDown(self):
-        for role in UserRole.by_domain(self.linked_domain):
+        for role in SQLUserRole.objects.get_by_domain(self.linked_domain):
             role.delete()
         super(TestUpdateRoles, self).tearDown()
 
     def test_update_report_list(self):
-        self.assertEqual([], UserRole.by_domain(self.linked_domain))
+        self.assertEqual([], SQLUserRole.objects.get_by_domain(self.linked_domain))
 
         report_mapping = {'master_report_id': 'linked_report_id'}
         with patch('corehq.apps.linked_domain.updates.get_static_report_mapping', return_value=report_mapping):
             update_user_roles(self.domain_link)
 
-        roles = {r.name: r for r in UserRole.by_domain(self.linked_domain)}
+        roles = {r.name: r for r in SQLUserRole.objects.get_by_domain(self.linked_domain)}
         self.assertEqual(2, len(roles))
         self.assertEqual(roles['test'].permissions.view_report_list, [get_ucr_class_name('linked_report_id')])
         self.assertTrue(roles['test'].is_non_admin_editable)
@@ -68,49 +56,48 @@ class TestUpdateRoles(BaseLinkedAppsTest):
         self.assertEqual(roles['other_test'].assignable_by, [roles['test'].get_id])
 
     def test_match_names(self):
-        self.assertEqual([], UserRole.by_domain(self.linked_domain))
+        self.assertEqual([], SQLUserRole.objects.get_by_domain(self.linked_domain))
 
-        role = UserRole(
-            domain=self.linked_domain,
-            name='other_test',
-            permissions=Permissions(
-                edit_web_users=False,
-                view_locations=True,
-            ),
-            assignable_by=[self.role.get_id],
+        # create role in linked domain with the same name but no 'upstream_id'
+        SQLUserRole.create(
+            self.linked_domain, 'other_test', Permissions(edit_web_users=True, view_locations=True)
         )
-        role.save()
 
         update_user_roles(self.domain_link)
-        roles = {r.name: r for r in UserRole.by_domain(self.linked_domain)}
+        roles = {r.name: r for r in SQLUserRole.objects.get_by_domain(self.linked_domain)}
         self.assertEqual(2, len(roles))
         self.assertTrue(roles['other_test'].permissions.edit_web_users)
         self.assertEqual(roles['other_test'].upstream_id, self.other_role.get_id)
 
     def test_match_ids(self):
-        self.assertEqual([], UserRole.by_domain(self.linked_domain))
+        self.assertEqual([], SQLUserRole.objects.get_by_domain(self.linked_domain))
 
-        role = UserRole(
-            domain=self.linked_domain,
-            name='id_test',
-            permissions=Permissions(
-                edit_web_users=False,
-                view_locations=True,
-            ),
-            assignable_by=[self.role.get_id],
+        # create role in linked domain with upstream_id and name not matching upstream name
+        SQLUserRole.create(
+            self.linked_domain, 'id_test', Permissions(edit_web_users=True, view_locations=True),
             upstream_id=self.other_role.get_id
         )
-        role.save()
 
         update_user_roles(self.domain_link)
-        roles = {r.name: r for r in UserRole.by_domain(self.linked_domain)}
-        self.assertEqual(2, len(roles))
+        roles = {r.name: r for r in SQLUserRole.objects.get_by_domain(self.linked_domain)}
+        self.assertEqual(2, len(roles), roles.keys())
         self.assertIsNotNone(roles.get('other_test'))
         self.assertTrue(roles['other_test'].permissions.edit_web_users)
         self.assertEqual(roles['other_test'].upstream_id, self.other_role.get_id)
 
 
 class TestUpdateRolesRemote(TestCase):
+
+    role_json_template = {
+        "name": None,
+        "permissions": None,
+        "default_landing_page": None,
+        "is_non_admin_editable": False,
+        "assignable_by": [],
+        "is_archived": False,
+        "upstream_id": None
+    }
+
     @classmethod
     def setUpClass(cls):
         super(TestUpdateRolesRemote, cls).setUpClass()
@@ -133,7 +120,7 @@ class TestUpdateRolesRemote(TestCase):
 
     def setUp(self):
         self.upstream_role1_id = uuid.uuid4().hex
-        self.role1 = UserRole(
+        self.role1 = SQLUserRole.create(
             domain=self.linked_domain,
             name='test',
             permissions=Permissions(
@@ -146,21 +133,20 @@ class TestUpdateRolesRemote(TestCase):
             is_non_admin_editable=True,
             upstream_id=self.upstream_role1_id
         )
-        self.role1.save()
 
-        self.other_role = UserRole(
+        self.other_role = SQLUserRole.create(
             domain=self.linked_domain,
             name='other_test',
             permissions=Permissions(
                 edit_web_users=True,
                 view_locations=True,
             ),
-            assignable_by=[self.role1.get_id],
+            assignable_by=[self.role1.id],
         )
         self.other_role.save()
 
     def tearDown(self):
-        for role in UserRole.by_domain(self.linked_domain):
+        for role in SQLUserRole.objects.get_by_domain(self.linked_domain):
             role.delete()
         super(TestUpdateRolesRemote, self).tearDown()
 
@@ -172,29 +158,35 @@ class TestUpdateRolesRemote(TestCase):
             view_report_list=['corehq.reports.static_report']
         )
         # sync with existing local role
-        remote_role1 = UserRole(
+        remote_role1 = self._make_remote_role_json(
             _id=self.upstream_role1_id,
-            name='test',
-            permissions=remote_permissions,
-            is_non_admin_editable=False
+            name="test",
+            permissions=remote_permissions.to_json(),
         )
+
         # create new role
-        remote_role_other = UserRole(
+        remote_role_other = self._make_remote_role_json(
             _id=uuid.uuid4().hex,
             name="another",
-            permissions=Permissions(),
+            permissions=Permissions().to_json(),
             assignable_by=[self.upstream_role1_id]
         )
+
         remote_get_user_roles.return_value = [
-            _clean_json(role.to_json()) for role in [remote_role1, remote_role_other]
+            _clean_json(role) for role in [remote_role1, remote_role_other]
         ]
 
         update_user_roles(self.domain_link)
 
-        roles = {r.name: r for r in UserRole.by_domain(self.linked_domain)}
+        roles = {r.name: r for r in SQLUserRole.objects.get_by_domain(self.linked_domain)}
         self.assertEqual(3, len(roles))
         self.assertEqual(roles['test'].permissions, remote_permissions)
         self.assertEqual(roles['test'].is_non_admin_editable, False)
         self.assertEqual(roles['another'].assignable_by, [self.role1.get_id])
         self.assertEqual(roles['another'].permissions, Permissions())
         self.assertEqual(roles['other_test'].assignable_by, [self.role1.get_id])
+
+    def _make_remote_role_json(self, **kwargs):
+        role_json = self.role_json_template.copy()
+        role_json.update(**kwargs)
+        return role_json

--- a/corehq/apps/linked_domain/updates.py
+++ b/corehq/apps/linked_domain/updates.py
@@ -86,7 +86,7 @@ from corehq.apps.userreports.util import (
     get_static_report_mapping,
     get_ucr_class_name,
 )
-from corehq.apps.users.models import UserRole
+from corehq.apps.users.models import SQLUserRole, Permissions
 from corehq.apps.users.views.mobile import UserFieldsView
 from corehq.toggles import NAMESPACE_DOMAIN
 
@@ -215,7 +215,7 @@ def update_user_roles(domain_link):
 
     _convert_reports_permissions(domain_link, master_results)
 
-    local_roles = UserRole.by_domain(domain_link.linked_domain, include_archived=True)
+    local_roles = SQLUserRole.objects.get_by_domain(domain_link.linked_domain, include_archived=True)
     local_roles_by_name = {}
     local_roles_by_upstream_id = {}
     for role in local_roles:
@@ -226,33 +226,29 @@ def update_user_roles(domain_link):
     # Update downstream roles based on upstream roles
     for role_def in master_results:
         role = local_roles_by_upstream_id.get(role_def['_id']) or local_roles_by_name.get(role_def['name'])
-        if role:
-            role_json = role.to_json()
-        else:
-            role_json = {'domain': domain_link.linked_domain}
-        role_json['upstream_id'] = role_def['_id']
+        if not role:
+            role = SQLUserRole(domain=domain_link.linked_domain)
+        local_roles_by_upstream_id[role_def['_id']] = role
+        role.upstream_id = role_def['_id']
 
-        upstream_role = copy(role_def)
-        upstream_role.pop('_id')
-        upstream_role.pop('upstream_id')
-        upstream_role.pop('assignable_by')  # handled below
-        role_json.update(upstream_role)
-        role = UserRole.wrap(role_json)
+        role.name = role_def["name"]
+        role.default_landing_page = role_def["default_landing_page"]
+        role.is_non_admin_editable = role_def["is_non_admin_editable"]
         role.save()
-        local_roles_by_upstream_id[role_json['upstream_id']] = role.to_json()
+
+        permissions = Permissions.wrap(role_def["permissions"])
+        role.set_permissions(permissions.to_list())
 
     # Update assignable_by ids - must be done after main update to guarantee all local roles have ids
     for role_def in master_results:
-        role_json = local_roles_by_upstream_id[role_def['_id']]
-        if role_def['assignable_by']:
-            role_json['assignable_by'] = [
-                local_roles_by_upstream_id[role_id]['_id']
-                for role_id in role_def['assignable_by']
+        local_role = local_roles_by_upstream_id[role_def['_id']]
+        assignable_by = []
+        if role_def["assignable_by"]:
+            assignable_by = [
+                local_roles_by_upstream_id[role_id].id
+                for role_id in role_def["assignable_by"]
             ]
-            UserRole.wrap(role_json).save()
-        elif role_json['assignable_by']:
-            role_json['assignable_by'] = None
-            UserRole.wrap(role_json).save()
+        local_role.set_assignable_by(assignable_by)
 
 
 def update_case_search_config(domain_link):


### PR DESCRIPTION
## Summary
PR on top of https://github.com/dimagi/commcare-hq/pull/29825

Update linked domains to use SQL roles.

## Feature Flag
"linked_domains"

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Covered by existing tests which have also been updated.

### Safety story
Only impacts updated roles in linked domains. Good covered by unit tests.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
