### PR TITLE
Remove @ prefix from v0.6 case API

### DIFF
--- a/corehq/apps/hqcase/api/core.py
+++ b/corehq/apps/hqcase/api/core.py
@@ -6,11 +6,11 @@ def serialize_case(case):
     """Serializes a case for the V0.6 Case API"""
     return {
         "domain": case.domain,
-        "@case_id": case.case_id,
-        "@case_type": case.type,
+        "case_id": case.case_id,
+        "case_type": case.type,
         "case_name": case.name,
         "external_id": case.external_id,
-        "@owner_id": case.owner_id,
+        "owner_id": case.owner_id,
         "date_opened": _isoformat(case.opened_on),
         "last_modified": _isoformat(case.modified_on),
         "server_last_modified": _isoformat(case.server_modified_on),
@@ -20,8 +20,8 @@ def serialize_case(case):
         "indices": {
             index.identifier: {
                 "case_id": index.referenced_id,
-                "@case_type": index.referenced_type,
-                "@relationship": index.relationship,
+                "case_type": index.referenced_type,
+                "relationship": index.relationship,
             }
             for index in case.indices if not index.is_deleted
         }
@@ -36,11 +36,11 @@ def serialize_es_case(case_doc):
     """Serializes a CaseSearch result for the V0.6 Case API"""
     return {
         "domain": case_doc['domain'],
-        "@case_id": case_doc['_id'],
-        "@case_type": case_doc['type'],
+        "case_id": case_doc['_id'],
+        "case_type": case_doc['type'],
         "case_name": case_doc['name'],
         "external_id": case_doc['external_id'],
-        "@owner_id": case_doc['owner_id'],
+        "owner_id": case_doc['owner_id'],
         "date_opened": case_doc['opened_on'],
         "last_modified": case_doc['modified_on'],
         "server_last_modified": case_doc['server_modified_on'],
@@ -54,8 +54,8 @@ def serialize_es_case(case_doc):
         "indices": {
             index['identifier']: {
                 "case_id": index['referenced_id'],
-                "@case_type": index['referenced_type'],
-                "@relationship": index['relationship'],
+                "case_type": index['referenced_type'],
+                "relationship": index['relationship'],
             }
             for index in case_doc['indices']
         },

--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -20,9 +20,8 @@ def is_simple_dict(d):
 class JsonIndex(jsonobject.JsonObject):
     case_id = jsonobject.StringProperty()
     temporary_id = jsonobject.StringProperty()
-    case_type = jsonobject.StringProperty(name='@case_type', required=True)
-    relationship = jsonobject.StringProperty(name='@relationship', required=True,
-                                             choices=('child', 'extension'))
+    case_type = jsonobject.StringProperty(required=True)
+    relationship = jsonobject.StringProperty(required=True, choices=('child', 'extension'))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -32,10 +31,10 @@ class JsonIndex(jsonobject.JsonObject):
 
 class BaseJsonCaseChange(jsonobject.JsonObject):
     case_name = jsonobject.StringProperty()
-    case_type = jsonobject.StringProperty(name='@case_type')
+    case_type = jsonobject.StringProperty()
     external_id = jsonobject.StringProperty()
     user_id = jsonobject.StringProperty(required=True)
-    owner_id = jsonobject.StringProperty(name='@owner_id')
+    owner_id = jsonobject.StringProperty()
     properties = jsonobject.DictProperty(validators=[is_simple_dict], default={})
     indices = jsonobject.DictProperty(JsonIndex)
     _is_case_creation = False
@@ -81,8 +80,8 @@ class JsonCaseCreation(BaseJsonCaseChange):
 
     # overriding from subclass to mark these required
     case_name = jsonobject.StringProperty(required=True)
-    case_type = jsonobject.StringProperty(name='@case_type', required=True)
-    owner_id = jsonobject.StringProperty(name='@owner_id', required=True)
+    case_type = jsonobject.StringProperty(required=True)
+    owner_id = jsonobject.StringProperty(required=True)
 
     _is_case_creation = True
 
@@ -130,7 +129,7 @@ def _get_bulk_updates(domain, all_data, user):
     if len(all_data) > CASEBLOCK_CHUNKSIZE:
         raise UserError(f"You cannot submit more than {CASEBLOCK_CHUNKSIZE} updates in a single request")
 
-    existing_ids = [c['@case_id'] for c in all_data if isinstance(c, dict) and '@case_id' in c]
+    existing_ids = [c['case_id'] for c in all_data if isinstance(c, dict) and 'case_id' in c]
     missing = _missing_cases(domain, existing_ids)
     if missing:
         raise UserError(f"The following case IDs were not found: {', '.join(missing)}")
@@ -139,7 +138,7 @@ def _get_bulk_updates(domain, all_data, user):
     errors = []
     for i, data in enumerate(all_data, start=1):
         try:
-            update = _get_case_update(data, user.user_id, data.pop('@case_id', None))
+            update = _get_case_update(data, user.user_id, data.pop('case_id', None))
             updates.append(update)
         except BadValueError as e:
             errors.append(f'Error in row {i}: {e}')

--- a/corehq/apps/hqcase/tests/test_case_sharing.py
+++ b/corehq/apps/hqcase/tests/test_case_sharing.py
@@ -15,10 +15,9 @@ class CaseSharingTest(TestCase):
     def setUp(self):
         """
         Two groups A and B, with users A1, A2 and B1, B2 respectively, and supervisor X who belongs to both.
-        
         """
         self.domain = "test-domain"
-        create_domain(self.domain)
+        self.domain_obj = create_domain(self.domain)
         password = "****"
 
         def create_user(username):
@@ -38,6 +37,9 @@ class CaseSharingTest(TestCase):
 
         self.groupA = create_group("A", self.userX, self.userA1, self.userA2)
         self.groupB = create_group("B", self.userX, self.userB1, self.userB2)
+
+    def tearDown(self):
+        self.domain_obj.delete()
 
     def test_sharing(self):
 

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -92,7 +92,7 @@ class TestCaseAPI(TestCase):
         case_id = self._make_case().case_id
         res = self.client.get(reverse('case_api', args=(self.domain, case_id)))
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json()['@case_id'], case_id)
+        self.assertEqual(res.json()['case_id'], case_id)
 
     def test_case_not_found(self):
         res = self.client.get(reverse('case_api', args=(self.domain, 'fake_id')))
@@ -115,17 +115,17 @@ class TestCaseAPI(TestCase):
     def test_create_case(self):
         res = self._create_case({
             # notable exclusions: case_id, date_opened, date_modified
-            '@case_type': 'player',
+            'case_type': 'player',
             'case_name': 'Elizabeth Harmon',
             'external_id': '1',
-            '@owner_id': 'methuen_home',
+            'owner_id': 'methuen_home',
             'properties': {
                 'sport': 'chess',
                 'dob': '1948-11-02',
             },
         }).json()
-        self.assertItemsEqual(res.keys(), ['case', '@form_id'])
-        case = self.case_accessor.get_case(res['case']['@case_id'])
+        self.assertItemsEqual(res.keys(), ['case', 'form_id'])
+        case = self.case_accessor.get_case(res['case']['case_id'])
         self.assertEqual(case.domain, self.domain)
         self.assertEqual(case.type, 'player')
         self.assertEqual(case.name, 'Elizabeth Harmon')
@@ -137,17 +137,17 @@ class TestCaseAPI(TestCase):
             'sport': 'chess',
         })
 
-        xform = self.form_accessor.get_form(res['@form_id'])
+        xform = self.form_accessor.get_form(res['form_id'])
         self.assertEqual(xform.xmlns, 'http://commcarehq.org/case_api')
         self.assertEqual(xform.metadata.userID, self.web_user.user_id)
         self.assertEqual(xform.metadata.deviceID, 'user agent string')
 
     def test_non_schema_updates(self):
         res = self._create_case({
-            '@case_type': 'player',
+            'case_type': 'player',
             'case_name': 'Elizabeth Harmon',
             'external_id': '1',
-            '@owner_id': 'methuen_home',
+            'owner_id': 'methuen_home',
             'bad_property': "this doesn't fit the schema!",
             'properties': {'sport': 'chess'},
         })
@@ -178,13 +178,13 @@ class TestCaseAPI(TestCase):
         res = self._update_case(case.case_id, {
             # notable exclusions: case_id, date_opened, date_modified, case_type
             'case_name': 'Beth Harmon',
-            '@owner_id': 'us_chess_federation',
+            'owner_id': 'us_chess_federation',
             'properties': {
                 'rank': '2100',
                 'champion': 'true',
             },
         }).json()
-        self.assertItemsEqual(res.keys(), ['case', '@form_id'])
+        self.assertItemsEqual(res.keys(), ['case', 'form_id'])
 
         case = self.case_accessor.get_case(case.case_id)
         self.assertEqual(case.name, 'Beth Harmon')
@@ -200,7 +200,7 @@ class TestCaseAPI(TestCase):
         case = self._make_case()
         res = self._update_case(case.case_id, {
             'case_name': 'Beth Harmon',
-            '@case_type': 'legend',
+            'case_type': 'legend',
         })
         self.assertEqual(res.status_code, 200)
         case = self.case_accessor.get_case(case.case_id)
@@ -209,7 +209,7 @@ class TestCaseAPI(TestCase):
     def test_update_case_bad_id(self):
         res = self._update_case('notarealcaseid', {
             'case_name': 'Beth Harmon',
-            '@owner_id': 'us_chess_federation',
+            'owner_id': 'us_chess_federation',
             'properties': {
                 'rank': '2100',
                 'champion': 'true',
@@ -229,7 +229,7 @@ class TestCaseAPI(TestCase):
         ).as_text()], domain='other_domain')
 
         res = self._update_case(case_id, {
-            '@owner_id': 'stealing_this_case',
+            'owner_id': 'stealing_this_case',
         })
         self.assertEqual(res.json()['error'], f"No case found with ID '{case_id}'")
         self.assertEqual(self.case_accessor.get_case_ids_in_domain(), [])
@@ -237,24 +237,24 @@ class TestCaseAPI(TestCase):
     def test_create_child_case(self):
         parent_case = self._make_case()
         res = self._create_case({
-            '@case_type': 'match',
+            'case_type': 'match',
             'case_name': 'Harmon/Luchenko',
             'external_id': '23',
-            '@owner_id': 'harmon',
+            'owner_id': 'harmon',
             'properties': {
                 'winner': 'Harmon',
             },
             'indices': {
                 'parent': {
                     'case_id': parent_case.case_id,
-                    '@case_type': 'player',
-                    '@relationship': 'child',
+                    'case_type': 'player',
+                    'relationship': 'child',
                 },
             },
         }).json()
-        self.assertItemsEqual(res.keys(), ['case', '@form_id'])
+        self.assertItemsEqual(res.keys(), ['case', 'form_id'])
 
-        case = self.case_accessor.get_case(res['case']['@case_id'])
+        case = self.case_accessor.get_case(res['case']['case_id'])
         self.assertEqual(case.name, 'Harmon/Luchenko')
         self.assertEqual(case.external_id, '23')
         self.assertEqual(case.owner_id, 'harmon')
@@ -270,9 +270,9 @@ class TestCaseAPI(TestCase):
         res = self._bulk_update_cases([
             {
                 # update existing case
-                '@case_id': existing_case.case_id,
+                'case_id': existing_case.case_id,
                 'case_name': 'Beth Harmon',
-                '@owner_id': 'us_chess_federation',
+                'owner_id': 'us_chess_federation',
                 'properties': {
                     'rank': '2100',
                     'champion': 'true',
@@ -280,10 +280,10 @@ class TestCaseAPI(TestCase):
             },
             {
                 # No case_id means this is a new case
-                '@case_type': 'player',
+                'case_type': 'player',
                 'case_name': 'Jolene',
                 'external_id': 'jolene',
-                '@owner_id': 'methuen_home',
+                'owner_id': 'methuen_home',
                 'properties': {
                     'sport': 'squash',
                     'dob': '1947-03-09',
@@ -291,7 +291,7 @@ class TestCaseAPI(TestCase):
             },
         ]).json()
         #  only returns a single form ID - chunking should happen in the client
-        self.assertItemsEqual(res.keys(), ['cases', '@form_id'])
+        self.assertItemsEqual(res.keys(), ['cases', 'form_id'])
 
         updated_case = self.case_accessor.get_case(existing_case.case_id)
         self.assertEqual(updated_case.name, 'Beth Harmon')
@@ -314,15 +314,15 @@ class TestCaseAPI(TestCase):
         res = self._bulk_update_cases([
             {
                 # attempt to update existing case, but it doesn't exist
-                '@case_id': 'notarealcaseid',
+                'case_id': 'notarealcaseid',
                 'case_name': 'Beth Harmon',
-                '@owner_id': 'us_chess_federation',
+                'owner_id': 'us_chess_federation',
             },
             {
                 # Also have a (valid) case creation, though it shouldn't go through
-                '@case_type': 'player',
+                'case_type': 'player',
                 'case_name': 'Jolene',
-                '@owner_id': 'methuen_home',
+                'owner_id': 'methuen_home',
             },
         ])
         self.assertEqual(res.json()['error'], "The following case IDs were not found: notarealcaseid")
@@ -331,16 +331,16 @@ class TestCaseAPI(TestCase):
     def test_create_parent_and_child_together(self):
         res = self._bulk_update_cases([
             {
-                '@case_type': 'player',
+                'case_type': 'player',
                 'case_name': 'Elizabeth Harmon',
-                '@owner_id': 'us_chess_federation',
+                'owner_id': 'us_chess_federation',
                 'external_id': 'beth',
                 'temporary_id': 'beth_harmon',
             },
             {
-                '@case_type': 'match',
+                'case_type': 'match',
                 'case_name': 'Harmon/Luchenko',
-                '@owner_id': 'harmon',
+                'owner_id': 'harmon',
                 'external_id': 'harmon-luchenko',
                 'properties': {
                     'winner': 'Harmon',
@@ -349,8 +349,8 @@ class TestCaseAPI(TestCase):
                     'parent': {
                         # case_id is unknown at this point
                         'temporary_id': 'beth_harmon',
-                        '@case_type': 'player',
-                        '@relationship': 'child',
+                        'case_type': 'player',
+                        'relationship': 'child',
                     },
                 },
             },
@@ -363,9 +363,9 @@ class TestCaseAPI(TestCase):
     def test_create_child_with_no_parent(self):
         res = self._bulk_update_cases([
             {
-                '@case_type': 'match',
+                'case_type': 'match',
                 'case_name': 'Harmon/Luchenko',
-                '@owner_id': 'harmon',
+                'owner_id': 'harmon',
                 'external_id': 'harmon-luchenko',
                 'properties': {
                     'winner': 'Harmon',
@@ -373,8 +373,8 @@ class TestCaseAPI(TestCase):
                 'indices': {
                     'parent': {
                         'temporary_id': 'MISSING',
-                        '@case_type': 'player',
-                        '@relationship': 'child',
+                        'case_type': 'player',
+                        'relationship': 'child',
                     },
                 },
             },
@@ -390,8 +390,8 @@ class TestCaseAPI(TestCase):
     def test_missing_required_field(self):
         res = self._create_case({
             # case_name is not provided!
-            '@case_type': 'player',
-            '@owner_id': 'methuen_home',
+            'case_type': 'player',
+            'owner_id': 'methuen_home',
             'properties': {'dob': '1948-11-02'},
         })
         self.assertEqual(res.status_code, 400)
@@ -400,8 +400,8 @@ class TestCaseAPI(TestCase):
     def test_invalid_properties(self):
         res = self._create_case({
             'case_name': 'Beth Harmon',
-            '@case_type': 'player',
-            '@owner_id': 'methuen_home',
+            'case_type': 'player',
+            'owner_id': 'methuen_home',
             'properties': {
                 'dob': '1948-11-02',
                 'age': 72,  # Can't pass integers
@@ -412,24 +412,24 @@ class TestCaseAPI(TestCase):
 
     def test_bad_index_reference(self):
         res = self._create_case({
-            '@case_type': 'match',
+            'case_type': 'match',
             'case_name': 'Harmon/Luchenko',
             'external_id': '23',
-            '@owner_id': 'harmon',
+            'owner_id': 'harmon',
             'properties': {
                 'dob': '1948-11-02',
             },
             'indices': {
                 'parent': {
                     'case_id': 'bad404bad',  # This doesn't exist
-                    '@case_type': 'player',
-                    '@relationship': 'child',
+                    'case_type': 'player',
+                    'relationship': 'child',
                 },
             },
         })
         self.assertEqual(res.status_code, 400)
         self.assertIn("InvalidCaseIndex", res.json()['error'])
-        form = self.form_accessor.get_form(res.json()['@form_id'])
+        form = self.form_accessor.get_form(res.json()['form_id'])
         self.assertEqual(form.is_error, True)
 
     def test_unset_external_id(self):

--- a/corehq/apps/hqcase/tests/test_get_case.py
+++ b/corehq/apps/hqcase/tests/test_get_case.py
@@ -24,6 +24,7 @@ class GetCaseTest(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.user.delete(deleted_by=None)
+        cls.domain.delete()
         super(GetCaseTest, cls).tearDownClass()
 
     def setUp(self):

--- a/corehq/apps/hqcase/tests/test_serialization.py
+++ b/corehq/apps/hqcase/tests/test_serialization.py
@@ -95,11 +95,11 @@ class TestAPISerialization(TestCase):
             serialize_case(self.case),
             {
                 "domain": self.domain,
-                "@case_id": self.case.case_id,
-                "@case_type": "match",
+                "case_id": self.case.case_id,
+                "case_type": "match",
                 "case_name": "Harmon/Luchenko",
                 "external_id": "14",
-                "@owner_id": "harmon",
+                "owner_id": "harmon",
                 "date_opened": "2021-02-18T10:59:00.000000Z",
                 "last_modified": "2021-02-18T10:59:00.000000Z",
                 "server_last_modified": "2021-02-18T10:59:00.000000Z",
@@ -112,8 +112,8 @@ class TestAPISerialization(TestCase):
                 "indices": {
                     "parent": {
                         "case_id": self.parent_case_id,
-                        "@case_type": "player",
-                        "@relationship": "child",
+                        "case_type": "player",
+                        "relationship": "child",
                     }
                 }
             }

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -140,15 +140,15 @@ def _handle_case_update(request, case_id=None):
     except SubmissionError as e:
         return JsonResponse({
             'error': str(e),
-            '@form_id': e.form_id,
+            'form_id': e.form_id,
         }, status=400)
 
     if isinstance(case_or_cases, list):
         return JsonResponse({
-            '@form_id': xform.form_id,
+            'form_id': xform.form_id,
             'cases': [serialize_case(case) for case in case_or_cases],
         })
     return JsonResponse({
-        '@form_id': xform.form_id,
+        'form_id': xform.form_id,
         'case': serialize_case(case_or_cases),
     })


### PR DESCRIPTION
## Summary
Discussed in depth and decided here:
https://docs.google.com/document/d/1XE-gUOcpRyxOQXRSQkEzI38q9JY5qwm5mj70vVV5vgM/edit?ts=5fbd21a9#heading=h.asga6nigq6wr
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
Enable the v0.6 Case API

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
fully tested

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The feature is unreleased

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
