### PR TITLE
Update management command that generates the HIPAA log report

### DIFF
--- a/corehq/apps/auditcare/management/commands/generate_request_report.py
+++ b/corehq/apps/auditcare/management/commands/generate_request_report.py
@@ -54,13 +54,23 @@ class Command(BaseCommand):
             if not domain_object:
                 raise CommandError("Domain not found")
 
-        users, super_users = get_users_to_export(user, domain)
+        users, removed_users, super_users = get_users_to_export(user, domain)
 
         with open(filename, 'w') as csvfile:
             writer = csv.writer(csvfile)
             writer.writerow(['Date', 'User', 'Domain', 'IP Address', 'Request Path'])
             for user in users:
                 write_log_events(writer, user, domain, start_date=options['start'], end_date=options['end'])
+
+            for user in removed_users:
+                write_log_events(
+                    writer,
+                    user,
+                    domain,
+                    override_user=f"{user} [REMOVED]",
+                    start_date=options['start'],
+                    end_date=options['end']
+                )
 
             for user in super_users:
                 write_log_events(

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -31,6 +31,9 @@ def navigation_events_by_user(user, start_date=None, end_date=None):
 
 
 def write_log_events(writer, user, domain=None, override_user=None, start_date=None, end_date=None):
+    start_date = string_to_datetime(start_date).replace(tzinfo=None) if start_date else None
+    end_date = string_to_datetime(end_date).replace(tzinfo=None) if end_date else None
+
     for event in navigation_events_by_user(user, start_date, end_date):
         if not domain or domain == event.domain:
             write_log_event(writer, event, override_user)


### PR DESCRIPTION
## Summary
This ensures that we include users that were once members of a domain (accepted an Invitation) as part of the log generation. These users who accepted an invite but are no longer domain members are tagged as "[REMOVED]" in this report.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
The core pieces of this management command are covered by tests.

### Safety story
Just updating a management command. Already tested & run in a limited release and verifies it does what the description says.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
