### PR TITLE
Cs/sc 1529 multiple mobile numbers upload

### DIFF
--- a/corehq/apps/callcenter/tests/test_utils.py
+++ b/corehq/apps/callcenter/tests/test_utils.py
@@ -382,7 +382,7 @@ class CallCenterUtilsUsercaseTests(TestCase):
             'name': 'James McNulty',
             'language': None,
             'is_active': 'True',
-            'phone-number': self.user.phone_number,
+            'phone-number': [self.user.phone_number],
             'password': 123,
             'email': None
         }, {
@@ -391,7 +391,7 @@ class CallCenterUtilsUsercaseTests(TestCase):
             'name': 'William Moreland',
             'language': None,
             'is_active': 'True',
-            'phone-number': '23424123',
+            'phone-number': ['23424123'],
             'password': 123,
             'email': None
         }]

--- a/corehq/apps/user_importer/helpers.py
+++ b/corehq/apps/user_importer/helpers.py
@@ -1,6 +1,6 @@
 import copy
-from django.utils.translation import ugettext_lazy as _
 from dimagi.utils.parsing import string_to_boolean
+from django.utils.translation import ugettext as _
 
 from corehq.apps.custom_data_fields.models import PROFILE_SLUG
 from corehq.apps.user_importer.exceptions import UserUploadError

--- a/corehq/apps/user_importer/helpers.py
+++ b/corehq/apps/user_importer/helpers.py
@@ -1,4 +1,3 @@
-import copy
 from dimagi.utils.parsing import string_to_boolean
 from django.utils.translation import ugettext as _
 
@@ -26,6 +25,7 @@ class UserChangeLogger(object):
         - text messages for changes
         - useful info for changes to associated data models like role/locations
     """
+
     def __init__(self, domain, user, is_new_user, changed_by_user, changed_via, upload_record_id):
         self.domain = domain
         self.user = user
@@ -100,6 +100,7 @@ class BaseUserImporter(object):
     Imports a Web/CommCareUser via bulk importer and also handles the logging
     save_log should be called explicitly to save logs, after user is saved
     """
+
     def __init__(self, upload_domain, user_domain, user, upload_user, is_new_user, via, upload_record_id):
         """
         :param upload_domain: domain on which the bulk upload is being done

--- a/corehq/apps/user_importer/helpers.py
+++ b/corehq/apps/user_importer/helpers.py
@@ -157,7 +157,11 @@ class CommCareUserImporter(BaseUserImporter):
         old_user_phone_numbers = self.user.phone_numbers
         fmt_phone_numbers = [_fmt_phone(n) for n in phone_numbers]
 
-        self.user.set_phone_numbers(fmt_phone_numbers, default_number=fmt_phone_numbers[0])
+        if any(fmt_phone_numbers):
+            self.user.set_phone_numbers(fmt_phone_numbers, default_number=fmt_phone_numbers[0])
+        else:
+            self.user.set_phone_numbers([])
+
         self._log_phone_number_changes(old_user_phone_numbers, fmt_phone_numbers)
 
     def update_name(self, name):

--- a/corehq/apps/user_importer/helpers.py
+++ b/corehq/apps/user_importer/helpers.py
@@ -1,5 +1,4 @@
 from dimagi.utils.parsing import string_to_boolean
-from django.utils.translation import ugettext as _
 
 from corehq.apps.custom_data_fields.models import PROFILE_SLUG
 from corehq.apps.user_importer.exceptions import UserUploadError
@@ -246,10 +245,10 @@ class CommCareUserImporter(BaseUserImporter):
         )
 
         for number in items_added:
-            self.logger.add_change_message(_(f"Added phone number {number}"))
+            self.logger.add_change_message(f"Added phone number {number}")
 
         for number in items_removed:
-            self.logger.add_change_message(_(f"Removed phone number {number}"))
+            self.logger.add_change_message(f"Removed phone number {number}")
 
 
 def _fmt_phone(phone_number):

--- a/corehq/apps/user_importer/helpers.py
+++ b/corehq/apps/user_importer/helpers.py
@@ -153,7 +153,7 @@ class CommCareUserImporter(BaseUserImporter):
         """
         The first item in 'phone_numbers' will be the default
         """
-        old_user_phone_numbers = copy.deepcopy(self.user.phone_numbers)
+        old_user_phone_numbers = self.user.phone_numbers
         fmt_phone_numbers = [_fmt_phone(n) for n in phone_numbers]
 
         self.user.set_phone_numbers(fmt_phone_numbers, default_number=fmt_phone_numbers[0])

--- a/corehq/apps/user_importer/helpers.py
+++ b/corehq/apps/user_importer/helpers.py
@@ -240,8 +240,8 @@ class CommCareUserImporter(BaseUserImporter):
 
     def _log_phone_number_changes(self, old_phone_numbers, new_phone_numbers):
         (items_added, items_removed) = find_differences_in_list(
-            list_to_compare=new_phone_numbers,
-            reference_list=old_phone_numbers
+            target=new_phone_numbers,
+            source=old_phone_numbers
         )
 
         for number in items_added:
@@ -327,21 +327,21 @@ def get_user_primary_location_name(user, domain):
         return primary_location.name
 
 
-def find_differences_in_list(list_to_compare: list, reference_list: list):
+def find_differences_in_list(target: list, source: list):
     """
-    Find the differences between 'list_to_compare' and 'reference_list' and
+    Find the differences between 'source' and 'target' and
     return (added_items, removed_items)
 
-    'added_items': items that are in 'list_to_compare' but not in 'reference_list'
-    'removed_items': items that are in 'reference_list' but not 'list_to_compare'
+    'added_items': items that are in 'target' but not in 'source'
+    'removed_items': items that are in 'source' but not 'target'
 
     >>> find_differences_in_list(list_to_compare=[3,4,5,6], reference_list=[1,2,3,5])
     ({4, 6}, {1, 2})
     """
 
-    shared_items = set(list_to_compare).intersection(reference_list)
+    shared_items = set(target).intersection(source)
 
-    added_items = set(list_to_compare).difference(shared_items)
-    removed_items = set(reference_list).difference(shared_items)
+    added_items = set(target).difference(shared_items)
+    removed_items = set(source).difference(shared_items)
 
     return added_items, removed_items

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -407,11 +407,11 @@ def format_location_codes(location_codes):
     return location_codes
 
 
-def clean_phone_numbers(phone_numbers, error_message=None):
+def clean_phone_numbers(phone_numbers):
     cleaned_numbers = []
     for number in phone_numbers:
         if number:
-            validate_phone_number(number, error_message)
+            validate_phone_number(number, f'Invalid phone number detected: {number}')
             cleaned_numbers.append(number)
     return cleaned_numbers
 
@@ -502,7 +502,7 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
                     status_row['flag'] = 'created'
 
                 if phone_numbers:
-                    phone_numbers = clean_phone_numbers(phone_numbers, 'Invalid phone number detected')
+                    phone_numbers = clean_phone_numbers(phone_numbers)
                     commcare_user_importer.update_phone_numbers(phone_numbers)
 
                 if name:
@@ -587,10 +587,9 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
 
                 for group_name in group_names:
                     domain_info.group_memoizer.by_name(group_name).add_user(user, save=False)
-
             except ValidationError as e:
                 status_row['flag'] = e.message
-            except (UserUploadError, CouchUser.Inconsistent, ValidationError) as e:
+            except (UserUploadError, CouchUser.Inconsistent) as e:
                 status_row['flag'] = str(e)
 
             ret["rows"].append(status_row)

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -78,17 +78,6 @@ def check_headers(user_specs, domain, is_web_upload=False):
 
     illegal_headers = headers - allowed_headers
 
-    pardoned_headers = []
-    for illegal_header in illegal_headers:
-        if illegal_header.startswith('phone-number-'):
-            try:
-                number = illegal_header.split('phone-number-')[1]
-                if int(number) > 0:
-                    pardoned_headers.append(illegal_header)
-            except ValueError:
-                pass
-    illegal_headers = illegal_headers - set(pardoned_headers)
-
     if is_web_upload:
         missing_headers = web_required_headers - headers
     else:
@@ -479,7 +468,7 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
             phone_numbers = []
             for header, value in row.items():
                 if value and 'phone-number' in header:
-                    if header == 'phone-number' or header == 'phone-number-1':
+                    if header == 'phone-number' or header == 'phone-number 1':
                         # Add default phone number at start of list
                         phone_numbers.insert(0, value)
                     else:

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -465,14 +465,10 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
             profile = row.get('user_profile', None)
             web_user_username = row.get('web_user')
 
-            phone_numbers = []
-            for header, value in row.items():
-                if value and 'phone-number' in header:
-                    if header == 'phone-number' or header == 'phone-number 1':
-                        # Add default phone number at start of list
-                        phone_numbers.insert(0, value)
-                    else:
-                        phone_numbers.append(value)
+            phone_numbers = row.get('phone-number', []) if 'phone-number' in row else None
+            if phone_numbers:
+                phone_numbers = [n for n in phone_numbers if n]
+
             try:
                 password = str(password) if password else None
 

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -77,6 +77,18 @@ def check_headers(user_specs, domain, is_web_upload=False):
         allowed_headers.add('domain')
 
     illegal_headers = headers - allowed_headers
+
+    pardoned_headers = []
+    for illegal_header in illegal_headers:
+        if illegal_header.startswith('phone-number-'):
+            try:
+                number = illegal_header.split('phone-number-')[1]
+                if int(number) > 0:
+                    pardoned_headers.append(illegal_header)
+            except ValueError:
+                pass
+    illegal_headers = illegal_headers - set(pardoned_headers)
+
     if is_web_upload:
         missing_headers = web_required_headers - headers
     else:

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -464,10 +464,7 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
             role = row.get('role', None)
             profile = row.get('user_profile', None)
             web_user_username = row.get('web_user')
-
             phone_numbers = row.get('phone-number', []) if 'phone-number' in row else None
-            if phone_numbers:
-                phone_numbers = [n for n in phone_numbers if n]
 
             try:
                 password = str(password) if password else None
@@ -493,6 +490,7 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
                     status_row['flag'] = 'created'
 
                 if phone_numbers:
+                    phone_numbers = [n for n in phone_numbers if n]  # remove empty items
                     commcare_user_importer.update_phone_numbers(phone_numbers)
 
                 if name:

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -589,8 +589,8 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
                     domain_info.group_memoizer.by_name(group_name).add_user(user, save=False)
 
             except ValidationError as e:
-                ret['errors'].append(e.message)
-            except (UserUploadError, CouchUser.Inconsistent) as e:
+                status_row['flag'] = e.message
+            except (UserUploadError, CouchUser.Inconsistent, ValidationError) as e:
                 status_row['flag'] = str(e)
 
             ret["rows"].append(status_row)

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -425,7 +425,6 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
     ret = {"errors": [], "rows": []}
 
     current = 0
-
     try:
         for row in user_specs:
             if update_progress:
@@ -457,7 +456,6 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
             language = row.get('language')
             name = row.get('name')
             password = row.get('password')
-            phone_number = row.get('phone-number')
             uncategorized_data = row.get('uncategorized_data', {})
             user_id = row.get('user_id')
             location_codes = row.get('location_code', []) if 'location_code' in row else None
@@ -466,6 +464,14 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
             profile = row.get('user_profile', None)
             web_user_username = row.get('web_user')
 
+            phone_numbers = []
+            for header, value in row.items():
+                if 'phone-number' in header:
+                    if header == 'phone-number' or header == 'phone-number-1':
+                        # Add default phone number at start of list
+                        phone_numbers.insert(0, value)
+                    else:
+                        phone_numbers.append(value)
             try:
                 password = str(password) if password else None
 
@@ -489,8 +495,9 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
                 else:
                     status_row['flag'] = 'created'
 
-                if phone_number:
-                    commcare_user_importer.update_phone_number(phone_number)
+                if phone_numbers:
+                    commcare_user_importer.update_phone_numbers(phone_numbers)
+
                 if name:
                     commcare_user_importer.update_name(name)
 
@@ -721,7 +728,6 @@ def create_or_update_web_users(upload_domain, user_specs, upload_user, upload_re
 def modify_existing_user_in_domain(upload_domain, domain, domain_info, location_codes, membership,
                                    role_qualified_id, upload_user, current_user, web_user_importer,
                                    max_tries=3):
-
     if domain_info.can_assign_locations and location_codes is not None:
         web_user_importer.update_locations(location_codes, membership, domain_info)
     web_user_importer.update_role(role_qualified_id)

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -478,7 +478,7 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
 
             phone_numbers = []
             for header, value in row.items():
-                if 'phone-number' in header:
+                if value and 'phone-number' in header:
                     if header == 'phone-number' or header == 'phone-number-1':
                         # Add default phone number at start of list
                         phone_numbers.insert(0, value)

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -1131,8 +1131,7 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.upload_record.pk,
             False
         )
-
-        self.assertEqual(res['messages']['errors'][0], 'Invalid phone number detected')
+        self.assertEqual(res['messages']['rows'][0]['flag'], 'Invalid phone number detected')
 
 
 class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -108,7 +108,7 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
             'name': 'Another One',
             'language': None,
             'is_active': 'True',
-            'phone-number': '23424123',
+            'phone-number': ['23424123'],
             'password': 123,
             'email': None
         }
@@ -1008,7 +1008,7 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
 
     def test_upload_with_phone_number(self):
         user_specs = self._get_spec()
-        user_specs['phone-number'] = '8765547824'
+        user_specs['phone-number'] = ['8765547824']
 
         import_users_and_groups(
             self.domain.name,
@@ -1028,13 +1028,11 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         user = CommCareUser.create(self.domain_name, f"hello@{self.domain.name}.commcarehq.org", "*******",
                                    created_by=None, created_via=None, phone_number='12345678912')
 
-        user_specs = self._get_spec(delete_keys=['phone-number'], user_id=user._id)
-
         number1 = '8765547824'
         number2 = '7765547823'
 
-        user_specs['phone-number 1'] = number1
-        user_specs['phone-number 2'] = number2
+        user_specs = self._get_spec(delete_keys=['phone-number'], user_id=user._id)
+        user_specs['phone-number'] = [number1, number2]
 
         import_users_and_groups(
             self.domain.name,
@@ -1062,14 +1060,11 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         initial_default_number = '12345678912'
         user = CommCareUser.create(self.domain_name, f"hello@{self.domain.name}.commcarehq.org", "*******",
                                    created_by=None, created_via=None, phone_number='12345678912')
-
-        user_specs = self._get_spec(delete_keys=['phone-number'], user_id=user._id)
-
         number1 = ''
         number2 = '7765547823'
 
-        user_specs['phone-number 1'] = number1
-        user_specs['phone-number 2'] = number2
+        user_specs = self._get_spec(delete_keys=['phone-number'], user_id=user._id)
+        user_specs['phone-number'] = [number1, number2]
 
         import_users_and_groups(
             self.domain.name,

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -1131,7 +1131,8 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.upload_record.pk,
             False
         )
-        self.assertEqual(res['messages']['rows'][0]['flag'], 'Invalid phone number detected')
+
+        self.assertEqual(res['messages']['rows'][0]['flag'], f'Invalid phone number detected: {bad_number}')
 
 
 class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -1058,6 +1058,40 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         self.assertEqual(user.default_phone_number, number1)
         self.assertEqual(user.phone_numbers, [number1, number2])
 
+    def test_upload_with_multiple_phone_numbers_and_some_blank(self):
+        initial_default_number = '12345678912'
+        user = CommCareUser.create(self.domain_name, f"hello@{self.domain.name}.commcarehq.org", "*******",
+                                   created_by=None, created_via=None, phone_number='12345678912')
+
+        user_specs = self._get_spec(delete_keys=['phone-number'], user_id=user._id)
+
+        number1 = ''
+        number2 = '7765547823'
+
+        user_specs['phone-number-1'] = number1
+        user_specs['phone-number-2'] = number2
+
+        import_users_and_groups(
+            self.domain.name,
+            [user_specs],
+            [],
+            self.uploading_user,
+            self.upload_record.pk,
+            False
+        )
+        user_history = UserHistory.objects.get(changed_by=self.uploading_user.get_id)
+        changes = user_history.message
+
+        self.assertTrue(f'Added phone number {number2}' in changes)
+        self.assertTrue(f'Removed phone number {initial_default_number}' in changes)
+
+        # Check if user is updated
+        users = CommCareUser.by_domain(self.domain.name)
+        user = next((u for u in users if u._id == user._id))
+
+        self.assertEqual(user.default_phone_number, number2)
+        self.assertEqual(user.phone_numbers, [number2])
+
 
 class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):
     @classmethod

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -1087,7 +1087,7 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         self.assertEqual(user.default_phone_number, number2)
         self.assertEqual(user.phone_numbers, [number2])
 
-    def test_upload_with_multiple_phone_numbers_with_duplciates(self):
+    def test_upload_with_multiple_phone_numbers_with_duplicates(self):
         user = CommCareUser.create(self.domain_name, f"hello@{self.domain.name}.commcarehq.org", "*******",
                                    created_by=None, created_via=None, phone_number='12345678912')
         number1 = '7765547823'
@@ -1115,6 +1115,24 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
 
         self.assertEqual(user.default_phone_number, number1)
         self.assertEqual(user.phone_numbers, [number1])
+
+    def test_upload_with_badly_formatted_phone_numbers(self):
+        number1 = '+27893224921'
+        bad_number = '2o34532445665'
+
+        user_specs = self._get_spec(delete_keys=['phone-number'])
+        user_specs['phone-number'] = [number1, bad_number]
+
+        res = import_users_and_groups(
+            self.domain.name,
+            [user_specs],
+            [],
+            self.uploading_user,
+            self.upload_record.pk,
+            False
+        )
+
+        self.assertEqual(res['messages']['errors'][0], 'Invalid phone number detected')
 
 
 class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -1033,8 +1033,8 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         number1 = '8765547824'
         number2 = '7765547823'
 
-        user_specs['phone-number-1'] = number1
-        user_specs['phone-number-2'] = number2
+        user_specs['phone-number 1'] = number1
+        user_specs['phone-number 2'] = number2
 
         import_users_and_groups(
             self.domain.name,
@@ -1068,8 +1068,8 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         number1 = ''
         number2 = '7765547823'
 
-        user_specs['phone-number-1'] = number1
-        user_specs['phone-number-2'] = number2
+        user_specs['phone-number 1'] = number1
+        user_specs['phone-number 2'] = number2
 
         import_users_and_groups(
             self.domain.name,

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -1008,6 +1008,58 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         self.assertEqual(user_history.details['changed_via'], USER_CHANGE_VIA_BULK_IMPORTER)
         self.assertEqual(user_history.message, '')
 
+    def test_upload_with_phone_number(self):
+        user_specs = self._get_spec()
+        user_specs['phone-number'] = '8765547824'
+
+        import_users_and_groups(
+            self.domain.name,
+            [user_specs],
+            [],
+            self.uploading_user,
+            self.upload_record.pk,
+            False
+        )
+        user_history = UserHistory.objects.get(changed_by=self.uploading_user.get_id)
+
+        numbers = user_history.details['changes']['phone_numbers']
+        self.assertEqual(numbers, ['8765547824'])
+
+    def test_upload_with_multiple_phone_numbers(self):
+        initial_default_number = '12345678912'
+        user = CommCareUser.create(self.domain_name, f"hello@{self.domain.name}.commcarehq.org", "*******",
+                                   created_by=None, created_via=None, phone_number='12345678912')
+
+        user_specs = self._get_spec(delete_keys=['phone-number'], user_id=user._id)
+
+        number1 = '8765547824'
+        number2 = '7765547823'
+
+        user_specs['phone-number-1'] = number1
+        user_specs['phone-number-2'] = number2
+
+        import_users_and_groups(
+            self.domain.name,
+            [user_specs],
+            [],
+            self.uploading_user,
+            self.upload_record.pk,
+            False
+        )
+        user_history = UserHistory.objects.get(changed_by=self.uploading_user.get_id)
+        changes = user_history.message
+
+        self.assertTrue(f'Added phone number {number1}' in changes)
+        self.assertTrue(f'Added phone number {number2}' in changes)
+        self.assertTrue(f'Removed phone number {initial_default_number}' in changes)
+
+        # Check if user is updated
+        users = CommCareUser.by_domain(self.domain.name)
+        user = next((u for u in users if u._id == user._id))
+
+        self.assertEqual(user.default_phone_number, number1)
+        self.assertEqual(user.phone_numbers, [number1, number2])
+
 
 class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):
     @classmethod

--- a/corehq/apps/users/bulk_download.py
+++ b/corehq/apps/users/bulk_download.py
@@ -198,6 +198,8 @@ def get_user_rows(user_dicts, user_headers):
 def get_user_headers(user_dicts):
     def get_phone_number_headers(users):
         mobile_headers = []
+        # Find the user with the most phone numbers associated and use that user's
+        # phone number keys as the phone number headers
         for user in users:
             user_keys = user.keys()
             phone_number_keys = [key for key in user_keys if 'phone-number' in key]

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1234,6 +1234,12 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         self.add_phone_number(phone_number, True)
         self.save()
 
+    def set_phone_numbers(self, new_phone_numbers, default_number=''):
+        self.phone_numbers = new_phone_numbers
+        if default_number:
+            self.add_phone_number(default_number, True)
+        self.save()
+
     @property
     def default_phone_number(self):
         return _get_default(self.phone_numbers)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1240,7 +1240,6 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         self.phone_numbers = list(set(new_phone_numbers))  # ensure uniqueness
         if default_number:
             self.add_phone_number(default_number, True)
-        self.save()
 
     @property
     def default_phone_number(self):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1237,7 +1237,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         self.save()
 
     def set_phone_numbers(self, new_phone_numbers, default_number=''):
-        self.phone_numbers = new_phone_numbers
+        self.phone_numbers = list(set(new_phone_numbers))  # ensure uniqueness
         if default_number:
             self.add_phone_number(default_number, True)
         self.save()

--- a/corehq/apps/users/tests/test_download.py
+++ b/corehq/apps/users/tests/test_download.py
@@ -64,6 +64,7 @@ class TestDownloadMobileWorkers(TestCase):
             None,
             first_name='Edith',
             last_name='Wharton',
+            phone_number='27786541239',
             metadata={'born': 1862}
         )
         cls.user1.set_location(cls.location)
@@ -101,10 +102,16 @@ class TestDownloadMobileWorkers(TestCase):
         super().tearDownClass()
 
     def test_download(self):
+        # Add multiple phone numbers to user1
+        self.__class__.user1.add_phone_number('27786544321')
+        self.__class__.user1.save()
+
         (headers, rows) = parse_mobile_users(self.domain_obj.name, {})
 
         rows = list(rows)
         self.assertEqual(2, len(rows))
+        self.assertTrue('phone-number-1' in headers)
+        self.assertTrue('phone-number-2' in headers)
 
         spec = dict(zip(headers, rows[0]))
         self.assertEqual('edith', spec['username'])
@@ -115,6 +122,8 @@ class TestDownloadMobileWorkers(TestCase):
         self.assertEqual('', spec['data: _type'])
         self.assertEqual(1862, spec['data: born'])
         self.assertEqual('1', spec['location_code 1'])
+        self.assertEqual(spec['phone-number-1'], '27786541239')
+        self.assertEqual(spec['phone-number-2'], '27786544321')
 
     def test_multiple_domain_download(self):
         (headers, rows) = parse_mobile_users(self.domain_obj.name, {'domains': ['bookshelf', 'book']})

--- a/corehq/apps/users/tests/test_download.py
+++ b/corehq/apps/users/tests/test_download.py
@@ -110,8 +110,8 @@ class TestDownloadMobileWorkers(TestCase):
 
         rows = list(rows)
         self.assertEqual(2, len(rows))
-        self.assertTrue('phone-number-1' in headers)
-        self.assertTrue('phone-number-2' in headers)
+        self.assertTrue('phone-number 1' in headers)
+        self.assertTrue('phone-number 2' in headers)
 
         spec = dict(zip(headers, rows[0]))
         self.assertEqual('edith', spec['username'])
@@ -122,8 +122,8 @@ class TestDownloadMobileWorkers(TestCase):
         self.assertEqual('', spec['data: _type'])
         self.assertEqual(1862, spec['data: born'])
         self.assertEqual('1', spec['location_code 1'])
-        self.assertEqual(spec['phone-number-1'], '27786541239')
-        self.assertEqual(spec['phone-number-2'], '27786544321')
+        self.assertEqual(spec['phone-number 1'], '27786541239')
+        self.assertEqual(spec['phone-number 2'], '27786544321')
 
     def test_multiple_domain_download(self):
         (headers, rows) = parse_mobile_users(self.domain_obj.name, {'domains': ['bookshelf', 'book']})


### PR DESCRIPTION
## Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-1529)

When downloading mobile users, the respective mobile users' phone numbers will now all be listed as columns in the file which the person downloading the file can manipulate and upload again. This allows for easy bulk editing/removing of mobile numbers. 

Scenario:
Mobile user X has 3 phone numbers associated with him/her. When a web user exports the mobile users to a file, the respective phone numbers will be listed in columns `phone-number 1`, `phone-number 2` and `phone-number 3` (similar to locations) with `phone-number 1` always being the default phone number. 
When the web user edits `phone-number 2` and imports the file, mobile user X will now have the new phone number associated with him/her. The same goes for delete - the web user can simply remove the value from `phone-number 2` column and import the file.

## Feature Flag
(Privileges) Bulk User Management

## Product Description
No visual changes on the platform itself, only in the file being downloaded.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Unit tests included which tests various scenarios when bulk uploading users. Tests include
 - uploading new phone numbers for existing user
 - uploading new phone numbers for existing user with existing (default) phone number
 - uploading new phone numbers for existing user but leaving some columns blank
 - uploading new phone numbers with duplicate mobile numbers
 - downloading users and checking the correct headers 

### QA Plan
[QA Ticket](https://dimagi-dev.atlassian.net/browse/QA-3336)
Test bulk upload process of mobile users

### Safety story
Tested on staging:
- Bulk download + upload of mobile users with various combinations of phone-number headers and values

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
