### PR TITLE
Mobile user bulk upload: handle empty phone numbers

### DIFF
--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -502,7 +502,7 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
                 else:
                     status_row['flag'] = 'created'
 
-                if phone_numbers:
+                if type(phone_numbers) is list:
                     phone_numbers = clean_phone_numbers(phone_numbers)
                     commcare_user_importer.update_phone_numbers(phone_numbers)
 

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -477,7 +477,7 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
             role = row.get('role', None)
             profile = row.get('user_profile', None)
             web_user_username = row.get('web_user')
-            phone_numbers = row.get('phone-number', []) if 'phone-number' in row else None
+            phone_numbers = row.get('phone-number', [])
 
             try:
                 password = str(password) if password else None

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -477,7 +477,7 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
             role = row.get('role', None)
             profile = row.get('user_profile', None)
             web_user_username = row.get('web_user')
-            phone_numbers = row.get('phone-number', [])
+            phone_numbers = row.get('phone-number', []) if 'phone-number' in row else None
 
             try:
                 password = str(password) if password else None
@@ -502,7 +502,7 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
                 else:
                     status_row['flag'] = 'created'
 
-                if type(phone_numbers) is list:
+                if phone_numbers is not None:
                     phone_numbers = clean_phone_numbers(phone_numbers)
                     commcare_user_importer.update_phone_numbers(phone_numbers)
 

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -1134,6 +1134,33 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
 
         self.assertEqual(res['messages']['rows'][0]['flag'], f'Invalid phone number detected: {bad_number}')
 
+    def test_upload_with_no_phone_numbers(self):
+        user = CommCareUser.create(self.domain_name, f"hello@{self.domain.name}.commcarehq.org", "*******",
+                                   created_by=None, created_via=None, phone_number='12345678912')
+
+        user_specs = self._get_spec(delete_keys=['phone-number'], user_id=user._id)
+        user_specs['phone-number'] = []
+
+        import_users_and_groups(
+            self.domain.name,
+            [user_specs],
+            [],
+            self.uploading_user,
+            self.upload_record.pk,
+            False
+        )
+        user_history = UserHistory.objects.get(changed_by=self.uploading_user.get_id)
+        changes = user_history.message
+        self.assertTrue('Removed phone number 12345678912' in changes)
+
+        # Check if user is updated
+        users = CommCareUser.by_domain(self.domain.name)
+        user = next((u for u in users if u._id == user._id))
+
+        self.assertEqual(user.default_phone_number, None)
+        self.assertEqual(user.phone_number, None)
+        self.assertEqual(user.phone_numbers, [])
+
 
 class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):
     @classmethod

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -1177,15 +1177,16 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         )
         user_history = UserHistory.objects.get(changed_by=self.uploading_user.get_id)
         changes = user_history.message
-        self.assertTrue('Removed phone number 12345678912' in changes)
+
+        self.assertTrue('Removed phone number 12345678912' not in changes)
 
         # Check if user is updated
         users = CommCareUser.by_domain(self.domain.name)
         user = next((u for u in users if u._id == user._id))
 
-        self.assertEqual(user.default_phone_number, None)
-        self.assertEqual(user.phone_number, None)
-        self.assertEqual(user.phone_numbers, [])
+        self.assertEqual(user.default_phone_number, '12345678912')
+        self.assertEqual(user.phone_number, '12345678912')
+        self.assertEqual(user.phone_numbers, ['12345678912'])
 
 
 class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):


### PR DESCRIPTION
## Summary
This branch is a fix to allow for bulk mobile user upload to support completely removing a user's phone numbers. 

The issue was with a simple `if` statement which checked for truthiness on a variable `phone_numbers`, which evaluated `False` in the case where `phone_numbers` equals `[]`. The empty list also needs to be handled. 

## Feature Flag
All

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Local testing + unit test

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
