### PR TITLE
Use repeater name in success message

### DIFF
--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -171,7 +171,7 @@ class AddRepeaterView(BaseRepeaterView):
         return self.repeater_class()
 
     def post_save(self, request, repeater):
-        messages.success(request, _("Forwarding set up to %s" % repeater.url))
+        messages.success(request, _("Forwarding set up to {}").format(repeater.name))
         return HttpResponseRedirect(
             reverse(DomainForwardingOptionsView.urlname, args=[self.domain])
         )


### PR DESCRIPTION
## Summary

Small. Fixes the success message when adding a new data forwarder.

![image](https://user-images.githubusercontent.com/708421/126623387-92c3e1a4-384a-4f4c-8d3c-7bdea3fec347.png)

Context: [SC-1635](https://dimagi-dev.atlassian.net/browse/SC-1635)


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Test included.


### Safety story

Only change is a UI message.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
