### PR TITLE
Prevent common properties in Case Search properties and filters

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -376,6 +376,10 @@ hqDefine("app_manager/js/details/case_claim", function () {
             );
         });
 
+        self.isCommon = function (prop) {
+            return self.commonProperties().indexOf(prop) !== -1;
+        };
+
         self.serialize = function () {
             return _.extend({
                 properties: self._getProperties(),

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -361,6 +361,22 @@ hqDefine("app_manager/js/details/case_claim", function () {
             );
         };
 
+        self.commonProperties = ko.computed(function (argument) {
+            var defaultProperties = _.map(self._getDefaultProperties(), function (p) {
+                return p.property;
+            });
+            var commonProperties = self.searchProperties().filter(function(n) {
+                return n.name().length > 0 && defaultProperties.indexOf(n.name()) !== -1;
+            });
+            return _.map(
+                commonProperties,
+                function (p) {
+                    return p.name()
+                }
+            );
+            debugger;
+        });
+
         self.serialize = function () {
             return _.extend({
                 properties: self._getProperties(),

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -361,20 +361,19 @@ hqDefine("app_manager/js/details/case_claim", function () {
             );
         };
 
-        self.commonProperties = ko.computed(function (argument) {
+        self.commonProperties = ko.computed(function () {
             var defaultProperties = _.map(self._getDefaultProperties(), function (p) {
                 return p.property;
             });
-            var commonProperties = self.searchProperties().filter(function(n) {
+            var commonProperties = self.searchProperties().filter(function (n) {
                 return n.name().length > 0 && defaultProperties.indexOf(n.name()) !== -1;
             });
             return _.map(
                 commonProperties,
                 function (p) {
-                    return p.name()
+                    return p.name();
                 }
             );
-            debugger;
         });
 
         self.serialize = function () {

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -199,9 +199,9 @@ hqDefine("app_manager/js/details/screen", function () {
                 }
             }
             if (self.config.search.commonProperties().length > 0) {
-                var msg = "Search Properties and Default Search Filters can't have common properties. " +
-                    "Please update following properties: ";
-                errors.push(gettext(msg) + self.config.search.commonProperties());
+                var msg = gettext("Search Properties and Default Search Filters can't have common properties. " +
+                    "Please update following properties: ");
+                errors.push(msg + self.config.search.commonProperties());
             }
             if (errors.length) {
                 alert(gettext("There are errors in your configuration.") + "\n" + errors.join("\n"));

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -199,7 +199,9 @@ hqDefine("app_manager/js/details/screen", function () {
                 }
             }
             if (self.config.search.commonProperties().length > 0) {
-                errors.push(gettext("Search Properties and Default Search Filters can't have common properties."));
+                var msg = "Search Properties and Default Search Filters can't have common properties. " +
+                    "Please update following properties: ";
+                errors.push(gettext(msg) + self.config.search.commonProperties());
             }
             if (errors.length) {
                 alert(gettext("There are errors in your configuration.") + "\n" + errors.join("\n"));

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -198,6 +198,9 @@ hqDefine("app_manager/js/details/screen", function () {
                     errors.push(gettext("All properties must be below a tab."));
                 }
             }
+            if (self.config.search.commonProperties()) {
+                errors.push(gettext("Search Properties and Default Search Filters can't have common properties."));
+            }
             if (errors.length) {
                 alert(gettext("There are errors in your configuration.") + "\n" + errors.join("\n"));
                 return;

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -198,7 +198,7 @@ hqDefine("app_manager/js/details/screen", function () {
                     errors.push(gettext("All properties must be below a tab."));
                 }
             }
-            if (self.config.search.commonProperties()) {
+            if (self.config.search.commonProperties().length > 0) {
                 errors.push(gettext("Search Properties and Default Search Filters can't have common properties."));
             }
             if (errors.length) {

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
@@ -66,7 +66,7 @@
                   </label><br>
                   <label for="search_default_properties">
                     <input type="checkbox" name="search_default_properties" id="search_default_properties"/>
-                    {% trans "Default search properties" %}
+                    {% trans "Default search filters" %}
                   </label><br>
                   <label for="search_claim_options">
                     <input type="checkbox" name="search_claim_options" id="search_claim_options"/>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -55,10 +55,10 @@
           </thead>
           <tbody data-bind="foreach: defaultProperties">
           <tr>
-            <td class="col-sm-4" data-bind="css: {'has-error': $parent.commonProperties().indexOf(ko.unwrap(property())) !== -1}">
+            <td class="col-sm-4" data-bind="css: {'has-error': $parent.isCommon(ko.unwrap(property()))}">
 
               <input class="form-control" type="text" data-bind="value: property"/>
-              <div data-bind="visible: $parent.commonProperties().indexOf(ko.unwrap(property())) !== -1" class="help-block">
+              <div data-bind="visible: $parent.isCommon(ko.unwrap(property()))" class="help-block">
                 {% trans "A property is not allowed both here and Search Properties. Please remove from one of the lists" %}
               </div>
             </td>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -41,7 +41,7 @@
     </div>
     <div class="panel panel-appmanager">
       <div class="panel-heading">
-        <h4 class="panel-title panel-title-nolink">{% trans "Default Search Properties" %}</h4>
+        <h4 class="panel-title panel-title-nolink">{% trans "Default Search Filters" %}</h4>
       </div>
       <div class="panel-body">
         <p>{% trans "Filter based on a specific value of any case property. These are applied to every search and are hidden from the user." %}</p>
@@ -55,8 +55,12 @@
           </thead>
           <tbody data-bind="foreach: defaultProperties">
           <tr>
-            <td class="col-sm-4">
+            <td class="col-sm-4" data-bind="css: {'has-error': $parent.commonProperties().indexOf(ko.unwrap(property())) !== -1}">
+
               <input class="form-control" type="text" data-bind="value: property"/>
+              <div data-bind="visible: $parent.commonProperties().indexOf(ko.unwrap(property())) !== -1" class="help-block">
+                {% trans "A property is not allowed both here and Search Properties. Please remove from one of the lists" %}
+              </div>
             </td>
             <td class="col-sm-6">
               <textarea

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -4,9 +4,9 @@
   <td class="text-center">
     <i class="grip sortable-handle hq-icon-full fa fa-arrows-v"></i>
   </td>
-  <td data-bind="css: {'has-error': $parent.commonProperties().indexOf(ko.unwrap(name())) !== -1}">
+  <td data-bind="css: {'has-error': $parent.isCommon(ko.unwrap(name()))}">
     <input class="form-control" type="text" data-bind="value: name"/>
-    <div data-bind="visible: $parent.commonProperties().indexOf(ko.unwrap(name())) !== -1" class="help-block">
+    <div data-bind="visible: $parent.isCommon(ko.unwrap(name()))" class="help-block">
       {% trans "A property is not allowed both here and Default Search Filters. Please remove from one of the lists" %}
     </div>
   </td>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -4,8 +4,11 @@
   <td class="text-center">
     <i class="grip sortable-handle hq-icon-full fa fa-arrows-v"></i>
   </td>
-  <td>
+  <td data-bind="css: {'has-error': $parent.commonProperties().indexOf(ko.unwrap(name())) !== -1}">
     <input class="form-control" type="text" data-bind="value: name"/>
+    <div data-bind="visible: $parent.commonProperties().indexOf(ko.unwrap(name())) !== -1" class="help-block">
+      {% trans "A property is not allowed both here and Default Search Filters. Please remove from one of the lists" %}
+    </div>
   </td>
   <td>
     <input class="form-control" type="text" data-bind="value: label"/>


### PR DESCRIPTION
## Summary
Adds a UI constraint to not let users create case search properties and filters on same property

https://dimagi-dev.atlassian.net/browse/USH-1147


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

Not necessary as it's a simple UI change

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
