### PR TITLE
Reminders/Session Endpoints: Exclude datums that can be computed

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/endpoints.py
+++ b/corehq/apps/app_manager/suite_xml/sections/endpoints.py
@@ -49,7 +49,7 @@ class SessionEndpointContributor(SuiteContributorByModule):
         stack.add_frame(frame)
         arguments = []
         for child in self._get_frame_children(module, form):
-            if isinstance(child, WorkflowDatumMeta):
+            if isinstance(child, WorkflowDatumMeta) and child.requires_selection:
                 arguments.append(Argument(id=child.id))
                 frame.add_datum(
                     StackDatum(id=child.id, value=f"${child.id}")

--- a/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
+++ b/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
@@ -39,6 +39,7 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
 
     def test_registration_form_session_endpoint_id(self):
         self.form.session_endpoint_id = 'my_form'
+        self.factory.form_opens_case(self.form, case_type=self.parent_case_type)
         self.assertXmlPartialEqual(
             """
             <partial>


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SC-1581?focusedCommentId=154108

Should resolve an issue where computable functions (eg: `uuid()`) were incorrectly turned into arguments that needed to be specified.

## Feature Flag
Enable session endpoints

## Product Description
Should resolve an issue where computable functions (eg: `uuid()`) were incorrectly turned into arguments that needed to be specified.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Feature is still not in use.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
