### PR TITLE
[SSO] Re-implement original SSO login UI (with mobile worker fix)

### DIFF
--- a/corehq/apps/domain/templates/login_and_password/login.html
+++ b/corehq/apps/domain/templates/login_and_password/login.html
@@ -32,6 +32,7 @@
 {% block content %}
   {% initial_page_data "hide_password_feedback" hide_password_feedback %}
   {% initial_page_data "enforce_sso_login" enforce_sso_login|BOOL %}
+  {% initial_page_data "login_domain" domain %}
   {% registerurl 'check_sso_login_status' %}
   {% registerurl 'iframe_sso_login_pending' %}
   {% block login-content %}

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -85,6 +85,15 @@ class CloudCareAuthenticationForm(EmailAuthenticationForm):
     username = forms.CharField(label=_("Username"), max_length=75,
                                widget=forms.TextInput(attrs={'class': 'form-control'}))
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if settings.ENFORCE_SSO_LOGIN:
+            self.fields['username'].widget = forms.TextInput(attrs={
+                'class': 'form-control',
+                'data-bind': 'textInput: authUsername, onEnterKey: continueOnEnter',
+                'placeholder': _("Enter username or email address"),
+            })
+
 
 class BulkUploadForm(forms.Form):
     bulk_upload_file = forms.FileField(label="")

--- a/corehq/apps/hqwebapp/templates/hqwebapp/iframe_domain_login.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/iframe_domain_login.html
@@ -41,6 +41,7 @@
   {% initial_page_data "hide_password_feedback" hide_password_feedback %}
   {% initial_page_data "enforce_sso_login" enforce_sso_login|BOOL %}
   {% initial_page_data 'is_session_expiration' is_session_expiration %}
+  {% initial_page_data "login_domain" domain %}
   {% registerurl 'check_sso_login_status' %}
   {% registerurl 'iframe_sso_login_pending' %}
   {% block login-content %}

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -458,6 +458,7 @@ def iframe_domain_login(req, domain):
         'restrict_domain_creation': True,
         'is_session_expiration': True,
         'ANALYTICS_IDS': {},
+        'domain': domain,
     })
 
 

--- a/corehq/apps/registration/static/registration/js/user_login_form.js
+++ b/corehq/apps/registration/static/registration/js/user_login_form.js
@@ -32,6 +32,7 @@ hqDefine('registration/js/user_login_form', [
         self.isSessionExpiration = options.isSessionExpiration;
         self.passwordField = options.passwordField;
         self.passwordFormGroup = options.passwordFormGroup;
+        self.passwordFormGroup.hide();
 
         self.authUsername = ko.observable(options.initialUsername);
         self.authUsername.subscribe(function (newValue) {
@@ -46,14 +47,14 @@ hqDefine('registration/js/user_login_form', [
         self.continueTextPromise = null;
         self.defaultContinueText = gettext("Continue");
         self.continueButtonText = ko.observable(self.defaultContinueText);
-        self.showContinueButton = ko.observable(false);
+        self.showContinueButton = ko.observable(true);
         self.showContinueSpinner = ko.observable(false);
 
         self.isContinueDisabled = ko.computed(function () {
             return !emailUtils.validateEmail(self.authUsername());
         });
 
-        self.showSignInButton = ko.observable(true);
+        self.showSignInButton = ko.observable(false);
 
         /**
          * This updates the "Continue" Button text with either "Continue"

--- a/corehq/apps/registration/static/registration/js/user_login_form.js
+++ b/corehq/apps/registration/static/registration/js/user_login_form.js
@@ -28,6 +28,7 @@ hqDefine('registration/js/user_login_form', [
 
         self.checkSsoLoginStatusUrl = initialPageData.reverse('check_sso_login_status');
         self.sessionExpirationSsoIframeUrl = initialPageData.reverse('iframe_sso_login_pending');
+        self.loginDomain = initialPageData.get('login_domain');
         self.nextUrl = options.nextUrl;
         self.isSessionExpiration = options.isSessionExpiration;
         self.passwordField = options.passwordField;

--- a/corehq/apps/registration/static/registration/js/user_login_form.js
+++ b/corehq/apps/registration/static/registration/js/user_login_form.js
@@ -37,7 +37,7 @@ hqDefine('registration/js/user_login_form', [
 
         self.authUsername = ko.observable(options.initialUsername);
         self.authUsername.subscribe(function (newValue) {
-            if (emailUtils.validateEmail(newValue)) {
+            if (self.isUsernameValid(newValue)) {
                 if (self.continueTextPromise) {
                     self.continueTextPromise.abort();
                 }
@@ -51,8 +51,15 @@ hqDefine('registration/js/user_login_form', [
         self.showContinueButton = ko.observable(true);
         self.showContinueSpinner = ko.observable(false);
 
+        self.isUsernameValid = function (username) {
+            if (!self.loginDomain || username.indexOf('@') !== -1) {
+                return emailUtils.validateEmail(username);
+            }
+            return self.loginDomain && username.length > 1;
+        };
+
         self.isContinueDisabled = ko.computed(function () {
-            return !emailUtils.validateEmail(self.authUsername());
+            return !self.isUsernameValid(self.authUsername());
         });
 
         self.showSignInButton = ko.observable(false);


### PR DESCRIPTION
## Summary
This reverts the change made in this PR: https://github.com/dimagi/commcare-hq/pull/30088, which means that the default login UI will show the `continue` button and the `username` field, with the exception of domain logins where the domain is not associated with SSO.

For the global login, the `continue` button will only be enabled when the username/email address is a valid email address. If the email address matches an SSO user (based on email domain) the `continue` button will change to `Continue to <sso IdP name>`. Otherwise, when the user clicks continue (or hits enter) they will see the password field.

For domain logins, the username field now accepts both email addresses and usernames for mobile workers, so the `continue` button will enable itself when the username field just has a username in it.

NOTE: this workflow only appears if `ENFORCE_SSO_LOGIN` is set to `True` in `localsettings`

## Product Description / screenshots
Global login default view:
![Screen Shot 2021-07-26 at 3 06 08 PM](https://user-images.githubusercontent.com/716573/126993599-680fe9a0-1b12-493c-aa88-4e41dc31234f.png)

Note the global login will not accept non-email usernames (it never did)
![Screen Shot 2021-07-26 at 2 20 20 PM](https://user-images.githubusercontent.com/716573/126993674-ec475508-1e6c-4ae9-9524-78e8b695a0fd.png)

When a valid username is entered in global login:
![Screen Shot 2021-07-26 at 2 20 33 PM](https://user-images.githubusercontent.com/716573/126993725-48efb115-6571-492d-9a92-a04a411f43d7.png)

If continue is clicked (or enter key), the password field appears
![Screen Shot 2021-07-26 at 2 20 38 PM](https://user-images.githubusercontent.com/716573/126993803-1bc62c46-af67-4ab1-bb40-a909d1d8746c.png)

If the username is an SSO user
![Screen Shot 2021-07-26 at 2 20 26 PM](https://user-images.githubusercontent.com/716573/126993838-7a8b5bef-0f3b-4abb-ac8d-3cc8e1c51f85.png)

Domain login default view:
![Screen Shot 2021-07-26 at 2 19 22 PM](https://user-images.githubusercontent.com/716573/126993874-fe94182a-c16e-4c7a-89e6-8a22dbc3cd60.png)

Note it accepts usernames for mobile workers now
![Screen Shot 2021-07-26 at 2 19 29 PM](https://user-images.githubusercontent.com/716573/126993917-97386e4b-e7ff-48be-a628-0bbfc762f2ef.png)

![Screen Shot 2021-07-26 at 2 19 37 PM](https://user-images.githubusercontent.com/716573/126993958-3e04bc03-af3e-41e8-b962-eafbdd5b6b84.png)

behavior for SSO user
![Screen Shot 2021-07-26 at 2 19 48 PM](https://user-images.githubusercontent.com/716573/126993995-56e853ed-b8c3-4565-9dd2-f0ec4de4e220.png)

behavior for regular web user
![Screen Shot 2021-07-26 at 2 19 58 PM](https://user-images.githubusercontent.com/716573/126994045-bc49bc8f-7cb7-4754-8b6d-8ce704400548.png)


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
None :(

### QA Plan
QA will do passes on this on staging. Also waiting for USH to sign off.

### Safety story
QA and thorough local testing

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
