### PR TITLE
Fix HUBSPOT_API_ID key errors happening in sentry

### DIFF
--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -108,7 +108,9 @@ def js_api_keys(request):
 
     if (api_keys['ANALYTICS_IDS'].get('HUBSPOT_API_ID')
             and not is_hubspot_js_allowed_for_request(request)):
-        del api_keys['ANALYTICS_IDS']['HUBSPOT_API_ID']
+        # set to an empty string rather than delete. otherwise a strange race
+        # happens in redis, throwing an error
+        api_keys['ANALYTICS_IDS']['HUBSPOT_API_ID'] = ''
 
     return api_keys
 

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -111,6 +111,7 @@ def js_api_keys(request):
         # set to an empty string rather than delete. otherwise a strange race
         # happens in redis, throwing an error
         api_keys['ANALYTICS_IDS']['HUBSPOT_API_ID'] = ''
+        api_keys['ANALYTICS_IDS']['HUBSPOT_API_KEY'] = ''
 
     return api_keys
 


### PR DESCRIPTION
## Summary
This should fix the following error happening in Sentry:
https://sentry.io/organizations/dimagi/issues/2541705825/?environment=production&project=136860&query=is%3Aunresolved&statsPeriod=1h

I'm still unsure as to how the code is getting in this state when `api_keys['ANALYTICS_IDS'].get('HUBSPOT_API_ID')` in the line above checks for the presence of `HUBSPOT_API_ID`.

When I test this out locally on a hubspot-disabled account, it behaves as expected...so this is rather strange.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
simple and straightforward code change. tested locally with a hubspot enabled and hubspot disabled account/project space. Behaves as expected.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
