### PR TITLE
Bump xmlsec from 1.3.9 to 1.3.11

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -669,7 +669,7 @@ xlrd==1.0.0
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
-xmlsec==1.3.9
+xmlsec==1.3.11
     # via python3-saml
 yapf==0.31.0
     # via -r dev-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -540,7 +540,7 @@ xlrd==1.0.0
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
-xmlsec==1.3.9
+xmlsec==1.3.11
     # via python3-saml
 zipp==3.4.0
     # via importlib-metadata

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -488,7 +488,7 @@ xlrd==1.0.0
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
-xmlsec==1.3.9
+xmlsec==1.3.11
     # via python3-saml
 zipp==3.4.0
     # via importlib-metadata

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -541,7 +541,7 @@ xlrd==1.0.0
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
-xmlsec==1.3.9
+xmlsec==1.3.11
     # via python3-saml
 zipp==3.4.0
     # via


### PR DESCRIPTION
Bump [xmlsec](https://github.com/mehcode/python-xmlsec) from 1.3.9 to 1.3.11

- [Releases](https://github.com/mehcode/python-xmlsec/releases)
- [Commits](https://github.com/mehcode/python-xmlsec/compare/1.3.9...1.3.11)

The `xmlsec` library was failing to pip-install with a fresh HQ environment on macOS when pinned at 1.3.9. Version 1.3.11 installs fine.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan

No QA.

### Safety story

Reviewed release notes and commit history. Change looks safe. Notable changes:
- drop support for Python 2.7
- improvements to wheel and other package builds

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
