### PR TITLE
Add linked project privilege for enterprise subscriptions

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -124,4 +124,5 @@ advanced_v0 = pro_v1 + [
 enterprise_v0 = advanced_v0 + [
     privileges.GEOCODER,
     privileges.DEFAULT_EXPORT_SETTINGS,
+    privileges.LINKED_PROJECTS,
 ]

--- a/corehq/apps/accounting/migrations/0055_linked_projects.py
+++ b/corehq/apps/accounting/migrations/0055_linked_projects.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+from django.core.management import call_command
+from corehq.util.django_migrations import skip_on_fresh_install
+
+from corehq.privileges import LINKED_PROJECTS
+
+
+@skip_on_fresh_install
+def _grandfather_basic_privs(apps, schema_editor):
+    call_command('cchq_prbac_bootstrap')
+    call_command(
+        'cchq_prbac_grandfather_privs',
+        LINKED_PROJECTS,
+        skip_edition='Paused,Community,Standard,Pro,Advanced',
+        noinput=True,
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('accounting', '0054_default_export_settings'),
+    ]
+
+    operations = [
+        migrations.RunPython(_grandfather_basic_privs),
+    ]

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -168,7 +168,10 @@ class Command(BaseCommand):
         Role(slug=privileges.GEOCODER, name='Geocoder', description='Address widget in Web Apps.'),
         Role(slug=privileges.DEFAULT_EXPORT_SETTINGS,
              name='Default Export Settings',
-             description='Allows ability to set default values for newly created exports.')
+             description='Allows ability to set default values for newly created exports.'),
+        Role(slug=privileges.LINKED_PROJECTS,
+             name='Linked Projects',
+             description='Allows admin users to push and/or pull content between linked projects.'),
     ]
 
     BOOTSTRAP_PLANS = [

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -81,6 +81,8 @@ APP_USER_PROFILES = 'app_user_profiles'
 
 DEFAULT_EXPORT_SETTINGS = 'default_export_settings'
 
+LINKED_PROJECTS = 'linked_projects'
+
 MAX_PRIVILEGES = [
     LOOKUP_TABLES,
     API_ACCESS,
@@ -125,6 +127,7 @@ MAX_PRIVILEGES = [
     APP_USER_PROFILES,
     GEOCODER,
     DEFAULT_EXPORT_SETTINGS,
+    LINKED_PROJECTS,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -181,4 +184,5 @@ class Titles(object):
             APP_USER_PROFILES: _("App User Profiles"),
             GEOCODER: _("Geocoder"),
             DEFAULT_EXPORT_SETTINGS: _("Default Export Settings"),
+            LINKED_PROJECTS: _("Linked Projects"),
         }.get(privilege, privilege)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Linked projects are being GAed and should go through this privilege now instead of a feature flag. This adds the privilege.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This only adds the privilege.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
