### PR TITLE
update prune_synclogs

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/tasks.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tasks.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from django.db.models import Min
 from django.db import connections, router
 

--- a/corehq/ex-submodules/casexml/apps/phone/tasks.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tasks.py
@@ -12,6 +12,8 @@ from casexml.apps.phone.cleanliness import set_cleanliness_flags_for_all_domains
 from casexml.apps.phone.models import SyncLogSQL
 from dimagi.utils.logging import notify_exception
 
+from corehq.util.metrics import metrics_gauge
+
 log = logging.getLogger(__name__)
 
 ASYNC_RESTORE_QUEUE = 'async_restore_queue'
@@ -92,10 +94,11 @@ def update_celery_state(sender=None, headers=None, **kwargs):
 )
 def prune_synclogs():
     """
-    Drops all partition tables containing data that's older than 63 days (7 weeks)
+    Drops all partition tables containing data that's older than 63 days (9 weeks)
     """
-    oldest_synclog = SyncLogSQL.objects.aggregate(Min('date'))['date__min']
-    while oldest_synclog and (datetime.today() - oldest_synclog).days > SYNCLOG_RETENTION_DAYS:
+    db = router.db_for_write(SyncLogSQL)
+    oldest_date = SyncLogSQL.objects.aggregate(Min('date'))['date__min']
+    while oldest_date and (datetime.today() - oldest_date).days > SYNCLOG_RETENTION_DAYS:
         year, week, _ = oldest_synclog.isocalendar()
         table_name = "{base_name}_y{year}w{week}".format(
             base_name=SyncLogSQL._meta.db_table,
@@ -103,7 +106,12 @@ def prune_synclogs():
             week="%02d" % week
         )
         drop_query = "DROP TABLE IF EXISTS {}".format(table_name)
-        db = router.db_for_write(SyncLogSQL)
         with connections[db].cursor() as cursor:
             cursor.execute(drop_query)
-        oldest_synclog = SyncLogSQL.objects.aggregate(Min('date'))['date__min']
+        oldest_date += timedelta(weeks=1)
+
+    # find and log synclogs for which the trigger did not function properly
+    with connections[db].cursor() as cursor:
+        cursor.execute("select count(*) from only phone_synclogsql")
+        orphaned_synclogs = cursor.fetchone()[0]
+        metrics_gauge('commcare.orphaned_synclogs', orphaned_synclogs)

--- a/corehq/ex-submodules/casexml/apps/phone/tasks.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tasks.py
@@ -99,7 +99,7 @@ def prune_synclogs():
     db = router.db_for_write(SyncLogSQL)
     oldest_date = SyncLogSQL.objects.aggregate(Min('date'))['date__min']
     while oldest_date and (datetime.today() - oldest_date).days > SYNCLOG_RETENTION_DAYS:
-        year, week, _ = oldest_synclog.isocalendar()
+        year, week, _ = oldest_date.isocalendar()
         table_name = "{base_name}_y{year}w{week}".format(
             base_name=SyncLogSQL._meta.db_table,
             year=year,


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12154
This is mainly to fix the infinite loop in the current version of the method caused by the single row in the parent table rather than a weekly partition, by incrementing the week in python rather than repeatedly checking the oldest log. I also added a datadog metric to log when there are synclogs in the parent table, but did not have this task delete them since I think it would be helpful to investigate next time it happens.

In the meantime, we can either leave that record or delete it. It will no longer cause harm, although it will make this task a tiny bit longer each week, since it deletes each week from the oldest record in the table until 9 weeks ago.

I still don't have a real sense how the db got into this state, but suspect the after insert trigger failed for some reason, and since it only happens on insert, that was our one chance to move the record. The before insert trigger is the one that puts it in the child table, so if I had to guess, this record was correctly put in the child table, but then never cleaned up from the parent one. I guess that means we may have had duplicate synclogs for this user?

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The changes do not affect which tables are allowed to be dropped (the bounds check does not move), so it is a safe change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
