### PR TITLE
Moving available custom rule config to HQ

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -745,10 +745,18 @@ AVAILABLE_CUSTOM_SCHEDULING_RECIPIENTS = {
 }
 
 LOCAL_AVAILABLE_CUSTOM_RULE_CRITERIA = {}
-AVAILABLE_CUSTOM_RULE_CRITERIA = {}
+AVAILABLE_CUSTOM_RULE_CRITERIA = {
+    'COVID_US_ASSOCIATED_USER_CASES':
+        ['custom.covid.rules.custom_criteria.associated_usercase_closed',
+         "Custom: filter checkin cases that are open, associated to a mobile worker, and usercase is closed"]
+}
 
 LOCAL_AVAILABLE_CUSTOM_RULE_ACTIONS = {}
-AVAILABLE_CUSTOM_RULE_ACTIONS = {}
+AVAILABLE_CUSTOM_RULE_ACTIONS = {
+    'COVID_US_CLOSE_CASES_ASSIGNED_CHECKIN':
+        ['custom.covid.rules.custom_actions.close_cases_assigned_to_checkin',
+         "Custom: closes patient and/or contact cases assigned to checkin case"]
+}
 
 ####### auditcare parameters #######
 AUDIT_ALL_VIEWS = False

--- a/settings.py
+++ b/settings.py
@@ -746,16 +746,12 @@ AVAILABLE_CUSTOM_SCHEDULING_RECIPIENTS = {
 
 LOCAL_AVAILABLE_CUSTOM_RULE_CRITERIA = {}
 AVAILABLE_CUSTOM_RULE_CRITERIA = {
-    'COVID_US_ASSOCIATED_USER_CASES':
-        ['custom.covid.rules.custom_criteria.associated_usercase_closed',
-         "Custom: filter checkin cases that are open, associated to a mobile worker, and usercase is closed"]
+    'COVID_US_ASSOCIATED_USER_CASES': 'custom.covid.rules.custom_criteria.associated_usercase_closed'
 }
 
 LOCAL_AVAILABLE_CUSTOM_RULE_ACTIONS = {}
 AVAILABLE_CUSTOM_RULE_ACTIONS = {
-    'COVID_US_CLOSE_CASES_ASSIGNED_CHECKIN':
-        ['custom.covid.rules.custom_actions.close_cases_assigned_to_checkin',
-         "Custom: closes patient and/or contact cases assigned to checkin case"]
+    'COVID_US_CLOSE_CASES_ASSIGNED_CHECKIN': 'custom.covid.rules.custom_actions.close_cases_assigned_to_checkin'
 }
 
 ####### auditcare parameters #######


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Prompted by this [Ticket](https://dimagi-dev.atlassian.net/browse/SUPPORT-10242)
Feedback from the [original PR](https://github.com/dimagi/commcare-cloud/pull/4841) to prevent this issue in the future.

Tied to https://github.com/dimagi/commcare-cloud/pull/4842 so wait for merge until that's ready

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
