### PR TITLE
ignore couch docs for sql domains in pillows

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from django.conf import settings
 
 from corehq.apps.domain_migration_flags.api import all_domains_with_migrations_in_progress
+from corehq.pillows.base import ignore_couch_changes_for_sql_domains
 from corehq.util.metrics import metrics_counter, metrics_histogram_timer
 from pillowtop.checkpoints.manager import KafkaPillowCheckpoint
 from pillowtop.const import DEFAULT_PROCESSOR_CHUNK_SIZE
@@ -341,6 +342,8 @@ class ConfigurableReportPillowProcessor(ConfigurableReportTableManagerMixin, Bul
         # break up changes by domain
         changes_by_domain = defaultdict(list)
         for change in changes:
+            if ignore_couch_changes_for_sql_domains(change):
+                continue
             # skip if no domain or no UCR tables in the domain
             if change.metadata.domain and change.metadata.domain in self.table_adapters_by_domain:
                 changes_by_domain[change.metadata.domain].append(change)

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from django.conf import settings
 
 from corehq.apps.domain_migration_flags.api import all_domains_with_migrations_in_progress
-from corehq.pillows.base import ignore_couch_changes_for_sql_domains
+from corehq.pillows.base import is_couch_change_for_sql_domain
 from corehq.util.metrics import metrics_counter, metrics_histogram_timer
 from pillowtop.checkpoints.manager import KafkaPillowCheckpoint
 from pillowtop.const import DEFAULT_PROCESSOR_CHUNK_SIZE
@@ -342,7 +342,7 @@ class ConfigurableReportPillowProcessor(ConfigurableReportTableManagerMixin, Bul
         # break up changes by domain
         changes_by_domain = defaultdict(list)
         for change in changes:
-            if ignore_couch_changes_for_sql_domains(change):
+            if is_couch_change_for_sql_domain(change):
                 continue
             # skip if no domain or no UCR tables in the domain
             if change.metadata.domain and change.metadata.domain in self.table_adapters_by_domain:

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -132,6 +132,11 @@ class BulkElasticProcessor(ElasticProcessor, BulkPillowProcessor):
     """
 
     def process_changes_chunk(self, changes_chunk):
+        if self.change_filter_fn:
+            changes_chunk = [
+                change for change in changes_chunk
+                if not self.change_filter_fn(change)
+            ]
         with self._datadog_timing('bulk_extract'):
             bad_changes, docs = bulk_fetch_changes_docs(changes_chunk)
 

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -51,7 +51,8 @@ class ElasticProcessor(PillowProcessor):
       - ES
     """
 
-    def __init__(self, elasticsearch, index_info, doc_prep_fn=None, doc_filter_fn=None):
+    def __init__(self, elasticsearch, index_info, doc_prep_fn=None, doc_filter_fn=None, change_filter_fn=None):
+        self.change_filter_fn = change_filter_fn or noop_filter
         self.doc_filter_fn = doc_filter_fn or noop_filter
         self.elasticsearch = elasticsearch
         self.es_interface = ElasticsearchInterface(self.elasticsearch)
@@ -62,6 +63,9 @@ class ElasticProcessor(PillowProcessor):
         return self.elasticsearch
 
     def process_change(self, change):
+        if self.change_filter_fn and self.change_filter_fn(change):
+            return
+
         if change.deleted and change.id:
             self._delete_doc_if_exists(change.id)
             return

--- a/corehq/ex-submodules/pillowtop/tests/test_bulk.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_bulk.py
@@ -1,19 +1,11 @@
 import uuid
 
 from django.test import SimpleTestCase, TestCase
-
 from mock import Mock, patch
 from six.moves import range
 
 from casexml.apps.case.signals import case_post_save
-from corehq.util.es.interface import ElasticsearchInterface
-from pillowtop.es_utils import initialize_index_and_mapping
-from pillowtop.feed.interface import Change, ChangeMeta
-from pillowtop.pillow.interface import PillowBase
-from pillowtop.processors.elastic import BulkElasticProcessor
-from pillowtop.tests.utils import TEST_INDEX_INFO
-from pillowtop.utils import bulk_fetch_changes_docs, get_errors_with_ids
-
+from corehq.apps.change_feed.data_sources import SOURCE_COUCH
 from corehq.apps.es.tests.utils import es_test
 from corehq.elastic import get_es_new
 from corehq.form_processor.document_stores import CaseDocumentStore
@@ -23,9 +15,19 @@ from corehq.form_processor.tests.utils import (
     create_form_for_test,
     use_sql_backend,
 )
+from corehq.form_processor.utils.general import set_local_domain_sql_backend_override, \
+    clear_local_domain_sql_backend_override
+from corehq.pillows.base import ignore_couch_changes_for_sql_domains
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.elastic import ensure_index_deleted
-from corehq.util.test_utils import trap_extra_setup
+from corehq.util.es.interface import ElasticsearchInterface
+from corehq.util.test_utils import trap_extra_setup, create_and_save_a_case
+from pillowtop.es_utils import initialize_index_and_mapping
+from pillowtop.feed.interface import Change, ChangeMeta
+from pillowtop.pillow.interface import PillowBase
+from pillowtop.processors.elastic import BulkElasticProcessor
+from pillowtop.tests.utils import TEST_INDEX_INFO
+from pillowtop.utils import bulk_fetch_changes_docs, get_errors_with_ids
 
 
 class BulkTest(SimpleTestCase):
@@ -141,3 +143,61 @@ class TestBulkDocOperations(TestCase):
             [self.case_ids[0]],
             [error[0].id for error in errors]
         )
+
+
+class TestBulkOperationsCaseToSQL(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.es = get_es_new()
+        cls.es_interface = ElasticsearchInterface(cls.es)
+        cls.index = TEST_INDEX_INFO.index
+        cls.es_alias = TEST_INDEX_INFO.alias
+
+        with trap_extra_setup(ConnectionError):
+            ensure_index_deleted(cls.index)
+            initialize_index_and_mapping(cls.es, TEST_INDEX_INFO)
+
+        cls.domain = uuid.uuid4().hex
+        cls.case_ids = [
+            uuid.uuid4().hex for i in range(4)
+        ]
+        with drop_connected_signals(case_post_save), drop_connected_signals(sql_case_post_save):
+            for case_id in cls.case_ids:
+                create_and_save_a_case(cls.domain, case_id, case_id)
+
+    @classmethod
+    def tearDownClass(cls):
+        FormProcessorTestUtils.delete_all_cases_forms_ledgers(cls.domain)
+        ensure_index_deleted(cls.index)
+        super().tearDownClass()
+
+    def _changes_from_ids(self, case_ids):
+        return [
+            Change(
+                id=case_id,
+                sequence_id=None,
+                document_store=CaseDocumentStore(self.domain),
+                metadata=ChangeMeta(
+                    document_id=case_id, domain=self.domain,
+                    data_source_type=SOURCE_COUCH, data_source_name='commcarehq'
+                )
+            )
+            for case_id in case_ids
+        ]
+
+    def test_process_changes_chunk_ignore_couch(self):
+        processor = BulkElasticProcessor(
+            self.es, TEST_INDEX_INFO, change_filter_fn=ignore_couch_changes_for_sql_domains)
+
+        changes = self._changes_from_ids(self.case_ids)
+
+        set_local_domain_sql_backend_override(self.domain)
+        self.addCleanup(clear_local_domain_sql_backend_override, self.domain)
+        retry, errors = processor.process_changes_chunk(changes)
+        self.assertEqual([], retry)
+        self.assertEqual([], errors)
+
+        es_docs = self.es_interface.get_bulk_docs(
+            self.es_alias, doc_type=TEST_INDEX_INFO.type, doc_ids=self.case_ids)
+        self.assertEqual([], es_docs)

--- a/corehq/ex-submodules/pillowtop/tests/test_bulk.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_bulk.py
@@ -17,7 +17,7 @@ from corehq.form_processor.tests.utils import (
 )
 from corehq.form_processor.utils.general import set_local_domain_sql_backend_override, \
     clear_local_domain_sql_backend_override
-from corehq.pillows.base import ignore_couch_changes_for_sql_domains
+from corehq.pillows.base import is_couch_change_for_sql_domain
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.elastic import ensure_index_deleted
 from corehq.util.es.interface import ElasticsearchInterface
@@ -188,7 +188,7 @@ class TestBulkOperationsCaseToSQL(TestCase):
 
     def test_process_changes_chunk_ignore_couch(self):
         processor = BulkElasticProcessor(
-            self.es, TEST_INDEX_INFO, change_filter_fn=ignore_couch_changes_for_sql_domains)
+            self.es, TEST_INDEX_INFO, change_filter_fn=is_couch_change_for_sql_domain)
 
         changes = self._changes_from_ids(self.case_ids)
 

--- a/corehq/messaging/pillow.py
+++ b/corehq/messaging/pillow.py
@@ -8,6 +8,7 @@ from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.messaging.tasks import update_messaging_for_case
+from corehq.pillows.base import ignore_couch_changes_for_sql_domains
 from pillowtop.checkpoints.manager import KafkaPillowCheckpoint
 from pillowtop.const import DEFAULT_PROCESSOR_CHUNK_SIZE
 from pillowtop.pillow.interface import ConstructedPillow
@@ -48,6 +49,8 @@ class CaseMessagingSyncProcessor(BulkPillowProcessor):
         return domain_rules.by_case_type.get(case_type, [])
 
     def process_change(self, change):
+        if ignore_couch_changes_for_sql_domains(change):
+            return
         try:
             case = CaseAccessors(change.metadata.domain).get_case(change.id)
         except CaseNotFound:

--- a/corehq/messaging/pillow.py
+++ b/corehq/messaging/pillow.py
@@ -8,7 +8,7 @@ from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.messaging.tasks import update_messaging_for_case
-from corehq.pillows.base import ignore_couch_changes_for_sql_domains
+from corehq.pillows.base import is_couch_change_for_sql_domain
 from pillowtop.checkpoints.manager import KafkaPillowCheckpoint
 from pillowtop.const import DEFAULT_PROCESSOR_CHUNK_SIZE
 from pillowtop.pillow.interface import ConstructedPillow
@@ -49,7 +49,7 @@ class CaseMessagingSyncProcessor(BulkPillowProcessor):
         return domain_rules.by_case_type.get(case_type, [])
 
     def process_change(self, change):
-        if ignore_couch_changes_for_sql_domains(change):
+        if is_couch_change_for_sql_domain(change):
             return
         try:
             case = CaseAccessors(change.metadata.domain).get_case(change.id)

--- a/corehq/pillows/base.py
+++ b/corehq/pillows/base.py
@@ -1,3 +1,6 @@
+from corehq.apps.change_feed.data_sources import SOURCE_COUCH
+from corehq.form_processor.utils import should_use_sql_backend
+
 VALUE_TAG = '#value'
 
 
@@ -53,3 +56,10 @@ def restore_property_dict(report_dict_item):
             restored[k] = v
 
     return restored
+
+
+def ignore_couch_changes_for_sql_domains(change):
+    if not change.metadata or not change.metadata.domain:
+        return False
+    if change.metadata.data_source_type == SOURCE_COUCH and should_use_sql_backend(change.metadata.domain):
+        return True

--- a/corehq/pillows/base.py
+++ b/corehq/pillows/base.py
@@ -58,7 +58,7 @@ def restore_property_dict(report_dict_item):
     return restored
 
 
-def ignore_couch_changes_for_sql_domains(change):
+def is_couch_change_for_sql_domain(change):
     if not change.metadata or not change.metadata.domain:
         return False
     if change.metadata.data_source_type == SOURCE_COUCH and should_use_sql_backend(change.metadata.domain):

--- a/corehq/pillows/base.py
+++ b/corehq/pillows/base.py
@@ -61,5 +61,4 @@ def restore_property_dict(report_dict_item):
 def is_couch_change_for_sql_domain(change):
     if not change.metadata or not change.metadata.domain:
         return False
-    if change.metadata.data_source_type == SOURCE_COUCH and should_use_sql_backend(change.metadata.domain):
-        return True
+    return change.metadata.data_source_type == SOURCE_COUCH and should_use_sql_backend(change.metadata.domain)

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -12,7 +12,7 @@ from corehq.apps.userreports.pillow import ConfigurableReportPillowProcessor
 from corehq.elastic import get_es_new
 from corehq.form_processor.backends.sql.dbaccessors import CaseReindexAccessor
 from corehq.messaging.pillow import CaseMessagingSyncProcessor
-from corehq.pillows.base import ignore_couch_changes_for_sql_domains
+from corehq.pillows.base import is_couch_change_for_sql_domain
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.pillows.case_search import get_case_search_processor
 from corehq.pillows.reportcase import get_case_to_report_es_processor
@@ -64,7 +64,7 @@ def get_case_to_elasticsearch_pillow(pillow_id='CaseToElasticsearchPillow', num_
         elasticsearch=get_es_new(),
         index_info=CASE_INDEX_INFO,
         doc_prep_fn=transform_case_for_elasticsearch,
-        change_filter_fn=ignore_couch_changes_for_sql_domains
+        change_filter_fn=is_couch_change_for_sql_domain
     )
     kafka_change_feed = KafkaChangeFeed(
         topics=CASE_TOPICS, client_id='cases-to-es', num_processes=num_processes, process_num=process_num
@@ -114,7 +114,7 @@ def get_case_pillow(
         elasticsearch=get_es_new(),
         index_info=CASE_INDEX_INFO,
         doc_prep_fn=transform_case_for_elasticsearch,
-        change_filter_fn=ignore_couch_changes_for_sql_domains
+        change_filter_fn=is_couch_change_for_sql_domain
     )
     case_search_processor = get_case_search_processor()
 

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -12,6 +12,7 @@ from corehq.apps.userreports.pillow import ConfigurableReportPillowProcessor
 from corehq.elastic import get_es_new
 from corehq.form_processor.backends.sql.dbaccessors import CaseReindexAccessor
 from corehq.messaging.pillow import CaseMessagingSyncProcessor
+from corehq.pillows.base import ignore_couch_changes_for_sql_domains
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.pillows.case_search import get_case_search_processor
 from corehq.pillows.reportcase import get_case_to_report_es_processor
@@ -62,7 +63,8 @@ def get_case_to_elasticsearch_pillow(pillow_id='CaseToElasticsearchPillow', num_
     case_processor = ElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=CASE_INDEX_INFO,
-        doc_prep_fn=transform_case_for_elasticsearch
+        doc_prep_fn=transform_case_for_elasticsearch,
+        change_filter_fn=ignore_couch_changes_for_sql_domains
     )
     kafka_change_feed = KafkaChangeFeed(
         topics=CASE_TOPICS, client_id='cases-to-es', num_processes=num_processes, process_num=process_num
@@ -111,7 +113,8 @@ def get_case_pillow(
     case_to_es_processor = BulkElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=CASE_INDEX_INFO,
-        doc_prep_fn=transform_case_for_elasticsearch
+        doc_prep_fn=transform_case_for_elasticsearch,
+        change_filter_fn=ignore_couch_changes_for_sql_domains
     )
     case_search_processor = get_case_search_processor()
 

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -23,6 +23,7 @@ from corehq.apps.es import CaseSearchES
 from corehq.elastic import get_es_new
 from corehq.form_processor.backends.sql.dbaccessors import CaseReindexAccessor
 from corehq.form_processor.utils.general import should_use_sql_backend
+from corehq.pillows.base import ignore_couch_changes_for_sql_domains
 from corehq.pillows.mappings.case_mapping import CASE_ES_TYPE
 from corehq.pillows.mappings.case_search_mapping import (
     CASE_SEARCH_INDEX,
@@ -101,6 +102,9 @@ class CaseSearchPillowProcessor(ElasticProcessor):
 
     def process_change(self, change):
         assert isinstance(change, Change)
+        if self.change_filter_fn and self.change_filter_fn(change):
+            return
+
         if change.metadata is not None:
             # Comes from KafkaChangeFeed (i.e. running pillowtop)
             domain = change.metadata.domain
@@ -124,7 +128,8 @@ def get_case_search_processor():
     return CaseSearchPillowProcessor(
         elasticsearch=get_es_new(),
         index_info=CASE_SEARCH_INDEX_INFO,
-        doc_prep_fn=transform_case_for_elasticsearch
+        doc_prep_fn=transform_case_for_elasticsearch,
+        change_filter_fn=ignore_couch_changes_for_sql_domains
     )
 
 

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -23,7 +23,7 @@ from corehq.apps.es import CaseSearchES
 from corehq.elastic import get_es_new
 from corehq.form_processor.backends.sql.dbaccessors import CaseReindexAccessor
 from corehq.form_processor.utils.general import should_use_sql_backend
-from corehq.pillows.base import ignore_couch_changes_for_sql_domains
+from corehq.pillows.base import is_couch_change_for_sql_domain
 from corehq.pillows.mappings.case_mapping import CASE_ES_TYPE
 from corehq.pillows.mappings.case_search_mapping import (
     CASE_SEARCH_INDEX,
@@ -129,7 +129,7 @@ def get_case_search_processor():
         elasticsearch=get_es_new(),
         index_info=CASE_SEARCH_INDEX_INFO,
         doc_prep_fn=transform_case_for_elasticsearch,
-        change_filter_fn=ignore_couch_changes_for_sql_domains
+        change_filter_fn=is_couch_change_for_sql_domain
     )
 
 

--- a/corehq/pillows/reportcase.py
+++ b/corehq/pillows/reportcase.py
@@ -11,7 +11,7 @@ from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import ElasticProcessor
 from pillowtop.reindexer.change_providers.case import get_domain_case_change_provider
 from pillowtop.reindexer.reindexer import ElasticPillowReindexer, ReindexerFactory
-from .base import convert_property_dict, ignore_couch_changes_for_sql_domains
+from .base import convert_property_dict, is_couch_change_for_sql_domain
 
 
 def report_case_filter(doc_dict):
@@ -38,7 +38,7 @@ def get_case_to_report_es_processor():
         index_info=REPORT_CASE_INDEX_INFO,
         doc_prep_fn=transform_case_to_report_es,
         doc_filter_fn=report_case_filter,
-        change_filter_fn=ignore_couch_changes_for_sql_domains
+        change_filter_fn=is_couch_change_for_sql_domain
     )
 
 

--- a/corehq/pillows/reportcase.py
+++ b/corehq/pillows/reportcase.py
@@ -11,7 +11,7 @@ from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import ElasticProcessor
 from pillowtop.reindexer.change_providers.case import get_domain_case_change_provider
 from pillowtop.reindexer.reindexer import ElasticPillowReindexer, ReindexerFactory
-from .base import convert_property_dict
+from .base import convert_property_dict, ignore_couch_changes_for_sql_domains
 
 
 def report_case_filter(doc_dict):
@@ -38,6 +38,7 @@ def get_case_to_report_es_processor():
         index_info=REPORT_CASE_INDEX_INFO,
         doc_prep_fn=transform_case_to_report_es,
         doc_filter_fn=report_case_filter,
+        change_filter_fn=ignore_couch_changes_for_sql_domains
     )
 
 

--- a/corehq/pillows/reportxform.py
+++ b/corehq/pillows/reportxform.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from corehq.elastic import get_es_new
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, KafkaCheckpointEventHandler
-from corehq.pillows.base import convert_property_dict
+from corehq.pillows.base import convert_property_dict, ignore_couch_changes_for_sql_domains
 from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_INDEX_INFO
 from corehq.pillows.xform import transform_xform_for_elasticsearch, xform_pillow_filter
 from pillowtop.checkpoints.manager import get_checkpoint_for_elasticsearch_pillow
@@ -44,7 +44,8 @@ def get_report_xform_to_elasticsearch_pillow(pillow_id='ReportXFormToElasticsear
         elasticsearch=get_es_new(),
         index_info=REPORT_XFORM_INDEX_INFO,
         doc_prep_fn=transform_xform_for_report_forms_index,
-        doc_filter_fn=report_xform_filter
+        doc_filter_fn=report_xform_filter,
+        change_filter_fn=ignore_couch_changes_for_sql_domains
     )
     kafka_change_feed = KafkaChangeFeed(
         topics=topics.FORM_TOPICS, client_id='report-forms-to-es',

--- a/corehq/pillows/reportxform.py
+++ b/corehq/pillows/reportxform.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from corehq.elastic import get_es_new
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, KafkaCheckpointEventHandler
-from corehq.pillows.base import convert_property_dict, ignore_couch_changes_for_sql_domains
+from corehq.pillows.base import convert_property_dict, is_couch_change_for_sql_domain
 from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_INDEX_INFO
 from corehq.pillows.xform import transform_xform_for_elasticsearch, xform_pillow_filter
 from pillowtop.checkpoints.manager import get_checkpoint_for_elasticsearch_pillow
@@ -45,7 +45,7 @@ def get_report_xform_to_elasticsearch_pillow(pillow_id='ReportXFormToElasticsear
         index_info=REPORT_XFORM_INDEX_INFO,
         doc_prep_fn=transform_xform_for_report_forms_index,
         doc_filter_fn=report_xform_filter,
-        change_filter_fn=ignore_couch_changes_for_sql_domains
+        change_filter_fn=is_couch_change_for_sql_domain
     )
     kafka_change_feed = KafkaChangeFeed(
         topics=topics.FORM_TOPICS, client_id='report-forms-to-es',

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -16,6 +16,7 @@ from corehq.apps.userreports.data_source_providers import DynamicDataSourceProvi
 from corehq.apps.userreports.pillow import ConfigurableReportPillowProcessor
 from corehq.elastic import get_es_new
 from corehq.form_processor.backends.sql.dbaccessors import FormReindexAccessor
+from corehq.pillows.base import ignore_couch_changes_for_sql_domains
 from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_INDEX_INFO
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
 from corehq.pillows.user import UnknownUsersProcessor
@@ -152,6 +153,7 @@ def get_xform_to_elasticsearch_pillow(pillow_id='XFormToElasticsearchPillow', nu
         index_info=XFORM_INDEX_INFO,
         doc_prep_fn=transform_xform_for_elasticsearch,
         doc_filter_fn=xform_pillow_filter,
+        change_filter_fn=ignore_couch_changes_for_sql_domains
     )
     kafka_change_feed = KafkaChangeFeed(
         topics=FORM_TOPICS, client_id='forms-to-es', num_processes=num_processes, process_num=process_num
@@ -203,6 +205,7 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
         index_info=XFORM_INDEX_INFO,
         doc_prep_fn=transform_xform_for_elasticsearch,
         doc_filter_fn=xform_pillow_filter,
+        change_filter_fn=ignore_couch_changes_for_sql_domains
     )
     unknown_user_form_processor = UnknownUsersProcessor()
     form_meta_processor = FormSubmissionMetadataTrackerProcessor()
@@ -225,7 +228,8 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
             elasticsearch=get_es_new(),
             index_info=REPORT_XFORM_INDEX_INFO,
             doc_prep_fn=transform_xform_for_report_forms_index,
-            doc_filter_fn=report_xform_filter
+            doc_filter_fn=report_xform_filter,
+            change_filter_fn=ignore_couch_changes_for_sql_domains
         )
         processors.append(xform_to_report_es_processor)
     if not skip_ucr:

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -16,7 +16,7 @@ from corehq.apps.userreports.data_source_providers import DynamicDataSourceProvi
 from corehq.apps.userreports.pillow import ConfigurableReportPillowProcessor
 from corehq.elastic import get_es_new
 from corehq.form_processor.backends.sql.dbaccessors import FormReindexAccessor
-from corehq.pillows.base import ignore_couch_changes_for_sql_domains
+from corehq.pillows.base import is_couch_change_for_sql_domain
 from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_INDEX_INFO
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
 from corehq.pillows.user import UnknownUsersProcessor
@@ -153,7 +153,7 @@ def get_xform_to_elasticsearch_pillow(pillow_id='XFormToElasticsearchPillow', nu
         index_info=XFORM_INDEX_INFO,
         doc_prep_fn=transform_xform_for_elasticsearch,
         doc_filter_fn=xform_pillow_filter,
-        change_filter_fn=ignore_couch_changes_for_sql_domains
+        change_filter_fn=is_couch_change_for_sql_domain
     )
     kafka_change_feed = KafkaChangeFeed(
         topics=FORM_TOPICS, client_id='forms-to-es', num_processes=num_processes, process_num=process_num
@@ -205,7 +205,7 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
         index_info=XFORM_INDEX_INFO,
         doc_prep_fn=transform_xform_for_elasticsearch,
         doc_filter_fn=xform_pillow_filter,
-        change_filter_fn=ignore_couch_changes_for_sql_domains
+        change_filter_fn=is_couch_change_for_sql_domain
     )
     unknown_user_form_processor = UnknownUsersProcessor()
     form_meta_processor = FormSubmissionMetadataTrackerProcessor()
@@ -229,7 +229,7 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
             index_info=REPORT_XFORM_INDEX_INFO,
             doc_prep_fn=transform_xform_for_report_forms_index,
             doc_filter_fn=report_xform_filter,
-            change_filter_fn=ignore_couch_changes_for_sql_domains
+            change_filter_fn=is_couch_change_for_sql_domain
         )
         processors.append(xform_to_report_es_processor)
     if not skip_ucr:

--- a/testapps/test_pillowtop/tests/test_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_xform_pillow.py
@@ -7,6 +7,8 @@ from django.test.testcases import SimpleTestCase, TestCase
 from couchdbkit import ResourceConflict
 from mock import patch
 
+from corehq.form_processor.utils.general import set_local_domain_sql_backend_override, \
+    clear_local_domain_sql_backend_override
 from dimagi.utils.parsing import string_to_utc_datetime
 from pillow_retry.models import PillowError
 
@@ -83,6 +85,18 @@ class XFormPillowTest(TestCase):
         self.assertEqual(self.domain, form_doc['domain'])
         self.assertEqual(metadata.xmlns, form_doc['xmlns'])
         self.assertEqual('XFormInstance', form_doc['doc_type'])
+
+    def test_xform_pillow_couch_to_sql(self):
+        self.process_form_changes.__enter__()
+        form = self._create_form()
+        self.assertTrue(hasattr(form, "_rev"))  # make sure it's a couch form
+
+        set_local_domain_sql_backend_override(self.domain)
+        self.addCleanup(clear_local_domain_sql_backend_override, self.domain)
+
+        self.process_form_changes.__exit__(None, None, None)
+        results = FormES().run()
+        self.assertEqual(0, results.total)
 
     @run_with_all_backends
     def test_form_soft_deletion(self):
@@ -218,11 +232,15 @@ class XFormPillowTest(TestCase):
 
     def _create_form_and_sync_to_es(self):
         with self.process_form_changes:
-            form = get_form_ready_to_save(self.metadata, is_db_test=True)
-            form_processor = FormProcessorInterface(domain=self.domain)
-            form_processor.save_processed_models([form])
+            form = self._create_form()
         self.elasticsearch.indices.refresh(XFORM_INDEX_INFO.index)
         return form, self.metadata
+
+    def _create_form(self):
+        form = get_form_ready_to_save(self.metadata, is_db_test=True)
+        form_processor = FormProcessorInterface(domain=self.domain)
+        form_processor.save_processed_models([form])
+        return form
 
 
 class TransformXformForESTest(SimpleTestCase):


### PR DESCRIPTION
## Summary
This ignores changes that come from CouchDB for cases and forms if the domain has been migrated to the SQL backend.

Once a domain is migrated to the SQL backend we should be able to ignore any changes coming from couch, whether the change is genuine or as a result of a pillow rewind.

The current use case is to speed up processing the backlog after a pillow rewind but it may be useful more generally in the future.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Tests added except for the following:
- ConfigurableReportPillowProcessor
- CaseMessagingSyncProcessor
- CaseSearchPillowProcessor

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
