### PR TITLE
prevents 403 error due to csrf token issue

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -175,7 +175,10 @@ hqDefine('hqwebapp/js/inactivity', [
                         try {
                             iframeInputValue = iframe.getElementsByTagName('input')[0].value;
                             outerCSRFInput.val(iframeInputValue);
-                        } catch (error) {
+                        } catch (err) {
+                            $button.removeClass("btn-default").addClass("btn-danger");
+                            error = gettext("There was a problem, please refresh and try again");
+                            $button.text(error);
                             return null;
                         }
                         $modal.modal('hide');

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -175,7 +175,7 @@ hqDefine('hqwebapp/js/inactivity', [
                         try {
                             iframeInputValue = iframe.getElementsByTagName('input')[0].value;
                             outerCSRFInput.val(iframeInputValue);
-                        } catch(error) {
+                        } catch (error) {
                             return null;
                         }
                         $modal.modal('hide');

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -169,9 +169,9 @@ hqDefine('hqwebapp/js/inactivity', [
                     } else {
                         // Keeps the input value in the outer window in sync with newest token generated in
                         // iframe_close_window after session timeout, avoiding csrf error.
-                        let iframe = $('iframe').get(0).contentWindow.document;
-                        let outerCSRFInput = $('#csrfTokenContainer');
-                        let iframeInputValue;
+                        var iframe = $('iframe').get(0).contentWindow.document;
+                        var outerCSRFInput = $('#csrfTokenContainer');
+                        var iframeInputValue;
                         try {
                             iframeInputValue = iframe.getElementsByTagName('input')[0].value;
                             outerCSRFInput.val(iframeInputValue);

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -167,6 +167,17 @@ hqDefine('hqwebapp/js/inactivity', [
                         $button.removeClass("btn-default").addClass("btn-danger");
                         $button.text(error);
                     } else {
+                        // Keeps the input value in the outer window in sync with newest token generated in
+                        // iframe_close_window after session timeout, avoiding csrf error.
+                        let iframe = $('iframe').get(0).contentWindow.document;
+                        let outerCSRFInput = $('#csrfTokenContainer');
+                        let iframeInputValue;
+                        try {
+                            iframeInputValue = iframe.getElementsByTagName('input')[0].value;
+                            outerCSRFInput.val(iframeInputValue);
+                        } catch(error) {
+                            return null;
+                        }
                         $modal.modal('hide');
                         $button.text(gettext("Done"));
                         _.delay(pollToShowModal, getDelayAndWarnIfNeeded(data.session_expiry));

--- a/corehq/apps/hqwebapp/templates/hqwebapp/iframe_close_window.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/iframe_close_window.html
@@ -8,6 +8,7 @@
     <script src="{% statici18n LANGUAGE_CODE %}"></script>
   </head>
   <body>
+    <input id="csrfTokenContainer" type="hidden" value="{{ csrf_token }}">
     <div class="hq-container">
       <div class="container-fluid">
         <div class="page-header">


### PR DESCRIPTION
## Summary
[USH-1043](https://dimagi-dev.atlassian.net/browse/USH-1043)
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
If a user is working in report builder and their session times out due to inactivity, they will be able to log back in and continue seamlessly. Previously they were presented with an error that required refreshing the page. 
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
none 
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
The scope of this change is limited to csrf issue in session timeout. Only affects whether the token in outer window is up to date after timeout.   
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
