### PR TITLE
Link reports and keywords on push if not found

### DIFF
--- a/corehq/apps/linked_domain/exceptions.py
+++ b/corehq/apps/linked_domain/exceptions.py
@@ -6,6 +6,10 @@ class MultipleDownstreamAppsError(Exception):
     pass
 
 
+class MultipleDownstreamKeywordsError(Exception):
+    pass
+
+
 class RemoteRequestError(Exception):
     def __init__(self, status_code=None):
         self.status_code = status_code

--- a/corehq/apps/linked_domain/keywords.py
+++ b/corehq/apps/linked_domain/keywords.py
@@ -3,8 +3,19 @@ import uuid
 from django.utils.translation import ugettext as _
 
 from corehq.apps.linked_domain.applications import get_downstream_app_id
-from corehq.apps.linked_domain.exceptions import DomainLinkError, MultipleDownstreamAppsError
+from corehq.apps.linked_domain.exceptions import (
+    DomainLinkError,
+    MultipleDownstreamAppsError,
+    MultipleDownstreamKeywordsError,
+)
 from corehq.apps.sms.models import Keyword
+
+
+def get_downstream_keyword(downstream_domain, upstream_keyword_id):
+    keywords = Keyword.objects.filter(domain=downstream_domain, upstream_id=str(upstream_keyword_id))
+    if len(keywords) > 1:
+        raise MultipleDownstreamKeywordsError
+    return keywords[0] if keywords else None
 
 
 def create_linked_keyword(domain_link, keyword_id):

--- a/corehq/apps/linked_domain/tasks.py
+++ b/corehq/apps/linked_domain/tasks.py
@@ -23,8 +23,12 @@ from corehq.apps.linked_domain.const import (
     MODEL_REPORT,
 )
 from corehq.apps.linked_domain.dbaccessors import get_domain_master_link
-from corehq.apps.linked_domain.keywords import update_keyword
-from corehq.apps.linked_domain.ucr import update_linked_ucr
+from corehq.apps.linked_domain.keywords import update_keyword, create_linked_keyword
+from corehq.apps.linked_domain.ucr import (
+    create_linked_ucr,
+    get_downstream_report,
+    update_linked_ucr,
+)
 from corehq.apps.linked_domain.updates import update_model_type
 from corehq.apps.linked_domain.util import (
     pull_missing_multimedia_for_app_and_notify,
@@ -153,23 +157,27 @@ The following linked project spaces received content:
     def _release_report(self, domain_link, model):
         report_id = model['detail']['report_id']
         found = False
-        for linked_report in get_report_configs_for_domain(domain_link.linked_domain):
-            if linked_report.report_meta.master_id == report_id:
-                found = True
-                update_linked_ucr(domain_link, linked_report.get_id)
+        linked_report = get_downstream_report(domain_link.linked_domain, report_id)
+        if linked_report:
+            found = True
+            update_linked_ucr(domain_link, linked_report.get_id)
 
         if not found:
-            report = ReportConfiguration.get(report_id)
-            if report.report_meta.created_by_builder:
-                view = 'edit_report_in_builder'
+            if toggles.ERM_DEVELOPMENT.enabled(self.master_domain):
+                linked_report_info = create_linked_ucr(domain_link, report_id)
+                update_linked_ucr(domain_link, linked_report_info.report.get_id)
             else:
-                view = 'edit_configurable_report'
-            url = get_url_base() + reverse(view, args=[domain_link.master_domain, report_id])
-            return self._error_tuple(
-                _('Could not find report. <a href="{}">Click here</a> and click "Link Report" to link this '
-                  + 'report.').format(url),
-                text=_('Could not find report. Please check that the report has been linked.'),
-            )
+                report = ReportConfiguration.get(report_id)
+                if report.report_meta.created_by_builder:
+                    view = 'edit_report_in_builder'
+                else:
+                    view = 'edit_configurable_report'
+                url = get_url_base() + reverse(view, args=[domain_link.master_domain, report_id])
+                return self._error_tuple(
+                    _('Could not find report. <a href="{}">Click here</a> and click "Link Report" to link this '
+                      + 'report.').format(url),
+                    text=_('Could not find report. Please check that the report has been linked.'),
+                )
 
     def _release_flag_dependent_model(self, domain_link, model, user, feature_flag):
         if not feature_flag.enabled(domain_link.linked_domain):
@@ -183,18 +191,21 @@ The following linked project spaces received content:
             linked_keyword_id = (Keyword.objects.values_list('id', flat=True)
                                  .get(domain=domain_link.linked_domain, upstream_id=upstream_id))
         except Keyword.DoesNotExist:
-            return self._error_tuple(
-                _('Could not find linked keyword in {domain}. '
-                  'Please check that the keyword has been linked from the '
-                  '<a href="{keyword_url}">Keyword Page</a>.').format(
-                    domain=domain_link.linked_domain,
-                    keyword_url=(
-                        get_url_base() + reverse(
-                            KeywordsListView.urlname, args=[domain_link.master_domain]
-                        ))
-                ),
-                _('Could not find linked keyword. Please check the keyword has been linked.'),
-            )
+            if toggles.ERM_DEVELOPMENT.enabled(self.master_domain):
+                linked_keyword_id = create_linked_keyword(domain_link, upstream_id)
+            else:
+                return self._error_tuple(
+                    _('Could not find linked keyword in {domain}. '
+                      'Please check that the keyword has been linked from the '
+                      '<a href="{keyword_url}">Keyword Page</a>.').format(
+                        domain=domain_link.linked_domain,
+                        keyword_url=(
+                            get_url_base() + reverse(
+                                KeywordsListView.urlname, args=[domain_link.master_domain]
+                            ))
+                    ),
+                    _('Could not find linked keyword. Please check the keyword has been linked.'),
+                )
 
         update_keyword(domain_link, linked_keyword_id)
 

--- a/corehq/apps/linked_domain/tests/test_release_manager.py
+++ b/corehq/apps/linked_domain/tests/test_release_manager.py
@@ -1,26 +1,42 @@
 from mock import patch
 
-from corehq.apps.app_manager.models import LinkedApplication, Module
+from corehq.apps.app_manager.models import (
+    Application,
+    LinkedApplication,
+    Module,
+)
 from corehq.apps.app_manager.views.utils import get_blank_form_xml
 from corehq.apps.linked_domain.const import (
     LINKED_MODELS_MAP,
     MODEL_APP,
     MODEL_CASE_SEARCH,
-    MODEL_FLAGS,
-    MODEL_USER_DATA,
     MODEL_DATA_DICTIONARY,
     MODEL_DIALER_SETTINGS,
-    MODEL_OTP_SETTINGS,
+    MODEL_FLAGS,
     MODEL_HMAC_CALLOUT_SETTINGS,
+    MODEL_OTP_SETTINGS,
+    MODEL_REPORT,
+    MODEL_USER_DATA, MODEL_KEYWORD,
 )
-from corehq.apps.linked_domain.models import AppLinkDetail
-from corehq.apps.linked_domain.tasks import release_domain
+from corehq.apps.linked_domain.keywords import create_linked_keyword, get_downstream_keyword
+from corehq.apps.linked_domain.models import AppLinkDetail, ReportLinkDetail, KeywordLinkDetail
+from corehq.apps.linked_domain.tasks import ReleaseManager, release_domain
 from corehq.apps.linked_domain.tests.test_linked_apps import BaseLinkedAppsTest
+from corehq.apps.linked_domain.ucr import (
+    create_linked_ucr,
+    get_downstream_report,
+)
+from corehq.apps.sms.models import Keyword
+from corehq.apps.userreports.tests.utils import (
+    get_sample_data_source,
+    get_sample_report_config,
+)
 from corehq.apps.users.models import WebUser
 from corehq.util.test_utils import flag_enabled
 
 
-class TestReleaseManager(BaseLinkedAppsTest):
+class BaseReleaseManagerTest(BaseLinkedAppsTest):
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -28,12 +44,20 @@ class TestReleaseManager(BaseLinkedAppsTest):
         master1_module = cls.master1.add_module(Module.new_module('Module for master1', None))
         master1_module.new_form('Form for master1', 'en', get_blank_form_xml('Form for master1'))
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete(cls.domain, deleted_by=None)
+        super().tearDownClass()
+
     def _model_status(self, _type, detail=None):
         return {
             'type': _type,
             'name': LINKED_MODELS_MAP[_type],
             'detail': detail,
         }
+
+
+class TestReleaseManager(BaseReleaseManagerTest):
 
     def _assert_release(self, models, domain=None, has_success=None, error=None, build_apps=False):
         domain = domain or self.linked_domain
@@ -148,3 +172,149 @@ class TestReleaseManager(BaseLinkedAppsTest):
             self._assert_release([
                 self._model_status(MODEL_APP, detail=AppLinkDetail(app_id=self.master1._id).to_json()),
             ], error="Updated app but did not build or release: Boom!", build_apps=True)
+
+
+class TestReleaseApp(BaseReleaseManagerTest):
+
+    def test_app_not_pushed_if_not_found_with_toggle_disabled(self):
+        unpushed_app = Application.new_app(self.domain, "Not Yet Pushed App")
+        unpushed_app.save()
+        self.addCleanup(unpushed_app.delete)
+        model = self._model_status(MODEL_APP, detail=AppLinkDetail(app_id=unpushed_app._id).to_json())
+        manager = ReleaseManager(self.domain, self.user.username)
+
+        errors = manager._release_app(self.domain_link, model, manager.user)
+
+        self.assertTrue("Could not find app" in errors)
+
+    @flag_enabled('ERM_DEVELOPMENT')
+    def test_app_not_pushed_if_not_found_with_toggle_enabled(self):
+        unpushed_app = Application.new_app(self.domain, "Not Yet Pushed App")
+        unpushed_app.save()
+        self.addCleanup(unpushed_app.delete)
+        model = self._model_status(MODEL_APP, detail=AppLinkDetail(app_id=unpushed_app._id).to_json())
+        manager = ReleaseManager(self.domain, self.user.username)
+
+        errors = manager._release_app(self.domain_link, model, manager.user)
+        self.assertTrue("Could not find app" in errors)
+
+
+class TestReleaseReport(BaseReleaseManagerTest):
+
+    def _create_new_report(self):
+        self.data_source = get_sample_data_source()
+        self.data_source.domain = self.domain
+        self.data_source.save()
+
+        self.report = get_sample_report_config()
+        self.report.config_id = self.data_source.get_id
+        self.report.domain = self.domain
+        self.report.save()
+        return self.report
+
+    def test_already_linked_report_is_pushed(self):
+        new_report = self._create_new_report()
+        new_report.title = "Title"
+        new_report.save()
+        self.addCleanup(new_report.delete)
+        linked_report_info = create_linked_ucr(self.domain_link, new_report.get_id)
+        self.addCleanup(linked_report_info.report.delete)
+        # after creating the link, update the upstream report
+        new_report.title = "Updated Title"
+        new_report.save()
+        model = self._model_status(MODEL_REPORT, detail=ReportLinkDetail(report_id=new_report.get_id).to_json())
+        manager = ReleaseManager(self.domain, self.user.username)
+
+        errors = manager._release_report(self.domain_link, model)
+        self.assertIsNone(errors)
+
+        downstream_report = get_downstream_report(self.linked_domain, new_report.get_id)
+        self.assertIsNotNone(downstream_report)
+        self.assertEqual("Updated Title", downstream_report.title)
+
+    def test_report_not_pushed_if_not_found_with_toggle_disabled(self):
+        unpushed_report = self._create_new_report()
+        self.addCleanup(unpushed_report.delete)
+        model = self._model_status(
+            MODEL_REPORT,
+            detail=ReportLinkDetail(report_id=unpushed_report.get_id).to_json()
+        )
+        manager = ReleaseManager(self.domain, self.user.username)
+
+        errors = manager._release_report(self.domain_link, model)
+        self.assertTrue('Could not find report. Please check that the report has been linked.' in errors)
+
+    @flag_enabled('ERM_DEVELOPMENT')
+    def test_report_pushed_if_not_found_with_toggle_enabled(self):
+        unpushed_report = self._create_new_report()
+        self.addCleanup(unpushed_report.delete)
+        model = self._model_status(
+            MODEL_REPORT,
+            detail=ReportLinkDetail(report_id=unpushed_report.get_id).to_json()
+        )
+        manager = ReleaseManager(self.domain, self.user.username)
+
+        errors = manager._release_report(self.domain_link, model)
+        self.assertIsNone(errors)
+
+        downstream_report = get_downstream_report(self.linked_domain, unpushed_report.get_id)
+        self.addCleanup(downstream_report.delete)
+        self.assertIsNotNone(downstream_report)
+
+
+class TestReleaseKeyword(BaseReleaseManagerTest):
+
+    def _create_new_keyword(self, keyword_name):
+        keyword = Keyword(
+            domain=self.domain_link.master_domain,
+            keyword=keyword_name,
+            description="The description",
+            override_open_sessions=True,
+        )
+        keyword.save()
+        return keyword
+
+    def test_already_linked_keyword_is_pushed(self):
+        keyword = self._create_new_keyword('keyword')
+        self.addCleanup(keyword.delete)
+        linked_keyword_id = create_linked_keyword(self.domain_link, keyword.id)
+        self.addCleanup(Keyword(id=linked_keyword_id).delete)
+        # after creating the link, update the upstream keyword
+        keyword.keyword = "updated-keyword"
+        keyword.save()
+        model = self._model_status(MODEL_KEYWORD, detail=KeywordLinkDetail(keyword_id=str(keyword.id)).to_json())
+        manager = ReleaseManager(self.domain, self.user.username)
+
+        errors = manager._release_keyword(self.domain_link, model)
+        self.assertIsNone(errors)
+
+        downstream_keyword = get_downstream_keyword(self.linked_domain, keyword.id)
+        self.addCleanup(downstream_keyword.delete)
+        self.assertIsNotNone(downstream_keyword)
+        self.assertEqual("updated-keyword", downstream_keyword.keyword)
+
+    def test_keyword_not_pushed_if_not_found_with_toggle_disabled(self):
+        keyword = self._create_new_keyword('keyword')
+        self.addCleanup(keyword.delete)
+        model = self._model_status(MODEL_KEYWORD, detail=KeywordLinkDetail(keyword_id=str(keyword.id)).to_json())
+
+        manager = ReleaseManager(self.domain, self.user.username)
+
+        errors = manager._release_keyword(self.domain_link, model)
+        self.assertTrue('Could not find linked keyword. Please check the keyword has been linked.' in errors)
+
+    @flag_enabled('ERM_DEVELOPMENT')
+    def test_keyword_pushed_if_not_found_with_toggle_enabled(self):
+        keyword = self._create_new_keyword('keyword')
+        self.addCleanup(keyword.delete)
+        model = self._model_status(MODEL_KEYWORD, detail=KeywordLinkDetail(keyword_id=str(keyword.id)).to_json())
+
+        manager = ReleaseManager(self.domain, self.user.username)
+
+        errors = manager._release_keyword(self.domain_link, model)
+        self.assertIsNone(errors)
+
+        downstream_keyword = get_downstream_keyword(self.linked_domain, keyword.id)
+        self.addCleanup(downstream_keyword.delete)
+        self.assertIsNotNone(downstream_keyword)
+        self.assertEqual("keyword", downstream_keyword.keyword)

--- a/corehq/apps/linked_domain/ucr.py
+++ b/corehq/apps/linked_domain/ucr.py
@@ -35,6 +35,13 @@ def create_linked_ucr(domain_link, report_config_id):
     return LinkedUCRInfo(datasource=new_datasource, report=new_report)
 
 
+def get_downstream_report(downstream_domain, upstream_report_id):
+    for linked_report in get_report_configs_for_domain(downstream_domain):
+        if linked_report.report_meta.master_id == upstream_report_id:
+            return linked_report
+    return None
+
+
 def _get_or_create_datasource_link(domain_link, datasource, app_id):
     domain_datsources = get_datasources_for_domain(domain_link.linked_domain)
     existing_linked_datasources = [d for d in domain_datsources if d.meta.master_id == datasource.get_id]

--- a/corehq/apps/reminders/templates/reminders/keyword_list.html
+++ b/corehq/apps/reminders/templates/reminders/keyword_list.html
@@ -21,7 +21,7 @@
       <i class="fa fa-plus"></i>
       {% trans 'Add Structured Keyword' %}
     </a>
-    {% if request|toggle_enabled:"LINKED_DOMAINS" %}
+    {% if not has_release_management_privilege and request|toggle_enabled:"LINKED_DOMAINS" %}
       {% if linked_domains %}
         {% include "reminders/link_keywords_modal.html" %}
       {% endif %}

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -14,6 +14,7 @@ from dimagi.utils.logging import notify_exception
 
 from corehq import privileges
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.hqwebapp.decorators import use_multiselect
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
@@ -25,6 +26,7 @@ from corehq.apps.reminders.forms import NO_RESPONSE, KeywordForm
 from corehq.apps.reminders.util import get_combined_id, split_combined_id
 from corehq.apps.sms.models import Keyword, KeywordAction
 from corehq.apps.sms.views import BaseMessagingSectionView
+from corehq.privileges import RELEASE_MANAGEMENT
 
 
 class AddStructuredKeywordView(BaseMessagingSectionView):
@@ -286,6 +288,7 @@ class KeywordsListView(BaseMessagingSectionView, CRUDPaginatedViewMixin):
             for domain_link in get_linked_domains(self.domain)
         ]
         context['linkable_keywords'] = self._linkable_keywords()
+        context['has_release_management_privilege'] = domain_has_privilege(self.domain, RELEASE_MANAGEMENT)
         return context
 
     def _linkable_keywords(self):

--- a/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
@@ -66,7 +66,7 @@
         {% include 'userreports/partials/delete_report_button.html' with report_id=existing_report.get_id %}
         &nbsp;
       {% endif %}
-      {% if request|toggle_enabled:"LINKED_DOMAINS" %}
+      {% if not has_release_management_privilege and request|toggle_enabled:"LINKED_DOMAINS" %}
         {% if existing_report %}
           {% include "userreports/partials/link_reports.html" %}
         {% endif %}

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -41,6 +41,7 @@ from pillowtop.dao.exceptions import DocumentNotFoundError
 
 from corehq import toggles
 from corehq.apps.accounting.models import Subscription
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import (
     HUBSPOT_SAVED_UCR_FORM_ID,
     send_hubspot_form,
@@ -146,6 +147,7 @@ from corehq.apps.userreports.util import (
 )
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
+from corehq.privileges import RELEASE_MANAGEMENT
 from corehq.tabs.tabclasses import ProjectReportsTab
 from corehq.util import reverse
 from corehq.util.couch import get_document_or_404
@@ -611,7 +613,8 @@ class ConfigureReport(ReportBuilderView):
             'date_range_options': [r._asdict() for r in get_simple_dateranges()],
             'linked_report_domain_list': linked_downstream_reports_by_domain(
                 self.domain, self.existing_report.get_id
-            ) if self.existing_report else {}
+            ) if self.existing_report else {},
+            'has_release_management_privilege': domain_has_privilege(self.domain, RELEASE_MANAGEMENT),
         }
 
     def _get_bound_form(self, report_data):


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SS-158

Most of these changes were done under [the previous PR](https://github.com/dimagi/commcare-hq/pull/30072). I squashed those commits into the first commit on this branch, and followed up by replacing the `ERM_DEVELOPMENT` toggle with the `RELEASE_MANAGEMENT` privilege, and then hid the `Link Report` and `Link Keywords` buttons if the privilege was enabled as that UI will not be needed. 

The aim is to have no impact on feature flag users of `LINKED_DOMAINS`.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests for linking reports and keywords if not found when pushing only if the `RELEASE_MANAGEMENT` privilege is found.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will run through QA on parent branch. See [ticket](https://dimagi-dev.atlassian.net/browse/QA-3315
).
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested that reports and keywords can be successfully linked just by pushing content. Locally tested that this is still visible for feature flag users, and not visible for privilege users.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
