### PR TITLE
Succeed even if the trailing slash is omitted

### DIFF
--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -34,6 +34,7 @@ from corehq.apps.fixtures.resources.v0_1 import (
     LookupTableResource,
 )
 from corehq.apps.hqcase.urls import case_api_urlpatterns
+from corehq.apps.hqcase.views import case_api
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.locations import resources as locations
 
@@ -119,7 +120,8 @@ def api_url_patterns():
               ODataFormMetadataView.as_view(), name=ODataFormMetadataView.table_urlname)
     yield url(r'v0.5/odata/forms/(?P<config_id>[\w\-:]+)/\$metadata$',
               ODataFormMetadataView.as_view(), name=ODataFormMetadataView.urlname)
-    yield url(r'v0.6/case/', include(case_api_urlpatterns))
+    yield url(r'v0.6/case$', case_api)  # We don't want Django to redirect to add a trailing slash
+    yield url(r'v0.6/case/?', include(case_api_urlpatterns))
     yield from versioned_apis(API_LIST)
     yield url(r'^case/attachment/(?P<case_id>[\w\-:]+)/(?P<attachment_id>.*)$', CaseAttachmentAPI.as_view(), name="api_case_attachment")
     yield url(r'^form/attachment/(?P<form_id>[\w\-:]+)/(?P<attachment_id>.*)$', FormAttachmentAPI.as_view(), name="api_form_attachment")

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -33,7 +33,6 @@ from corehq.apps.fixtures.resources.v0_1 import (
     LookupTableItemResource,
     LookupTableResource,
 )
-from corehq.apps.hqcase.urls import case_api_urlpatterns
 from corehq.apps.hqcase.views import case_api
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.locations import resources as locations
@@ -120,8 +119,8 @@ def api_url_patterns():
               ODataFormMetadataView.as_view(), name=ODataFormMetadataView.table_urlname)
     yield url(r'v0.5/odata/forms/(?P<config_id>[\w\-:]+)/\$metadata$',
               ODataFormMetadataView.as_view(), name=ODataFormMetadataView.urlname)
-    yield url(r'v0.6/case$', case_api)  # We don't want Django to redirect to add a trailing slash
-    yield url(r'v0.6/case/?', include(case_api_urlpatterns))
+    # match v0.6/case/ AND v0.6/case/e0ad6c2e-514c-4c2b-85a7-da35bbeb1ff1/ trailing slash optional
+    yield url(r'v0\.6/case(?:/(?P<case_id>[\w-]+))?/?$', case_api, name='case_api')
     yield from versioned_apis(API_LIST)
     yield url(r'^case/attachment/(?P<case_id>[\w\-:]+)/(?P<attachment_id>.*)$', CaseAttachmentAPI.as_view(), name="api_case_attachment")
     yield url(r'^form/attachment/(?P<form_id>[\w\-:]+)/(?P<attachment_id>.*)$', FormAttachmentAPI.as_view(), name="api_form_attachment")

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -453,3 +453,19 @@ class TestCaseAPI(TestCase):
         self.assertEqual(res.status_code, 200)
         case = self.case_accessor.get_case(case.case_id)
         self.assertEqual(case.external_id, '1')
+
+    def test_urls_without_trailing_slash(self):
+        case_id = self._make_case().case_id
+        urls = [
+            (self.client.post, reverse('case_api', args=(self.domain,)).rstrip("/")),
+            (self.client.put, reverse('case_api', args=(self.domain, case_id)).rstrip("/")),
+        ]
+        for request_fn, url in urls:
+            res = request_fn(
+                url,
+                {'body': 'bad case update format'},
+                content_type="application/json;charset=utf-8",
+                HTTP_USER_AGENT="user agent string",
+            )
+            # These requests should return a 400 because of the bad body, not a 301 redirect
+            self.assertEqual(res.status_code, 400)

--- a/corehq/apps/hqcase/urls.py
+++ b/corehq/apps/hqcase/urls.py
@@ -12,5 +12,5 @@ urlpatterns = [
 
 case_api_urlpatterns = [
     url(r'^$', case_api, name='case_api'),
-    url(r'^(?P<case_id>[\w-]+)/$', case_api, name='case_api'),
+    url(r'^(?P<case_id>[\w-]+)/?$', case_api, name='case_api'),
 ]

--- a/corehq/apps/hqcase/urls.py
+++ b/corehq/apps/hqcase/urls.py
@@ -1,16 +1,8 @@
 from django.conf.urls import url
 
-from corehq.apps.hqcase.views import (
-    ExplodeCasesView,
-    case_api,
-)
+from corehq.apps.hqcase.views import ExplodeCasesView
 
 urlpatterns = [
     # for load testing
     url(r'explode/', ExplodeCasesView.as_view(), name=ExplodeCasesView.url_name),
-]
-
-case_api_urlpatterns = [
-    url(r'^$', case_api, name='case_api'),
-    url(r'^(?P<case_id>[\w-]+)/?$', case_api, name='case_api'),
 ]


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/QA-3148

I'd like to be able to do this with a better URL pattern, but don't think it's possible.  This is at least explicit, the duplication is minimal (it's essentially registering another valid URL pattern), and I think it's worth the trade-off to provide a better user experience.

## Feature Flag
"Enable the v0.6 Case API"

## Product Description
Succeed even if the trailing slash is omitted

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
This is in response to a QA ticket

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This feature is unreleased and in QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
