### PR TITLE
[ERM UI] Update release content page to match mock ups

### DIFF
--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -77,7 +77,6 @@ hqDefine("linked_domain/js/domain_links", [
             self.pullReleaseContentViewModel = PullReleaseContentViewModel(pullReleaseContentData);
         }
 
-
         // General data
         self.domain = data.domain;
         self.domain_links = ko.observableArray(_.map(data.linked_domains, DomainLink));

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -24,8 +24,8 @@
       {% if is_linked_domain %}
         <li class="active"><a data-toggle="tab" href="#tabs-pull-content">{% trans "Manage Linked Project" %}</a></li>
       {% endif %}
-      <li{% if not is_linked_domain %} class="active"{% endif %}><a data-toggle="tab" href="#tabs-manage-downstream">{% trans "Projects linked to this one" %}</a></li>
-      <li><a data-toggle="tab" href="#tabs-push-content">{% trans "Release Content" %}</a></li>
+      <li{% if not is_linked_domain %} class="active"{% endif %}><a data-toggle="tab" href="#tabs-manage-downstream">{% trans "Downstream Projects" %}</a></li>
+      <li><a data-toggle="tab" href="#tabs-push-content">{% trans "Push Content" %}</a></li>
     </ul>
     <div class="spacer"></div>
   {% elif is_linked_domain %}

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
@@ -5,7 +5,7 @@
   <div data-bind="if: domainLink">
     <p>
       {% blocktrans %}
-        This project is linked to the upstream project <a data-bind="attr: {'href': domainLink.upstreamUrl}, text: domainLink.upstreamDomain"></a>.<br/>
+        This project is linked to the upstream project <a data-bind="attr: {'href': domainLink.upstreamUrl}, text: domainLink.master_domain"></a>.<br/>
         The data models below can be synced with the existing data models in the upstream project.<br/>
         <a href="#" target="_blank">Learn more</a> about syncing data between linked projects.
       {% endblocktrans %}

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
@@ -5,7 +5,7 @@
   <div data-bind="if: domainLink">
     <p>
       {% blocktrans %}
-        This project is linked to the upstream project <a data-bind="attr: {'href': domainLink.upstreamUrl}, text: domainLink.master_domain"></a>.<br/>
+        This project is linked to the upstream project <a data-bind="attr: {'href': domainLink.upstreamUrl}, text: domainLink.upstreamDomain"></a>.<br/>
         The data models below can be synced with the existing data models in the upstream project.<br/>
         <a href="#" target="_blank">Learn more</a> about syncing data between linked projects.
       {% endblocktrans %}

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
@@ -5,8 +5,8 @@
   <h3>{% trans "Push Content" %}</h3>
   <p>
     {% blocktrans %}
-      Prepare a new release by selecting which data models you would like to push to the selected downstream project spaces.<br/>
-      <a href="#" target="_blank">Learn more</a> about pushing release content with linked projects.
+      Select which data models you would like to push to the specified downstream project spaces.<br/>
+      <a href="#" target="_blank">Learn more</a> about pushing content with linked projects.
     {% endblocktrans %}
   </p>
   <div class="spacer"></div>
@@ -20,7 +20,7 @@
                 data-bind="selectedOptions: modelsToRelease,
                            multiselect: {
                                selectableHeaderTitle: '{% trans_html_attr "All content" %}',
-                               selectedHeaderTitle: '{% trans_html_attr "Content to release" %}',
+                               selectedHeaderTitle: '{% trans_html_attr "Content to push" %}',
                                searchItemTitle: '{% trans_html_attr "Search content" %}',
                           }">
           {% for model in view_data.master_model_status %}
@@ -38,7 +38,7 @@
                 data-bind="selectedOptions: domainsToRelease,
                            multiselect: {
                                selectableHeaderTitle: '{% trans_html_attr "All projects" %}',
-                               selectedHeaderTitle: '{% trans_html_attr "Projects to release to" %}',
+                               selectedHeaderTitle: '{% trans_html_attr "Projects to push to" %}',
                                searchItemTitle: '{% trans_html_attr "Search projects" %}',
                           }">
           {% for link in view_data.linked_domains %}
@@ -64,7 +64,7 @@
       <div class="col-sm-offset-3 col-md-offset-2 controls col-sm-9 col-md-8 col-lg-6">
         <button type="button" class="btn btn-primary" data-bind="click: createRelease, enable: enableReleaseButton">
           <i class="fa fa-refresh fa-spin icon-refresh icon-spin" data-bind="visible: releaseInProgress"></i>
-          {% trans "Create Release" %}
+          {% trans "Push Content" %}
         </button>
       </div>
     </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
@@ -2,6 +2,14 @@
 {% load i18n %}
 
 <div id="ko-tabs-push-content" class="ko-template">
+  <h3>{% trans "Push Content" %}</h3>
+  <p>
+    {% blocktrans %}
+      Prepare a new release by selecting which data models you would like to push to the selected downstream project spaces.<br/>
+      <a href="#" target="_blank">Learn more</a> about pushing release content with linked projects.
+    {% endblocktrans %}
+  </p>
+  <div class="spacer"></div>
   <form class="form-horizontal">
     <div class="form-group">
       <label class="col-sm-3 col-md-2 control-label">
@@ -43,14 +51,13 @@
     </div>
     <div class="form-group">
       <label class="col-sm-3 col-md-2 control-label" for="build-apps">
-        {% trans "Create and release new build for apps" %}
+        {% trans "Re-Build Applications" %}
       </label>
       <div class="col-sm-9 col-md-10 controls">
-        <div class="checkbox">
-          <label>
-            <input type="checkbox" data-bind="checked: buildAppsOnRelease" />
-          </label>
-        </div>
+        <label class="checkbox">
+          <input type="checkbox" data-bind="checked: buildAppsOnRelease" />
+          {% trans "Create and release new build for apps" %}
+        </label>
       </div>
     </div>
     <div class="form-actions">

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
@@ -51,7 +51,7 @@
     </div>
     <div class="form-group">
       <label class="col-sm-3 col-md-2 control-label" for="build-apps">
-        {% trans "Re-Build Applications" %}
+        {% trans "Rebuild Applications" %}
       </label>
       <div class="col-sm-9 col-md-10 controls">
         <label class="checkbox">


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Straggler PR I forgot about. My local env is totally borked right now, otherwise I would attach a screenshot. This is mainly wording changes, as well as adding text to the checkbox on the Push Content page. I know I ran this locally when my local env worked fine. I'll add a screenshot once I fix my issue, but wanted to create the PR in the meantime.

<img width="1199" alt="Screen Shot 2021-06-18 at 9 37 03 AM" src="https://user-images.githubusercontent.com/15785053/122569529-d5d17a80-d018-11eb-9794-07046c4472d0.png">

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will run through QA on parent branch.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested at some point. Cannot locally test right now.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
