### PR TITLE
Updated URL for smart links

### DIFF
--- a/corehq/apps/cloudcare/urls.py
+++ b/corehq/apps/cloudcare/urls.py
@@ -11,7 +11,6 @@ from corehq.apps.cloudcare.views import (
     default,
     form_context,
     report_formplayer_error,
-    session_endpoint,
 )
 from corehq.apps.hqwebapp.decorators import waf_allow
 
@@ -27,11 +26,6 @@ app_urls = [
     ),
     url(r'^preview_app/(?P<app_id>[\w-]+)/$', PreviewAppView.as_view(), name=PreviewAppView.urlname),
     url(r'^report_formplayer_error', report_formplayer_error, name='report_formplayer_error'),
-    url(
-        r'^session_endpoint/(?P<app_id>[\w-]+)/(?P<endpoint_id>[\w_-]+)/$',
-        session_endpoint,
-        name='session_endpoint'
-    ),
 ]
 
 api_urls = [

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import include, url
 from two_factor.gateways.twilio.urls import urlpatterns as tf_twilio_urls
 from two_factor.urls import urlpatterns as tf_urls
 
+from corehq.apps.cloudcare.views import session_endpoint
 from corehq.apps.domain.views.sms import PublicSMSRatesView
 from corehq.apps.hqwebapp.session_details_endpoint.views import (
     SessionDetailsView,
@@ -108,6 +109,7 @@ domain_specific = [
     url(r'^retreive_download/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
         retrieve_download, {'template': 'hqwebapp/includes/file_download.html'},
         name='hq_soil_download'),
+    url(r'^app/v1/(?P<app_id>[\w-]+)/(?P<endpoint_id>[\w_-]+)/$', session_endpoint, name='session_endpoint'),
 ]
 
 prelogin_root = [


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-1187

PR in https://github.com/dimagi/commcare-hq/pull/30002, see there for risk/QA details.

@ctsims This changes the smart linking URL template.
Old: `/a/<domain>/cloudcare/apps/<endpoint_id>/?<endpoint_args>`
New: `/a/<domain>/app/v1/<app_id>/<endpoint_id>/?<endpoint_args>`