### PR TITLE
[SSO] temporarily make default state of general login form show both username and password fields initially

### DIFF
--- a/corehq/apps/registration/static/registration/js/user_login_form.js
+++ b/corehq/apps/registration/static/registration/js/user_login_form.js
@@ -32,7 +32,6 @@ hqDefine('registration/js/user_login_form', [
         self.isSessionExpiration = options.isSessionExpiration;
         self.passwordField = options.passwordField;
         self.passwordFormGroup = options.passwordFormGroup;
-        self.passwordFormGroup.hide();
 
         self.authUsername = ko.observable(options.initialUsername);
         self.authUsername.subscribe(function (newValue) {
@@ -47,14 +46,14 @@ hqDefine('registration/js/user_login_form', [
         self.continueTextPromise = null;
         self.defaultContinueText = gettext("Continue");
         self.continueButtonText = ko.observable(self.defaultContinueText);
-        self.showContinueButton = ko.observable(true);
+        self.showContinueButton = ko.observable(false);
         self.showContinueSpinner = ko.observable(false);
 
         self.isContinueDisabled = ko.computed(function () {
             return !emailUtils.validateEmail(self.authUsername());
         });
 
-        self.showSignInButton = ko.observable(false);
+        self.showSignInButton = ko.observable(true);
 
         /**
          * This updates the "Continue" Button text with either "Continue"


### PR DESCRIPTION
## Summary
To give certain clients extra time to communicate the SSO UI, we are TEMPORARILY defaulting to showing the username and password fields by default on the regular login screen (rather than the username + continue button).

When an SSO user types in their email address, the UI will asynchronously detect that they should login with SSO and it will then remove the password field and display the "Continue to <SSO>" button instead.

## Product Description
default view
<img width="627" alt="Screen Shot 2021-07-20 at 7 19 25 PM" src="https://user-images.githubusercontent.com/716573/126367871-1374ba85-4610-4952-8d92-53f4cc1d3faf.png">

when an sso user's email address is entered
<img width="518" alt="Screen Shot 2021-07-20 at 7 19 32 PM" src="https://user-images.githubusercontent.com/716573/126367960-f0bf0404-85bb-40e7-b125-10dd661368f1.png">

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Tested on staging. Very small change. Easily reversible on the fly with a localsettings flag.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
