### PR TITLE
add missing method override

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -438,6 +438,10 @@ class ConfigurableReportPillowProcessor(BulkPillowProcessor):
             })
         self.domain_timing_context.clear()
 
+    def bootstrap_if_needed(self):
+        self.table_manager.bootstrap_if_needed()
+
+
 
 class ConfigurableReportKafkaPillow(ConstructedPillow):
     # todo; To remove after full rollout of https://github.com/dimagi/commcare-hq/pull/21329/

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -369,6 +369,11 @@ class ChunkedUCRProcessorTest(TestCase):
         invalid_data = InvalidUCRData.objects.all().values_list('doc_id', flat=True)
         self.assertEqual(set([case.case_id for case in cases]), set(invalid_data))
 
+    @mock.patch('corehq.apps.userreports.pillow.ConfigurableReportTableManager.bootstrap_if_needed')
+    def test_bootstrap_if_needed(self, bootstrap_if_needed):
+        self._create_and_process_changes()
+        bootstrap_if_needed.assert_called_once_with()
+
 
 class IndicatorPillowTest(TestCase):
 


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/2509802851/

## Summary
This method used to be implemented by the mixin. When the mixin was removed (https://github.com/dimagi/commcare-hq/pull/30014) the method override went with it.

This PR adds back the method override and calls the appropriate method.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Could do with a test - I'll try add one in a follow up PR.


### Safety story
bugfix

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
