### PR TITLE
tag domain for all restore timings

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -25,7 +25,6 @@ from casexml.apps.phone.restore_caching import AsyncRestoreTaskIdCache, RestoreP
 from casexml.apps.phone.tasks import get_async_restore_payload, ASYNC_RESTORE_SENT
 from casexml.apps.phone.utils import get_cached_items_with_count
 from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED
-from corehq.util.metrics.utils import maybe_add_domain_tag
 from corehq.util.metrics import metrics_counter, metrics_histogram
 from corehq.util.timer import TimingContext
 from memoized import memoized
@@ -773,7 +772,7 @@ class RestoreConfig(object):
             'status_code': status,
             'device_type': 'webapps' if is_webapps else 'other',
         }
-        maybe_add_domain_tag(self.domain, tags)
+        tags['domain'] = self.domain
         timer_buckets = (1, 5, 20, 60, 120, 300, 600)
         for timer in timing.to_list(exclude_root=True):
             segment = None

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -771,8 +771,8 @@ class RestoreConfig(object):
         tags = {
             'status_code': status,
             'device_type': 'webapps' if is_webapps else 'other',
+            'domain': self.domain,
         }
-        tags['domain'] = self.domain
         timer_buckets = (1, 5, 20, 60, 120, 300, 600)
         for timer in timing.to_list(exclude_root=True):
             segment = None

--- a/corehq/util/metrics/utils.py
+++ b/corehq/util/metrics/utils.py
@@ -64,9 +64,3 @@ def bucket_value(value, buckets, unit=''):
         if value < bucket:
             return lt_template.format(bucket, unit)
     return over_template.format(buckets[-1], unit)
-
-
-def maybe_add_domain_tag(domain_name, tags):
-    """Conditionally add a domain tag to the given list of tags"""
-    if (settings.SERVER_ENVIRONMENT, domain_name) in settings.METRICS_TAGGED_DOMAINS:
-        tags['domain'] = domain_name

--- a/settings.py
+++ b/settings.py
@@ -2027,19 +2027,6 @@ THROTTLE_SCHED_REPORTS_PATTERNS = (
     'mvp-',
 )
 
-# Domains that we want to tag in metrics provider
-METRICS_TAGGED_DOMAINS = {
-    # ("env", "domain"),
-    ("production", "born-on-time-2"),
-    ("production", "hki-nepal-suaahara-2"),
-    ("production", "malawi-fp-study"),
-    ("production", "no-lean-season"),
-    ("production", "rec"),
-    ("production", "isth-production"),
-    ("production", "sauti-1"),
-    ("production", "ndoh-wbot"),
-}
-
 #### Django Compressor Stuff after localsettings overrides ####
 
 COMPRESS_OFFLINE_CONTEXT = {


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Removes allowed list of domains for restore timing metrics in favor of recording that timing for all domains.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Metrics only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
