### PR TITLE
Fix conflicting active tabs on linked projects page

### DIFF
--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -100,11 +100,27 @@ hqDefine("linked_domain/js/domain_links", [
         // doesn't need to be observable because it is impossible to update the existing page to change this property
         self.isDownstreamDomain = data.is_downstream_domain;
 
-        self.pullTabActiveStatus = ko.computed(function () {
-            return self.isDownstreamDomain ? "in active" : "";
+        self.isOnlyDownstreamDomain = ko.computed(function () {
+            return !self.isUpstreamDomain() && self.isDownstreamDomain;
         });
 
-        self.manageTabActiveStatus = self.isDownstreamDomain ? "" : "in active";
+        // Tab Header Statuses
+        self.manageDownstreamDomainsTabStatus = ko.computed(function () {
+           return self.isUpstreamDomain() ? "active" : "";
+        });
+
+        self.pullContentTabStatus = ko.computed(function () {
+            return self.isOnlyDownstreamDomain() ? "active" : "";
+        });
+
+        // Tab Content Statuses
+        self.manageTabActiveStatus = ko.computed(function() {
+            return self.isUpstreamDomain() ? "in active" : "";
+        });
+
+        self.pullTabActiveStatus = ko.computed(function () {
+            return self.isOnlyDownstreamDomain() ? "in active" : "";
+        });
 
         self.showGetStarted = ko.computed(function () {
             return !self.isUpstreamDomain() && !self.isDownstreamDomain;
@@ -114,9 +130,6 @@ hqDefine("linked_domain/js/domain_links", [
             return self.isUpstreamDomain() || (self.isDownstreamDomain && self.showRemoteReports());
         });
 
-        self.isOnlyDownstreamDomain = ko.computed(function () {
-            return !self.isUpstreamDomain() && self.isDownstreamDomain && !self.showRemoteReports();
-        });
 
         // can only push content if a link with a downstream domain exists
         var pushContentData = {

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -23,11 +23,11 @@
       <!-- ko if: showMultipleTabs -->
         <ul class="nav nav-tabs">
           <!-- ko if: isUpstreamDomain -->
-            <li class="active"><a data-toggle="tab" href="#tabs-manage-downstream">{% trans "Downstream Project Spaces" %}</a></li>
+            <li data-bind="class: manageDownstreamDomainsTabStatus"><a data-toggle="tab" href="#tabs-manage-downstream">{% trans "Downstream Project Spaces" %}</a></li>
             <li><a data-toggle="tab" href="#tabs-push-content">{% trans "Push Content" %}</a></li>
           <!-- /ko -->
           <!-- ko if: isDownstreamDomain -->
-            <li class="active"><a data-toggle="tab" href="#tabs-pull-content">{% trans "Manage Linked Project Space" %}</a></li>
+            <li data-bind="class: pullContentTabStatus"><a data-toggle="tab" href="#tabs-pull-content">{% trans "Manage Linked Project Space" %}</a></li>
             {% if view_data.linkable_ucr %}
               <li><a data-toggle="tab" href="#tabs-remote-report">{% trans "Add Remote Reports" %}</a></li>
             {% endif %}


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

While we do not "support" grandfathered links (upstream -> midstream -> downstream), we also don't want to break that workflow if it exists in other divisions. The active class was being set on multiple tabs causing a conflict in the form of a UI bug. I rearranged this to only make the pullContent tab header active if it is both not an upstream domain, and a downstream domain. Previously, there was only a check to see if it was a downstream domain.

Before
<img width="1203" alt="Screen Shot 2021-07-28 at 7 55 51 AM" src="https://user-images.githubusercontent.com/15785053/127345158-0b2dea91-a7c4-47a9-ac18-8a9e483fa3c2.png">
After
<img width="1199" alt="Screen Shot 2021-07-28 at 7 56 13 AM" src="https://user-images.githubusercontent.com/15785053/127345169-770b9d96-576e-4bbb-a743-cc3b19c10bd0.png">

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS`
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
