### PR TITLE
add 'date_last_activity' to messaging event API and allow ordering / filtering on it

### DIFF
--- a/corehq/apps/api/resources/messaging_event/filters.py
+++ b/corehq/apps/api/resources/messaging_event/filters.py
@@ -35,12 +35,12 @@ def filter_query(query, request_data):
     return query
 
 
-def _get_date_filter_consumer():
+def _get_date_filter_consumer(field):
     """date.{lt, lte, gt, gte}=<ISO DATE>"""
-    date_filter = make_date_filter(functools.partial(django_date_filter, field_name="date"))
+    date_filter = make_date_filter(functools.partial(django_date_filter, field_name=field))
 
     def _date_consumer(key, value):
-        if '.' in key and key.split(".")[0] == "date":
+        if '.' in key and key.split(".")[0] == field:
             prefix, qualifier = key.split(".", maxsplit=1)
             try:
                 return date_filter(qualifier, value)
@@ -162,7 +162,8 @@ def _make_simple_consumer(filter_name, model_filter_arg, validator=None):
 
 
 COMPOUND_FILTERS = [
-    _get_date_filter_consumer(),
+    _get_date_filter_consumer("date"),
+    _get_date_filter_consumer("date_last_activity"),  # computed field
 ]
 
 SIMPLE_FILTERS = {

--- a/corehq/apps/api/resources/messaging_event/serializers.py
+++ b/corehq/apps/api/resources/messaging_event/serializers.py
@@ -108,10 +108,11 @@ def _get_messages_for_email(event):
     except Email.DoesNotExist:
         return []
 
+    date_modified = email.date_modified.isoformat() if email.date_modified else None
     return [{
         "message_id": email.id,
         "date": email.date.isoformat(),
-        "date_modified": email.date_modified.isoformat(),
+        "date_modified": date_modified,
         "type": "email",
         "direction": "outgoing",
         "content": email.body,
@@ -148,10 +149,11 @@ def _get_message_dicts_for_sms(event, messages, type_):
         else:
             status = MessagingEvent.STATUS_SLUGS.get(event.status, "unknown")
 
+        date_modified = sms.date_modified.isoformat() if sms.date_modified else None
         message_data = {
             "message_id": sms.id,
             "date": sms.date,
-            "date_modified": sms.date_modified.isoformat(),
+            "date_modified": date_modified,
             "type": type_,
             "direction": SMS.DIRECTION_SLUGS.get(sms.direction, "unknown"),
             "content": sms.text,

--- a/corehq/apps/api/resources/messaging_event/serializers.py
+++ b/corehq/apps/api/resources/messaging_event/serializers.py
@@ -10,6 +10,7 @@ def serialize_event(event):
         "id": event.id,
         "content_type": MessagingEvent.CONTENT_TYPE_SLUGS.get(event.content_type, "unknown"),
         "date": event.date.isoformat(),
+        "date_last_activity": event.date_last_activity.isoformat(),
         "case_id": event.case_id,
         "domain": event.parent.domain,
         "error": _serialize_event_error(event),
@@ -110,6 +111,7 @@ def _get_messages_for_email(event):
     return [{
         "message_id": email.id,
         "date": email.date,
+        "date_modified": email.date_modified,
         "type": "email",
         "direction": "outgoing",
         "content": email.body,
@@ -149,6 +151,7 @@ def _get_message_dicts_for_sms(event, messages, type_):
         message_data = {
             "message_id": sms.id,
             "date": sms.date,
+            "date_modified": sms.date_modified,
             "type": type_,
             "direction": SMS.DIRECTION_SLUGS.get(sms.direction, "unknown"),
             "content": sms.text,

--- a/corehq/apps/api/resources/messaging_event/serializers.py
+++ b/corehq/apps/api/resources/messaging_event/serializers.py
@@ -104,23 +104,18 @@ def _serialize_event_form(event):
 def _get_messages_for_email(event):
     try:
         email = Email.objects.get(messaging_subevent=event.pk)
-        content = email.body
-        recipient_address = email.recipient_address
-        message_id = email.id
     except Email.DoesNotExist:
-        content = None
-        recipient_address = None
-        message_id = None
+        return []
 
     return [{
-        "message_id": message_id,
-        "date": event.date,
+        "message_id": email.id,
+        "date": email.date,
         "type": "email",
         "direction": "outgoing",
-        "content": content,
+        "content": email.body,
         "status": MessagingEvent.STATUS_SLUGS.get(event.status, 'unknown'),
         "backend": "email",
-        "email_address": recipient_address
+        "email_address": email.recipient_address
     }]
 
 

--- a/corehq/apps/api/resources/messaging_event/serializers.py
+++ b/corehq/apps/api/resources/messaging_event/serializers.py
@@ -110,8 +110,8 @@ def _get_messages_for_email(event):
 
     return [{
         "message_id": email.id,
-        "date": email.date,
-        "date_modified": email.date_modified,
+        "date": email.date.isoformat(),
+        "date_modified": email.date_modified.isoformat(),
         "type": "email",
         "direction": "outgoing",
         "content": email.body,
@@ -151,7 +151,7 @@ def _get_message_dicts_for_sms(event, messages, type_):
         message_data = {
             "message_id": sms.id,
             "date": sms.date,
-            "date_modified": sms.date_modified,
+            "date_modified": sms.date_modified.isoformat(),
             "type": type_,
             "direction": SMS.DIRECTION_SLUGS.get(sms.direction, "unknown"),
             "content": sms.text,

--- a/corehq/apps/api/resources/messaging_event/utils.py
+++ b/corehq/apps/api/resources/messaging_event/utils.py
@@ -31,16 +31,19 @@ def sort_query(query, request_params):
 
     This is required for the cursor pagination.
     """
+    order_by = get_order_by_field(request_params)
+    return query.order_by(order_by, "id")
+
+
+def get_order_by_field(request_params):
     order_by = request_params.get("order_by")
 
     if not order_by:
-        order_by_args = ["date", "id"]
-    else:
-        if order_by not in ("date", "-date"):
-            raise BadRequest(_("No matching '{field_name}' field for ordering").format(field_name=order_by))
-        order_by_args = [order_by, "id"]
+        return "date"
 
-    return query.order_by(*order_by_args)
+    if order_by not in ("date", "-date", "date_last_activity", "-date_last_activity"):
+        raise BadRequest(_("No matching '{field_name}' field for ordering").format(field_name=order_by))
+    return order_by
 
 
 @attrs

--- a/corehq/apps/api/resources/messaging_event/view.py
+++ b/corehq/apps/api/resources/messaging_event/view.py
@@ -1,3 +1,5 @@
+from django.db.models import OuterRef, Subquery
+from django.db.models.functions import Greatest
 from django.http import JsonResponse, HttpResponseNotFound
 from django.views.decorators.csrf import csrf_exempt
 from tastypie.exceptions import BadRequest
@@ -11,7 +13,7 @@ from corehq.apps.api.resources.messaging_event.serializers import serialize_even
 from corehq.apps.api.resources.messaging_event.utils import sort_query, get_request_params
 from corehq.apps.case_importer.views import require_can_edit_data
 from corehq.apps.domain.decorators import api_auth
-from corehq.apps.sms.models import MessagingSubEvent
+from corehq.apps.sms.models import MessagingSubEvent, SMS, Email
 
 
 @csrf_exempt
@@ -47,8 +49,26 @@ def _get_individual(request, event_id):
 
 def _get_list(request):
     request_params = get_request_params(request)
-    query = MessagingSubEvent.objects.select_related("parent").filter(parent__domain=request.domain)
+    query = _get_base_query(request.domain)
     filtered_query = filter_query(query, request_params)
     sorted_query = sort_query(filtered_query, request_params)
     data = get_paged_data(sorted_query, request_params)
     return JsonResponse(data)
+
+
+def _get_base_query(domain):
+    query = MessagingSubEvent.objects.select_related("parent").filter(parent__domain=domain)
+    newest_sms = (
+        SMS.objects.filter(messaging_subevent=OuterRef('pk'))
+        .order_by('-date_modified')
+        .values('date_modified')[:1]
+    )
+    newest_email = (
+       Email.objects.filter(messaging_subevent=OuterRef('pk'))
+       .order_by('-date_modified')
+       .values('date_modified')[:1]
+    )
+    query = query.annotate(date_last_activity=Greatest(
+        'date', 'xforms_session__modified_time', Subquery(newest_sms), Subquery(newest_email)
+    ))
+    return query

--- a/corehq/apps/api/resources/messaging_event/view.py
+++ b/corehq/apps/api/resources/messaging_event/view.py
@@ -57,6 +57,15 @@ def _get_list(request):
 
 
 def _get_base_query(domain):
+    """The base query includes a 'date_last_activity' field. This field
+    is calculated as:
+      Max(
+        event.date,
+        xform_session.modified_time,  # if it exists
+        Max(sms.date_modified),  # max for the current event
+        Max(email.date_modified)  # max for the current event
+      )
+  """
     query = MessagingSubEvent.objects.select_related("parent").filter(parent__domain=domain)
     newest_sms = (
         SMS.objects.filter(messaging_subevent=OuterRef('pk'))

--- a/corehq/apps/api/tests/test_messaging_event_api.py
+++ b/corehq/apps/api/tests/test_messaging_event_api.py
@@ -91,7 +91,7 @@ class TestMessagingEventResource(BaseMessagingEventResourceTest):
         self.assertEqual(5, len(ordered_data))
         dates = [r['date_last_activity'] for r in ordered_data]
         expected_order = sms[1:] + [sms[0]]  # modification order
-        self.assertEqual(dates, [sms.date_modified.isoformat() for sms in expected_order])
+        self.assertEqual(dates, [s.date_modified.isoformat() for s in expected_order])
 
         response = self._auth_get_resource(f'{self.list_endpoint}?order_by=-date_last_activity')
         self.assertEqual(response.status_code, 200, response.content)

--- a/corehq/apps/api/tests/test_messaging_event_api.py
+++ b/corehq/apps/api/tests/test_messaging_event_api.py
@@ -493,6 +493,63 @@ class TestMessagingEventResourceDateFilter(BaseMessagingEventResourceTest):
         self.assertEqual(actual, expected)
 
 
+class TestMessagingEventResourceDateLastActivityFilter(BaseMessagingEventResourceTest):
+    def test_date_filter_lt(self):
+        dates = self._setup_for_date_filter_test()
+        self._check_date_filtering_response({
+            "date_last_activity.lt": dates[3].isoformat()
+        }, [d.isoformat() for d in dates[:3]])
+
+    def test_date_filter_lte(self):
+        dates = self._setup_for_date_filter_test()
+        self._check_date_filtering_response({
+            "date_last_activity.lte": dates[3].isoformat()
+        }, [d.isoformat() for d in dates[:4]])
+
+    def test_date_filter_lte_date(self):
+        """`lte` filter with a date (not datetime) should include data
+        on that day."""
+        dates = self._setup_for_date_filter_test()
+        self._check_date_filtering_response({
+            "date_last_activity.lte": str(dates[0].date())
+        }, [d.isoformat() for d in dates])
+
+    def test_date_filter_gt(self):
+        dates = self._setup_for_date_filter_test()
+        self._check_date_filtering_response({
+            "date_last_activity.gt": dates[2].isoformat(),
+        }, [d.isoformat() for d in dates[3:]])
+
+    def test_date_filter_gte(self):
+        """`gte` filter with a date (not datetime) should include data
+        on that day."""
+        dates = self._setup_for_date_filter_test()
+        self._check_date_filtering_response({
+            "date_last_activity.gte": dates[2].isoformat(),
+        }, [d.isoformat() for d in dates[2:]])
+
+    def test_date_filter_gte_date(self):
+        dates = self._setup_for_date_filter_test()
+        self._check_date_filtering_response({
+            "date_last_activity.gte": str(dates[0].date())
+        }, [d.isoformat() for d in dates])
+
+    def _setup_for_date_filter_test(self):
+        results = _create_sms_messages(self.domain, 5, randomize=True)
+        results[0].save()  # update modification date
+        expected_order = results[1:] + [results[0]]  # modification order
+        return list(
+            sms.date_modified for sms in expected_order
+        )
+
+    def _check_date_filtering_response(self, filters, expected):
+        url = f'{self.list_endpoint}?order_by=date_last_activity&' + urllib.parse.urlencode(filters)
+        response = self._auth_get_resource(url)
+        self.assertEqual(response.status_code, 200, response.content)
+        actual = [event["date_last_activity"] for event in json.loads(response.content)['objects']]
+        self.assertEqual(actual, expected)
+
+
 def _create_sms_messages(domain, count, randomize):
     results = []
     for i in range(count):

--- a/corehq/apps/sms/tests/data_generator.py
+++ b/corehq/apps/sms/tests/data_generator.py
@@ -229,9 +229,12 @@ def make_email_event_for_test(domain, schedule_name, user_ids, utcnow=None):
         )
         instance.send_current_event_content_to_recipients()
 
+    subevents = {}
     for event in MessagingEvent.objects.filter(source_id=broadcast.id):
         for subevent in MessagingSubEvent.objects.filter(parent=event):
             handle_email_messaging_subevent({
                 "eventType": "Delivery",
                 "delivery": {"timestamp": "2021-05-27T07:09:42.318Z"}
             }, subevent.id)
+            subevents[subevent.recipient_id] = subevent
+    return subevents


### PR DESCRIPTION
## Summary
Builds on https://github.com/dimagi/commcare-hq/pull/29982 which added the `date_modified` fields to SMS and Email.

Can be reviewed by commit.

This PR adds the ability to sort and filter the messaging event API results by the 'last_date_activity' calculated field.

This field is:
```
Max(
    event.date,
    xform_session.modified_time,  # if it exists
    Max(sms.date_modified),  # max for the current event
    Max(email.date_modified)  # max for the current event
)
```

The Django query can be seen here: https://github.com/dimagi/commcare-hq/commit/d2e5831ef41c27397adbaf45f22a29d22e15a225

This results in the following SQL:
```sql
SELECT "sms_messagingsubevent".*, 
  GREATEST(
    "sms_messagingsubevent"."date",
    "smsforms_sqlxformssession"."modified_time", 
    (
      SELECT U0."date_modified" FROM "sms_sms" U0 WHERE U0."messaging_subevent_id" = ("sms_messagingsubevent"."id") ORDER BY U0."date_modified" DESC  LIMIT 1
    ), 
    (
      SELECT U0."date_modified" FROM "sms_email" U0 WHERE U0."messaging_subevent_id" = ("sms_messagingsubevent"."id") ORDER BY U0."date_modified" DESC  LIMIT 1
    )
  ) AS "date_last_activity"
FROM "sms_messagingsubevent" 
INNER JOIN "sms_messagingevent" ON ("sms_messagingsubevent"."parent_id" = "sms_messagingevent"."id")
LEFT OUTER JOIN "smsforms_sqlxformssession" ON ("sms_messagingsubevent"."xforms_session_id" = "smsforms_sqlxformssession"."id")
WHERE (
  "sms_messagingevent"."domain" = %s 
  AND
  GREATEST(
    "sms_messagingsubevent"."date",
    "smsforms_sqlxformssession"."modified_time",
    (
      SELECT U0."date_modified" FROM "sms_sms" U0 WHERE U0."messaging_subevent_id" = ("sms_messagingsubevent"."id") ORDER BY U0."date_modified" DESC  LIMIT 1
    ),
    (
      SELECT U0."date_modified" FROM "sms_email" U0 WHERE U0."messaging_subevent_id" = ("sms_messagingsubevent"."id") ORDER BY U0."date_modified" DESC  LIMIT 1
    )
  ) < %s
)
ORDER BY "date_last_activity" ASC, "sms_messagingsubevent"."id" ASC
```

The query plan for this is:
```SQL
Sort  (cost=1075987.35..1076009.00 rows=8661 width=668) (actual time=37.570..37.616 rows=194 loops=1)
   Sort Key: (GREATEST(sms_messagingsubevent.date, smsforms_sqlxformssession.modified_time, (SubPlan 1), (SubPlan 2))) DESC
   Sort Method: quicksort  Memory: 217kB
   ->  Nested Loop Left Join  (cost=1.56..1072844.91 rows=8661 width=668) (actual time=0.082..37.320 rows=194 loops=1)
         Filter: (GREATEST(sms_messagingsubevent.date, smsforms_sqlxformssession.modified_time, (SubPlan 3), (SubPlan 4)) > '2021-05-01 00:00:00+00'::timestamp with time zone)
         Rows Removed by Filter: 1532
         ->  Nested Loop  (cost=1.13..364072.33 rows=25984 width=660) (actual time=0.030..10.631 rows=1726 loops=1)
               ->  Index Scan using sms_messagingevent_domain on sms_messagingevent  (cost=0.56..75672.14 rows=23479 width=347) (actual time=0.021..1.759 rows=1494 loops=1)
                     Index Cond: ((domain)::text = 'alaska-covid-19-project'::text)
               ->  Index Scan using sms_messagingsubevent_parent_id on sms_messagingsubevent  (cost=0.56..11.97 rows=31 width=313) (actual time=0.004..0.005 rows=1 loops=1494)
                     Index Cond: (parent_id = sms_messagingevent.id)
         ->  Index Scan using smsforms_sqlxformssession_pkey on smsforms_sqlxformssession  (cost=0.43..0.55 rows=1 width=12) (actual time=0.002..0.002 rows=1 loops=1726)
               Index Cond: (sms_messagingsubevent.xforms_session_id = id)
         SubPlan 1
           ->  Limit  (cost=11.57..11.57 rows=1 width=8) (actual time=0.007..0.007 rows=1 loops=194)
                 ->  Sort  (cost=11.57..11.62 rows=18 width=8) (actual time=0.006..0.006 rows=1 loops=194)
                       Sort Key: u0.date DESC
                       Sort Method: top-N heapsort  Memory: 25kB
                       ->  Index Scan using sms_sms_messaging_subevent_id on sms_sms u0  (cost=0.56..11.48 rows=18 width=8) (actual time=0.003..0.004 rows=4 loops=194)
                             Index Cond: (messaging_subevent_id = sms_messagingsubevent.id)
         SubPlan 2
           ->  Limit  (cost=8.46..8.46 rows=1 width=8) (actual time=0.003..0.003 rows=0 loops=194)
                 ->  Sort  (cost=8.46..8.46 rows=1 width=8) (actual time=0.003..0.003 rows=0 loops=194)
                       Sort Key: u0_1.date DESC
                       Sort Method: quicksort  Memory: 25kB
                       ->  Index Scan using sms_email_messaging_subevent_id_e06043f9 on sms_email u0_1  (cost=0.43..8.45 rows=1 width=8) (actual time=0.002..0.002 rows=0 loops=194)
                             Index Cond: (messaging_subevent_id = sms_messagingsubevent.id)
         SubPlan 3
           ->  Limit  (cost=11.57..11.57 rows=1 width=8) (actual time=0.006..0.006 rows=0 loops=1726)
                 ->  Sort  (cost=11.57..11.62 rows=18 width=8) (actual time=0.006..0.006 rows=0 loops=1726)
                       Sort Key: u0_2.date DESC
                       Sort Method: quicksort  Memory: 25kB
                       ->  Index Scan using sms_sms_messaging_subevent_id on sms_sms u0_2  (cost=0.56..11.48 rows=18 width=8) (actual time=0.004..0.004 rows=1 loops=1726)
                             Index Cond: (messaging_subevent_id = sms_messagingsubevent.id)
         SubPlan 4
           ->  Limit  (cost=8.46..8.46 rows=1 width=8) (actual time=0.004..0.004 rows=0 loops=1726)
                 ->  Sort  (cost=8.46..8.46 rows=1 width=8) (actual time=0.004..0.004 rows=0 loops=1726)
                       Sort Key: u0_3.date DESC
                       Sort Method: quicksort  Memory: 25kB
                       ->  Index Scan using sms_email_messaging_subevent_id_e06043f9 on sms_email u0_3  (cost=0.43..8.45 rows=1 width=8) (actual time=0.003..0.003 rows=0 loops=1726)
                             Index Cond: (messaging_subevent_id = sms_messagingsubevent.id)
 Planning time: 1.889 ms
 Execution time: 37.743 ms
```

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added + updated

### Safety story
Updates limited to new messaging API which is not currently in use

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
