### PR TITLE
[ERM UI] Update domains to push to if a new domain is added 

### DIFF
--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -81,6 +81,16 @@ hqDefine("linked_domain/js/domain_links", [
         self.domain = data.domain;
         self.domain_links = ko.observableArray(_.map(data.linked_domains, DomainLink));
 
+
+        // can only push content if a link with a downstream domain exists
+        var pushContentData = null;
+        if (data.linked_domains.length > 0) {
+            pushContentData = {
+                parent: self,
+            };
+            self.pushContentViewModel = PushContentViewModel(pushContentData);
+        }
+
         // Manage Downstream Domains Tab
         // search box
         self.query = ko.observable();
@@ -135,30 +145,6 @@ hqDefine("linked_domain/js/domain_links", [
             });
         };
 
-        // Push Content Tab
-        self.domainsToRelease = ko.observableArray();
-        self.modelsToRelease = ko.observableArray();
-        self.buildAppsOnRelease = ko.observable(false);
-        self.releaseInProgress = ko.observable(false);
-        self.enableReleaseButton = ko.computed(function () {
-            return self.domainsToRelease().length && self.modelsToRelease().length && !self.releaseInProgress();
-        });
-
-        self.createRelease = function () {
-            self.releaseInProgress(true);
-            _private.RMI("create_release", {
-                models: _.map(self.modelsToRelease(), JSON.parse),
-                linked_domains: self.domainsToRelease(),
-                build_apps: self.buildAppsOnRelease(),
-            }).done(function (data) {
-                alertUser.alert_user(data.message, data.success ? 'success' : 'danger');
-                self.releaseInProgress(false);
-            }).fail(function () {
-                alertUser.alert_user(gettext('Something unexpected happened.\nPlease try again, or report an issue if the problem persists.'), 'danger');
-                self.releaseInProgress(false);
-            });
-        };
-
         return self;
     };
 
@@ -172,6 +158,39 @@ hqDefine("linked_domain/js/domain_links", [
         self.downstreamUrl = link.downstream_url;
         return self;
     };
+
+    var PushContentViewModel = function (data) {
+        self.parent = data.parent;
+        self.domainsToPush = ko.observableArray();
+        self.modelsToPush = ko.observableArray();
+        self.buildAppsOnPush = ko.observable(false);
+        self.pushInProgress = ko.observable(false);
+        self.enablePushButton = ko.computed(function () {
+            return self.domainsToPush().length && self.modelsToPush().length && !self.pushInProgress();
+        });
+
+        self.localDomainLinks = ko.computed(function () {
+           return _.filter(self.parent.domain_links(), function (link) {
+                return !link.is_remote;
+           });
+        });
+
+        self.pushContent = function () {
+            self.pushInProgress(true);
+            _private.RMI("create_release", {
+                models: _.map(self.modelsToPush(), JSON.parse),
+                linked_domains: self.domainsToPush(),
+                build_apps: self.buildAppsOnPush(),
+            }).done(function (data) {
+                alertUser.alert_user(data.message, data.success ? 'success' : 'danger');
+                self.pushInProgress(false);
+            }).fail(function () {
+                alertUser.alert_user(gettext('Something unexpected happened.\nPlease try again, or report an issue if the problem persists.'), 'danger');
+                self.pushInProgress(false);
+            });
+        };
+
+    }
 
     var PullReleaseContentViewModel = function (data) {
         // Pull Content Tab
@@ -260,7 +279,7 @@ hqDefine("linked_domain/js/domain_links", [
             $("#ko-tabs-pull-content").koApplyBindings(model.pullReleaseContentViewModel);
         }
         if ($("#ko-tabs-push-content").length) {
-            $("#ko-tabs-push-content").koApplyBindings(model);
+            $("#ko-tabs-push-content").koApplyBindings(model.pushContentViewModel);
         }
         if ($("#ko-tabs-manage-downstream").length) {
             $("#ko-tabs-manage-downstream").koApplyBindings(model);

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -170,9 +170,9 @@ hqDefine("linked_domain/js/domain_links", [
         });
 
         self.localDomainLinks = ko.computed(function () {
-           return _.filter(self.parent.domain_links(), function (link) {
+            return _.filter(self.parent.domain_links(), function (link) {
                 return !link.is_remote;
-           });
+            });
         });
 
         self.pushContent = function () {
@@ -190,7 +190,8 @@ hqDefine("linked_domain/js/domain_links", [
             });
         };
 
-    }
+        return self;
+    };
 
     var PullReleaseContentViewModel = function (data) {
         // Pull Content Tab

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -83,14 +83,10 @@ hqDefine("linked_domain/js/domain_links", [
 
 
         // can only push content if a link with a downstream domain exists
-        var pushContentData = null;
-        if (data.linked_domains.length > 0) {
-            pushContentData = {
-                parent: self,
-            };
-            self.pushContentViewModel = PushContentViewModel(pushContentData);
-        }
-
+        var pushContentData = {
+            parent: self,
+        };
+        self.pushContentViewModel = PushContentViewModel(pushContentData);
         // Manage Downstream Domains Tab
         // search box
         self.query = ko.observable();
@@ -173,6 +169,10 @@ hqDefine("linked_domain/js/domain_links", [
             return _.filter(self.parent.domain_links(), function (link) {
                 return !link.is_remote;
             });
+        });
+
+        self.canPush = ko.computed(function () {
+            return self.localDomainLinks().length > 0;
         });
 
         self.pushContent = function () {

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
@@ -17,7 +17,7 @@
       </label>
       <div class="col-sm-9 col-md-10 controls">
         <select multiple class="form-control"
-                data-bind="selectedOptions: modelsToRelease,
+                data-bind="selectedOptions: modelsToPush,
                            multiselect: {
                                selectableHeaderTitle: '{% trans_html_attr "All content" %}',
                                selectedHeaderTitle: '{% trans_html_attr "Content to push" %}',
@@ -35,17 +35,15 @@
       </label>
       <div class="col-sm-9 col-md-10 controls">
         <select multiple class="form-control"
-                data-bind="selectedOptions: domainsToRelease,
+                data-bind="selectedOptions: domainsToPush,
+                           options: localDomainLinks,
+                           optionsText: 'linked_domain',
+                           optionsValue: 'linked_domain',
                            multiselect: {
                                selectableHeaderTitle: '{% trans_html_attr "All projects" %}',
                                selectedHeaderTitle: '{% trans_html_attr "Projects to push to" %}',
                                searchItemTitle: '{% trans_html_attr "Search projects" %}',
                           }">
-          {% for link in view_data.linked_domains %}
-            {% if not linked_domain.is_remote %}
-              <option value="{{ link.linked_domain }}">{{ link.linked_domain }}</option>
-            {% endif %}
-          {% endfor %}
         </select>
       </div>
     </div>
@@ -55,15 +53,15 @@
       </label>
       <div class="col-sm-9 col-md-10 controls">
         <label class="checkbox">
-          <input type="checkbox" data-bind="checked: buildAppsOnRelease" />
+          <input type="checkbox" data-bind="checked: buildAppsOnPush" />
           {% trans "Create and release new build for apps" %}
         </label>
       </div>
     </div>
     <div class="form-actions">
       <div class="col-sm-offset-3 col-md-offset-2 controls col-sm-9 col-md-8 col-lg-6">
-        <button type="button" class="btn btn-primary" data-bind="click: createRelease, enable: enableReleaseButton">
-          <i class="fa fa-refresh fa-spin icon-refresh icon-spin" data-bind="visible: releaseInProgress"></i>
+        <button type="button" class="btn btn-primary" data-bind="click: pushContent, enable: enablePushButton">
+          <i class="fa fa-refresh fa-spin icon-refresh icon-spin" data-bind="visible: pushInProgress"></i>
           {% trans "Push Content" %}
         </button>
       </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
@@ -2,69 +2,71 @@
 {% load i18n %}
 
 <div id="ko-tabs-push-content" class="ko-template">
-  <h3>{% trans "Push Content" %}</h3>
-  <p>
-    {% blocktrans %}
-      Select which data models you would like to push to the specified downstream project spaces.<br/>
-      <a href="#" target="_blank">Learn more</a> about pushing content with linked projects.
-    {% endblocktrans %}
-  </p>
-  <div class="spacer"></div>
-  <form class="form-horizontal">
-    <div class="form-group">
-      <label class="col-sm-3 col-md-2 control-label">
-        {% trans "Models" %}
-      </label>
-      <div class="col-sm-9 col-md-10 controls">
-        <select multiple class="form-control"
-                data-bind="selectedOptions: modelsToPush,
-                           multiselect: {
-                               selectableHeaderTitle: '{% trans_html_attr "All content" %}',
-                               selectedHeaderTitle: '{% trans_html_attr "Content to push" %}',
-                               searchItemTitle: '{% trans_html_attr "Search content" %}',
-                          }">
-          {% for model in view_data.master_model_status %}
-            <option value="{% html_attr model %}">{{ model.name }}</option>
-          {% endfor %}
-        </select>
-      </div>
-    </div>
-    <div class="form-group">
-      <label class="col-sm-3 col-md-2 control-label">
-        {% trans "Projects" %}
-      </label>
-      <div class="col-sm-9 col-md-10 controls">
-        <select multiple class="form-control"
-                data-bind="selectedOptions: domainsToPush,
-                           options: localDomainLinks,
-                           optionsText: 'linked_domain',
-                           optionsValue: 'linked_domain',
-                           multiselect: {
-                               selectableHeaderTitle: '{% trans_html_attr "All projects" %}',
-                               selectedHeaderTitle: '{% trans_html_attr "Projects to push to" %}',
-                               searchItemTitle: '{% trans_html_attr "Search projects" %}',
-                          }">
-        </select>
-      </div>
-    </div>
-    <div class="form-group">
-      <label class="col-sm-3 col-md-2 control-label" for="build-apps">
-        {% trans "Rebuild Applications" %}
-      </label>
-      <div class="col-sm-9 col-md-10 controls">
-        <label class="checkbox">
-          <input type="checkbox" data-bind="checked: buildAppsOnPush" />
-          {% trans "Create and release new build for apps" %}
+  <div data-bind="if: canPush()">
+    <h3>{% trans "Push Content" %}</h3>
+    <p>
+      {% blocktrans %}
+        Select which data models you would like to push to the specified downstream project spaces.<br/>
+        <a href="#" target="_blank">Learn more</a> about pushing content with linked projects.
+      {% endblocktrans %}
+    </p>
+    <div class="spacer"></div>
+    <form class="form-horizontal">
+      <div class="form-group">
+        <label class="col-sm-3 col-md-2 control-label">
+          {% trans "Models" %}
         </label>
+        <div class="col-sm-9 col-md-10 controls">
+          <select multiple class="form-control"
+                  data-bind="selectedOptions: modelsToPush,
+                             multiselect: {
+                                 selectableHeaderTitle: '{% trans_html_attr "All content" %}',
+                                 selectedHeaderTitle: '{% trans_html_attr "Content to push" %}',
+                                 searchItemTitle: '{% trans_html_attr "Search content" %}',
+                            }">
+            {% for model in view_data.master_model_status %}
+              <option value="{% html_attr model %}">{{ model.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
       </div>
-    </div>
-    <div class="form-actions">
-      <div class="col-sm-offset-3 col-md-offset-2 controls col-sm-9 col-md-8 col-lg-6">
-        <button type="button" class="btn btn-primary" data-bind="click: pushContent, enable: enablePushButton">
-          <i class="fa fa-refresh fa-spin icon-refresh icon-spin" data-bind="visible: pushInProgress"></i>
-          {% trans "Push Content" %}
-        </button>
+      <div class="form-group">
+        <label class="col-sm-3 col-md-2 control-label">
+          {% trans "Projects" %}
+        </label>
+        <div class="col-sm-9 col-md-10 controls">
+          <select multiple class="form-control"
+                  data-bind="selectedOptions: domainsToPush,
+                             options: localDomainLinks,
+                             optionsText: 'linked_domain',
+                             optionsValue: 'linked_domain',
+                             multiselect: {
+                                 selectableHeaderTitle: '{% trans_html_attr "All projects" %}',
+                                 selectedHeaderTitle: '{% trans_html_attr "Projects to push to" %}',
+                                 searchItemTitle: '{% trans_html_attr "Search projects" %}',
+                            }">
+          </select>
+        </div>
       </div>
-    </div>
-  </form>
+      <div class="form-group">
+        <label class="col-sm-3 col-md-2 control-label" for="build-apps">
+          {% trans "Rebuild Applications" %}
+        </label>
+        <div class="col-sm-9 col-md-10 controls">
+          <label class="checkbox">
+            <input type="checkbox" data-bind="checked: buildAppsOnPush" />
+            {% trans "Create and release new build for apps" %}
+          </label>
+        </div>
+      </div>
+      <div class="form-actions">
+        <div class="col-sm-offset-3 col-md-offset-2 controls col-sm-9 col-md-8 col-lg-6">
+          <button type="button" class="btn btn-primary" data-bind="click: pushContent, enable: enablePushButton">
+            <i class="fa fa-refresh fa-spin icon-refresh icon-spin" data-bind="visible: pushInProgress"></i>
+            {% trans "Push Content" %}
+          </button>
+        </div>
+      </div>
+    </form>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-155)

As the ticket explains, the issue is if using the "Add downstream project" workflow, the newly added link is not added to available domains to push to without refreshing. Instead of relying on django templating, I moved the select options to use knockout, allowing the array to be updated on the client side.

As noted below, I manually tested a domain link with `is_remote` set to true to make sure it is still filtered out on the push content page. 

The changes entail the following:
- create push content view model to house localDomainLinks array
- move other push related data to this view model
- rename release to push where applicable
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
UI Changes.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested. Manually added a remote domain link to make sure those are still filtered out correctly with this change. 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
