### PR TITLE
[Case Search] Allow searching for missing case properties

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2089,6 +2089,7 @@ class CaseSearchProperty(DocumentSchema):
     default_value = StringProperty()
     hint = DictProperty()
     hidden = BooleanProperty(default=False)
+    allow_blank_value = BooleanProperty(default=False)
 
     # applicable when appearance is a receiver
     receiver_expression = StringProperty()

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -85,6 +85,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             hint: '',
             appearance: '',
             isMultiselect: false,
+            allowBlankValue: false,
             defaultValue: '',
             hidden: false,
             receiverExpression: '',
@@ -97,6 +98,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         self.hint = ko.observable(options.hint);
         self.appearance = ko.observable(options.appearance);
         self.isMultiselect = ko.observable(options.isMultiselect);
+        self.allowBlankValue = ko.observable(options.allowBlankValue);
         self.defaultValue = ko.observable(options.defaultValue);
         self.hidden = ko.observable(options.hidden);
         self.appearanceFinal = ko.computed(function () {
@@ -148,8 +150,10 @@ hqDefine("app_manager/js/details/case_claim", function () {
         });
         self.itemset = itemsetModel(options.itemsetOptions, saveButton);
 
-        subscribeToSave(self,
-            ['name', 'label', 'hint', 'appearance', 'defaultValue', 'hidden', 'receiverExpression', 'isMultiselect'], saveButton);
+        subscribeToSave(self, [
+            'name', 'label', 'hint', 'appearance', 'defaultValue', 'hidden',
+            'receiverExpression', 'isMultiselect', 'allowBlankValue',
+        ], saveButton);
         return self;
     };
 
@@ -258,6 +262,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
 
         if (searchProperties.length > 0) {
             for (var i = 0; i < searchProperties.length; i++) {
+                // searchProperties is a list of CaseSearchProperty objects
                 // property labels/hints come in keyed by lang.
                 var label = searchProperties[i].label[lang];
                 var hint = searchProperties[i].hint[lang] || "";
@@ -284,6 +289,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                     hint: hint,
                     appearance: appearance,
                     isMultiselect: isMultiselect,
+                    allowBlankValue: searchProperties[i].allow_blank_value,
                     defaultValue: searchProperties[i].default_value,
                     hidden: searchProperties[i].hidden,
                     receiverExpression: searchProperties[i].receiver_expression,
@@ -321,6 +327,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                         hint: p.hint(),
                         appearance: p.appearanceFinal(),
                         is_multiselect: p.isMultiselect(),
+                        allow_blank_value: p.allowBlankValue(),
                         default_value: p.defaultValue(),
                         hidden: p.hidden(),
                         receiver_expression: p.receiverExpression(),

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -211,6 +211,8 @@ class RemoteRequestFactory(object):
                     value_ref=prop.itemset.value,
                     sort_ref=prop.itemset.sort,
                 )
+            if prop.allow_blank_value:
+                kwargs['allow_blank_value'] = prop.allow_blank_value
             prompts.append(QueryPrompt(**kwargs))
         return prompts
 

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -20,6 +20,11 @@ class XPathField(StringField):
     pass
 
 
+class BooleanField(SimpleBooleanField):
+    def __init__(self, xpath, *args, **kwargs):
+        return super().__init__(xpath, 'true', 'false', *args, **kwargs)
+
+
 class OrderedXmlObject(XmlObject):
     ORDER = ()
 
@@ -204,7 +209,7 @@ class LocaleResource(AbstractResource):
 class MediaResource(AbstractResource):
     ROOT_NAME = 'media'
     path = StringField('@path')
-    lazy = SimpleBooleanField('resource/@lazy', true="true", false="false")
+    lazy = BooleanField('resource/@lazy')
 
 
 class PracticeUserRestoreResource(AbstractResource):
@@ -373,7 +378,7 @@ class SessionDatum(IdNode, OrderedXmlObject):
     detail_confirm = StringField('@detail-confirm')
     detail_persistent = StringField('@detail-persistent')
     detail_inline = StringField('@detail-inline')
-    autoselect = SimpleBooleanField('@autoselect', true="true", false="false")
+    autoselect = BooleanField('@autoselect')
 
 
 class StackDatum(IdNode):
@@ -524,10 +529,10 @@ class QueryPrompt(DisplayNode):
     key = StringField('@key')
     appearance = StringField('@appearance', required=False)
     receive = StringField('@receive', required=False)
-    hidden = SimpleBooleanField('@hidden', 'true', 'false', required=False)
+    hidden = BooleanField('@hidden', required=False)
     input_ = StringField('@input', required=False)
     default_value = StringField('@default', required=False)
-    allow_blank_value = SimpleBooleanField('@allow_blank_value', 'true', 'false', required=False)
+    allow_blank_value = BooleanField('@allow_blank_value', required=False)
 
     itemset = NodeField('itemset', Itemset)
 
@@ -549,7 +554,7 @@ class RemoteRequestQuery(OrderedXmlObject, XmlObject):
     template = StringField('@template')
     data = NodeListField('data', QueryData)
     prompts = NodeListField('prompt', QueryPrompt)
-    default_search = SimpleBooleanField("@default_search", "true", "false")
+    default_search = BooleanField("@default_search")
 
 
 class RemoteRequestSession(OrderedXmlObject, XmlObject):
@@ -731,7 +736,7 @@ class Lookup(OrderedXmlObject):
     ORDER = ('auto_launch', 'extras', 'responses', 'field')
 
     name = StringField("@name")
-    auto_launch = SimpleBooleanField("@auto_launch", "true", "false")
+    auto_launch = BooleanField("@auto_launch")
     action = StringField("@action", required=True)
     image = StringField("@image")
     extras = NodeListField('extra', Extra)
@@ -746,7 +751,7 @@ class ActionMixin(OrderedXmlObject):
     stack = NodeField('stack', Stack)
     relevant = XPathField('@relevant')
     auto_launch = StringField("@auto_launch")
-    redo_last = SimpleBooleanField("@redo_last", "true", "false")
+    redo_last = BooleanField("@redo_last")
 
 
 class Action(ActionMixin):

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -527,6 +527,7 @@ class QueryPrompt(DisplayNode):
     hidden = SimpleBooleanField('@hidden', 'true', 'false', required=False)
     input_ = StringField('@input', required=False)
     default_value = StringField('@default', required=False)
+    allow_blank_value = SimpleBooleanField('@allow_blank_value', 'true', 'false', required=False)
 
     itemset = NodeField('itemset', Itemset)
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -85,11 +85,19 @@
                     </div>
                   </div>
                   <div class="form-group" data-bind="visible: appearanceFinal() == 'fixture'">
+                      <label class="control-label col-xs-12 col-sm-3">
+                          {% trans "Allow multiple selections" %}
+                      </label>
+                      <div class="col-xs-12 col-sm-9">
+                          <input type="checkbox" data-bind="checked: isMultiselect"/>
+                      </div>
+                  </div>
+                  <div class="form-group">
                     <label class="control-label col-xs-12 col-sm-3">
-                      {% trans "Allow multiple selections" %}
+                      {% trans "Allow searching for blank values" %}
                     </label>
                     <div class="col-xs-12 col-sm-9">
-                      <input type="checkbox" data-bind="checked: isMultiselect"/>
+                      <input type="checkbox" data-bind="checked: allowBlankValue"/>
                     </div>
                   </div>
                 {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -92,7 +92,7 @@
                           <input type="checkbox" data-bind="checked: isMultiselect"/>
                       </div>
                   </div>
-                  <div class="form-group">
+                  <div class="form-group" data-bind="visible: appearanceFinal() !== 'address'">
                     <label class="control-label col-xs-12 col-sm-3">
                       {% trans "Allow searching for blank values" %}
                     </label>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -56,7 +56,7 @@
                     <p class="help-block" data-bind="visible: appearance() == 'daterange'">
                       {% trans 'In "YYYY-MM-DD to YYYY-MM-DD" format' %}
                     </p>
-                    <p class="help-block" data-bind="visible: isMultiselect">
+                    <p class="help-block" data-bind="visible: appearanceFinal() == 'fixture' && isMultiselect()">
                       {% trans 'e.g. Use #,# as seperator to select multiple values' %}
                     </p>
                   </div>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -485,7 +485,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     def test_prompt_address_receiver(self, *args):
         """Setting the appearance to "address"
         """
-        # Shouldn't be included for versions before 2.50
         self.module.search_config.properties[0].receiver_expression = 'home-street'
         suite = self.app.create_suite()
         expected = """
@@ -504,7 +503,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     def test_prompt_hidden(self, *args):
         """Setting the appearance to "address"
         """
-        # Shouldn't be included for versions before 2.50
         self.module.search_config.properties[0].hidden = True
         suite = self.app.create_suite()
         expected = """
@@ -523,7 +521,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     def test_prompt_address_receiver_itemset(self, *args):
         """Setting the appearance to "address"
         """
-        # Shouldn't be included for versions before 2.50
         self.module.search_config.properties[0].receiver_expression = 'home-street'
         self.module.search_config.properties[0].input_ = 'select1'
         self.module.search_config.properties[0].itemset = Itemset(
@@ -634,6 +631,22 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         expected = """
         <partial>
           <prompt default="3" key="name">
+            <display>
+              <text>
+                <locale id="search_property.m0.name"/>
+              </text>
+            </display>
+          </prompt>
+        </partial>
+        """
+        self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
+
+    def test_allow_blank_value(self, *args):
+        self.module.search_config.properties[0].allow_blank_value = True
+        suite = self.app.create_suite()
+        expected = """
+        <partial>
+          <prompt key="name" allow_blank_value="true">
             <display>
               <text>
                 <locale id="search_property.m0.name"/>

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -995,6 +995,8 @@ def _update_search_properties(module, search_properties, lang='en'):
             ret['hint'] = hint
         if prop['hidden']:
             ret['hidden'] = prop['hidden']
+        if prop['allow_blank_value']:
+            ret['allow_blank_value'] = prop['allow_blank_value']
         if prop.get('appearance', '') == 'fixture':
             if prop.get('is_multiselect', False):
                 ret['input_'] = 'select'

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -73,6 +73,11 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             hqHelp: '.hq-help',
             dateRange: 'input.daterange',
             queryField: '.query-field',
+            blankSearchCheckbox: 'input.search-for-blank',
+        },
+
+        events: {
+            'change @ui.blankSearchCheckbox': 'toggleInputField',
         },
 
         modelEvents: {
@@ -218,6 +223,11 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 this.$el.hide();
             }
         },
+
+        toggleInputField: function () {
+            this.ui.queryField.prop('disabled', this.ui.blankSearchCheckbox.prop('checked'));
+        },
+
     });
 
     var QueryListView = Marionette.CollectionView.extend({
@@ -257,7 +267,10 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             $inputGroups.each(function (index) {
                 var queryValue = $(this).find('.query-field').val(),
                     searchForBlank = $(this).find('.search-for-blank').prop('checked');
-                if (queryValue !== '' || searchForBlank) {
+
+                if (searchForBlank) {
+                    answers[model[index].get('id')] = '';
+                } else if (queryValue !== '') {
                     answers[model[index].get('id')] = encodeValue(model[index], queryValue);
                 }
             });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -280,9 +280,11 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     searchForBlank = $(this).find('.search-for-blank').prop('checked');
                 }
 
+                var nothingSelected = (queryValue === ''
+                                       || (_.isArray(queryValue) && _.isEmpty(queryValue)));
                 if (searchForBlank) {
                     answers[model[index].get('id')] = '';
-                } else if (queryValue !== '') {
+                } else if (!nothingSelected) {
                     answers[model[index].get('id')] = encodeValue(model[index], queryValue);
                 }
             });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -266,7 +266,19 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 model = this.parentModel;
             $inputGroups.each(function (index) {
                 var queryValue = $(this).find('.query-field').val(),
+                    inputType = model[index].get('input'),
+                    searchForBlank;
+
+                if (inputType === 'select1') {
+                    searchForBlank = queryValue === "-1";
+                } else if (inputType === 'select') {
+                    searchForBlank = false;  // handle it here instead
+                    queryValue = _.map(queryValue, function (val) {
+                        return val === "-1" ? "" : val;
+                    });
+                } else {
                     searchForBlank = $(this).find('.search-for-blank').prop('checked');
+                }
 
                 if (searchForBlank) {
                     answers[model[index].get('id')] = '';

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -283,10 +283,11 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     var choices = response.models[i].get('itemsetChoices');
                     if (choices) {
                         var $field = $($fields.get(i)),
-                            value = response.models[i].get('value');
+                            value = $field.val();
+
                         $field.select2('close');    // force close dropdown, the set below can interfere with this when clearing selection
-                        if ($field.attr('multiple')) {
-                            value = value.split(selectDelimiter);
+                        if (!$field.attr('multiple')) {
+                            value = String(value);
                         }
                         self.collection.models[i].set({
                             itemsetChoices: choices,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -251,12 +251,14 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         },
 
         getAnswers: function () {
-            var $fields = $(".query-field"),
+            var $inputGroups = $(".query-input-group"),
                 answers = {},
                 model = this.parentModel;
-            $fields.each(function (index) {
-                if (this.value !== '') {
-                    answers[model[index].get('id')] = encodeValue(model[index], $(this).val());
+            $inputGroups.each(function (index) {
+                var queryValue = $(this).find('.query-field').val(),
+                    searchForBlank = $(this).find('.search-for-blank').prop('checked');
+                if (queryValue !== '' || searchForBlank) {
+                    answers[model[index].get('id')] = encodeValue(model[index], queryValue);
                 }
             });
             return answers;

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -35,37 +35,37 @@
   </td>
   <td class="col-sm-2">
     <div class="query-input-group">
-    <% if (input == "select1") { %>
-      <select class="query-field form-control hqwebapp-select2" data-receive="<%- receive %>">
-        <option value=""></option>
-        <% for (var i = 0; i < itemsetChoices.length; i++) { %>
-          <option value="<%- i %>" <% if (value === String(i)) { %>selected<% } %>>
-            <%- itemsetChoices[i] %>
-          </option>
-        <% } %>
-      <select>
-    <% } else if (input == "select") { %>
-      <select multiple class="query-field form-control hqwebapp-select2" data-receive="<%- receive %>">
-        <% for (var i = 0; i < itemsetChoices.length; i++) { %>
-          <option value="<%- i %>" <% if (value && value.indexOf(String(i)) > -1) { %>selected<% } %>>
-            <%- itemsetChoices[i] %>
-          </option>
-        <% } %>
-      <select>
-    <% } else if (input == "daterange") { %>
-      <input type="text" class="daterange query-field form-control" value="<%- value %>">
-    <% } else if (input == "address") { %>
-      <div class="query-field" value="<%- value %>" id="<%- id %>_mapbox" data-address="<%- id %>">
-      </div>
-    <% } else { %>
-      <input type="text" class="query-field form-control" value="<%- value %>" data-receive="<%- receive %>">
-    <% } %>
-    <% if (typeof allow_blank_value !== "undefined" && allow_blank_value) { %>
-    <label>
-        <input type="checkbox" class="search-for-blank">
-        {% trans "Search for blank values" %}
-    </label>
-    <% } %>
+      <% if (input == "select1") { %>
+        <select class="query-field form-control hqwebapp-select2" data-receive="<%- receive %>">
+          <option value=""></option>
+          <% for (var i = 0; i < itemsetChoices.length; i++) { %>
+            <option value="<%- i %>" <% if (value === String(i)) { %>selected<% } %>>
+              <%- itemsetChoices[i] %>
+            </option>
+          <% } %>
+        <select>
+      <% } else if (input == "select") { %>
+        <select multiple class="query-field form-control hqwebapp-select2" data-receive="<%- receive %>">
+          <% for (var i = 0; i < itemsetChoices.length; i++) { %>
+            <option value="<%- i %>" <% if (value && value.indexOf(String(i)) > -1) { %>selected<% } %>>
+              <%- itemsetChoices[i] %>
+            </option>
+          <% } %>
+        <select>
+      <% } else if (input == "daterange") { %>
+        <input type="text" class="daterange query-field form-control" value="<%- value %>">
+      <% } else if (input == "address") { %>
+        <div class="query-field" value="<%- value %>" id="<%- id %>_mapbox" data-address="<%- id %>">
+        </div>
+      <% } else { %>
+        <input type="text" class="query-field form-control" value="<%- value %>" data-receive="<%- receive %>">
+      <% } %>
+      <% if (typeof allow_blank_value !== "undefined" && allow_blank_value) { %>
+      <label>
+          <input type="checkbox" class="search-for-blank">
+          {% trans "Search for blank values" %}
+      </label>
+      <% } %>
     </div>
   </td>
 </script>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -20,7 +20,7 @@
 
 
 <script type="text/template" id="query-view-item-template">
-  <td class="col-sm-2">
+  <td class="col-sm-6">
     <div>
       <%- text ? text : "" %>
       <% if (typeof hint !== "undefined" && hint !== null) { %>
@@ -33,7 +33,7 @@
     </div>
   </td>
   </td>
-  <td class="col-sm-2">
+  <td class="col-sm-6">
     <div class="query-input-group">
       <% if (input == "select1") { %>
         <select class="query-field form-control hqwebapp-select2" data-receive="<%- receive %>">

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -67,6 +67,12 @@
 
       <% } else if (input == "daterange") { %>
         <input type="text" class="daterange query-field form-control" value="<%- value %>">
+        <% if (allow_blank_value) { %>
+        <label>
+            <input type="checkbox" class="search-for-blank">
+            {% trans "Search for blank values" %}
+        </label>
+        <% } %>
 
       <% } else if (input == "address") { %>
         <div class="query-field" value="<%- value %>" id="<%- id %>_mapbox" data-address="<%- id %>">

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -34,6 +34,7 @@
   </td>
   </td>
   <td class="col-sm-2">
+    <div class="query-input-group">
     <% if (input == "select1") { %>
       <select class="query-field form-control hqwebapp-select2" data-receive="<%- receive %>">
         <option value=""></option>
@@ -59,5 +60,12 @@
     <% } else { %>
       <input type="text" class="query-field form-control" value="<%- value %>" data-receive="<%- receive %>">
     <% } %>
+    <% if (typeof allow_blank_value !== "undefined" && allow_blank_value) { %>
+    <label>
+        <input type="checkbox" class="search-for-blank">
+        {% trans "Search for blank values" %}
+    </label>
+    <% } %>
+    </div>
   </td>
 </script>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -35,37 +35,53 @@
   </td>
   <td class="col-sm-6">
     <div class="query-input-group">
+
       <% if (input == "select1") { %>
         <select class="query-field form-control hqwebapp-select2" data-receive="<%- receive %>">
           <option value=""></option>
+
+          <% if (allow_blank_value) { %>
+          <option value="-1" <% if (value === "-1") { %>selected<% } %>>(empty)</option>
+          <% } %>
+
           <% for (var i = 0; i < itemsetChoices.length; i++) { %>
             <option value="<%- i %>" <% if (value === String(i)) { %>selected<% } %>>
               <%- itemsetChoices[i] %>
             </option>
           <% } %>
         <select>
+
       <% } else if (input == "select") { %>
         <select multiple class="query-field form-control hqwebapp-select2" data-receive="<%- receive %>">
+
+          <% if (allow_blank_value) { %>
+          <option value="-1" <% if (_.contains(value, "-1")) { %>selected<% } %>>(empty)</option>
+          <% } %>
+
           <% for (var i = 0; i < itemsetChoices.length; i++) { %>
             <option value="<%- i %>" <% if (value && value.indexOf(String(i)) > -1) { %>selected<% } %>>
               <%- itemsetChoices[i] %>
             </option>
           <% } %>
         <select>
+
       <% } else if (input == "daterange") { %>
         <input type="text" class="daterange query-field form-control" value="<%- value %>">
+
       <% } else if (input == "address") { %>
         <div class="query-field" value="<%- value %>" id="<%- id %>_mapbox" data-address="<%- id %>">
         </div>
+
       <% } else { %>
         <input type="text" class="query-field form-control" value="<%- value %>" data-receive="<%- receive %>">
+        <% if (allow_blank_value) { %>
+        <label>
+            <input type="checkbox" class="search-for-blank">
+            {% trans "Search for blank values" %}
+        </label>
+        <% } %>
       <% } %>
-      <% if (typeof allow_blank_value !== "undefined" && allow_blank_value) { %>
-      <label>
-          <input type="checkbox" class="search-for-blank">
-          {% trans "Search for blank values" %}
-      </label>
-      <% } %>
+
     </div>
   </td>
 </script>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-1150
https://dimagi-dev.atlassian.net/browse/USH-1105
https://docs.google.com/document/d/1sLHXEFPfj56zcLw8ZZPDXMVOUxqHiIpxKIcp2hE2ueE/edit#
To be deployed with https://github.com/dimagi/formplayer/pull/987
See product description below

## Feature Flag
"Enable synchronous mobile searching and case claiming"

## Product Description
This adds the ability to search for cases missing specific values.  Here's the configuration screen:

![image](https://user-images.githubusercontent.com/2367539/128071032-a274483a-aa51-424d-a34b-c381249ab939.png)

And here's how it looks in the UI.  The field types below are multiselect, single select, date range, text, and barcode, in that order:

![image](https://user-images.githubusercontent.com/2367539/128070625-86b2c43f-9823-4095-992d-7052f6926cbb.png)

Note that the UX is a little different for each type.  The select types get an `(empty)` option, which mirrors how this is done in excel (thanks, @orangejenny for the suggestion).  Date range, text, and barcode fields get a checkbox.  When selected, the checkbox disables the main input widget and ignores its contents, though it doesn't clear them.  Geocoder questions cannot be configured to search for blank values.

Values are considered to be blank/empty if they are not set on the case or are set to the empty string.

## Safety Assurance

- [ ] Risk label is set correctly
- [ ] All migrations are backwards compatible and won't block deploy
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-3205

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
