### PR TITLE
Cleanup for make superuser access

### DIFF
--- a/corehq/apps/domain/management/commands/make_superuser.py
+++ b/corehq/apps/domain/management/commands/make_superuser.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
 
     @signalcommand
     def handle(self, username, **options):
-        if settings.IS_SAAS_ENVIRONMENT or settings.IS_INDIA_ENVIRONMENT:
+        if not settings.ALLOW_MAKE_SUPERUSER_COMMAND:
             from dimagi.utils.web import get_site_domain
             raise CommandError(f"""You cannot run this command in SaaS Enviornments.
             Use https://{get_site_domain()}/hq/admin/superuser_management/ for granting superuser permissions""")

--- a/settings.py
+++ b/settings.py
@@ -1162,8 +1162,6 @@ _location = lambda x: os.path.join(FILEPATH, x)
 
 IS_SAAS_ENVIRONMENT = SERVER_ENVIRONMENT in ('production', 'staging')
 
-IS_INDIA_ENVIRONMENT = SERVER_ENVIRONMENT == 'india'
-
 ALLOW_MAKE_SUPERUSER_COMMAND = True
 
 if 'KAFKA_URL' in globals():

--- a/settings.py
+++ b/settings.py
@@ -1164,6 +1164,8 @@ IS_SAAS_ENVIRONMENT = SERVER_ENVIRONMENT in ('production', 'staging')
 
 IS_INDIA_ENVIRONMENT = SERVER_ENVIRONMENT == 'india'
 
+ALLOW_MAKE_SUPERUSER_COMMAND = True
+
 if 'KAFKA_URL' in globals():
     import warnings
     warnings.warn(inspect.cleandoc("""KAFKA_URL is deprecated


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This is cleanup for https://github.com/dimagi/commcare-hq/pull/29787
PR adds a new localsettings `ALLOW_MAKE_SUPERUSER_COMMAND` which has been set to False on India, Prod and staging in https://github.com/dimagi/commcare-cloud/pull/4832

This should not be deployed until it's commcare cloud PR is merged.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Pretty low risk and has been tested on local.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
