### PR TITLE
do not index large case property values

### DIFF
--- a/corehq/pillows/mappings/case_search_mapping.json
+++ b/corehq/pillows/mappings/case_search_mapping.json
@@ -34,7 +34,8 @@
                         "exact": {
                             "index": "not_analyzed",
                             "type": "string",
-                            "null_value": ""
+                            "null_value": "",
+                            "ignore_above": 8191
                         },
                         "numeric": {
                             "type": "double",


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Followup from https://dimagi-dev.atlassian.net/browse/SAAS-12367

This change will cause the case search index not to index case property values that are over 8191 characters. They will still be stored in the document, so will be retrieved when a case matches another query, but cannot be searched. This is due to a limit in lucene that indexed fields cannot exceed 32766 bytes. Given how case search is used (equality searching only), this is extremely unlikely to affect actual usage, since it would require someone inputting 8000 character exact matches in the application.

8192 was chosen because it is the max length allowed if all characters were 4 byte utf-8 characters, as recommended by ES.

ES docs on the setting https://www.elastic.co/guide/en/elasticsearch/reference/2.4/ignore-above.html

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This is a simple settings change that will not affect any existing data, and can be applied with zero downtime.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 

To rollback this change, the PR must be reverted and then `cchq <env> django-manage update_es_mapping case_search` must be run on all environments on which it was deployed.
