### PR TITLE
remove unused function

### DIFF
--- a/corehq/apps/users/cases.py
+++ b/corehq/apps/users/cases.py
@@ -54,17 +54,3 @@ def get_wrapped_owner(owner_id, support_deleted=False):
         return cls.wrap(owner_doc) if cls else None
 
     return None
-
-
-def get_owning_users(owner_id):
-    """
-    Given an owner ID, get a list of the owning users, regardless of whether
-    it's a user or group.
-    """
-    owner = get_wrapped_owner(owner_id)
-    if not owner:
-        return []
-    elif isinstance(owner, Group):
-        return owner.get_users()
-    else:
-        return [owner]

--- a/corehq/apps/users/tests/case_utils.py
+++ b/corehq/apps/users/tests/case_utils.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 from corehq.apps.groups.models import Group
-from corehq.apps.users.cases import get_owning_users, get_wrapped_owner
+from corehq.apps.users.cases import get_wrapped_owner
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import user_id_to_username
 from corehq.util.test_utils import generate_cases
@@ -25,34 +25,6 @@ class CaseUtilsTestCase(TestCase):
         self.addCleanup(group.delete)
         wrapped = get_wrapped_owner(group._id)
         self.assertTrue(isinstance(wrapped, Group))
-
-    def test_owned_by_user(self):
-        user = CommCareUser.create(self.domain, 'owned-user-test', 'password', None, None)
-        user.save()
-        self.addCleanup(user.delete, self.domain, deleted_by=None)
-        owners = get_owning_users(user._id)
-        self.assertEqual(1, len(owners))
-        self.assertEqual(owners[0]._id, user._id)
-        self.assertTrue(isinstance(owners[0], CommCareUser))
-
-    def test_owned_by_group(self):
-        ids = []
-        for i in range(5):
-            user = CommCareUser.create(self.domain, 'owned-group-test-user-%s' % i, 'password', None, None)
-            user.save()
-            self.addCleanup(user.delete, self.domain, deleted_by=None)
-            ids.append(user._id)
-
-        group = Group(domain=self.domain, name='owned-group-test-group', users=ids)
-        group.save()
-        self.addCleanup(group.delete)
-        owners = get_owning_users(group._id)
-        self.assertEqual(5, len(owners))
-        ids_back = []
-        for o in owners:
-            self.assertTrue(isinstance(o, CommCareUser))
-            ids_back.append(o._id)
-        self.assertEqual(set(ids), set(ids_back))
 
 
 @generate_cases(


### PR DESCRIPTION
## Summary
This is unused in current code. History:
* Added: 21b029be23f4fc8740159e85cce31eab7d0d0c6b
* Usage: 908f165659156ebca12ce72f505fe26f94156232
* Last usage removed: e1d81c40e9ef9984d1e1987cc58ee838ea1f0aa1

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
NA

### Safety story
Removing unused code

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
