### PR TITLE
Enable the case search index when turning on new case API flag

### DIFF
--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -97,21 +97,10 @@ class TestCaseAPI(TestCase):
         self.assertEqual(res.json()['case_id'], case_id)
 
     def test_basic_get_list(self):
-        with patch('corehq.apps.hqcase.views.domain_needs_search_index',
-                   lambda domain: True):
-            with patch('corehq.apps.hqcase.views.get_list',
-                       lambda *args: {'example': 'result'}):
-                res = self.client.get(reverse('case_api', args=(self.domain,)))
+        with patch('corehq.apps.hqcase.views.get_list', lambda *args: {'example': 'result'}):
+            res = self.client.get(reverse('case_api', args=(self.domain,)))
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.json(), {'example': 'result'})
-
-    def test_missing_case_search_index(self):
-        res = self.client.get(reverse('case_api', args=(self.domain,)))
-        self.assertEqual(res.status_code, 405)
-        self.assertEqual(
-            res.json()['error'],
-            "You need the case search index to use this feature"
-        )
 
     def test_case_not_found(self):
         res = self.client.get(reverse('case_api', args=(self.domain, 'fake_id')))

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -3,6 +3,8 @@ import uuid
 from django.test import TestCase
 from django.urls import reverse
 
+from mock import patch
+
 from casexml.apps.case.mock import CaseBlock
 
 from corehq import privileges
@@ -93,6 +95,23 @@ class TestCaseAPI(TestCase):
         res = self.client.get(reverse('case_api', args=(self.domain, case_id)))
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.json()['case_id'], case_id)
+
+    def test_basic_get_list(self):
+        with patch('corehq.apps.hqcase.views.domain_needs_search_index',
+                   lambda domain: True):
+            with patch('corehq.apps.hqcase.views.get_list',
+                       lambda *args: {'example': 'result'}):
+                res = self.client.get(reverse('case_api', args=(self.domain,)))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json(), {'example': 'result'})
+
+    def test_missing_case_search_index(self):
+        res = self.client.get(reverse('case_api', args=(self.domain,)))
+        self.assertEqual(res.status_code, 405)
+        self.assertEqual(
+            res.json()['error'],
+            "You need the case search index to use this feature"
+        )
 
     def test_case_not_found(self):
         res = self.client.get(reverse('case_api', args=(self.domain, 'fake_id')))

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -91,8 +91,12 @@ class ExplodeCasesView(BaseProjectSettingsView, TemplateView):
 def case_api(request, domain, case_id=None):
     if request.method == 'GET' and case_id:
         return _handle_individual_get(request, case_id)
-    if request.method == 'GET' and not case_id and domain_needs_search_index(domain):
-        return _handle_list_view(request)
+    if request.method == 'GET' and not case_id:
+        if domain_needs_search_index(domain):
+            return _handle_list_view(request)
+        return JsonResponse({
+            'error': "You need the case search index to use this feature"
+        }, status=405)
     if request.method == 'POST' and not case_id:
         return _handle_case_update(request)
     if request.method == 'PUT' and case_id:

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -22,7 +22,6 @@ from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.utils import should_use_sql_backend
-from corehq.pillows.case_search import domain_needs_search_index
 from corehq.toggles import CASE_API_V0_6
 from corehq.util.view_utils import reverse
 
@@ -92,11 +91,7 @@ def case_api(request, domain, case_id=None):
     if request.method == 'GET' and case_id:
         return _handle_individual_get(request, case_id)
     if request.method == 'GET' and not case_id:
-        if domain_needs_search_index(domain):
-            return _handle_list_view(request)
-        return JsonResponse({
-            'error': "You need the case search index to use this feature"
-        }, status=405)
+        return _handle_list_view(request)
     if request.method == 'POST' and not case_id:
         return _handle_case_update(request)
     if request.method == 'PUT' and case_id:

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -31,6 +31,7 @@ from corehq.pillows.mappings.case_search_mapping import (
     CASE_SEARCH_MAPPING,
 )
 from corehq.toggles import (
+    CASE_API_V0_6,
     CASE_LIST_EXPLORER,
     EXPLORE_CASE_DATA,
     ECD_MIGRATED_DOMAINS,
@@ -62,7 +63,8 @@ def domains_needing_search_index():
     return set(list(case_search_enabled_domains())
                + CASE_LIST_EXPLORER.get_enabled_domains()
                + EXPLORE_CASE_DATA.get_enabled_domains()
-               + ECD_MIGRATED_DOMAINS.get_enabled_domains())
+               + ECD_MIGRATED_DOMAINS.get_enabled_domains()
+               + CASE_API_V0_6.get_enabled_domains())
 
 
 def domain_needs_search_index(domain):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -808,11 +808,13 @@ WEBAPPS_STICKY_SEARCH = StaticToggle(
 
 def _enable_search_index(domain, enabled):
     from corehq.apps.case_search.tasks import reindex_case_search_for_domain
+    from corehq.apps.es import CaseSearchES
     from corehq.pillows.case_search import domains_needing_search_index
     domains_needing_search_index.clear()
-    if enabled:
-        # action is no longer reversible due to roll out of EXPLORE_CASE_DATA
-        # and upcoming migration of CaseES to CaseSearchES
+
+    has_case_search_cases = CaseSearchES().domain(domain).count() > 0
+    if enabled and not has_case_search_cases:
+        # action is not reversible, we want all projects here eventually
         reindex_case_search_for_domain.delay(domain)
 
 
@@ -858,6 +860,7 @@ CASE_API_V0_6 = StaticToggle(
     'Enable the v0.6 Case API',
     TAG_SOLUTIONS_LIMITED,
     namespaces=[NAMESPACE_DOMAIN],
+    save_fn=_enable_search_index,
 )
 
 HIPAA_COMPLIANCE_CHECKBOX = StaticToggle(


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/QA-3314

## Feature Flag
Enable the v0.6 Case API

## Product Description
Enable the case search index when turning on new case API flag

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
