### PR TITLE
Fix tab issue

### DIFF
--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -104,7 +104,7 @@ hqDefine("linked_domain/js/domain_links", [
             return self.isDownstreamDomain ? "in active" : "";
         });
 
-        self.manageTabActiveStatus = self.isDownstreamDomain ? "" : "in active";
+        self.manageTabActiveStatus = self.isDownstreamDomain || document.getElementById("tabs-push-content").classList.contains("active") ? "" : "in active";
 
         self.showGetStarted = ko.computed(function () {
             return !self.isUpstreamDomain() && !self.isDownstreamDomain;

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -104,7 +104,7 @@ hqDefine("linked_domain/js/domain_links", [
             return self.isDownstreamDomain ? "in active" : "";
         });
 
-        self.manageTabActiveStatus = self.isDownstreamDomain || document.getElementById("tabs-push-content").classList.contains("active") ? "" : "in active";
+        self.manageTabActiveStatus = self.isDownstreamDomain ? "" : "in active";
 
         self.showGetStarted = ko.computed(function () {
             return !self.isUpstreamDomain() && !self.isDownstreamDomain;

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -9,16 +9,17 @@
   {% registerurl 'linked_domain:domain_link_rmi' domain %}
   {% registerurl 'app_settings' domain '---' %}
 
+  {% comment %}
+    Ideally would keep the tab headers out of the .ko-template div because they use .sticky-tabs, which is subject
+    to race condition problems if the tabs aren't visible when its document ready handler runs. This page needs to
+    update tabs dynamically, so here we are.
+  {% endcomment %}
   <div id="ko-linked-projects" class="ko-template">
     <!-- ko if: showGetStarted -->
       {% include 'linked_domain/get_started.html' %}
     <!-- /ko -->
     <!-- ko ifnot: showGetStarted -->
       <!-- ko if: showMultipleTabs -->
-        {% comment %}
-          Keep the tab headers out of the .ko-template div because they use .sticky-tabs, which is subject
-          to race condition problems if the tabs aren't visible when its document ready handler runs.
-        {% endcomment %}
         <ul class="nav nav-tabs sticky-tabs">
           <!-- ko if: isUpstreamDomain -->
             <li class="active"><a data-toggle="tab" href="#tabs-manage-downstream">{% trans "Downstream Projects" %}</a></li>

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -9,18 +9,13 @@
   {% registerurl 'linked_domain:domain_link_rmi' domain %}
   {% registerurl 'app_settings' domain '---' %}
 
-  {% comment %}
-    Ideally would keep the tab headers out of the .ko-template div because they use .sticky-tabs, which is subject
-    to race condition problems if the tabs aren't visible when its document ready handler runs. This page needs to
-    update tabs dynamically, so here we are.
-  {% endcomment %}
   <div id="ko-linked-projects" class="ko-template">
     <!-- ko if: showGetStarted -->
       {% include 'linked_domain/get_started.html' %}
     <!-- /ko -->
     <!-- ko ifnot: showGetStarted -->
       <!-- ko if: showMultipleTabs -->
-        <ul class="nav nav-tabs sticky-tabs">
+        <ul class="nav nav-tabs">
           <!-- ko if: isUpstreamDomain -->
             <li class="active"><a data-toggle="tab" href="#tabs-manage-downstream">{% trans "Downstream Projects" %}</a></li>
             <li><a data-toggle="tab" href="#tabs-push-content">{% trans "Push Content" %}</a></li>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
QA flagged [this issue with tabs](https://dimagi-dev.atlassian.net/browse/QA-3312) likely caused by including the sticky tab headers within the ko-template class. Unfortunately this seems necessary for the UI to function as desired, and the quick fix is to check if the pull tab is active before setting the manage downstream tab as active. 


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA ticket linked above as this was found in QA.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
