### PR TITLE
[SSO] Ensure that the first domain for new SSO users is active

### DIFF
--- a/corehq/apps/registration/tests/test_utils.py
+++ b/corehq/apps/registration/tests/test_utils.py
@@ -1,0 +1,60 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, RequestFactory
+
+from corehq.apps.accounting.models import Subscription
+from corehq.apps.domain.models import Domain
+from corehq.apps.registration.utils import request_new_domain
+from corehq.apps.users.models import WebUser
+
+
+class TestRequestNewDomain(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.new_user = WebUser.create(
+            None, 'new@dimagi.org', 'testpwd', None, None
+        )
+        cls.request = RequestFactory().get('/registration')
+        django_user = User.objects.get(username=cls.new_user.username)
+        cls.request.user = django_user
+        cls.domain_sso_test = 'test-sso-1'
+        cls.domain_test = 'test-1'
+
+    def tearDown(self):
+        for domain in [self.domain_sso_test, self.domain_test]:
+            Subscription._get_active_subscription_by_domain.clear(
+                Subscription,
+                domain
+            )
+        super().tearDown()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.new_user.delete(None)
+        super().tearDownClass()
+
+    def test_domain_is_active_for_new_sso_user(self):
+        """
+        Ensure that the first domain created by a new SSO user is active.
+        """
+        domain_name = request_new_domain(
+            self.request,
+            'test-sso-1',
+            is_new_user=True,
+            is_new_sso_user=True,
+        )
+        domain = Domain.get_by_name(domain_name)
+        self.assertTrue(domain.is_active)
+
+    def test_domain_is_not_active_for_new_user(self):
+        """
+        Ensure that the first domain created by a new user is not active.
+        """
+        domain_name = request_new_domain(
+            self.request,
+            'test-sso-2',
+            is_new_user=True,
+        )
+        domain = Domain.get_by_name(domain_name)
+        self.assertFalse(domain.is_active)

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -105,7 +105,7 @@ def activate_new_user(
     return new_user
 
 
-def request_new_domain(request, project_name, is_new_user=True):
+def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=False):
     now = datetime.utcnow()
     current_user = CouchUser.from_django_user(request.user, strict=True)
 
@@ -132,7 +132,7 @@ def request_new_domain(request, project_name, is_new_user=True):
         # Avoid projects created by dimagi.com staff members as self started
         new_domain.internal.self_started = not current_user.is_dimagi
 
-        if not is_new_user:
+        if not is_new_user or is_new_sso_user:
             new_domain.is_active = True
 
         # ensure no duplicate domain documents get created on cloudant
@@ -163,7 +163,7 @@ def request_new_domain(request, project_name, is_new_user=True):
             f"{new_domain.name} during registration"
         )
 
-    if is_new_user:
+    if is_new_user and not is_new_sso_user:
         dom_req.save()
         if settings.IS_SAAS_ENVIRONMENT:
             #  Load template apps to the user's new domain in parallel

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -186,7 +186,13 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
                                            dom_req.activation_guid,
                                            request.user.get_full_name(),
                                            request.user.first_name)
-    send_new_request_update_email(request.user, get_ip(request), new_domain.name, is_new_user=is_new_user)
+    send_new_request_update_email(
+        request.user,
+        get_ip(request),
+        new_domain.name,
+        is_new_user=is_new_user,
+        is_new_sso_user=is_new_sso_user
+    )
 
     send_hubspot_form(HUBSPOT_CREATED_NEW_PROJECT_SPACE_FORM_ID, request)
     return new_domain.name
@@ -206,10 +212,13 @@ def _setup_subscription(domain_name, user):
     billing_contact.save()
 
 
-def send_new_request_update_email(user, requesting_ip, entity_name, entity_type="domain", is_new_user=False, is_confirming=False):
+def send_new_request_update_email(user, requesting_ip, entity_name, entity_type="domain",
+                                  is_new_user=False, is_confirming=False, is_new_sso_user=False):
     entity_texts = {"domain": ["project space", "Project"],
                    "org": ["organization", "Organization"]}[entity_type]
-    if is_confirming:
+    if is_new_sso_user:
+        message = f"A new SSO user just requested a {entity_texts[0]} called {entity_name}."
+    elif is_confirming:
         message = "A (basically) brand new user just confirmed his/her account. The %s requested was %s." % (entity_texts[0], entity_name)
     elif is_new_user:
         message = "A brand new user just requested a %s called %s." % (entity_texts[0], entity_name)

--- a/corehq/apps/sso/views/saml.py
+++ b/corehq/apps/sso/views/saml.py
@@ -106,7 +106,12 @@ def sso_saml_acs(request, idp_slug):
         async_signup = AsyncSignupRequest.get_by_username(user.username)
         if async_signup and async_signup.project_name:
             try:
-                request_new_domain(request, async_signup.project_name, is_new_user=True)
+                request_new_domain(
+                    request,
+                    async_signup.project_name,
+                    is_new_user=True,
+                    is_new_sso_user=True
+                )
             except NameUnavailableException:
                 # this should never happen, but in the off chance it does
                 # we don't want to throw a 500 on this view


### PR DESCRIPTION
## Summary
This fixes the issue QA found [here](https://dimagi-dev.atlassian.net/browse/QA-3166) where an SSO going through the signup form is asked to confirm their email after finishing the sign up process. This confirmation step is not necessary for SSO users since we know that the email received from the IdP is valid.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added test coverage for the changes.

### QA Plan
QA for SSO is ongoing on staging.

### Safety story
This change will be merged after QA signs off, though it is a fairly simple change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
