### PR TITLE
[couch-to-sql roles] replace usages of couch role with SQL for authorization

### DIFF
--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -28,7 +28,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import (
     CommCareUser,
     Permissions,
-    UserRole,
+    SQLUserRole,
     UserRolePresets,
     WebUser,
 )
@@ -76,8 +76,8 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
         )
         self.other_domain.save()
         initialize_domain_with_default_roles(self.domain.name)
-        self.user_roles = UserRole.by_domain(self.domain.name)
-        self.custom_role = UserRole.create(
+        self.user_roles = SQLUserRole.objects.get_by_domain(self.domain.name)
+        self.custom_role = SQLUserRole.create(
             self.domain.name,
             "Custom Role",
             permissions=Permissions(
@@ -120,7 +120,7 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
         self._change_std_roles()
         subscription.change_plan(DefaultProductPlan.get_default_plan_version())
 
-        custom_role = UserRole.get(self.custom_role.get_id)
+        custom_role = SQLUserRole.objects.by_couch_id(self.custom_role.get_id)
         self.assertTrue(custom_role.is_archived)
 
         self._assertInitialRoles()
@@ -133,10 +133,10 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
         )
         self._change_std_roles()
         new_subscription = subscription.change_plan(DefaultProductPlan.get_default_plan_version())
-        custom_role = UserRole.get(self.custom_role.get_id)
+        custom_role = SQLUserRole.objects.by_couch_id(self.custom_role.get_id)
         self.assertTrue(custom_role.is_archived)
         new_subscription.change_plan(self.advanced_plan, web_user=self.admin_username)
-        custom_role = UserRole.get(self.custom_role.get_id)
+        custom_role = SQLUserRole.objects.by_couch_id(self.custom_role.get_id)
         self.assertFalse(custom_role.is_archived)
 
         self._assertInitialRoles()
@@ -144,8 +144,8 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
 
     def _change_std_roles(self):
         for u in self.user_roles:
-            user_role = UserRole.get(u.get_id)
-            user_role.permissions = Permissions(
+            user_role = SQLUserRole.objects.by_couch_id(u.get_id)
+            user_role.set_permissions(Permissions(
                 view_reports=True,
                 edit_commcare_users=True,
                 view_commcare_users=True,
@@ -157,12 +157,11 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
                 view_apps=True,
                 edit_data=True,
                 edit_reports=True
-            )
-            user_role.save()
+            ).to_list())
 
     def _assertInitialRoles(self):
         for u in self.user_roles:
-            user_role = UserRole.get(u.get_id)
+            user_role = SQLUserRole.objects.by_couch_id(u.get_id)
             self.assertEqual(
                 user_role.permissions,
                 UserRolePresets.get_permissions(user_role.name)

--- a/corehq/apps/api/tests/test_auth.py
+++ b/corehq/apps/api/tests/test_auth.py
@@ -7,7 +7,7 @@ from django.test import TestCase, RequestFactory
 from corehq.apps.api.resources.auth import LoginAuthentication, LoginAndDomainAuthentication, \
     RequirePermissionAuthentication
 from corehq.apps.domain.models import Domain
-from corehq.apps.users.models import WebUser, HQApiKey, Permissions, UserRole
+from corehq.apps.users.models import WebUser, HQApiKey, Permissions, SQLUserRole
 from corehq.util.test_utils import softer_assert
 
 
@@ -159,13 +159,13 @@ class RequirePermissionAuthenticationTest(AuthenticationTestBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.role_with_permission = UserRole.create(
+        cls.role_with_permission = SQLUserRole.create(
             cls.domain, 'edit-data', permissions=Permissions(edit_data=True)
         )
-        cls.role_without_permission = UserRole.create(
+        cls.role_without_permission = SQLUserRole.create(
             cls.domain, 'no-edit-data', permissions=Permissions(edit_data=False)
         )
-        cls.role_with_permission_but_no_api_access = UserRole.create(
+        cls.role_with_permission_but_no_api_access = SQLUserRole.create(
             cls.domain, 'no-api-access', permissions=Permissions(edit_data=True, access_api=False)
         )
         cls.domain_admin = WebUser.create(cls.domain, 'domain_admin', cls.password, None, None, is_admin=True)

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -7,7 +7,7 @@ from casexml.apps.case.mock import CaseBlock
 
 from corehq import privileges
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.users.models import Permissions, UserRole, WebUser
+from corehq.apps.users.models import Permissions, SQLUserRole, WebUser
 from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
     FormAccessors,
@@ -32,7 +32,7 @@ class TestCaseAPI(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.domain_obj = create_domain(cls.domain)
-        role = UserRole.create(
+        role = SQLUserRole.create(
             cls.domain, 'edit-data', permissions=Permissions(edit_data=True)
         )
         cls.web_user = WebUser.create(cls.domain, 'netflix', 'password', None, None, role_id=role.get_id)

--- a/corehq/apps/hqwebapp/tests/test_default_landing_page.py
+++ b/corehq/apps/hqwebapp/tests/test_default_landing_page.py
@@ -11,7 +11,7 @@ from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import (
     CommCareUser,
     Permissions,
-    UserRole,
+    SQLUserRole,
     WebUser,
 )
 from corehq.util.test_utils import flag_enabled, generate_cases
@@ -30,21 +30,18 @@ class TestDefaultLandingPages(TestCase):
         cls.domain_object = Domain(name=cls.domain, is_active=True)
         cls.domain_object.save()
 
-        cls.reports_role = UserRole(
+        cls.reports_role = SQLUserRole.create(
             domain=cls.domain, name='reports-role', default_landing_page='reports',
             permissions=Permissions(view_reports=True),
         )
-        cls.reports_role.save()
-        cls.webapps_role = UserRole(
+        cls.webapps_role = SQLUserRole.create(
             domain=cls.domain, name='webapps-role', default_landing_page='webapps',
             permissions=Permissions(access_web_apps=True),
         )
-        cls.webapps_role.save()
-        cls.downloads_role = UserRole(
+        cls.downloads_role = SQLUserRole.create(
             domain=cls.domain, name='webapps-role', default_landing_page='downloads',
             permissions=Permissions.max(),
         )
-        cls.downloads_role.save()
         cls.global_password = 'secret'
 
         # make an app because not having one changes the default dashboard redirect to the apps page

--- a/corehq/apps/locations/tests/util.py
+++ b/corehq/apps/locations/tests/util.py
@@ -6,7 +6,7 @@ from dimagi.utils.couch.database import iter_bulk_delete
 
 from corehq.apps.commtrack.models import SupplyPointCase
 from corehq.apps.commtrack.tests.util import bootstrap_domain
-from corehq.apps.users.models import Permissions, UserRole
+from corehq.apps.users.models import Permissions, SQLUserRole
 from corehq.util.test_utils import unit_testing_only
 
 from ..models import LocationType, SQLLocation, make_location
@@ -133,7 +133,7 @@ def setup_locations_and_types(domain, location_types, stock_tracking_types, loca
 
 
 def restrict_user_by_location(domain, user):
-    role = UserRole(
+    role = SQLUserRole.create(
         domain=domain,
         name='Regional Supervisor',
         permissions=Permissions(edit_commcare_users=True,
@@ -144,7 +144,6 @@ def restrict_user_by_location(domain, user):
                                 view_locations=True,
                                 access_all_locations=False),
     )
-    role.save()
     user.set_role(domain, role.get_qualified_id())
     user.save()
 

--- a/corehq/apps/saved_reports/tests/test_scheduled_reports.py
+++ b/corehq/apps/saved_reports/tests/test_scheduled_reports.py
@@ -11,7 +11,7 @@ from corehq.apps.saved_reports.scheduled import (
     get_scheduled_report_ids,
     guess_reporting_minute,
 )
-from corehq.apps.users.models import Permissions, UserRole, WebUser
+from corehq.apps.users.models import Permissions, SQLUserRole, WebUser
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.util.elastic import ensure_active_es, ensure_index_deleted
 
@@ -184,7 +184,7 @@ class ScheduledReportSendingTest(TestCase):
         super(ScheduledReportSendingTest, cls).setUpClass()
 
         cls.domain_obj = create_domain(cls.domain)
-        cls.reports_role = UserRole.create(cls.domain, 'Test Role', permissions=Permissions(
+        cls.reports_role = SQLUserRole.create(cls.domain, 'Test Role', permissions=Permissions(
             view_report_list=[cls.REPORT_NAME_LOOKUP['worker_activity']]
         ))
         cls.user = WebUser.create(
@@ -193,7 +193,7 @@ class ScheduledReportSendingTest(TestCase):
             password='secret',
             created_by=None,
             created_via=None,
-            role_id=cls.reports_role._id
+            role_id=cls.reports_role.get_id
         )
 
         initialize_index_and_mapping(es, CASE_INDEX_INFO)

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -21,8 +21,7 @@ from corehq.apps.userreports.models import (
     ReportConfiguration,
 )
 from corehq.apps.userreports.reports.view import ConfigurableReportView
-from corehq.apps.userreports.util import get_indicator_adapter
-from corehq.apps.users.models import Permissions, UserRole, WebUser
+from corehq.apps.users.models import Permissions, SQLUserRole, WebUser
 
 from corehq.sql_db.connections import Session
 from corehq.util.context_managers import drop_connected_signals
@@ -225,7 +224,8 @@ class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
             username = 'editor' if can_edit_reports else 'viewer'
             toggles.USER_CONFIGURABLE_REPORTS.set(username, True, toggles.NAMESPACE_USER)
 
-            user_role = UserRole(
+            # user_role should be deleted along with the domain.
+            user_role = SQLUserRole.create(
                 domain=domain.name,
                 name=rolename,
                 permissions=Permissions(edit_commcare_users=True,
@@ -240,8 +240,6 @@ class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
                                         view_reports=True
                                         )
             )
-            user_role.save()
-            # user_role should be deleted along with the domain.
 
             web_user = WebUser.create(domain.name, username, '***', None, None)
             web_user.set_role(domain.name, user_role.get_qualified_id())

--- a/corehq/apps/users/management/commands/populate_user_role.py
+++ b/corehq/apps/users/management/commands/populate_user_role.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from corehq.apps.cleanup.management.commands.populate_sql_model_from_couch_model import PopulateSQLCommand
 from corehq.apps.users.models import UserRole, Permissions
 from corehq.apps.users.models_sql import (
@@ -9,7 +11,7 @@ from corehq.apps.users.models_sql import (
 class Command(PopulateSQLCommand):
     @classmethod
     def couch_db_slug(cls):
-        return "users"
+        return settings.USERS_GROUPS_DB
 
     @classmethod
     def couch_doc_type(self):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -511,9 +511,12 @@ class DomainMembership(Membership):
             return StaticRole.domain_admin(self.domain)
         elif self.role_id:
             try:
-                return UserRole.get(self.role_id)
-            except ResourceNotFound:
-                logging.exception('no role with id %s found in domain %s' % (self.role_id, self.domain))
+                return SQLUserRole.objects.by_couch_id(self.role_id)
+            except SQLUserRole.DoesNotExist:
+                logging.exception('no role found in domain', extra={
+                    'role_id': self.role_id,
+                    'domain': self.domain
+                })
                 return None
         else:
             return None

--- a/corehq/apps/users/tests/permissions.py
+++ b/corehq/apps/users/tests/permissions.py
@@ -1,8 +1,7 @@
 from couchdbkit.ext.django.schema import ListProperty
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase
 
 import mock
-from memoized import Memoized
 from testil import eq, assert_raises
 
 from corehq.apps.export.views.utils import user_can_view_deid_exports
@@ -10,7 +9,6 @@ from corehq.apps.users.decorators import get_permission_name
 from corehq.apps.users.models import (
     DomainMembership,
     Permissions,
-    UserRole,
     WebUser, PARAMETERIZED_PERMISSIONS, PermissionInfo,
 )
 from corehq.apps.users.permissions import DEID_EXPORT_PERMISSION, has_permission_to_view_report, \
@@ -38,9 +36,10 @@ class PermissionsHelpersTest(SimpleTestCase):
         test_self = self
 
         def get_role(self, domain=None):
-            return UserRole(
+            return mock.Mock(
                 domain=test_self.domain,
-                permissions=test_self.permissions
+                permissions=test_self.permissions,
+                spec=["domain", "permissions"]
             )
 
         assert hasattr(WebUser.has_permission, "get_cache"), "not memoized?"

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -816,9 +816,9 @@ def post_user_role(request, domain):
     try:
         role = _update_role_from_view(domain, role_data)
     except ValueError as e:
-        response = HttpResponseBadRequest()
-        response.content = str(e)
-        return response
+        return JsonResponse({
+            "message": str(e)
+        }, status=400)
 
     response_data = role.to_json()
     user_count = get_role_user_count(domain, role.couch_id)

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -19,15 +19,13 @@ from django.http import (
     HttpResponseBadRequest,
 )
 from django.http.response import HttpResponseServerError
-from django.shortcuts import redirect, render
+from django.shortcuts import render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy, ugettext_noop
+from django.utils.translation import ugettext as _, ngettext, ugettext_lazy, ugettext_noop
 
 from corehq.apps.users.analytics import get_role_user_count
-from soil import DownloadBase
 from soil.exceptions import TaskFailedError
 from soil.util import expose_cached_download, get_download_context
 from django.views.decorators.csrf import csrf_exempt
@@ -47,7 +45,6 @@ from corehq.apps.analytics.tasks import (
     track_workflow,
 )
 from corehq.apps.app_manager.dbaccessors import get_app_languages
-from corehq.apps.cloudcare.dbaccessors import get_cloudcare_apps
 from corehq.apps.domain.decorators import (
     domain_admin_required,
     login_and_domain_required,
@@ -57,14 +54,12 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.es import UserES
 from corehq.apps.hqwebapp.crispy import make_form_readonly
-from corehq.apps.hqwebapp.views import BasePageView, logout
 from corehq.apps.locations.permissions import (
     location_safe,
     user_can_access_other_user,
 )
 from corehq.apps.registration.forms import (
     AdminInvitesUserForm,
-    WebUserInvitationForm,
 )
 from corehq.apps.reports.util import get_possible_reports
 from corehq.apps.sms.mixin import BadSMSConfigException
@@ -105,9 +100,6 @@ from corehq.apps.users.models import (
     WebUser,
     Permissions,
     SQLUserRole,
-)
-from corehq.apps.users.tasks import (
-    bulk_download_users_async,
 )
 from corehq.apps.users.views.utils import get_editable_role_choices, BulkUploadResponseWrapper
 from corehq.apps.user_importer.importer import UserUploadError, check_headers
@@ -878,6 +870,17 @@ def delete_user_role(request, domain):
     if not domain_has_privilege(domain, privileges.ROLE_BASED_ACCESS):
         return JsonResponse({})
     role_data = json.loads(request.body.decode('utf-8'))
+    user_count = get_role_user_count(domain, role_data["_id"])
+    if user_count:
+        return JsonResponse({
+            "message": ngettext(
+                "Unable to delete role '{role}'. It has one user still assigned to it. "
+                "Remove all users assigned to the role before deleting it.",
+                "Unable to delete role '{role}'. It has {user_count} users still assigned to it. "
+                "Remove all users assigned to the role before deleting it.",
+                user_count
+            ).format(role=role_data["name"], user_count=user_count)
+        }, status=400)
     try:
         role = SQLUserRole.objects.by_couch_id(role_data["_id"], domain=domain)
     except SQLUserRole.DoesNotExist:


### PR DESCRIPTION
## Summary
The primary change here is to return the SQL role from `user.get_role` (`domain_membership.role`): d134ff4
All other changes are related to tests.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Updated

### QA Plan
This will be QA'd on staging.

### Safety story
SQL roles are already the primary model in the user / role views and other places in HQ. This change will be the last one that get's merged (outside of tests / cleanup). Prior to merging this we will run the migration command to verify the state of the SQL roles.

[ ] Validate SQL roles on Dimagi envs (`populate_user_role --verify-only`)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
