### PR TITLE
hide deactivated users from reassign case list

### DIFF
--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -277,7 +277,7 @@ class ReassignCaseOptionsController(CaseListFilterOptionsController):
         if self.request.can_access_all_locations:
             sources.append((self.get_sharing_groups_size, self.get_sharing_groups))
         sources.append((self.get_locations_size, self.get_locations))
-        sources.append((self.get_all_users_size, self.get_all_users))
+        sources.append((self.get_active_users_size, self.get_active_users))
         return sources
 
 


### PR DESCRIPTION
## Summary
Ticket: [SAAS-11613](https://dimagi-dev.atlassian.net/browse/SAAS-11613). This is the simplest fix for that ticket -- preventing deactivated mobile workers from showing up in the reassignment list. However, this does not prevent cases being assigned to deactivated workers, as other flows still exist that allow this, and this change is purely on the front-end.

## Product Description
Case reassignment will no longer display deactivated mobile workers.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No automated tests were done.

### QA Plan

No QA is necessary

### Safety story
Local testing was performed to verify that mobile workers no longer appeared in the drop-down menu.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
