### PR TITLE
[couch-to-sql roles] role dump load

### DIFF
--- a/corehq/apps/dump_reload/couch/dump.py
+++ b/corehq/apps/dump_reload/couch/dump.py
@@ -25,7 +25,6 @@ DOC_PROVIDERS = {
     DocTypeIDProvider('Program'),
     WebUserIDProvider(),
     DocTypeIDProvider('CommCareUser'),
-    DocTypeIDProvider('UserRole'),
     DocTypeIDProvider('Group'),
     DocTypeIDProvider('ReportConfiguration'),
     DocTypeIDProvider('ReportNotification'),

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -126,6 +126,8 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('linked_domain.DomainLinkHistory', SimpleFilter('link__linked_domain')),
     FilteredModelIteratorBuilder('users.DomainPermissionsMirror', SimpleFilter('source')),
     FilteredModelIteratorBuilder('users.SQLUserRole', SimpleFilter('domain')),
+    FilteredModelIteratorBuilder('users.RolePermission', SimpleFilter('role__domain')),
+    FilteredModelIteratorBuilder('users.RoleAssignableBy', SimpleFilter('role__domain')),
     FilteredModelIteratorBuilder('locations.LocationFixtureConfiguration', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('commtrack.CommtrackConfig', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('commtrack.ActionConfig', SimpleFilter('commtrack_config__domain')),

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -331,6 +331,35 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
 
         self._dump_and_load(expected_object_counts)
 
+    def test_dump_roles(self):
+        from corehq.apps.users.models import SQLUserRole, Permissions, RoleAssignableBy, RolePermission
+
+        expected_object_counts = Counter({
+            SQLUserRole: 2,
+            RolePermission: 9,
+            RoleAssignableBy: 1
+        })
+
+        role1 = SQLUserRole.create(self.domain_name, 'role1')
+        role2 = SQLUserRole.create(
+            self.domain_name, 'role1',
+            permissions=Permissions(edit_web_users=True),
+            assignable_by=[role1.id]
+        )
+        self.addCleanup(role1.delete)
+        self.addCleanup(role2.delete)
+
+        self._dump_and_load(expected_object_counts)
+
+        role1_loaded = SQLUserRole.objects.get(id=role1.id)
+        role2_loaded = SQLUserRole.objects.get(id=role2.id)
+
+        self.assertEqual(role1_loaded.permissions.to_list(), Permissions().to_list())
+        self.assertEqual(role1_loaded.assignable_by, [])
+        self.assertEqual(role2_loaded.permissions.to_list(), Permissions(edit_web_users=True).to_list())
+        self.assertEqual(role2_loaded.assignable_by, [role1_loaded.get_id])
+
+
     def test_device_logs(self):
         from corehq.apps.receiverwrapper.util import submit_form_locally
         from phonelog.models import DeviceReportEntry, ForceCloseEntry, UserEntry, UserErrorEntry


### PR DESCRIPTION
## Summary
Update (and fix) the dump / load commands to only use SQL Roles (and related models).

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added

### Safety story
Only affects the dump / load management commands.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
