### PR TITLE
Fix remote reports issues

### DIFF
--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -58,6 +58,7 @@ hqDefine("linked_domain/js/domain_links", [
 
     var DomainLinksViewModel = function (data) {
         var self = {};
+        self.upstreamLink = data.master_link ? DomainLink(data.master_link) : null;
 
         // setup getting started view model
         var gettingStartedData = {
@@ -75,11 +76,11 @@ hqDefine("linked_domain/js/domain_links", [
 
         // can only pull content if a link with an upstream domain exists
         var pullReleaseContentData = null;
-        if (data.master_link) {
+        if (self.upstreamLink) {
             pullReleaseContentData = {
                 parent: self,
                 linkedDataViewModels: _.map(data.model_status, LinkedDataViewModel),
-                domainLink: DomainLink(data.master_link),
+                domainLink: self.upstreamLink,
             };
             self.pullReleaseContentViewModel = PullReleaseContentViewModel(pullReleaseContentData);
         }
@@ -169,12 +170,13 @@ hqDefine("linked_domain/js/domain_links", [
         };
 
         self.linkableUcr = ko.observableArray(_.map(data.linkable_ucr, function (report) {
-            return RemoteLinkableReport(report, self.master_link);
+            return RemoteLinkableReport(report, self.upstreamLink);
         }));
+
         self.createRemoteReportLink = function (reportId) {
             _private.RMI("create_remote_report_link", {
-                "master_domain": self.master_link.master_domain,
-                "linked_domain": self.master_link.linked_domain,
+                "master_domain": self.upstreamLink.master_domain,
+                "linked_domain": self.upstreamLink.linked_domain(),
                 "report_id": reportId,
             }).done(function (data) {
                 if (data.success) {
@@ -314,7 +316,7 @@ hqDefine("linked_domain/js/domain_links", [
         return self;
     };
 
-    var RemoteLinkableReport = function (report, masterLink) {
+    var RemoteLinkableReport = function (report, upstreamLink) {
         var self = {};
         self.id = report.id;
         self.title = report.title;
@@ -322,8 +324,8 @@ hqDefine("linked_domain/js/domain_links", [
 
         self.createLink = function () {
             _private.RMI("create_remote_report_link", {
-                "master_domain": masterLink.master_domain,
-                "linked_domain": masterLink.linked_domain,
+                "master_domain": upstreamLink.master_domain,
+                "linked_domain": upstreamLink.linked_domain(),
                 "report_id": self.id,
             }).done(function (data) {
                 if (data.success) {

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -383,6 +383,7 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
             'domain_link': build_domain_link_view_model(domain_link, timezone)
         }
 
+    @allow_remote_invocation
     def create_remote_report_link(self, in_data):
         linked_domain = in_data['linked_domain']
         master_domain = in_data['master_domain'].strip('/').split('/')[-1]


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SS-195

I originally thought this would only be a matter of fixing `domain_links.js` due to variable name issues. After fixing those, I ran into a 403 error when trying to link a remote report from production to staging within a USH link (Shu also ran into this). I added the `@allow_remote_invocation` decorator, which when gave me this 500 error ([sentry link](https://sentry.io/organizations/dimagi/issues/2551957239/?environment=staging&project=136860&query=is%3Aunresolved&statsPeriod=1h)). 

@proteusvacuum I'm not familiar enough with remote links to know what should be working/why this wouldn't be working. It's possible it is still related to my changes, but wanted to pull you in as you are more familiar with this part of linked projects than I am. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
