### PR TITLE
Fix location restriction bug in Worker Activity Report

### DIFF
--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -345,7 +345,10 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         # The queryset returned by this method is location-safe
         q = user_es.UserES().domain(domain, allow_mirroring=True)
         q = customize_user_query(request_user, domain, q)
-        if ExpandedMobileWorkerFilter.no_filters_selected(mobile_user_and_group_slugs):
+        if (
+            ExpandedMobileWorkerFilter.no_filters_selected(mobile_user_and_group_slugs)
+            and request_user.has_permission(domain, 'access_all_locations')
+        ):
             return q.show_inactive()
 
         user_ids = cls.selected_user_ids(mobile_user_and_group_slugs)

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -103,9 +103,7 @@ class SubmitHistoryMixin(ElasticProjectInspectionReport,
                  .domain(self.domain)
                  .filter(time_filter(gte=self.datespan.startdate,
                                      lt=self.datespan.enddate_adjusted))
-                 .filter(self._get_users_filter(mobile_user_and_group_slugs)
-                         if not EMWF.no_filters_selected(mobile_user_and_group_slugs)
-                         else match_all()))  # If no filters are selected, return all results
+                 .filter(self._get_users_filter(mobile_user_and_group_slugs)))
 
         # filter results by app and xmlns if applicable
         if FormsByApplicationFilter.has_selections(self.request):


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12427
When no filter was selected then all the data was displayed to the user who has access to limited locations in Submit History Report. The PR fixes that.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The changes have been tested on staging and the report seemed to work fine.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
