### PR TITLE
Add lookup table info to app summary

### DIFF
--- a/corehq/apps/app_manager/app_schemas/app_case_metadata.py
+++ b/corehq/apps/app_manager/app_schemas/app_case_metadata.py
@@ -260,6 +260,7 @@ class FormQuestion(JsonObject):
     required = BooleanProperty()
     comment = StringProperty()
     setvalue = StringProperty()
+    data_source = DictProperty(exclude_if_none=True)
 
     @property
     def icon(self):

--- a/corehq/apps/app_manager/app_schemas/form_metadata.py
+++ b/corehq/apps/app_manager/app_schemas/form_metadata.py
@@ -167,7 +167,8 @@ class _AppSummaryFormDataGenerator(object):
         questions_by_path = OrderedDict(
             (question.value, question)
             for raw_question in form.get_questions(self.app.langs, include_triggers=True,
-                                                   include_groups=True, include_translations=True)
+                                                   include_groups=True, include_translations=True,
+                                                   include_fixtures=True)
             for question in self._get_question(form.unique_id, raw_question)
         )
         for path, question in questions_by_path.items():

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1168,7 +1168,8 @@ class FormBase(DocumentSchema):
         return self.get_questions([], include_triggers=True, include_groups=True)
 
     @time_method()
-    @quickcache(['self.source', 'langs', 'include_triggers', 'include_groups', 'include_translations'],
+    @quickcache(['self.source', 'langs', 'include_triggers', 'include_groups', 'include_translations',
+                 'include_fixtures'],
                 timeout=24 * 60 * 60)
     def get_questions(self, langs, include_triggers=False,
                       include_groups=False, include_translations=False, include_fixtures=False):

--- a/corehq/apps/app_manager/templates/app_manager/form_summary_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_summary_base.html
@@ -112,6 +112,16 @@
       <!-- ko template: {name: 'form-question'}--><!-- /ko -->
     </ol>
     <!-- /ko -->
+    <!-- ko if: type == "Select" -->
+    <!-- ko if: data_source.nodeset -->
+    <ul class="fa-ul text-muted" data-bind="visible: $root.showDefaultValues">
+      <li><strong>{% trans "Instance" %}:</strong> <span data-bind="text:data_source.instance_id"></span></li>
+      <li><strong>{% trans "Nodeset" %}:</strong> <span data-bind="text:data_source.nodeset"></span></li>
+      <li><strong>{% trans "Value" %}:</strong> <span data-bind="text:data_source.value_ref"></span></li>
+      <li><strong>{% trans "Label" %}:</strong> <span data-bind="text:data_source.label_ref"></span></li>
+    </ul>
+    <!-- /ko -->
+    <!-- /ko -->
     <!-- ko if:  comment || calculate || relevant || constraint || setvalue || load_properties || save_properties  -->
     <ul class="fa-ul">
       <!-- ko if: comment -->


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Hid this behind the "Default Value" toggle, as I didn't think it warranted its own button. Would love some UI feedback.
This came from a Field/Dev conversation, and seemed easy enough.

My one concern is changing the quickcache signature. I'm not sure if this invalidates all the caches that exist already?

![Screenshot from 2021-07-09 14-29-46](https://user-images.githubusercontent.com/146896/125122242-22adeb80-e0c3-11eb-916d-c24fb05f930e.png)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Adds lookup table information to the app summary.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
