### PR TITLE
Smart linking MVP: stop claiming cases on HQ

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -152,30 +152,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
         }
 
         // If an endpoint is provided, first claim any cases it references, then navigate
-        var deferred = $.Deferred();
-        $.ajax({
-            type: 'POST',
-            url: initialPageData.reverse('claim_all_cases'),
-            data: {
-                username: user.restoreAs || user.username,
-                case_ids: _.values(options.endpointArgs),
-            },
-            success: function () {
-                API.queryFormplayer(options, "get_endpoint").done(function (menuResponse) {
-                    deferred.resolve(menuResponse);
-                }).fail(function () {
-                    deferred.reject();
-                    // Just go home. Error message will be displayed by the error handler in queryFormplayer.
-                    FormplayerFrontend.trigger('navigateHome');
-                });
-            },
-            error: function (xhr) {
-                deferred.reject();
-                FormplayerFrontend.trigger('showError', xhr.responseText);
-                FormplayerFrontend.trigger('navigateHome');
-            },
-        });
-        return deferred;
+        return API.queryFormplayer(options, "get_endpoint");
     });
 
     FormplayerFrontend.getChannel().reply("entity:get:details", function (options, isPersistent) {

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -87,7 +87,6 @@
   {% registerurl 'list_case_exports' request.domain %}
   {% registerurl 'list_form_exports' request.domain %}
   {% registerurl 'case_data' request.domain '---' %}
-  {% registerurl 'claim_all_cases' request.domain %}
   {% registerurl 'render_form_data' request.domain '---' %}
   {% registerurl 'report_formplayer_error' request.domain %}
   {% registerurl 'dialer_view' request.domain %}

--- a/corehq/apps/cloudcare/templates/preview_app/base.html
+++ b/corehq/apps/cloudcare/templates/preview_app/base.html
@@ -43,7 +43,6 @@
   {% registerurl 'list_form_exports' request.domain %}
   {% registerurl 'login_new_window' %}
   {% registerurl 'case_data' request.domain '---' %}
-  {% registerurl 'claim_all_cases' request.domain %}
   {% registerurl 'render_form_data' request.domain '---' %}
   {% registerurl 'report_formplayer_error' request.domain %}
   {% registerurl 'dialer_view' request.domain %}

--- a/corehq/apps/ota/urls.py
+++ b/corehq/apps/ota/urls.py
@@ -4,7 +4,6 @@ from corehq.apps.hqadmin.views.users import DomainAdminRestoreView
 from corehq.apps.ota.views import (
     app_aware_search,
     claim,
-    claim_all,
     get_next_id,
     heartbeat,
     recovery_measures,
@@ -20,7 +19,6 @@ urlpatterns = [
     url(r'^search/$', search, name='remote_search'),
     url(r'^search/(?P<app_id>[\w-]+)/$', app_aware_search, name='app_aware_remote_search'),
     url(r'^claim-case/$', claim, name='claim_case'),
-    url(r'^claim_all/$', claim_all, name='claim_all_cases'),
     url(r'^heartbeat/(?P<app_build_id>[\w-]+)/$', heartbeat, name='phone_heartbeat'),
     url(r'^get_next_id/$', get_next_id, name='get_next_id'),
     url(r'^recovery_measures/(?P<build_id>[\w-]+)/$', recovery_measures, name='recovery_measures'),


### PR DESCRIPTION
PR into https://github.com/dimagi/commcare-hq/pull/30002

https://dimagi-dev.atlassian.net/browse/USH-1185

This removes the `claim_all` view, added in https://github.com/dimagi/commcare-hq/pull/30026/, since we're moving responsibility for claiming cases to fromplayer.