### PR TITLE
Updated success messages for enterprise permissions

### DIFF
--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -390,7 +390,9 @@ def add_enterprise_permissions_domain(request, domain, target_domain):
         config.save()
         if config.source_domain:
             clear_enterprise_permissions_cache_for_all_users.delay(config.id, config.source_domain)
-    messages.success(request, _('Users in {} now have access to {}.').format(config.source_domain, target_domain))
+
+    messages.success(request, _('{} is now included in enterprise permissions.').format(target_domain))
+
     return HttpResponseRedirect(redirect)
 
 
@@ -410,8 +412,7 @@ def remove_enterprise_permissions_domain(request, domain, target_domain):
         config.save()
         if config.source_domain:
             clear_enterprise_permissions_cache_for_all_users.delay(config.id, config.source_domain)
-    messages.success(request, _('Users in {} no longer have access to {}.').format(config.source_domain,
-                                                                                   target_domain))
+    messages.success(request, _('{} is now excluded from enterprise permissions.').format(target_domain))
     return HttpResponseRedirect(redirect)
 
 


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/QA-3106

## Feature Flag
Enterprise permissions

## Product Description
Makes minor changes to messages on enterprise permissions configuration page.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No

### QA Plan

No QA. 

### Safety story
Tiny, tested locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
