### PR TITLE
sync permissions / assignable_by to couch directly

### DIFF
--- a/corehq/apps/users/role_utils.py
+++ b/corehq/apps/users/role_utils.py
@@ -31,7 +31,6 @@ def reset_initial_roles_for_domain(domain):
     ]
     for role in initial_roles:
         role.set_permissions(UserRolePresets.get_permissions(role.name).to_list())
-        role._migration_do_sync()  # sync role to couch
 
 
 def initialize_domain_with_default_roles(domain):

--- a/corehq/apps/users/tests/test_migrate_roles_to_sql.py
+++ b/corehq/apps/users/tests/test_migrate_roles_to_sql.py
@@ -53,10 +53,7 @@ class UserRoleCouchToSqlTests(TestCase):
         )
         couch_role.save()
 
-        sql_roles = list(SQLUserRole.objects.filter(domain=self.domain).all())
-        self.assertEqual(2, len(sql_roles))
-        sql_role = [role for role in sql_roles if role.name == couch_role.name][0]
-
+        sql_role = SQLUserRole.objects.by_couch_id(couch_role.get_id)
         for field in UserRole._migration_get_fields():
             self.assertEqual(getattr(couch_role, field), getattr(sql_role, field))
 
@@ -88,9 +85,7 @@ class UserRoleCouchToSqlTests(TestCase):
         # sync the permissions
         sql_role._migration_do_sync()
 
-        couch_roles = UserRole.by_domain(self.domain)
-        self.assertEqual(len(couch_roles), 2)
-        couch_role = [r for r in couch_roles if r.name == sql_role.name][0]
+        couch_role = UserRole.get(sql_role.couch_id)
 
         # compare json since it gives a nice diff view on failure
         self.assertDictEqual(couch_role.permissions.to_json(), sql_role.permissions.to_json())
@@ -106,9 +101,7 @@ class UserRoleCouchToSqlTests(TestCase):
             upstream_id=self.app_editor_sql.couch_id
         )
         sql_role.save()
-        couch_roles = UserRole.by_domain(self.domain)
-        self.assertEqual(len(couch_roles), 2)
-        couch_role = [r for r in couch_roles if r.name == sql_role.name][0]
+        couch_role = UserRole.get(sql_role.couch_id)
         self.assertEqual(couch_role.permissions.to_list(), [])
 
         sql_role.set_permissions([
@@ -130,9 +123,7 @@ class UserRoleCouchToSqlTests(TestCase):
             upstream_id=self.app_editor_sql.couch_id
         )
         sql_role.save()
-        couch_roles = UserRole.by_domain(self.domain)
-        self.assertEqual(len(couch_roles), 2)
-        couch_role = [r for r in couch_roles if r.name == sql_role.name][0]
+        couch_role = UserRole.get(sql_role.couch_id)
         self.assertEqual(couch_role.assignable_by, [])
 
         sql_role.set_assignable_by([self.app_editor_sql.id])

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -869,7 +869,6 @@ def _update_role_from_view(domain, role_data):
 
     assignable_by = role_data["assignable_by"]
     role.set_assignable_by_couch(assignable_by)
-    role._migration_do_sync()  # update permissions and assignable_by
     return role
 
 


### PR DESCRIPTION
## Summary
To avoid issues where changes to roles are only partially synced call the sync directly when changing permissions / assignable_by.

See https://github.com/dimagi/commcare-hq/pull/29971#discussion_r660023926

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Covered by existing tests.

### Safety story
This removes the need to call `role._migration_do_sync` after updating related models. The sync can be disabled by passing `sync_to_couch=False` but this is only done in selected places where it is safe to do so:
- when updating the SQL role from couch
- when creating new roles (the sync happens after the SQL role is fully created).

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
