### PR TITLE
Move help text in forms

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -293,7 +293,7 @@
 </script>
 
 <script type="text/html" id="text-entry-ko-template">
-  <span class="help-block type" data-bind="
+  <span class="help-block type sr-only" data-bind="
         text: helpText()
     "></span>
   <textarea class="textfield form-control" data-bind="
@@ -305,20 +305,24 @@
             'aria-required': $parent.required() ? 'true' : 'false',
         },
     "></textarea>
+  <span class="help-block type" aria-hidden="true" data-bind="
+        text: helpText()
+    "></span>
 </script>
 
 <script type="text/html" id="password-entry-ko-template">
-  <span class="help-block type" data-bind="text: helpText()"></span>
+  <span class="help-block type sr-only" data-bind="text: helpText()"></span>
   <input type="password" class="form-control" data-bind="
         value: $data.rawAnswer,
         valueUpdate: valueUpdate,
         id: entryId,
         attr: {'aria-required': $parent.required() ? 'true' : 'false'},
     "/>
+  <span class="help-block type" aria-hidden="true" data-bind="text: helpText()"></span>
 </script>
 
 <script type="text/html" id="str-entry-ko-template">
-  <span class="help-block type" data-bind="
+  <span class="help-block type sr-only" data-bind="
         text: helpText()
     "></span>
   <input autocomplete="off" type="text" class="form-control" data-bind="
@@ -331,6 +335,9 @@
             'aria-required': $parent.required() ? 'true' : 'false',
         }
     "/>
+  <span class="help-block type" aria-hidden="true" data-bind="
+        text: helpText()
+    "></span>
 </script>
 <script type="text/html" id="unsupported-entry-ko-template">
   <div class="unsupported alert alert-warning">
@@ -415,7 +422,7 @@
   </div>
 </script>
 <script type="text/html" id="dropdown-entry-ko-template">
-  <span class="help-block type" data-bind="
+  <span class="help-block type sr-only" data-bind="
         text: helpText(),
         visible: helpText(),
     "></span>
@@ -430,9 +437,13 @@
         ">
     <option data-bind="value: id, text: text"></option>
   </select>
+  <span class="help-block type" aria-hidden="true" data-bind="
+        text: helpText(),
+        visible: helpText(),
+    "></span>
 </script>
 <script type="text/html" id="multidropdown-entry-ko-template">
-  <span class="help-block type" data-bind="
+  <span class="help-block type sr-only" data-bind="
         text: helpText(),
         visible: helpText(),
     "></span>
@@ -447,6 +458,10 @@
         ">
     <option data-bind="value: id, text: text"></option>
   </select>
+  <span class="help-block type" aria-hidden="true" data-bind="
+        text: helpText(),
+        visible: helpText(),
+    "></span>
 </script>
 <script type="text/html" id="choice-label-entry-ko-template">
   <div class="row">
@@ -492,11 +507,12 @@
 </script>
 
 <script type="text/html" id="time-entry-ko-template">
-  <span class="help-block">{% trans "24-hour clock" %}</span>
+  <span class="help-block sr-only">{% trans "24-hour clock" %}</span>
   <div class="input-group">
     <input type="text" class="form-control" data-bind="attr: { id: entryId, 'aria-required': $parent.required() ? 'true' : 'false' }"/>
     <span class="input-group-addon"><i class="fa fa-clock-o"></i></span>
   </div>
+  <span class="help-block" aria-hidden="true">{% trans "24-hour clock" %}</span>
 </script>
 
 <script type="text/html" id="ethiopian-date-entry-ko-template">

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -293,6 +293,9 @@
 </script>
 
 <script type="text/html" id="text-entry-ko-template">
+  <span class="help-block type" data-bind="
+        text: helpText()
+    "></span>
   <textarea class="textfield form-control" data-bind="
         value: $data.rawAnswer,
         valueUpdate: valueUpdate,
@@ -302,22 +305,22 @@
             'aria-required': $parent.required() ? 'true' : 'false',
         },
     "></textarea>
-  <span class="help-block type" data-bind="
-        text: helpText()
-    "></span>
 </script>
 
 <script type="text/html" id="password-entry-ko-template">
+  <span class="help-block type" data-bind="text: helpText()"></span>
   <input type="password" class="form-control" data-bind="
         value: $data.rawAnswer,
         valueUpdate: valueUpdate,
         id: entryId,
         attr: {'aria-required': $parent.required() ? 'true' : 'false'},
     "/>
-  <span class="help-block type" data-bind="text: helpText()"></span>
 </script>
 
 <script type="text/html" id="str-entry-ko-template">
+  <span class="help-block type" data-bind="
+        text: helpText()
+    "></span>
   <input autocomplete="off" type="text" class="form-control" data-bind="
         value: $data.rawAnswer,
         valueUpdate: valueUpdate,
@@ -328,9 +331,6 @@
             'aria-required': $parent.required() ? 'true' : 'false',
         }
     "/>
-  <span class="help-block type" data-bind="
-        text: helpText()
-    "></span>
 </script>
 <script type="text/html" id="unsupported-entry-ko-template">
   <div class="unsupported alert alert-warning">
@@ -415,6 +415,10 @@
   </div>
 </script>
 <script type="text/html" id="dropdown-entry-ko-template">
+  <span class="help-block type" data-bind="
+        text: helpText(),
+        visible: helpText(),
+    "></span>
   <select class="form-control" data-bind="
         foreach: options,
         value: rawAnswer,
@@ -426,12 +430,12 @@
         ">
     <option data-bind="value: id, text: text"></option>
   </select>
+</script>
+<script type="text/html" id="multidropdown-entry-ko-template">
   <span class="help-block type" data-bind="
         text: helpText(),
         visible: helpText(),
     "></span>
-</script>
-<script type="text/html" id="multidropdown-entry-ko-template">
   <select multiple class="form-control" data-bind="
         foreach: options,
         selectedOptions: rawAnswer,
@@ -443,10 +447,6 @@
         ">
     <option data-bind="value: id, text: text"></option>
   </select>
-  <span class="help-block type" data-bind="
-        text: helpText(),
-        visible: helpText(),
-    "></span>
 </script>
 <script type="text/html" id="choice-label-entry-ko-template">
   <div class="row">

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -492,11 +492,11 @@
 </script>
 
 <script type="text/html" id="time-entry-ko-template">
+  <span class="help-block">{% trans "24-hour clock" %}</span>
   <div class="input-group">
     <input type="text" class="form-control" data-bind="attr: { id: entryId, 'aria-required': $parent.required() ? 'true' : 'false' }"/>
     <span class="input-group-addon"><i class="fa fa-clock-o"></i></span>
   </div>
-  <span class="help-block">{% trans "24-hour clock" %}</span>
 </script>
 
 <script type="text/html" id="ethiopian-date-entry-ko-template">

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/utils.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/utils.less
@@ -8,10 +8,6 @@
   display: block;
 }
 
-.sr-only {
-  display: none;
-}
-
 .ko-template {
   display: none;
 }


### PR DESCRIPTION
## Summary
[USH-497](https://dimagi-dev.atlassian.net/browse/USH-497)
Help text spans moved from below to above related select and input elements. This stops screen readers from reading headings multiple times and reads help text before the user enters input/select area as per accessibility guidelines. 
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
Help text appears above related input/select and is read before entering input/select area. 
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
https://dimagi-dev.atlassian.net/browse/QA-3229
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
