### PR TITLE
[js dependencies] resolve minimist to at least 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
         "js-yaml": "^3.13.1",
         "lodash": "^4.17.19",
         "mem": "^4.0.0",
+        "minimist": "^0.2.1",
         "minimatch": "^3.0.2",
         "ssri": "^8.0.1",
         "yargs-parser": "^18.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3813,15 +3813,10 @@ minimist-options@^4.0.2:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@0.0.8, minimist@^0.2.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.1.tgz#827ba4e7593464e7c221e8c5bed930904ee2c455"
+  integrity sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==
 
 minipass@^2.3.5, minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
   version "2.9.0"


### PR DESCRIPTION
## Summary
Since only `mocha` depends on the sub dependencies that then depend on `minimist`, if our js tests pass, then I think this is safe to merge. If the tests don't pass, I will look into upgrading mocha.


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
yes. this is a sub dependency of a sub dependency of `mocha`, which is used to run automated tests for our javascript.

### QA Plan
No QA needed. If tests pass, then we're good.

### Safety story
Only related to tests.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
