### PR TITLE
quote tablename

### DIFF
--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -198,6 +198,6 @@ def track_pg_limits():
             cursor.execute(query)
             results = cursor.fetchall()
             for table, sequence in results:
-                cursor.execute(f'select last_value from {sequence}')
+                cursor.execute(f'select last_value from "{sequence}"')
                 current_value = cursor.fetchone()[0]
                 metrics_gauge('commcare.postgres.sequence.current_value', current_value, {'table': table, 'database': db})


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Some of our table names have `-` in them which need to be quoted. This was causing a sql error when looking up the sequences.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested in a shell and metrics only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
