### PR TITLE
Replace comment to be more explicit

### DIFF
--- a/corehq/apps/custom_data_fields/models.py
+++ b/corehq/apps/custom_data_fields/models.py
@@ -16,8 +16,8 @@ COMMCARE_USER_TYPE_DEMO = 'demo'
 # This stores the id of the user's CustomDataFieldsProfile, if any
 PROFILE_SLUG = "commcare_profile"
 
-# This list is used to grandfather in existing data, any new fields should use
-# the system prefix defined below
+# Any new fields should use the system prefix defined by SYSTEM_PREFIX
+# SYSTEM_FIELDS is a list of fields predating that convention that have been exempted from it
 SYSTEM_FIELDS = ("commtrack-supply-point", 'name', 'type', 'owner_id', 'external_id', 'hq_user_id',
                  COMMCARE_USER_TYPE_KEY)
 SYSTEM_PREFIX = "commcare"

--- a/corehq/apps/custom_data_fields/models.py
+++ b/corehq/apps/custom_data_fields/models.py
@@ -16,8 +16,8 @@ COMMCARE_USER_TYPE_DEMO = 'demo'
 # This stores the id of the user's CustomDataFieldsProfile, if any
 PROFILE_SLUG = "commcare_profile"
 
-# Any new fields should use the system prefix defined by SYSTEM_PREFIX
-# SYSTEM_FIELDS is a list of fields predating that convention that have been exempted from it
+# Any new fields should use the system prefix defined by SYSTEM_PREFIX.
+# SYSTEM_FIELDS is a list of fields predating SYSTEM_PREFIX that are exempt from that convention.
 SYSTEM_FIELDS = ("commtrack-supply-point", 'name', 'type', 'owner_id', 'external_id', 'hq_user_id',
                  COMMCARE_USER_TYPE_KEY)
 SYSTEM_PREFIX = "commcare"


### PR DESCRIPTION
## Summary

Replace comment to be more explicit and avoid unintentionally problematic vocabulary. Just something I came across. There are a few usages of 'grandfather' in this sense in the codebase I invite others to change, but this was the simplest to because it was in a comment rather than a variable name, filename, or in a couch view.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Just a comment change
