### PR TITLE
Added more time_method decorators within create_suite

### DIFF
--- a/corehq/apps/app_manager/suite_xml/features/scheduler.py
+++ b/corehq/apps/app_manager/suite_xml/features/scheduler.py
@@ -19,11 +19,13 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
 )
 from corehq.apps.app_manager.templatetags.xforms_extras import trans
 from corehq.apps.app_manager.xpath import ScheduleFormXPath
+from corehq.util.timer import time_method
 
 
 class SchedulerFixtureContributor(SectionContributor):
     section_name = 'fixtures'
 
+    @time_method()
     def get_section_elements(self):
         schedule_modules = (module for module in self.modules
                             if getattr(module, 'has_schedule', False) and module.all_forms_require_a_case)

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -9,11 +9,13 @@ from corehq import toggles
 from corehq.apps.app_manager.exceptions import DuplicateInstanceIdError
 from corehq.apps.app_manager.suite_xml.contributors import PostProcessor
 from corehq.apps.app_manager.suite_xml.xml_models import Instance
+from corehq.util.timer import time_method
 
 
 class EntryInstances(PostProcessor):
     """Adds instance declarations to the suite file"""
 
+    @time_method()
     def update_suite(self):
         for entry in self.suite.entries:
             self.add_entry_instances(entry)

--- a/corehq/apps/app_manager/suite_xml/post_process/menu.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/menu.py
@@ -1,10 +1,12 @@
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.suite_xml.contributors import PostProcessor
 from corehq.apps.app_manager.suite_xml.xml_models import Menu, Text
+from corehq.util.timer import time_method
 
 
 class GridMenuHelper(PostProcessor):
 
+    @time_method()
     def update_suite(self):
         """
         Ensure that there exists at least one menu where id="root".

--- a/corehq/apps/app_manager/suite_xml/post_process/resources.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/resources.py
@@ -6,6 +6,7 @@ from corehq.apps.app_manager.suite_xml.contributors import PostProcessor
 from corehq.apps.app_manager.suite_xml.sections.resources import FormResourceContributor
 from corehq.apps.app_manager.suite_xml.xml_models import XFormResource
 from corehq.util.quickcache import quickcache
+from corehq.util.timer import time_method
 
 
 class ResourceOverride(models.Model):
@@ -86,6 +87,7 @@ def get_xform_resource_overrides(domain, app_id):
 
 class ResourceOverrideHelper(PostProcessor):
 
+    @time_method()
     def update_suite(self):
         """
         Applies manual overrides of resource ids.

--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -23,6 +23,7 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
     StackDatum,
 )
 from corehq.apps.app_manager.xpath import CaseIDXPath, XPath, session_var
+from corehq.util.timer import time_method
 
 
 class WorkflowHelper(PostProcessor):
@@ -39,6 +40,7 @@ class WorkflowHelper(PostProcessor):
             for datum in self.get_module_datums('m{}'.format(module.id)).values()
         ]
 
+    @time_method()
     def update_suite(self):
         """
         Add stack elements to form entry elements to configure app workflow. This updates

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -48,6 +48,7 @@ from corehq.apps.app_manager.util import (
     module_offers_search,
 )
 from corehq.apps.app_manager.xpath import CaseXPath, CaseTypeXpath, XPath, session_var
+from corehq.util.timer import time_method
 
 AUTO_LAUNCH_EXPRESSION = "$next_input = '' or count(instance('casedb')/casedb/case[@case_id=$next_input]) = 0"
 
@@ -55,6 +56,7 @@ AUTO_LAUNCH_EXPRESSION = "$next_input = '' or count(instance('casedb')/casedb/ca
 class DetailContributor(SectionContributor):
     section_name = 'details'
 
+    @time_method()
     def get_section_elements(self):
         if self.app.use_custom_suite:
             return []

--- a/corehq/apps/app_manager/suite_xml/sections/endpoints.py
+++ b/corehq/apps/app_manager/suite_xml/sections/endpoints.py
@@ -17,7 +17,7 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
     Stack,
     StackDatum,
 )
-from corehq.apps.app_manager.xpath import XPath
+from corehq.util.timer import time_method
 
 
 class SessionEndpointContributor(SuiteContributorByModule):
@@ -28,6 +28,7 @@ class SessionEndpointContributor(SuiteContributorByModule):
     case IDs) must be provided to get there.
     """
 
+    @time_method()
     def get_module_contributions(self, module) -> List[SessionEndpoint]:
         endpoints = []
         if module.session_endpoint_id:

--- a/corehq/apps/app_manager/suite_xml/sections/fixtures.py
+++ b/corehq/apps/app_manager/suite_xml/sections/fixtures.py
@@ -2,11 +2,13 @@ from lxml import etree
 
 from corehq.apps.app_manager.suite_xml.contributors import SectionContributor
 from corehq.apps.app_manager.suite_xml.xml_models import Fixture
+from corehq.util.timer import time_method
 
 
 class FixtureContributor(SectionContributor):
     section_name = 'fixtures'
-    
+
+    @time_method()
     def get_section_elements(self):
         if self.app.case_sharing:
             f = Fixture(id='user-groups')

--- a/corehq/apps/app_manager/suite_xml/sections/resources.py
+++ b/corehq/apps/app_manager/suite_xml/sections/resources.py
@@ -10,11 +10,13 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
 )
 from corehq.apps.app_manager.templatetags.xforms_extras import trans
 from corehq.apps.app_manager.util import languages_mapping
+from corehq.util.timer import time_method
 
 
 class FormResourceContributor(SectionContributor):
     section_name = 'xform_resources'
 
+    @time_method()
     def get_section_elements(self):
         from corehq.apps.app_manager.models import ShadowForm
         for form_stuff in self.app.get_forms(bare=False):
@@ -53,6 +55,7 @@ class FormResourceContributor(SectionContributor):
 class LocaleResourceContributor(SectionContributor):
     section_name = 'locale_resources'
 
+    @time_method()
     def get_section_elements(self):
         langs = self.app.get_build_langs(self.build_profile_id)
         for lang in ["default"] + langs:


### PR DESCRIPTION
## Summary
Timing some more methods in anticipation of https://dimagi-dev.atlassian.net/browse/USH-1162

Profiling a couple of USH apps on prod shows a bunch of unaccounted-for time in `create_suite`, which is the biggest contributor to the overall build time. This PR should make sure there's timing data for all of the individual contributors to the suite.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

There are tests that make a build.

### QA Plan

No QA: this has fine test coverage and is a low-risk change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
