### PR TITLE
don't restrict knockout select2 binding to single selects

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select2_knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select2_knockout_bindings.ko.js
@@ -32,7 +32,6 @@ hqDefine("hqwebapp/js/select2_knockout_bindings.ko", [
         self.init = function (element) {
             var $el = $(element);
             $el.select2({
-                multiple: false,
                 width: "element",
             });
         };


### PR DESCRIPTION
## Summary
Restricting in JS like this prevents using this binding for multiselects. The standard way to tell select2 that you want a multiselect is to add the `multiple` attribute to the select element:
```html
<select multiple ...>
```

There is another select2 binding which is used in the CLE: https://github.com/dimagi/commcare-hq/blob/20b4cb2f0ad31e5ac56533ecf96d151258bec993/corehq/apps/reports/static/reports/v2/js/datagrid/binding_handlers.js#L61


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
I've looked at all the usages of select2 bindings this change should not impact any of them.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
