### PR TITLE
smaller batch

### DIFF
--- a/corehq/ex-submodules/pillow_retry/management/commands/run_pillow_retry_queue.py
+++ b/corehq/ex-submodules/pillow_retry/management/commands/run_pillow_retry_queue.py
@@ -14,7 +14,7 @@ from pillow_retry.models import PillowError
 from corehq.apps.change_feed.producer import ChangeProducer
 from corehq.sql_db.util import handle_connection_failure
 
-BATCH_SIZE = 10000
+BATCH_SIZE = 100
 
 producer = ChangeProducer(auto_flush=False)
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This will be run in a private release on India because the current batch size is too large for the data in the existing pillow errors.