### PR TITLE
Reference fetched datasource to account for remote links

### DIFF
--- a/corehq/apps/linked_domain/ucr.py
+++ b/corehq/apps/linked_domain/ucr.py
@@ -29,7 +29,7 @@ def create_linked_ucr(domain_link, report_config_id):
         datasource = DataSourceConfiguration.get(report_config.config_id)
 
     # grab the linked app this linked report references
-    downstream_app_id = get_downstream_app_id(domain_link.linked_domain, report_config.config.meta.build.app_id)
+    downstream_app_id = get_downstream_app_id(domain_link.linked_domain, datasource.meta.build.app_id)
     new_datasource = _get_or_create_datasource_link(domain_link, datasource, downstream_app_id)
     new_report = _get_or_create_report_link(domain_link, report_config, new_datasource)
     return LinkedUCRInfo(datasource=new_datasource, report=new_report)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SS-195

This causes an issue when creating a linked report within a remote link because `report.config` fetches the datasource config from the database. When I added this line, I should have used the existing `datasource` var as the legwork to fetch a local or remote datasource has already been done, and this way we do not attempt to look for a datasource that does not exist in the current context. 

See [related sentry error](https://sentry.io/organizations/dimagi/issues/2551957239/?environment=staging&project=136860&query=is%3Aunresolved&statsPeriod=1h). 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested on staging.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
