### PR TITLE
Get some more detail on app build timings

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4871,6 +4871,7 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
             else:
                 form.version = None
 
+    @time_method()
     def set_media_versions(self):
         """
         Set the media version numbers for all media in the app to the current app version

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -284,8 +284,6 @@ def release_build(request, domain, app_id, saved_app_id):
 def save_copy(request, domain, app_id):
     """
     Saves a copy of the app to a new doc.
-    See ApplicationBase.save_copy
-
     """
     track_built_app_on_hubspot.delay(request.couch_user)
     comment = request.POST.get('comment')

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -589,7 +589,6 @@ class AppBuildTimingsView(TemplateView):
                     filename='app-profile-test.ccz',
                     download_targeted_version=False,
                     task=None,
-                    expose_link=True,
                 )
 
         os.remove(fpath)

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -1,5 +1,6 @@
 import csv
 import itertools
+import os
 import uuid
 from collections import Counter
 from datetime import datetime, timedelta
@@ -51,7 +52,7 @@ from corehq.apps.hqadmin.forms import (
     SuperuserManagementForm,
 )
 from corehq.apps.hqadmin.views.utils import BaseAdminSectionView
-from corehq.apps.hqmedia.tasks import build_application_zip
+from corehq.apps.hqmedia.tasks import create_files_for_ccz
 from corehq.apps.ota.views import get_restore_params, get_restore_response
 from corehq.apps.users.models import CommCareUser, CouchUser, WebUser
 from corehq.apps.users.util import format_username, log_user_change
@@ -567,19 +568,29 @@ class AppBuildTimingsView(TemplateView):
 
     @staticmethod
     def get_timing_context(app):
+        # Intended to reproduce a live-preview app build
+        # Contents should mirror the work done in the direct_ccz view
         with app.timing_context:
             errors = app.validate_app()
             assert not errors, errors
 
+            app.set_media_versions()
+
             with app.timing_context("build_zip"):
-                build_application_zip(
+                # mirroring the content of build_application_zip
+                # but with the same `app` instance to preserve timing data
+                fpath = create_files_for_ccz(
+                    build=app,
+                    build_profile_id=None,
                     include_multimedia_files=True,
                     include_index_files=True,
-                    domain=app.domain,
-                    app_id=app.id,
                     download_id=None,
                     compress_zip=True,
                     filename='app-profile-test.ccz',
+                    download_targeted_version=False,
+                    task=None,
+                    expose_link=True,
                 )
 
+        os.remove(fpath)
         return app.timing_context

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -126,10 +126,18 @@ def build_application_zip(include_multimedia_files, include_index_files, domain,
                           download_targeted_version=False):
     DownloadBase.set_progress(build_application_zip, 0, 100)
     app = get_app(domain, app_id)
-    fpath = create_files_for_ccz(app, build_profile_id, include_multimedia_files, include_index_files,
-                                 download_id, compress_zip, filename, download_targeted_version,
-                                 task=build_application_zip, expose_link=True)
-    _expose_download_link(fpath, filename, compress_zip, download_id)
+    fpath = create_files_for_ccz(
+        app,
+        build_profile_id,
+        include_multimedia_files,
+        include_index_files,
+        download_id,
+        compress_zip,
+        filename,
+        download_targeted_version,
+        task=build_application_zip,
+        expose_link=True,
+    )
     DownloadBase.set_progress(build_application_zip, 100, 100)
 
 

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -136,7 +136,6 @@ def build_application_zip(include_multimedia_files, include_index_files, domain,
         filename,
         download_targeted_version,
         task=build_application_zip,
-        expose_link=True,
     )
     DownloadBase.set_progress(build_application_zip, 100, 100)
 
@@ -204,10 +203,9 @@ def _zip_files_for_ccz(fpath, files, current_progress, file_progress, file_count
 
 def create_files_for_ccz(build, build_profile_id, include_multimedia_files=True, include_index_files=True,
                          download_id=None, compress_zip=False, filename="commcare.zip",
-                         download_targeted_version=False, task=None, expose_link=False):
+                         download_targeted_version=False, task=None):
     """
     :param task: celery task whose progress needs to be set when being run asynchronously by celery
-    :param expose_link: expose downloadable link for the file created
     :return: path to the ccz file
     """
     compression = zipfile.ZIP_DEFLATED if compress_zip else zipfile.ZIP_STORED
@@ -261,9 +259,8 @@ def create_files_for_ccz(build, build_profile_id, include_multimedia_files=True,
             raise Exception('\t' + '\t'.join(errors))
     else:
         DownloadBase.set_progress(task, current_progress + file_progress, 100)
-    if expose_link:
-        with build.timing_context("_expose_download_link"):
-            _expose_download_link(fpath, filename, compress_zip, download_id)
+    with build.timing_context("_expose_download_link"):
+        _expose_download_link(fpath, filename, compress_zip, download_id)
     DownloadBase.set_progress(task, 100, 100)
     return fpath
 


### PR DESCRIPTION
## Summary
This adds some info to the `build_zip` section of the app build timings:

![image](https://user-images.githubusercontent.com/2367539/126834103-16e14716-7541-40ff-965a-8d1c1037e3e6.png)

I also found a (presumably small) redundancy and removed that.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The changes here seem pretty safe, but app builds are big and scary, so I'd be interested in a second opinion on the safety of the change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
