### PR TITLE
Removed duplicate button

### DIFF
--- a/corehq/apps/data_interfaces/templates/data_interfaces/case_rule.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/case_rule.html
@@ -22,8 +22,10 @@
       {% crispy rule_form %}
       {% crispy criteria_form %}
       {% crispy actions_form %}
-      <div class="col-xs-1">
-        <button type="submit" class="btn btn-primary">Save</button>
+      <div class="form-actions">
+        <div class="col-xs-1">
+          <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
+        </div>
       </div>
     </form>
   </div>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_actions.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_actions.html
@@ -23,10 +23,6 @@
           <i class="fa fa-plus"></i>
           {% trans "Add Action" %}
         </button>
-        <button class="btn btn-default" type="button" data-toggle="dropdown">
-          <i class="fa fa-plus"></i>
-          {% trans "Select an action" %}
-        </button>
         <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
           <span class="caret"></span>
         </button>
@@ -98,7 +94,7 @@
       <input type="text" class="textinput form-control" data-bind="value: name" required placeholder="{% trans 'custom action id' %}" />
     </div>
     <label class="col-xs-1 control-label">
-      <span class="label label-primary">Requires System Admin</span>
+      <span class="label label-primary">{% trans "Requires System Admin" %}</span>
     </label>
   </div>
 </script>


### PR DESCRIPTION
## Summary
This seems wrong: one dropdown, two (mis-aligned) buttons.

<img width="309" alt="Screen Shot 2021-07-23 at 3 31 54 PM" src="https://user-images.githubusercontent.com/1486591/126832501-c3fbc510-4456-4637-97f1-2857df7939b2.png">

Now there's just one button:

<img width="325" alt="Screen Shot 2021-07-23 at 3 30 13 PM" src="https://user-images.githubusercontent.com/1486591/126832534-b32cca85-2e2d-45c9-868d-3314836ba588.png">

@biyeun This was added back in https://github.com/dimagi/commcare-hq/pull/23080, maybe just an oversight? It looks like that PR was more focused on the schedule & criteria areas than the actions area.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None

### QA Plan

None

### Safety story
HTML only, tested locally

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
