### PR TITLE
Dynamic options for multiselect custom binding

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -170,8 +170,8 @@ hqDefine('hqwebapp/js/multiselect_utils', [
             // have to access the observable to get the `update` method to fire on changes
             ko.unwrap(valueAccessor());
             $(element).multiSelect('refresh');
-        }
-    }
+        },
+    };
 
     return multiselect_utils;
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -141,8 +141,9 @@ hqDefine('hqwebapp/js/multiselect_utils', [
     };
 
     /*
-     * A custom binding for using multiselect in knockout content.
-     * This binding does not handle dynamic options, but could be extended to do so.
+     * A custom binding for setting multiselect properties in knockout content.
+     * This binding does not handle dynamic properties, but could be extended to do so.
+     * For a list of available options, see http://loudev.com/ under Options
      */
     ko.bindingHandlers.multiselect = {
         init: function (element, valueAccessor) {
@@ -155,6 +156,22 @@ hqDefine('hqwebapp/js/multiselect_utils', [
             );
         },
     };
+
+    /*
+    * A custom binding for dynamically updating select options when using the multiselect binding
+    * Replace the `options` binding with `multiselectOptions`, and the binding will take care of the rest
+    */
+    ko.bindingHandlers.multiselectOptions = {
+        init: function (element, valueAccessor) {
+            // add the `options` binding to the element, valueAccessor() should return an observable
+            ko.applyBindingsToNode(element, {options: valueAccessor()});
+        },
+        update: function (element, valueAccessor) {
+            // have to access the observable to get the `update` method to fire on changes
+            ko.unwrap(valueAccessor());
+            $(element).multiSelect('refresh');
+        }
+    }
 
     return multiselect_utils;
 });

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -225,7 +225,7 @@ hqDefine("linked_domain/js/domain_links", [
         });
 
         self.localDownstreamDomains = ko.computed(function () {
-            return self.parent.domain_links().reduce(function(result, link) {
+            return self.parent.domain_links().reduce(function (result, link) {
                 if (!link.is_remote) {
                     return result.concat(link.linked_domain());
                 }
@@ -237,7 +237,7 @@ hqDefine("linked_domain/js/domain_links", [
             selectableHeaderTitle: gettext("All project spaces"),
             selectedHeaderTitle: gettext("Project spaces to push to"),
             searchItemTitle: gettext("Search project spaces"),
-        }
+        };
 
         self.canPush = ko.computed(function () {
             return self.localDownstreamDomains().length > 0;

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -224,14 +224,23 @@ hqDefine("linked_domain/js/domain_links", [
             return self.domainsToPush().length && self.modelsToPush().length && !self.pushInProgress();
         });
 
-        self.localDomainLinks = ko.computed(function () {
-            return _.filter(self.parent.domain_links(), function (link) {
-                return !link.is_remote;
-            });
+        self.localDownstreamDomains = ko.computed(function () {
+            return self.parent.domain_links().reduce(function(result, link) {
+                if (!link.is_remote) {
+                    return result.concat(link.linked_domain());
+                }
+                return result;
+            }, []);
         });
 
+        self.multiselectProperties = {
+            selectableHeaderTitle: gettext("All project spaces"),
+            selectedHeaderTitle: gettext("Project spaces to push to"),
+            searchItemTitle: gettext("Search project spaces"),
+        }
+
         self.canPush = ko.computed(function () {
-            return self.localDomainLinks().length > 0;
+            return self.localDownstreamDomains().length > 0;
         });
 
         self.pushContent = function () {

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
@@ -37,14 +37,8 @@
         <div class="col-sm-9 col-md-10 controls">
           <select multiple class="form-control"
                   data-bind="selectedOptions: domainsToPush,
-                             options: localDomainLinks,
-                             optionsText: 'linked_domain',
-                             optionsValue: 'linked_domain',
-                             multiselect: {
-                                 selectableHeaderTitle: '{% trans_html_attr "All project spaces" %}',
-                                 selectedHeaderTitle: '{% trans_html_attr "Project spaces to push to" %}',
-                                 searchItemTitle: '{% trans_html_attr "Search project spaces" %}',
-                            }">
+                             multiselect: multiselectProperties,
+                             multiselectOptions: localDownstreamDomains">
           </select>
         </div>
       </div>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SS-155

The issue found by QA was that when a domain link was added or removed on the manage downstream domains tab, the push content tab's list of downstream domains was not updating. As knockout observables were already setup on this property, it became apparent that the issue was related to our `multiselect` custom binding. When it is not used, the `options` knockout binding updates a select element on changes properly. This is not the case once the `multiselect` custom binding is added.

I created a separate binding that expects an observable array to represent the options in a multiselect, and refreshes the multiselect element when the observable array updates. This effectively wraps the `options` binding, as the `multiselectOptions` binding handles adding the `options` binding to the element. This also is the least disruptive to existing uses of the `multiselect` binding, as that has not changed at all.

Specific to linked domains, I removed the `optionsText` and `optionsValue` bindings in favor of simply passing an array of domain names, since these two bindings were both reading that value anyway. I double checked that pushing still works as expected, and especially when pushing to a recently added domain.  

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Soon to be `RELEASE_MANAGEMENT` privilege users
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The push content page list of domains updates after adding/removing downstream domains.
## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
UI changes.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
[This ticket](https://dimagi-dev.atlassian.net/browse/QA-3315) hasn't been started yet, so this could still make it in there.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
