### PR TITLE
DHIS2: Add support for sending geolocation

### DIFF
--- a/corehq/motech/dhis2/README.md
+++ b/corehq/motech/dhis2/README.md
@@ -324,6 +324,7 @@ tracked entity attributes.
 In "Followup Form", add questions:
 * "LMP Date" (Question ID: `lmp_date`)
 * "Visit Comment" (Question ID: `visit_comment`)
+* "Location" (Question ID: `event_location`)
 * and the rest of the case properties, so you can modify them if you
   want.
 
@@ -409,6 +410,9 @@ Paste the following into "Case config":
         "form_question": "/data/lmp_date"
       },
       "event_status": "ACTIVE",
+      "event_location": {
+          "form_question": "/data/event_location"
+      },
       "datavalue_maps": [
         {
           "data_element_id": "OuJ6sgPyAbC",
@@ -501,6 +505,12 @@ from a form question value.
 "event_date" is the date of the start of the event. "event_status" is
 one of "ACTIVE", "COMPLETED", "VISITED", "SCHEDULED", "OVERDUE" or
 "SKIPPED".
+
+"event_location" is the location of the event. In the example above the
+location is specified as a `form_question`, so it assumes the app has a
+question capturing the geolocation which can be referenced with
+`/data/event_location`. \
+Note: It's assumed that the event location will also be the enrollment location.
 
 And lastly, "datavalue_maps" sets DHIS2 data element values. In this
 example we are only collecting one, but setting data element values is

--- a/corehq/motech/dhis2/const.py
+++ b/corehq/motech/dhis2/const.py
@@ -66,4 +66,3 @@ DHIS2_UID_MESSAGE = _('A DHIS2 "UID" is exactly 11 alpha-numeric characters '
 XMLNS_DHIS2 = 'http://commcarehq.org/dhis2-integration'
 
 DHIS2_MAX_VERSION = "2.35.1"
-DEFAULT_DHIS2_FEATURE_TYPE = 'NONE'

--- a/corehq/motech/dhis2/const.py
+++ b/corehq/motech/dhis2/const.py
@@ -66,3 +66,4 @@ DHIS2_UID_MESSAGE = _('A DHIS2 "UID" is exactly 11 alpha-numeric characters '
 XMLNS_DHIS2 = 'http://commcarehq.org/dhis2-integration'
 
 DHIS2_MAX_VERSION = "2.35.1"
+DEFAULT_DHIS2_FEATURE_TYPE = 'NONE'

--- a/corehq/motech/dhis2/dhis2_config.py
+++ b/corehq/motech/dhis2/dhis2_config.py
@@ -46,6 +46,7 @@ class Dhis2FormConfig(DocumentSchema):
     })
     completed_date = DictProperty(required=False)
     datavalue_maps = SchemaListProperty(FormDataValueMap)
+    event_location = DictProperty(required=False, default={})
 
     @classmethod
     def wrap(cls, data):

--- a/corehq/motech/dhis2/dhis2_config.py
+++ b/corehq/motech/dhis2/dhis2_config.py
@@ -46,6 +46,9 @@ class Dhis2FormConfig(DocumentSchema):
     })
     completed_date = DictProperty(required=False)
     datavalue_maps = SchemaListProperty(FormDataValueMap)
+    coordinate = DictProperty(required=False, default={
+        "form_question": "/metadata/location/#text"
+    })
 
     @classmethod
     def wrap(cls, data):

--- a/corehq/motech/dhis2/dhis2_config.py
+++ b/corehq/motech/dhis2/dhis2_config.py
@@ -46,9 +46,6 @@ class Dhis2FormConfig(DocumentSchema):
     })
     completed_date = DictProperty(required=False)
     datavalue_maps = SchemaListProperty(FormDataValueMap)
-    coordinate = DictProperty(required=False, default={
-        "form_question": "/metadata/location/#text"
-    })
 
     @classmethod
     def wrap(cls, data):

--- a/corehq/motech/dhis2/entities_helpers.py
+++ b/corehq/motech/dhis2/entities_helpers.py
@@ -396,8 +396,8 @@ def get_geo_json(form_config, case_trigger_info):
         return {
             'type': 'Point',
             'coordinates': [
-                float(point['latitude']),
-                float(point['longitude'])
+                point['latitude'],
+                point['longitude']
             ]
         }
     return {}

--- a/corehq/motech/dhis2/entities_helpers.py
+++ b/corehq/motech/dhis2/entities_helpers.py
@@ -391,7 +391,7 @@ def get_tracked_entity_type(requests, entity_type_id):
 
 def get_geo_json(form_config, case_trigger_info):
     coordinate_dict = _get_coordinate(form_config, case_trigger_info)
-    if coordinate_dict['coordinate']:
+    if coordinate_dict.get('coordinate'):
         point = coordinate_dict['coordinate']
         return {
             'type': 'Point',

--- a/corehq/motech/dhis2/entities_helpers.py
+++ b/corehq/motech/dhis2/entities_helpers.py
@@ -9,7 +9,7 @@ from schema import Schema, SchemaError
 from casexml.apps.case.mock import CaseBlock
 
 from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.motech.dhis2.const import XMLNS_DHIS2, DEFAULT_DHIS2_FEATURE_TYPE
+from corehq.motech.dhis2.const import XMLNS_DHIS2
 from corehq.motech.dhis2.events_helpers import get_event, _get_coordinate
 from corehq.motech.dhis2.exceptions import (
     BadTrackedEntityInstanceID,

--- a/corehq/motech/dhis2/entities_helpers.py
+++ b/corehq/motech/dhis2/entities_helpers.py
@@ -133,7 +133,11 @@ def update_tracked_entity_instance(
         )
         set_te_attr(tracked_entity["attributes"], attr_id, value)
         case_updates.update(case_update)
-    enrollments_with_new_events = get_enrollments(case_trigger_info, case_config)
+    enrollments_with_new_events = get_enrollments(
+        case_trigger_info,
+        case_config,
+        tracked_entity.get('featureType')
+    )
     if enrollments_with_new_events:
         tracked_entity["enrollments"] = update_enrollments(
             tracked_entity, enrollments_with_new_events
@@ -190,13 +194,15 @@ def register_tracked_entity_instance(requests, case_trigger_info, case_config):
         "orgUnit": get_value(case_config.org_unit_id, case_trigger_info),
         "attributes": [],
     }
+    entity_type = get_tracked_entity_type(requests, case_config.te_type_id)
+
     for attr_id, value_source_config in case_config.attributes.items():
         value, case_update = get_or_generate_value(
             requests, attr_id, value_source_config, case_trigger_info
         )
         set_te_attr(tracked_entity["attributes"], attr_id, value)
         case_updates.update(case_update)
-    enrollments = get_enrollments(case_trigger_info, case_config)
+    enrollments = get_enrollments(case_trigger_info, case_config, entity_type.get('featureType'))
     if enrollments:
         tracked_entity["enrollments"] = enrollments
     validate_tracked_entity(tracked_entity)
@@ -270,7 +276,7 @@ def generate_value(requests, attr_id, generator_params, case_trigger_info):
     return response.json()["value"]
 
 
-def get_enrollments(case_trigger_info, case_config):
+def get_enrollments(case_trigger_info, case_config, entity_feature_type=None):
     """
     DHIS2 allows tracked entity instances to be enrolled in programs
     without any events, but CommCare does not currently have a mechanism
@@ -278,7 +284,7 @@ def get_enrollments(case_trigger_info, case_config):
     in that program occurs.
     """
     case_org_unit = get_value(case_config.org_unit_id, case_trigger_info)
-    programs_by_id = get_programs_by_id(case_trigger_info, case_config)
+    programs_by_id = get_programs_by_id(case_trigger_info, case_config, entity_feature_type)
     enrollments = []
     for program_id, program in programs_by_id.items():
         enrollment = {
@@ -297,7 +303,7 @@ def get_enrollments(case_trigger_info, case_config):
     return enrollments
 
 
-def get_programs_by_id(case_trigger_info, case_config):
+def get_programs_by_id(case_trigger_info, case_config, entity_feature_type=None):
     programs_by_id = defaultdict(lambda: {"events": []})
     for form_config in case_config.form_configs:
         if case_trigger_info.form_question_values['/metadata/xmlns'] != form_config.xmlns:
@@ -308,7 +314,7 @@ def get_programs_by_id(case_trigger_info, case_config):
             program["events"].append(event)
             program["orgUnit"] = get_value(form_config.org_unit_id, case_trigger_info)
             program["status"] = get_value(form_config.program_status, case_trigger_info)
-            program["geometry"] = get_geo_json(form_config, case_trigger_info)
+            program["geometry"] = get_geo_json(form_config, case_trigger_info, entity_feature_type)
             program.update(get_program_dates(form_config, case_trigger_info))
     return programs_by_id
 
@@ -379,12 +385,22 @@ def validate_tracked_entity(tracked_entity):
         raise ConfigurationError from err
 
 
-def get_geo_json(form_config, case_trigger_info):
+def get_tracked_entity_type(requests, entity_type_id):
+    endpoint = f"/api/trackedEntityTypes/{entity_type_id}"
+    response = requests.get(endpoint, raise_for_status=True)
+    return response.json()
+
+
+def get_geo_json(form_config, case_trigger_info, entity_feature_type=None):
+    feature_type = 'NONE'  # feature_type = 'NONE' for most entities, including 'Person'
+    if entity_feature_type:
+        feature_type = entity_feature_type
+
     coordinate_dict = _get_coordinates(form_config, case_trigger_info)
     if coordinate_dict['coordinate']:
         point = coordinate_dict['coordinate']
         return {
-            'type': 'Point',
+            'type': feature_type,
             'coordinates': [
                 float(point['latitude']),
                 float(point['longitude'])

--- a/corehq/motech/dhis2/entities_helpers.py
+++ b/corehq/motech/dhis2/entities_helpers.py
@@ -392,7 +392,7 @@ def get_tracked_entity_type(requests, entity_type_id):
 
 
 def get_geo_json(form_config, case_trigger_info, entity_feature_type=None):
-    feature_type = 'NONE'  # feature_type = 'NONE' for most entities, including 'Person'
+    feature_type = 'NONE'
     if entity_feature_type:
         feature_type = entity_feature_type
 

--- a/corehq/motech/dhis2/entities_helpers.py
+++ b/corehq/motech/dhis2/entities_helpers.py
@@ -9,8 +9,8 @@ from schema import Schema, SchemaError
 from casexml.apps.case.mock import CaseBlock
 
 from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.motech.dhis2.const import XMLNS_DHIS2
-from corehq.motech.dhis2.events_helpers import get_event, _get_coordinates
+from corehq.motech.dhis2.const import XMLNS_DHIS2, DEFAULT_DHIS2_FEATURE_TYPE
+from corehq.motech.dhis2.events_helpers import get_event, _get_coordinate
 from corehq.motech.dhis2.exceptions import (
     BadTrackedEntityInstanceID,
     Dhis2Exception,
@@ -392,11 +392,11 @@ def get_tracked_entity_type(requests, entity_type_id):
 
 
 def get_geo_json(form_config, case_trigger_info, entity_feature_type=None):
-    feature_type = 'NONE'
+    feature_type = DEFAULT_DHIS2_FEATURE_TYPE
     if entity_feature_type:
         feature_type = entity_feature_type
 
-    coordinate_dict = _get_coordinates(form_config, case_trigger_info)
+    coordinate_dict = _get_coordinate(form_config, case_trigger_info)
     if coordinate_dict['coordinate']:
         point = coordinate_dict['coordinate']
         return {

--- a/corehq/motech/dhis2/entities_helpers.py
+++ b/corehq/motech/dhis2/entities_helpers.py
@@ -10,7 +10,7 @@ from casexml.apps.case.mock import CaseBlock
 
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.motech.dhis2.const import XMLNS_DHIS2
-from corehq.motech.dhis2.events_helpers import get_event
+from corehq.motech.dhis2.events_helpers import get_event, _get_geo_json
 from corehq.motech.dhis2.exceptions import (
     BadTrackedEntityInstanceID,
     Dhis2Exception,
@@ -287,6 +287,8 @@ def get_enrollments(case_trigger_info, case_config):
             "status": program["status"],
             "events": program["events"],
         }
+        if program.get("geometry"):
+            enrollment["geometry"] = program["geometry"]
         if program.get("enrollmentDate"):
             enrollment["enrollmentDate"] = program["enrollmentDate"]
         if program.get("incidentDate"):
@@ -306,6 +308,7 @@ def get_programs_by_id(case_trigger_info, case_config):
             program["events"].append(event)
             program["orgUnit"] = get_value(form_config.org_unit_id, case_trigger_info)
             program["status"] = get_value(form_config.program_status, case_trigger_info)
+            program["geometry"] = _get_geo_json(form_config, case_trigger_info)
             program.update(get_program_dates(form_config, case_trigger_info))
     return programs_by_id
 

--- a/corehq/motech/dhis2/events_helpers.py
+++ b/corehq/motech/dhis2/events_helpers.py
@@ -107,8 +107,8 @@ def _get_coordinate(config, case_trigger_info):
     if location and location.latitude and location.longitude:
         return {
             'coordinate': {
-                'latitude': str(round(location.latitude, 4)),
-                'longitude': str(round(location.longitude, 4))
+                'latitude': float(round(location.latitude, 4)),
+                'longitude': float(round(location.longitude, 4))
             }
         }
     else:

--- a/corehq/motech/dhis2/events_helpers.py
+++ b/corehq/motech/dhis2/events_helpers.py
@@ -110,30 +110,23 @@ def _get_coordinates(config, case_trigger_info):
     return {}
 
 
-def _get_geo_json(form_config, case_trigger_info):
-    coordinate_dict = _get_coordinates(form_config, case_trigger_info)
-    if coordinate_dict['coordinate']:
-        point = coordinate_dict['coordinate']
-        return {
-            'type': 'Point',
-            'coordinates': [
-                point['latitude'],
-                point['longitude']
-            ]
-        }
-    return {}
-
-
-def _to_dhis2_coordinate(coordinate: str):
+def _to_dhis2_coordinate(coordinate_string: str):
     """
     Example
-    coordinate: "-35.8655497 14.6940185 138.66 5.4"
-    Returns: {"latitude": -35.8655497, "longitude": 14.6940185}
+    coordinate: "-35.8655497 14.6941185 138.66 5.4"
+    Returns: {"latitude": "-35.8655", "longitude": "14.6941"} conforming to EPSG:4326
+
+    Notes
+    According to the documentation no more than a maximum of 4
+    significant decimal places should ever be necessary:
+    https://docs.dhis2.org/en/use/user-guides/dhis-core-version-234/configuring-the-system/maps.html#gis_creating_setup
     """
-    (lat, lon) = coordinate.split(' ')[:2]
+    coordinate = coordinate_string.split(' ')[:2]
+    (lat, lon) = [round(float(item), 4) for item in coordinate]
+
     return {
-        'latitude': float(lat),
-        'longitude': float(lon)
+        'latitude': str(lat),
+        'longitude': str(lon)
     }
 
 

--- a/corehq/motech/dhis2/events_helpers.py
+++ b/corehq/motech/dhis2/events_helpers.py
@@ -32,6 +32,7 @@ def get_event(domain, config, form_json=None, info=None):
         _get_event_status,
         _get_completed_date,
         _get_datavalues,
+        _get_coordinates
     ]
     for func in event_property_functions:
         event.update(func(config, info))
@@ -97,6 +98,29 @@ def _get_datavalues(config, case_trigger_info):
                 'value': value
             })
     return {'dataValues': values}
+
+
+def _get_coordinates(config, case_trigger_info):
+    if config.coordinate:
+        coordinate = get_value(config.coordinate, case_trigger_info)
+
+        if coordinate:
+            return {'coordinate': _to_dhis2_coordinate(coordinate)}
+
+    return {}
+
+
+def _to_dhis2_coordinate(coordinate: str):
+    """
+    Example
+    coordinate: "-35.8655497 14.6940185 138.66 5.4"
+    Returns: {"latitude": -35.8655497, "longitude": 14.6940185}
+    """
+    (lat, lon) = coordinate.split(' ')[:2]
+    return {
+        'latitude': float(lat),
+        'longitude': float(lon)
+    }
 
 
 def validate_event_schema(event):

--- a/corehq/motech/dhis2/events_helpers.py
+++ b/corehq/motech/dhis2/events_helpers.py
@@ -110,6 +110,20 @@ def _get_coordinates(config, case_trigger_info):
     return {}
 
 
+def _get_geo_json(form_config, case_trigger_info):
+    coordinate_dict = _get_coordinates(form_config, case_trigger_info)
+    if coordinate_dict['coordinate']:
+        point = coordinate_dict['coordinate']
+        return {
+            'type': 'Point',
+            'coordinates': [
+                point['latitude'],
+                point['longitude']
+            ]
+        }
+    return {}
+
+
 def _to_dhis2_coordinate(coordinate: str):
     """
     Example

--- a/corehq/motech/dhis2/tests/data/tracked_entity_type.json
+++ b/corehq/motech/dhis2/tests/data/tracked_entity_type.json
@@ -1,0 +1,173 @@
+{
+  "lastUpdated": "2018-02-22T09:05:13.160",
+  "id": "nEenWmSyUEp",
+  "href": "https://play.dhis2.org/2.36.2/api/trackedEntityTypes/nEenWmSyUEp",
+  "created": "2014-08-20T12:28:56.409",
+  "name": "Person",
+  "displayName": "Person",
+  "publicAccess": "rwrw----",
+  "description": "Person",
+  "externalAccess": false,
+  "allowAuditLog": false,
+  "featureType": "NONE",
+  "minAttributesRequiredToSearch": 1,
+  "displayDescription": "Person",
+  "sharing": {
+    "owner": "xE7jOejl9FI",
+    "external": false,
+    "users": {},
+    "userGroups": {},
+    "public": "rwrw----"
+  },
+  "displayFormName": "Person",
+  "maxTeiCountToReturn": 0,
+  "favorite": false,
+  "access": {
+    "read": true,
+    "update": true,
+    "externalize": false,
+    "delete": true,
+    "write": true,
+    "manage": true,
+    "data": {
+      "read": true,
+      "write": true
+    }
+  },
+  "lastUpdatedBy": {
+    "displayName": "John Traore",
+    "name": "John Traore",
+    "id": "xE7jOejl9FI",
+    "username": "admin"
+  },
+  "createdBy": {
+    "displayName": "John Traore",
+    "name": "John Traore",
+    "id": "xE7jOejl9FI",
+    "username": "admin"
+  },
+  "user": {
+    "displayName": "John Traore",
+    "name": "John Traore",
+    "id": "xE7jOejl9FI",
+    "username": "admin"
+  },
+  "favorites": [],
+  "trackedEntityTypeAttributes": [
+    {
+      "lastUpdated": "2018-02-21T13:54:18.693",
+      "id": "Jdd8hMStmvF",
+      "created": "2018-02-21T13:54:18.324",
+      "name": "Person Unique ID",
+      "displayName": "Person Unique ID",
+      "displayShortName": "null Unique identifier",
+      "externalAccess": false,
+      "valueType": "TEXT",
+      "sharing": {
+        "external": false,
+        "users": {},
+        "userGroups": {}
+      },
+      "searchable": false,
+      "displayInList": false,
+      "favorite": false,
+      "access": {
+        "read": true,
+        "update": true,
+        "externalize": false,
+        "delete": true,
+        "write": true,
+        "manage": true
+      },
+      "trackedEntityAttribute": {
+        "id": "lZGmxYbs97q"
+      },
+      "trackedEntityType": {
+        "id": "nEenWmSyUEp"
+      },
+      "favorites": [],
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": []
+    },
+    {
+      "lastUpdated": "2018-02-21T13:54:18.694",
+      "id": "EGn5VqU7pHv",
+      "created": "2018-02-21T13:54:18.324",
+      "name": "Person First name",
+      "displayName": "Person First name",
+      "displayShortName": "null First name",
+      "externalAccess": false,
+      "valueType": "TEXT",
+      "sharing": {
+        "external": false,
+        "users": {},
+        "userGroups": {}
+      },
+      "searchable": true,
+      "displayInList": true,
+      "favorite": false,
+      "access": {
+        "read": true,
+        "update": true,
+        "externalize": false,
+        "delete": true,
+        "write": true,
+        "manage": true
+      },
+      "trackedEntityAttribute": {
+        "id": "w75KJ2mc4zz"
+      },
+      "trackedEntityType": {
+        "id": "nEenWmSyUEp"
+      },
+      "favorites": [],
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": []
+    },
+    {
+      "lastUpdated": "2018-02-21T13:54:18.694",
+      "id": "JBJ3AWsrg9P",
+      "created": "2018-02-21T13:54:18.324",
+      "name": "Person Last name",
+      "displayName": "Person Last name",
+      "displayShortName": "null Last name",
+      "externalAccess": false,
+      "valueType": "TEXT",
+      "sharing": {
+        "external": false,
+        "users": {},
+        "userGroups": {}
+      },
+      "searchable": true,
+      "displayInList": true,
+      "favorite": false,
+      "access": {
+        "read": true,
+        "update": true,
+        "externalize": false,
+        "delete": true,
+        "write": true,
+        "manage": true
+      },
+      "trackedEntityAttribute": {
+        "id": "zDhUuAYrxNC"
+      },
+      "trackedEntityType": {
+        "id": "nEenWmSyUEp"
+      },
+      "favorites": [],
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": []
+    }
+  ],
+  "translations": [],
+  "userGroupAccesses": [],
+  "attributeValues": [],
+  "userAccesses": []
+}

--- a/corehq/motech/dhis2/tests/test_entities_helpers.py
+++ b/corehq/motech/dhis2/tests/test_entities_helpers.py
@@ -105,6 +105,7 @@ class TestDhis2EntitiesHelpers(TestCase):
                 "@xmlns": "test_xmlns",
                 "event_date": "2017-05-25T21:06:27.012000",
                 "completed_date": "2017-05-25T21:06:27.012000",
+                "event_location": "-33.6543213 19.12344312 abcdefg",
                 "name": "test event",
                 "meta": {
                     "location": 'test location',
@@ -121,6 +122,9 @@ class TestDhis2EntitiesHelpers(TestCase):
                 'xmlns': 'test_xmlns',
                 'program_id': program_id,
                 'event_status': 'COMPLETED',
+                'event_location': {
+                    'form_question': '/data/event_location'
+                },
                 'completed_date': {
                     'doc_type': 'FormQuestion',
                     'form_question': '/data/completed_date',

--- a/corehq/motech/dhis2/tests/test_entities_helpers.py
+++ b/corehq/motech/dhis2/tests/test_entities_helpers.py
@@ -155,11 +155,11 @@ class TestDhis2EntitiesHelpers(TestCase):
             form_question_values=get_form_question_values(form),
         )
 
-        programs = get_programs_by_id(info, repeater.dhis2_config, None)
+        programs = get_programs_by_id(info, repeater.dhis2_config)
 
         self.assertDictEqual(
             programs[program_id]['geometry'],
-            {'type': 'NONE', 'coordinates': [-33.6543, 19.1234]}
+            {'type': 'Point', 'coordinates': [-33.6543, 19.1234]}
         )
 
 

--- a/corehq/motech/dhis2/tests/test_entities_helpers.py
+++ b/corehq/motech/dhis2/tests/test_entities_helpers.py
@@ -1,9 +1,26 @@
 import doctest
+import json
 
-from django.test import TestCase, SimpleTestCase
+from django.test import SimpleTestCase
+from django.test.testcases import TestCase
 
 from corehq.motech.dhis2.entities_helpers import validate_tracked_entity
 from corehq.motech.exceptions import ConfigurationError
+
+from fakecouch import FakeCouchDb
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.locations.models import LocationType, SQLLocation
+from corehq.apps.users.models import WebUser
+from corehq.motech.dhis2.const import DHIS2_DATA_TYPE_DATE, LOCATION_DHIS_ID
+from corehq.motech.dhis2.dhis2_config import Dhis2FormConfig
+from corehq.motech.dhis2.forms import Dhis2ConfigForm
+from corehq.motech.dhis2.repeaters import Dhis2Repeater
+from corehq.motech.dhis2.entities_helpers import get_programs_by_id
+from corehq.motech.value_source import CaseTriggerInfo, get_form_question_values
+
+
+DOMAIN = "dhis2-test"
 
 
 class ValidateTrackedEntityTests(SimpleTestCase):
@@ -43,19 +60,115 @@ class ValidateTrackedEntityTests(SimpleTestCase):
             validate_tracked_entity(tracked_entity)
 
 
+class TestDhis2EntitiesHelpers(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = create_domain(DOMAIN)
+        location_type = LocationType.objects.create(
+            domain=DOMAIN,
+            name='test_location_type',
+        )
+        cls.location = SQLLocation.objects.create(
+            domain=DOMAIN,
+            name='test location',
+            location_id='test_location',
+            location_type=location_type,
+            metadata={LOCATION_DHIS_ID: "dhis2_location_id"},
+        )
+        cls.user = WebUser.create(DOMAIN, 'test', 'passwordtest', None, None)
+        cls.user.set_location(DOMAIN, cls.location)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete(deleted_by=None)
+        cls.location.delete()
+        cls.domain.delete()
+        super().tearDownClass()
+
+    def setUp(self):
+        self.db = Dhis2Repeater.get_db()
+        self.fakedb = FakeCouchDb()
+        Dhis2Repeater.set_db(self.fakedb)
+
+    def tearDown(self):
+        Dhis2Repeater.set_db(self.db)
+
+    def test_get_programs_by_id(self):
+        program_id = 'test program'
+
+        form = {
+            "domain": DOMAIN,
+            "form": {
+                "@xmlns": "test_xmlns",
+                "event_date": "2017-05-25T21:06:27.012000",
+                "completed_date": "2017-05-25T21:06:27.012000",
+                "name": "test event",
+                "meta": {
+                    "location": {
+                        '#text': '-32.1455497 10.6140145 138.66 5.4',
+                        '@xmlns': 'http://commcarehq.org/xforms'
+                    },
+                    "timeEnd": "2017-05-25T21:06:27.012000",
+                    "timeStart": "2017-05-25T21:06:17.739000",
+                    "userID": self.user.user_id,
+                    "username": self.user.username
+                }
+            },
+            "received_on": "2017-05-26T09:17:23.692083Z",
+        }
+        config = {
+            'form_configs': json.dumps([{
+                'xmlns': 'test_xmlns',
+                'program_id': program_id,
+                'event_status': 'COMPLETED',
+                'completed_date': {
+                    'doc_type': 'FormQuestion',
+                    'form_question': '/data/completed_date',
+                    'external_data_type': DHIS2_DATA_TYPE_DATE
+                },
+                'org_unit_id': {
+                    'doc_type': 'FormUserAncestorLocationField',
+                    'form_user_ancestor_location_field': LOCATION_DHIS_ID
+                },
+                'datavalue_maps': [
+                    {
+                        'data_element_id': 'dhis2_element_id',
+                        'value': {
+                            'doc_type': 'FormQuestion',
+                            'form_question': '/data/name'
+                        }
+                    }
+                ],
+                'coordinate': {
+                    "form_question": "/metadata/location/#text"
+                }
+            }])
+        }
+        config_form = Dhis2ConfigForm(data=config)
+        self.assertTrue(config_form.is_valid())
+        data = config_form.cleaned_data
+        repeater = Dhis2Repeater()
+        repeater.dhis2_config.form_configs = [Dhis2FormConfig.wrap(fc) for fc in data['form_configs']]
+        repeater.save()
+
+        info = CaseTriggerInfo(
+            domain=DOMAIN,
+            case_id=None,
+            form_question_values=get_form_question_values(form),
+        )
+
+        programs = get_programs_by_id(info, repeater.dhis2_config)
+
+        self.assertDictEqual(
+            programs[program_id]['geometry'],
+            {'type': 'Point', 'coordinates': [-32.1455, 10.6140]}
+        )
+
+
 def test_doctests():
     from corehq.motech.dhis2 import entities_helpers
 
     results = doctest.testmod(entities_helpers)
     assert results.failed == 0
-
-
-class TestGetEnrolments(TesCase):
-
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
-    def test_

--- a/corehq/motech/dhis2/tests/test_entities_helpers.py
+++ b/corehq/motech/dhis2/tests/test_entities_helpers.py
@@ -19,7 +19,6 @@ from corehq.motech.dhis2.repeaters import Dhis2Repeater
 from corehq.motech.dhis2.entities_helpers import get_programs_by_id
 from corehq.motech.value_source import CaseTriggerInfo, get_form_question_values
 
-
 DOMAIN = "dhis2-test"
 
 
@@ -75,6 +74,8 @@ class TestDhis2EntitiesHelpers(TestCase):
             name='test location',
             location_id='test_location',
             location_type=location_type,
+            latitude='-33.6543',
+            longitude='19.1234',
             metadata={LOCATION_DHIS_ID: "dhis2_location_id"},
         )
         cls.user = WebUser.create(DOMAIN, 'test', 'passwordtest', None, None)
@@ -106,10 +107,7 @@ class TestDhis2EntitiesHelpers(TestCase):
                 "completed_date": "2017-05-25T21:06:27.012000",
                 "name": "test event",
                 "meta": {
-                    "location": {
-                        '#text': '-32.1455497 10.6140145 138.66 5.4',
-                        '@xmlns': 'http://commcarehq.org/xforms'
-                    },
+                    "location": 'test location',
                     "timeEnd": "2017-05-25T21:06:27.012000",
                     "timeStart": "2017-05-25T21:06:17.739000",
                     "userID": self.user.user_id,
@@ -140,10 +138,7 @@ class TestDhis2EntitiesHelpers(TestCase):
                             'form_question': '/data/name'
                         }
                     }
-                ],
-                'coordinate': {
-                    "form_question": "/metadata/location/#text"
-                }
+                ]
             }])
         }
         config_form = Dhis2ConfigForm(data=config)
@@ -156,6 +151,7 @@ class TestDhis2EntitiesHelpers(TestCase):
         info = CaseTriggerInfo(
             domain=DOMAIN,
             case_id=None,
+            owner_id='test_location',
             form_question_values=get_form_question_values(form),
         )
 
@@ -163,7 +159,7 @@ class TestDhis2EntitiesHelpers(TestCase):
 
         self.assertDictEqual(
             programs[program_id]['geometry'],
-            {'type': 'NONE', 'coordinates': [-32.1455, 10.6140]}
+            {'type': 'NONE', 'coordinates': [-33.6543, 19.1234]}
         )
 
 

--- a/corehq/motech/dhis2/tests/test_entities_helpers.py
+++ b/corehq/motech/dhis2/tests/test_entities_helpers.py
@@ -1,6 +1,6 @@
 import doctest
 
-from django.test import SimpleTestCase
+from django.test import TestCase, SimpleTestCase
 
 from corehq.motech.dhis2.entities_helpers import validate_tracked_entity
 from corehq.motech.exceptions import ConfigurationError
@@ -48,3 +48,14 @@ def test_doctests():
 
     results = doctest.testmod(entities_helpers)
     assert results.failed == 0
+
+
+class TestGetEnrolments(TesCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_

--- a/corehq/motech/dhis2/tests/test_entities_helpers.py
+++ b/corehq/motech/dhis2/tests/test_entities_helpers.py
@@ -159,11 +159,11 @@ class TestDhis2EntitiesHelpers(TestCase):
             form_question_values=get_form_question_values(form),
         )
 
-        programs = get_programs_by_id(info, repeater.dhis2_config)
+        programs = get_programs_by_id(info, repeater.dhis2_config, None)
 
         self.assertDictEqual(
             programs[program_id]['geometry'],
-            {'type': 'Point', 'coordinates': [-32.1455, 10.6140]}
+            {'type': 'NONE', 'coordinates': [-32.1455, 10.6140]}
         )
 
 

--- a/corehq/motech/dhis2/tests/test_events_helpers.py
+++ b/corehq/motech/dhis2/tests/test_events_helpers.py
@@ -56,6 +56,7 @@ class TestDhis2EventsHelpers(TestCase):
                 "@xmlns": "test_xmlns",
                 "event_date": "2017-05-25T21:06:27.012000",
                 "completed_date": "2017-05-25T21:06:27.012000",
+                "event_location": "-33.6543213 19.12344312 abcdefg",
                 "name": "test event",
                 "meta": {
                     "location": '',
@@ -80,6 +81,9 @@ class TestDhis2EventsHelpers(TestCase):
                 'org_unit_id': {
                     'doc_type': 'FormUserAncestorLocationField',
                     'form_user_ancestor_location_field': LOCATION_DHIS_ID
+                },
+                'event_location': {
+                    'form_question': '/data/event_location'
                 },
                 'datavalue_maps': [
                     {
@@ -127,34 +131,9 @@ class TestDhis2EventsHelpers(TestCase):
                 'eventDate': '2017-05-26',
                 'orgUnit': 'dhis2_location_id',
                 'coordinate': {
-                    'latitude': -33.8655,
-                    'longitude': 18.6941
+                    'latitude': -33.6543,
+                    'longitude': 19.1234
                 }
-            },
-            event
-        )
-
-    def test_form_processing_without_owner(self):
-        info = CaseTriggerInfo(
-            domain=DOMAIN,
-            case_id=None,
-            form_question_values=get_form_question_values(self.form),
-        )
-        event = get_event(DOMAIN, self.repeater.dhis2_config.form_configs[0], form_json=self.form, info=info)
-
-        self.assertDictEqual(
-            {
-                'dataValues': [
-                    {
-                        'dataElement': 'dhis2_element_id',
-                        'value': 'test event'
-                    }
-                ],
-                'status': 'COMPLETED',
-                'completedDate': '2017-05-25',
-                'program': 'test program',
-                'eventDate': '2017-05-26',
-                'orgUnit': 'dhis2_location_id',
             },
             event
         )

--- a/corehq/motech/dhis2/tests/test_events_helpers.py
+++ b/corehq/motech/dhis2/tests/test_events_helpers.py
@@ -127,8 +127,8 @@ class TestDhis2EventsHelpers(TestCase):
                 'eventDate': '2017-05-26',
                 'orgUnit': 'dhis2_location_id',
                 'coordinate': {
-                    'latitude': "-33.8655",
-                    'longitude': "18.6941"
+                    'latitude': -33.8655,
+                    'longitude': 18.6941
                 }
             },
             event

--- a/corehq/motech/dhis2/tests/test_events_helpers.py
+++ b/corehq/motech/dhis2/tests/test_events_helpers.py
@@ -12,6 +12,7 @@ from corehq.motech.dhis2.dhis2_config import Dhis2FormConfig
 from corehq.motech.dhis2.events_helpers import get_event
 from corehq.motech.dhis2.forms import Dhis2ConfigForm
 from corehq.motech.dhis2.repeaters import Dhis2Repeater
+from corehq.motech.value_source import CaseTriggerInfo, get_form_question_values
 
 DOMAIN = "dhis2-test"
 
@@ -31,6 +32,8 @@ class TestDhis2EventsHelpers(TestCase):
             name='test location',
             location_id='test_location',
             location_type=location_type,
+            latitude='-33.8655',
+            longitude='18.6941',
             metadata={LOCATION_DHIS_ID: "dhis2_location_id"},
         )
         cls.user = WebUser.create(DOMAIN, 'test', 'passwordtest', None, None)
@@ -46,13 +49,8 @@ class TestDhis2EventsHelpers(TestCase):
     def setUp(self):
         self.db = Dhis2Repeater.get_db()
         self.fakedb = FakeCouchDb()
-        Dhis2Repeater.set_db(self.fakedb)
 
-    def tearDown(self):
-        Dhis2Repeater.set_db(self.db)
-
-    def test_form_processing(self):
-        form = {
+        self.form = {
             "domain": DOMAIN,
             "form": {
                 "@xmlns": "test_xmlns",
@@ -60,10 +58,7 @@ class TestDhis2EventsHelpers(TestCase):
                 "completed_date": "2017-05-25T21:06:27.012000",
                 "name": "test event",
                 "meta": {
-                    "location": {
-                        '#text': '-33.8655497 18.6941185 138.66 5.4',
-                        '@xmlns': 'http://commcarehq.org/xforms'
-                    },
+                    "location": '',
                     "timeEnd": "2017-05-25T21:06:27.012000",
                     "timeStart": "2017-05-25T21:06:17.739000",
                     "userID": self.user.user_id,
@@ -72,7 +67,7 @@ class TestDhis2EventsHelpers(TestCase):
             },
             "received_on": "2017-05-26T09:17:23.692083Z",
         }
-        config = {
+        self.config = {
             'form_configs': json.dumps([{
                 'xmlns': 'test_xmlns',
                 'program_id': 'test program',
@@ -94,19 +89,29 @@ class TestDhis2EventsHelpers(TestCase):
                             'form_question': '/data/name'
                         }
                     }
-                ],
-                'coordinate': {
-                    "form_question": "/metadata/location/#text"
-                }
+                ]
             }])
         }
-        config_form = Dhis2ConfigForm(data=config)
+        config_form = Dhis2ConfigForm(data=self.config)
         self.assertTrue(config_form.is_valid())
         data = config_form.cleaned_data
-        repeater = Dhis2Repeater()
-        repeater.dhis2_config.form_configs = [Dhis2FormConfig.wrap(fc) for fc in data['form_configs']]
-        repeater.save()
-        event = get_event(DOMAIN, repeater.dhis2_config.form_configs[0], form)
+        self.repeater = Dhis2Repeater()
+        self.repeater.dhis2_config.form_configs = [Dhis2FormConfig.wrap(fc) for fc in data['form_configs']]
+        self.repeater.save()
+
+        Dhis2Repeater.set_db(self.fakedb)
+
+    def tearDown(self):
+        Dhis2Repeater.set_db(self.db)
+
+    def test_form_processing_with_owner(self):
+        info = CaseTriggerInfo(
+            domain=DOMAIN,
+            case_id=None,
+            owner_id='test_location',
+            form_question_values=get_form_question_values(self.form),
+        )
+        event = get_event(DOMAIN, self.repeater.dhis2_config.form_configs[0], form_json=self.form, info=info)
 
         self.assertDictEqual(
             {
@@ -125,6 +130,31 @@ class TestDhis2EventsHelpers(TestCase):
                     'latitude': "-33.8655",
                     'longitude': "18.6941"
                 }
+            },
+            event
+        )
+
+    def test_form_processing_without_owner(self):
+        info = CaseTriggerInfo(
+            domain=DOMAIN,
+            case_id=None,
+            form_question_values=get_form_question_values(self.form),
+        )
+        event = get_event(DOMAIN, self.repeater.dhis2_config.form_configs[0], form_json=self.form, info=info)
+
+        self.assertDictEqual(
+            {
+                'dataValues': [
+                    {
+                        'dataElement': 'dhis2_element_id',
+                        'value': 'test event'
+                    }
+                ],
+                'status': 'COMPLETED',
+                'completedDate': '2017-05-25',
+                'program': 'test program',
+                'eventDate': '2017-05-26',
+                'orgUnit': 'dhis2_location_id',
             },
             event
         )

--- a/corehq/motech/dhis2/tests/test_events_helpers.py
+++ b/corehq/motech/dhis2/tests/test_events_helpers.py
@@ -2,7 +2,6 @@ import doctest
 import json
 
 from django.test.testcases import TestCase
-
 from fakecouch import FakeCouchDb
 
 from corehq.apps.domain.shortcuts import create_domain
@@ -61,7 +60,10 @@ class TestDhis2EventsHelpers(TestCase):
                 "completed_date": "2017-05-25T21:06:27.012000",
                 "name": "test event",
                 "meta": {
-                    "location": self.location.location_id,
+                    "location": {
+                        '#text': '-33.8655497 18.6941185 138.66 5.4',
+                        '@xmlns': 'http://commcarehq.org/xforms'
+                    },
                     "timeEnd": "2017-05-25T21:06:27.012000",
                     "timeStart": "2017-05-25T21:06:17.739000",
                     "userID": self.user.user_id,
@@ -92,7 +94,10 @@ class TestDhis2EventsHelpers(TestCase):
                             'form_question': '/data/name'
                         }
                     }
-                ]
+                ],
+                'coordinate': {
+                    "form_question": "/metadata/location/#text"
+                }
             }])
         }
         config_form = Dhis2ConfigForm(data=config)
@@ -102,6 +107,7 @@ class TestDhis2EventsHelpers(TestCase):
         repeater.dhis2_config.form_configs = [Dhis2FormConfig.wrap(fc) for fc in data['form_configs']]
         repeater.save()
         event = get_event(DOMAIN, repeater.dhis2_config.form_configs[0], form)
+
         self.assertDictEqual(
             {
                 'dataValues': [
@@ -114,7 +120,11 @@ class TestDhis2EventsHelpers(TestCase):
                 'completedDate': '2017-05-25',
                 'program': 'test program',
                 'eventDate': '2017-05-26',
-                'orgUnit': 'dhis2_location_id'
+                'orgUnit': 'dhis2_location_id',
+                'coordinate': {
+                    'latitude': "-33.8655",
+                    'longitude': "18.6941"
+                }
             },
             event
         )


### PR DESCRIPTION
## Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-691)

This PR adds support for sending geolocation information on `events` and `enrolments` of TrackedEntities.
[Doc](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-236/tracker.html#webapi_tracker_api)

## Feature Flag
DHIS2

## Product description
A [config setting](https://staging.commcarehq.org/a/ben-test/motech/forwarding/config/Dhis2EntityRepeater/cd3f680f288829c5a7545bfc3ce61e65/) (`event_location`) is added to DHIS2 `form_configs` when configuring DHIS2 Tracked Entities and / or Anonymous Events. The app builders should decide where they want the event location to come from (i.e. `form_question`, `case_property` etc.).   

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Unit tests included for parsing location data when forwarding cases to DHIS2

### Safety story
Unit tests included

Tests performed on Staging:
- Location configured and captured from form_question: [here's](https://staging.commcarehq.org/a/ben-test/motech/logs/520019/) the Remote API response as the location is being sent to DHIS2 for event and enrollment.
- No location or configuration specified (tested for backwards compatibility) - response [here](https://staging.commcarehq.org/a/ben-test/motech/logs/520013/) (same as would have been previously). Thus, this change should not affect current projects.

 

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
