### PR TITLE
Change query to use a substitute for 'exclude'

### DIFF
--- a/corehq/apps/users/management/commands/add_download_reports_permission.py
+++ b/corehq/apps/users/management/commands/add_download_reports_permission.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
 
+from dimagi.utils.chunked import chunked
 from corehq.apps.users.models_sql import SQLPermission, SQLUserRole
 
 
@@ -9,13 +10,16 @@ class Command(BaseCommand):
     def handle(self, **options):
         permission, created = SQLPermission.objects.get_or_create(value='download_reports')
         num_roles_modified = 0
-        all_roles = SQLUserRole.objects.all()
-        roles_with_new_permission = SQLUserRole.objects.filter(rolepermission__permission_fk_id=permission.id)
-        for role in all_roles.difference(roles_with_new_permission).iterator():
-            rp, created = role.rolepermission_set.get_or_create(permission_fk=permission,
-                                                                defaults={"allow_all": True})
-            if created:
-                role._migration_do_sync()
-                num_roles_modified += 1
-            if num_roles_modified % 5000 == 0:
-                print("Updated {} roles".format(num_roles_modified))
+        all_role_ids = set(SQLUserRole.objects.all().values_list("id", flat=True))
+        role_ids_with_new_permission = set(SQLUserRole.objects.filter(rolepermission__permission_fk_id=permission.id)
+                                           .values_list("id", flat=True))
+        difference = all_role_ids.difference(role_ids_with_new_permission)
+        for chunk in chunked(difference, 50):
+            for role in SQLUserRole.objects.filter(id__in=chunk):
+                rp, created = role.rolepermission_set.get_or_create(permission_fk=permission,
+                                                                    defaults={"allow_all": True})
+                if created:
+                    role._migration_do_sync()
+                    num_roles_modified += 1
+                if num_roles_modified % 5000 == 0:
+                    print("Updated {} roles".format(num_roles_modified))

--- a/corehq/apps/users/management/commands/add_download_reports_permission.py
+++ b/corehq/apps/users/management/commands/add_download_reports_permission.py
@@ -9,7 +9,9 @@ class Command(BaseCommand):
     def handle(self, **options):
         permission, created = SQLPermission.objects.get_or_create(value='download_reports')
         num_roles_modified = 0
-        for role in SQLUserRole.objects.exclude(rolepermission__permission_fk_id=permission.id).iterator():
+        all_roles = SQLUserRole.objects.all()
+        roles_with_new_permission = SQLUserRole.objects.filter(rolepermission__permission_fk_id=permission.id)
+        for role in all_roles.difference(roles_with_new_permission).iterator():
             rp, created = role.rolepermission_set.get_or_create(permission_fk=permission,
                                                                 defaults={"allow_all": True})
             if created:


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Replaces the "exclude" filtering that was working, but now is taking way too long to run.

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
In all previous testing, the `exclude` was working, but now it takes way too long if it ever completes. Interesting using the `~Q` syntax like: `SQLUserRole.objects.filter(~Q(rolepermission__permission_fk_id=permission.id))` also takes too long to complete. I had to do a roundabout way where I fetch all roles and then subtract from that set the elements that do have the permission. I have verified via that shell that it returns the correct number of roles and also that those roles do not contain the new permission and quickly. 

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The previous filter is currently not completing within an hour of running it so is currently non-functional.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
