### PR TITLE
Export docker variables to keep compose from complaining

### DIFF
--- a/scripts/docker
+++ b/scripts/docker
@@ -227,6 +227,7 @@ export DATADOG_API_KEY="$DATADOG_API_KEY"
 export DATADOG_APP_KEY="$DATADOG_APP_KEY"
 export UCR_CITUS_DB="${UCR_CITUS_DB:-commcare_ucr_citus}"
 export JS_TEST_EXTENSIONS="$JS_TEST_EXTENSIONS"
+export DOCKER_HQ_OVERLAYFS_METACOPY="${DOCKER_HQ_OVERLAYFS_METACOPY:-off}"
 
 if [ "$TRAVIS" == "true" -o "$DOCKER_HQ_OVERLAY" == "none" ]; then
     # don't mount /mnt/commcare-hq-ro volume read-only on travis
@@ -237,6 +238,12 @@ else
     # TODO: use overlayfs and drop support for aufs
     export RO=":ro"
     export DOCKER_HQ_OVERLAY="${DOCKER_HQ_OVERLAY:-aufs}"
+fi
+
+if [ "$DOCKER_HQ_OVERLAY" == "overlayfs" ]; then
+    export DOCKER_HQ_OVERLAYFS_CHMOD="${DOCKER_HQ_OVERLAYFS_CHMOD:-yes}"
+else
+    export DOCKER_HQ_OVERLAYFS_CHMOD="${DOCKER_HQ_OVERLAYFS_CHMOD:-no}"
 fi
 
 case $CMD in


### PR DESCRIPTION
## Summary

Fix detail missed in PR #29779, export new docker env vars so `compose` doesn't complain about them missing.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
