### PR TITLE
Updated web apps error navigation to not happen until submit

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -295,7 +295,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
             var qs = [];
             for (var i = 0; i < questions.length; i++) {
                 // eslint-disable-next-line
-                if (questions[i].error() != null || questions[i].serverError() != null || questions[i].requiredNotAnswered()) {
+                if (questions[i].error() != null || questions[i].serverError() != null) {
                     qs.push(questions[i]);
                 }
             }
@@ -601,10 +601,6 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
             if (!resourceType || !_.isFunction(Utils.resourceMap)) { return ''; }
             return Utils.resourceMap(resourceType);
         };
-
-        self.requiredNotAnswered = ko.computed(function () {
-            return self.required() && self.answer() === Const.NO_ANSWER;
-        });
 
         self.navigateTo = function () {
             // toggle nested collapsible Groups


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-1144

This was originally added in https://github.com/dimagi/commcare-hq/commit/8861b8d85b61467eca80cf4a040b2c0058654342

My read of the code is that this was intentional and `requiredNotAnswered` exists for the sake of showing errors before submission, and it was only after release that we realized / got feedback that it caused confusion.

I do think it was nicer on that the previous UX let you see errors before submitting, but I don't think there's a good way to detect that you're **about** to submit that'll work for all forms.

## Product Description
This will cause the [jump to errors](https://github.com/dimagi/commcare-hq/pull/29475) feature in web apps to not show the button until the first time the user tries to submit the form.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests for this particular workflow.

### QA Plan

Requesting QA - this is a small change but it's a finicky UI. [QA ticket](https://dimagi-dev.atlassian.net/browse/QA-3329)

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
