### PR TITLE
Validate case name and external ID max length

### DIFF
--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -377,7 +377,7 @@ class _CaseImportRow(object):
 
     def _check_valid_external_id(self):
         if self.external_id and len(self.external_id) > 255:
-            raise exceptions.ExternalIdTooLong('name')
+            raise exceptions.ExternalIdTooLong('external_id')
 
         if self.config.search_field == 'external_id' and not self.search_id:
             # do not allow blank external id since we save this

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -358,8 +358,9 @@ class _CaseImportRow(object):
         self.owner_accessor = owner_accessor
 
         self.case_name = fields_to_update.pop('name', None)
+        self._check_case_name()
         self.external_id = fields_to_update.pop('external_id', None)
-        self.check_valid_external_id()
+        self._check_valid_external_id()
         self.parent_id = fields_to_update.pop('parent_id', None)
         self.parent_external_id = fields_to_update.pop('parent_external_id', None)
         self.parent_type = fields_to_update.pop('parent_type', self.config.case_type)
@@ -370,7 +371,14 @@ class _CaseImportRow(object):
         self.uploaded_owner_id = fields_to_update.pop('owner_id', None)
         self.date_opened = fields_to_update.pop(CASE_TAG_DATE_OPENED, None)
 
-    def check_valid_external_id(self):
+    def _check_case_name(self):
+        if self.case_name and len(self.case_name) > 255:
+            raise exceptions.CaseNameTooLong('name')
+
+    def _check_valid_external_id(self):
+        if self.external_id and len(self.external_id) > 255:
+            raise exceptions.ExternalIdTooLong('name')
+
         if self.config.search_field == 'external_id' and not self.search_id:
             # do not allow blank external id since we save this
             raise exceptions.BlankExternalId()

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -22,6 +22,7 @@ from corehq.apps.receiverwrapper.rate_limiter import rate_limit_submission
 from corehq.apps.users.cases import get_wrapped_owner
 from corehq.apps.users.models import CouchUser, DomainPermissionsMirror
 from corehq.apps.users.util import format_username
+from corehq.form_processor.models import STANDARD_CHARFIELD_LENGTH
 from corehq.toggles import BULK_UPLOAD_DATE_OPENED, DOMAIN_PERMISSIONS_MIRROR
 from corehq.util.metrics import metrics_counter, metrics_histogram
 from corehq.util.metrics.load_counters import case_load_counter
@@ -372,11 +373,11 @@ class _CaseImportRow(object):
         self.date_opened = fields_to_update.pop(CASE_TAG_DATE_OPENED, None)
 
     def _check_case_name(self):
-        if self.case_name and len(self.case_name) > 255:
+        if self.case_name and len(self.case_name) > STANDARD_CHARFIELD_LENGTH:
             raise exceptions.CaseNameTooLong('name')
 
     def _check_valid_external_id(self):
-        if self.external_id and len(self.external_id) > 255:
+        if self.external_id and len(self.external_id) > STANDARD_CHARFIELD_LENGTH:
             raise exceptions.ExternalIdTooLong('external_id')
 
         if self.config.search_field == 'external_id' and not self.search_id:

--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -2,6 +2,8 @@ from django.utils.translation import ugettext_lazy, ugettext_noop
 
 import xlrd
 
+from corehq.form_processor.models import STANDARD_CHARFIELD_LENGTH
+
 
 class ImporterError(Exception):
     """
@@ -142,9 +144,9 @@ class TooManyMatches(CaseRowError):
 
 class CaseNameTooLong(CaseRowError):
     title = ugettext_noop('Name Too Long')
-    message = ugettext_lazy("The case name cannot be longer than 255 characters")
+    message = ugettext_lazy(f"The case name cannot be longer than {STANDARD_CHARFIELD_LENGTH} characters")
 
 
 class ExternalIdTooLong(CaseRowError):
     title = ugettext_noop('External ID Too Long')
-    message = ugettext_lazy("The external id cannot be longer than 255 characters")
+    message = ugettext_lazy(f"The external id cannot be longer than {STANDARD_CHARFIELD_LENGTH} characters")

--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -138,3 +138,13 @@ class TooManyMatches(CaseRowError):
         "These rows matched more than one case at the same time - this means "
         "that there are cases in your system with the same external ID."
     )
+
+
+class CaseNameTooLong(CaseRowError):
+    title = ugettext_noop('Name Too Long')
+    message = ugettext_lazy("The case name cannot be longer than 255 characters")
+
+
+class ExternalIdTooLong(CaseRowError):
+    title = ugettext_noop('External ID Too Long')
+    message = ugettext_lazy("The external id cannot be longer than 255 characters")

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -630,6 +630,19 @@ class ImporterTest(TestCase):
         ])
         self.assertIn(exceptions.InvalidOwner.title, res['errors'])
 
+    @run_with_all_backends
+    def test_case_name_too_long(self):
+        res = self.import_mock_file([
+            ['case_id', 'name', 'external_id', 'favorite_color'],
+            ['', 'normal name', '', 'blue'],
+            ['', 'A' * 300, '', 'polka dot'],
+            ['', 'another normal name', 'A' * 300, 'polka dot'],
+        ])
+        self.assertEqual(1, res['created_count'])
+        self.assertEqual(2, res['failed_count'])
+        self.assertIn(exceptions.CaseNameTooLong.title, res['errors'])
+        self.assertIn(exceptions.ExternalIdTooLong.title, res['errors'])
+
 
 def make_worksheet_wrapper(*rows):
     return WorksheetWrapper(make_worksheet(rows))

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -32,6 +32,7 @@ from corehq.form_processor.models import (
     CommCareCaseIndexSQL,
     CommCareCaseSQL,
     RebuildWithReason,
+    STANDARD_CHARFIELD_LENGTH,
 )
 from corehq.form_processor.update_strategy_base import UpdateStrategy
 from corehq.util import cmp
@@ -53,10 +54,10 @@ def _validate_length(length):
 
 PROPERTY_TYPE_MAPPING = {
     'opened_on': iso8601.parse_date,
-    'name': _validate_length(255),
-    'type': _validate_length(255),
-    'owner_id': _validate_length(255),
-    'external_id': _validate_length(255),
+    'name': _validate_length(STANDARD_CHARFIELD_LENGTH),
+    'type': _validate_length(STANDARD_CHARFIELD_LENGTH),
+    'owner_id': _validate_length(STANDARD_CHARFIELD_LENGTH),
+    'external_id': _validate_length(STANDARD_CHARFIELD_LENGTH),
 }
 
 

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -43,6 +43,8 @@ from memoized import memoized
 from .abstract_models import AbstractXFormInstance, AbstractCommCareCase, IsImageMixin
 from .exceptions import AttachmentNotFound
 
+STANDARD_CHARFIELD_LENGTH = 255
+
 XFormInstanceSQL_DB_TABLE = 'form_processor_xforminstancesql'
 XFormOperationSQL_DB_TABLE = 'form_processor_xformoperationsql'
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://sentry.io/organizations/dimagi/issues/2025167624/
There's a [hard limit](https://github.com/dimagi/commcare-hq/blob/703310fd517e34ffc74ee1b42389f6620f05b960/corehq/form_processor/backends/sql/update_strategy.py#L54-L60) on the formprocessing side, so if these are too long you'll see errors (at least on the SQL backend)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
Catch one category of errors in case import and return an actionable error message.  These were previously being reported only as:

> Problems in importing cases. Please check the Excel file.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
tests included in PR

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
