### PR TITLE
FHIRImporter: Create parent-child relationships

### DIFF
--- a/corehq/motech/fhir/migrations/0009_jsonpathtoresourcetype_related_resource_is_parent.py
+++ b/corehq/motech/fhir/migrations/0009_jsonpathtoresourcetype_related_resource_is_parent.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fhir', '0008_blank_search_params'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='jsonpathtoresourcetype',
+            name='related_resource_is_parent',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/corehq/motech/fhir/models.py
+++ b/corehq/motech/fhir/models.py
@@ -437,6 +437,9 @@ class JSONPathToResourceType(models.Model):
         on_delete=models.CASCADE,
     )
 
+    # Create index on child case to imported parent case?
+    related_resource_is_parent = models.BooleanField(default=False)
+
     def __str__(self):
         jsonpath = self.jsonpath
         if jsonpath.startswith('$.'):

--- a/corehq/motech/fhir/tasks.py
+++ b/corehq/motech/fhir/tasks.py
@@ -1,4 +1,5 @@
-from typing import Generator
+from collections import namedtuple
+from typing import Generator, List
 from uuid import uuid4
 
 from celery.schedules import crontab
@@ -18,6 +19,12 @@ from corehq.motech.utils import simplify_list
 from .bundle import get_bundle, get_next_url, iter_bundle
 from .const import IMPORT_FREQUENCY_DAILY, SYSTEM_URI_CASE_ID, XMLNS_FHIR
 from .models import FHIRImporter, FHIRImporterResourceType
+
+
+ParentInfo = namedtuple(
+    'ParentInfo',
+    ['child_case_id', 'parent_ref', 'parent_resource_type'],
+)
 
 
 @periodic_task(run_every=crontab(hour=5, minute=5), queue='background_queue')
@@ -41,22 +48,24 @@ def run_importer(importer):
         return
     requests = importer.connection_settings.get_requests()
     # TODO: Check service is online, else retry with exponential backoff
+    child_cases = []
     for resource_type in (
             importer.resource_types
             .filter(import_related_only=False)
             .prefetch_related('jsonpaths_to_related_resource_types')
             .all()
     ):
-        import_resource_type(requests, resource_type)
+        import_resource_type(requests, resource_type, child_cases)
 
 
 def import_resource_type(
     requests: Requests,
     resource_type: FHIRImporterResourceType,
+    child_cases: List[ParentInfo],
 ):
     try:
         for resource in iter_resources(requests, resource_type):
-            import_resource(requests, resource_type, resource)
+            import_resource(requests, resource_type, resource, child_cases)
     except Exception as err:
         requests.notify_exception(str(err))
 
@@ -83,6 +92,7 @@ def import_resource(
     requests: Requests,
     resource_type: FHIRImporterResourceType,
     resource: dict,
+    child_cases: List[ParentInfo],
 ):
     if 'resourceType' not in resource:
         raise RemoteAPIError(
@@ -112,7 +122,13 @@ def import_resource(
         xmlns=XMLNS_FHIR,
         device_id=f'FHIRImporter-{resource_type.fhir_importer.pk}',
     )
-    import_related(requests, resource_type, resource)
+    import_related(
+        requests,
+        resource_type,
+        resource,
+        case_block.case_id,
+        child_cases,
+    )
 
 
 def claim_service_request(requests, service_request, case_id):
@@ -236,12 +252,32 @@ def get_name(resource):
     return ''
 
 
-def import_related(requests, resource_type, resource):
+def import_related(
+    requests: Requests,
+    resource_type: FHIRImporterResourceType,
+    resource: dict,
+    case_id: str,
+    child_cases: List[ParentInfo],
+):
     for rel in resource_type.jsonpaths_to_related_resource_types.all():
         jsonpath = jsonpath_parse(rel.jsonpath)
         reference = simplify_list([x.value for x in jsonpath.find(resource)])
         related_resource = get_resource(requests, reference)
-        import_resource(requests, rel.related_resource_type, related_resource)
+
+        if rel.related_resource_is_parent:
+            parent_info = ParentInfo(
+                child_case_id=case_id,
+                parent_ref=reference,
+                parent_resource_type=rel.related_resource_type,
+            )
+            child_cases.append(parent_info)
+
+        import_resource(
+            requests,
+            rel.related_resource_type,
+            related_resource,
+            child_cases,
+        )
 
 
 def get_resource(requests, reference):


### PR DESCRIPTION
## Summary

This change allows related, imported FHIR resources to be linked to each other using parent-child relationships. This can associate a patient's data with the patient.

It is useful, for example, with LTFU workflows, where one would want referrals to be linked to their patients, so that mobile workers have the case data they need.

This PR is based off the `nh/fhir/importer_admin` branch, featured in PR #29849. To keep that PR clean, I will merge once it has been reviewed.


## Feature Flag
"FHIR Integration"


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Automated test coverage

Includes tests.


### Safety story

FHIR integration is not yet released. No projects are using it in production.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
