### PR TITLE
[Enterprise] Don't throw a 500 if `couch_user` is not an attribute of `request`

### DIFF
--- a/corehq/apps/accounting/utils/account.py
+++ b/corehq/apps/accounting/utils/account.py
@@ -13,5 +13,5 @@ def get_account_or_404(domain):
 
 
 def request_has_permissions_for_enterprise_admin(request, account):
-    return(account.has_enterprise_admin(request.couch_user.username)
-           or has_privilege(request, privileges.ACCOUNTING_ADMIN))
+    return (account.has_enterprise_admin(request.couch_user.username)
+            or has_privilege(request, privileges.ACCOUNTING_ADMIN))

--- a/corehq/apps/enterprise/decorators.py
+++ b/corehq/apps/enterprise/decorators.py
@@ -11,6 +11,9 @@ from corehq.apps.accounting.utils.account import (
 def require_enterprise_admin(view_func):
     @wraps(view_func)
     def _inner(request, domain, *args, **kwargs):
+        if not hasattr(request, 'couch_user'):
+            raise Http404()
+        
         account = get_account_or_404(domain)
         if not request_has_permissions_for_enterprise_admin(request, account):
             # we want these urls to remain ambiguous/not discoverable so

--- a/corehq/apps/enterprise/decorators.py
+++ b/corehq/apps/enterprise/decorators.py
@@ -13,7 +13,7 @@ def require_enterprise_admin(view_func):
     def _inner(request, domain, *args, **kwargs):
         if not hasattr(request, 'couch_user'):
             raise Http404()
-        
+
         account = get_account_or_404(domain)
         if not request_has_permissions_for_enterprise_admin(request, account):
             # we want these urls to remain ambiguous/not discoverable so


### PR DESCRIPTION
## Summary
Fixes [this issue](https://sentry.io/organizations/dimagi/issues/2377630480/?project=136860&query=is%3Aunresolved) that's been happening on the enterprise views.

Issue is that when logged-out users attempt to visit an enterprise admin URL directly, a 500 error is thrown because `couch_user` is not an attribute of `request` in a logged out session.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Super safe change. Fixes existing bug. Tested on staging.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
