### PR TITLE
data registry signals and invitation email

### DIFF
--- a/corehq/apps/registry/app_config.py
+++ b/corehq/apps/registry/app_config.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class RegistryAppConfig(AppConfig):
+    name = 'corehq.apps.registry'
+
+    def ready(self):
+        # Make sure hooks get registered
+        from . import signals  # noqa

--- a/corehq/apps/registry/notifications.py
+++ b/corehq/apps/registry/notifications.py
@@ -1,0 +1,22 @@
+from django.template.loader import render_to_string
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from corehq.apps.hqwebapp.tasks import send_html_email_async
+
+
+def send_invitation_email(registry, invitation):
+    subject = _("Data Registry Invitation from {domain}").format(registry.domain)
+    context = {
+        'domain': invitation.domain,
+        'owning_domain': registry.domain,
+        'registry_url': reverse('manage_registry', args=[invitation.domain, registry.slug])
+    }
+
+    contact_email = ''
+    email_html = render_to_string('registry/email/invitation.html', context)
+    email_plaintext = render_to_string('registry/email/invitation.txt', context)
+    send_html_email_async.delay(
+        subject, contact_email, email_html,
+        text_content=email_plaintext,
+    )

--- a/corehq/apps/registry/signals.py
+++ b/corehq/apps/registry/signals.py
@@ -1,0 +1,12 @@
+from django.dispatch import Signal
+
+data_registry_activated = Signal(providing_args=["registry"])
+data_registry_deactivated = Signal(providing_args=["registry"])
+data_registry_schema_changed = Signal(providing_args=["registry", "new_schema", "old_schema"])
+data_registry_invitation_created = Signal(providing_args=["registry", "invitation"])
+data_registry_invitation_removed = Signal(providing_args=["registry", "invitation"])
+data_registry_invitation_accepted = Signal(providing_args=["registry", "invitation", "previous_status"])
+data_registry_invitation_rejected = Signal(providing_args=["registry", "invitation", "previous_status"])
+data_registry_grant_created = Signal(providing_args=["registry", "from_domain", "to_domains"])
+data_registry_grant_removed = Signal(providing_args=["registry", "from_domain", "to_domains"])
+data_registry_deleted = Signal(providing_args=["registry"])

--- a/corehq/apps/registry/templates/registry/email/invitation.html
+++ b/corehq/apps/registry/templates/registry/email/invitation.html
@@ -1,0 +1,28 @@
+{% load i18n %}
+
+<p>
+  {% blocktrans %}
+    Dear {{ domain }} administrator,
+  {% endblocktrans %}
+</p>
+
+<p>
+  {% blocktrans %}
+    The {{ domain }} project space has been invited to participate in the "{{ name }}" CommCare data registry by {{ owning_domain }}.
+  {% endblocktrans %}
+</p>
+
+<p>
+  {% blocktrans %}You can opt in or out of the registry by following this link: {% endblocktrans %}<a href="{{ registry_url }}">{{ registry_url }}</a>
+</p>
+<p>
+  {% blocktrans %}Thank you for using CommCare.{% endblocktrans %}
+</p>
+
+<p>
+  {% blocktrans %}
+    Best regards, <br />
+    The CommCare HQ Team  <br />
+    www.commcarehq.org
+  {% endblocktrans %}
+</p>

--- a/corehq/apps/registry/templates/registry/email/invitation.txt
+++ b/corehq/apps/registry/templates/registry/email/invitation.txt
@@ -1,0 +1,13 @@
+{% load i18n %}
+{% blocktrans %}
+Dear {{ domain }} administrator,
+
+The {{ domain }} project space has been invited to participate in the "{{ name }}" CommCare data registry by {{ owning_domain }}.
+
+You can opt in or out of the registry by following this link: {{ registry_url }}
+
+Thank you for using CommCare.
+Best regards,
+The CommCare HQ Team
+www.commcarehq.org
+{% endblocktrans %}

--- a/corehq/apps/registry/utils.py
+++ b/corehq/apps/registry/utils.py
@@ -3,6 +3,18 @@ from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 
 from corehq.apps.registry.models import DataRegistry, RegistryInvitation, RegistryGrant
+from corehq.apps.registry.signals import (
+    data_registry_activated,
+    data_registry_deactivated,
+    data_registry_schema_changed,
+    data_registry_invitation_created,
+    data_registry_invitation_removed,
+    data_registry_invitation_accepted,
+    data_registry_invitation_rejected,
+    data_registry_grant_created,
+    data_registry_grant_removed,
+    data_registry_deleted,
+)
 
 
 def _get_registry_or_404(domain, registry_slug):
@@ -16,7 +28,6 @@ class DataRegistryCrudHelper:
     def __init__(self, domain, registry_slug, request_user):
         self.registry = _get_registry_or_404(domain, registry_slug)
         self.user = request_user
-        # TODO: fire signals
 
     def set_attr(self, attr, value):
         setattr(self.registry, attr, value)
@@ -31,10 +42,12 @@ class DataRegistryCrudHelper:
     def activate(self):
         if not self.registry.is_active:
             self.registry.activate(self.user)
+            data_registry_activated.send(sender=DataRegistry, registry=self.registry)
 
     def deactivate(self):
         if self.registry.is_active:
             self.registry.deactivate(self.user)
+            data_registry_deactivated.send(sender=DataRegistry, registry=self.registry)
 
     @transaction.atomic
     def update_schema(self, schema):
@@ -43,6 +56,9 @@ class DataRegistryCrudHelper:
             self.registry.schema = schema
             self.registry.save()
             self.registry.logger.schema_changed(self.user, schema, old_schema)
+            data_registry_schema_changed.send(
+                sender=DataRegistry, registry=self.registry, new_schema=schema, old_schema=old_schema
+            )
 
     @transaction.atomic
     def get_or_create_invitation(self, domain):
@@ -55,6 +71,7 @@ class DataRegistryCrudHelper:
         invitation, created = self.registry.invitations.get_or_create(domain=domain)
         if created:
             self.registry.logger.invitation_added(self.user, invitation)
+            data_registry_invitation_created(sender=DataRegistry, registry=self.registry, initation=invitation)
         return invitation, created
 
     @transaction.atomic
@@ -69,6 +86,7 @@ class DataRegistryCrudHelper:
 
         invitation.delete()
         self.registry.logger.invitation_removed(self.user, invitation_id, invitation)
+        data_registry_invitation_removed.send(sender=DataRegistry, registry=self.registry, initation=invitation)
 
     @transaction.atomic
     def get_or_create_grant(self, from_domain, to_domains):
@@ -82,6 +100,9 @@ class DataRegistryCrudHelper:
         grant, created = self.registry.grants.get_or_create(from_domain=from_domain, to_domains=to_domains)
         if created:
             self.registry.logger.grant_added(self.user, grant)
+            data_registry_grant_created.send(
+                sender=DataRegistry, from_domain=from_domain, to_domains=to_domains
+            )
         return grant, created
 
     @transaction.atomic
@@ -94,6 +115,9 @@ class DataRegistryCrudHelper:
         assert grant.registry_id == self.registry.id
         grant.delete()
         self.registry.logger.grant_removed(self.user, grant_id, grant)
+        data_registry_grant_removed.send(
+            sender=DataRegistry, from_domain=from_domain, to_domains=grant.to_domains
+        )
         return grant
 
     def accept_invitation(self, domain):
@@ -103,7 +127,11 @@ class DataRegistryCrudHelper:
             raise Http404
 
         if not invitation.is_accepted:
+            previous_status = invitation.status
             invitation.accept(self.user)
+            data_registry_invitation_accepted.send(
+                sender=DataRegistry, registry=self.registry, previous_status=previous_status
+            )
         return invitation
 
     def reject_invitation(self, domain):
@@ -113,10 +141,15 @@ class DataRegistryCrudHelper:
             raise Http404
 
         if not invitation.is_rejected:
+            previous_status = invitation.status
             invitation.reject(self.user)
+            data_registry_invitation_rejected.send(
+                sender=DataRegistry, registry=self.registry, previous_status=previous_status
+            )
         return invitation
 
     @transaction.atomic
     def delete_registry(self):
         # TODO: figure out what to do here
         self.registry.delete()
+        data_registry_deleted.send(sender=DataRegistry, registry=self.registry)

--- a/corehq/apps/registry/utils.py
+++ b/corehq/apps/registry/utils.py
@@ -3,6 +3,7 @@ from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 
 from corehq.apps.registry.models import DataRegistry, RegistryInvitation, RegistryGrant
+from corehq.apps.registry.notifications import send_invitation_email
 
 
 def _get_registry_or_404(domain, registry_slug):
@@ -54,6 +55,7 @@ class DataRegistryCrudHelper:
 
         invitation, created = self.registry.invitations.get_or_create(domain=domain)
         if created:
+            send_invitation_email(self.registry, invitation)
             self.registry.logger.invitation_added(self.user, invitation)
         return invitation, created
 

--- a/settings.py
+++ b/settings.py
@@ -266,7 +266,7 @@ HQ_APPS = (
     'corehq.apps.locations',
     'corehq.apps.products',
     'corehq.apps.programs',
-    'corehq.apps.registry',
+    'corehq.apps.registry.app_config.RegistryAppConfig',
     'corehq.project_limits',
     'corehq.apps.commtrack',
     'corehq.apps.consumption',


### PR DESCRIPTION
## Summary
Add signals for data registry events.

Add signal handler to send invitation email when a new invitation is created.

This is a PR into https://github.com/dimagi/commcare-hq/pull/30150

## Feature Flag
data_registry

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
None

### QA Plan
None

### Safety story
Change only affects Data Registry app which is yet to be released.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
