### PR TITLE
Linked Project Space UI Improvements

### DIFF
--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -25,7 +25,7 @@
             <li><a data-toggle="tab" href="#tabs-push-content">{% trans "Push Content" %}</a></li>
           <!-- /ko -->
           <!-- ko if: isDownstreamDomain -->
-            <li class="active"><a data-toggle="tab" href="#tabs-pull-content">{% trans "Manage Linked Project" %}</a></li>
+            <li class="active"><a data-toggle="tab" href="#tabs-pull-content">{% trans "Manage Linked Project Space" %}</a></li>
             {% if view_data.linkable_ucr %}
               <li><a data-toggle="tab" href="#tabs-remote-report">{% trans "Add Remote Reports" %}</a></li>
             {% endif %}
@@ -33,7 +33,7 @@
         </ul>
       <!-- /ko -->
       <!-- ko ifnot: showMultipleTabs -->
-        <h2>{% trans "Manage Linked Project" %}</h2>  {# header for the only tab that will be displayed #}
+        <h2>{% trans "Manage Linked Project Space" %}</h2>  {# header for the only tab that will be displayed #}
       <!-- /ko -->
       <div id="domain_links">
         <div class="tab-content">
@@ -65,9 +65,9 @@
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>
-          <h4 class="modal-title">{% trans 'Add Downstream Project' %}</h4>
+          <h4 class="modal-title">{% trans 'Add Downstream Project Space' %}</h4>
           <!-- ko if: parent.showGetStarted -->
-            <p>To make this project an upstream project, you need to add a downstream project.</p>
+            <p>To make this project space an upstream project space, you need to add a downstream project space.</p>
           <!-- /ko -->
         </div>
         <div class="modal-body">

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -21,7 +21,7 @@
         {% endcomment %}
         <ul class="nav nav-tabs sticky-tabs">
           <!-- ko if: isUpstreamDomain -->
-            <li class="active"><a data-toggle="tab" href="#tabs-manage-downstream">{% trans "Downstream Projects" %}</a></li>
+            <li class="active"><a data-toggle="tab" href="#tabs-manage-downstream">{% trans "Downstream Project Spaces" %}</a></li>
             <li><a data-toggle="tab" href="#tabs-push-content">{% trans "Push Content" %}</a></li>
           <!-- /ko -->
           <!-- ko if: isDownstreamDomain -->

--- a/corehq/apps/linked_domain/templates/linked_domain/get_started.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/get_started.html
@@ -2,22 +2,27 @@
 {% load i18n %}
 
 <div id="ko-getting-started" data-bind="with: $root.gettingStartedViewModel">
-  <h3>{% trans "Linked Projects" %}</h3>
+  <h3>{% trans "Linked Project Spaces" %}</h3>
+  <p>{% trans "Create links between upstream and downstream project spaces." %}</p>
+  <p>{% trans "Linked project spaces allow you to:" %}</p>
+  <ol>
+    <li>{% trans "Push content to a downstream project space" %}</li>
+    <li>{% trans "Pull content from an upstream project space" %}</li>
+  </ol>
   <p>
     {% blocktrans %}
-      Get started by creating a link between two projects, allowing you to push and pull content.<br/>
-      If you want to pull content from another project into this project, make it a downstream project.<br/>
-      <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about linked projects.
+      <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about Linked Project Spaces.
     {% endblocktrans %}
   </p>
   <div class="spacer"></div>
   <div class="row">
     <!-- ko if: upstreamDomains().length > 0 -->
       <div class="col-sm-6">
-        <h4>Add as Downstream Project</h4>
+        <h4>{% trans "Link to an existing upstream project space" %}</h4>
         <p>
           {% blocktrans %}
-            If you want to pull content from an upstream project, link this project to an upstream project.
+            To pull content from an upstream project space, link this project space to an upstream project space.
+            The link can only be created from the upstream project space.
           {% endblocktrans %}
         </p>
         <!-- ko if: upstreamDomains().length == 1 -->
@@ -25,7 +30,7 @@
                 class="btn btn-primary"
                 id="go-to-upstream-project"
                 data-bind="click: goToUpstream">
-            {% trans "Go to upstream project" %}
+            {% trans "Go To Upstream Project Space" %}
           </button>
         <!-- /ko -->
         <!-- ko if: upstreamDomains().length > 1 -->
@@ -36,10 +41,11 @@
       </div>
     <!-- /ko -->
     <div class="col-sm-6">
-      <h4>{% trans "Make Upstream Project" %}</h4>
+      <h4>{% trans "Make this an upstream project space" %}</h4>
       <p>
         {% blocktrans %}
-          If you want to push content in this project to other projects, make this an upstream project.
+          To push content from this project space to other project spaces, make this project space an upstream project space.
+          This can be done by linking this project space to downstream project spaces.
         {% endblocktrans %}
       </p>
       <button type="button"
@@ -48,7 +54,7 @@
               id="add-downstream-domain"
               data-toggle="modal"
               data-target="#new-downstream-domain-modal">
-        {% trans "Yes, make upstream project" %}
+        {% trans "Link Downstream Project Spaces" %}
       </button>
     </div>
   </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/manage_downstream_domains_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/manage_downstream_domains_tab.html
@@ -3,11 +3,11 @@
 
 <div id="ko-tabs-manage-downstream" data-bind="with: $root">
   <div data-bind="if: domain_links().length">
-    <h3>{% trans "Manage Downstream Projects" %}</h3>
+    <h3>{% trans "Manage Downstream Project Spaces" %}</h3>
     <p>
       {% blocktrans %}
-        This project is an upstream project space for the projects listed below.<br/>
-        <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about Linked Projects.
+        This project space is an upstream project space for the project spaces listed below.<br/>
+        <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about Linked Project Spaces.
       {% endblocktrans %}
     </p>
     {% if is_erm_ff_enabled %}
@@ -16,24 +16,24 @@
               id="add-downstream-domain"
               data-toggle="modal"
               data-target="#new-downstream-domain-modal">
-        <i class="fa fa-plus"></i> {% trans "Add Downstream Project" %}
+        <i class="fa fa-plus"></i> {% trans "Add Downstream Project Space" %}
       </button>
     {% endif %}
     <div class="spacer"></div>
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title">{% trans 'Downstream Projects' %}</h3>
+        <h3 class="panel-title">{% trans 'Downstream Project Spaces' %}</h3>
       </div>
       <div class="panel-body">
         <search-box data-apply-bindings="false"
                   params="value: query,
                           action: filter,
                           immediate: true,
-                          placeholder: '{% trans_html_attr "Search Downstream Projects..." %}'"></search-box>
+                          placeholder: '{% trans_html_attr "Search Downstream Project Spaces..." %}'"></search-box>
         <table class="table table-striped table-hover" id="linked-domains-table">
           <thead>
           <tr>
-            <th>{% trans "Project Name" %}</th>
+            <th>{% trans "Project Space Name" %}</th>
             <th>{% trans "Last Updated" %} ({{ timezone }})</th>
             <th></th>
           </tr>
@@ -52,7 +52,7 @@
                   <div class="modal-content">
                     <div class="modal-header">
                       <button type="button" class="close" data-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>
-                      <h4 class="modal-title">{% trans 'Remove Project Link' %}</h4>
+                      <h4 class="modal-title">{% trans 'Remove Project Space Link' %}</h4>
                     </div>
                     <div class="modal-body">
                       <h4>
@@ -62,8 +62,7 @@
                       </h4>
                       <p>
                         {% blocktrans %}
-                          Removing the link will also remove links between upstream and downstream data models.<br/>
-                          <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about what happens when downstream project links are removed.
+                          <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about what happens when downstream project space links are removed.
                         {% endblocktrans %}
                       </p>
                     </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
@@ -5,26 +5,26 @@
   <div data-bind="if: domainLink">
     <p>
       {% blocktrans %}
-        This project is linked to the upstream project <a data-bind="attr: {'href': domainLink.upstreamUrl}, text: domainLink.master_domain"></a>.<br/>
-        The data models below can be synced with the existing data models in the upstream project.<br/>
-        <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about syncing data between linked projects.
+        This project space is linked to the upstream project space <a data-bind="attr: {'href': domainLink.upstreamUrl}, text: domainLink.master_domain"></a>.<br/>
+        The content below can be synced with the existing content in the upstream project space.<br/>
+        <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about pulling content with Linked Project Spaces.
       {% endblocktrans %}
     </p>
 
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title">{% trans 'Linked Data Models' %}</h3>
+        <h3 class="panel-title">{% trans 'Linked Content' %}</h3>
       </div>
       <div class="panel-body">
         <search-box data-apply-bindings="false"
           params="value: query,
                   action: filter,
                   immediate: true,
-                  placeholder: '{% trans_html_attr "Search Data Models..." %}'"></search-box>
+                  placeholder: '{% trans_html_attr "Search Content..." %}'"></search-box>
         <table class="table table-striped table-hover">
           <thead>
           <tr>
-            <th class="col-sm-5">{% trans "Linked Model" %}</th>
+            <th class="col-sm-5">{% trans "Linked Content" %}</th>
             <th class="col-sm-2">{% trans "Last Updated" %} ({{ timezone }})</th>
             <th class="col-sm-5"></th>
           </tr>
@@ -52,8 +52,8 @@
                       </h4>
                       <p>
                         {% blocktrans %}
-                          This will pull <!-- ko text: name --><!-- /ko --> from the upstream project <b data-bind="text: domainLink.master_domain"></b>, overwriting the existing <!-- ko text: name --><!-- /ko --> data model.<br/>
-                          <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about pulling content from an upstream project into a downstream project.
+                          This will pull <!-- ko text: name --><!-- /ko --> from the upstream project space <b data-bind="text: domainLink.master_domain"></b>, overwriting the existing <!-- ko text: name --><!-- /ko -->.<br/>
+                          <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about pulling content from an upstream project space into a downstream project space.
                         {% endblocktrans %}
                       </p>
                     </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
@@ -6,15 +6,15 @@
     <h3>{% trans "Push Content" %}</h3>
     <p>
       {% blocktrans %}
-        Select which data models you would like to push to the specified downstream project spaces.<br/>
-        <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about pushing content with linked projects.
+        Select which content you would like to push to the specified downstream project spaces.<br/>
+        <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about pushing content with Linked Project Spaces.
       {% endblocktrans %}
     </p>
     <div class="spacer"></div>
     <form class="form-horizontal">
       <div class="form-group">
         <label class="col-sm-3 col-md-2 control-label">
-          {% trans "Models" %}
+          {% trans "Content" %}
         </label>
         <div class="col-sm-9 col-md-10 controls">
           <select multiple class="form-control"
@@ -32,7 +32,7 @@
       </div>
       <div class="form-group">
         <label class="col-sm-3 col-md-2 control-label">
-          {% trans "Projects" %}
+          {% trans "Project Spaces" %}
         </label>
         <div class="col-sm-9 col-md-10 controls">
           <select multiple class="form-control"
@@ -41,9 +41,9 @@
                              optionsText: 'linked_domain',
                              optionsValue: 'linked_domain',
                              multiselect: {
-                                 selectableHeaderTitle: '{% trans_html_attr "All projects" %}',
-                                 selectedHeaderTitle: '{% trans_html_attr "Projects to push to" %}',
-                                 searchItemTitle: '{% trans_html_attr "Search projects" %}',
+                                 selectableHeaderTitle: '{% trans_html_attr "All project spaces" %}',
+                                 selectedHeaderTitle: '{% trans_html_attr "Project spaces to push to" %}',
+                                 searchItemTitle: '{% trans_html_attr "Search project spaces" %}',
                             }">
           </select>
         </div>

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1980,11 +1980,11 @@ def _get_feature_flag_items(domain):
 
     if toggles.LINKED_DOMAINS.enabled(domain):
         feature_flag_items.append({
-            'title': _('Linked Projects'),
+            'title': _('Linked Project Spaces'),
             'url': reverse('domain_links', args=[domain])
         })
         feature_flag_items.append({
-            'title': _('Linked Project History'),
+            'title': _('Linked Project Space History'),
             'url': reverse('domain_report_dispatcher', args=[domain, 'project_link_report'])
         })
     return feature_flag_items


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-181)

Following [this doc](https://dimagi-dev.atlassian.net/wiki/spaces/PD/pages/1943732228/UI+improvements) to update text to be more consistent and clear.

- be consistent about "project space", not "project"
- be consistent about "content", not "data models" (still up for debate, but I picked one)
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Subtle text changes on linked project space pages.
## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Text changes.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will be part of a regression test.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
