### PR TITLE
get doc shard counts

### DIFF
--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -21,7 +21,9 @@ from pillowtop.utils import get_couch_pillow_instances
 from corehq.apps.es.users import UserES
 from corehq.apps.hqadmin.models import HistoricalPillowCheckpoint
 from corehq.apps.hqwebapp.tasks import send_html_email_async
+from corehq.elastic import get_es_new
 from corehq.util.celery_utils import periodic_task_when_true
+from corehq.util.metrics import metrics_gauge
 from corehq.util.soft_assert import soft_assert
 
 from .utils import check_for_rewind

--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -179,4 +179,4 @@ def track_es_doc_counts():
                         'shard': f'{name}_{number}',
                     }
                     metrics_gauge('elasticsearch.shards.docs.count', i['docs']['count'], tags)
-                    metrics.gauge('elasticsearch.shards.docs.deleted', i['docs']['deleted'], tags)
+                    metrics_gauge('elasticsearch.shards.docs.deleted', i['docs']['deleted'], tags)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12356
This provides shard level doc counts to datadog every 5 minutes to catch a number of issues we have seen in the past (doc count limits, deleted shards, etc.)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
It's a standalone celery task that just sends metrics

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
