### PR TITLE
refactor alert_user.js + add option to have messages fade out after a fixed interval

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alert_user.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alert_user.js
@@ -35,7 +35,7 @@ function (
         if (fadeOut) {
             self.timer = setTimeout(removeAlertTimerFunc(self), 5000);
         }
-        self.restartTimer = () => {
+        self.restartTimer = function () {
             if (self.timer) {
                 clearTimeout(self.timer);
                 self.timer = setTimeout(removeAlertTimerFunc(self), 5000);
@@ -44,16 +44,16 @@ function (
         return self;
     };
 
-    const ViewModel = function() {
-        let self = this;
+    const ViewModel = function () {
+        let self = {};
         self.alerts = ko.observableArray();
-        self.removeAlert = (alertObj) => {
+        self.removeAlert = function (alertObj) {
             self.alerts.remove(alertObj);
         };
 
-        self.fadeOut = function(element) {
+        self.fadeOut = function (element) {
             $(element).fadeOut('slow');
-        }
+        };
 
         self.alert_user = function (message, emphasis, append, fadeOut) {
             var tags = "alert-" + emphasis;
@@ -74,11 +74,11 @@ function (
         return self;
     };
 
-    const removeAlertTimerFunc = (alertObj) => {
+    const removeAlertTimerFunc = function (alertObj) {
         return () => {
             viewModel.removeAlert(alertObj);
-        }
-    }
+        };
+    };
 
     const viewModel = ViewModel();
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alert_user.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alert_user.js
@@ -21,53 +21,61 @@ function (
     $,
     ko
 ) {
-    var message_alert = function (message, tags) {
-        var alert_obj = {
+    var MessageAlert = function (message, tags) {
+        var self = {
             "message": ko.observable(message),
             "alert_class": ko.observable(
                 "alert fade in message-alert"
             ),
         };
         if (tags) {
-            alert_obj.alert_class(alert_obj.alert_class() + " " + tags);
+            self.alert_class(self.alert_class() + " " + tags);
         }
-        return alert_obj;
+        return self;
     };
-    var message_alerts = ko.observableArray();
 
-    var alert_user = function (message, emphasis, append) {
-        var tags = "alert-" + emphasis;
-        if (!append || message_alerts().length === 0) {
-            message_alerts.push(message_alert(message, tags));
-        } else {
-            var alert = message_alerts()[0];
-            alert.message(alert.message() + "<br>" + message);
-            if (!alert.alert_class().includes(tags)) {
-                alert.alert_class(alert.alert_class() + ' ' + tags);
+    const ViewModel = function() {
+        let self = this;
+        self.alerts = ko.observableArray();
+        self.removeAlert = (alertObj) => {
+            self.alerts.remove(alertObj);
+        };
+
+        self.alert_user = function (message, emphasis, append) {
+            var tags = "alert-" + emphasis;
+            if (!append || self.alerts().length === 0) {
+                self.alerts.push(MessageAlert(message, tags));
+            } else {
+                var alert = self.alerts()[0];
+                alert.message(alert.message() + "<br>" + message);
+                if (!alert.alert_class().includes(tags)) {
+                    alert.alert_class(alert.alert_class() + ' ' + tags);
+                }
             }
-        }
 
-        // Scroll to top of page to see alert
-        document.body.scrollTop = document.documentElement.scrollTop = 0;
+            // Scroll to top of page to see alert
+            document.body.scrollTop = document.documentElement.scrollTop = 0;
+        };
+        return self;
     };
+
+    const viewModel = ViewModel();
 
     $(function () {
         // remove closed alerts from backend model
         $(document).on('close.bs.alert','.message-alert', function () {
-            message_alerts.remove(ko.dataFor(this));
+            viewModel.removeAlert(ko.dataFor(this));
         });
 
         var message_element = $("#message-alerts").get(0);
         // this element is not available on templates like iframe_domain_login.html
         if (message_element) {
             ko.cleanNode(message_element);
-            $(message_element).koApplyBindings({
-                alerts: message_alerts,
-            });
+            $(message_element).koApplyBindings(viewModel);
         }
     });
 
     return {
-        alert_user: alert_user,
+        alert_user: viewModel.alert_user,
     };
 });

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base_navigation.html
@@ -111,7 +111,7 @@
         {% endif %}
         <div id="message-alerts"
              class="ko-template"
-             data-bind="foreach: alerts">
+             data-bind="foreach: {data: alerts, beforeRemove: fadeOut}">
           <div data-bind="attr: {'class': alert_class}">
             <a class="close"
                data-dismiss="alert" href="#">&times;</a>


### PR DESCRIPTION
## Summary
This adds an option to the `alert_user` JS function that will cause messages to automatically be removed from the UI after 5s. This can be useful for UI's that make ajax requests and display messages.

![Peek 2021-07-28 10-24](https://user-images.githubusercontent.com/249606/127289961-cc3e0785-79e5-432a-9a2c-a624bacda74e.gif)

@biyeun @orangejenny any thoughts on this? One thing I don't like is the we have these set up in the UI so that when they are removed the whole UI moves up. It would great if they could 'float' on top or something.

If we don't want to keep the 'fadeOut' option I'll remove that commit but I think the refactor is still worth keeping. Also this fixes the fade in which was broken.

Review by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story
This changes a small part of the HQ UI that's related to displaying alerts from JS. I have tested this locally.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
