### PR TITLE
Updated save button trigger on custom fields page

### DIFF
--- a/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
+++ b/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
@@ -111,6 +111,9 @@ hqDefine('custom_data_fields/js/custom_data_fields', [
             String(Math.random()).slice(2),
             gettext("Profile")
         );
+        self.fields.on("change", function () {
+            $(":submit").prop("disabled", false);
+        });
         self.fields.val(options.fields);
         self.$fields = self.fields.ui;
 
@@ -247,10 +250,6 @@ hqDefine('custom_data_fields/js/custom_data_fields', [
             $("#save-custom-fields").prop("disabled", false);
         }).on("input", null, null, function () {
             $("#save-custom-fields").prop("disabled", false);
-        });
-
-        $('.modal-footer button').on("click", function () {
-            $(":submit").prop("disabled", false);
         });
     });
 });


### PR DESCRIPTION
## Summary
It's a little gross that this handler uses the modal close button to enable the save button. This just switches to hook into the popup widget's change event, which will only fire when the data actually changes.

fyi @kmtracey 

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None

### QA Plan

No QA.

### Safety story
Small, low-risk change, tested locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
