### PR TITLE
[User history] fix only userdata log

### DIFF
--- a/corehq/apps/user_importer/helpers.py
+++ b/corehq/apps/user_importer/helpers.py
@@ -117,8 +117,7 @@ class BaseUserImporter(object):
     def _include_user_data_changes(self):
         # ToDo: consider putting just the diff
         if self.logger.original_user_doc and self.logger.original_user_doc['user_data'] != self.user.user_data:
-            self.logger.fields_changed['user_data'] = self.user.user_data
-            self._save = True
+            self.logger.add_changes({'user_data': self.user.user_data})
 
 
 class CommCareUserImporter(BaseUserImporter):

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -975,6 +975,28 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         self.assertEqual(last_entry.user_id, self.user.user_id)
         self.assertEqual(last_entry.action, UserModelAction.UPDATE.value)
 
+    def test_ensure_user_history_on_only_userdata_update(self):
+        user = CommCareUser.create(self.domain_name, f"hello@{self.domain.name}.commcarehq.org", "*******",
+                                   created_by=None, created_via=None)
+        import_users_and_groups(
+            self.domain.name,
+            [{'data': {'key': 'F#'}, 'user_id': user._id}],
+            [],
+            self.uploading_user,
+            mock.MagicMock(),
+            False
+        )
+        user_history = UserHistory.objects.get(action=UserModelAction.UPDATE.value,
+                                               changed_by=self.uploading_user.get_id)
+        self.assertDictEqual(
+            user_history.details['changes'],
+            {
+                'user_data': {'commcare_project': 'mydomain', 'key': 'F#'}
+            }
+        )
+        self.assertEqual(user_history.details['changed_via'], USER_CHANGE_VIA_BULK_IMPORTER)
+        self.assertEqual(user_history.message, '')
+
 
 class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):
     @classmethod


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Bug introduced in https://github.com/dimagi/commcare-hq/pull/29935/commits/55958b87cbd5df577474352d4bbae32497794f7f when the method definition was moved to Importer instead of logger, it was missed that `_save` is present on logger and not on importer. Because of this, if `_save` was never set to `True` on logger and the log was not saved for existing users, if there was no other change to the user.
Improved upon the implementation to call `add_changes` to log user_data instead.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally that user data is saved now, also added a failing test that passes now.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

Same as base PR
