### PR TITLE
Added help text to data dictionary date fields if validation is on

### DIFF
--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -84,7 +84,7 @@
           </td>
           <td data-bind="text: name"></td>
           <td>
-            <select class ="form-control"
+            <select class="form-control"
                     data-bind="
                                 options: $root.availableDataTypes,
                                 optionsCaption: 'Select a data type',
@@ -92,6 +92,11 @@
                                 optionsValue: 'value',
                                 value: dataType,
                             "></select>
+            {% if request|toggle_enabled:'CASE_IMPORT_DATA_DICTIONARY_VALIDATION' %}
+              <p class="help-block" data-bind="visible: dataType() === 'date'">
+                {% trans "YYYY-MM-DD" %}
+              </p>
+            {% endif %}
           </td>
           <td>
                             <textarea class="form-control vertical-resize" data-bind="


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-1189?focusedCommentId=159563

Adds help text to date fields with required format, only if case import validation flag is turned on.

![Screen Shot 2021-08-02 at 12 22 42 PM](https://user-images.githubusercontent.com/1486591/127912186-1ef5c085-985e-4e0c-abac-00e2fe50b4f2.png)


## Feature Flag
Validate data per data dictionary definitions during case import

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None

### QA Plan

Not requesting QA.

### Safety story
Little HTML-only change on a custom feature flag. Tested locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
