### PR TITLE
Add management commands to setup linked domains

### DIFF
--- a/corehq/apps/linked_domain/README.md
+++ b/corehq/apps/linked_domain/README.md
@@ -74,27 +74,18 @@ Project data like forms and cases would not be shared.
 
 ### On 'master domain':
 
-```
-DomainLink.link_domains('https://url.of.linked.hq/a/linked_domain_name/', 'master_domain_name')
-```
+Run `add_downstream_domain` management command on source HQ.
 
 This gets used as a permissions check during remote requests to ensure
 that the remote domain is allowed to sync from this domain.
 
 ### On 'linked domain'
 
-```
-remote_details = RemoteLinkDetails(
-    url_base='https://url.of.master.hq',
-    username='username@email.com',
-    api_key='api key for username'
-)
-DomainLink.link_domains('linked_domain_name', 'master_domain_name', remote_details)
-```
+Run `link_to_upstream_domain` management command on downsream HQ.
 
 ### Pulling changes from master
 
-On remote HQ, enable `linked_domains` feature flag and navigate to `project settings > Linked Projects` page which has a UI to pull changes from master domain for custom data fields for Location, User and Product models, user roles and feature flags/previews.
+On downstream HQ, enable `linked_domains` feature flag and navigate to `project settings > Linked Projects` page which has a UI to pull changes from master domain for custom data fields for Location, User and Product models, user roles and feature flags/previews.
 
 Linked apps can be setup between linked domains by running `link_app_to_remote` command on linked domain.
 

--- a/corehq/apps/linked_domain/README.md
+++ b/corehq/apps/linked_domain/README.md
@@ -76,6 +76,10 @@ Project data like forms and cases would not be shared.
 
 Run `add_downstream_domain` management command on source HQ.
 
+```
+$ ./manage.py add_downstream_domain --url {https://url.of.linked.hq/a/linked_domain_name/} --domain {upstream_domain_name}
+```
+
 This gets used as a permissions check during remote requests to ensure
 that the remote domain is allowed to sync from this domain.
 

--- a/corehq/apps/linked_domain/management/commands/add_downstream_domain.py
+++ b/corehq/apps/linked_domain/management/commands/add_downstream_domain.py
@@ -9,10 +9,10 @@ class Command(BaseCommand):
     """
 
     def add_arguments(self, parser):
-        parser.add_argument('-r', '--url', required=True,
+        parser.add_argument('-r', '--downstream_url', required=True,
                             help="URL of downstream domain to link https://url.of.linked.hq/a/linked_domain_name/")
-        parser.add_argument('-d', '--domain', required=True,
+        parser.add_argument('-d', '--upstream_domain', required=True,
                             help="upsteam domain on this HQ.")
 
-    def handle(self, url, domain, **options):
-        DomainLink.link_domains(url, domain)
+    def handle(self, downstream_url, upstream_domain, **options):
+        DomainLink.link_domains(downstream_url, upstream_domain)

--- a/corehq/apps/linked_domain/management/commands/add_downstream_domain.py
+++ b/corehq/apps/linked_domain/management/commands/add_downstream_domain.py
@@ -1,0 +1,18 @@
+from django.core.management import BaseCommand
+
+from corehq.apps.linked_domain.models import DomainLink
+
+
+class Command(BaseCommand):
+    """
+    Links a remote domain as a downstream domain to a given upstream domain on this HQ
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument('-r', '--url', required=True,
+                            help="URL of downstream domain to link https://url.of.linked.hq/a/linked_domain_name/")
+        parser.add_argument('-d', '--domain', required=True,
+                            help="upsteam domain on this HQ.")
+
+    def handle(self, url, domain, **options):
+        DomainLink.link_domains(url, domain)

--- a/corehq/apps/linked_domain/management/commands/link_to_upstream_domain.py
+++ b/corehq/apps/linked_domain/management/commands/link_to_upstream_domain.py
@@ -1,0 +1,29 @@
+from django.core.management import BaseCommand
+
+from corehq.apps.linked_domain.models import DomainLink, RemoteLinkDetails
+
+
+class Command(BaseCommand):
+    """
+    Setup a domain on this HQ as a downstream domain to a remote upstream domain
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument('-r', '--url_base', required=True,
+                            help="Base URL of remote upstream HQ e.g. https://www.commcarehq.org")
+        parser.add_argument('-m', '--master_domain', required=True,
+                            help="Upstream master domain.")
+        parser.add_argument('-u', '--username', required=True,
+                            help="Username for remote authentication")
+        parser.add_argument('-k', '--api_key', required=True,
+                            help="ApiKey for remote authentication")
+        parser.add_argument('-d', '--domain', required=True,
+                            help="Downstream domain on this HQ.")
+
+    def handle(self, url_base, master_domain, username, api_key, domain, **options):
+        remote_details = RemoteLinkDetails(
+            url_base=url_base,
+            username=username,
+            api_key=api_key
+        )
+        DomainLink.link_domains(domain, master_domain, remote_details)

--- a/corehq/apps/linked_domain/management/commands/link_to_upstream_domain.py
+++ b/corehq/apps/linked_domain/management/commands/link_to_upstream_domain.py
@@ -11,19 +11,19 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('-r', '--url_base', required=True,
                             help="Base URL of remote upstream HQ e.g. https://www.commcarehq.org")
-        parser.add_argument('-m', '--master_domain', required=True,
+        parser.add_argument('-m', '--upstream_domain', required=True,
                             help="Upstream master domain.")
         parser.add_argument('-u', '--username', required=True,
                             help="Username for remote authentication")
         parser.add_argument('-k', '--api_key', required=True,
                             help="ApiKey for remote authentication")
-        parser.add_argument('-d', '--domain', required=True,
+        parser.add_argument('-d', '--downstream_domain', required=True,
                             help="Downstream domain on this HQ.")
 
-    def handle(self, url_base, master_domain, username, api_key, domain, **options):
+    def handle(self, url_base, upstream_domain, username, api_key, downstream_domain, **options):
         remote_details = RemoteLinkDetails(
             url_base=url_base,
             username=username,
             api_key=api_key
         )
-        DomainLink.link_domains(domain, master_domain, remote_details)
+        DomainLink.link_domains(downstream_domain, upstream_domain, remote_details)


### PR DESCRIPTION
## Summary

Current process to setup domain links involve running HQ code in a Django shell. This moves the code to run into management commands.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
 NA

### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
