### PR TITLE
use freezegun in test

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/tasks.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tasks.py
@@ -108,7 +108,7 @@ def prune_synclogs():
         drop_query = "DROP TABLE IF EXISTS {}".format(table_name)
         with connections[db].cursor() as cursor:
             cursor.execute(drop_query)
-        oldest_date = datetime.fromisocalendar(year, week + 1, 1)
+        oldest_date += timedelta(weeks=1)
 
     # find and log synclogs for which the trigger did not function properly
     with connections[db].cursor() as cursor:

--- a/corehq/ex-submodules/casexml/apps/phone/tasks.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tasks.py
@@ -108,7 +108,7 @@ def prune_synclogs():
         drop_query = "DROP TABLE IF EXISTS {}".format(table_name)
         with connections[db].cursor() as cursor:
             cursor.execute(drop_query)
-        oldest_date += timedelta(weeks=1)
+        oldest_date = datetime.fromisocalendar(year, week + 1, 1)
 
     # find and log synclogs for which the trigger did not function properly
     with connections[db].cursor() as cursor:

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_prune.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_prune.py
@@ -3,6 +3,8 @@ import datetime
 from django.test import TestCase
 
 from casexml.apps.case.tests.util import delete_all_sync_logs
+from freezegun import freeze_time
+
 from casexml.apps.phone.models import (
     SimplifiedSyncLog,
     SyncLogSQL,
@@ -13,6 +15,7 @@ from casexml.apps.phone.tasks import SYNCLOG_RETENTION_DAYS, prune_synclogs
 from corehq.util.test_utils import DocTestMixin
 
 
+@freeze_time('2021-08-02')
 class SyncLogPruneTest(TestCase, DocTestMixin):
     maxDiff = None
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Edit:
This PR switches the test to use freezegun so the `prune_synclog` task doesn't have to worry about week boundaries.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The function is limited in scope and covered by tests.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
