### PR TITLE
[couch-to-sql role] remove role migrations and replace with block

### DIFF
--- a/corehq/apps/users/dbaccessors.py
+++ b/corehq/apps/users/dbaccessors.py
@@ -361,12 +361,3 @@ def get_practice_mode_mobile_workers(domain):
         .fields(['_id', 'username'])
         .run().hits
     )
-
-
-def get_all_role_ids():
-    roles = UserRole.view(
-        'users/roles_by_domain',
-        include_docs=False,
-        reduce=False
-    ).all()
-    return [r['id'] for r in roles]

--- a/corehq/apps/users/migrations/0016_webappspermissions.py
+++ b/corehq/apps/users/migrations/0016_webappspermissions.py
@@ -1,26 +1,6 @@
 from django.db import migrations
 
-from corehq.apps.users.dbaccessors import get_all_role_ids
-from dimagi.utils.couch.database import iter_docs
-
-from corehq.apps.users.models import UserRole
-from corehq.util.django_migrations import skip_on_fresh_install
-
-
-@skip_on_fresh_install
-def _migrate_web_apps_permissions(apps, schema_editor):
-    for role_doc in iter_docs(UserRole.get_db(), get_all_role_ids()):
-        role = UserRole.wrap(role_doc)
-
-        changed = False
-        if role.permissions.edit_data:
-            role.permissions.access_web_apps = True
-            changed = True
-        elif role.permissions.access_web_apps:
-            role.permissions.access_web_apps = False
-            changed = True
-        if changed:
-            role.save()
+from corehq.util.django_migrations import block_upgrade_for_removed_migration
 
 
 class Migration(migrations.Migration):
@@ -30,5 +10,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(_migrate_web_apps_permissions, migrations.RunPython.noop)
+        block_upgrade_for_removed_migration('4c7d3a96e061680bc87567d5916ae1e90dd60858')
     ]

--- a/corehq/apps/users/migrations/0016_webappspermissions.py
+++ b/corehq/apps/users/migrations/0016_webappspermissions.py
@@ -10,5 +10,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        block_upgrade_for_removed_migration('4c7d3a96e061680bc87567d5916ae1e90dd60858')
+        block_upgrade_for_removed_migration('a7c40ca6acf609b22b495ab986c11f3524b47ce7')
     ]

--- a/corehq/apps/users/migrations/0019_editreportspermissions.py
+++ b/corehq/apps/users/migrations/0019_editreportspermissions.py
@@ -1,26 +1,6 @@
 from django.db import migrations
 
-from corehq.apps.users.dbaccessors import get_all_role_ids
-from dimagi.utils.couch.database import iter_docs
-
-from corehq.apps.users.models import UserRole
-from corehq.util.django_migrations import skip_on_fresh_install
-
-
-@skip_on_fresh_install
-def _migrate_edit_reports_permissions(apps, schema_editor):
-    for role_doc in iter_docs(UserRole.get_db(), get_all_role_ids()):
-        role = UserRole.wrap(role_doc)
-
-        changed = False
-        if role.permissions.edit_data:
-            role.permissions.edit_reports = True
-            changed = True
-        elif role.permissions.edit_reports:
-            role.permissions.edit_reports = False
-            changed = True
-        if changed:
-            role.save()
+from corehq.util.django_migrations import block_upgrade_for_removed_migration
 
 
 class Migration(migrations.Migration):
@@ -30,5 +10,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(_migrate_edit_reports_permissions, migrations.RunPython.noop)
+        block_upgrade_for_removed_migration('4c7d3a96e061680bc87567d5916ae1e90dd60858')
     ]

--- a/corehq/apps/users/migrations/0019_editreportspermissions.py
+++ b/corehq/apps/users/migrations/0019_editreportspermissions.py
@@ -10,5 +10,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        block_upgrade_for_removed_migration('4c7d3a96e061680bc87567d5916ae1e90dd60858')
+        block_upgrade_for_removed_migration('a7c40ca6acf609b22b495ab986c11f3524b47ce7')
     ]

--- a/corehq/apps/users/migrations/0021_add_view_apps_permission.py
+++ b/corehq/apps/users/migrations/0021_add_view_apps_permission.py
@@ -1,20 +1,6 @@
 from django.db import migrations
 
-from corehq.apps.users.dbaccessors import get_all_role_ids
-from dimagi.utils.couch.database import iter_docs
-
-from corehq.apps.users.models import UserRole
-from corehq.util.django_migrations import skip_on_fresh_install
-
-
-@skip_on_fresh_install
-def _migrate_view_apps_permission(apps, schema_editor):
-    for role_doc in iter_docs(UserRole.get_db(), get_all_role_ids()):
-        role = UserRole.wrap(role_doc)
-
-        if role.permissions.edit_apps:
-            role.permissions.view_apps = True
-            role.save()
+from corehq.util.django_migrations import block_upgrade_for_removed_migration
 
 
 class Migration(migrations.Migration):
@@ -24,7 +10,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(_migrate_view_apps_permission,
-                             reverse_code=migrations.RunPython.noop,
-                             elidable=True)
+        block_upgrade_for_removed_migration('4c7d3a96e061680bc87567d5916ae1e90dd60858')
     ]

--- a/corehq/apps/users/migrations/0021_add_view_apps_permission.py
+++ b/corehq/apps/users/migrations/0021_add_view_apps_permission.py
@@ -10,5 +10,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        block_upgrade_for_removed_migration('4c7d3a96e061680bc87567d5916ae1e90dd60858')
+        block_upgrade_for_removed_migration('a7c40ca6acf609b22b495ab986c11f3524b47ce7')
     ]

--- a/corehq/apps/users/migrations/0024_add_login_as_all_users.py
+++ b/corehq/apps/users/migrations/0024_add_login_as_all_users.py
@@ -10,5 +10,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = {
-        block_upgrade_for_removed_migration('4c7d3a96e061680bc87567d5916ae1e90dd60858')
+        block_upgrade_for_removed_migration('a7c40ca6acf609b22b495ab986c11f3524b47ce7')
     }

--- a/corehq/apps/users/migrations/0024_add_login_as_all_users.py
+++ b/corehq/apps/users/migrations/0024_add_login_as_all_users.py
@@ -1,20 +1,6 @@
 from django.db import migrations
 
-from corehq.apps.users.dbaccessors import get_all_role_ids
-from dimagi.utils.couch.database import iter_docs
-
-from corehq.apps.users.models import UserRole
-from corehq.util.django_migrations import skip_on_fresh_install
-
-
-@skip_on_fresh_install
-def migrate_login_as_all_users_permission(apps, schema_editor):
-    for role_doc in iter_docs(UserRole.get_db(), get_all_role_ids()):
-        role = UserRole.wrap(role_doc)
-
-        if role.permissions.edit_commcare_users:
-            role.permissions.login_as_all_users = True
-            role.save()
+from corehq.util.django_migrations import block_upgrade_for_removed_migration
 
 
 class Migration(migrations.Migration):
@@ -23,8 +9,6 @@ class Migration(migrations.Migration):
         ('users', '0023_hqapikey_role_id'),
     ]
 
-    operations = [
-        migrations.RunPython(migrate_login_as_all_users_permission,
-                             reverse_code=migrations.RunPython.noop,
-                             elidable=True)
-    ]
+    operations = {
+        block_upgrade_for_removed_migration('4c7d3a96e061680bc87567d5916ae1e90dd60858')
+    }


### PR DESCRIPTION
## Summary
This removes role permissions migrations and will block deploy if the migrations have not been run (except for fresh installs).

The dates the migrations were added are as follows:

* 0016_webappspermissions: 2020-06-10
* 0019_editreportspermissions: 2020-07-20
* 0021_add_view_apps_permission: 2020-07-30
* 0024_add_login_as_all_users: 2020-09-32

I have used the commit hash from the last commit before the removals. This will mean that if there are any other blocking migrations between these and the commit selected they will also come across them when running these ones instead of only finding out when they re-run the deploy.

Pinging a wider audience on this one in case there is discussion on the approach.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan
Tested 

### Safety story
This should only impact tests, new installs and envs that have not yet run these migrations. All the migrations were marked with `@skip_on_fresh_install` so there is not change in functionality for that case. Tests won't run these because of that same decorator and all Dimagi managed envs have already run these migrations.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
