### PR TITLE
CSRF protection for formplayer

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -20,7 +20,11 @@ hqDefine("cloudcare/js/formplayer/app", function () {
     var WebFormSession = hqImport('cloudcare/js/form_entry/webformsession').WebFormSession;
     var appcues = hqImport('analytix/js/appcues');
 
-    FormplayerFrontend.on("before:start", function () {
+    FormplayerFrontend.on("before:start", function (app, options) {
+        // Make a get call if the csrf token isn't available when the page loads.
+        if ($.cookie('XSRF-TOKEN') === undefined) {
+            $.get({url: options.formplayer_url + '/serverup', global: false, xhrFields: { withCredentials: true }});
+        }
         var RegionContainer = Marionette.View.extend({
             el: "#menu-container",
 

--- a/corehq/apps/cloudcare/templates/formplayer/dependencies.html
+++ b/corehq/apps/cloudcare/templates/formplayer/dependencies.html
@@ -35,6 +35,31 @@
   <script src="{% static 'clipboard/dist/clipboard.js' %}"></script>
   <script src="{% static 'reports/js/readable_form.js' %}"></script>
   <script src="{% static 'url-polyfill/url-polyfill.js' %}"></script>
+  <script>
+      function getCookie(cname) {
+        let name = cname + "=";
+        let decodedCookie = decodeURIComponent(document.cookie);
+        let ca = decodedCookie.split(';');
+        for(let i = 0; i <ca.length; i++) {
+          let c = ca[i];
+          while (c.charAt(0) == ' ') {
+            c = c.substring(1);
+          }
+          if (c.indexOf(name) == 0) {
+            return c.substring(name.length, c.length);
+          }
+        }
+        return "";
+      }
+      var token = getCookie('XSRF-TOKEN')
+      $.ajaxSetup({
+        beforeSend: function(xhr, settings) {
+          if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type)) {
+            xhr.setRequestHeader('X-XSRF-TOKEN', token);
+          }
+        }
+      });
+  </script>
 {% endcompress %}
 
 {% include 'hqwebapp/includes/ui_element_js.html' %}

--- a/corehq/apps/cloudcare/templates/formplayer/dependencies.html
+++ b/corehq/apps/cloudcare/templates/formplayer/dependencies.html
@@ -35,32 +35,6 @@
   <script src="{% static 'clipboard/dist/clipboard.js' %}"></script>
   <script src="{% static 'reports/js/readable_form.js' %}"></script>
   <script src="{% static 'url-polyfill/url-polyfill.js' %}"></script>
-  <script>
-      function getCookie(cname) {
-        let name = cname + "=";
-        let decodedCookie = decodeURIComponent(document.cookie);
-        let ca = decodedCookie.split(';');
-        for(let i = 0; i <ca.length; i++) {
-          let c = ca[i];
-          while (c.charAt(0) == ' ') {
-            c = c.substring(1);
-          }
-          if (c.indexOf(name) == 0) {
-            return c.substring(name.length, c.length);
-          }
-        }
-        return "";
-      }
-      $.ajaxSetup({
-        beforeSend: function(xhr, settings) {
-          var token = getCookie('XSRF-TOKEN')
-          if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type)) {
-            xhr.setRequestHeader('X-XSRF-TOKEN', token);
-          }
-          xhr.withCredentials = true;
-        }
-      });
-  </script>
 {% endcompress %}
 
 {% include 'hqwebapp/includes/ui_element_js.html' %}

--- a/corehq/apps/cloudcare/templates/formplayer/dependencies.html
+++ b/corehq/apps/cloudcare/templates/formplayer/dependencies.html
@@ -51,12 +51,13 @@
         }
         return "";
       }
-      var token = getCookie('XSRF-TOKEN')
       $.ajaxSetup({
         beforeSend: function(xhr, settings) {
+          var token = getCookie('XSRF-TOKEN')
           if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type)) {
             xhr.setRequestHeader('X-XSRF-TOKEN', token);
           }
+          xhr.withCredentials = true;
         }
       });
   </script>

--- a/corehq/apps/formplayer_api/form_validation.py
+++ b/corehq/apps/formplayer_api/form_validation.py
@@ -10,6 +10,8 @@ from corehq.apps.formplayer_api.exceptions import (
     FormplayerRequestException,
 )
 from corehq.apps.formplayer_api.utils import get_formplayer_url
+from corehq.util.hmac_request import get_hmac_digest
+from django.conf import settings
 
 
 class ValidationAPIProblem(jsonobject.JsonObject):
@@ -45,7 +47,10 @@ def validate_form(form_xml):
         response = requests.post(
             get_formplayer_url() + const.ENDPOINT_VALIDATE_FORM,
             data=form_xml,
-            headers={'Content-Type': 'application/xml'}
+            headers={
+                'Content-Type': 'application/xml',
+                'X-MAC-DIGEST': get_hmac_digest(settings.FORMPLAYER_INTERNAL_AUTH_KEY, form_xml),
+            }
         )
     except RequestException as e:
         notify_exception(None, "Error calling Formplayer form validation endpoint")

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
@@ -148,11 +148,10 @@ hqDefine("hqwebapp/js/hq.helpers", [
         beforeSend: function (xhr, settings) {
             // Don't pass csrftoken cross domain
             // Ignore HTTP methods that do not require CSRF protection
-            if (!/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type)) {
-                if (!this.crossDomain) {
-                    var $csrf_token = $("#csrfTokenContainer").val();
-                    xhr.setRequestHeader("X-CSRFToken", $csrf_token);
-                }
+            if (!/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type) && !this.crossDomain) {
+                var $csrf_token = $("#csrfTokenContainer").val();
+                xhr.setRequestHeader("X-CSRFToken", $csrf_token);
+
                 var xsrf_token = $.cookie('XSRF-TOKEN');
                 xhr.setRequestHeader('X-XSRF-TOKEN', xsrf_token);
             }

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
@@ -148,9 +148,11 @@ hqDefine("hqwebapp/js/hq.helpers", [
         beforeSend: function (xhr, settings) {
             // Don't pass csrftoken cross domain
             // Ignore HTTP methods that do not require CSRF protection
-            if (!/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type) && !this.crossDomain) {
-                var $csrf_token = $("#csrfTokenContainer").val();
-                xhr.setRequestHeader("X-CSRFToken", $csrf_token);
+            if (!/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type)) {
+                if (!this.crossDomain) {
+                    var $csrf_token = $("#csrfTokenContainer").val();
+                    xhr.setRequestHeader("X-CSRFToken", $csrf_token);
+                }
                 var xsrf_token = $.cookie('XSRF-TOKEN');
                 xhr.setRequestHeader('X-XSRF-TOKEN', xsrf_token);
             }

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
@@ -151,7 +151,10 @@ hqDefine("hqwebapp/js/hq.helpers", [
             if (!/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type) && !this.crossDomain) {
                 var $csrf_token = $("#csrfTokenContainer").val();
                 xhr.setRequestHeader("X-CSRFToken", $csrf_token);
+                var xsrf_token = $.cookie('XSRF-TOKEN');
+                xhr.setRequestHeader('X-XSRF-TOKEN', xsrf_token);
             }
+            xhr.withCredentials = true;
         },
     });
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
@@ -148,10 +148,11 @@ hqDefine("hqwebapp/js/hq.helpers", [
         beforeSend: function (xhr, settings) {
             // Don't pass csrftoken cross domain
             // Ignore HTTP methods that do not require CSRF protection
-            if (!/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type) && !this.crossDomain) {
-                var $csrf_token = $("#csrfTokenContainer").val();
-                xhr.setRequestHeader("X-CSRFToken", $csrf_token);
-
+            if (!/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type)) {
+                if (!this.crossDomain) {
+                    var $csrf_token = $("#csrfTokenContainer").val();
+                    xhr.setRequestHeader("X-CSRFToken", $csrf_token);
+                }
                 var xsrf_token = $.cookie('XSRF-TOKEN');
                 xhr.setRequestHeader('X-XSRF-TOKEN', xsrf_token);
             }


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Jira: https://dimagi-dev.atlassian.net/browse/SAAS-11750
Corresponding formplayer PR: https://github.com/dimagi/formplayer/pull/977

I've enabled csrf protection in formplayer using `CookieCsrfTokenRepository` which sends the csrf token to the browser in a cookie named  `XSRF-TOKEN`. Browser then needs to send the token back to formplayer in all post requests in a header `X-XSRF-TOKEN`. 

I added a script where I modify all the ajax calls to use the `XSRF-TOKEN` from the cookie and send it as `X-XSRF-TOKEN`  header to formplayer. 

**Big Assumption: I'm assuming that all the formplayer api requests are using ajax, otherwise the formplayer requests will throw 403.**  


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Need to do manual QA. 

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Needs to be tested on staging. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
The formplayer PR https://github.com/dimagi/formplayer/pull/977 should be reverted first. Then only this PR can be reverted. 

- [ ] This PR can be reverted after deploy with no further considerations 
