### PR TITLE
fix queue name for reminder bulk update queue

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -571,8 +571,8 @@ CELERY_TASK_ANNOTATIONS = {
 CELERY_MAIN_QUEUE = 'celery'
 CELERY_PERIODIC_QUEUE = 'celery_periodic'
 CELERY_REMINDER_RULE_QUEUE = 'reminder_rule_queue'
-CELERY_REMINDER_CASE_UPDATE_QUEUE = 'reminder_rule_queue'  # override in localsettings
-CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE = 'reminder_case_update_bulk_queue'
+CELERY_REMINDER_CASE_UPDATE_QUEUE = 'reminder_case_update_queue'
+CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE = 'reminder_rule_queue'  # override in localsettings
 CELERY_REPEAT_RECORD_QUEUE = 'repeat_record_queue'
 CELERY_LOCATION_REASSIGNMENT_QUEUE = 'celery'
 


### PR DESCRIPTION
## Summary
Bug from this commit. The wrong queue was renamed:
https://github.com/dimagi/commcare-hq/commit/5390b9efe9d3a1fc460ac6077c84b6aaf7751458

In parallel to fixing this I am going to roll out changes to deploy the queue to production.

## Product impact
The impact is that any changes to case update rules are not being processed by the bulk update tasks since there is no queue running to process them.



## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below



### Safety story
Reverting previous change

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
