### PR TITLE
added label with count of linked mobile users

### DIFF
--- a/corehq/apps/users/templates/users/enterprise_users.html
+++ b/corehq/apps/users/templates/users/enterprise_users.html
@@ -58,8 +58,10 @@
               "></i>
               <i class="fa fa-link" data-bind="visible: loginAsUser" style="margin-left: 15px;"></i>
               <span data-bind="attr: {style: (loginAsUserCount || loginAsUser ? 'margin-left: 1px' : 'margin-left: 15px;')}, text: username"></span>
+              <span class="label label-success" data-bind="text: loginAsUserCount"></span>
             </td>
-            <td data-bind="text: name"></td>
+            <td data-bind="text: name">
+            </td>
             <td data-bind="text: role"></td>
             {% if show_profile_column %}
               <td data-bind="text: profile"></td>


### PR DESCRIPTION
## Summary
[USH-1164
](https://dimagi-dev.atlassian.net/browse/USH-1164)<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
Enterprise User Management
<!-- If this is specific to a feature flag, which one? -->

## Product Description
A label appears next to username that displays the number of mobile worker linked to that user
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
Tiny change that only occurs under EUM feature flag.
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
