### PR TITLE
Remove unnecessary reference to outdated variable

### DIFF
--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -67,7 +67,6 @@ hqDefine("linked_domain/js/domain_links", [
         }
 
         self.can_update = data.can_update;
-        self.models = data.models;
 
         self.model_status = _.map(data.model_status, ModelStatus);
 

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -292,10 +292,6 @@ class DomainLinkView(BaseAdminProjectSettingsView):
                 'model_status': sorted(view_models_to_pull, key=lambda m: m['name']),
                 'master_model_status': sorted(view_models_to_push, key=lambda m: m['name']),
                 'linked_domains': sorted(linked_domains, key=lambda d: d['linked_domain']),
-                'models': [
-                    {'slug': model[0], 'name': model[1]}
-                    for model in LINKED_MODELS
-                ],
                 'linkable_ucr': remote_linkable_ucr,
             },
         }


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I didn't catch this when making the change on [this PR](https://github.com/dimagi/commcare-hq/pull/29936). This made it past QA because another branch on staging removes this line of code, but that branch is not yet merged. There has not been a prod deploy since the mentioned PR was merged, so the bug is not yet live (though it is live on india and swiss). 

Update: The original PR has been reverted, but this change still stands on its own because this variable is unused in `domain_links.html` and only assigned in `domain_links.js`. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested. The `models` property is not used in either the html or js file for linked projects. It is only set. This is simply removing dead code.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
