### PR TITLE
[SSO] ensure that the username received by the Identity Provider is in lowercase

### DIFF
--- a/corehq/apps/sso/backends.py
+++ b/corehq/apps/sso/backends.py
@@ -35,6 +35,8 @@ class SsoBackend(ModelBackend):
         if not (request and username and idp_slug and is_handshake_successful):
             return None
 
+        username = username.lower()
+
         try:
             identity_provider = IdentityProvider.objects.get(slug=idp_slug)
         except IdentityProvider.DoesNotExist:

--- a/corehq/apps/sso/tests/test_backends.py
+++ b/corehq/apps/sso/tests/test_backends.py
@@ -400,6 +400,37 @@ class TestSsoBackend(TestCase):
             ]
         )
 
+    def test_new_user_with_capitals_in_username(self):
+        """
+        It is possible for the Identity Provider to supply a username with
+        uppercase characters in it, which we do not support. If the username
+        is not made lowercase, a BadValueError and a User.DoesNotExist error
+        will be thrown during the user creation process. This test ensures
+        that we process the username correctly.
+        """
+        username = 'Hello.World.313@vaultwax.com'
+        generator.store_full_name_in_saml_user_data(
+            self.request,
+            'Hello',
+            'World'
+        )
+        user = auth.authenticate(
+            request=self.request,
+            username=username,
+            idp_slug=self.idp.slug,
+            is_handshake_successful=True,
+        )
+        self.assertIsNotNone(user)
+        self.assertEqual(user.username, username.lower())
+        self.assertEqual(user.first_name, 'Hello')
+        self.assertEqual(user.last_name, 'World')
+        self.assertEqual(
+            self.request.sso_new_user_messages['success'],
+            [
+                f'User account for {username.lower()} created.',
+            ]
+        )
+
     def test_successful_login(self):
         """
         This test demonstrates the requirements necessary for a SsoBackend to


### PR DESCRIPTION
## Summary
We experienced an issue during pilot testing where the username in Azure AD had uppercase characters in it. When supplied to the Django `User` object, this of course throws a `BadValueError` and a `User.DoesNotExist` error when we attempt to fetch the user.

This change ensures that the username supplied is always in lowercase and that we have a test for this to ensure this doesn't happen in the future.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
SSO is well-tested and a new test was added to ensure this issue doesn't happen in the future.

### QA Plan
QA is ongoing on staging right now. This came out of that QA/pilot testing effort.

### Safety story
Safe to merge after approval as this does not touch an area that's currently being used by a live production project

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
