### PR TITLE
Only disable linked apps for release management privilege

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -36,7 +36,7 @@ hqDefine("app_manager/js/app_view", function () {
 
             self.domainChanged = function (data, event) {
                 if (self.shouldLimitToLinkedDomains) {
-                    var selectedDomain = event.target.options[event.target.selectedIndex].value;
+                    var selectedDomain = event.currentTarget.options[event.currentTarget.selectedIndex].value;
                     self.shouldEnableLinkedAppOption(self.linkableDomains.includes(selectedDomain));
 
                     // ensure not checked if linked apps is not allowed

--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -29,17 +29,20 @@ hqDefine("app_manager/js/app_view", function () {
             // prepend with blank so placeholder works
             self.domainNames = [''].concat(data("domain_names"));
             self.linkableDomains = data("linkable_domains");
+            self.shouldLimitToLinkedDomains = data("limit_to_linked_domains");
 
             self.isChecked = ko.observable(false);
             self.shouldEnableLinkedAppOption = ko.observable(true);
 
             self.domainChanged = function (data, event) {
-                var selectedDomain = event.target.options[event.target.selectedIndex].value;
-                self.shouldEnableLinkedAppOption(self.linkableDomains.includes(selectedDomain));
+                if (self.shouldLimitToLinkedDomains) {
+                    var selectedDomain = event.target.options[event.target.selectedIndex].value;
+                    self.shouldEnableLinkedAppOption(self.linkableDomains.includes(selectedDomain));
 
-                // ensure not checked if linked apps is not allowed
-                if (!self.shouldEnableLinkedAppOption()) {
-                    self.isChecked(false);
+                    // ensure not checked if linked apps is not allowed
+                    if (!self.shouldEnableLinkedAppOption()) {
+                        self.isChecked(false);
+                    }
                 }
             };
 

--- a/corehq/apps/app_manager/templates/app_manager/app_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view_settings.html
@@ -29,6 +29,7 @@
   {% initial_page_data 'app_view_options' app_view_options %}
   {% initial_page_data 'domain_names' domain_names %}
   {% initial_page_data 'linkable_domains' linkable_domains %}
+  {% initial_page_data 'limit_to_linked_domains' limit_to_linked_domains %}
   {% initial_page_data 'is_remote_app' app.is_remote_app %}
   {% initial_page_data 'is_superuser' request.user.is_superuser %}
   {% initial_page_data 'langs' app.langs %}

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -280,6 +280,7 @@ def view_generic(request, domain, app_id, module_id=None, form_id=None,
     context.update({
         'domain_names': sorted(domain_names),
         'linkable_domains': sorted(linkable_domains),
+        'limit_to_linked_domains': domain_has_privilege(request.domain, RELEASE_MANAGEMENT)
     })
     context.update({
         'copy_app_form': copy_app_form,

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -280,7 +280,8 @@ def view_generic(request, domain, app_id, module_id=None, form_id=None,
     context.update({
         'domain_names': sorted(domain_names),
         'linkable_domains': sorted(linkable_domains),
-        'limit_to_linked_domains': domain_has_privilege(request.domain, RELEASE_MANAGEMENT)
+        'limit_to_linked_domains': (domain_has_privilege(request.domain, RELEASE_MANAGEMENT)
+                                    and not request.couch_user.is_superuser)
     })
     context.update({
         'copy_app_form': copy_app_form,


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
While QA was testing this as a linked projects feature flag user, they used a workflow I had not anticipated which was typing the domain name into the dropdown field, allowing them to attempt to copy/link apps outside of what is in the dropdown. I want to do everything I can to avoid disrupting current workflows, so I made this change to only limit domains if the release management privilege is enabled. This does mean in the future this would be a limitation.

I'm still on the fence if superusers should be able to access this regardless of feature flag vs privilege version. I'm leaning towards yes.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
UI Changes.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This change reduces the scope of impact of this previously introduced change.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
