### PR TITLE
Sync data to couch after updating role related models.

### DIFF
--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.dbaccessors import delete_all_users
-from corehq.apps.users.models import CouchUser, WebUser, Permissions
+from corehq.apps.users.models import CouchUser, WebUser, Permissions, UserRole
 from corehq.apps.users.models_sql import SQLUserRole
 from corehq.apps.users.views import _update_role_from_view
 from corehq.apps.users.views.mobile.users import MobileWorkerListView
@@ -123,6 +123,10 @@ class TestUpdateRoleFromView(TestCase):
         self.assertEqual(role.assignable_by, [self.role.couch_id])
         self.assertEqual(role.permissions.to_json(), role_data['permissions'])
 
+        couch_role = UserRole.get(role.couch_id)
+        self.assertEqual(couch_role.permissions.to_list(), role.permissions.to_list())
+        self.assertEqual(couch_role.assignable_by, [self.role.couch_id])
+
     def test_update_role(self):
         self.test_create_role()
 
@@ -137,6 +141,10 @@ class TestUpdateRoleFromView(TestCase):
         self.assertTrue(role.is_non_admin_editable)
         self.assertEqual(role.assignable_by, [])
         self.assertEqual(role.permissions.to_json(), role_data['permissions'])
+
+        couch_role = UserRole.get(role.couch_id)
+        self.assertEqual(couch_role.permissions.to_list(), role.permissions.to_list())
+        self.assertEqual(couch_role.assignable_by, [])
 
     def test_landing_page_validation(self):
         role_data = self.BASE_JSON.copy()

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -869,6 +869,7 @@ def _update_role_from_view(domain, role_data):
 
     assignable_by = role_data["assignable_by"]
     role.set_assignable_by_couch(assignable_by)
+    role._migration_do_sync()  # update permissions and assignable_by
     return role
 
 


### PR DESCRIPTION
## Summary
Sync data to couch after updating role related models.

This fixes a bug where permissions changes to the SQL model do not get synced to the Couch model.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Test updated to check this condition

### Safety story
Tested locally and in unit tests.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
