### PR TITLE
Updated web apps question error button text & icon

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -124,7 +124,7 @@
               {% blocktrans %}
                 Please correct the answers below before submitting.
                 <br>
-                You can use the <strong><i class='fa fa-arrow-down'></i> Next Question</strong> button on the left-hand side of the screen to navigate between required fields.
+                You can use the <strong><i class='fa fa-fast-forward'></i> Next Error</strong> button on the left-hand side of the screen to navigate between required fields.
               {% endblocktrans %}
               <ul data-bind="foreach: erroredQuestions">
                   <li>
@@ -175,8 +175,8 @@
           {% endif %}
         {% endif %}
         <div id="scroll-bottom" class="btn btn-danger" style="position: fixed; bottom: 35px" title="{% trans_html_attr "Jump between required/errored questions" %}" data-bind="click: jumpToErrors">
-          <i class='fa fa-arrow-down'> </i>
-              {% trans "Next Question" %}
+          <i class='fa fa-fast-forward'> </i>
+              {% trans "Next Error" %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/USH-1144

Changes icon and updates button text to say "Next Error" instead of "Next Question."

![Screen Shot 2021-08-06 at 10 38 40 AM](https://user-images.githubusercontent.com/1486591/128527742-bd5cdd7c-17dd-4d9e-88c4-20ee155e7f34.png)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None

### QA Plan

Not requesting QA.

### Safety story
HTML-only change, tested locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
