### PR TITLE
refactor UCR view report_preview_data

### DIFF
--- a/corehq/apps/userreports/reports/util.py
+++ b/corehq/apps/userreports/reports/util.py
@@ -67,6 +67,11 @@ class ReportExport(object):
             for column in self.data_source.inner_columns if column.data_tables_column.visible
         ]]
 
+    @property
+    @memoized
+    def total_rows(self):
+        return [self.data_source.get_total_row()] if self.data_source.has_total_row else []
+
     @memoized
     def get_table(self):
         """Generate a table of all rows of this report
@@ -81,12 +86,11 @@ class ReportExport(object):
                 column_ids.extend(column_id_to_expanded_column_ids.get(column.column_id, [column.column_id]))
 
         rows = [[raw_row[column_id] for column_id in column_ids] for raw_row in self.data_source.get_data()]
-        total_rows = [self.data_source.get_total_row()] if self.data_source.has_total_row else []
 
         export_table = [
             [
                 self.title,
-                self.header_rows + rows + total_rows
+                self.header_rows + rows + self.total_rows
             ]
         ]
 

--- a/corehq/apps/userreports/reports/util.py
+++ b/corehq/apps/userreports/reports/util.py
@@ -60,15 +60,17 @@ class ReportExport(object):
         """
         return export_from_tables(self.get_table(), file_path, format_)
 
+    @property
+    def header_rows(self):
+        return [[
+            column.header
+            for column in self.data_source.inner_columns if column.data_tables_column.visible
+        ]]
+
     @memoized
     def get_table(self):
         """Generate a table of all rows of this report
         """
-        headers = [
-            column.header
-            for column in self.data_source.inner_columns if column.data_tables_column.visible
-        ]
-
         column_id_to_expanded_column_ids = get_expanded_columns(
             self.data_source.top_level_columns,
             self.data_source.config
@@ -84,7 +86,7 @@ class ReportExport(object):
         export_table = [
             [
                 self.title,
-                [headers] + rows + total_rows
+                self.header_rows + rows + total_rows
             ]
         ]
 

--- a/corehq/apps/userreports/reports/util.py
+++ b/corehq/apps/userreports/reports/util.py
@@ -72,10 +72,9 @@ class ReportExport(object):
     def total_rows(self):
         return [self.data_source.get_total_row()] if self.data_source.has_total_row else []
 
+    @property
     @memoized
-    def get_table(self):
-        """Generate a table of all rows of this report
-        """
+    def data_rows(self):
         column_id_to_expanded_column_ids = get_expanded_columns(
             self.data_source.top_level_columns,
             self.data_source.config
@@ -85,12 +84,16 @@ class ReportExport(object):
             if column.visible:
                 column_ids.extend(column_id_to_expanded_column_ids.get(column.column_id, [column.column_id]))
 
-        rows = [[raw_row[column_id] for column_id in column_ids] for raw_row in self.data_source.get_data()]
+        return [[raw_row[column_id] for column_id in column_ids] for raw_row in self.data_source.get_data()]
 
+    @memoized
+    def get_table(self):
+        """Generate a table of all rows of this report
+        """
         export_table = [
             [
                 self.title,
-                self.header_rows + rows + self.total_rows
+                self.header_rows + self.data_rows + self.total_rows
             ]
         ]
 

--- a/corehq/apps/userreports/reports/util.py
+++ b/corehq/apps/userreports/reports/util.py
@@ -86,6 +86,9 @@ class ReportExport(object):
 
         return [[raw_row[column_id] for column_id in column_ids] for raw_row in self.data_source.get_data()]
 
+    def get_table_data(self):
+        return self.header_rows + self.data_rows + self.total_rows
+
     @memoized
     def get_table(self):
         """Generate a table of all rows of this report
@@ -93,7 +96,7 @@ class ReportExport(object):
         export_table = [
             [
                 self.title,
-                self.header_rows + self.data_rows + self.total_rows
+                self.get_table_data()
             ]
         ]
 

--- a/corehq/apps/userreports/reports/util.py
+++ b/corehq/apps/userreports/reports/util.py
@@ -67,6 +67,10 @@ class ReportExport(object):
             for column in self.data_source.inner_columns if column.data_tables_column.visible
         ]]
 
+    @memoized
+    def get_data(self):
+        return list(self.data_source.get_data())
+
     @property
     @memoized
     def total_rows(self):
@@ -84,7 +88,7 @@ class ReportExport(object):
             if column.visible:
                 column_ids.extend(column_id_to_expanded_column_ids.get(column.column_id, [column.column_id]))
 
-        return [[raw_row[column_id] for column_id in column_ids] for raw_row in self.data_source.get_data()]
+        return [[raw_row[column_id] for column_id in column_ids] for raw_row in self.get_data()]
 
     def get_table_data(self):
         return self.header_rows + self.data_rows + self.total_rows

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -577,23 +577,22 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
         return result
 
     @classmethod
-    def report_preview_data(cls, domain, temp_report):
-        with tmp_report_config(temp_report) as report_config:
-            try:
-                export = ReportExport(domain, report_config.title, report_config, "en", {})
-                return {
-                    "table": cls.sanitize_export_table(export.get_table_data()),
-                    "map_config": report_config.map_config,
-                    "chart_configs": report_config.charts,
-                    "aaData": cls.sanitize_page(export.get_data()),
-                }
-            except UserReportsError:
-                # User posted an invalid report configuration
-                return None
-            except DataSourceConfigurationNotFoundError:
-                # A temporary data source has probably expired
-                # TODO: It would be more helpful just to quietly recreate the data source config from GET params
-                return None
+    def report_preview_data(cls, domain, report_config):
+        try:
+            export = ReportExport(domain, report_config.title, report_config, "en", {})
+            return {
+                "table": cls.sanitize_export_table(export.get_table_data()),
+                "map_config": report_config.map_config,
+                "chart_configs": report_config.charts,
+                "aaData": cls.sanitize_page(export.get_data()),
+            }
+        except UserReportsError:
+            # User posted an invalid report configuration
+            return None
+        except DataSourceConfigurationNotFoundError:
+            # A temporary data source has probably expired
+            # TODO: It would be more helpful just to quietly recreate the data source config from GET params
+            return None
 
 
 # Base class for classes that provide custom rendering for UCRs

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -132,7 +132,7 @@ def query_dict_to_dict(query_dict, domain, string_type_params):
 
 
 @contextmanager
-def tmp_report_config(report_config):
+def delete_report_config(report_config):
     yield report_config
     report_config.delete()
 

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -180,6 +180,28 @@ class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
         ]
         self.assertEqual(view.export_table, expected)
 
+    def test_report_preview_data(self):
+        """
+        Test the output of ConfigurableReportView.export_table()
+        """
+        report, view = self._build_report_and_view()
+
+        actual = ConfigurableReportView.report_preview_data(report.domain, report)
+        expected = {
+            "table": [
+                ['report_column_display_fruit', 'report_column_display_percent'],
+                ['apple', '150%']
+            ],
+            "map_config": report.map_config,
+            "chart_configs": report.charts,
+            "aaData": [{
+                "report_column_col_id_fruit": "apple",
+                "report_column_col_id_percent": "150%"
+            }]
+        }
+        self.maxDiff = None
+        self.assertEqual(actual, expected)
+
     def test_paginated_build_table(self):
         """
         Simulate building a report where chunking occurs

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -199,7 +199,6 @@ class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
                 "report_column_col_id_percent": "150%"
             }]
         }
-        self.maxDiff = None
         self.assertEqual(actual, expected)
 
     def test_paginated_build_table(self):

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -123,7 +123,7 @@ from corehq.apps.userreports.reports.filters.choice_providers import (
     ChoiceQueryContext,
 )
 from corehq.apps.userreports.reports.util import report_has_location_filter
-from corehq.apps.userreports.reports.view import ConfigurableReportView, tmp_report_config
+from corehq.apps.userreports.reports.view import ConfigurableReportView, delete_report_config
 from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
 from corehq.apps.userreports.tasks import (
     rebuild_indicators,
@@ -736,7 +736,7 @@ class ReportPreview(BaseDomainView):
         if bound_form.is_valid():
             try:
                 temp_report = bound_form.create_temp_report(data_source, self.request.user.username)
-                with tmp_report_config(temp_report) as report_config:
+                with delete_report_config(temp_report) as report_config:
                     response_data = ConfigurableReportView.report_preview_data(self.domain, report_config)
                 if response_data:
                     return json_response(response_data)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -123,7 +123,7 @@ from corehq.apps.userreports.reports.filters.choice_providers import (
     ChoiceQueryContext,
 )
 from corehq.apps.userreports.reports.util import report_has_location_filter
-from corehq.apps.userreports.reports.view import ConfigurableReportView
+from corehq.apps.userreports.reports.view import ConfigurableReportView, tmp_report_config
 from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
 from corehq.apps.userreports.tasks import (
     rebuild_indicators,
@@ -736,7 +736,8 @@ class ReportPreview(BaseDomainView):
         if bound_form.is_valid():
             try:
                 temp_report = bound_form.create_temp_report(data_source, self.request.user.username)
-                response_data = ConfigurableReportView.report_preview_data(self.domain, temp_report)
+                with tmp_report_config(temp_report) as report_config:
+                    response_data = ConfigurableReportView.report_preview_data(self.domain, report_config)
                 if response_data:
                     return json_response(response_data)
             except BadBuilderConfigError as e:


### PR DESCRIPTION
## Summary
This is a simple refactor to remove the hacky fake view call. It also removes a redundant SQL query to get the data.

Best reviewed by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added

### QA Plan
Tested locally & with unit tests

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
