### PR TITLE
fix bugs in track_es_doc_counts

### DIFF
--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -170,10 +170,10 @@ def cleanup_stale_es_on_couch_domains_task():
 def track_es_doc_counts():
     es = get_es_new()
     stats = es.indices.stats(level='shards', metric='docs')
-    for name, data in stats['indices'].keys():
-        for number, shard in data['shards'].keys():
+    for name, data in stats['indices'].items():
+        for number, shard in data['shards'].items():
             for i in shard:
-                if shard['routing']['primary']:
+                if i['routing']['primary']:
                     tags = {
                         'index': name,
                         'shard': f'{name}_{number}',


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This fixes some issues in https://github.com/dimagi/commcare-hq/pull/30119, which were preventing the metrics from coming in.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Metrics only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
