### PR TITLE
[SSO] Fall back to Display Name if First and Last names are blank

### DIFF
--- a/corehq/apps/sso/tests/generator.py
+++ b/corehq/apps/sso/tests/generator.py
@@ -86,6 +86,13 @@ def store_full_name_in_saml_user_data(request, first_name, last_name):
 
 
 @unit_testing_only
+def store_display_name_in_saml_user_data(request, display_name):
+    request.session['samlUserdata'] = {
+        'http://schemas.microsoft.com/identity/claims/displayname': [display_name],
+    }
+
+
+@unit_testing_only
 def get_public_cert_file(expiration_in_seconds=certificates.DEFAULT_EXPIRATION):
     key_pair = certificates.create_key_pair()
     cert = certificates.create_self_signed_cert(

--- a/corehq/apps/sso/utils/session_helpers.py
+++ b/corehq/apps/sso/utils/session_helpers.py
@@ -31,16 +31,33 @@ def _get_saml_user_data_property(request, prop_slug):
     return value
 
 
+def _get_display_name_from_session(request):
+    """
+    This gets the display name from SSO user data stored in the session SAML
+    data.
+    :param request: HttpRequest
+    :return: string or None
+    """
+    return _get_saml_user_data_property(
+        request,
+        'http://schemas.microsoft.com/identity/claims/displayname'
+    )
+
+
 def get_sso_user_first_name_from_session(request):
     """
     This gets the first name from sso user data stored in the session SAML data.
     :param request: HttpRequest
     :return: string or None
     """
-    return _get_saml_user_data_property(
+    first_name = _get_saml_user_data_property(
         request,
         'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname'
     )
+    if not first_name:
+        display_name = _get_display_name_from_session(request)
+        first_name = display_name.split(' ')[0] if display_name else None
+    return first_name
 
 
 def get_sso_user_last_name_from_session(request):
@@ -49,7 +66,13 @@ def get_sso_user_last_name_from_session(request):
     :param request: HttpRequest
     :return: string or None
     """
-    return _get_saml_user_data_property(
+    last_name = _get_saml_user_data_property(
         request,
         'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname'
     )
+    if not last_name:
+        display_name = _get_display_name_from_session(request)
+        display_name_parts = display_name.split(' ') if display_name else []
+        if len(display_name_parts) > 1:
+            last_name = ' '.join(display_name_parts[1:])
+    return last_name


### PR DESCRIPTION
## Summary
From QA we learned that it was possible for a new user to join and have their First and Last names be blank. This is because Azure AD does not make these fields required by default. However, Display Name is set to required.

This is a simple fix to ensure that if a First/Last name isn't available, we fall back to the Display Name

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Extremely well-tested area and new tests were added for this change.

### QA Plan
Addresses a QA bug.

### Safety story
Area is well tested and this is code that is presently not active on production, so it can be merged immediately after approval.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
