### PR TITLE
Remove the unused is_commtrack function

### DIFF
--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -26,16 +26,6 @@ def base_template(request):
     }
 
 
-def is_commtrack(project, request):
-    if project:
-        return project.commtrack_enabled
-    try:
-        return 'commtrack.org' in request.get_host()
-    except Exception:
-        # get_host might fail for bad requests, e.g. scheduled reports
-        return False
-
-
 def get_per_domain_context(project, request=None):
     custom_logo_url = None
     if (project and project.has_custom_logo


### PR DESCRIPTION
This function is nowhere used in HQ. I tried searching is usage but could not find any. Since This is raising this https://dimagi-dev.atlassian.net/browse/SAAS-12252 security issue so removing it.

@esoergel  could you please confirm I am right and its no more used in the codebase.


@dannyroberts  fyi