### PR TITLE
Smart linking MVP: claim cases

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -436,6 +436,8 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         );
     });
 
+    // Support for workflows that require Login As before moving on to the
+    // screen that the user originally requested.
     FormplayerFrontend.on('setLoginAsNextOptions', function (options) {
         FormplayerFrontend.LoginAsNextOptions = options;
         if (Object.freeze) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -436,6 +436,21 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         );
     });
 
+    FormplayerFrontend.on('setLoginAsNextOptions', function (options) {
+        FormplayerFrontend.LoginAsNextOptions = options;
+        if (Object.freeze) {
+            Object.freeze(FormplayerFrontend.LoginAsNextOptions);
+        }
+    });
+
+    FormplayerFrontend.on('clearLoginAsNextOptions', function () {
+        return FormplayerFrontend.LoginAsNextOptions = null;
+    });
+
+    FormplayerFrontend.getChannel().reply('getLoginAsNextOptions', function () {
+        return FormplayerFrontend.LoginAsNextOptions || null;
+    });
+
     /**
      * clearRestoreAsUser
      *

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -154,11 +154,13 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
                     deferred.resolve(menuResponse);
                 }).fail(function () {
                     deferred.reject();
+                    // Just go home. Error message will be displayed by the error handler in queryFormplayer.
                     FormplayerFrontend.trigger('navigateHome');
                 });
             },
-            error: function () {
+            error: function (xhr) {
                 deferred.reject();
+                FormplayerFrontend.trigger('showError', xhr.responseText);
                 FormplayerFrontend.trigger('navigateHome');
             },
         });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -141,6 +141,9 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
 
         var user = FormplayerFrontend.getChannel().request('currentUser');
         if (options.forceLoginAs && !user.restoreAs) {
+            // Workflow requires a mobile user, likely because we're trying to access
+            // a session endpoint as a web user. If user isn't logged in as, send them
+            // to Login As and save the current request options for when that's done.
             FormplayerFrontend.trigger("setLoginAsNextOptions", options);
             FormplayerFrontend.trigger("restore_as:list");
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -139,8 +139,16 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
             return API.queryFormplayer(options, options.isInitial ? "navigate_menu_start" : "navigate_menu");
         }
 
-        // If an endpoint is provided, first claim any cases it references, then navigate
         var user = FormplayerFrontend.getChannel().request('currentUser');
+        if (options.forceLoginAs && !user.restoreAs) {
+            FormplayerFrontend.trigger("setLoginAsNextOptions", options);
+            FormplayerFrontend.trigger("restore_as:list");
+
+            // Caller expects a menu response, return a fake one
+            return {abort: true};
+        }
+
+        // If an endpoint is provided, first claim any cases it references, then navigate
         var deferred = $.Deferred();
         $.ajax({
             type: 'POST',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -3,8 +3,9 @@
  */
 
 hqDefine("cloudcare/js/formplayer/menus/api", function () {
-    var FormplayerFrontend = hqImport("cloudcare/js/formplayer/app");
-    var Util = hqImport("cloudcare/js/formplayer/utils/util");
+    var FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),
+        Util = hqImport("cloudcare/js/formplayer/utils/util"),
+        initialPageData = hqImport("hqwebapp/js/initial_page_data");
 
     var API = {
         queryFormplayer: function (params, route) {
@@ -134,19 +135,33 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
     };
 
     FormplayerFrontend.getChannel().reply("app:select:menus", function (options) {
-        var route = "navigate_menu";
-        if (options.isInitial) {
-            route = "navigate_menu_start";
-        } else if (options.endpointId) {
-            route = "get_endpoint";
+        if (!options.endpointId) {
+            return API.queryFormplayer(options, options.isInitial ? "navigate_menu_start" : "navigate_menu");
         }
 
-        var deferred = API.queryFormplayer(options, route);
-        if (options.endpointId) {
-            deferred.fail(function (response) {
+        // If an endpoint is provided, first claim any cases it references, then navigate
+        var user = FormplayerFrontend.getChannel().request('currentUser');
+        var deferred = $.Deferred();
+        $.ajax({
+            type: 'POST',
+            url: initialPageData.reverse('claim_all_cases'),
+            data: {
+                username: user.restoreAs || user.username,
+                case_ids: _.values(options.endpointArgs),
+            },
+            success: function () {
+                API.queryFormplayer(options, "get_endpoint").done(function (menuResponse) {
+                    deferred.resolve(menuResponse);
+                }).fail(function () {
+                    deferred.reject();
+                    FormplayerFrontend.trigger('navigateHome');
+                });
+            },
+            error: function () {
+                deferred.reject();
                 FormplayerFrontend.trigger('navigateHome');
-            });
-        }
+            },
+        });
         return deferred;
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -16,6 +16,9 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
          a list of entities (cases) and their details
          */
         $.when(fetchingNextMenu).done(function (menuResponse) {
+            if (menuResponse.abort) {
+                return;
+            }
 
             //set title of tab to application name
             if (menuResponse.breadcrumbs) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
@@ -52,19 +52,26 @@ hqDefine("cloudcare/js/formplayer/users/views", function () {
         },
         onClickUser: function () {
             Util.confirmationModal({
-                title: gettext('Log in as ' + this.model.get('username') + '?'),
+                title: _.template(gettext('Log in as <%= username %>?'))({username: this.model.get('username')}),
                 message: _.template($('#user-data-template').html())(
                     { user: this.model.toJSON() }
                 ),
                 confirmText: gettext('Yes, log in as this user'),
                 onConfirm: function () {
                     hqImport("cloudcare/js/formplayer/users/utils").Users.logInAsUser(this.model.get('username'));
-                    FormplayerFrontend.trigger('navigateHome');
                     FormplayerFrontend.regions.getRegion('restoreAsBanner').show(
                         new RestoreAsBanner({
                             model: FormplayerFrontend.getChannel().request('currentUser'),
                         })
                     );
+                    var loginAsNextOptions = FormplayerFrontend.getChannel().request('getLoginAsNextOptions');
+                    if (loginAsNextOptions) {
+                        FormplayerFrontend.trigger("clearLoginAsNextOptions");
+                        var menusController = hqImport("cloudcare/js/formplayer/menus/controller");
+                        menusController.selectMenu(loginAsNextOptions);
+                    } else {
+                        FormplayerFrontend.trigger('navigateHome');
+                    }
                 }.bind(this),
             });
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -168,6 +168,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
         this.queryData = options.queryData;
         this.singleApp = options.singleApp;
         this.sortIndex = options.sortIndex;
+        this.forceLoginAs = options.forceLoginAs;
         this.forceManualAction = options.forceManualAction;
 
         this.setSteps = function (steps) {
@@ -229,7 +230,11 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
         this.replaceEndpoint = function (steps) {
             delete this.endpointId;
             delete this.endpointArgs;
-            this.steps = steps;
+            this.steps = steps || [];
+        };
+
+        this.resetForceLoginAs = function () {
+            this.forceLoginAs = false;
         };
 
         this.clearExceptApp = function () {
@@ -287,6 +292,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             queryData: self.queryData || {},    // formplayer can't handle a null
             singleApp: self.singleApp,
             sortIndex: self.sortIndex,
+            forceLoginAs: self.forceLoginAs,
             forceManualAction: self.forceManualAction,
         };
         return JSON.stringify(dict);
@@ -306,6 +312,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             'queryData': data.queryData,
             'singleApp': data.singleApp,
             'sortIndex': data.sortIndex,
+            'forceLoginAs': data.forceLoginAs,
             'forceManualAction': data.forceManualAction,
         };
         return new Util.CloudcareUrl(options);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -233,10 +233,6 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             this.steps = steps || [];
         };
 
-        this.resetForceLoginAs = function () {
-            this.forceLoginAs = false;
-        };
-
         this.clearExceptApp = function () {
             this.sessionId = null;
             this.steps = null;

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -87,6 +87,7 @@
   {% registerurl 'list_case_exports' request.domain %}
   {% registerurl 'list_form_exports' request.domain %}
   {% registerurl 'case_data' request.domain '---' %}
+  {% registerurl 'claim_all_cases' request.domain %}
   {% registerurl 'render_form_data' request.domain '---' %}
   {% registerurl 'report_formplayer_error' request.domain %}
   {% registerurl 'dialer_view' request.domain %}

--- a/corehq/apps/cloudcare/templates/preview_app/base.html
+++ b/corehq/apps/cloudcare/templates/preview_app/base.html
@@ -43,6 +43,7 @@
   {% registerurl 'list_form_exports' request.domain %}
   {% registerurl 'login_new_window' %}
   {% registerurl 'case_data' request.domain '---' %}
+  {% registerurl 'claim_all_cases' request.domain %}
   {% registerurl 'render_form_data' request.domain '---' %}
   {% registerurl 'report_formplayer_error' request.domain %}
   {% registerurl 'dialer_view' request.domain %}

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -607,7 +607,7 @@ def session_endpoint(request, domain, app_id, endpoint_id):
         return _fail(_("This link does not exist. "
                        "Your app may have changed so that the given link is no longer valid."))
 
-    (restore_as_user, set_cookie) = FormplayerMain.get_restore_as_user(request, domain)
+    restore_as_user, set_cookie = FormplayerMain.get_restore_as_user(request, domain)
     force_login_as = not restore_as_user.is_commcare_user()
     if force_login_as and not can_use_restore_as(request):
         _fail(_("This user cannot access this link."))

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -26,7 +26,6 @@ import six.moves.urllib.parse
 import six.moves.urllib.request
 from text_unidecode import unidecode
 
-from casexml.apps.case.cleanup import claim_case, get_first_claim
 from corehq.apps.formplayer_api.utils import get_formplayer_url
 from corehq.util.metrics import metrics_counter
 from corehq.util.view_utils import get_case_or_404

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -26,6 +26,7 @@ import six.moves.urllib.parse
 import six.moves.urllib.request
 from text_unidecode import unidecode
 
+from casexml.apps.case.cleanup import claim_case, get_first_claim
 from corehq.apps.formplayer_api.utils import get_formplayer_url
 from corehq.util.metrics import metrics_counter
 from corehq.util.view_utils import get_case_or_404
@@ -587,7 +588,8 @@ def session_endpoint(request, domain, app_id, endpoint_id):
     if not toggles.SESSION_ENDPOINTS.enabled_for_request(request):
         _fail(_("Linking directly into Web Apps has been disabled."))
 
-    for case_id in request.GET.values():
+    case_ids = request.GET.values()
+    for case_id in case_ids:
         try:
             get_case_or_404(domain, case_id)
         except Http404:

--- a/corehq/apps/ota/urls.py
+++ b/corehq/apps/ota/urls.py
@@ -4,6 +4,7 @@ from corehq.apps.hqadmin.views.users import DomainAdminRestoreView
 from corehq.apps.ota.views import (
     app_aware_search,
     claim,
+    claim_all,
     get_next_id,
     heartbeat,
     recovery_measures,
@@ -19,6 +20,7 @@ urlpatterns = [
     url(r'^search/$', search, name='remote_search'),
     url(r'^search/(?P<app_id>[\w-]+)/$', app_aware_search, name='app_aware_remote_search'),
     url(r'^claim-case/$', claim, name='claim_case'),
+    url(r'^claim_all/$', claim_all, name='claim_all_cases'),
     url(r'^heartbeat/(?P<app_build_id>[\w-]+)/$', heartbeat, name='phone_heartbeat'),
     url(r'^get_next_id/$', get_next_id, name='get_next_id'),
     url(r'^recovery_measures/(?P<build_id>[\w-]+)/$', recovery_measures, name='recovery_measures'),

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -181,12 +181,15 @@ def claim(request, domain):
 @require_POST
 @check_domain_migration
 def claim_all(request, domain):
-    username = request.POST.get("username")     # username may or may not be fully qualified
-    username = format_username(raw_username(username), domain)
-    user_id = username_to_user_id(username)
+    username = request.POST.get("username")     # username may be web user or unqualified mobile username
+    user = CouchUser.get_by_username(username)
+    if not user:
+        username = format_username(username, domain)
+        user = CouchUser.get_by_username(username)
 
-    if not user_id:
-        return HttpResponse(_('Could not find user "{}"').format(user_id), status=500)
+    if not user:
+        return HttpResponse(_('Could not find user "{}".').format(username), status=500)
+    user_id = user._id
 
     for case_id in request.POST.getlist("case_ids[]"):
         try:

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -51,7 +51,7 @@ from corehq.apps.es.case_search import flatten_result
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.ota.decorators import require_mobile_access
 from corehq.apps.ota.rate_limiter import rate_limit_restore
-from corehq.apps.users.util import format_username, raw_username, username_to_user_id
+from corehq.apps.users.util import format_username
 from corehq.apps.users.models import CouchUser, UserReportingMetadataStaging
 from corehq.const import ONE_DAY, OPENROSA_VERSION_MAP
 from corehq.form_processor.exceptions import CaseNotFound

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -197,7 +197,7 @@ def claim_all(request, domain):
         user = CouchUser.get_by_username(username)
 
     if not user:
-        return HttpResponse(_('Could not find user "{}".').format(username), status=500)
+        return HttpResponseNotFound(_('Could not find user "{}".').format(username))
     user_id = user._id
 
     if not user.is_member_of(domain_obj, allow_mirroring=True):

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -7,6 +7,8 @@ from django.http import (
     Http404,
     HttpResponse,
     HttpResponseBadRequest,
+    HttpResponseForbidden,
+    HttpResponseNotFound,
     JsonResponse,
 )
 from django.utils.translation import ugettext as _
@@ -201,7 +203,8 @@ def claim_all(request, domain):
     user_id = user._id
 
     if not user.is_member_of(domain_obj, allow_mirroring=True):
-        return HttpResponseForbidden(_('{user} is not a member of {domain}.').format(user=user.username, domain=domain))
+        return HttpResponseForbidden(_('{user} is not a member of {domain}.').format(user=user.username,
+                                                                                     domain=domain))
 
     for case_id in request.POST.getlist("case_ids[]"):
         try:

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -183,7 +183,7 @@ def claim(request, domain):
 def claim_all(request, domain):
     domain_obj = Domain.get_by_name(domain)
     if not domain_obj:
-        return HttpResponse(_('Invalid project space "{}".').format(domain), status=500)
+        return HttpResponseNotFound(_('Invalid project space "{}".').format(domain))
 
     if not request.couch_user.is_member_of(domain_obj, allow_mirroring=True):
         return HttpResponseForbidden(_('{user} is not a member of {domain}.').format(

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -185,6 +185,9 @@ def claim_all(request, domain):
     username = format_username(raw_username(username), domain)
     user_id = username_to_user_id(username)
 
+    if not user_id:
+        return HttpResponse(_('Could not find user "{}"').format(user_id), status=500)
+
     for case_id in request.POST.getlist("case_ids[]"):
         try:
             case = get_case_or_404(domain, case_id)

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -201,7 +201,7 @@ def claim_all(request, domain):
     user_id = user._id
 
     if not user.is_member_of(domain_obj, allow_mirroring=True):
-        return HttpResponse(_('{} is not a member of {}.').format(user.username, domain), status=500)
+        return HttpResponseForbidden(_('{user} is not a member of {domain}.').format(user=user.username, domain=domain))
 
     for case_id in request.POST.getlist("case_ids[]"):
         try:

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -186,7 +186,9 @@ def claim_all(request, domain):
         return HttpResponse(_('Invalid project space "{}".').format(domain), status=500)
 
     if not request.couch_user.is_member_of(domain_obj, allow_mirroring=True):
-        return HttpResponse(_('{} is not a member of {}.').format(request.couch_user.username, domain), status=500)
+        return HttpResponseForbidden(_('{user} is not a member of {domain}.').format(
+            use=request.couch_user.username, domain=domain
+        ))
 
     username = request.POST.get("username")     # username may be web user or unqualified mobile username
     user = CouchUser.get_by_username(username)

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -49,12 +49,14 @@ from corehq.apps.es.case_search import flatten_result
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.ota.decorators import require_mobile_access
 from corehq.apps.ota.rate_limiter import rate_limit_restore
+from corehq.apps.users.util import format_username, raw_username, username_to_user_id
 from corehq.apps.users.models import CouchUser, UserReportingMetadataStaging
 from corehq.const import ONE_DAY, OPENROSA_VERSION_MAP
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.utils.xform import adjust_text_to_datetime
 from corehq.middleware import OPENROSA_VERSION_HEADER
 from corehq.util.quickcache import quickcache
+from corehq.util.view_utils import get_case_or_404
 
 from .models import DeviceLogRequest, MobileRecoveryMeasure, SerialIdBucket
 from .utils import (
@@ -172,6 +174,28 @@ def claim(request, domain):
         return HttpResponse('The case "{}" you are trying to claim was not found'.format(case_id),
                             status=410)
     return HttpResponse(status=200)
+
+
+@location_safe
+@csrf_exempt
+@require_POST
+@check_domain_migration
+def claim_all(request, domain):
+    username = request.POST.get("username")     # username may or may not be fully qualified
+    username = format_username(raw_username(username), domain)
+    user_id = username_to_user_id(username)
+
+    for case_id in request.POST.getlist("case_ids[]"):
+        try:
+            case = get_case_or_404(domain, case_id)
+        except Http404:
+            return HttpResponse(_('Could not find case "{}"').format(case_id), status=410)
+        if get_first_claim(domain, user_id, case_id):
+            continue
+        claim_case(domain, user_id, case_id, host_type=case.type, host_name=case.name,
+                   device_id=__name__ + ".claim_all")
+
+    return JsonResponse({"success": 1})
 
 
 def get_restore_params(request, domain):


### PR DESCRIPTION
PR into https://github.com/dimagi/commcare-hq/pull/30002

https://dimagi-dev.atlassian.net/browse/USH-1122

This makes web apps request to claim all cases provided as endpoint arguments before continuing into the app. I had initially thought this could be done in cloudcare's new `session_endpoint` view, but that doesn't have access to the browser cookie where the user's Login As username is stored.

FYI @shubham1g5 