### PR TITLE
add task to track pg primary key

### DIFF
--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -187,7 +187,6 @@ def track_es_doc_counts():
 def track_pg_limits():
     for db in settings.DATABASES:
         with connections[db].cursor() as cursor:
-            cursor.execute("select table_name, data_type from information_schema.columns where column_name = 'id'")
             query = """
             select tab.relname, seq.relname, attlen
               from pg_class seq

--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -190,9 +190,9 @@ def track_pg_limits():
             query = """
             select tab.relname, seq.relname
               from pg_class seq
-              join pg_depend dep on seq.oid=dep.objid
+              join pg_depend as dep on seq.oid=dep.objid
               join pg_class as tab on dep.refobjid = tab.oid
-              join pg_attribute on att.attrelid=tab.oid and att.attnum=dep.refobjsubid
+              join pg_attribute as att on att.attrelid=tab.oid and att.attnum=dep.refobjsubid
               where seq.relkind='S' and att.attlen=4
             """
             cursor.execute(query)

--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -182,6 +182,7 @@ def track_es_doc_counts():
                     metrics_gauge('elasticsearch.shards.docs.count', i['docs']['count'], tags)
                     metrics_gauge('elasticsearch.shards.docs.deleted', i['docs']['deleted'], tags)
 
+
 @periodic_task(queue='background_queue', run_every=crontab(minute="0", hour="0"))
 def track_pg_limits():
     for db in settings.DATABASES:
@@ -189,9 +190,9 @@ def track_pg_limits():
             cursor.execute("select table_name, data_type from information_schema.columns where column_name = 'id'")
             query = """
             select tab.relname, seq.relname, attlen
-              from pg_class seq 
-              join pg_depend dep on seq.oid=dep.objid 
-              join pg_class as tab on (dep.refobjid = tab.oid) 
+              from pg_class seq
+              join pg_depend dep on seq.oid=dep.objid
+              join pg_class as tab on (dep.refobjid = tab.oid)
               join pg_attribute on attrelid=tab.oid and attnum=refobjsubid
               where seq.relkind='S'
             """
@@ -202,4 +203,4 @@ def track_pg_limits():
                 if length == 4:
                     cursor.execute(f'select last_value from {sequence}')
                     current_value = cursor.fetchone()[0]
-                    metrics_gauge('postgres.sequence.current_value', current_value, {'table': table, 'database': db} 
+                    metrics_gauge('postgres.sequence.current_value', current_value, {'table': table, 'database': db})

--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -4,6 +4,7 @@ from datetime import date, timedelta
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.db import connections
 from django.db.models import Q
 from django.template import Context, Template
 from django.template.loader import render_to_string
@@ -180,3 +181,25 @@ def track_es_doc_counts():
                     }
                     metrics_gauge('elasticsearch.shards.docs.count', i['docs']['count'], tags)
                     metrics_gauge('elasticsearch.shards.docs.deleted', i['docs']['deleted'], tags)
+
+@periodic_task(queue='background_queue', run_every=crontab(minute="0", hour="0"))
+def track_pg_limits():
+    for db in settings.DATABASES:
+        with connections[db].cursor() as cursor:
+            cursor.execute("select table_name, data_type from information_schema.columns where column_name = 'id'")
+            query = """
+            select tab.relname, seq.relname, attlen
+              from pg_class seq 
+              join pg_depend dep on seq.oid=dep.objid 
+              join pg_class as tab on (dep.refobjid = tab.oid) 
+              join pg_attribute on attrelid=tab.oid and attnum=refobjsubid
+              where seq.relkind='S'
+            """
+            cursor.execute(query)
+            results = cursor.fetchall()
+            for table, sequence, length in results:
+                # Only track integer columns, ignoring ones that are already bigint
+                if length == 4:
+                    cursor.execute(f'select last_value from {sequence}')
+                    current_value = cursor.fetchone()[0]
+                    metrics_gauge('postgres.sequence.current_value', current_value, {'table': table, 'database': db} 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This PR adds a way to collect the current value of all our postgres primary key sequences, so that we will be able to determine whether we need to upgrade the columns to bigints. That turned out to be a bit more complex than expected, but it does a query to find all sequences, and the columns that own them. Then for those whose columns are integers, it queries the sequence to find the current value. It seemed like this was the kind of thing we could do only once per day.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Metrics only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
