### PR TITLE
Fix duplicate export properties

### DIFF
--- a/corehq/apps/export/tests/test_table_configuration.py
+++ b/corehq/apps/export/tests/test_table_configuration.py
@@ -4,12 +4,31 @@ from corehq.apps.export.const import USERNAME_TRANSFORM
 from corehq.apps.export.models import (
     DocRow,
     ExportColumn,
+    ExportItem,
     ExportRow,
     PathNode,
     RowNumberColumn,
     ScalarItem,
     TableConfiguration,
 )
+
+
+class TableConfigurationDuplicateTests(SimpleTestCase):
+    def test_table_containing_duplicate_paths_with_differing_doc_types_can_find_either(self):
+        path = [PathNode(name='closed')]
+        prop1 = ScalarItem(path=path)
+        prop2 = ExportItem(path=path)
+        table_config = TableConfiguration(
+            columns=[
+                ExportColumn(item=prop1), ExportColumn(item=prop2)
+            ]
+        )
+
+        scalarIndex, _ = table_config.get_column(path, 'ScalarItem', None)
+        exportIndex, _ = table_config.get_column(path, 'ExportItem', None)
+
+        self.assertEqual(scalarIndex, 0)
+        self.assertEqual(exportIndex, 1)
 
 
 class TableConfigurationTest(SimpleTestCase):


### PR DESCRIPTION
## Summary
Initial ticket: https://dimagi-dev.atlassian.net/browse/SAAS-11729.

In rare circumstances, duplicate export properties can be generated.  This occurs because we do not account for the possibility of two properties, with the same path but different doc types.  Bizarrely, despite `closed` being a reserved keyword, several of the applications on the domain in the above ticket generate a `closed` property -- including applications which appear to be blank. This closed property gets added like a user-specified property, with the doc type `ScalarItem`. `closed` then also is generated for the internal properties, this time using the type `ExportItem`. Because of the difference, `TableConfiguration.get_column()` returns as if no column exists. This causes the export generator to continually add on new columns (first you'll have 2, then the next edit with have 4, then 6, etc).

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

A test suite for the above scenario is covered within _test_table_configuration.py_

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

No QA is required. While I would like to be sure that removing the cache regeneration code won't cause any problems, I don't believe QA would be able to test that, as the comment listed it as an edge case anyway.

### Safety story
Beyond the test suite, I verified this locally. The previous optimizations were put in place because [the case export edit form failed to load for large cases](https://dimagi-dev.atlassian.net/browse/SAAS-10103). I wanted to be sure that these changes would not re-introduce this problem, so I imported the `irc-erd-kenya` applications locally, and looked at the timings before and after these changes.

Before, generating the case export took ~21 seconds. After, likely due to the removal of some redundant code, I'm seeing the export take ~20.6 seconds. While I still had the redundant code in, I saw times rise by ~.5 secs, which makes sense, as the changes do perform more computation. Given the difference between the two, I think it's very unlikely that these changes make any difference performance-wise. However, 20 seconds is still far too long for this process, and I hope to tackle this is another ticket I'll attach later.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
