### PR TITLE
Query to grab keyword object based on id

### DIFF
--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -457,7 +457,7 @@ class DomainLinkHistoryReport(GenericTabularReport):
             keyword_name = ugettext_lazy('Unknown Keyword')
             if detail:
                 try:
-                    keyword_name = Keyword.objects.get(detail.keyword_id)
+                    keyword_name = Keyword.objects.get(couch_id=detail.keyword_id).keyword
                 except Keyword.DoesNotExist:
                     pass
             return f'{name} ({keyword_name})'


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Found during QA of GAing linked projects. Here is the [QA ticket](https://dimagi-dev.atlassian.net/browse/QA-3199).

QA reported they could not load the report if they selected `All` data models. I saw that this was also the case if `Keyword` was selected, and confirmed keywords were the issue based on this [sentry error](https://sentry.io/organizations/dimagi/issues/2469720914/?environment=staging&project=136860&query=is%3Aunresolved+domain%3A3157-3156-down&statsPeriod=14d). 

I'm unsure if this report would have ever worked with keyword events in it, unless there was some recent update that would change this behavior.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
