### PR TITLE
[User History] log role update only when role changes

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -196,7 +196,7 @@ class UpdateUserRoleForm(BaseUpdateUserForm):
 
     @staticmethod
     def _role_updated(old_role, new_role):
-        if (old_role and not new_role) or (new_role and not old_role):
+        if bool(old_role) ^ bool(new_role):
             return True
         if old_role and new_role and new_role.get_qualified_id() != old_role.get_qualified_id():
             return True


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Fixes a bug introduced in https://github.com/dimagi/commcare-hq/pull/28631/commits/22720360186faeabd8c59dc65f0d900155d33571#diff-8440ff6f063677238da8fc25000acb8bbfb4345c3b9d97a0cf81414d15702265R182 where role update was logged irrespective of a real role change

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally that this works as expected. This is also going through QA in the base PR

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

same as base PR
