### PR TITLE
Add domain link create and push events to kissmetrics

### DIFF
--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -331,7 +331,11 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
         except (DomainLinkError, UnsupportedActionError) as e:
             error = str(e)
 
-        track_workflow(self.request.couch_user.username, "Linked domain: updated '{}' model".format(type_))
+        track_workflow(
+            self.request.couch_user.username,
+            "Linked domain: pulled data model",
+            {"data_model": type_}
+        )
 
         timezone = get_timezone_for_request()
         return {

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -358,7 +358,11 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
         push_models.delay(self.domain, in_data['models'], in_data['linked_domains'],
                           in_data['build_apps'], self.request.couch_user.username)
 
-        track_workflow(self.request.couch_user.username, f"Linked domain: pushed data models {in_data['models']}")
+        track_workflow(
+            self.request.couch_user.username,
+            "Linked domain: pushed data models",
+            {"data_models": in_data['models']}
+        )
 
         return {
             'success': True,

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -357,6 +357,9 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
     def create_release(self, in_data):
         push_models.delay(self.domain, in_data['models'], in_data['linked_domains'],
                           in_data['build_apps'], self.request.couch_user.username)
+
+        track_workflow(self.request.couch_user.username, f"Linked domain: pushed data models {in_data['models']}")
+
         return {
             'success': True,
             'message': ugettext('''
@@ -376,6 +379,8 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
                 'success': False,
                 'message': str(e)
             }
+
+        track_workflow(self.request.couch_user.username, "Linked domain: domain link created")
 
         timezone = get_timezone_for_request()
         return {


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SS-128

Need to track domain link create events and push events since those aren't being tracked that I know of.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Adding an already used line of code for other actions with a slight text change.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
