### PR TITLE
Display multimedia for choices in multiple choice questions

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -387,7 +387,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         EntryArrayAnswer.call(this, question, options);
         self.templateType = 'select';
         self.choices = question.choices;
-        self.choices_v2 = _.map(question.choices_v2(), function(choice) {
+        self.choices_v2 = _.map(question.choices_v2(), function (choice) {
             // add mediaSrc definition to question context, otherwise will not be defined
             choice["mediaSrc"] = question.mediaSrc;
             return choice;
@@ -442,7 +442,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         var self = this;
         EntrySingleAnswer.call(this, question, options);
         self.choices = question.choices;
-        self.choices_v2 = _.map(question.choices_v2(), function(choice) {
+        self.choices_v2 = _.map(question.choices_v2(), function (choice) {
             // add mediaSrc definition to question context, otherwise will not be defined
             choice["mediaSrc"] = question.mediaSrc;
             return choice;

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -387,6 +387,11 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         EntryArrayAnswer.call(this, question, options);
         self.templateType = 'select';
         self.choices = question.choices;
+        self.choices_v2 = _.map(question.choices_v2(), function(choice) {
+            // add mediaSrc definition to question context, otherwise will not be defined
+            choice["mediaSrc"] = question.mediaSrc;
+            return choice;
+        });
         self.isMulti = true;
 
         self.onClear = function () {
@@ -437,6 +442,11 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         var self = this;
         EntrySingleAnswer.call(this, question, options);
         self.choices = question.choices;
+        self.choices_v2 = _.map(question.choices_v2(), function(choice) {
+            // add mediaSrc definition to question context, otherwise will not be defined
+            choice["mediaSrc"] = question.mediaSrc;
+            return choice;
+        });
         self.templateType = 'select';
         self.isMulti = false;
         self.onClear = function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -575,6 +575,12 @@ hqDefine("cloudcare/js/form_entry/fullform-ui", function () {
             return self.error() === null && self.serverError() === null;
         };
 
+        self.mediaSrc = function (resourceType) {
+            // needs to be defined before calling getEntry()
+            if (!resourceType || !_.isFunction(Utils.resourceMap)) { return ''; }
+            return Utils.resourceMap(resourceType);
+        };
+
         self.is_select = (self.datatype() === 'select' || self.datatype() === 'multiselect');
         self.entry = hqImport("cloudcare/js/form_entry/entrycontrols_full").getEntry(self);
         self.entryTemplate = function () {
@@ -596,11 +602,6 @@ hqDefine("cloudcare/js/form_entry/fullform-ui", function () {
             $.publish('formplayer.' + Const.ANSWER, self);
         }, self.throttle);
         self.onchange = self.triggerAnswer;
-
-        self.mediaSrc = function (resourceType) {
-            if (!resourceType || !_.isFunction(Utils.resourceMap)) { return ''; }
-            return Utils.resourceMap(resourceType);
-        };
 
         self.requiredNotAnswered = ko.computed(function () {
             return self.required() && self.answer() === Const.NO_ANSWER;

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -392,7 +392,7 @@
 </script>
 <script type="text/html" id="select-entry-ko-template">
   <div class="sel clear">
-    <div data-bind="foreach: choices, as: 'choice'">
+    <div data-bind="foreach: { data: choices_v2, as: 'choice' }">
       <div data-bind="css: { checkbox: $parent.isMulti, radio: !$parent.isMulti }">
         <label>
           <input data-bind="
@@ -405,8 +405,11 @@
                           class: 'group-' + $parent.entryId,
                       },
                   "/>
-          <span data-bind="renderMarkdown: $data"></span>
+          <span data-bind="renderMarkdown: choice.value()"></span>
         </label>
+        <div class="widget-multimedia" data-bind="
+                template: { name: 'widget-multimedia-ko-template', data: choice }">
+        </div>
       </div>
     </div>
     <button class="btn btn-default btn-xs pull-right" data-bind="click: onClear, fadeVisible: !isMulti && rawAnswer()">


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-10816)

As the ticket describes, the issue is that app preview/web apps does not display multimedia for choices of a question. This is a 2 part issue, the first of which was addressed in formplayer [here](https://github.com/dimagi/formplayer/pull/974) by returning a more detailed response for choices that includes caption/multimedia data.

This PR addresses using the more detailed response in HQ. A multimedia widget has been added to the select-entry element which is used by both SingleSelect and MultiSelect elements. 

The trickiest part was getting `mediaSrc` to be defined within the context that the new choice values are used. For example, this is the definition of the multimedia widget: https://github.com/dimagi/commcare-hq/blob/3df5579bf7df40d3fb06565f6dcbacb1fb3c1c05/corehq/apps/cloudcare/templates/form_entry/templates.html#L282-L293 
This previously did not have issues because the multimedia widget was passed the question object, which contained the mediaSrc function: https://github.com/dimagi/commcare-hq/blob/3df5579bf7df40d3fb06565f6dcbacb1fb3c1c05/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js#L578-L582

This required passing the `mediaSrc` function into each choice object so the multimedia widget has access to it.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
UI changes.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will request QA.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested on both app preview and web apps.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
