### PR TITLE
[Case Search] Make property = '' match both blank and missing values

### DIFF
--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -55,6 +55,8 @@ class CaseSearchES(CaseES):
         Can be chained with regular filters . Running a set_query after this will destroy it.
         Clauses can be any of SHOULD, MUST, or MUST_NOT
         """
+        if value == '':
+            return self.add_query(case_property_missing(case_property_name), clause)
         if fuzzy:
             positive_clause = clause != queries.MUST_NOT
             return (

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -505,6 +505,10 @@ class TestCaseSearchLookups(TestCase):
         self._assert_related_case_ids(cases, {"host", "parent"}, {"c2", "c4"})
         self._assert_related_case_ids(cases, {"host", "parent/parent"}, {"c4", "c1"})
 
+    def _assert_related_case_ids(self, cases, paths, ids):
+        results = get_related_case_results(self.domain, cases, paths)
+        self.assertEqual(ids, {result['_id'] for result in results})
+
     def test_multiple_case_types(self):
         cases = [
             {'_id': 'c1', 'case_type': 'song', 'description': 'New York'},
@@ -522,6 +526,19 @@ class TestCaseSearchLookups(TestCase):
         )
         config.delete()
 
-    def _assert_related_case_ids(self, cases, paths, ids):
-        results = get_related_case_results(self.domain, cases, paths)
-        self.assertEqual(ids, {result['_id'] for result in results})
+    def test_blank_property_value(self):
+        # foo = '' should match all cases where foo is empty or absent
+        config, _ = CaseSearchConfig.objects.get_or_create(pk=self.domain, enabled=True)
+        self._assert_query_runs_correctly(
+            self.domain,
+            [
+                {'_id': 'c1', 'foo': 'redbeard'},
+                {'_id': 'c2', 'foo': 'blackbeard'},
+                {'_id': 'c3', 'foo': ''},
+                {'_id': 'c4'},
+            ],
+            CaseSearchCriteria(self.domain, [self.case_type], {'foo': ''}).search_es,
+            None,
+            ['c3', 'c4']
+        )
+        config.delete()

--- a/corehq/apps/hqcase/tasks.py
+++ b/corehq/apps/hqcase/tasks.py
@@ -144,6 +144,8 @@ def delete_exploded_case_task(domain, explosion_id):
 
 
 def delete_exploded_cases(domain, explosion_id, task=None):
+    if not explosion_id:
+        raise Exception("explosion_id is falsy, aborting rather than deleting all cases")
     NotAllowed.check(domain)
     if task:
         DownloadBase.set_progress(delete_exploded_case_task, 0, 0)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-1150
This is a backend-only change.  It won't have any effect on its own until the corresponding webapps change is released.  Right now, fields are optional, so if you leave a value blank, it doesn't send it to the server.  If you _were_ able to send it, the current behavior would be to return only cases where the value is set, but blank.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Enable synchronous mobile searching and case claiming

## Product Description


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
