### PR TITLE
fix messaging event detail

### DIFF
--- a/corehq/apps/api/resources/messaging_event/pagination.py
+++ b/corehq/apps/api/resources/messaging_event/pagination.py
@@ -70,4 +70,4 @@ def _get_cursor(objects, request_params):
     })
     encoded_params = urlencode(cursor_params)
     next_params = {'cursor': b64encode(encoded_params.encode('utf-8'))}
-    return reverse('api_messaging_events', args=[request_params.domain], params=next_params, absolute=True)
+    return reverse('api_messaging_event_list', args=[request_params.domain], params=next_params, absolute=True)

--- a/corehq/apps/api/resources/messaging_event/view.py
+++ b/corehq/apps/api/resources/messaging_event/view.py
@@ -38,9 +38,7 @@ def messaging_events(request, domain, event_id=None):
 
 def _get_individual(request, event_id):
     try:
-        event = MessagingSubEvent.objects.select_related("parent").get(
-            parent__domain=request.domain, id=event_id
-        )
+        event = _get_base_query(request.domain).get(id=event_id)
     except MessagingSubEvent.DoesNotExist:
         return HttpResponseNotFound()
 

--- a/corehq/apps/api/tests/test_messaging_event_api.py
+++ b/corehq/apps/api/tests/test_messaging_event_api.py
@@ -19,52 +19,36 @@ from corehq.apps.users.models import CommCareUser
 
 class BaseMessagingEventResourceTest(APIResourceTest):
     @classmethod
+    def _get_detail_endpoint(cls, event_id):
+        return reverse('api_messaging_event_detail', kwargs={"domain": cls.domain.name, "event_id": event_id})
+
+    @classmethod
     def _get_list_endpoint(cls):
-        return reverse('api_messaging_events', kwargs=dict(domain=cls.domain.name))
+        return reverse('api_messaging_event_list', kwargs={"domain": cls.domain.name})
 
     def _auth_get_resource(self, url):
         return self._assert_auth_get_resource(url, allow_session_auth=True)
 
 
-class TestMessagingEventResource(BaseMessagingEventResourceTest):
-    def _serialized_messaging_event(self, sms):
-        return {
-            "content_type": "sms",
-            "date": "2016-01-01T12:00:00",
-            "date_last_activity": sms.date_modified.isoformat() if sms.date_modified else "2016-01-01T12:00:00",
-            "case_id": None,
-            "domain": "qwerty",
-            "error": None,
-            "form": None,
-            'messages': [
-                {
-                    'message_id': sms.id,
-                    'backend': 'fake-backend-id',
-                    'phone_number': '99912345678',
-                    'content': 'test sms text',
-                    'date': '2016-01-01T12:00:00',
-                    'date_modified': sms.date_modified.isoformat() if sms.date_modified else None,
-                    'direction': 'outgoing',
-                    'status': 'sent',
-                    'type': 'sms'
-                }
-            ],
-            # "id": 1,  # ids are explicitly removed from comparison
-            "recipient": {'name': 'unknown', 'recipient_id': None, 'type': 'case'},
-            "source": {'source_id': None, 'name': 'sms', 'type': "other"},
-            "status": "completed",
-        }
+class TestMessagingEventResourceDetail(BaseMessagingEventResourceTest):
+    def test_get_single(self):
+        [sms] = _create_sms_messages(self.domain, 1, randomize=False)
+        response = self._auth_get_resource(self._get_detail_endpoint(sms.messaging_subevent_id))
+        self.assertEqual(response.status_code, 200, response.content)
+        data = json.loads(response.content)
+        self.assertEqual(_serialized_messaging_event(sms), data)
 
+
+class TestMessagingEventResource(BaseMessagingEventResourceTest):
     def test_get_list_simple(self):
         expected = []
         for sms in _create_sms_messages(self.domain, 2, randomize=False):
-            expected.append(self._serialized_messaging_event(sms))
+            expected.append(_serialized_messaging_event(sms))
         response = self._auth_get_resource(self.list_endpoint)
         self.assertEqual(response.status_code, 200, response.content)
         data = json.loads(response.content)['objects']
         self.assertEqual(2, len(data))
         for result, expected_result in zip(data, expected):
-            del result['id']  # don't bother comparing ids
             self.assertEqual(expected_result, result)
 
     def test_sms_null_date_modified(self):
@@ -79,8 +63,7 @@ class TestMessagingEventResource(BaseMessagingEventResourceTest):
         data = json.loads(response.content)['objects']
         self.assertEqual(1, len(data))
         result = data[0]
-        del result['id']  # don't bother comparing ids
-        self.assertEqual(self._serialized_messaging_event(sms), result)
+        self.assertEqual(_serialized_messaging_event(sms), result)
 
     def test_date_ordering(self):
         _create_sms_messages(self.domain, 5, randomize=True)
@@ -600,3 +583,33 @@ def _create_sms_messages(domain, count, randomize):
         sms, _ = create_fake_sms(domain, randomize=randomize)
         results.append(sms)
     return results
+
+
+def _serialized_messaging_event(sms):
+    return {
+        "id": sms.messaging_subevent_id,
+        "content_type": "sms",
+        "date": "2016-01-01T12:00:00",
+        "date_last_activity": sms.date_modified.isoformat() if sms.date_modified else "2016-01-01T12:00:00",
+        "case_id": None,
+        "domain": "qwerty",
+        "error": None,
+        "form": None,
+        'messages': [
+            {
+                'message_id': sms.id,
+                'backend': 'fake-backend-id',
+                'phone_number': '99912345678',
+                'content': 'test sms text',
+                'date': '2016-01-01T12:00:00',
+                'date_modified': sms.date_modified.isoformat() if sms.date_modified else None,
+                'direction': 'outgoing',
+                'status': 'sent',
+                'type': 'sms'
+            }
+        ],
+        # "id": 1,  # ids are explicitly removed from comparison
+        "recipient": {'name': 'unknown', 'recipient_id': None, 'type': 'case'},
+        "source": {'source_id': None, 'name': 'sms', 'type': "other"},
+        "status": "completed",
+    }

--- a/corehq/apps/api/tests/test_messaging_event_api.py
+++ b/corehq/apps/api/tests/test_messaging_event_api.py
@@ -608,7 +608,6 @@ def _serialized_messaging_event(sms):
                 'type': 'sms'
             }
         ],
-        # "id": 1,  # ids are explicitly removed from comparison
         "recipient": {'name': 'unknown', 'recipient_id': None, 'type': 'case'},
         "source": {'source_id': None, 'name': 'sms', 'type': "other"},
         "status": "completed",

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -119,8 +119,8 @@ def api_url_patterns():
               ODataFormMetadataView.as_view(), name=ODataFormMetadataView.table_urlname)
     yield url(r'v0.5/odata/forms/(?P<config_id>[\w\-:]+)/\$metadata$',
               ODataFormMetadataView.as_view(), name=ODataFormMetadataView.urlname)
-    yield url(r'v0.5/messaging-event/$', messaging_events, name="api_messaging_events")
-    yield url(r'v0.5/messaging-event/(?P<event_id>\d+)/$', messaging_events, name="api_messaging_event")
+    yield url(r'v0.5/messaging-event/$', messaging_events, name="api_messaging_event_list")
+    yield url(r'v0.5/messaging-event/(?P<event_id>\d+)/$', messaging_events, name="api_messaging_event_detail")
     # match v0.6/case/ AND v0.6/case/e0ad6c2e-514c-4c2b-85a7-da35bbeb1ff1/ trailing slash optional
     yield url(r'v0\.6/case(?:/(?P<case_id>[\w-]+))?/?$', case_api, name='case_api')
     yield from versioned_apis(API_LIST)


### PR DESCRIPTION
## Summary
The detail endpoint is failing because of the missing `date_last_activity` field. This updates the detail endpoint to use the same base query as the list endpoint to ensure compatibility.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
added

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
