### PR TITLE
[ERM UI] Hide downstream projects content

### DIFF
--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/manage_downstream_domains_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/manage_downstream_domains_tab.html
@@ -2,34 +2,34 @@
 {% load i18n %}
 
 <div id="ko-tabs-manage-downstream" class="ko-template">
-  <h3>{% trans "Manage Downstream Projects" %}</h3>
-  <p>
-    {% blocktrans %}
-      This project is an upstream project space for the projects listed below.<br/>
-      <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about Linked Projects.
-    {% endblocktrans %}
-  </p>
-  {% if is_erm_ff_enabled %}
-    <button type="button"
-            class="btn btn-primary"
-            id="add-downstream-domain"
-            data-toggle="modal"
-            data-target="#new-downstream-domain-modal">
-      <i class="fa fa-plus"></i> {% trans "Add Downstream Project" %}
-    </button>
-  {% endif %}
-  <div class="spacer"></div>
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h3 class="panel-title">{% trans 'Downstream Projects' %}</h3>
-    </div>
-    <div class="panel-body">
-      <search-box data-apply-bindings="false"
-                params="value: query,
-                        action: filter,
-                        immediate: true,
-                        placeholder: '{% trans_html_attr "Search Downstream Projects..." %}'"></search-box>
-      <div data-bind="if: domain_links().length">
+  <div data-bind="if: domain_links().length">
+    <h3>{% trans "Manage Downstream Projects" %}</h3>
+    <p>
+      {% blocktrans %}
+        This project is an upstream project space for the projects listed below.<br/>
+        <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about Linked Projects.
+      {% endblocktrans %}
+    </p>
+    {% if is_erm_ff_enabled %}
+      <button type="button"
+              class="btn btn-primary"
+              id="add-downstream-domain"
+              data-toggle="modal"
+              data-target="#new-downstream-domain-modal">
+        <i class="fa fa-plus"></i> {% trans "Add Downstream Project" %}
+      </button>
+    {% endif %}
+    <div class="spacer"></div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">{% trans 'Downstream Projects' %}</h3>
+      </div>
+      <div class="panel-body">
+        <search-box data-apply-bindings="false"
+                  params="value: query,
+                          action: filter,
+                          immediate: true,
+                          placeholder: '{% trans_html_attr "Search Downstream Projects..." %}'"></search-box>
         <table class="table table-striped table-hover" id="linked-domains-table">
           <thead>
           <tr>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Just a small issue I noticed. When adding the content above the table, I did not also move the if statement that determines if the table should be displayed to encapsulate this new content. This simply hides the manage downstream domains tab if there are no domain links.

Bad
<img width="1198" alt="Screen Shot 2021-06-23 at 12 14 20 PM" src="https://user-images.githubusercontent.com/15785053/123132307-9b068280-d41c-11eb-9f9d-33dc26e9b7e9.png">

Good
<img width="1196" alt="Screen Shot 2021-06-23 at 12 14 25 PM" src="https://user-images.githubusercontent.com/15785053/123132323-9fcb3680-d41c-11eb-88f5-fbf570e4ea9c.png">

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
