### PR TITLE
DomainChoiceProvider for domain filtering

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -877,6 +877,27 @@ STATIC_PREFIX = 'static-'
 CUSTOM_REPORT_PREFIX = 'custom-'
 
 
+class RegistryReportConfiguration(ReportConfiguration):
+    @property
+    def registry_slug(self):
+        return self.config.registry_slug
+
+    @cached_property
+    def registry_helper(self):
+        return DataRegistryHelper(self.domain, self.registry_slug)
+
+    @property
+    @memoized
+    def config(self):
+        try:
+            config = get_document_or_not_found(RegistryDataSourceConfiguration, self.domain, self.config_id)
+        except DocumentNotFound:
+            raise DataSourceConfigurationNotFoundError(_(
+                'The data source referenced by this report could not be found.'
+            ))
+        return config
+
+
 class StaticDataSourceConfiguration(JsonObject):
     """
     For custom data sources maintained in the repository.

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -1294,8 +1294,7 @@ def get_datasource_config(config_id, domain, data_source_type=DATA_SOURCE_TYPE_S
                 _raise_not_found()
         else:
             try:
-                config = get_document_or_not_found(DataSourceConfiguration, domain, config_id,
-                                                   additional_doc_types=[RegistryDataSourceConfiguration.__name__])
+                config = get_document_or_not_found(DataSourceConfiguration, domain, config_id)
             except DocumentNotFound:
                 _raise_not_found()
         return config, is_static

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -1273,7 +1273,8 @@ def get_datasource_config(config_id, domain, data_source_type=DATA_SOURCE_TYPE_S
                 _raise_not_found()
         else:
             try:
-                config = get_document_or_not_found(DataSourceConfiguration, domain, config_id)
+                config = get_document_or_not_found(DataSourceConfiguration, domain, config_id,
+                                                   additional_doc_types=[RegistryDataSourceConfiguration.__name__])
             except DocumentNotFound:
                 _raise_not_found()
         return config, is_static

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -404,11 +404,7 @@ class DomainChoiceProvider(ChainableChoiceProvider):
         for registry in registries:
             domains.update(registry.get_granted_domains(domain))
         if query_text:
-            domains_filtered_by_user = set()
-            for domain in domains:
-                if re.search(query_text, domain):
-                    domains_filtered_by_user.add(domain)
-            domains = domains_filtered_by_user
+            domains = {domain for domain in domains if re.search(query_text, domain)}
         return list(domains)
 
     def query(self, query_context):
@@ -423,11 +419,7 @@ class DomainChoiceProvider(ChainableChoiceProvider):
 
     def get_choices_for_known_values(self, values, user):
         domains = self._query_domains(self.domain, None)
-        domains.sort()
-        domain_options = []
-        for domain in domains:
-            if domain in values:
-                domain_options.append(domain)
+        domain_options = [domain for domain in domains if domain in values]
         return self._domains_to_choices(domain_options)
 
     def default_value(self, user):

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -399,11 +399,14 @@ class GroupChoiceProvider(ChainableChoiceProvider):
 
 class DomainChoiceProvider(ChainableChoiceProvider):
 
-    def _query_domains(self, domain, query_text):  # should we account for multiple registries?
-        registries = DataRegistry.objects.accessible_to_domain(domain)
+    def _query_domains(self, domain, query_text):
+        registry_slug = self.report.config.registry_slug
+        try:
+            registry = DataRegistry.objects.accessible_to_domain(domain, slug=registry_slug).get()
+        except DataRegistry.DoesNotExist:
+            return {domain}
         domains = {domain}
-        for registry in registries:
-            domains.update(registry.get_granted_domains(domain))
+        domains.update(registry.get_granted_domains(domain))
         if query_text:
             domains = {domain for domain in domains if re.search(query_text, domain)}
         return list(domains)

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -7,6 +7,7 @@ from django.utils.translation import ugettext
 from sqlalchemy import or_
 from sqlalchemy.exc import ProgrammingError
 
+from corehq.apps.domain.models import Domain
 from corehq.apps.es import GroupES, UserES
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.registry.models import DataRegistry
@@ -426,7 +427,7 @@ class DomainChoiceProvider(ChainableChoiceProvider):
         return self._domains_to_choices([self.domain])
 
     def _domains_to_choices(self, domains):
-        return [Choice(domain, domain) for domain in domains]
+        return [Choice(domain, Domain.get_by_name(domain).display_name()) for domain in domains]
 
 
 class AbstractMultiProvider(ChoiceProvider):

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from memoized import memoized
 import re
 
 from django.utils.functional import cached_property
@@ -399,6 +400,7 @@ class GroupChoiceProvider(ChainableChoiceProvider):
 
 class DomainChoiceProvider(ChainableChoiceProvider):
 
+    @memoized
     def _query_domains(self, domain, query_text):
         domains = {domain}
         try:

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -9,6 +9,7 @@ import mock
 from pillowtop.es_utils import initialize_index_and_mapping
 
 from corehq.apps.domain.shortcuts import create_domain, create_user
+from corehq.apps.domain.tests.test_utils import delete_all_domains
 from corehq.apps.es.fake.groups_fake import GroupESFake
 from corehq.apps.es.fake.users_fake import UserESFake
 from corehq.apps.es.tests.utils import es_test
@@ -516,6 +517,12 @@ class DomainChoiceProviderTest(TestCase, ChoiceProviderTestMixin):
     @classmethod
     def setUpClass(cls):
         super(DomainChoiceProviderTest, cls).setUpClass()
+        cls.domain_a = create_domain(name="A")
+        cls.domain_b = create_domain(name="B")
+        cls.domain_c = create_domain(name="C")
+        cls.domain_d = create_domain(name="D")
+        for domain in [cls.domain_a, cls.domain_b, cls.domain_c, cls.domain_d]:
+            domain.save()
         report = ReportConfiguration(domain="A")
         cls.user = create_user("admin", "123")
         cls.web_user = UserChoiceProviderTest.make_web_user('web-user@example.com', domain="A")
@@ -541,6 +548,7 @@ class DomainChoiceProviderTest(TestCase, ChoiceProviderTestMixin):
     @classmethod
     def tearDownClass(cls):
         delete_all_users()
+        delete_all_domains()
         super(DomainChoiceProviderTest, cls).tearDownClass()
 
     def test_query_search(self):

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -17,7 +17,8 @@ from corehq.apps.groups.models import Group
 from corehq.apps.locations.tests.util import LocationHierarchyTestCase
 from corehq.apps.registry.tests.utils import Invitation, create_registry_for_test, Grant
 from corehq.apps.reports_core.filters import Choice
-from corehq.apps.userreports.models import ReportConfiguration, RegistryDataSourceConfiguration
+from corehq.apps.userreports.models import ReportConfiguration, RegistryDataSourceConfiguration, \
+    RegistryReportConfiguration
 from corehq.apps.userreports.reports.filters.choice_providers import (
     ChoiceQueryContext,
     GroupChoiceProvider,
@@ -541,7 +542,7 @@ class DomainChoiceProviderTest(TestCase, ChoiceProviderTestMixin):
         )
         cls.config.save()
 
-        cls.report = ReportConfiguration(domain="A", config_id=cls.config._id)
+        cls.report = RegistryReportConfiguration(domain="A", config_id=cls.config._id)
         cls.report.save()
 
         choices = [
@@ -590,7 +591,7 @@ class DomainChoiceProviderTest(TestCase, ChoiceProviderTestMixin):
             referenced_doc_type='CommCareCase', registry_slug=self.registry.slug,
         )
         config.save()
-        report = ReportConfiguration(domain="B", config_id=config._id)
+        report = RegistryReportConfiguration(domain="B", config_id=config._id)
         self.choice_provider = DomainChoiceProvider(report, None)
         self.assertEqual([Choice(value='B', display='B'), Choice(value='C', display='C')],
                          self.choice_provider.query(ChoiceQueryContext(query='', offset=0)))
@@ -602,7 +603,7 @@ class DomainChoiceProviderTest(TestCase, ChoiceProviderTestMixin):
             referenced_doc_type='CommCareCase', registry_slug=self.registry.slug,
         )
         config.save()
-        report = ReportConfiguration(domain="C", config_id=config._id)
+        report = RegistryReportConfiguration(domain="C", config_id=config._id)
         self.choice_provider = DomainChoiceProvider(report, None)
         self.assertEqual([Choice(value='C', display='C')],
                          self.choice_provider.query(ChoiceQueryContext(query='', offset=0)))


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket [here](https://dimagi-dev.atlassian.net/browse/USH-1139)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This domain filter returns options of each of the available domains. It excludes domains that are in the data source, but not accessible to requesting domain

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added `DomainChoiceProviderTest`

### QA Plan
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not requesting QA at this stage

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Just the new model

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 