### PR TITLE
Cs/sc 1622 Feature flags download button

### DIFF
--- a/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
@@ -38,22 +38,7 @@ hqDefine('toggle_ui/js/flags', [
 
     var downloadToFile = function() {
         var appliedFilter = viewModel.tagFilter();
-        var data = {
-            filter: appliedFilter
-        };
-
-        $.ajax({
-            url: 'prepare_download/',
-            data: data,
-            method: 'POST',
-            success: function (response) {
-                console.log(response.status);
-                return response;
-            },
-            error: function (response) {
-                console.log(response);
-            }
-        });
+        open('export_flags?tag=' + appliedFilter)
     };
 
     $('#export-button').koApplyBindings({downloadFile: downloadToFile});

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
@@ -38,6 +38,9 @@ hqDefine('toggle_ui/js/flags', [
 
     var downloadToFile = function () {
         var appliedFilter = viewModel.tagFilter();
+        if (appliedFilter == "all") {
+            appliedFilter = '';
+        }
         open('export_flags?tag=' + appliedFilter);
     };
 

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
@@ -6,7 +6,7 @@ hqDefine('toggle_ui/js/flags', [
 ], function (
     $,
     ko,
-    datatablesConfig
+    datatablesConfig,
 ) {
     var dataTableElem = '.datatable';
     var viewModel = {
@@ -35,4 +35,26 @@ hqDefine('toggle_ui/js/flags', [
     viewModel.tagFilter.subscribe(function (value) {
         table.datatable.fnDraw();
     });
+
+    var downloadToFile = function() {
+        var appliedFilter = viewModel.tagFilter();
+        var data = {
+            filter: appliedFilter
+        };
+
+        $.ajax({
+            url: 'prepare_download/',
+            data: data,
+            method: 'POST',
+            success: function (response) {
+                console.log(response.status);
+                return response;
+            },
+            error: function (response) {
+                console.log(response);
+            }
+        });
+    };
+
+    $('#export-button').koApplyBindings({downloadFile: downloadToFile});
 });

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
@@ -6,7 +6,7 @@ hqDefine('toggle_ui/js/flags', [
 ], function (
     $,
     ko,
-    datatablesConfig,
+    datatablesConfig
 ) {
     var dataTableElem = '.datatable';
     var viewModel = {

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
@@ -36,9 +36,9 @@ hqDefine('toggle_ui/js/flags', [
         table.datatable.fnDraw();
     });
 
-    var downloadToFile = function() {
+    var downloadToFile = function () {
         var appliedFilter = viewModel.tagFilter();
-        open('export_flags?tag=' + appliedFilter)
+        open('export_flags?tag=' + appliedFilter);
     };
 
     $('#export-button').koApplyBindings({downloadFile: downloadToFile});

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
@@ -41,7 +41,7 @@ hqDefine('toggle_ui/js/flags', [
         if (appliedFilter === "all") {
             appliedFilter = '';
         }
-        open('export_flags?tag=' + appliedFilter);
+        open('export_toggles?tag=' + appliedFilter);
     };
 
     $('#export-button').koApplyBindings({downloadFile: downloadToFile});

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
@@ -38,7 +38,7 @@ hqDefine('toggle_ui/js/flags', [
 
     var downloadToFile = function () {
         var appliedFilter = viewModel.tagFilter();
-        if (appliedFilter == "all") {
+        if (appliedFilter === "all") {
             appliedFilter = '';
         }
         open('export_flags?tag=' + appliedFilter);

--- a/corehq/apps/toggle_ui/templates/toggle/flags.html
+++ b/corehq/apps/toggle_ui/templates/toggle/flags.html
@@ -27,6 +27,10 @@
       {% trans "Show usage metrics" %}
     </a>
   {% endif %}
+  <button id="export-button" data-bind="click: downloadFile" class="ko-template btn btn-default btn-xs pull-right">
+    <i class="fa fa-info-circle"></i>
+    {% trans "Export to .xlsx" %}
+  </button>
   <div id="table-filters" class="ko-template">
     <select-toggle data-apply-bindings="false"
                    params="options: [

--- a/corehq/apps/toggle_ui/templates/toggle/flags.html
+++ b/corehq/apps/toggle_ui/templates/toggle/flags.html
@@ -28,7 +28,7 @@
     </a>
   {% endif %}
   <button id="export-button" data-bind="click: downloadFile" class="ko-template btn btn-default btn-xs pull-right">
-    <i class="fa fa-info-circle"></i>
+    <i class="fa fa-cloud-download"></i>
     {% trans "Export to .xlsx" %}
   </button>
   <div id="table-filters" class="ko-template">

--- a/corehq/apps/toggle_ui/templates/toggle/flags.html
+++ b/corehq/apps/toggle_ui/templates/toggle/flags.html
@@ -29,7 +29,7 @@
   {% endif %}
   <button id="export-button" data-bind="click: downloadFile" class="ko-template btn btn-default btn-xs pull-right">
     <i class="fa fa-cloud-download"></i>
-    {% trans "Export to .xlsx" %}
+    {% trans "Export to Excel" %}
   </button>
   <div id="table-filters" class="ko-template">
     <select-toggle data-apply-bindings="false"

--- a/corehq/apps/toggle_ui/urls.py
+++ b/corehq/apps/toggle_ui/urls.py
@@ -4,12 +4,12 @@ from corehq.apps.toggle_ui.views import (
     ToggleEditView,
     ToggleListView,
     set_toggle,
-    prepare_download,
+    export_flags,
 )
 
 urlpatterns = [
     url(r'^$', ToggleListView.as_view(), name=ToggleListView.urlname),
-    url(r'^prepare_download/$', prepare_download, name='prepare_download'),
+    url(r'^export_flags/$', export_flags, name='export_flags'),
     url(r'^edit/(?P<toggle>[\w_-]+)/$', ToggleEditView.as_view(), name=ToggleEditView.urlname),
     url(r'^set_toggle/(?P<toggle_slug>[\w_-]+)/$', set_toggle, name='set_toggle'),
 ]

--- a/corehq/apps/toggle_ui/urls.py
+++ b/corehq/apps/toggle_ui/urls.py
@@ -4,10 +4,12 @@ from corehq.apps.toggle_ui.views import (
     ToggleEditView,
     ToggleListView,
     set_toggle,
+    prepare_download,
 )
 
 urlpatterns = [
     url(r'^$', ToggleListView.as_view(), name=ToggleListView.urlname),
+    url(r'^prepare_download/$', prepare_download, name='prepare_download'),
     url(r'^edit/(?P<toggle>[\w_-]+)/$', ToggleEditView.as_view(), name=ToggleEditView.urlname),
     url(r'^set_toggle/(?P<toggle_slug>[\w_-]+)/$', set_toggle, name='set_toggle'),
 ]

--- a/corehq/apps/toggle_ui/urls.py
+++ b/corehq/apps/toggle_ui/urls.py
@@ -4,12 +4,12 @@ from corehq.apps.toggle_ui.views import (
     ToggleEditView,
     ToggleListView,
     set_toggle,
-    export_flags,
+    export_toggles,
 )
 
 urlpatterns = [
     url(r'^$', ToggleListView.as_view(), name=ToggleListView.urlname),
-    url(r'^export_flags/$', export_flags, name='export_flags'),
+    url(r'^export_toggles/$', export_toggles, name='export_toggles'),
     url(r'^edit/(?P<toggle>[\w_-]+)/$', ToggleEditView.as_view(), name=ToggleEditView.urlname),
     url(r'^set_toggle/(?P<toggle_slug>[\w_-]+)/$', set_toggle, name='set_toggle'),
 ]

--- a/corehq/apps/toggle_ui/utils.py
+++ b/corehq/apps/toggle_ui/utils.py
@@ -14,23 +14,23 @@ def find_static_toggle(slug):
             return toggle
 
 
-def get_flags_attachment_file(tag=None):
+def get_toggles_attachment_file(tag=None):
     """
     This function returns an excel file which contains information regarding
-    the feature flags filtered by the 'tag' argument. For 'tag' = None, all
-    flags will be returned.
+    the toggles filtered by the 'tag' argument. For 'tag' = None, all
+    toggles will be returned.
 
     The excel file has the following format:
-    Each feature flag is represented as a different sheet in the file. For each
-    feature flag sheet, the top of the file specifies basic information regarding
-    the feature flag, i.e. Label, Slug, Tag, etc.
+    Each toggle is represented as a different sheet in the file. For each
+    toggle sheet, the top of the file specifies basic information regarding
+    the toggle, i.e. Label, Slug, Tag, etc.
 
-    The rest of the sheet shows all the domains which has the specific feature flag
+    The rest of the sheet shows all the domains which has the specific toggle
     enabled, along with some additional information regarding each domain.
     """
 
-    flags = get_feature_flags(tag)
-    headers_table, sheets = parse_flags_to_file_info(flags)
+    toggles = get_toggles_with_tag(tag)
+    headers_table, sheets = parse_toggles_to_file_info(toggles)
 
     with Excel2007ExportWriter() as writer:
         outfile = BytesIO()
@@ -40,7 +40,7 @@ def get_flags_attachment_file(tag=None):
     return outfile
 
 
-def get_feature_flags(tag=None):
+def get_toggles_with_tag(tag=None):
     flags = []
     for toggle in all_toggles():
         if not tag or tag in toggle.tag.name:
@@ -48,7 +48,7 @@ def get_feature_flags(tag=None):
     return flags
 
 
-def parse_flags_to_file_info(toggles):
+def parse_toggles_to_file_info(toggles):
     file_headers = []
     sheets = {}
 

--- a/corehq/apps/toggle_ui/utils.py
+++ b/corehq/apps/toggle_ui/utils.py
@@ -3,6 +3,9 @@ from django.utils.translation import ugettext as _
 from io import BytesIO
 from corehq.toggles import all_toggles
 
+from corehq.apps.accounting.models import Subscription
+from corehq.apps.es import UserES
+
 
 def find_static_toggle(slug):
     for toggle in all_toggles():
@@ -10,49 +13,94 @@ def find_static_toggle(slug):
             return toggle
 
 
+def get_subscription_info(domain):
+    subscription = Subscription.get_active_subscription_by_domain(domain)
+    if subscription:
+        return subscription.service_type, subscription.plan_version.plan.name
+    else:
+        return None, None
+
+
+def has_dimagi_user(domain):
+    return UserES().web_users().domain(domain).search_string_query('@dimagi.com').count()
+
+
+def parse_flags_to_file_info(toggles):
+    def parse_header(slug):
+        return (slug, [(
+            _("Label"),
+            _("Slug"),
+            _("Tag"),
+            _("Documention link"),
+            _("Description")
+        )])
+
+    def get_toggle_data_rows(toggle_):
+        rows = []
+
+        for domain in toggle_.get_enabled_domains():
+            (service_type, plan) = get_subscription_info(domain)
+
+            data_row = [
+                domain,
+                service_type,
+                plan,
+                has_dimagi_user(domain),
+            ]
+            rows.append(data_row)
+
+        return rows
+
+    file_headers = []
+    toggles_rows_info = {}
+
+    data_header_row = [
+        _("Domain"),
+        _("Service Type"),
+        _("Plan"),
+        _("Has Dimagi User"),
+    ]
+
+    for toggle in toggles:
+        file_headers.append(parse_header(toggle.slug))
+
+        header_row_info = [
+            toggle.label or '',
+            toggle.slug,
+            toggle.tag.name,
+            toggle.help_link or '',
+            toggle.description or '',
+        ]
+
+        toggle_sheet_rows = [
+            header_row_info,
+            [],  # leaves empty row
+            data_header_row,
+        ]
+        toggle_sheet_rows.extend(get_toggle_data_rows(toggle))
+        toggles_rows_info[toggle.slug] = toggle_sheet_rows
+
+    return file_headers, toggles_rows_info
+
+
 def get_flags_with_tag(tag):
-    toggles_info = {}
-    headers = []
-
+    flags = []
     for toggle in all_toggles():
-        if tag == 'all' or toggle.tag.name == tag:
-            header_titles = (toggle.slug, [(
-                _("label"),
-                _("documention_link"),
-                _("description")
-            )])
-            headers.append(header_titles)
-
-            toggle_info = {
-                toggle.slug: {
-                    'description': toggle.description or '',
-                    'documention_link': toggle.help_link or '',
-                    'label': toggle.label or '',
-                }
-            }
-            toggles_info.update(toggle_info)
-
-    return headers, toggles_info
+        if tag == 'all' or tag in toggle.tag.name:
+            flags.append(toggle)
+    return flags
 
 
-def parse_excel_attachment_data(tag):
-    (headers, tabs_info) = get_flags_with_tag(tag)
+def get_flags_attachment_file(tag='all'):
+    flags = get_flags_with_tag(tag)
+    (headers_table, tabs) = parse_flags_to_file_info(flags)
 
     writer = Excel2007ExportWriter()
     outfile = BytesIO()
-    writer.open(header_table=headers, file=outfile)
+    writer.open(header_table=headers_table, file=outfile)
 
-    for tab_name, tab_info in tabs_info.items():
-        first_row = [
-            tab_info['description'],
-            tab_info['documention_link'],
-            tab_info['label']
-        ]
-        # data_rows = [[1, 2], [3, 4]]
-
-        rows = [first_row]
-        print(rows)
-        writer.write([(tab_name, rows)])
+    for tab_name, tab_rows in tabs.items():
+        writer.write([(tab_name, tab_rows)])
 
     writer.close()
     return outfile

--- a/corehq/apps/toggle_ui/utils.py
+++ b/corehq/apps/toggle_ui/utils.py
@@ -1,3 +1,6 @@
+from couchexport.writers import Excel2007ExportWriter
+from django.utils.translation import ugettext as _
+from io import BytesIO
 from corehq.toggles import all_toggles
 
 
@@ -5,3 +8,51 @@ def find_static_toggle(slug):
     for toggle in all_toggles():
         if toggle.slug == slug:
             return toggle
+
+
+def get_flags_with_tag(tag):
+    toggles_info = {}
+    headers = []
+
+    for toggle in all_toggles():
+        if tag == 'all' or toggle.tag.name == tag:
+            header_titles = (toggle.slug, [(
+                _("label"),
+                _("documention_link"),
+                _("description")
+            )])
+            headers.append(header_titles)
+
+            toggle_info = {
+                toggle.slug: {
+                    'description': toggle.description or '',
+                    'documention_link': toggle.help_link or '',
+                    'label': toggle.label or '',
+                }
+            }
+            toggles_info.update(toggle_info)
+
+    return headers, toggles_info
+
+
+def parse_excel_attachment_data(tag):
+    (headers, tabs_info) = get_flags_with_tag(tag)
+
+    writer = Excel2007ExportWriter()
+    outfile = BytesIO()
+    writer.open(header_table=headers, file=outfile)
+
+    for tab_name, tab_info in tabs_info.items():
+        first_row = [
+            tab_info['description'],
+            tab_info['documention_link'],
+            tab_info['label']
+        ]
+        # data_rows = [[1, 2], [3, 4]]
+
+        rows = [first_row]
+        print(rows)
+        writer.write([(tab_name, rows)])
+
+    writer.close()
+    return outfile

--- a/corehq/apps/toggle_ui/utils.py
+++ b/corehq/apps/toggle_ui/utils.py
@@ -19,8 +19,7 @@ def get_subscription_info(domain):
     subscription = Subscription.get_active_subscription_by_domain(domain)
     if subscription:
         return subscription.service_type, subscription.plan_version.plan.name
-    else:
-        return None, None
+    return None, None
 
 
 @quickcache(['domain'], timeout=60 * 10)

--- a/corehq/apps/toggle_ui/utils.py
+++ b/corehq/apps/toggle_ui/utils.py
@@ -14,7 +14,7 @@ def find_static_toggle(slug):
             return toggle
 
 
-@quickcache(['domain'], timeout=10)
+@quickcache(['domain'], timeout=60 * 10)
 def get_subscription_info(domain):
     subscription = Subscription.get_active_subscription_by_domain(domain)
     if subscription:
@@ -23,39 +23,39 @@ def get_subscription_info(domain):
         return None, None
 
 
-@quickcache(['domain'], timeout=10)
+@quickcache(['domain'], timeout=60 * 10)
 def has_dimagi_user(domain):
     return UserES().web_users().domain(domain).search_string_query('@dimagi.com').count()
 
 
+def _get_toggle_data_rows(toggle_):
+    rows = []
+
+    for domain in toggle_.get_enabled_domains():
+        service_type, plan = get_subscription_info(domain)
+
+        data_row = [
+            domain,
+            service_type,
+            plan,
+            has_dimagi_user(domain),
+        ]
+        rows.append(data_row)
+
+    return rows
+
+
 def parse_flags_to_file_info(toggles):
-    def get_header(slug):
-        return (slug, [(
-            _("Label"),
-            _("Slug"),
-            _("Tag"),
-            _("Documention link"),
-            _("Description")
-        )])
-
-    def get_toggle_data_rows(toggle_):
-        rows = []
-
-        for domain in toggle_.get_enabled_domains():
-            (service_type, plan) = get_subscription_info(domain)
-
-            data_row = [
-                domain,
-                service_type,
-                plan,
-                has_dimagi_user(domain),
-            ]
-            rows.append(data_row)
-
-        return rows
-
     file_headers = []
     sheets = {}
+
+    toggle_headers = [(
+        _("Label"),
+        _("Slug"),
+        _("Tag"),
+        _("Documention link"),
+        _("Description")
+    )]
 
     sheet_data_header_row = [
         _("Domain"),
@@ -65,7 +65,7 @@ def parse_flags_to_file_info(toggles):
     ]
 
     for toggle in toggles:
-        file_headers.append(get_header(toggle.slug))
+        file_headers.append((toggle.slug, toggle_headers))
 
         sheet_header_row_info = [
             toggle.label or '',
@@ -80,23 +80,37 @@ def parse_flags_to_file_info(toggles):
             [],  # leaves empty row
             sheet_data_header_row,
         ]
-        sheet_rows.extend(get_toggle_data_rows(toggle))
+        sheet_rows.extend(_get_toggle_data_rows(toggle))
         sheets[toggle.slug] = sheet_rows
 
     return file_headers, sheets
 
 
-def get_flags_with_tag(tag):
+def get_feature_flags(tag=None):
     flags = []
     for toggle in all_toggles():
-        if tag == 'all' or tag in toggle.tag.name:
+        if not tag or tag in toggle.tag.name:
             flags.append(toggle)
     return flags
 
 
-def get_flags_attachment_file(tag='all'):
-    flags = get_flags_with_tag(tag)
-    (headers_table, sheets) = parse_flags_to_file_info(flags)
+def get_flags_attachment_file(tag=None):
+    """
+    This function returns an excel file which contains information regarding
+    the feature flags filtered by the 'tag' argument. For 'tag' = None, all
+    flags will be returned.
+
+    The excel file has the following format:
+    Each feature flag is represented as a different sheet in the file. For each
+    feature flag sheet, the top of the file specifies basic information regarding
+    the feature flag, i.e. Label, Slug, Tag, etc.
+
+    The rest of the sheet shows all the domains which has the specific feature flag
+    enabled, along with some additional information regarding each domain.
+    """
+
+    flags = get_feature_flags(tag)
+    headers_table, sheets = parse_flags_to_file_info(flags)
 
     with Excel2007ExportWriter() as writer:
         outfile = BytesIO()

--- a/corehq/apps/toggle_ui/utils.py
+++ b/corehq/apps/toggle_ui/utils.py
@@ -26,7 +26,7 @@ def has_dimagi_user(domain):
 
 
 def parse_flags_to_file_info(toggles):
-    def parse_header(slug):
+    def get_header(slug):
         return (slug, [(
             _("Label"),
             _("Slug"),
@@ -52,9 +52,9 @@ def parse_flags_to_file_info(toggles):
         return rows
 
     file_headers = []
-    toggles_rows_info = {}
+    sheets = {}
 
-    data_header_row = [
+    sheet_data_header_row = [
         _("Domain"),
         _("Service Type"),
         _("Plan"),
@@ -62,9 +62,9 @@ def parse_flags_to_file_info(toggles):
     ]
 
     for toggle in toggles:
-        file_headers.append(parse_header(toggle.slug))
+        file_headers.append(get_header(toggle.slug))
 
-        header_row_info = [
+        sheet_header_row_info = [
             toggle.label or '',
             toggle.slug,
             toggle.tag.name,
@@ -72,15 +72,15 @@ def parse_flags_to_file_info(toggles):
             toggle.description or '',
         ]
 
-        toggle_sheet_rows = [
-            header_row_info,
+        sheet_rows = [
+            sheet_header_row_info,
             [],  # leaves empty row
-            data_header_row,
+            sheet_data_header_row,
         ]
-        toggle_sheet_rows.extend(get_toggle_data_rows(toggle))
-        toggles_rows_info[toggle.slug] = toggle_sheet_rows
+        sheet_rows.extend(get_toggle_data_rows(toggle))
+        sheets[toggle.slug] = sheet_rows
 
-    return file_headers, toggles_rows_info
+    return file_headers, sheets
 
 
 def get_flags_with_tag(tag):
@@ -93,14 +93,14 @@ def get_flags_with_tag(tag):
 
 def get_flags_attachment_file(tag='all'):
     flags = get_flags_with_tag(tag)
-    (headers_table, tabs) = parse_flags_to_file_info(flags)
+    (headers_table, sheets) = parse_flags_to_file_info(flags)
 
     writer = Excel2007ExportWriter()
     outfile = BytesIO()
     writer.open(header_table=headers_table, file=outfile)
 
-    for tab_name, tab_rows in tabs.items():
-        writer.write([(tab_name, tab_rows)])
+    for sheet_name, sheet_rows in sheets.items():
+        writer.write([(sheet_name, sheet_rows)])
 
     writer.close()
     return outfile

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -21,7 +21,7 @@ from corehq.apps.accounting.models import Subscription
 from corehq.apps.domain.decorators import require_superuser_or_contractor
 from corehq.apps.hqwebapp.decorators import use_datatables
 from corehq.apps.hqwebapp.views import BasePageView
-from corehq.apps.toggle_ui.utils import find_static_toggle, parse_excel_attachment_data
+from corehq.apps.toggle_ui.utils import find_static_toggle, get_flags_attachment_file
 from corehq.apps.users.models import CouchUser
 from corehq.toggles import (
     ALL_NAMESPACES,
@@ -372,7 +372,7 @@ def export_flags(request):
 
     response = HttpResponse(content_type=Format.from_format('xlsx').mimetype)
     response['Content-Disposition'] = 'attachment; filename="flags.xlsx"'
-    outfile = parse_excel_attachment_data(tag)
+    outfile = get_flags_attachment_file(tag)
     response.write(outfile.getvalue())
 
     return response

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -21,7 +21,7 @@ from corehq.apps.accounting.models import Subscription
 from corehq.apps.domain.decorators import require_superuser_or_contractor
 from corehq.apps.hqwebapp.decorators import use_datatables
 from corehq.apps.hqwebapp.views import BasePageView
-from corehq.apps.toggle_ui.utils import find_static_toggle, get_flags_attachment_file
+from corehq.apps.toggle_ui.utils import find_static_toggle, get_toggles_attachment_file
 from corehq.apps.users.models import CouchUser
 from corehq.toggles import (
     ALL_NAMESPACES,
@@ -367,12 +367,12 @@ def set_toggle(request, toggle_slug):
 
 
 @require_superuser_or_contractor
-def export_flags(request):
+def export_toggles(request):
     tag = request.GET['tag'] or None
 
     response = HttpResponse(content_type=Format.from_format('xlsx').mimetype)
     response['Content-Disposition'] = 'attachment; filename="flags.xlsx"'
-    outfile = get_flags_attachment_file(tag)
+    outfile = get_toggles_attachment_file(tag)
     response.write(outfile.getvalue())
 
     return response

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -366,14 +366,13 @@ def set_toggle(request, toggle_slug):
     return HttpResponse(json.dumps({'success': True}), content_type="application/json")
 
 
-@require_POST
 @require_superuser_or_contractor
-def prepare_download(request):
-    flags_filter = request.POST['filter']
+def export_flags(request):
+    tag = request.GET['tag']
 
     response = HttpResponse(content_type=Format.from_format('xlsx').mimetype)
     response['Content-Disposition'] = 'attachment; filename="flags.xlsx"'
-    outfile = parse_excel_attachment_data(flags_filter)
+    outfile = parse_excel_attachment_data(tag)
     response.write(outfile.getvalue())
 
     return response

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -368,7 +368,7 @@ def set_toggle(request, toggle_slug):
 
 @require_superuser_or_contractor
 def export_flags(request):
-    tag = request.GET['tag']
+    tag = request.GET['tag'] or None
 
     response = HttpResponse(content_type=Format.from_format('xlsx').mimetype)
     response['Content-Disposition'] = 'attachment; filename="flags.xlsx"'


### PR DESCRIPTION
## Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-1622)

## Product Description
Added a download button to `/hq/flags/` page which downloads information regarding the feature flags to an Excel (.xlsx) file. The information respects the tag filter selected. Every toggle is exported to a different sheet in the workbook, with each sheet reporting on the following information:
**Toggle info:**
- Label
- Slug
- Tag
- Document link
- Description

**Toggle data**
- Domain
- Service Type
- Plan
- Has Dimagi User


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
No automated tests included.

### Safety story
Local test: exported feature flags to file and selecting different tag filters to ensure tags are being respected.

- [x] This PR can be reverted after deploy with no further considerations 
