### PR TITLE
Fixed notification popup for required questions always displaying

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -149,7 +149,7 @@
       </div>
       <div data-bind="visible: erroredQuestions().length > 0">
         {% if environment == "web-apps" %}
-          {% if True or request|ui_notify_enabled:"JUMP_TO_INVALID_QUESTIONS_WEBAPPS" %}
+          {% if request|ui_notify_enabled:"JUMP_TO_INVALID_QUESTIONS_WEBAPPS" %}
             <div class="alert alert-ui-notify alert-dismissible helpbubble helpbubble-purple helpbubble-bottom-left fade in"
                  style="position: fixed; width: 300px; bottom: 65px;"
                  data-slug="{{ "JUMP_TO_INVALID_QUESTIONS_WEBAPPS"|ui_notify_slug }}"


### PR DESCRIPTION
## Summary
Debugging code I added in https://github.com/dimagi/commcare-hq/pull/29673 and forgot to remove.

I'm a little surprised no one has complained about this, but most users had probably already seen and dismissed the popup by the time the bad code was deployed, a few days after the initial feature release.

## Product description

Not worth announcing, this isn't likely to affect many people. But it's possible some small number of people have been seeing the purple bubble announcement notification for required question every time they've opened Web Apps, even if they previously dismissed it.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No

### QA Plan

No

### Safety story
Tiny and HTML only

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
