### PR TITLE
Remove inheritance of reports templates from tableau visualizations  

### DIFF
--- a/corehq/apps/reports/templates/reports/tableau_template.html
+++ b/corehq/apps/reports/templates/reports/tableau_template.html
@@ -1,18 +1,11 @@
 
-{% extends "reports/standard/base_template.html" %}
+{% extends "hqwebapp/two_column.html" %}
 {% load compress %}
 {% load hq_shared_tags %}
 {% load i18n %}
-{% block js %}{{ block.super }}
-  {% compress js %}
-    <script src="{% static 'reports/js/report_config_models.js' %}"></script>
-    <script src="{% static "reports/js/base.js" %}"></script>
-    <script src="{% static "reports/js/base_maps.js" %}"></script>
-  {% endcompress %}
-{% endblock %}
+{% block js %}{% endblock js %}
 
-{% block filter_panel %}
-
+{% block page_content %}
 <script src="https://{{ validate_hostname }}/javascripts/api/tableau-2.5.0.min.js"></script>
 
 <script type="text/javascript">
@@ -36,12 +29,4 @@
 <body onload="initViz();">
     <div id="vizContainer"></div>
 </body>
-
-{% endblock %}
-
-{% block additional_initial_page_data %}
-  {% initial_page_data 'default_config' default_config %}
-  {% initial_page_data 'has_datespan' report.has_datespan %}
-  {% initial_page_data 'report_configs' report_configs %}
-  {% registerurl 'add_report_config' domain %}
 {% endblock %}

--- a/corehq/apps/reports/templates/reports/tableau_template.html
+++ b/corehq/apps/reports/templates/reports/tableau_template.html
@@ -3,14 +3,6 @@
 {% load compress %}
 {% load hq_shared_tags %}
 {% load i18n %}
-{% block js %}{{ block.super }}
-  {% compress js %}
-    <script src="{% static 'reports/js/report_config_models.js' %}"></script>
-    <script src="{% static 'reports/js/base.js' %}"></script>
-    <script src="{% static 'reports/js/base_maps.js' %}"></script>
-    <script src="{% static 'reports/js/filters/main.js' %}"></script>
-  {% endcompress %}
-{% endblock %}
 
 {% block page_content %}
 <script src="https://{{ validate_hostname }}/javascripts/api/tableau-2.5.0.min.js"></script>

--- a/corehq/apps/reports/templates/reports/tableau_template.html
+++ b/corehq/apps/reports/templates/reports/tableau_template.html
@@ -3,7 +3,14 @@
 {% load compress %}
 {% load hq_shared_tags %}
 {% load i18n %}
-{% block js %}{% endblock js %}
+{% block js %}{{ block.super }}
+  {% compress js %}
+    <script src="{% static 'reports/js/report_config_models.js' %}"></script>
+    <script src="{% static 'reports/js/base.js' %}"></script>
+    <script src="{% static 'reports/js/base_maps.js' %}"></script>
+    <script src="{% static 'reports/js/filters/main.js' %}"></script>
+  {% endcompress %}
+{% endblock %}
 
 {% block page_content %}
 <script src="https://{{ validate_hostname }}/javascripts/api/tableau-2.5.0.min.js"></script>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Source of the bug in this ticket: [USH-1117](https://dimagi-dev.atlassian.net/browse/USH-1117)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[EMBEDDED_TABLEAU](https://staging.commcarehq.org/hq/flags/edit/embedded_tableau/)

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No user-facing changes, except the removal of the unwanted 404 popups seen here:
![image](https://user-images.githubusercontent.com/36681924/125341253-6a31b300-e321-11eb-8670-8484e5f50002.png)


## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This only affects the tableau_template which is a feature that is not live on any projects

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
