### PR TITLE
Remove computed var

### DIFF
--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -104,9 +104,7 @@ hqDefine("linked_domain/js/domain_links", [
             return self.isDownstreamDomain ? "in active" : "";
         });
 
-        self.manageTabActiveStatus = ko.computed(function () {
-            return self.isDownstreamDomain ? "" : "in active";
-        });
+        self.manageTabActiveStatus = self.isDownstreamDomain ? "" : "in active";
 
         self.showGetStarted = ko.computed(function () {
             return !self.isUpstreamDomain() && !self.isDownstreamDomain;


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Followup on [this comment](https://github.com/dimagi/commcare-hq/pull/30052#discussion_r671412515) I missed earlier.

Since `isDownstreamDomain` isn't an observable, there is no need to use a computed observable here.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested. Safe change.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
