### PR TITLE
Limit upstream domains based on account vs user

### DIFF
--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -76,8 +76,8 @@ def get_available_domains_to_link_for_account(upstream_domain_name, user, accoun
     """
     Finds available domains to link based on domains associated with the provided account
     """
-    eligible_domains = account.get_domains() if account else []
-    return list({domain for domain in eligible_domains
+    domains_in_account = account.get_domains() if account else []
+    return list({domain for domain in domains_in_account
                  if is_domain_available_to_link(upstream_domain_name, domain, user)})
 
 
@@ -85,8 +85,8 @@ def get_available_domains_to_link_for_user(upstream_domain_name, user):
     """
     Finds available domains to link based on domains that the provided user is active in
     """
-    potential_domains = [d.name for d in Domain.active_for_user(user)]
-    return list({potential_domain for potential_domain in potential_domains if is_domain_available_to_link(
+    domains_for_user = [d.name for d in Domain.active_for_user(user)]
+    return list({potential_domain for potential_domain in domains_for_user if is_domain_available_to_link(
         upstream_domain_name, potential_domain, user, should_enforce_admin=False)})
 
 
@@ -116,13 +116,13 @@ def get_available_upstream_domains_for_account(domain_name, user, account):
     :return: list of domain names that are active upstream domains within the account
     """
     domains_in_account = account.get_domains() if account else []
-    return list({d for d in domains_in_account if is_available_upstream_domain(d.name, domain_name, user)})
+    return list({d for d in domains_in_account if is_available_upstream_domain(d, domain_name, user)})
 
 
 def get_available_upstream_domains_for_user(domain_name, user):
     domains_for_user = [d.name for d in Domain.active_for_user(user)]
     return list({d for d in domains_for_user
-                 if is_available_upstream_domain(d.name, domain_name, user, should_enforce_admin=False)})
+                 if is_available_upstream_domain(d, domain_name, user, should_enforce_admin=False)})
 
 
 def get_accessible_downstream_domains(upstream_domain_name, user):

--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -76,8 +76,8 @@ def get_available_domains_to_link_for_account(upstream_domain_name, user, accoun
     """
     Finds available domains to link based on domains associated with the provided account
     """
-    domains_in_account = account.get_domains() if account else []
-    return list({domain for domain in domains_in_account
+    domains = account.get_domains() if account else []
+    return list({domain for domain in domains
                  if is_domain_available_to_link(upstream_domain_name, domain, user)})
 
 
@@ -85,44 +85,38 @@ def get_available_domains_to_link_for_user(upstream_domain_name, user):
     """
     Finds available domains to link based on domains that the provided user is active in
     """
-    domains_for_user = [d.name for d in Domain.active_for_user(user)]
-    return list({potential_domain for potential_domain in domains_for_user if is_domain_available_to_link(
-        upstream_domain_name, potential_domain, user, should_enforce_admin=False)})
+    domains = [d.name for d in Domain.active_for_user(user)]
+    return list({domain for domain in domains if is_domain_available_to_link(
+        upstream_domain_name, domain, user, should_enforce_admin=False)})
 
 
-def get_available_upstream_domains_for_downstream_domain(domain_name, user, billing_account=None):
+def get_available_upstream_domains(downstream_domain, user, billing_account=None):
     """
     This supports both the old feature flagged version of linked projects and the GAed version
     The GAed version is only available to enterprise customers and only usable by admins, but the feature flagged
-    version is available to anyone who can obtain access (the wild west)
-    :param domain_name: potential upstream domain candidate
+    version is available to anyone who can obtain access
+    :param downstream_domain: potential upstream domain candidate
     :param user: user object
     :param billing_account: optional parameter to limit available domains to within an enterprise account
     :return: list of domain names available to link as downstream projects
     """
-    if domain_has_privilege(domain_name, RELEASE_MANAGEMENT):
-        return get_available_upstream_domains_for_account(domain_name, user, billing_account)
-    elif toggles.LINKED_DOMAINS.enabled(domain_name):
-        return get_available_upstream_domains_for_user(domain_name, user)
+    if domain_has_privilege(downstream_domain, RELEASE_MANAGEMENT):
+        return get_available_upstream_domains_for_account(downstream_domain, user, billing_account)
+    elif toggles.LINKED_DOMAINS.enabled(downstream_domain):
+        return get_available_upstream_domains_for_user(downstream_domain, user)
 
     return []
 
 
-def get_available_upstream_domains_for_account(domain_name, user, account):
-    """
-    :param domain_name: desired downstream domain
-    :param user: couch user object
-    :param account: billing account to grab domains from
-    :return: list of domain names that are active upstream domains within the account
-    """
-    domains_in_account = account.get_domains() if account else []
-    return list({d for d in domains_in_account if is_available_upstream_domain(d, domain_name, user)})
+def get_available_upstream_domains_for_account(downstream_domain, user, account):
+    domains = account.get_domains() if account else []
+    return list({d for d in domains if is_available_upstream_domain(d, downstream_domain, user)})
 
 
 def get_available_upstream_domains_for_user(domain_name, user):
-    domains_for_user = [d.name for d in Domain.active_for_user(user)]
-    return list({d for d in domains_for_user
-                 if is_available_upstream_domain(d, domain_name, user, should_enforce_admin=False)})
+    domains = [d.name for d in Domain.active_for_user(user)]
+    return list({domain for domain in domains
+                 if is_available_upstream_domain(domain, domain_name, user, should_enforce_admin=False)})
 
 
 def get_accessible_downstream_domains(upstream_domain_name, user):

--- a/corehq/apps/linked_domain/tests/test_dbaccessors.py
+++ b/corehq/apps/linked_domain/tests/test_dbaccessors.py
@@ -2,8 +2,64 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
-from corehq.apps.linked_domain.dbaccessors import get_available_domains_to_link
+from corehq.apps.linked_domain.dbaccessors import (
+    get_available_domains_to_link,
+    get_available_upstream_domains_for_downstream_domain,
+)
 from corehq.util.test_utils import flag_enabled
+
+
+class TestGetAvailableUpstreamDomainsForDownstreamDomain(SimpleTestCase):
+
+    @patch('corehq.apps.users.models.CouchUser')
+    @patch('corehq.apps.accounting.models.BillingAccount')
+    def test_no_privilege_or_feature_flag_returns_none(self, mock_user, mock_account):
+        mock_account.get_domains.return_value = ['upstream', 'downstream-1', 'downstream-2']
+        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
+            upstream_domains = get_available_upstream_domains_for_downstream_domain(
+                'downstream-1', mock_user, mock_account
+            )
+        self.assertFalse(upstream_domains)
+
+    @flag_enabled("LINKED_DOMAINS")
+    @patch('corehq.apps.users.models.CouchUser')
+    @patch('corehq.apps.accounting.models.BillingAccount')
+    def test_release_management_privilege_returns_domains_for_account(self, mock_user, mock_account):
+        """NOTE: this also tests that the release_management privilege overrides the linked domains flag"""
+        mock_account.get_domains.return_value = ['upstream', 'downstream-1', 'downstream-2']
+        expected_upstream_domains = ['upstream']
+        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
+             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_account') \
+             as mock_account_domains,\
+             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_user') \
+             as mock_user_domains:
+            mock_domain_has_privilege.return_value = True
+            mock_account_domains.return_value = expected_upstream_domains
+            mock_user_domains.return_value = ['wrong']
+            upstream_domains = get_available_upstream_domains_for_downstream_domain(
+                'downstream-1', mock_user, mock_account
+            )
+        self.assertEqual(expected_upstream_domains, upstream_domains)
+
+    @flag_enabled("LINKED_DOMAINS")
+    @patch('corehq.apps.users.models.CouchUser')
+    @patch('corehq.apps.accounting.models.BillingAccount')
+    def test_linked_domains_flag_returns_domains_for_user(self, mock_user, mock_account):
+        expected_upstream_domains = ['upstream']
+        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
+             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_account') \
+             as mock_account_domains,\
+             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_user') \
+             as mock_user_domains:
+            mock_domain_has_privilege.return_value = False
+            mock_account_domains.return_value = ['wrong']
+            mock_user_domains.return_value = expected_upstream_domains
+            upstream_domains = get_available_upstream_domains_for_downstream_domain(
+                'downstream-1', mock_user, mock_account
+            )
+
+        self.assertEqual(expected_upstream_domains, upstream_domains)
 
 
 class TestGetAvailableDomainsToLink(SimpleTestCase):

--- a/corehq/apps/linked_domain/tests/test_dbaccessors.py
+++ b/corehq/apps/linked_domain/tests/test_dbaccessors.py
@@ -4,7 +4,7 @@ from django.test import SimpleTestCase
 
 from corehq.apps.linked_domain.dbaccessors import (
     get_available_domains_to_link,
-    get_available_upstream_domains_for_downstream_domain,
+    get_available_upstream_domains,
 )
 from corehq.util.test_utils import flag_enabled
 
@@ -17,7 +17,7 @@ class TestGetAvailableUpstreamDomainsForDownstreamDomain(SimpleTestCase):
         mock_account.get_domains.return_value = ['upstream', 'downstream-1', 'downstream-2']
         with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
-            upstream_domains = get_available_upstream_domains_for_downstream_domain(
+            upstream_domains = get_available_upstream_domains(
                 'downstream-1', mock_user, mock_account
             )
         self.assertFalse(upstream_domains)
@@ -37,7 +37,7 @@ class TestGetAvailableUpstreamDomainsForDownstreamDomain(SimpleTestCase):
             mock_domain_has_privilege.return_value = True
             mock_account_domains.return_value = expected_upstream_domains
             mock_user_domains.return_value = ['wrong']
-            upstream_domains = get_available_upstream_domains_for_downstream_domain(
+            upstream_domains = get_available_upstream_domains(
                 'downstream-1', mock_user, mock_account
             )
         self.assertEqual(expected_upstream_domains, upstream_domains)
@@ -55,7 +55,7 @@ class TestGetAvailableUpstreamDomainsForDownstreamDomain(SimpleTestCase):
             mock_domain_has_privilege.return_value = False
             mock_account_domains.return_value = ['wrong']
             mock_user_domains.return_value = expected_upstream_domains
-            upstream_domains = get_available_upstream_domains_for_downstream_domain(
+            upstream_domains = get_available_upstream_domains(
                 'downstream-1', mock_user, mock_account
             )
 

--- a/corehq/apps/linked_domain/tests/test_linked_domain_utils.py
+++ b/corehq/apps/linked_domain/tests/test_linked_domain_utils.py
@@ -2,7 +2,69 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
-from corehq.apps.linked_domain.util import is_domain_available_to_link
+from corehq.apps.linked_domain.util import (
+    is_available_upstream_domain,
+    is_domain_available_to_link,
+)
+
+
+class TestIsAvailableUpstreamDomain(SimpleTestCase):
+
+    @patch('corehq.apps.users.models.CouchUser')
+    def test_none_potential_upstream_domain_returns_false(self, mock_user):
+        result = is_available_upstream_domain(None, 'downstream', mock_user)
+        self.assertFalse(result)
+
+    @patch('corehq.apps.users.models.CouchUser')
+    def test_none_downstream_domain_returns_false(self, mock_user):
+        result = is_available_upstream_domain('potential-upstream', None, mock_user)
+        self.assertFalse(result)
+
+    @patch('corehq.apps.users.models.CouchUser')
+    def test_none_potential_upstream_and_none_downstream_returns_false(self, mock_user):
+        result = is_available_upstream_domain(None, None, mock_user)
+        self.assertFalse(result)
+
+    @patch('corehq.apps.users.models.CouchUser')
+    def test_same_domain_returns_false(self, mock_user):
+        result = is_available_upstream_domain('domain', 'domain', mock_user)
+        self.assertFalse(result)
+
+    @patch('corehq.apps.users.models.CouchUser')
+    def test_not_active_upstream_domain_returns_false(self, mock_user):
+        with patch('corehq.apps.linked_domain.dbaccessors.is_active_upstream_domain') as mock_active_upstream:
+            mock_active_upstream.return_value = False
+            result = is_available_upstream_domain('potential-upstream', 'downstream', mock_user)
+        self.assertFalse(result)
+
+    @patch('corehq.apps.users.models.CouchUser')
+    def test_active_upstream_domain_without_admin_check_returns_true(self, mock_user):
+        with patch('corehq.apps.linked_domain.dbaccessors.is_active_upstream_domain') as mock_active_upstream:
+            mock_active_upstream.return_value = True
+            result = is_available_upstream_domain('potential-upstream', 'downstream', mock_user,
+                                                  should_enforce_admin=False)
+        self.assertTrue(result)
+
+    @patch('corehq.apps.users.models.CouchUser')
+    def test_user_without_admin_access_returns_false(self, mock_user):
+        with patch('corehq.apps.linked_domain.dbaccessors.is_active_upstream_domain') as mock_active_upstream,\
+             patch('corehq.apps.linked_domain.util.user_has_admin_access_in_all_domains') as mock_admin:
+            mock_active_upstream.return_value = True
+            mock_admin.return_value = False
+            result = is_available_upstream_domain('potential-upstream', 'downstream', mock_user,
+                                                  should_enforce_admin=True)
+        self.assertFalse(result)
+
+    @patch('corehq.apps.users.models.CouchUser')
+    def test_user_with_admin_access_returns_true(self, mock_user):
+        with patch('corehq.apps.linked_domain.dbaccessors.is_active_upstream_domain') as mock_active_upstream, \
+            patch(
+                'corehq.apps.linked_domain.util.user_has_admin_access_in_all_domains') as mock_admin:
+            mock_active_upstream.return_value = True
+            mock_admin.return_value = True
+            result = is_available_upstream_domain('potential-upstream', 'downstream', mock_user,
+                                                 should_enforce_admin=True)
+        self.assertTrue(result)
 
 
 class TestIsDomainAvailableToLink(SimpleTestCase):

--- a/corehq/apps/linked_domain/util.py
+++ b/corehq/apps/linked_domain/util.py
@@ -115,6 +115,32 @@ def is_domain_available_to_link(upstream_domain_name, candidate_name, user, shou
         return True
 
 
+def is_available_upstream_domain(potential_upstream_name, downstream_domain_name, user, should_enforce_admin=True):
+    """
+    :param potential_upstream_name: potential upstream domain
+    :param downstream_domain_name: domain that would be downstream in this link if able
+    :param user: couch user
+    :param should_enforce_admin: enforce user is admin in both domains
+    :return: True if the potential upstream domain is eligible to link to the specified downstream domain
+    """
+    from corehq.apps.linked_domain.dbaccessors import is_active_upstream_domain
+
+    if not potential_upstream_name or not downstream_domain_name:
+        return False
+
+    if potential_upstream_name == downstream_domain_name:
+        return False
+
+    if not is_active_upstream_domain(potential_upstream_name):
+        # needs to be an active upstream domain
+        return False
+
+    if should_enforce_admin:
+        return user_has_admin_access_in_all_domains(user, [downstream_domain_name, potential_upstream_name])
+    else:
+        return True
+
+
 def is_domain_in_active_link(domain_name):
     from corehq.apps.linked_domain.dbaccessors import (
         is_active_downstream_domain,

--- a/corehq/apps/linked_domain/util.py
+++ b/corehq/apps/linked_domain/util.py
@@ -115,28 +115,28 @@ def is_domain_available_to_link(upstream_domain_name, candidate_name, user, shou
         return True
 
 
-def is_available_upstream_domain(potential_upstream_name, downstream_domain_name, user, should_enforce_admin=True):
+def is_available_upstream_domain(potential_upstream_domain, downstream_domain, user, should_enforce_admin=True):
     """
-    :param potential_upstream_name: potential upstream domain
-    :param downstream_domain_name: domain that would be downstream in this link if able
+    :param potential_upstream_domain: potential upstream domain
+    :param downstream_domain: domain that would be downstream in this link if able
     :param user: couch user
     :param should_enforce_admin: enforce user is admin in both domains
     :return: True if the potential upstream domain is eligible to link to the specified downstream domain
     """
     from corehq.apps.linked_domain.dbaccessors import is_active_upstream_domain
 
-    if not potential_upstream_name or not downstream_domain_name:
+    if not potential_upstream_domain or not downstream_domain:
         return False
 
-    if potential_upstream_name == downstream_domain_name:
+    if potential_upstream_domain == downstream_domain:
         return False
 
-    if not is_active_upstream_domain(potential_upstream_name):
+    if not is_active_upstream_domain(potential_upstream_domain):
         # needs to be an active upstream domain
         return False
 
     if should_enforce_admin:
-        return user_has_admin_access_in_all_domains(user, [downstream_domain_name, potential_upstream_name])
+        return user_has_admin_access_in_all_domains(user, [downstream_domain, potential_upstream_domain])
     else:
         return True
 

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -46,7 +46,7 @@ from corehq.apps.linked_domain.const import (
 )
 from corehq.apps.linked_domain.dbaccessors import (
     get_available_domains_to_link,
-    get_available_upstream_domains_for_downstream_domain,
+    get_available_upstream_domains,
     get_linked_domains,
     get_upstream_domain_link,
 )
@@ -283,12 +283,12 @@ class DomainLinkView(BaseAdminProjectSettingsView):
                                                                   self.request.couch_user,
                                                                   billing_account=account)
 
-        upstream_domain_view_models = []
-        upstream_domains = get_available_upstream_domains_for_downstream_domain(self.request.domain,
-                                                                                self.request.couch_user,
-                                                                                billing_account=account)
+        upstream_domain_urls = []
+        upstream_domains = get_available_upstream_domains(self.request.domain,
+                                                          self.request.couch_user,
+                                                          billing_account=account)
         for domain in upstream_domains:
-            upstream_domain_view_models.append({'name': domain, 'url': reverse('domain_links', args=[domain])})
+            upstream_domain_urls.append({'name': domain, 'url': reverse('domain_links', args=[domain])})
 
         if master_link and master_link.is_remote:
             remote_linkable_ucr = get_remote_linkable_ucr(master_link)
@@ -301,7 +301,7 @@ class DomainLinkView(BaseAdminProjectSettingsView):
             'has_release_management_privilege': domain_has_privilege(self.domain, RELEASE_MANAGEMENT),
             'view_data': {
                 'is_downstream_domain': bool(master_link),
-                'upstream_domains': upstream_domain_view_models,
+                'upstream_domains': upstream_domain_urls,
                 'available_domains': available_domains_to_link,
                 'master_link': build_domain_link_view_model(master_link, timezone) if master_link else None,
                 'model_status': sorted(view_models_to_pull, key=lambda m: m['name']),

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -45,10 +45,11 @@ from corehq.apps.linked_domain.const import (
     SUPERUSER_DATA_MODELS,
 )
 from corehq.apps.linked_domain.dbaccessors import (
+    get_accessible_upstream_domains,
     get_available_domains_to_link,
+    get_available_upstream_domains_for_downstream_domain,
     get_linked_domains,
     get_upstream_domain_link,
-    get_upstream_domains,
 )
 from corehq.apps.linked_domain.decorators import require_linked_domain
 from corehq.apps.linked_domain.exceptions import (
@@ -282,9 +283,13 @@ class DomainLinkView(BaseAdminProjectSettingsView):
         available_domains_to_link = get_available_domains_to_link(self.request.domain,
                                                                   self.request.couch_user,
                                                                   billing_account=account)
-        upstream_domains = []
-        for domain in get_upstream_domains(self.request.domain, self.request.couch_user):
-            upstream_domains.append({'name': domain, 'url': reverse('domain_links', args=[domain])})
+
+        upstream_domain_view_models = []
+        upstream_domains = get_available_upstream_domains_for_downstream_domain(self.request.domain,
+                                                                                self.request.couch_user,
+                                                                                billing_account=account)
+        for domain in upstream_domains:
+            upstream_domain_view_models.append({'name': domain, 'url': reverse('domain_links', args=[domain])})
 
         if master_link and master_link.is_remote:
             remote_linkable_ucr = get_remote_linkable_ucr(master_link)
@@ -297,7 +302,7 @@ class DomainLinkView(BaseAdminProjectSettingsView):
             'has_release_management_privilege': domain_has_privilege(self.domain, RELEASE_MANAGEMENT),
             'view_data': {
                 'is_downstream_domain': bool(master_link),
-                'upstream_domains': upstream_domains,
+                'upstream_domains': upstream_domain_view_models,
                 'available_domains': available_domains_to_link,
                 'master_link': build_domain_link_view_model(master_link, timezone) if master_link else None,
                 'model_status': sorted(view_models_to_pull, key=lambda m: m['name']),

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -45,7 +45,6 @@ from corehq.apps.linked_domain.const import (
     SUPERUSER_DATA_MODELS,
 )
 from corehq.apps.linked_domain.dbaccessors import (
-    get_accessible_upstream_domains,
     get_available_domains_to_link,
     get_available_upstream_domains_for_downstream_domain,
     get_linked_domains,


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SS-187

On the landing page for linked project spaces, the list of upstream domains should be limited to within an enterprise account if the `release_management` privilege is enabled. This essentially does the same thing that was done for fetching available downstream domains to link, but instead checks fo actively linked upstream domains.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS` and soon to be `RELEASE_MANAGEMENT` privilege.
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added automated tests for methods related to fetching available upstream domains.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will run through QA on parent branch.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
