### PR TITLE
allow web users to be added to groups

### DIFF
--- a/corehq/apps/hqcase/static/hqcase/js/explode_cases.js
+++ b/corehq/apps/hqcase/static/hqcase/js/explode_cases.js
@@ -15,7 +15,7 @@ hqDefine('hqcase/js/explode_cases', [
         });
         $('#explode-user_id').select2({
             ajax: {
-                url: initialPageData.reverse('users_select2_options'),
+                url: initialPageData.reverse('mobile_workers_select2_options'),
                 type: 'POST',
                 dataType: 'json',
                 quietMills: 250,

--- a/corehq/apps/hqcase/templates/hqcase/explode_cases.html
+++ b/corehq/apps/hqcase/templates/hqcase/explode_cases.html
@@ -4,7 +4,7 @@
 {% requirejs_main 'hqcase/js/explode_cases' %}
 
 {% block page_content %}
-  {% registerurl "users_select2_options" domain %}
+  {% registerurl "mobile_workers_select2_options" domain %}
 
   <div id="explode">
     <h1>Explode Cases 💣</h1>

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -19,6 +19,7 @@ from corehq.apps.reports.filters.controllers import (
     EmwfOptionsController,
     MobileWorkersOptionsController,
     ReassignCaseOptionsController,
+    UserOptionsController,
 )
 from corehq.apps.users.analytics import get_search_users_in_domain_es_query
 from corehq.elastic import ESError
@@ -106,6 +107,19 @@ class MobileWorkersOptionsView(EmwfOptionsView):
             'results': [],
             'total': 0,
         })
+
+
+class UserOptionsView(EmwfOptionsView):
+    """
+    Paginated Options for the Users selection tool
+    """
+    urlname = 'users_select2_options'
+
+    @property
+    @memoized
+    def options_controller(self):
+        return UserOptionsController(self.request, self.domain, self.search)
+
 
 
 @location_safe

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -70,7 +70,7 @@ class MobileWorkersOptionsView(EmwfOptionsView):
     """
     Paginated Options for the Mobile Workers selection tool
     """
-    urlname = 'users_select2_options'
+    urlname = 'mobile_workers_select2_options'
 
     @property
     @memoized

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -200,7 +200,7 @@ class EmwfOptionsController(object):
         return count, results
 
 
-class MobileWorkersOptionsController(EmwfOptionsController):
+class UserOptionsController(EmwfOptionsController):
 
     @property
     @memoized
@@ -225,6 +225,8 @@ class MobileWorkersOptionsController(EmwfOptionsController):
             (self.get_active_users_size, self.get_active_users),
         ]
 
+
+class MobileWorkersOptionsController(UserOptionsController):
     def active_user_es_query(self, query):
         query = super(MobileWorkersOptionsController, self).active_user_es_query(query)
         return query.mobile_users()

--- a/corehq/apps/reports/filters/urls.py
+++ b/corehq/apps/reports/filters/urls.py
@@ -12,7 +12,7 @@ from .location import LocationGroupFilterOptions
 
 urlpatterns = [
     url(r'^emwf_options_all_users/$', EmwfOptionsView.as_view(), name='emwf_options_all_users'),
-    url(r'^users_options/$', MobileWorkersOptionsView.as_view(), name=MobileWorkersOptionsView.urlname),
+    url(r'^mobile_users_options/$', MobileWorkersOptionsView.as_view(), name=MobileWorkersOptionsView.urlname),
     url(r'^case_list_options/$', CaseListFilterOptions.as_view(), name='case_list_options'),
     url(r'^reassign_case_options/$', ReassignCaseOptions.as_view(), name='reassign_case_options'),
     url(r'^grouplocationfilter_options/$', LocationGroupFilterOptions.as_view(),

--- a/corehq/apps/reports/filters/urls.py
+++ b/corehq/apps/reports/filters/urls.py
@@ -13,8 +13,8 @@ from .location import LocationGroupFilterOptions
 
 urlpatterns = [
     url(r'^emwf_options_all_users/$', EmwfOptionsView.as_view(), name='emwf_options_all_users'),
-    url(r'^users_options/$', MobileWorkersOptionsView.as_view(), name=MobileWorkersOptionsView.urlname),
-    url(r'^all_users_options/$', UserOptionsView.as_view(), name=UserOptionsView.urlname),
+    url(r'^mobile_user_options/$', MobileWorkersOptionsView.as_view(), name=MobileWorkersOptionsView.urlname),
+    url(r'^user_options/$', UserOptionsView.as_view(), name=UserOptionsView.urlname),
     url(r'^case_list_options/$', CaseListFilterOptions.as_view(), name='case_list_options'),
     url(r'^reassign_case_options/$', ReassignCaseOptions.as_view(), name='reassign_case_options'),
     url(r'^grouplocationfilter_options/$', LocationGroupFilterOptions.as_view(),

--- a/corehq/apps/reports/filters/urls.py
+++ b/corehq/apps/reports/filters/urls.py
@@ -6,13 +6,15 @@ from .api import (
     DeviceLogUsers,
     EmwfOptionsView,
     MobileWorkersOptionsView,
+    UserOptionsView,
     ReassignCaseOptions,
 )
 from .location import LocationGroupFilterOptions
 
 urlpatterns = [
     url(r'^emwf_options_all_users/$', EmwfOptionsView.as_view(), name='emwf_options_all_users'),
-    url(r'^mobile_users_options/$', MobileWorkersOptionsView.as_view(), name=MobileWorkersOptionsView.urlname),
+    url(r'^users_options/$', MobileWorkersOptionsView.as_view(), name=MobileWorkersOptionsView.urlname),
+    url(r'^all_users_options/$', UserOptionsView.as_view(), name=UserOptionsView.urlname),
     url(r'^case_list_options/$', CaseListFilterOptions.as_view(), name='case_list_options'),
     url(r'^reassign_case_options/$', ReassignCaseOptions.as_view(), name='reassign_case_options'),
     url(r'^grouplocationfilter_options/$', LocationGroupFilterOptions.as_view(),

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -2120,4 +2120,5 @@ WEB_USERS_IN_GROUPS = StaticToggle(
     'Allow Web Users in groups',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
+    help_link="https://confluence.dimagi.com/display/USH/Web+Users+in+Groups"
 )

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -2105,10 +2105,19 @@ DATA_REGISTRY = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
     help_link="https://docs.google.com/document/d/1h1chIrRkDtnPVQzFJHuB7JbZq8S4HNQf2dBA8z_MCkg/edit",
 )
-  
+
+
 CASE_IMPORT_DATA_DICTIONARY_VALIDATION = StaticToggle(
     'case_import_data_dictionary_validaton',
     'Validate data per data dictionary definitions during case import',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
+
+WEB_USERS_IN_GROUPS = StaticToggle(
+    'web_users_in_groups',
+    'Allow Web Users in groups',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
 )


### PR DESCRIPTION
## Summary
Allow adding web users to groups to facility access to Data Registries.

The Group model already supports having Web Users as members and allows filtering members to get only mobile workers:
```python
group.get_users(only_commcare=True)
```

## Feature Flag
WEB_USERS_IN_GROUPS (web_users_in_groups)

## Product Description
Allow web users to be added to groups. This is only enabled if the FF is set and will be used for Data Registry permissions.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added

### Safety story
All places that use groups make use of the `only_commcare` filter in `Group.get_users` except for the following:

* Group API "user_ids" field
* CaseExportFilterBuilder which is used to generate ES filters for case exports
* Conditional Alerts sent to groups

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
