### PR TITLE
Ensure hubspot JS does not run on projects that have opted out of hubspot

### DIFF
--- a/corehq/apps/analytics/tests/test_utils.py
+++ b/corehq/apps/analytics/tests/test_utils.py
@@ -1,0 +1,91 @@
+from django.test import TestCase, RequestFactory, override_settings
+
+from corehq.apps.accounting.models import (
+    Subscription,
+    DefaultProductPlan,
+    SoftwarePlanEdition,
+)
+from corehq.apps.analytics.utils import is_hubspot_js_allowed_for_request
+from corehq.apps.domain.models import Domain
+from corehq.apps.accounting.tests import generator as accounting_generator
+
+
+class TestIsHubspotJsAllowedForRequest(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        billing_contact = accounting_generator.create_arbitrary_web_user_name()
+        dimagi_user = accounting_generator.create_arbitrary_web_user_name(is_dimagi=True)
+        plan = DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.ADVANCED)
+
+        account_no_hubspot = accounting_generator.billing_account(
+            dimagi_user, billing_contact
+        )
+        account_no_hubspot.block_hubspot_data_for_all_users = True
+        account_no_hubspot.save()
+
+        cls.domain_no_hubspot = Domain.get_or_create_with_name(
+            "domain-no-hubspot-001",
+            is_active=True
+        )
+        cls.subscription_no_hubspot = Subscription.new_domain_subscription(
+            account=account_no_hubspot,
+            domain=cls.domain_no_hubspot.name,
+            plan_version=plan,
+        )
+
+        regular_account = accounting_generator.billing_account(
+            dimagi_user, billing_contact
+        )
+        cls.regular_domain = Domain.get_or_create_with_name(
+            "domain-with-analytics-001",
+            is_active=True
+        )
+        cls.regular_subscription = Subscription.new_domain_subscription(
+            account=regular_account,
+            domain=cls.regular_domain.name,
+            plan_version=plan,
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.request = RequestFactory().get('/analytics/test')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_no_hubspot.delete()
+        cls.regular_domain.delete()
+        super().tearDownClass()
+
+    def test_returns_false_if_account_disabled_hubspot(self):
+        """
+        Ensures that if the BillingAccount associated with a subscription
+        has disabled hubspot, is_hubspot_js_allowed_for_request returns False
+        """
+        self.request.subscription = self.subscription_no_hubspot
+        self.assertFalse(is_hubspot_js_allowed_for_request(self.request))
+
+    def test_returns_true_for_normal_subscription(self):
+        """
+        Ensures that if the BillingAccount associated with a subscription
+        has NOT disabled hubspot, is_hubspot_js_allowed_for_request returns True
+        """
+        self.request.subscription = self.regular_subscription
+        self.assertTrue(is_hubspot_js_allowed_for_request(self.request))
+
+    def test_returns_true_if_no_subscription(self):
+        """
+        Ensures that if no subscription attribute is set on the HttpRequest
+        object, is_hubspot_js_allowed_for_request returns True
+        """
+        self.assertTrue(is_hubspot_js_allowed_for_request(self.request))
+
+    @override_settings(IS_SAAS_ENVIRONMENT=False)
+    def test_returns_false_if_not_saas_environment(self):
+        """
+        Ensures that if the environment is not a SaaS environment,
+        is_hubspot_js_allowed_for_request returns False
+        """
+        self.assertFalse(is_hubspot_js_allowed_for_request(self.request))

--- a/corehq/apps/analytics/tests/test_utils.py
+++ b/corehq/apps/analytics/tests/test_utils.py
@@ -59,6 +59,7 @@ class TestIsHubspotJsAllowedForRequest(TestCase):
         cls.regular_domain.delete()
         super().tearDownClass()
 
+    @override_settings(IS_SAAS_ENVIRONMENT=True)
     def test_returns_false_if_account_disabled_hubspot(self):
         """
         Ensures that if the BillingAccount associated with a subscription
@@ -67,6 +68,7 @@ class TestIsHubspotJsAllowedForRequest(TestCase):
         self.request.subscription = self.subscription_no_hubspot
         self.assertFalse(is_hubspot_js_allowed_for_request(self.request))
 
+    @override_settings(IS_SAAS_ENVIRONMENT=True)
     def test_returns_true_for_normal_subscription(self):
         """
         Ensures that if the BillingAccount associated with a subscription
@@ -75,6 +77,7 @@ class TestIsHubspotJsAllowedForRequest(TestCase):
         self.request.subscription = self.regular_subscription
         self.assertTrue(is_hubspot_js_allowed_for_request(self.request))
 
+    @override_settings(IS_SAAS_ENVIRONMENT=True)
     def test_returns_true_if_no_subscription(self):
         """
         Ensures that if no subscription attribute is set on the HttpRequest

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -302,3 +302,25 @@ def remove_blocked_domain_contacts_from_hubspot(stdout=None):
                 }
             )
 
+
+def is_hubspot_js_allowed_for_request(request):
+    """
+    This determines whether a particular request is allowed to load any
+    Hubspot javascript, even when Hubspot analytics is supported by the
+    environment. This is done to ensure that no accidental Hubspot popups and
+    scripts are executed on projects that have explicitly asked to be excluded
+    from Hubspot analytics.
+    :param request: HttpRequest
+    :return: boolean (True if Hubspot javascript is allowed)
+    """
+    if not settings.IS_SAAS_ENVIRONMENT:
+        return False
+
+    is_hubspot_js_allowed = True
+    if hasattr(request, 'subscription'):
+        try:
+            account = request.subscription.account
+            is_hubspot_js_allowed = not account.block_hubspot_data_for_all_users
+        except BillingAccount.DoesNotExist:
+            pass
+    return is_hubspot_js_allowed

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -9,6 +9,7 @@ from ws4redis.context_processors import default
 from corehq import feature_previews, privileges, toggles
 from corehq.apps.accounting.models import BillingAccount, SubscriptionType
 from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.apps.analytics.utils import is_hubspot_js_allowed_for_request
 from corehq.apps.hqwebapp.utils import get_environment_friendly_name
 
 COMMCARE = 'commcare'
@@ -104,6 +105,11 @@ def js_api_keys(request):
     }
     if getattr(request, 'project', None) and request.project.ga_opt_out and api_keys['ANALYTICS_IDS'].get('GOOGLE_ANALYTICS_API_ID'):
         del api_keys['ANALYTICS_IDS']['GOOGLE_ANALYTICS_API_ID']
+
+    if (api_keys['ANALYTICS_IDS'].get('HUBSPOT_API_ID')
+            and not is_hubspot_js_allowed_for_request(request)):
+        del api_keys['ANALYTICS_IDS']['HUBSPOT_API_ID']
+
     return api_keys
 
 


### PR DESCRIPTION
## Summary
We experienced an issue recently where some feature of hubspot launched a popup on HQ asking "Let us know if you have a query or comment". We are still unsure if this was a new "feature" of hubspot or a new form that was added. We've since ensured that any new forms only load at a specific address.

Regardless, we want to prevent this from happening in the future, so I've added a context processor to determine whether we should allow the hubspot js to load at all depending on whether the block_hubspot_data_for_all_users flag is set at the BillingAccount level.

see https://dimagi-dev.atlassian.net/browse/SAAS-12412
this is part of a followup ticket https://dimagi-dev.atlassian.net/browse/SAAS-12416

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added tests for new utility

### Safety story
Fairly small isolated change. Testing this out on staging.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
