### PR TITLE
Fix mock test issue

### DIFF
--- a/corehq/tabs/tests.py
+++ b/corehq/tabs/tests.py
@@ -51,7 +51,7 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
     @patch('corehq.apps.users.models.CouchUser')
     @patch('corehq.apps.domain.models.Domain')
     def test_get_release_management_items_returns_none(self, mock_user, mock_domain):
-        mock_user.is_domain_admin = False
+        mock_user.is_domain_admin.return_value = False
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
@@ -62,7 +62,7 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
     @patch('corehq.apps.users.models.CouchUser')
     @patch('corehq.apps.domain.models.Domain')
     def test_get_release_management_items_returns_none_with_admin(self, mock_user, mock_domain):
-        mock_user.is_domain_admin = True
+        mock_user.is_domain_admin.return_value = True
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
@@ -73,7 +73,7 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
     @patch('corehq.apps.users.models.CouchUser')
     @patch('corehq.apps.domain.models.Domain')
     def test_get_release_management_items_returns_none_with_domain_privilege(self, mock_user, mock_domain):
-        mock_user.is_domain_admin = False
+        mock_user.is_domain_admin.return_value = False
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = True
@@ -84,7 +84,7 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
     @patch('corehq.apps.users.models.CouchUser')
     @patch('corehq.apps.domain.models.Domain')
     def test_get_release_management_items_returns_some(self, mock_user, mock_domain):
-        mock_user.is_domain_admin = True
+        mock_user.is_domain_admin.return_value = True
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege, \
              patch('corehq.tabs.tabclasses.reverse') as mock_reverse:


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Introduced test failures by the change [here](https://github.com/dimagi/commcare-hq/pull/30185). Should have run tests here and updated, but honestly don't think I would have remembered to run tests in `corehq.tabs`. Looking forward to primarily working off of master again.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Updating tests.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
