### PR TITLE
fix soft assert

### DIFF
--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -179,8 +179,8 @@ def track_es_doc_counts():
                         'index': name,
                         'shard': f'{name}_{number}',
                     }
-                    metrics_gauge('elasticsearch.shards.docs.count', i['docs']['count'], tags)
-                    metrics_gauge('elasticsearch.shards.docs.deleted', i['docs']['deleted'], tags)
+                    metrics_gauge('commcare.elasticsearch.shards.docs.count', i['docs']['count'], tags)
+                    metrics_gauge('commcare.elasticsearch.shards.docs.deleted', i['docs']['deleted'], tags)
 
 
 @periodic_task(queue='background_queue', run_every=crontab(minute="0", hour="0"))
@@ -200,4 +200,4 @@ def track_pg_limits():
             for table, sequence in results:
                 cursor.execute(f'select last_value from {sequence}')
                 current_value = cursor.fetchone()[0]
-                metrics_gauge('postgres.sequence.current_value', current_value, {'table': table, 'database': db})
+                metrics_gauge('commcare.postgres.sequence.current_value', current_value, {'table': table, 'database': db})


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This was triggering a soft assert meant to enforce metric naming conventions.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Metrics only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
