### PR TITLE
Fix access control for release management/linked projects

### DIFF
--- a/corehq/apps/linked_domain/tests/test_decorators.py
+++ b/corehq/apps/linked_domain/tests/test_decorators.py
@@ -23,7 +23,7 @@ class TestCanAccessLinkedDomains(SimpleTestCase):
 
     @patch('corehq.apps.users.models.CouchUser')
     def test_returns_false_if_domain_has_privilege_but_user_is_not_admin(self, mock_user):
-        mock_user.is_domain_admin = False
+        mock_user.is_domain_admin.return_value = False
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = True
@@ -33,7 +33,7 @@ class TestCanAccessLinkedDomains(SimpleTestCase):
 
     @patch('corehq.apps.users.models.CouchUser')
     def test_returns_true_if_domain_has_privilege_and_user_is_admin(self, mock_user):
-        mock_user.is_domain_admin = True
+        mock_user.is_domain_admin.return_value = True
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = True

--- a/corehq/apps/linked_domain/util.py
+++ b/corehq/apps/linked_domain/util.py
@@ -17,13 +17,13 @@ def can_access_linked_domains(user, domain):
     if not user or not domain:
         return False
     if domain_has_privilege(domain, RELEASE_MANAGEMENT):
-        return user.is_domain_admin
+        return user.is_domain_admin()
     else:
         return toggles.LINKED_DOMAINS.enabled(domain)
 
 
 def can_access_release_management_feature(user, domain):
-    return domain_has_privilege(domain, RELEASE_MANAGEMENT) and user.is_domain_admin
+    return domain_has_privilege(domain, RELEASE_MANAGEMENT) and user.is_domain_admin()
 
 
 def _clean_json(doc):


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SS-193

I noticed that my user with an app editor role was able to _see_ the ERM section, but not access it. After looking into it, I realized I was using `is_domain_admin` as a property, when it is a method. The dangers of mocking in tests 🤦.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Has test coverage.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
