### PR TITLE
Fixed form linking logic to support form in a different child module

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -337,9 +337,9 @@ class EndOfFormNavigationWorkflow(object):
         else:
             frame_children = _get_datums_matched_to_source(target_frame_children, source_form_datums)
 
-        # I think this is a bug - it only executes when linking to a child of the current module
-        if target_module in module.get_child_modules():
-            frame_children = prepend_parent_frame_children(self.helper, frame_children, module)
+        if target_module.root_module_id:
+            root_module = self.helper.app.get_module_by_unique_id(target_module.root_module_id)
+            frame_children = prepend_parent_frame_children(self.helper, frame_children, root_module)
 
         return StackFrameMeta(link.xpath, frame_children, current_session=source_form_datums)
 

--- a/corehq/apps/app_manager/tests/data/form_workflow/form_link_submodule.xml
+++ b/corehq/apps/app_manager/tests/data/form_workflow/form_link_submodule.xml
@@ -26,9 +26,10 @@
     </session>
     <stack>
       <create if="true()">
-        <command value="'m1'"/>
+        <command value="'m0'"/>
         <datum id="case_id" value="instance('commcaresession')/session/data/case_id"/>
         <datum id="case_id_new_visit_0" value="uuid()"/>
+        <command value="'m1'"/>
         <datum id="case_id_load_visit_0" value="instance('commcaresession')/session/data/case_id_load_visit_0"/>
         <command value="'m1-f1'"/>
       </create>

--- a/corehq/apps/app_manager/tests/test_form_workflow.py
+++ b/corehq/apps/app_manager/tests/test_form_workflow.py
@@ -378,14 +378,11 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         """
         self.assertXmlPartialEqual(expected, factory.app.create_suite(), "./entry[2]/stack")
 
-        # m2f0 links to m1f0, a form in a separate child module, here's the stack there
-        # Note that the command for m0 is absent. This is because prepend_parent_frame_children
-        # is only called if the target module is one of the current module's child modules,
-        # rather than for all child modules
         expected = """
         <partial>
             <stack>
                 <create if="true()">
+                    <command value="'m0'"/>
                     <command value="'m1'"/>
                     <datum id="case_id_new_mother_0" value="uuid()"/>
                     <datum id="case_id" value="instance('commcaresession')/session/data/case_id"/>

--- a/corehq/apps/app_manager/tests/test_form_workflow.py
+++ b/corehq/apps/app_manager/tests/test_form_workflow.py
@@ -361,6 +361,7 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         m2, m2f0 = factory.new_basic_module('other_module', 'baby')
         m2f0.post_form_workflow = WORKFLOW_FORM
         m2f0.form_links = [FormLink(xpath='true()', form_id=m1f0.unique_id)]
+        suite_xml = factory.app.create_suite()
 
         # m0f1 links to m1f0, a form in its child module. Here's the stack for that:
         expected = """
@@ -376,8 +377,9 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
             </stack>
         </partial>
         """
-        self.assertXmlPartialEqual(expected, factory.app.create_suite(), "./entry[2]/stack")
+        self.assertXmlPartialEqual(expected, suite_xml, "./entry[2]/stack")
 
+        # m2f0 links to m1f0, a form in a separate child module, here's the stack there
         expected = """
         <partial>
             <stack>
@@ -391,7 +393,7 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
             </stack>
         </partial>
         """
-        self.assertXmlPartialEqual(expected, factory.app.create_suite(), "./entry[4]/stack")
+        self.assertXmlPartialEqual(expected, suite_xml, "./entry[4]/stack")
 
     def _build_workflow_app(self, mode):
         factory = AppFactory(build_version='2.9.0')


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-1201

## Feature Flag
Form linking workflow available on forms

## Product Description
This fixes a bug where form linking was not working if the linked form was in a different menu than the current form, and that linked form's menu was a child menu.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Tests in PR (thanks @esoergel )

### QA Plan

Not requesting QA.

### Safety story
Has test coverage. This only touches a pretty specific use case for a feature that's flagged.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
