### PR TITLE
Temporarily hide Enterprise SMS Billables Report

### DIFF
--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1,4 +1,3 @@
-from corehq.apps.enterprise.dispatcher import EnterpriseReportDispatcher
 from django.conf import settings
 from django.http import Http404
 from django.urls import reverse
@@ -1625,8 +1624,6 @@ class EnterpriseSettingsTab(UITab):
 
         items.append((_('Manage Enterprise'), enterprise_views))
 
-        items.extend(EnterpriseReportDispatcher.navigation_sections(
-            request=self._request, domain=self.domain))
         return items
 
 


### PR DESCRIPTION
## Summary
Prompted by https://dimagi-dev.atlassian.net/browse/SAAS-12519.
An emergency revert of https://github.com/dimagi/commcare-hq/pull/29836 would have been cleaner, but it appears conflicting code has since been updated from that PR, which prevents that revert. This simply hides the feature so that we can figure out a better solution in the future.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests

### QA Plan

No QA required

### Safety story

Local testing was performed to verify that the Enterprise SMS Billables report does not display on the Enterprise Console

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
