### PR TITLE
Fixed decorator on ScheduledReportsView

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -568,7 +568,7 @@ class ScheduledReportsView(BaseProjectReportSectionView):
     page_title = _("Scheduled Report")
     template_name = 'reports/edit_scheduled_report.html'
 
-    @require_permission(Permissions.download_reports)
+    @method_decorator(require_permission(Permissions.download_reports))
     @use_multiselect
     @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):


### PR DESCRIPTION
## Summary

https://dimagi-dev.atlassian.net/browse/SUPPORT-10291 / https://dimagi-dev.atlassian.net/browse/SAAS-12513

Introduced in https://github.com/dimagi/commcare-hq/pull/30050/

## Product Description
Fixes 500 error affecting scheduled reports config pages in HQ.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No

### QA Plan

None

### Safety story
Fixes an error on a page that's currently 500ing. Small change, tested locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
