### PR TITLE
Use ugligy3 to minify JS

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -78,15 +78,16 @@ class Command(ResourceStaticCommand):
             # and pass in the file contents, since get_hash does another read.
             file_hash = self.get_hash(filename)
 
-            # Overwrite source map reference. Source maps are accessed on the CDN,
-            # so they need to have the version hash appended.
-            with open(filename, 'r') as fin:
-                lines = fin.readlines()
-            with open(filename, 'w') as fout:
-                for line in lines:
-                    if re.search(r'sourceMappingURL=bundle.js.map$', line):
-                        line = re.sub(r'bundle.js.map', 'bundle.js.map?version=' + file_hash, line)
-                    fout.write(line)
+            if not no_optimize:
+                # Overwrite source map reference. Source maps are accessed on the CDN,
+                # so they need to have the version hash appended.
+                with open(filename, 'r') as fin:
+                    lines = fin.readlines()
+                with open(filename, 'w') as fout:
+                    for line in lines:
+                        if re.search(r'sourceMappingURL=bundle.js.map$', line):
+                            line = re.sub(r'bundle.js.map', 'bundle.js.map?version=' + file_hash, line)
+                        fout.write(line)
             resource_versions[module['name'] + ".js"] = file_hash
 
         # Write out resource_versions.js for all js files in resource_versions

--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -148,7 +148,7 @@ def _r_js(local=False):
 
     ret = call(["node", "node_modules/requirejs/bin/r.js", "-o", BUILD_JS_FILENAME])
     if ret:
-        exit(1)
+        raise CommandError("Failed to build JS bundles")
 
     return config, local_js_dirs
 

--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 from collections import defaultdict
+from pathlib import Path
 from uuid import uuid4
 from shutil import copyfile
 from subprocess import call
@@ -155,14 +156,14 @@ def _r_js(local=False):
 
 def _minify(config):
     for module in with_progress_bar(config['modules'], prefix="Minifying", oneline=False):
-        filename = module['name'] + ".js"
-        path = os.path.join(ROOT_DIR, 'staticfiles', filename)
+        rel_path = Path(module['name'] + ".js")
+        path = os.path.join(ROOT_DIR, 'staticfiles', rel_path)
         ret = call([
             "node", "node_modules/uglify-js/bin/uglifyjs", path, "--compress", "--mangle", "--output", path,
-            "--source-map", f"url={filename}.map"
+            "--source-map", f"url={rel_path.name}.map"
         ])
         if ret:
-            raise CommandError(f"Failed to minify {filename}")
+            raise CommandError(f"Failed to minify {rel_path}")
 
 
 def _get_html_files_and_local_js_dirs(local):

--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -44,7 +44,7 @@ class Command(ResourceStaticCommand):
         logger.setLevel('DEBUG')
 
         local = options['local']
-        no_optimize = options['no_optimize']
+        optimize = not options['no_optimize']
 
         if local:
             _confirm_or_exit()
@@ -56,7 +56,7 @@ class Command(ResourceStaticCommand):
             raise ResourceVersionsNotFoundException()
 
         config, local_js_dirs = _r_js(local=local)
-        if not no_optimize:
+        if optimize:
             _minify(config)
 
         if local:
@@ -78,7 +78,7 @@ class Command(ResourceStaticCommand):
             # and pass in the file contents, since get_hash does another read.
             file_hash = self.get_hash(filename)
 
-            if not no_optimize:
+            if optimize:
                 # Overwrite source map reference. Source maps are accessed on the CDN,
                 # so they need to have the version hash appended.
                 with open(filename, 'r') as fin:

--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -158,7 +158,7 @@ def _minify(config):
         filename = module['name'] + ".js"
         path = os.path.join(ROOT_DIR, 'staticfiles', filename)
         ret = call([
-            "node", "node_modules/uglify-js/bin/uglifyjs", path, "-c", "-m", "-o", path,
+            "node", "node_modules/uglify-js/bin/uglifyjs", path, "--compress", "--mangle", "--output", path,
             "--source-map", f"url={filename}.map"
         ])
         if ret:

--- a/corehq/apps/hqwebapp/static/hqwebapp/yaml/requirejs.yaml
+++ b/corehq/apps/hqwebapp/static/hqwebapp/yaml/requirejs.yaml
@@ -6,7 +6,8 @@ allowSourceOverwrites: true
 keepBuildDir: true
 findNestedDependencies: true
 skipDirOptimize: true   # could turn this off to minify everything
-generateSourceMaps: true
+generateSourceMaps: false
+optimize: none
 fileExclusionRegExp: ^\.|\.css$
 modules:
   # These two modules are referenced in hqwebapp/base.html, not in a requirejs_main tag,

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "requirejs": "2.3.6",
         "select2": "4.1.0-rc.0",
         "topojson": "3.0.2",
-        "uglify-js": "2.8.29",
+        "uglify-js": "3",
         "ui-select": "npm:ui-select#0.13.2",
         "underscore": "1.13.1",
         "url-polyfill": "1.1.10",

--- a/scripts/build-requirejs.sh
+++ b/scripts/build-requirejs.sh
@@ -1,4 +1,5 @@
 rm -rf staticfiles/ &&
+./manage.py resource_static &&
 ./manage.py collectstatic --noinput &&
 ./manage.py compilejsi18n &&
 ./manage.py build_requirejs

--- a/yarn.lock
+++ b/yarn.lock
@@ -189,15 +189,6 @@ ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-align-text@^0.1.1, align-text@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
-  integrity sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=
-  dependencies:
-    kind-of "^3.0.2"
-    longest "^1.0.1"
-    repeat-string "^1.5.2"
-
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
@@ -754,11 +745,6 @@ camelcase@5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
   integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
 
-camelcase@^1.0.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
-  integrity sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=
-
 camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
@@ -783,14 +769,6 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
-
-center-align@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
-  integrity sha1-qg0yYptu6XIgBBHL1EYckHvCt60=
-  dependencies:
-    align-text "^0.1.3"
-    lazy-cache "^1.0.3"
 
 chai@3.3.0:
   version "3.3.0"
@@ -915,15 +893,6 @@ clipboard@1.5.15:
     good-listener "^1.2.0"
     select "^1.0.6"
     tiny-emitter "^1.0.0"
-
-cliui@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
-  integrity sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=
-  dependencies:
-    center-align "^0.1.1"
-    right-align "^0.1.1"
-    wordwrap "0.0.2"
 
 cliui@^3.2.0:
   version "3.2.0"
@@ -1302,7 +1271,7 @@ decamelize-keys@^1.1.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.2.0:
+decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -3228,11 +3197,6 @@ latest-version@^3.0.0:
   dependencies:
     package-json "^4.0.0"
 
-lazy-cache@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
-  integrity sha1-odePw6UEdMuAhF07O24dpJpEbo4=
-
 lazy-property@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lazy-property/-/lazy-property-1.0.0.tgz#84ddc4b370679ba8bd4cdcfa4c06b43d57111147"
@@ -3566,11 +3530,6 @@ lolex@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
   integrity sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=
-
-longest@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
-  integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
 
 lowercase-keys@1.0.0:
   version "1.0.0"
@@ -5232,7 +5191,7 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.5.2, repeat-string@^1.6.1:
+repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
@@ -5341,13 +5300,6 @@ retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
-
-right-align@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
-  integrity sha1-YTObci/mo1FWiSENJOFMlhSGE+8=
-  dependencies:
-    align-text "^0.1.1"
 
 rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
@@ -5628,7 +5580,7 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@^0.5.6, source-map@~0.5.1:
+source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -6219,20 +6171,10 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
-uglify-js@2.8.29:
-  version "2.8.29"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
-  integrity sha1-KcVzMUgFe7Th913zW3qcty5qWd0=
-  dependencies:
-    source-map "~0.5.1"
-    yargs "~3.10.0"
-  optionalDependencies:
-    uglify-to-browserify "~1.0.0"
-
-uglify-to-browserify@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
-  integrity sha1-bgkk1r2mta/jSeOabWMoUKD4grc=
+uglify-js@3:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.14.1.tgz#e2cb9fe34db9cb4cf7e35d1d26dfea28e09a7d06"
+  integrity sha512-JhS3hmcVaXlp/xSo3PKY5R0JqKs5M3IV+exdLHW99qKvKivPO4Z8qbej6mte17SOPqAOVMjt/XGgWacnFSzM3g==
 
 "ui-select@npm:ui-select#0.13.2":
   version "0.19.8"
@@ -6518,20 +6460,10 @@ widest-line@^2.0.0:
   dependencies:
     string-width "^2.1.1"
 
-window-size@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
-  integrity sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=
-
 word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
-
-wordwrap@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
-  integrity sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=
 
 wordwrap@~0.0.2:
   version "0.0.3"
@@ -6733,16 +6665,6 @@ yargs@^8.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
-
-yargs@~3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
-  integrity sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=
-  dependencies:
-    camelcase "^1.0.2"
-    cliui "^2.1.0"
-    decamelize "^1.0.0"
-    window-size "0.1.0"
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12521

## Summary
This switches from using the requirejs bundled version of uglify (v2) to standalone v3 so that we can support JS ES6.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan
* Deploy to staging (complete)
* QA smoke test

### Safety story
Changes to the JS build pipeline could cause issues anywhere in HQ. There is some safety in the fact that deploy will fail if the minification step fails. Also if a deploy goes through and the basic testing of the UI is successful then it is most likely that all the UI will work.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
