### PR TITLE
register champ_pva url in JS test

### DIFF
--- a/custom/champ/static/champ/js/spec/service_uptake.spec.js
+++ b/custom/champ/static/champ/js/spec/service_uptake.spec.js
@@ -8,6 +8,7 @@ describe('ServiceUptakeModel', function() {
     var ALL_OPTION = {'id': '', 'text': 'All'};
 
     pageData.registerUrl('service_uptake', 'service_uptake');
+    pageData.registerUrl('champ_pva', 'champ_pva');
 
     beforeEach(function() {
         viewModel = hqImport("champ/js/knockout/service_uptake").model();


### PR DESCRIPTION
## Summary
This test has failed a few times on Travis. It was also failing for me locally. I looked at a few other builds which also had this error but the build passed. Not sure why some are failing and others not.

Example of build that passed (but has the error): https://travis-ci.com/github/dimagi/commcare-hq/jobs/515560708
Example of build that failed: https://travis-ci.com/github/dimagi/commcare-hq/jobs/514989349

#### Test output showing the error
Running Test 'champ'
http://localhost:8000/mocha/champ

  ․․․․․․․․․․․․․․
  14 passing (56ms)
[10:10:56] Page loaded, session expires at undefined
[10:10:56] Could not find modal, returning
[Error: Error: URL 'champ_pva' not found in registry
    at reverse (http://localhost:8000/static/hqwebapp/js/initial_page_data.js:94:23)
    at Object.self.getChartData (http://localhost:8000/static/champ/js/knockout/prevision_vs_achievement_graph.js:285:27)
    at Object.generate (http://localhost:8000/static/champ/js/knockout/prevision_vs_achievement_graph.js:308:18)
    at http://localhost:8000/static/nvd3/nv.d3.js:63:21]
[Error: Error: Uncaught Error: URL 'champ_pva' not found in registry (http://localhost:8000/static/hqwebapp/js/initial_page_data.js:94)
    at commonjsGlobal.onerror (http://localhost:8000/static/mocha/mocha.js:29960:11)]


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
change only impacts JS tests

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
