### PR TITLE
[User history] fix user filters for report

### DIFF
--- a/corehq/apps/reports/standard/users/reports.py
+++ b/corehq/apps/reports/standard/users/reports.py
@@ -61,18 +61,18 @@ class UserHistoryReport(GetParamsMixin, DatespanMixin, GenericTabularReport, Pro
 
     @memoized
     def _get_queryset(self):
-        user_ids = self._get_user_ids()
-        changed_by_user_ids = self._get_changed_by_user_ids()
+        user_slugs = self.request.GET.getlist(EMWF.slug)
+        user_ids = self._get_user_ids(user_slugs)
+
+        changed_by_user_slugs = self.request.GET.getlist(ChangedByUserFilter.slug)
+        changed_by_user_ids = self._get_user_ids(changed_by_user_slugs)
+
         actions = self.request.GET.getlist('action')
         query = self._build_query(user_ids, changed_by_user_ids, actions)
         return query
 
-    def _get_user_ids(self):
-        es_query = self._get_users_es_query(self.request.GET.getlist(EMWF.slug))
-        return es_query.values_list('_id', flat=True)
-
-    def _get_changed_by_user_ids(self):
-        es_query = self._get_users_es_query(self.request.GET.getlist(ChangedByUserFilter.slug))
+    def _get_user_ids(self, slugs):
+        es_query = self._get_users_es_query(slugs)
         return es_query.values_list('_id', flat=True)
 
     def _get_users_es_query(self, slugs):

--- a/corehq/apps/reports/standard/users/reports.py
+++ b/corehq/apps/reports/standard/users/reports.py
@@ -63,9 +63,15 @@ class UserHistoryReport(GetParamsMixin, DatespanMixin, GenericTabularReport, Pro
     def _get_queryset(self):
         user_slugs = self.request.GET.getlist(EMWF.slug)
         user_ids = self._get_user_ids(user_slugs)
+        # return empty queryset if no matching users were found
+        if user_slugs and not user_ids:
+            return UserHistory.objects.none()
 
         changed_by_user_slugs = self.request.GET.getlist(ChangedByUserFilter.slug)
         changed_by_user_ids = self._get_user_ids(changed_by_user_slugs)
+        # return empty queryset if no matching users were found
+        if changed_by_user_slugs and not changed_by_user_ids:
+            return UserHistory.objects.none()
 
         actions = self.request.GET.getlist('action')
         query = self._build_query(user_ids, changed_by_user_ids, actions)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Bug introduced in filters added for users in report at https://github.com/dimagi/commcare-hq/pull/29909/files#diff-97674072217e37379be148b9fdf743f686c009d5d9741d8ca3607fa16a4d526fR88-R92 
When the slugs are passed to filter but there are no matching users to filter on, currently we are still showing results with records for accessible users, which is confusing.
So this PR updates to return no records in case the filter yields no users.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_HISTORY_REPORT`

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No UI changes

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally that this works okay.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

Same as base PR
