### PR TITLE
[User History] track superuser web edit

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -201,12 +201,12 @@ class UpdateUserRoleForm(BaseUpdateUserForm):
 
 
 class UpdateUserPermissionForm(forms.Form):
-    super_user = forms.BooleanField(label=ugettext_lazy('System Super User'), required=False)
+    superuser = forms.BooleanField(label=ugettext_lazy('System Super User'), required=False)
 
-    def update_user_permission(self, couch_user=None, editable_user=None, is_super_user=None):
+    def update_user_permission(self, couch_user=None, editable_user=None, is_superuser=None):
         is_update_successful = False
         if editable_user and couch_user.is_superuser:
-            editable_user.is_superuser = is_super_user
+            editable_user.is_superuser = is_superuser
             editable_user.save()
             is_update_successful = True
 

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -462,8 +462,13 @@ class EditWebUserView(BaseEditUserView):
 
         if self.request.POST['form_type'] == "update-user-permissions" and self.can_grant_superuser_access:
             is_super_user = True if 'super_user' in self.request.POST and self.request.POST['super_user'] == 'on' else False
+            current_super_user_status = self.editable_user.is_superuser
             if self.form_user_update_permissions.update_user_permission(couch_user=self.request.couch_user,
                                                                         editable_user=self.editable_user, is_super_user=is_super_user):
+                if current_super_user_status != is_super_user:
+                    log_user_change(self.domain, self.editable_user, changed_by_user=self.couch_user,
+                                    changed_via=USER_CHANGE_VIA_WEB,
+                                    fields_changed={'is_superuser': is_super_user})
                 messages.success(self.request, _('Changed system permissions for user "%s"') % self.editable_user.username)
         return super(EditWebUserView, self).post(request, *args, **kwargs)
 

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -464,12 +464,14 @@ class EditWebUserView(BaseEditUserView):
             is_super_user = 'super_user' in self.request.POST and self.request.POST['super_user'] == 'on'
             current_super_user_status = self.editable_user.is_superuser
             if self.form_user_update_permissions.update_user_permission(couch_user=self.request.couch_user,
-                                                                        editable_user=self.editable_user, is_super_user=is_super_user):
+                                                                        editable_user=self.editable_user,
+                                                                        is_super_user=is_super_user):
                 if current_super_user_status != is_super_user:
                     log_user_change(self.domain, self.editable_user, changed_by_user=self.couch_user,
                                     changed_via=USER_CHANGE_VIA_WEB,
                                     fields_changed={'is_superuser': is_super_user})
-                messages.success(self.request, _('Changed system permissions for user "%s"') % self.editable_user.username)
+                messages.success(self.request,
+                                 _('Changed system permissions for user "%s"') % self.editable_user.username)
         return super(EditWebUserView, self).post(request, *args, **kwargs)
 
 

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -461,7 +461,7 @@ class EditWebUserView(BaseEditUserView):
                 )
 
         if self.request.POST['form_type'] == "update-user-permissions" and self.can_grant_superuser_access:
-            is_super_user = True if 'super_user' in self.request.POST and self.request.POST['super_user'] == 'on' else False
+            is_super_user = 'super_user' in self.request.POST and self.request.POST['super_user'] == 'on'
             current_super_user_status = self.editable_user.is_superuser
             if self.form_user_update_permissions.update_user_permission(couch_user=self.request.couch_user,
                                                                         editable_user=self.editable_user, is_super_user=is_super_user):

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -381,10 +381,7 @@ class EditWebUserView(BaseEditUserView):
 
     @property
     def form_user_update_permissions(self):
-        user = self.editable_user
-        is_super_user = user.is_superuser
-
-        return UpdateUserPermissionForm(auto_id=False, initial={'super_user': is_super_user})
+        return UpdateUserPermissionForm(auto_id=False, initial={'superuser': self.editable_user.is_superuser})
 
     @property
     def main_context(self):
@@ -461,15 +458,15 @@ class EditWebUserView(BaseEditUserView):
                 )
 
         if self.request.POST['form_type'] == "update-user-permissions" and self.can_grant_superuser_access:
-            is_super_user = 'super_user' in self.request.POST and self.request.POST['super_user'] == 'on'
-            current_super_user_status = self.editable_user.is_superuser
+            is_superuser = 'superuser' in self.request.POST and self.request.POST['superuser'] == 'on'
+            current_superuser_status = self.editable_user.is_superuser
             if self.form_user_update_permissions.update_user_permission(couch_user=self.request.couch_user,
                                                                         editable_user=self.editable_user,
-                                                                        is_super_user=is_super_user):
-                if current_super_user_status != is_super_user:
+                                                                        is_superuser=is_superuser):
+                if current_superuser_status != is_superuser:
                     log_user_change(self.domain, self.editable_user, changed_by_user=self.couch_user,
                                     changed_via=USER_CHANGE_VIA_WEB,
-                                    fields_changed={'is_superuser': is_super_user})
+                                    fields_changed={'is_superuser': is_superuser})
                 messages.success(self.request,
                                  _('Changed system permissions for user "%s"') % self.editable_user.username)
         return super(EditWebUserView, self).post(request, *args, **kwargs)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Noticed in QA for https://github.com/dimagi/commcare-hq/pull/29887, that we were not tracking superuser access update from Web user edit view.
This PR simply adds that

Easier to review by commit

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally that changes don't break functionality

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

same as base PR
