### PR TITLE
Moved tableau import to fix docs build

### DIFF
--- a/corehq/apps/reports/standard/tableau.py
+++ b/corehq/apps/reports/standard/tableau.py
@@ -5,7 +5,6 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _, ugettext_lazy
 
 import requests
-from requests_toolbelt.adapters import host_header_ssl
 
 from corehq import toggles
 from corehq.apps.reports.models import TableauVisualization
@@ -62,6 +61,7 @@ class TableauView(BaseProjectReportSectionView):
         return super().get(request, *args, **kwargs)
 
     def tableau_server_response(self):
+        from requests_toolbelt.adapters import host_header_ssl  # avoid top-level import that breaks docs build
         context = self.page_context
         tabserver_url = 'https://{}/trusted/'.format(self.visualization.server.server_name)
         post_arguments = {'username': self.visualization.server.domain_username}


### PR DESCRIPTION
## Summary
It came up in conversation with Kim that the covid custom sms actions docs had disappeared.

The [docs build](https://readthedocs.org/api/v2/build/14338315.txt) passes but fails to build the covid autodoc, with the following warning. Moving the referenced tableau.py import fixes it - basically it's the same issue as https://github.com/dimagi/commcare-hq/pull/29733/

```
WARNING: autodoc: failed to import module 'custom_actions' from module 'custom.covid.rules'; the following exception was raised:
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/commcare-hq/envs/latest/lib/python3.7/site-packages/sphinx/ext/autodoc/importer.py", line 70, in import_module
    return importlib.import_module(modname)
...
  File "/home/docs/checkouts/readthedocs.org/user_builds/commcare-hq/checkouts/latest/corehq/apps/reports/urls.py", line 7, in <module>
    from corehq.apps.reports.standard.tableau import TableauView
  File "/home/docs/checkouts/readthedocs.org/user_builds/commcare-hq/checkouts/latest/corehq/apps/reports/standard/tableau.py", line 8, in <module>
    from requests_toolbelt.adapters import host_header_ssl
...
  File "/home/docs/checkouts/readthedocs.org/user_builds/commcare-hq/envs/latest/lib/python3.7/site-packages/urllib3/contrib/pyopenssl.py", line 107, in <module>
    + OpenSSL.SSL.VERIFY_FAIL_IF_NO_PEER_CERT,
TypeError: unsupported operand type(s) for +: 'VERIFY_PEER' and 'VERIFY_FAIL_IF_NO_PEER_CERT'
```

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
I don't think there are view-level tableau tests.

### QA Plan
No QA.

### Safety story
Tiny change to flagged functionality that isn't used externally yet.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
