### PR TITLE
[User History] Don't translate messages

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -994,7 +994,7 @@ class TransferDomainRequest(models.Model):
         if by_user:
             log_user_change(self.domain, couch_user=self.from_user,
                             changed_by_user=by_user, changed_via=transfer_via,
-                            message=_("Removed from domain '{domain_name}'").format(domain_name=self.domain))
+                            message=f"Removed from domain '{self.domain}'")
         self.to_user.save()
         self.active = False
         self.save()

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -268,8 +268,7 @@ class MyProjectsList(BaseMyAccountView):
                 self.request.couch_user.save()
                 log_user_change(None, couch_user=request.couch_user,
                                 changed_by_user=request.couch_user, changed_via=USER_CHANGE_VIA_WEB,
-                                message=_("Removed from domain '{domain_name}'").format(
-                                    domain_name=self.domain_to_remove),
+                                message=f"Removed from domain '{self.domain_to_remove}'",
                                 domain_required_for_log=False,
                                 )
                 messages.success(request, _("You are no longer part of the project %s") % self.domain_to_remove)

--- a/corehq/apps/user_importer/helpers.py
+++ b/corehq/apps/user_importer/helpers.py
@@ -1,5 +1,4 @@
 from dimagi.utils.parsing import string_to_boolean
-from django.utils.translation import ugettext as _
 
 from corehq.apps.custom_data_fields.models import PROFILE_SLUG
 from corehq.apps.user_importer.exceptions import UserUploadError
@@ -130,10 +129,7 @@ class BaseUserImporter(object):
         if self.role_updated:
             new_role = self.user.get_role(domain=self.user_domain)
             if new_role:
-                self.logger.add_info(_("Role: {new_role_name}[{new_role_id}]").format(
-                    new_role_name=new_role.name,
-                    new_role_id=new_role.get_qualified_id()
-                ))
+                self.logger.add_info(f"Role: {new_role.name}[{new_role.get_qualified_id()}]")
             else:
                 self.logger.add_info("Role: None")
 
@@ -149,14 +145,12 @@ class BaseUserImporter(object):
 class CommCareUserImporter(BaseUserImporter):
     def update_password(self, password):
         self.user.set_password(password)
-        self.logger.add_change_message(_("Password Reset"))
+        self.logger.add_change_message("Password Reset")
 
     def update_phone_number(self, phone_number):
         fmt_phone_number = _fmt_phone(phone_number)
         if fmt_phone_number not in self.user.phone_numbers:
-            self.logger.add_change_message(_("Added phone number {new_phone_number}").format(
-                new_phone_number=fmt_phone_number)
-            )
+            self.logger.add_change_message(f"Added phone number {fmt_phone_number}")
         # always call this to set phone number as default if needed
         self.user.add_phone_number(fmt_phone_number, default=True)
 
@@ -190,7 +184,7 @@ class CommCareUserImporter(BaseUserImporter):
                 self.user.pop_metadata(key)
 
         if self.user.user_data.get(PROFILE_SLUG) and self.user.user_data[PROFILE_SLUG] != current_profile_id:
-            self.logger.add_info(_("CommCare Profile: {profile_name}").format(
+            self.logger.add_info("CommCare Profile: {profile_name}".format(
                 profile_name=domain_info.profile_name_by_id[self.user.user_data[PROFILE_SLUG]])
             )
 
@@ -226,19 +220,14 @@ class CommCareUserImporter(BaseUserImporter):
             if location_ids:
                 location_names = [get_location_from_site_code(code, domain_info.location_cache).name
                                   for code in location_codes]
-                self.logger.add_info(_("Assigned locations: {location_names}").format(
-                    location_names=location_names
-                ))
+                self.logger.add_info(f"Assigned locations: {location_names}")
 
         # log this after assigned locations are updated, which can re-set primary location
         if self.user.location_id != user_current_primary_location_id:
             self.logger.add_changes({'location_id': self.user.location_id})
             if self.user.location_id:
                 user_updated_primary_location_name = get_user_primary_location_name(self.user, self.user_domain)
-                self.logger.add_info(
-                    _("Primary location: {primary_location_name}").format(
-                        primary_location_name=user_updated_primary_location_name
-                    ))
+                self.logger.add_info(f"Primary location: {user_updated_primary_location_name}")
 
 
 def _fmt_phone(phone_number):
@@ -252,19 +241,13 @@ class WebUserImporter(BaseUserImporter):
         self.user.add_as_web_user(self.user_domain, role=role_qualified_id, location_id=location_id)
         self.role_updated = bool(role_qualified_id)
 
-        self.logger.add_change_message(_("Added as web user to domain '{domain_name}'").format(
-            domain_name=self.user_domain)
-        )
+        self.logger.add_change_message(f"Added as web user to domain '{self.user_domain}'")
         if location_id:
             self._log_primary_location_info()
 
     def _log_primary_location_info(self):
         primary_location = self.user.get_sql_location(self.user_domain)
-        self.logger.add_info(
-            _("Primary location: {primary_location_name}[{primary_location_id}]").format(
-                primary_location_name=primary_location.name,
-                primary_location_id=primary_location.location_id
-            ))
+        self.logger.add_info(f"Primary location: {primary_location.name}[{primary_location.location_id}]")
 
     def update_primary_location(self, location_id):
         current_primary_location_id = get_user_primary_location_id(self.user, self.user_domain)
@@ -300,9 +283,7 @@ class WebUserImporter(BaseUserImporter):
                 locations_info = ", ".join([f"{location.name}[{location.location_id}]" for location in locations])
             else:
                 locations_info = []
-            self.logger.add_info(_("Assigned locations: {locations_info}").format(
-                locations_info=locations_info
-            ))
+            self.logger.add_info(f"Assigned locations: {locations_info}")
 
         # log this after assigned locations are updated, which can re-set primary location
         user_updated_primary_location_id = get_user_primary_location_id(self.user, self.user_domain)
@@ -310,7 +291,7 @@ class WebUserImporter(BaseUserImporter):
             if user_updated_primary_location_id:
                 self._log_primary_location_info()
             else:
-                self.logger.add_info(_("Primary location: None"))
+                self.logger.add_info("Primary location: None")
 
 
 def get_user_primary_location_id(user, domain):

--- a/corehq/apps/user_importer/helpers.py
+++ b/corehq/apps/user_importer/helpers.py
@@ -57,7 +57,7 @@ class UserChangeLogger(object):
 
     def add_change_message(self, message):
         """
-        Add text messages for changes that are not exactly user properties.
+        Add raw/untranslated text messages for changes that are not exactly user properties.
         Ignored for new user since the whole user doc is logged for a new user
         :param message: text message for the change like 'Password Reset' / 'Added as web user to domain foo'
         """
@@ -68,7 +68,7 @@ class UserChangeLogger(object):
 
     def add_info(self, info):
         """
-        Useful info for display, specifically of associated data models like roles/locations.
+        Useful raw/untranslated info for display, specifically of associated data models like roles/locations.
         Info will also include ID if the data model is not linked directly on the user like
         primary location for CommCareUser is present on the user record but for a WebUser it's
         stored on Domain Membership. So for WebUser, info should also include the primary location's location id.

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -306,7 +306,7 @@ def create_or_update_web_user_invite(email, domain, role_qualified_id, upload_us
     if invite_created and send_email:
         invite.send_activation_email()
     if invite_created and user_change_logger:
-        user_change_logger.add_change_message(_("Invited to domain '{domain_name}'").format(domain_name=domain))
+        user_change_logger.add_change_message(f"Invited to domain '{domain}'")
 
 
 def find_location_id(location_codes, location_cache):
@@ -775,9 +775,7 @@ def remove_web_user_from_domain(domain, user, username, upload_user, user_change
         if is_web_upload:
             remove_invited_web_user(domain, username)
             if user_change_logger:
-                user_change_logger.add_change_message(_("Invitation revoked for domain '{domain_name}'").format(
-                    domain_name=domain
-                ))
+                user_change_logger.add_change_message(f"Invitation revoked for domain '{domain}'")
         else:
             raise UserUploadError(_("You cannot remove a web user that is not a member of this project."
                                     " {web_user} is not a member.").format(web_user=user))
@@ -787,6 +785,4 @@ def remove_web_user_from_domain(domain, user, username, upload_user, user_change
         user.delete_domain_membership(domain)
         user.save()
         if user_change_logger:
-            user_change_logger.add_change_message(_("Removed from domain '{domain_name}'").format(
-                domain_name=domain
-            ))
+            user_change_logger.add_change_message(f"Removed from domain '{domain}'")

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -338,7 +338,8 @@ def log_user_change(domain, couch_user, changed_by_user, changed_via=None,
     :param couch_user: user being changed
     :param changed_by_user: user making the change or SYSTEM_USER_ID
     :param changed_via: changed via medium i.e API/Web
-    :param message: Optional Message text
+    :param message: Optional Message text. This message should NEVER be a translated message.
+        Refer https://github.com/dimagi/commcare-hq/pull/30064 for details.
     :param fields_changed: dict of user fields that have changed with their current value
     :param action: action on the user
     :param domain_required_for_log: set to False to allow domain less log for specific changes

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -864,7 +864,7 @@ def remove_web_user(request, domain, couch_user_id):
         user.save()
         log_user_change(request.domain, couch_user=user,
                         changed_by_user=request.couch_user, changed_via=USER_CHANGE_VIA_WEB,
-                        message=_("Removed from domain '{domain_name}'").format(domain_name=domain))
+                        message=f"Removed from domain '{domain}'")
         if record:
             message = _('You have successfully removed {username} from your '
                         'project space. <a href="{url}" class="post-link">Undo</a>')


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This PR skips translating messages before storing them for User History.
At some point we would need to parse back these messages, which would not be possible if they are translated.
If translation is needed, it should be handled at the UI level and not the message being stored.

[User History Feature](https://github.com/dimagi/commcare-hq/pull/29887) was merged on July 12th.

Translations updated last in master with [commit](https://github.com/dimagi/commcare-hq/commit/c7e498725df7a04c5b8133fbbaa750c6fbe3486b)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There are tests for importer changes.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Simple changes.
I just need to confirm that there has not been any translations yet. open to suggestions if any. Considering checking django translation files that if a translation for any of the string was added

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
