### PR TITLE
Fix observed issues with ERM deploy

### DIFF
--- a/corehq/apps/linked_domain/decorators.py
+++ b/corehq/apps/linked_domain/decorators.py
@@ -2,8 +2,6 @@ from functools import wraps
 
 from django.http import HttpResponseBadRequest, HttpResponseForbidden
 
-from no_exceptions.exceptions import Http403
-
 from corehq.apps.linked_domain.dbaccessors import get_upstream_domain_link
 from corehq.apps.linked_domain.util import can_access_linked_domains
 
@@ -20,7 +18,7 @@ def require_access_to_linked_domains(view_func):
         if can_access_linked_domains(user, domain):
             return call_view()
         else:
-            raise Http403()
+            return HttpResponseForbidden()
 
     return _inner
 

--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -54,10 +54,7 @@ class DomainLink(models.Model):
     @property
     def downstream_url(self):
         if self.is_remote:
-            return '{}{}'.format(
-                self.remote_base_url,
-                reverse('domain_homepage', args=[self.linked_domain])
-            )
+            return self.linked_domain
         else:
             return reverse('domain_links', args=[self.linked_domain])
 

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -230,6 +230,7 @@ hqDefine("linked_domain/js/domain_links", [
     };
 
     var PushContentViewModel = function (data) {
+        var self = {};
         self.parent = data.parent;
         self.domainsToPush = ko.observableArray();
         self.modelsToPush = ko.observableArray();
@@ -277,6 +278,7 @@ hqDefine("linked_domain/js/domain_links", [
     };
 
     var PullReleaseContentViewModel = function (data) {
+        var self = {};
         // Pull Content Tab
         self.parent = data.parent;
         self.linkedDataViewModels = data.linkedDataViewModels;

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
@@ -52,7 +52,7 @@
                       </h4>
                       <p>
                         {% blocktrans %}
-                          This will pull <!-- ko text: name --><!-- /ko --> from the upstream project space <b data-bind="text: domainLink.master_domain"></b>, overwriting the existing <!-- ko text: name --><!-- /ko -->.<br/>
+                          This will pull <!-- ko text: name --><!-- /ko --> from the upstream project space <b data-bind="text: $parent.domainLink.master_domain"></b>, overwriting the existing <!-- ko text: name --><!-- /ko -->.<br/>
                           <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about pulling content from an upstream project space into a downstream project space.
                         {% endblocktrans %}
                       </p>

--- a/corehq/apps/linked_domain/tests/test_domain_link_methods.py
+++ b/corehq/apps/linked_domain/tests/test_domain_link_methods.py
@@ -49,5 +49,5 @@ class DomainLinkUrlsTest(TestCase):
         domain_link.save()
         self.addCleanup(domain_link.delete)
 
-        expected_downstream_url = 'test.base.url/a/downstream-domain/'
+        expected_downstream_url = self.downstream.name  # remote downstream urls are equal to the name
         self.assertEqual(expected_downstream_url, domain_link.downstream_url)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
There were 3 issues observed after this morning's deploy. 

#### JS error rendering the "Manage Linked Project Space" page in downstream domains useless. 

The error message was `domainLink is not defined`. This issue did not present itself until [a last minute PR](https://github.com/dimagi/commcare-hq/pull/30198) was added in an attempt to fix a JS complaint during India/Swiss deploy. I checked India after the first deploy with ERM changes, but once it was redeployed with this PR, I did not check again because the change seemed harmless. Lesson learned.

The reason this issue was not uncovered until correcting my missing `self` declarations in the `PullReleaseContentViewModel` and `PushContentViewModel` is likely related to how Knockout resolves variables referenced within a `data-bind`. Without defining a local `var self = {};`, it appears that self referenced the `Window` object, and appended the variables within the `PullReleaseContentViewModel` to that object. Once I added the `self` definition, the view model variables were only defined inside the view model, not globally in the `Window` object. When defined globally, [this reference](https://github.com/dimagi/commcare-hq/blob/daaa9f51b5b9de1c5df2a90d54f2881b0eff6b55/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html#L55) to `domainLink` succeeded, but when correctly scoped this line needed to be changed to specifically reference `$parent.domainLink`. For more info, see [this post](https://groups.google.com/g/knockoutjs/c/fHl0-Qch-uM).

#### 500 error on upstream project spaces

[Here](https://sentry.io/organizations/dimagi/issues/2555837357/?project=136860&query=is%3Aunresolved+domain%3Any-dev-cdcms&statsPeriod=14d) is the sentry error. This was introduced when I [refactored how urls to downstream domains](https://github.com/dimagi/commcare-hq/pull/29891/files#diff-d24e64fa4edede0b4440fbcdafc002d0aa1896db4f3fc065a11d401e13e3844cR55-R62) were resolved. I didn't understand that `remote_base_url` is only used to refer to the upstream domain, and that in remote domain links, the linked/downstream domain url is the same as the name. So `link.linked_domain == link.downstream_url`. 

This was not caught on staging because we needed to view the upstream domain of a remote link. We had only viewed downstream domains within remote links, so there was no attempt to resolve remote downstream urls which would have surfaced this issue.  

#### 500 error when access is denied

I noticed this one locally, but instead of returning a `HttpResponseForbidden` response, I raised a `Http403` exception which results in a 500 and is not how we want to handle this. Updated to return the proper response.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
For the 1st issue, I'm not sure if any automated tests would help here. For the 2nd issue, I've updated the tests to reflect the changes. The original tests reflect the misunderstanding I had of `remote_base_url` which is why they did not catch this issue. The 3rd issue doesn't seem like it needs a test. The underlying access method is tested, this is just a matter of returning a response instead of raising an exception. Certainly could add a test, but I don't feel it is necessary.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested. Will test on staging as well and have more in depth tests around remote links.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
