### PR TITLE
Reverse execution order in Auditcare Migration

### DIFF
--- a/corehq/apps/auditcare/couch_to_sql.py
+++ b/corehq/apps/auditcare/couch_to_sql.py
@@ -49,6 +49,7 @@ def _get_couch_docs(start_key, end_key):
         endkey=end_key,
         reduce=False,
         include_docs=True,
+        descending=True,
         limit=COUCH_QUERY_LIMIT
     )
     return list(result)

--- a/corehq/apps/auditcare/tests/test_auditcare_migration.py
+++ b/corehq/apps/auditcare/tests/test_auditcare_migration.py
@@ -138,13 +138,13 @@ class TestManagementCommand(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        AuditCareMigrationUtil().set_next_batch_start(datetime(2021, 6, 1))
+        AuditCareMigrationUtil().set_next_batch_start(datetime(2021, 6, 30))
         cls.couch_doc_ids = [save_couch_doc(**doc) for doc in navigation_test_docs + audit_test_docs + failed_docs]
 
         # setup for adding errored batches
         cls.errored_keys = [
-            f'{datetime(2021,5,15)}_{datetime(2021,5,16)}',
-            f'{datetime(2021,5,1)}_{datetime(2021,5,2)}',
+            f'{datetime(2021,5,16)}_{datetime(2021,5,15)}',
+            f'{datetime(2021,5,2)}_{datetime(2021,5,1)}',
         ]
         return super().setUpClass()
 
@@ -154,6 +154,7 @@ class TestManagementCommand(TestCase):
         delete_couch_docs(cls.couch_doc_ids)
         return super().tearDownClass()
 
+    @patch('corehq.apps.auditcare.utils.migration.CUTOFF_TIME', datetime(2021, 6, 1))
     def test_copy_all_events(self):
         call_command("copy_events_to_sql", "--workers=10", "--batch_by=d")
         total_object_count = NavigationEventAudit.objects.all().count() + AccessAudit.objects.all().count()
@@ -208,11 +209,11 @@ class TestCopyEventsToSQL(AuditcareTest):
             self.assertEqual(AccessAudit.objects.first().path, "/a/delmar/login/")
 
         NavigationEventAudit(event_date=datetime(2021, 2, 1, 4), path="just/a/checkpoint").save()
-        copy_events_to_sql(start_time=datetime(2021, 2, 1, 2), end_time=datetime(2021, 2, 1, 5))
+        copy_events_to_sql(start_time=datetime(2021, 2, 1, 5), end_time=datetime(2021, 2, 1, 2))
         _assert()
 
         # Re-copying should have no effect
-        copy_events_to_sql(start_time=datetime(2021, 2, 1, 2), end_time=datetime(2021, 2, 1, 5))
+        copy_events_to_sql(start_time=datetime(2021, 2, 1, 5), end_time=datetime(2021, 2, 1, 2))
         _assert()
 
     @patch('corehq.apps.auditcare.couch_to_sql.COUCH_QUERY_LIMIT', 2)
@@ -230,5 +231,5 @@ class TestCopyEventsToSQL(AuditcareTest):
             self.assertEqual(AccessAudit.objects.count(), 1)
             self.assertEqual(AccessAudit.objects.first().path, "/a/delmar/login/")
 
-        copy_events_to_sql(start_time=datetime(2021, 1, 1), end_time=datetime(2021, 2, 2))
+        copy_events_to_sql(start_time=datetime(2021, 2, 2), end_time=datetime(2021, 1, 1))
         _assert()

--- a/corehq/apps/auditcare/tests/test_auditcare_migration.py
+++ b/corehq/apps/auditcare/tests/test_auditcare_migration.py
@@ -49,22 +49,45 @@ class TestAuditcareMigrationUtil(TestCase):
 
     @patch(
         'corehq.apps.auditcare.utils.migration.AuditCareMigrationUtil.get_next_batch_start',
-        return_value=start_time
+        return_value=datetime(2020, 6, 1, 12)
     )
     def test_generate_batches(self, _):
         batches = self.util.generate_batches(2, 'h')
         expected_batches = [
-            [datetime(2020, 6, 1), datetime(2020, 6, 1, 1)],
-            [datetime(2020, 6, 1, 1), datetime(2020, 6, 1, 2)]
+            [datetime(2020, 6, 1, 12), datetime(2020, 6, 1, 11)],
+            [datetime(2020, 6, 1, 11), datetime(2020, 6, 1, 10)]
         ]
         self.assertEquals(batches, expected_batches)
 
         batches = self.util.generate_batches(2, 'd')
         expected_batches = [
-            [datetime(2020, 6, 1), datetime(2020, 6, 2)],
-            [datetime(2020, 6, 2), datetime(2020, 6, 3)]
+            [datetime(2020, 6, 1, 12), datetime(2020, 5, 31)],
+            [datetime(2020, 5, 31), datetime(2020, 5, 30)]
         ]
         self.assertEquals(batches, expected_batches)
+
+    @patch(
+        'corehq.apps.auditcare.utils.migration.AuditCareMigrationUtil.get_next_batch_start',
+        return_value=datetime(2013, 1, 3)
+    )
+    def test_generate_batches_after_cutoff_date(self, _):
+        # If the script has crossed cutoff dates then batch
+        # generation should stop
+        batches = self.util.generate_batches(5, 'd')
+        expected_batches = [
+            [datetime(2013, 1, 3), datetime(2013, 1, 2)],
+            [datetime(2013, 1, 2), datetime(2013, 1, 1)],
+        ]
+        self.assertEquals(batches, expected_batches)
+
+    @patch(
+        'corehq.apps.auditcare.utils.migration.AuditCareMigrationUtil.get_next_batch_start',
+        return_value=None
+    )
+    @patch('corehq.apps.auditcare.utils.migration.get_sql_start_date', return_value=None)
+    def test_generate_batches_for_first_call(self, mock, _):
+        self.util.generate_batches(1, 'd')
+        self.assertTrue(mock.called)
 
     def test_log_batch_start(self):
         self.util.log_batch_start(self.key)

--- a/corehq/apps/auditcare/tests/test_auditcare_migration.py
+++ b/corehq/apps/auditcare/tests/test_auditcare_migration.py
@@ -57,14 +57,14 @@ class TestAuditcareMigrationUtil(TestCase):
             [datetime(2020, 6, 1, 12), datetime(2020, 6, 1, 11)],
             [datetime(2020, 6, 1, 11), datetime(2020, 6, 1, 10)]
         ]
-        self.assertEquals(batches, expected_batches)
+        self.assertEqual(batches, expected_batches)
 
         batches = self.util.generate_batches(2, 'd')
         expected_batches = [
             [datetime(2020, 6, 1, 12), datetime(2020, 5, 31)],
             [datetime(2020, 5, 31), datetime(2020, 5, 30)]
         ]
-        self.assertEquals(batches, expected_batches)
+        self.assertEqual(batches, expected_batches)
 
     @patch(
         'corehq.apps.auditcare.utils.migration.AuditCareMigrationUtil.get_next_batch_start',
@@ -78,7 +78,7 @@ class TestAuditcareMigrationUtil(TestCase):
             [datetime(2013, 1, 3), datetime(2013, 1, 2)],
             [datetime(2013, 1, 2), datetime(2013, 1, 1)],
         ]
-        self.assertEquals(batches, expected_batches)
+        self.assertEqual(batches, expected_batches)
 
     @patch(
         'corehq.apps.auditcare.utils.migration.AuditCareMigrationUtil.get_next_batch_start',

--- a/corehq/apps/auditcare/utils/migration.py
+++ b/corehq/apps/auditcare/utils/migration.py
@@ -5,7 +5,7 @@ from django.core.cache import cache
 from dimagi.utils.dates import force_to_datetime
 
 from corehq.apps.auditcare.models import AuditcareMigrationMeta
-from corehq.apps.auditcare.utils.export import get_fixed_start_date_for_sql
+from corehq.apps.auditcare.utils.export import get_sql_start_date
 
 INITIAL_START_DATE = datetime(2013, 1, 1)
 CACHE_TTL = 14 * 24 * 60 * 60  # 14 days

--- a/corehq/apps/auditcare/utils/migration.py
+++ b/corehq/apps/auditcare/utils/migration.py
@@ -22,30 +22,33 @@ class AuditCareMigrationUtil():
 
     def generate_batches(self, worker_count, batch_by):
         batches = []
-        # todo : Change get_fixed_start_date_for_sql to something generic
-        cutoff_time = get_fixed_start_date_for_sql()
-        if not cutoff_time:
-            cutoff_time = datetime.now()
         with cache.lock(self.start_lock_key, timeout=10):
             start_datetime = self.get_next_batch_start()
+            print(start_datetime)
             if not start_datetime:
-                # for the first call
                 if AuditcareMigrationMeta.objects.count() != 0:
-                    raise Exception("Unable to get start time. Exiting.")
-                start_datetime = INITIAL_START_DATE
+                    raise Exception("""The migration process has been started before
+                    We are unable to determine where to start.
+                    You can manually set key using AuditCareMigraionUtil.set_next_batch_start()""")
+                # For first run set the start_datetime to the event_time of the first record
+                # in the SQL. If there are no records in SQL, start_time would be set as
+                # current time
+                start_datetime = get_sql_start_date()
+                if not start_datetime:
+                    start_datetime = datetime.now()
 
-            if start_datetime > cutoff_time:
+            if start_datetime < CUTOFF_TIME:
                 print("Migration Successfull")
                 return
 
-            start_time = _get_formatted_start_time(start_datetime, batch_by)
+            start_time = start_datetime
             end_time = None
 
             for index in range(worker_count):
                 end_time = _get_end_time(start_time, batch_by)
-                batches.append([start_time, end_time])
-                if end_time > cutoff_time:
+                if end_time < CUTOFF_TIME:
                     break
+                batches.append([start_time, end_time])
                 start_time = end_time
             self.set_next_batch_start(end_time)
 

--- a/corehq/apps/auditcare/utils/migration.py
+++ b/corehq/apps/auditcare/utils/migration.py
@@ -7,7 +7,7 @@ from dimagi.utils.dates import force_to_datetime
 from corehq.apps.auditcare.models import AuditcareMigrationMeta
 from corehq.apps.auditcare.utils.export import get_sql_start_date
 
-INITIAL_START_DATE = datetime(2013, 1, 1)
+CUTOFF_TIME = datetime(2013, 1, 1)
 CACHE_TTL = 14 * 24 * 60 * 60  # 14 days
 
 
@@ -87,11 +87,8 @@ def get_datetimes_from_key(key):
 
 def _get_end_time(start_time, batch_by):
     delta = timedelta(hours=1) if batch_by == 'h' else timedelta(days=1)
-    return start_time + delta
-
-
-def _get_formatted_start_time(start_time, batch_by):
+    end_time = start_time - delta
     if batch_by == 'h':
-        return start_time.replace(minute=0, second=0, microsecond=0)
+        return end_time.replace(minute=0, second=0, microsecond=0)
     else:
-        return start_time.replace(hour=0, minute=0, second=0, microsecond=0)
+        return end_time.replace(hour=0, minute=0, second=0, microsecond=0)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
A part of Auditcare Migration - 
https://dimagi-dev.atlassian.net/browse/SAAS-12241

This builds on top of https://dimagi-dev.atlassian.net/browse/SAAS-12241 and the base has been set on that branch itself. 

The changes alter the execution order which was earlier from older records to recent records. These changes enable the migration process to run from the latest records to older records.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There are a fair amount of tests that were added/updated to ensure that the changes work fine.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
