### PR TITLE
[SSO] Update documentation links

### DIFF
--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -19,6 +19,7 @@ from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput
 from corehq.apps.sso import certificates
 from corehq.apps.sso.models import IdentityProvider
 from corehq.apps.sso.utils import url_helpers
+from corehq.apps.sso.utils.url_helpers import get_documentation_url
 
 log = logging.getLogger(__name__)
 
@@ -163,7 +164,7 @@ class ServiceProviderDetailsForm(forms.Form):
 
     @property
     def service_provider_help_block(self):
-        help_link = "#"  # todo
+        help_link = get_documentation_url(self.idp)
         help_text = format_html(
             _('<a href="{}">Please read this guide</a> on how to set up '
               'CommCare HQ with Azure AD.<br />You will need the following '

--- a/corehq/apps/sso/utils/url_helpers.py
+++ b/corehq/apps/sso/utils/url_helpers.py
@@ -16,8 +16,8 @@ def get_saml_login_url(identity_provider):
 
 
 def get_documentation_url(identity_provider):
-    # todo update documentation URL (will change depending on IdP)
-    return '#'
+    # todo we are only supporting docs for Azure AD here. OneLogin, etc to come later
+    return 'https://confluence.dimagi.com/display/commcarepublic/Set+up+SSO+for+CommCare+HQ'
 
 
 def get_dashboard_link(identity_provider):


### PR DESCRIPTION
## Summary
Simple PR. Updates documentation links to the public confluence page.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
text change

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
