### PR TITLE
More confluence link updates

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
@@ -172,7 +172,7 @@
 
 - id: mobile_ucr_restore_version
   name: Mobile UCR Restore Version
-  description: Version of mobile UCRs to use. Read more on the  <a target="_blank" href="https://help.commcarehq.org/display/ccinternal/Moving+to+Mobile+UCR+V2">Help Site</a>
+  description: Version of mobile UCRs to use. Read more on the  <a target="_blank" href="https://help.commcarehq.org/display/saas/Moving+to+Mobile+UCR+V2">Help Site</a>
   toggle: MOBILE_UCR
   values: ['1.0', '1.5', '2.0']
   value_names: ['1.0', '1.5', '2.0']

--- a/corehq/apps/app_manager/static_strings.py
+++ b/corehq/apps/app_manager/static_strings.py
@@ -215,7 +215,7 @@ STATICALLY_ANALYZABLE_TRANSLATIONS = [
     ugettext_noop('Validate Multimedia'),
     ugettext_noop('Version 1 translations (old)'),
     ugettext_noop('Version 2 translations (recommended)'),
-    ugettext_noop('Version of mobile UCRs to use. Read more on the  <a target="_blank" href="https://help.commcarehq.org/display/ccinternal/Moving+to+Mobile+UCR+V2">Help Site</a>'),
+    ugettext_noop('Version of mobile UCRs to use. Read more on the  <a target="_blank" href="https://help.commcarehq.org/display/saas/Moving+to+Mobile+UCR+V2">Help Site</a>'),
     ugettext_noop('We frequently release new versions of CommCare Mobile. Use the latest version to take advantage of new features and bug fixes. Note that if you are using CommCare for Android you must also update your version of CommCare from the Google Play Store.'),
     ugettext_noop('We suggest moving to CommCare 2.0 and above, unless your project is using referrals'),
     ugettext_noop('Web App'),

--- a/corehq/apps/app_manager/views/app_summary.py
+++ b/corehq/apps/app_manager/views/app_summary.py
@@ -101,7 +101,7 @@ class AppFormSummaryView(AppSummaryView):
             messages.warning(
                 self.request,
                 'Hey Dimagi User! Have you tried out '
-                '<a href="https://confluence.dimagi.com/display/ccinternal/Viewing+App+Changes+between+versions" '
+                '<a href="https://confluence.dimagi.com/display/saas/Viewing+App+Changes+between+versions" '
                 'target="_blank">Viewing App Changes between Versions</a> yet? It might be just what you are '
                 'looking for!',
                 extra_tags='html'

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -180,7 +180,7 @@ class CaseListReport(CaseListMixin, ProjectInspectionReport, ReportDataSource):
         if self.can_upgrade_to_case_list_explorer:
             messages.warning(
                 self.request,
-                'Hey Dimagi User! Have you tried out the <a href="https://confluence.dimagi.com/display/ccinternal/Case+List+Explorer" target="_blank">Case List Explorer</a> yet? It might be just what you are looking for!',
+                'Hey Dimagi User! Have you tried out the <a href="https://confluence.dimagi.com/display/saas/Case+List+Explorer" target="_blank">Case List Explorer</a> yet? It might be just what you are looking for!',
                 extra_tags='html',
             )
         return super(CaseListReport, self).view_response

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -666,7 +666,7 @@ MM_CASE_PROPERTIES = StaticToggle(
     'mm_case_properties',
     'Multimedia Case Properties',
     TAG_DEPRECATED,
-    help_link='https://confluence.dimagi.com/display/ccinternal/Multimedia+Case+Properties+Feature+Flag',
+    help_link='https://confluence.dimagi.com/display/saas/Multimedia+Case+Properties+Feature+Flag',
     namespaces=[NAMESPACE_DOMAIN],
 )
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -5016,7 +5016,7 @@ msgstr ""
 #: corehq/apps/app_manager/static_strings.py:218
 msgid ""
 "Version of mobile UCRs to use. Read more on the  <a target=\"_blank\" href="
-"\"https://help.commcarehq.org/display/ccinternal/Moving+to+Mobile+UCR"
+"\"https://help.commcarehq.org/display/saas/Moving+to+Mobile+UCR"
 "+V2\">Help Site</a>"
 msgstr ""
 

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -5292,7 +5292,7 @@ msgstr "Versión 2 de traducciones (recomendado)"
 #: corehq/apps/app_manager/static_strings.py:218
 msgid ""
 "Version of mobile UCRs to use. Read more on the  <a target=\"_blank\" href="
-"\"https://help.commcarehq.org/display/ccinternal/Moving+to+Mobile+UCR"
+"\"https://help.commcarehq.org/display/saas/Moving+to+Mobile+UCR"
 "+V2\">Help Site</a>"
 msgstr ""
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -4898,7 +4898,7 @@ msgstr ""
 #: corehq/apps/app_manager/static_strings.py:218
 msgid ""
 "Version of mobile UCRs to use. Read more on the  <a target=\"_blank\" href="
-"\"https://help.commcarehq.org/display/ccinternal/Moving+to+Mobile+UCR"
+"\"https://help.commcarehq.org/display/saas/Moving+to+Mobile+UCR"
 "+V2\">Help Site</a>"
 msgstr ""
 

--- a/locale/fra/LC_MESSAGES/django.po
+++ b/locale/fra/LC_MESSAGES/django.po
@@ -5212,7 +5212,7 @@ msgstr ""
 #: corehq/apps/app_manager/static_strings.py:218
 msgid ""
 "Version of mobile UCRs to use. Read more on the  <a target=\"_blank\" href="
-"\"https://help.commcarehq.org/display/ccinternal/Moving+to+Mobile+UCR"
+"\"https://help.commcarehq.org/display/saas/Moving+to+Mobile+UCR"
 "+V2\">Help Site</a>"
 msgstr ""
 

--- a/locale/hin/LC_MESSAGES/django.po
+++ b/locale/hin/LC_MESSAGES/django.po
@@ -4911,7 +4911,7 @@ msgstr ""
 #: corehq/apps/app_manager/static_strings.py:218
 msgid ""
 "Version of mobile UCRs to use. Read more on the  <a target=\"_blank\" href="
-"\"https://help.commcarehq.org/display/ccinternal/Moving+to+Mobile+UCR"
+"\"https://help.commcarehq.org/display/saas/Moving+to+Mobile+UCR"
 "+V2\">Help Site</a>"
 msgstr ""
 

--- a/locale/por/LC_MESSAGES/django.po
+++ b/locale/por/LC_MESSAGES/django.po
@@ -4947,7 +4947,7 @@ msgstr ""
 #: corehq/apps/app_manager/static_strings.py:218
 msgid ""
 "Version of mobile UCRs to use. Read more on the  <a target=\"_blank\" href="
-"\"https://help.commcarehq.org/display/ccinternal/Moving+to+Mobile+UCR"
+"\"https://help.commcarehq.org/display/saas/Moving+to+Mobile+UCR"
 "+V2\">Help Site</a>"
 msgstr ""
 

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -4902,7 +4902,7 @@ msgstr ""
 #: corehq/apps/app_manager/static_strings.py:218
 msgid ""
 "Version of mobile UCRs to use. Read more on the  <a target=\"_blank\" href="
-"\"https://help.commcarehq.org/display/ccinternal/Moving+to+Mobile+UCR"
+"\"https://help.commcarehq.org/display/saas/Moving+to+Mobile+UCR"
 "+V2\">Help Site</a>"
 msgstr ""
 


### PR DESCRIPTION
## Summary

https://dimagi-dev.atlassian.net/browse/USH-1116
Follow up on https://github.com/dimagi/commcare-hq/pull/29977


## Product Description
Corrects the outdated confluence links



## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage


### QA Plan

Quite a safe change to do and planning to merge this without any QA.

### Safety story


Locally tested that all the updated links are indeed correct replacements for the old ones.




### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
