### PR TITLE
Only save a generated invoice pdf once

### DIFF
--- a/corehq/apps/accounting/invoice_pdf.py
+++ b/corehq/apps/accounting/invoice_pdf.py
@@ -178,10 +178,11 @@ class InvoiceTemplate(object):
         else:
             self.draw_header()
             self.draw_table(items)
-            self.canvas.showPage()
-            self.canvas.save()
             if len(items_to_draw) == 0:
                 self.draw_totals_on_new_page()
+
+            self.canvas.showPage()
+            self.canvas.save()
 
     def draw_logo(self):
         self.canvas.drawImage(self.logo_filename, inches(0.5), inches(2.5),
@@ -578,9 +579,6 @@ class InvoiceTemplate(object):
 
         self.draw_totals(totals_x=inches(5.85), line_height=inches(0.25), subtotal_y=inches(7.0))
         self.draw_footer()
-
-        self.canvas.showPage()
-        self.canvas.save()
 
     def draw_totals(self, totals_x, line_height, subtotal_y):
         tax_y = subtotal_y - line_height

--- a/corehq/apps/accounting/invoice_pdf.py
+++ b/corehq/apps/accounting/invoice_pdf.py
@@ -172,6 +172,10 @@ class InvoiceTemplate(object):
         else:
             self.draw_table_with_header_and_footer(self.items)
 
+        # should only call save once to avoid reportlab exception
+        self.canvas.showPage()
+        self.canvas.save()
+
     def draw_customer_invoice(self, items, items_to_draw):
         if len(items) <= 4:
             self.draw_table_with_header_and_footer(items)
@@ -180,9 +184,6 @@ class InvoiceTemplate(object):
             self.draw_table(items)
             if len(items_to_draw) == 0:
                 self.draw_totals_on_new_page()
-
-            self.canvas.showPage()
-            self.canvas.save()
 
     def draw_logo(self):
         self.canvas.drawImage(self.logo_filename, inches(0.5), inches(2.5),
@@ -563,8 +564,6 @@ class InvoiceTemplate(object):
             self.draw_table(items)
         self.draw_totals(totals_x=inches(5.85), line_height=inches(0.25), subtotal_y=inches(3.5))
         self.draw_footer()
-        self.canvas.showPage()
-        self.canvas.save()
 
     def draw_totals_on_new_page(self):
         self.canvas.setStrokeColor(STROKE_COLOR)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12403

When generating an invoice pdf, some domains hit this error https://sentry.io/organizations/dimagi/issues/2489262358/?project=136860&query=is%3Aunresolved+invoice&statsPeriod=7d. 

It seems like only a few domains hit the edge case where `len(items_to_draw) == 0` which triggers `self.draw_totals_on_new_page()`, hence we are not seeing this issue on every domain. This way, we don't call `save()` in that method, but instead just after we are completely done drawing the pdf.

`draw_total_on_new_page` is only called from one spot which is what makes this safe. If in the future we call this method on it's own we will need to add some optional parameter to specify it should save.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
There is little risk in this PR as we are still calling save, just eliminating an unnecessary save call.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
