### PR TITLE
OpenMRS: Fix faulty zip() logic for repeater

### DIFF
--- a/corehq/motech/repeater_helpers.py
+++ b/corehq/motech/repeater_helpers.py
@@ -34,18 +34,18 @@ def get_relevant_case_updates_from_form_json(domain, form_json, case_types, extr
             case_create = case_block.get('create') or {}
             case_update = case_block.get('update') or {}
 
-            if case_create or case_update:
-                result.append(CaseTriggerInfo(
-                    domain=domain,
-                    case_id=case_block['@case_id'],
-                    type=case.type,
-                    name=case.name,
-                    owner_id=case.owner_id,
-                    modified_by=case.modified_by,
-                    updates={**case_create, **case_update},
-                    created='create' in case_block,
-                    closed='close' in case_block,
-                    extra_fields={field: case.get_case_property(field) for field in extra_fields},
-                    form_question_values=form_question_values or {},
-                ))
+            result.append(CaseTriggerInfo(
+                domain=domain,
+                case_id=case_block['@case_id'],
+                type=case.type,
+                name=case.name,
+                owner_id=case.owner_id,
+                modified_by=case.modified_by,
+                updates={**case_create, **case_update},
+                created='create' in case_block,
+                closed='close' in case_block,
+                extra_fields={field: case.get_case_property(field) for field in extra_fields},
+                form_question_values=form_question_values or {},
+            ))
+
     return result

--- a/corehq/motech/repeater_helpers.py
+++ b/corehq/motech/repeater_helpers.py
@@ -24,22 +24,28 @@ def get_relevant_case_updates_from_form_json(domain, form_json, case_types, extr
     case_blocks = extract_case_blocks(form_json)
     cases = CaseAccessors(domain).get_cases(
         [case_block['@case_id'] for case_block in case_blocks], ordered=True)
-    for case, case_block in zip(cases, case_blocks):
-        assert case_block['@case_id'] == case.case_id
+
+    db_case_dict = {case.case_id: case for case in cases}
+
+    for case_block in case_blocks:
+        case = db_case_dict[case_block['@case_id']]
+
         if not case_types or case.type in case_types:
             case_create = case_block.get('create') or {}
             case_update = case_block.get('update') or {}
-            result.append(CaseTriggerInfo(
-                domain=domain,
-                case_id=case_block['@case_id'],
-                type=case.type,
-                name=case.name,
-                owner_id=case.owner_id,
-                modified_by=case.modified_by,
-                updates={**case_create, **case_update},
-                created='create' in case_block,
-                closed='close' in case_block,
-                extra_fields={field: case.get_case_property(field) for field in extra_fields},
-                form_question_values=form_question_values or {},
-            ))
+
+            if case_create or case_update:
+                result.append(CaseTriggerInfo(
+                    domain=domain,
+                    case_id=case_block['@case_id'],
+                    type=case.type,
+                    name=case.name,
+                    owner_id=case.owner_id,
+                    modified_by=case.modified_by,
+                    updates={**case_create, **case_update},
+                    created='create' in case_block,
+                    closed='close' in case_block,
+                    extra_fields={field: case.get_case_property(field) for field in extra_fields},
+                    form_question_values=form_question_values or {},
+                ))
     return result

--- a/corehq/motech/tests/test_repeater_helpers.py
+++ b/corehq/motech/tests/test_repeater_helpers.py
@@ -47,9 +47,7 @@ class TestRepeaterHelpers(TestCase):
             ['paciente'],
             self.extra_fields
         )
-
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].updates, {'name': 'John Lennon'})
+        self.assertEqual(len(result), 2)
 
     @patch.object(CaseAccessors, 'get_cases')
     def test__get_relevant_case_updates_from_form_json_without_case_types(self, get_cases):
@@ -61,7 +59,7 @@ class TestRepeaterHelpers(TestCase):
             [],
             self.extra_fields
         )
-        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result), 3)
 
 
 def create_commcare_case(data):
@@ -86,7 +84,8 @@ def _get_form_json():
                 'form.xml': {
                     'content_type': 'text/xml',
                     'length': 10975,
-                    'url': 'https://www.commcarehq.org/a/infomovel-pepfar/api/form/attachment/CONFIDENTIAL/form.xml'
+                    'url': 'https://www.commcarehq.org/a/infomovel-pepfar'
+                           '/api/form/attachment/CONFIDENTIAL/form.xml'
                 }
             },
             'build_id': 'BUILD_ID',
@@ -106,9 +105,13 @@ def _get_form_json():
                                                 '@date_modified': '2021-06-24T08:43:06.746000Z',
                                                 '@user_id': 'USER ID',
                                                 '@xmlns': 'http://commcarehq.org/case/transaction/v2',
-                                                'index': {'parent': {'#text': '6ca13e74-8ba3-4d0d-l09j-66371e8895dc',
-                                                                     '@case_type': '',
-                                                                     '@relationship': 'child'}}}},
+                                                'index': {
+                                                    'parent': {
+                                                        '#text': '6ca13e74-8ba3-4d0d-l09j-66371e8895dc',
+                                                        '@case_type': '',
+                                                        '@relationship': 'child'
+                                                    }
+                                                }}},
                                        'criar_actualizar_casa': {
                                            'case': {'@case_id': '6ca13e74-8ba3-4d0d-l09j-66371e8895dc',
                                                     '@date_modified': '2021-05-24T08:43:06.746000Z',

--- a/corehq/motech/tests/test_repeater_helpers.py
+++ b/corehq/motech/tests/test_repeater_helpers.py
@@ -1,0 +1,139 @@
+from django.test.testcases import TestCase
+from mock import patch
+from corehq.form_processor.models import CommCareCaseSQL
+from datetime import datetime
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.motech.repeater_helpers import get_relevant_case_updates_from_form_json
+
+
+class TestRepeaterHelpers(TestCase):
+
+    def setUp(self):
+        self.domain = 'test-domain'
+        self.extra_fields = []
+        self.form_question_values = {}
+
+        case_1_data = {
+            'case_id': '5ca13e74-8ba3-4d0d-l09j-66371e8895dd',
+            'domain': self.domain,
+            'type': 'paciente',
+            'name': 'case1',
+            'owner_id': 'owner_1',
+            'modified_by': 'modified_by',
+        }
+        case_2_data = {
+            'case_id': '6ca13e74-8ba3-4d0d-l09j-66371e8895dc',
+            'domain': self.domain,
+            'type': 'casa',
+            'name': 'case2',
+            'owner_id': 'owner_2',
+            'modified_by': 'modified_by',
+        }
+
+        self.case_1 = create_commcare_case(case_1_data)
+        self.case_2 = create_commcare_case(case_2_data)
+
+    def tearDown(self):
+        self.case_1.delete()
+        self.case_2.delete()
+
+    @patch.object(CaseAccessors, 'get_cases')
+    def test__get_relevant_case_updates_from_form_json_with_case_types(self, get_cases):
+        get_cases.return_value = [self.case_1, self.case_2]
+
+        result = get_relevant_case_updates_from_form_json(
+            self.domain,
+            _get_form_json(),
+            ['paciente'],
+            self.extra_fields
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].updates, {'name': 'John Lennon'})
+
+    @patch.object(CaseAccessors, 'get_cases')
+    def test__get_relevant_case_updates_from_form_json_without_case_types(self, get_cases):
+        get_cases.return_value = [self.case_1, self.case_2]
+
+        result = get_relevant_case_updates_from_form_json(
+            self.domain,
+            _get_form_json(),
+            [],
+            self.extra_fields
+        )
+        self.assertEqual(len(result), 2)
+
+
+def create_commcare_case(data):
+    cccsql = CommCareCaseSQL(
+        case_id=data['case_id'],
+        domain=data['domain'],
+        type=data['type'],
+        name=data['name'],
+        owner_id=data['owner_id'],
+        modified_by=data['modified_by'],
+        modified_on=datetime.utcnow(),
+        server_modified_on=datetime.utcnow(),
+    )
+    cccsql.save()
+    return cccsql
+
+
+def _get_form_json():
+    return {'app_id': 'APP_ID',
+            'archived': False,
+            'attachments': {
+                'form.xml': {
+                    'content_type': 'text/xml',
+                    'length': 10975,
+                    'url': 'https://www.commcarehq.org/a/infomovel-pepfar/api/form/attachment/CONFIDENTIAL/form.xml'
+                }
+            },
+            'build_id': 'BUILD_ID',
+            'domain': 'infomovel-pepfar',
+            'edited_by_user_id': None,
+            'edited_on': None,
+            'form': {'#type': 'data',
+                     '@name': 'SOME NAME',
+                     '@uiVersion': '1',
+                     '@version': 'VERSION',
+                     '@xmlns': 'http://openrosa.org/formdesigner/IDIDID',
+                     'casa_data': {'convivente_cascade': {},
+                                   'conviventes_names': {},
+                                   'index_cascade': {},
+                                   'save_to_case': {'alocar_paciente_casa': {
+                                       'case': {'@case_id': '5ca13e74-8ba3-4d0d-l09j-66371e8895dd',
+                                                '@date_modified': '2021-06-24T08:43:06.746000Z',
+                                                '@user_id': 'USER ID',
+                                                '@xmlns': 'http://commcarehq.org/case/transaction/v2',
+                                                'index': {'parent': {'#text': '6ca13e74-8ba3-4d0d-l09j-66371e8895dc',
+                                                                     '@case_type': '',
+                                                                     '@relationship': 'child'}}}},
+                                       'criar_actualizar_casa': {
+                                           'case': {'@case_id': '6ca13e74-8ba3-4d0d-l09j-66371e8895dc',
+                                                    '@date_modified': '2021-05-24T08:43:06.746000Z',
+                                                    '@user_id': 'USER ID',
+                                                    '@xmlns': 'http://commcarehq.org/case/transaction/v2',
+                                                    'create': {'case_name': 'CASE NAME',
+                                                               'case_type': 'casa',
+                                                               'owner_id': 'owner_1'},
+                                                    'update': {
+                                                        'age_range1': '25-30',
+                                                        'age_range2': '25-30 anos',
+                                                    }
+                                                    }}},
+                                   'tb_patient_in_household': '0'},
+                     'case': {'@case_id': '5ca13e74-8ba3-4d0d-l09j-66371e8895dd',
+                              '@date_modified': '2021-06-24T08:43:06.746000Z',
+                              '@user_id': 'USER ID',
+                              '@xmlns': 'http://commcarehq.org/case/transaction/v2',
+                              'update': {'name': 'John Lennon'}},
+                     'confirm_info': {},
+                     'confirmar_perfil': {},
+                     'imported_properties': {},
+                     'indicators_v4': {},
+                     'key_workflow_properties': {},
+                     'meta': {},
+                     'patient_data': {}, },
+            'metadata': {},
+            }


### PR DESCRIPTION
## Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-1517)

There's an issue with one domain's OpenMRS repeaters not showing logs for cancelled payloads on the [Remote API Logs](https://www.commcarehq.org/a/infomovel-pepfar/motech/logs/) page. Upon closer inspection I found that no POST logs were ever present. Turns out payloads were failing due to a `zip()` function which took two arguments, the incoming case and corresponding db case, and looping through them in parallel, but for some reason the function that parses the incoming cases (`extract_case_blocks`) sometimes returns 2 list items for the same case, effectively causing the incoming cases and db cases lists to be out of sync. It was decided to not fiddle with `extract_case_blocks` since it's been around for a long time and used all over, but rather fix the `zip()` issue at hand.
#### Solution
The logic was reworked a bit to use a dictionary which takes the case id as the key and the db case object as the body, thus making it possible to only loop through the incoming cases list and use the incoming case id to retrieve the db case info from the constructed dictionary.

## Feature Flag
OpenMRS

## Product Description
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
2 unit tests included


- [x] This PR can be reverted after deploy with no further considerations 
