### PR TITLE
[SSO] ensure that SSO superusers do not have access to superuser functionality beyond their domain

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -625,15 +625,24 @@ def require_superuser_or_contractor(view_func):
     return _inner
 
 
+def require_superuser(view_func):
+    @wraps(view_func)
+    def _inner(request, *args, **kwargs):
+        user = request.user
+        if user.is_superuser and not is_request_using_sso(request):
+            return view_func(request, *args, **kwargs)
+        else:
+            return HttpResponseRedirect(reverse("no_permissions"))
+
+    return _inner
+
+
 # Parallel to what we did with login_and_domain_required, above
 domain_admin_required = domain_admin_required_ex()
 cls_domain_admin_required = cls_to_view(additional_decorator=domain_admin_required)
 
 ########################################################################################################
-# couldn't figure how to call reverse, so login_url is the actual url
-require_superuser = permission_required("is_superuser", login_url='/no_permissions/')
 cls_require_superusers = cls_to_view(additional_decorator=require_superuser)
-
 cls_require_superuser_or_contractor = cls_to_view(additional_decorator=require_superuser_or_contractor)
 
 

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -616,7 +616,8 @@ def require_superuser_or_contractor(view_func):
     @wraps(view_func)
     def _inner(request, *args, **kwargs):
         user = request.user
-        if IS_CONTRACTOR.enabled(user.username) or user.is_superuser:
+        if ((IS_CONTRACTOR.enabled(user.username) or user.is_superuser)
+                and not is_request_using_sso(request)):
             return view_func(request, *args, **kwargs)
         else:
             return HttpResponseRedirect(reverse("no_permissions"))

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -9,6 +9,7 @@ from django_prbac.exceptions import PermissionDenied
 from django_prbac.utils import has_privilege
 
 from corehq.apps.domain.utils import get_custom_domain_module
+from corehq.apps.sso.utils.request_helpers import is_request_using_sso
 from dimagi.utils.decorators.datespan import datespan_in_request
 from dimagi.utils.modules import to_function
 
@@ -311,7 +312,11 @@ class AdminReportDispatcher(ReportDispatcher):
     map_name = 'ADMIN_REPORTS'
 
     def permissions_check(self, report, request, domain=None, is_navigation_check=False):
-        return hasattr(request, 'couch_user') and request.user.has_perm("is_superuser")
+        return (
+            hasattr(request, 'couch_user')
+            and request.user.has_perm("is_superuser")
+            and not is_request_using_sso(request)
+        )
 
 
 class QuestionTemplateDispatcher(ProjectReportDispatcher):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -68,6 +68,7 @@ from corehq.apps.reports.models import ReportsSidebarOrdering
 from corehq.apps.saved_reports.models import ReportConfig
 from corehq.apps.smsbillables.dispatcher import SMSAdminInterfaceDispatcher
 from corehq.apps.sso.models import IdentityProvider
+from corehq.apps.sso.utils.request_helpers import is_request_using_sso
 from corehq.apps.styleguide.views import MainStyleGuideView
 from corehq.apps.translations.integrations.transifex.utils import (
     transifex_details_available_for_domain,
@@ -2246,9 +2247,10 @@ class AdminTab(UITab):
 
     @property
     def _is_viewable(self):
-        return (self.couch_user and
-                (self.couch_user.is_superuser or
-                 toggles.IS_CONTRACTOR.enabled(self.couch_user.username)))
+        return (self.couch_user
+                and (self.couch_user.is_superuser
+                     or toggles.IS_CONTRACTOR.enabled(self.couch_user.username))
+                and not is_request_using_sso(self._request))
 
 
 def _get_repeat_record_report(domain):


### PR DESCRIPTION
## Summary
SSO superusers should not be a thing, ever, but on the rare occasion this may happen in place is a security feature to ensure the only superuser activity they have access to is with the domain that has authorized their IdP. No site-wide superuser functionality will be supported.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
There doesn't seem to be any test coverage for the `require_superuser` or `require_contractor_or_superuser` decorators. 

### QA Plan
QA has already signed off https://dimagi-dev.atlassian.net/browse/QA-3164

### Safety story
QA has already tested and signed off on this change

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
