### PR TITLE
Forms & cases Couch to SQL fixes

### DIFF
--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -263,7 +263,8 @@ class StockTransactionLoader:
             txx[(tx.report.form_id, tx.report.type)] += 1
         return any(
             self.count_ledger_refs(form_id, report_type, ref) < num_tx
-            for (form_id, report_type), num_tx in txx.items() if num_tx > 1
+            for (form_id, report_type), num_tx in txx.items()
+            if num_tx > 1 and self.has_ledger_refs(form_id, report_type, ref)
         )
 
     def diff_missing_ledger(self, ledger, *, sql_miss=False):
@@ -313,15 +314,21 @@ class StockTransactionLoader:
             self.case_locations[case_id] = loc
         return loc
 
+    def has_ledger_refs(self, form_id, report_type, ref):
+        try:
+            # the result of this call is cached, so a second call
+            # with the same arguments will be fast
+            return self.count_ledger_refs(form_id, report_type, ref) > 0
+        except XFormNotFound:
+            return False
+
     def count_ledger_refs(self, form_id, report_type, ref):
         if form_id not in self.ledger_refs:
             ref_counts = defaultdict(lambda: defaultdict(int))
             for tx_report_type, tx in self.iter_stock_transactions(form_id):
                 ref_counts[tx_report_type][tx.ledger_reference] += 1
             self.ledger_refs[form_id] = ref_counts
-        num = self.ledger_refs[form_id][report_type][ref]
-        assert num > 0, (form_id, report_type, ref)
-        return num
+        return self.ledger_refs[form_id][report_type][ref]
 
     def iter_stock_transactions(self, form_id):
         xform = get_couch_form(form_id)

--- a/corehq/apps/couch_sql_migration/management/commands/couch_domain_report.py
+++ b/corehq/apps/couch_sql_migration/management/commands/couch_domain_report.py
@@ -10,7 +10,7 @@ import django.db.models as models
 from django.core.management.base import BaseCommand
 
 from corehq.apps.accounting.models import Subscription
-from corehq.apps.es.domains import DomainES
+from corehq.apps.es.domains import DomainES, filters
 
 from ...tinypanda import TinyPanda
 
@@ -146,7 +146,10 @@ def get_couch_domains():
     """
     return (
         DomainES()
-        .term("use_sql_backend", False)
+        .filter(filters.OR(
+            filters.term("use_sql_backend", False),
+            filters.missing("use_sql_backend")
+        ))
         .size(DOMAIN_COUNT_UPPER_BOUND)
         .sort("name")
         .values(

--- a/corehq/apps/couch_sql_migration/management/commands/couch_domain_report.py
+++ b/corehq/apps/couch_sql_migration/management/commands/couch_domain_report.py
@@ -161,7 +161,7 @@ def get_couch_domains():
     )
 
 
-DOMAIN_COUNT_UPPER_BOUND = 1000
+DOMAIN_COUNT_UPPER_BOUND = 20000
 
 
 def write_domain_csv(output_dir, domain_sets):


### PR DESCRIPTION
Fixed a few bugs in the case diff logic and fixed a major bug in the `couch_domain_report` management command. Previously some older domains that need to be migrated were not found by the report.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None added. The case diff logic fixes were for errors that prevented certain domains from being migrated. It was easy to verify that the fixes worked manually.

### QA Plan

No QA.

### Safety story

Changes in this PR only affect migration code.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
