### PR TITLE
Add domain param to user delete

### DIFF
--- a/corehq/apps/registration/tests/test_utils.py
+++ b/corehq/apps/registration/tests/test_utils.py
@@ -31,7 +31,7 @@ class TestRequestNewDomain(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.new_user.delete(None)
+        cls.new_user.delete(cls.domain_test, deleted_by=None)
         super().tearDownClass()
 
     def test_domain_is_active_for_new_sso_user(self):


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Looks like https://github.com/dimagi/commcare-hq/pull/29901 conflicted with https://github.com/dimagi/commcare-hq/pull/29999
(Tests only)
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
