### PR TITLE
[SSO] If a domain is not using SSO, do not enforce SSO login on the domain-specifc login UI

### DIFF
--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -106,6 +106,7 @@ from corehq.util.metrics.utils import sanitize_url
 from corehq.util.view_utils import reverse
 from corehq.apps.sso.models import IdentityProvider
 from corehq.apps.sso.utils.request_helpers import is_request_using_sso
+from corehq.apps.sso.utils.domain_helpers import is_domain_using_sso
 from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
 from dimagi.utils.django.email import COMMCARE_MESSAGE_ID_HEADER
 from dimagi.utils.django.request import mutable_querydict
@@ -496,6 +497,11 @@ class HQLoginView(LoginView):
             settings.ENFORCE_SSO_LOGIN
             and self.steps.current == 'auth'
         )
+        domain = context.get('domain')
+        if domain and not is_domain_using_sso(domain):
+            # ensure that domain login pages not associated with SSO do not
+            # enforce SSO on the login screen
+            context['enforce_sso_login'] = False
         return context
 
 

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -226,9 +226,18 @@ class IdentityProvider(models.Model):
         for email_domain in all_email_domains_for_idp:
             self.clear_email_domain_caches(email_domain)
 
+    def clear_all_domain_subscriber_caches(self):
+        """
+        Ensure that we clear all domain caches tied to the Subscriptions
+        associated with the BillingAccount owner of this IdentityProvider.
+        """
+        for domain in self.get_active_projects():
+            self.clear_domain_caches(domain)
+
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
         self.clear_all_email_domain_caches()
+        self.clear_all_domain_subscriber_caches()
 
     def create_trust_with_domain(self, domain, username):
         """

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -202,6 +202,8 @@ class IdentityProvider(models.Model):
         """
         IdentityProvider.does_domain_trust_this_idp.clear(self, domain)
         IdentityProvider.is_domain_an_active_member.clear(self, domain)
+        from corehq.apps.sso.utils.domain_helpers import is_domain_using_sso
+        is_domain_using_sso.clear(domain)
 
     @staticmethod
     def clear_email_domain_caches(email_domain):

--- a/corehq/apps/sso/tests/test_domain_helpers.py
+++ b/corehq/apps/sso/tests/test_domain_helpers.py
@@ -1,4 +1,4 @@
-from django.test import TestCase, RequestFactory, override_settings
+from django.test import TestCase
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.sso.tests import generator

--- a/corehq/apps/sso/tests/test_domain_helpers.py
+++ b/corehq/apps/sso/tests/test_domain_helpers.py
@@ -37,7 +37,7 @@ class TestIsDomainUsingSso(TestCase):
 
         cls.account_pending_sso = generator.get_billing_account_for_idp()
         cls.domain_pending_sso = Domain.get_or_create_with_name(
-            "dimagi-org-001",
+            "dimagi-dot-org-001",
             is_active=True
         )
         Subscription.new_domain_subscription(
@@ -87,6 +87,7 @@ class TestIsDomainUsingSso(TestCase):
         TrustedIdentityProvider.objects.all().delete()
         IdentityProvider.objects.all().delete()
         cls.domain_with_sso.delete()
+        cls.domain_pending_sso.delete()
         cls.domain_with_inactive_sso.delete()
         cls.domain_trusting_idp.delete()
         cls.domain_trusting_inactive_idp.delete()
@@ -137,4 +138,5 @@ class TestIsDomainUsingSso(TestCase):
         new_idp = generator.create_idp('dimagi-org', self.account_pending_sso)
         new_idp.is_active = True
         new_idp.save()
+        new_idp.save()  # this avoids a race condition with tests
         self.assertTrue(is_domain_using_sso(self.domain_pending_sso.name))

--- a/corehq/apps/sso/tests/test_domain_helpers.py
+++ b/corehq/apps/sso/tests/test_domain_helpers.py
@@ -1,0 +1,118 @@
+from django.test import TestCase, RequestFactory, override_settings
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.sso.tests import generator
+from corehq.apps.sso.models import (
+    AuthenticatedEmailDomain,
+    IdentityProvider,
+    TrustedIdentityProvider,
+)
+from corehq.apps.accounting.models import Subscription
+from corehq.apps.sso.utils.domain_helpers import is_domain_using_sso
+
+
+class TestIsDomainUsingSso(TestCase):
+    """
+    These tests ensure that is_domain_using_sso returns the correct result
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        enterprise_plan = generator.get_enterprise_plan()
+
+        cls.account = generator.get_billing_account_for_idp()
+        cls.domain_with_sso = Domain.get_or_create_with_name(
+            "helping-earth-001",
+            is_active=True
+        )
+        Subscription.new_domain_subscription(
+            account=cls.account,
+            domain=cls.domain_with_sso.name,
+            plan_version=enterprise_plan,
+        )
+        cls.idp = generator.create_idp('helping-earth', cls.account)
+        cls.idp.is_active = True
+        cls.idp.save()
+
+        cls.inactive_idp_account = generator.get_billing_account_for_idp()
+        cls.domain_with_inactive_sso = Domain.get_or_create_with_name(
+            "vaultwax-001",
+            is_active=True
+        )
+        Subscription.new_domain_subscription(
+            account=cls.inactive_idp_account,
+            domain=cls.domain_with_inactive_sso.name,
+            plan_version=enterprise_plan,
+        )
+        cls.inactive_idp = generator.create_idp('vaultwax', cls.inactive_idp_account)
+
+        cls.domain_trusting_idp = Domain.get_or_create_with_name(
+            "domain-trusts-helping-earth",
+            is_active=True
+        )
+        cls.idp.create_trust_with_domain(
+            cls.domain_trusting_idp.name,
+            "test@helpingearth.org"
+        )
+
+        cls.domain_trusting_inactive_idp = Domain.get_or_create_with_name(
+            "domain-trusts-vaultwax",
+            is_active=True
+        )
+        cls.inactive_idp.create_trust_with_domain(
+            cls.domain_trusting_inactive_idp.name,
+            "test@vaultwax.com"
+        )
+
+        cls.other_domain = Domain.get_or_create_with_name(
+            "hello-test",
+            is_active=True
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        AuthenticatedEmailDomain.objects.all().delete()
+        TrustedIdentityProvider.objects.all().delete()
+        IdentityProvider.objects.all().delete()
+        cls.domain_with_sso.delete()
+        cls.domain_with_inactive_sso.delete()
+        cls.domain_trusting_idp.delete()
+        cls.domain_trusting_inactive_idp.delete()
+        cls.other_domain.delete()
+        super().tearDownClass()
+
+    def test_domain_under_active_idp_returns_true(self):
+        """
+        Ensure that domains which are members of a BillingAccount tied
+        to an active Identity Provider return True on is_domain_using_sso
+        """
+        self.assertTrue(is_domain_using_sso(self.domain_with_sso.name))
+
+    def test_domain_under_inactive_idp_returns_false(self):
+        """
+        Ensure that domains which are members of a BillingAccount tied
+        to an inactive Identity Provider return False on is_domain_using_sso
+        """
+        self.assertFalse(is_domain_using_sso(self.domain_with_inactive_sso.name))
+
+    def test_domain_trusting_active_idp_returns_true(self):
+        """
+        Ensure that a domain which trusts an active Identity Provider
+        returns true
+        """
+        self.assertTrue(is_domain_using_sso(self.domain_trusting_idp.name))
+
+    def test_domain_trusting_inactive_idp_returns_false(self):
+        """
+        Ensure that a domain which trusts an inactive Identity Provider
+        returns false
+        """
+        self.assertFalse(is_domain_using_sso(self.domain_trusting_inactive_idp.name))
+
+    def test_non_sso_domain_returns_false(self):
+        """
+        Ensure that a domain which is not tied to an active Identity Provider
+        either by trusting one or through an account returns false
+        """
+        self.assertFalse(is_domain_using_sso(self.other_domain.name))

--- a/corehq/apps/sso/utils/domain_helpers.py
+++ b/corehq/apps/sso/utils/domain_helpers.py
@@ -1,7 +1,9 @@
 from corehq.apps.accounting.models import BillingAccount
 from corehq.apps.sso.models import IdentityProvider, TrustedIdentityProvider
+from corehq.util.quickcache import quickcache
 
 
+@quickcache(['domain'])
 def is_domain_using_sso(domain):
     """
     Determines whether a given project is under an active Identity Provider or

--- a/corehq/apps/sso/utils/domain_helpers.py
+++ b/corehq/apps/sso/utils/domain_helpers.py
@@ -1,0 +1,19 @@
+from corehq.apps.accounting.models import BillingAccount
+from corehq.apps.sso.models import IdentityProvider, TrustedIdentityProvider
+
+
+def is_domain_using_sso(domain):
+    """
+    Determines whether a given project is under an active Identity Provider or
+    if it trusts an active Identity Provider.
+    :param domain: domain name (string)
+    :return: boolean (True if using SSO based on the criteria above)
+    """
+    account = BillingAccount.get_account_by_domain(domain)
+    return (
+        IdentityProvider.objects.filter(owner=account, is_active=True).exists()
+        or TrustedIdentityProvider.objects.filter(
+            domain=domain,
+            identity_provider__is_active=True
+        ).exists()
+    )


### PR DESCRIPTION
## Summary
This is fix addresses part of the issue raised by https://dimagi-dev.atlassian.net/browse/SAAS-12452

It will ensure that the domain-specific login screen for domains that are not part of an SSO `IdentityProvider` or that have not explicitly trusted an SSO `IdentityProvider` retains the original pre-SSO functionality and does not enforce an SSO login for any user.

The issue with mobile workers not being able to type in their username without the `@<domain>.commcarehq.org` complete "email" is not fixed by this, but this should not affect any projects on HQ right now as no one has enabled SSO and also the SSO enabled projects will not have this as a pain point yet.

The issue with mobile workers will still be addressed in a future PR. However, since that fix will be more involved, I will want to have some more in-depth QA on it.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Tests were created to ensure the new helper function returns the expected result.

### QA Plan
No QA is needed for this change as it's easily tested locally and on staging and is a very straightforward change.

### Safety story
Straightforward change with the default behavior favoring never enforcing SSO on the domain login experience.

### Rollback instructions
Can be easily rolled back or enabled/disabled with `ENFORCE_SSO_LOGIN` flag in localsettings set to `False` followed by an `update-config` and a `restart_services`.
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
