### PR TITLE
Single view for Tableau reports

### DIFF
--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -230,6 +230,10 @@ class TableauVisualization(models.Model):
     server = models.ForeignKey(TableauServer, on_delete=models.CASCADE)
     view_url = models.CharField(max_length=256)
 
+    @property
+    def name(self):
+        return '/'.join(self.view_url.split('?')[0].split('/')[-2:])
+
     def __str__(self):
         return '{domain} {server} {view}'.format(domain=self.domain,
                                                  server=self.server,

--- a/corehq/apps/reports/standard/tableau.py
+++ b/corehq/apps/reports/standard/tableau.py
@@ -1,17 +1,53 @@
 import sys
 
+from django.shortcuts import render
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.utils.translation import ugettext
+
 import requests
 from requests_toolbelt.adapters import host_header_ssl
 
-from django.shortcuts import render
-from django.utils.translation import ugettext
-
+from corehq import toggles
 from corehq.apps.locations.permissions import location_safe
-from corehq.apps.reports.standard import (
-    ProjectReport,
-)
-
 from corehq.apps.reports.models import TableauVisualization
+from corehq.apps.reports.standard import ProjectReport
+from corehq.apps.reports.views import BaseProjectReportSectionView
+from corehq.apps.users.decorators import require_permission
+from corehq.apps.users.models import Permissions
+
+
+@method_decorator(require_permission(Permissions.edit_data), name='dispatch')   # TODO: is that the right perm?
+@method_decorator(toggles.EMBEDDED_TABLEAU.required_decorator(), name='dispatch')
+class TableauView(BaseProjectReportSectionView):    # TODO: breadcrumbs aren't showing
+    urlname = 'tableau'
+    page_title = "TODO"  #ugettext_noop("TODO")
+    template_name = 'reports/tableau_template.html'
+
+    @property
+    def visualization(self):
+        return TableauVisualization.objects.get(domain=self.domain, id=self.kwargs.get("viz_id"))
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname, args=(self.domain, self.visualization.id,))
+
+    @property
+    def page_context(self):
+        if self.visualization.server.validate_hostname == '':
+            hostname = self.visualization.server.server_name
+        else:
+            hostname = self.visualization.server.validate_hostname
+        return {
+            "domain": self.visualization.server.domain,
+            "server_type": self.visualization.server.server_type,
+            "server_address": self.visualization.server.server_name,
+            "validate_hostname": hostname,
+            "target_site": self.visualization.server.target_site,
+            "allow_domain_username_override": self.visualization.server.allow_domain_username_override,
+            "domain_username": self.visualization.server.domain_username,
+            "view_url": self.visualization.view_url,
+        }
 
 
 class TableauReport(ProjectReport):

--- a/corehq/apps/reports/standard/tableau.py
+++ b/corehq/apps/reports/standard/tableau.py
@@ -3,7 +3,7 @@ import sys
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext
+from django.utils.translation import ugettext as _
 
 import requests
 from requests_toolbelt.adapters import host_header_ssl
@@ -21,8 +21,11 @@ from corehq.apps.users.models import Permissions
 @method_decorator(toggles.EMBEDDED_TABLEAU.required_decorator(), name='dispatch')
 class TableauView(BaseProjectReportSectionView):    # TODO: breadcrumbs aren't showing
     urlname = 'tableau'
-    page_title = "TODO"  #ugettext_noop("TODO")
     template_name = 'reports/tableau_template.html'
+
+    @property
+    def page_title(self):
+        return self.visualization.name
 
     @property
     def visualization(self):
@@ -49,42 +52,10 @@ class TableauView(BaseProjectReportSectionView):    # TODO: breadcrumbs aren't s
             "view_url": self.visualization.view_url,
         }
 
-
-class TableauReport(ProjectReport):
-    """
-    Base class for all Tableau reports
-    """
-    base_template = 'reports/tableau_template.html'
-    emailable = False
-    exportable = False
-    exportable_all = False
-    ajax_pagination = False
-    fields = []
-    primary_sort_prop = None
-
-    @property
-    def template_context(self):
-        context = super().template_context
-        if self.visualization.server.validate_hostname == '':
-            hostname = self.visualization.server.server_name
-        else:
-            hostname = self.visualization.server.validate_hostname
-        context.update({"domain": self.visualization.server.domain,
-                        "server_type": self.visualization.server.server_type,
-                        "server_address": self.visualization.server.server_name,
-                        "validate_hostname": hostname,
-                        "target_site": self.visualization.server.target_site,
-                        "allow_domain_username_override": self.visualization.server.allow_domain_username_override,
-                        "domain_username": self.visualization.server.domain_username,
-                        "view_url": self.visualization.view_url})
-        return context
-
-    @property
-    def view_response(self):
+    def get(self, request, *args, **kwargs):
         if self.visualization.server.server_type == 'server':
             return self.tableau_server_response()
-        else:
-            return self.tableau_online_response()
+        return super().get(request, *args, **kwargs)
 
     def get_post_username(self):
         if self.visualization.server.allow_domain_username_override:
@@ -94,6 +65,7 @@ class TableauReport(ProjectReport):
         return self.visualization.server.domain_username
 
     def tableau_server_response(self):
+        context = self.page_context
         tabserver_url = 'https://{}/trusted/'.format(self.visualization.server.server_name)
         post_arguments = {'username': self.get_post_username()}
         if self.visualization.server.target_site != 'Default':
@@ -110,46 +82,19 @@ class TableauReport(ProjectReport):
 
         if tabserver_response.status_code == 200:
             if tabserver_response.content != b'-1':
-                self.context.update({'ticket': tabserver_response.content.decode('utf-8')})
-                return super().view_response
+                context.update({'ticket': tabserver_response.content.decode('utf-8')})
+                return render(self.request, self.template_name, context)
             else:
-                self.context.update({"failure_message": ugettext("Tableau trusted authentication failed")})
-                return render(self.request, 'reports/tableau_server_request_failed.html',
-                              self.context)
+                context.update({"failure_message": _("Tableau trusted authentication failed")})
+                return render(self.request, 'reports/tableau_server_request_failed.html', context)
         else:
-            message = "Request to Tableau failed with status code {}".format(tabserver_response.status_code)
-            self.context.update({"failure_message": ugettext(message)})
-            return render(self.request, 'reports/tableau_server_request_failed.html',
-                          self.context)
-
-    def tableau_online_response(self):
-        # Call the Tableau server to get a ticket.
-        return super().view_response
+            message = _("Request to Tableau failed with status code {}").format(tabserver_response.status_code)
+            context.update({"failure_message": message})
+            return render(self.request, 'reports/tableau_server_request_failed.html', context)
 
 
 # Making a class per visualization (and on each page load) is overkill, but
 # a class is expected for items in the left nav bar, so we do that for
 # expedience.
 def get_reports(domain):
-    result = []
-    for vis_num, v in enumerate(TableauVisualization.objects.filter(domain=domain)):
-        visualization_class = _make_visualization_class(vis_num, v)
-        if visualization_class is not None:
-            result.append(visualization_class)
-    return tuple(result)
-
-
-def _make_visualization_class(num, vis):
-    # See _make_report_class in corehq/reports.py
-    type_name = 'TableauVisualization{}'.format(num)
-
-    view_sheet = '/'.join(vis.view_url.split('?')[0].split('/')[-2:])
-
-    new_class = type(type_name, (TableauReport,), {
-        'name': view_sheet,
-        'slug': 'tableau_visualization_{}'.format(num),
-        'visualization': vis,
-    })
-    # Make the class a module attribute
-    setattr(sys.modules[__name__], type_name, new_class)
-    return location_safe(new_class)
+    return []

--- a/corehq/apps/reports/standard/tableau.py
+++ b/corehq/apps/reports/standard/tableau.py
@@ -3,25 +3,23 @@ import sys
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext_lazy
 
 import requests
 from requests_toolbelt.adapters import host_header_ssl
 
 from corehq import toggles
-from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.models import TableauVisualization
-from corehq.apps.reports.standard import ProjectReport
 from corehq.apps.reports.views import BaseProjectReportSectionView
-from corehq.apps.users.decorators import require_permission
-from corehq.apps.users.models import Permissions
 
 
-@method_decorator(require_permission(Permissions.edit_data), name='dispatch')   # TODO: is that the right perm?
 @method_decorator(toggles.EMBEDDED_TABLEAU.required_decorator(), name='dispatch')
-class TableauView(BaseProjectReportSectionView):    # TODO: breadcrumbs aren't showing
+class TableauView(BaseProjectReportSectionView):
     urlname = 'tableau'
     template_name = 'reports/tableau_template.html'
+
+    # Override BaseProjectReportSectionView, but it'll still link to reports home
+    section_name = ugettext_lazy("Tableau Reports")
 
     @property
     def page_title(self):

--- a/corehq/apps/reports/standard/tableau.py
+++ b/corehq/apps/reports/standard/tableau.py
@@ -1,5 +1,4 @@
-import sys
-
+from django.http import Http404
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -27,11 +26,19 @@ class TableauView(BaseProjectReportSectionView):
 
     @property
     def visualization(self):
-        return TableauVisualization.objects.get(domain=self.domain, id=self.kwargs.get("viz_id"))
+        try:
+            return TableauVisualization.objects.get(domain=self.domain, id=self.kwargs.get("viz_id"))
+        except TableauVisualization.DoesNotExist:
+            return None
 
     @property
     def page_url(self):
         return reverse(self.urlname, args=(self.domain, self.visualization.id,))
+
+    def dispatch(self, request, *args, **kwargs):
+        if self.visualization is None:
+            raise Http404()
+        return super().dispatch(request, *args, **kwargs)
 
     @property
     def page_context(self):

--- a/corehq/apps/reports/standard/tableau.py
+++ b/corehq/apps/reports/standard/tableau.py
@@ -91,10 +91,3 @@ class TableauView(BaseProjectReportSectionView):    # TODO: breadcrumbs aren't s
             message = _("Request to Tableau failed with status code {}").format(tabserver_response.status_code)
             context.update({"failure_message": message})
             return render(self.request, 'reports/tableau_server_request_failed.html', context)
-
-
-# Making a class per visualization (and on each page load) is overkill, but
-# a class is expected for items in the left nav bar, so we do that for
-# expedience.
-def get_reports(domain):
-    return []

--- a/corehq/apps/reports/templates/reports/tableau_template.html
+++ b/corehq/apps/reports/templates/reports/tableau_template.html
@@ -1,5 +1,4 @@
-
-{% extends "hqwebapp/two_column.html" %}
+{% extends "hqwebapp/base_section.html" %}
 {% load compress %}
 {% load hq_shared_tags %}
 {% load i18n %}

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -4,6 +4,7 @@ from django.conf.urls import include, url
 from django.core.exceptions import ImproperlyConfigured
 
 from corehq.apps.reports.standard.forms.reports import ReprocessXFormErrorView
+from corehq.apps.reports.standard.tableau import TableauView
 from corehq.apps.userreports.reports.view import (
     ConfigurableReportView,
     CustomConfigurableReportDispatcher,
@@ -144,6 +145,8 @@ urlpatterns = [
 
     # V2 Reports
     url(r'^v2/', include('corehq.apps.reports.v2.urls')),
+
+    url(r'^tableau/(?P<viz_id>[\d]+)/$', TableauView.as_view(), name=TableauView.urlname),
 
     # Internal Use
     url(r'^reprocess_error_form/$', ReprocessXFormErrorView.as_view(),

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -119,10 +119,6 @@ def REPORTS(project):
         (ugettext_lazy("Manage Deployments"), deployments_reports),
     ])
 
-    if toggles.EMBEDDED_TABLEAU.enabled(project.name):
-        tableau_reports = tableau.get_reports(project.name)
-        reports.extend([(ugettext_lazy("Tableau Views"), tableau_reports)])
-
     if project.commtrack_enabled:
         supply_reports = (
             commtrack.SimplifiedInventoryReport,

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -130,18 +130,8 @@ class ProjectReportsTab(UITab):
     @property
     def sidebar_items(self):
         tools = self._get_tools_items()
+        tableau = self._get_tableau_items()
         report_builder_nav = self._get_report_builder_items()
-
-        # TODO: check flag, extract to function
-        from corehq.apps.reports.models import TableauVisualization
-        from corehq.apps.reports.standard.tableau import TableauView
-        tableau = [(_("Tableau Reports"), [
-            {
-                'title': viz.name,
-                'url': reverse(TableauView.urlname, args=[self.domain, viz.id]),
-                'show_in_dropdown': False,
-            } for viz in TableauVisualization.objects.filter(domain=self.domain)
-        ])]
 
         project_reports = ProjectReportDispatcher.navigation_sections(
             request=self._request, domain=self.domain)
@@ -179,6 +169,20 @@ class ProjectReportsTab(UITab):
                 'icon': 'icon-tasks fa fa-wrench',
             })
         return [(_("Tools"), tools)]
+
+    def _get_tableau_items(self):
+        if not toggles.EMBEDDED_TABLEAU.enabled(self.domain):
+            return []
+
+        from corehq.apps.reports.models import TableauVisualization
+        from corehq.apps.reports.standard.tableau import TableauView
+        items = [{
+            'title': viz.name,
+            'url': reverse(TableauView.urlname, args=[self.domain, viz.id]),
+            'show_in_dropdown': False,
+        } for viz in TableauVisualization.objects.filter(domain=self.domain)]
+
+        return [(_("Tableau Reports"), items)] if items else []
 
     def _get_report_builder_items(self):
         user_reports = []

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -131,11 +131,23 @@ class ProjectReportsTab(UITab):
     def sidebar_items(self):
         tools = self._get_tools_items()
         report_builder_nav = self._get_report_builder_items()
+
+        # TODO: check flag, extract to function
+        from corehq.apps.reports.models import TableauVisualization
+        from corehq.apps.reports.standard.tableau import TableauView
+        tableau = [(_("Tableau Reports"), [
+            {
+                'title': viz.name,
+                'url': reverse(TableauView.urlname, args=[self.domain, viz.id]),
+                'show_in_dropdown': False,
+            } for viz in TableauVisualization.objects.filter(domain=self.domain)
+        ])]
+
         project_reports = ProjectReportDispatcher.navigation_sections(
             request=self._request, domain=self.domain)
         custom_reports = CustomProjectReportDispatcher.navigation_sections(
             request=self._request, domain=self.domain)
-        sidebar_items = (tools + report_builder_nav
+        sidebar_items = (tools + tableau + report_builder_nav
                          + self._regroup_sidebar_items(custom_reports + project_reports))
         return self._filter_sidebar_items(sidebar_items)
 


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-1181

The 404 is [this one](https://github.com/dimagi/commcare-hq/blob/2c2e3711a28160809ff5ef25d93ee36d023646be/corehq/apps/reports/dispatcher.py#L158) and is happening because the earlier [to_function call](https://github.com/dimagi/commcare-hq/blob/2c2e3711a28160809ff5ef25d93ee36d023646be/corehq/apps/reports/dispatcher.py#L140) is silently failing. Passing `failhard=True` to `to_function` results in [this error](https://sentry.io/organizations/dimagi/issues/2518033227/?environment=staging&project=136860&query=is%3Aunresolved): `module 'corehq.apps.reports.standard.tableau' has no attribute 'TableauVisualization1'` So something is going wrong with the dynamic class generation / module loading, but only happening intermittently.

This PR sidesteps the issue by replacing the dynamic classes with a single view that doesn't use the report view hierarchy.

For permissions, the new view checks `user_can_view_reports`, inheriting that check from `BaseProjectReportSectionView`.

## Feature Flag
COVID: Enable retrieving and embedding tableau visualizations from a Tableau Server

## Product Description
The only user-facing change is that this moves the tableau menu section up near the top.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

I don't think there are view-level tests for tableau.

### QA Plan

Not requesting QA. @stephherbers I tested that the demo report on staging works, let me know if there's other testing I should do.

### Safety story
This change is limited to a feature flag that isn't yet used by external users.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
