### PR TITLE
Ensure hubspot JS does not run on projects that have opted out of hubspot

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/hubspot.js
+++ b/corehq/apps/analytics/static/analytix/js/hubspot.js
@@ -27,6 +27,10 @@ hqDefine('analytix/js/hubspot', [
         var apiId = _get('apiId'),
             scriptUrl = '//js.hs-analytics.net/analytics/' + utils.getDateHash() + '/' + apiId + '.js';
 
+        if (!_get('isHubspotJsAllowed')) {
+            // ensure that Hubspot javascript never loads on project spaces that have blocked Hubspot data entirely
+            apiId = null;
+        }
         _logger = logging.getLoggerForApi('Hubspot');
         _ready = utils.initApi(_ready, apiId, scriptUrl, _logger);
 

--- a/corehq/apps/analytics/templates/analytics/initial/hubspot.html
+++ b/corehq/apps/analytics/templates/analytics/initial/hubspot.html
@@ -2,3 +2,4 @@
 {% initial_analytics_data 'hubspot.apiId' ANALYTICS_IDS.HUBSPOT_API_ID %}
 {% initial_analytics_data 'hubspot.isDemoVisible' is_demo_visible %}
 {% initial_analytics_data 'hubspot.isDemoTrial' is_demo_trial %}
+{% initial_analytics_data 'hubspot.isHubspotJsAllowed' is_hubspot_js_allowed %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base_navigation.html
@@ -38,7 +38,7 @@
         <nav class="navbar-menus navbar-signin" role="navigation">
           <div class="nav-settings-bar pull-right">
             <a href="{% url "login" %}" class="btn btn-primary navbar-btn">{% trans 'Sign In' %}</a>
-            {% if is_saas_environment and ANALYTICS_IDS.HUBSPOT_API_ID %}
+            {% if is_saas_environment and ANALYTICS_IDS.HUBSPOT_API_ID and is_hubspot_js_allowed %}
               <a href="#cta-form-get-demo"
                  data-toggle="modal"
                  id="cta-form-get-demo-button-header"

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -257,3 +257,29 @@ def get_demo(request):
             'is_demo_visible': True,
         })
     return context
+
+
+def hubspot_js(request):
+    """
+    This provides context as to whether a particular page is allowed to load
+    any Hubspot javascript even when Hubspot analytics is supported by the
+    environment. This is done to ensure that no accidental Hubspot popups and
+    scripts are executed on projects that have explicitly asked to be excluded
+    from Hubspot analytics.
+    """
+    if not settings.IS_SAAS_ENVIRONMENT:
+        return {
+            'is_hubspot_js_allowed': False,
+        }
+
+    is_hubspot_js_allowed = True
+    if hasattr(request, 'subscription'):
+        try:
+            account = request.subscription.account
+            is_hubspot_js_allowed = not account.block_hubspot_data_for_all_users
+        except BillingAccount.DoesNotExist:
+            pass
+
+    return {
+        'is_hubspot_js_allowed': is_hubspot_js_allowed,
+    }

--- a/settings.py
+++ b/settings.py
@@ -1205,6 +1205,7 @@ TEMPLATES = [
                 'corehq.util.context_processors.websockets_override',
                 'corehq.util.context_processors.commcare_hq_names',
                 'corehq.util.context_processors.emails',
+                'corehq.util.context_processors.hubspot_js',
             ],
             'debug': DEBUG,
             'loaders': [


### PR DESCRIPTION
## Summary
We experienced an issue recently where some feature of hubspot launched a popup on HQ asking "Let us know if you have a query or comment". We are still unsure if this was a new "feature" of hubspot or a new form that was added. We've since ensured that any new forms only load at a specific address.

Regardless, we want to prevent this from happening in the future, so I've added a context processor to determine whether we should allow the hubspot js to load at all depending on whether the `block_hubspot_data_for_all_users` flag is set at the `BillingAccount` level.

see https://dimagi-dev.atlassian.net/browse/SAAS-12412
this is part of a followup ticket https://dimagi-dev.atlassian.net/browse/SAAS-12416

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Fairly small isolated change. Testing this out on staging.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
