### PR TITLE
Add release management priv to enterprise_plan_v1

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -126,3 +126,7 @@ enterprise_v0 = advanced_v0 + [
     privileges.DEFAULT_EXPORT_SETTINGS,
     privileges.LINKED_PROJECTS,
 ]
+
+enterprise_v1 = enterprise_v0 + [
+    privileges.RELEASE_MANAGEMENT,
+]

--- a/corehq/apps/accounting/migrations/0056_add_release_management.py
+++ b/corehq/apps/accounting/migrations/0056_add_release_management.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+from django.core.management import call_command
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _grandfather_basic_privs(apps, schema_editor):
+    call_command('cchq_prbac_bootstrap')
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('accounting', '0055_linked_projects'),
+    ]
+
+    operations = [
+        migrations.RunPython(_grandfather_basic_privs),
+    ]

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -172,6 +172,9 @@ class Command(BaseCommand):
         Role(slug=privileges.LINKED_PROJECTS,
              name='Linked Projects',
              description='Allows admin users to push and/or pull content between linked projects.'),
+        Role(slug=privileges.RELEASE_MANAGEMENT,
+             name='Release Management',
+             description='Allows access to features that help manage releasing content between projects.'),
     ]
 
     BOOTSTRAP_PLANS = [
@@ -185,6 +188,7 @@ class Command(BaseCommand):
         Role(slug='pro_plan_v1', name='Pro Plan', description=''),
         Role(slug='advanced_plan_v0', name='Advanced Plan', description=''),
         Role(slug='enterprise_plan_v0', name='Enterprise Plan', description=''),
+        Role(slug='enterprise_plan_v1', name='Enterprise Plan', description=''),
     ] + [
         Role(slug='standard_plan_report_builder_v0', name='Standard Plan - 5 Reports', description=''),
         Role(slug='pro_plan_report_builder_v0', name='Pro Plan - 5 Reports', description=''),
@@ -207,4 +211,5 @@ class Command(BaseCommand):
         'pro_plan_v1': features.pro_v1,
         'advanced_plan_v0': features.advanced_v0,
         'enterprise_plan_v0': features.enterprise_v0,
+        'enterprise_plan_v1': features.enterprise_v1,
     }

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -174,7 +174,8 @@ class Command(BaseCommand):
              description='Allows admin users to push and/or pull content between linked projects.'),
         Role(slug=privileges.RELEASE_MANAGEMENT,
              name='Release Management',
-             description='Allows access to features that help manage releasing content between projects.'),
+             description='Allows access to features that help manage releases between projects, like the linked '
+                         'projects feature.'),
     ]
 
     BOOTSTRAP_PLANS = [

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -83,6 +83,8 @@ DEFAULT_EXPORT_SETTINGS = 'default_export_settings'
 
 LINKED_PROJECTS = 'linked_projects'
 
+RELEASE_MANAGEMENT = 'release_management'
+
 MAX_PRIVILEGES = [
     LOOKUP_TABLES,
     API_ACCESS,
@@ -128,6 +130,7 @@ MAX_PRIVILEGES = [
     GEOCODER,
     DEFAULT_EXPORT_SETTINGS,
     LINKED_PROJECTS,
+    RELEASE_MANAGEMENT,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -185,4 +188,5 @@ class Titles(object):
             GEOCODER: _("Geocoder"),
             DEFAULT_EXPORT_SETTINGS: _("Default Export Settings"),
             LINKED_PROJECTS: _("Linked Projects"),
+            RELEASE_MANAGEMENT: _("Release Management"),
         }.get(privilege, privilege)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[This PR](https://github.com/dimagi/commcare-hq/pull/30059) was a mistake in that we now do not want all enterprise accounts to have access to linked projects (now called release management)...yet. This allows us to prepare for rolling all enterprise accounts to the new version, but in the meantime manually update SaaS partners to the v1 plan that contains the `release_management` privilege.

Another PR will be created to remove the linked projects privilege, but for now it will live on the enterprise_v0 plan doing nothing. There is [a PR](https://github.com/dimagi/commcare-hq/pull/30075) aimed towards removing privileges from existing roles that will likely be apart of that solution if interested.

Apologies for creating this mess by prematurely rolling out to all enterprise plans. On the bright side, this is a better name for this privilege as it will encompass multiple features.

I tested this locally and needed the new migration to trigger creating the new `release_management` privilege, rather than re-running the previous migration. I verified that I could update my plan to enterprise_plan_v1` in accounting. We are not adding the enterprise account "officially" yet, as this will still be custom added to specific accounts.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
