### PR TITLE
[SSO] ensure that the check for the user redirect on the invitation view matches what is expected for validating the form

### DIFF
--- a/corehq/apps/users/views/web.py
+++ b/corehq/apps/users/views/web.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login
+from django.contrib.auth.models import User
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect, JsonResponse
@@ -161,7 +162,8 @@ class UserInvitationView(object):
                     send_hubspot_form(HUBSPOT_NEW_USER_INVITE_FORM, request, user)
                     return HttpResponseRedirect(self.redirect_to_on_success(invitation.email, invitation.domain))
             else:
-                if CouchUser.get_by_username(invitation.email):
+                if (CouchUser.get_by_username(invitation.email)
+                        or User.objects.filter(username__iexact=invitation.email).count() > 0):
                     login_url = reverse("login")
                     accept_invitation_url = reverse(
                         'domain_accept_invitation',


### PR DESCRIPTION
## Summary
Not quite SSO-related as this issue has been there for a while, but basically, we need to ensure that not only a `CouchUser` does not exist, but that there are no matching `User` objects. Tagged as SSO to ensure this gets pushed with SSO changes.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
small isolated bugfix. Works on staging and tested locally.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
