### PR TITLE
UCR builder refactor

### DIFF
--- a/corehq/apps/userreports/app_manager/data_source_meta.py
+++ b/corehq/apps/userreports/app_manager/data_source_meta.py
@@ -1,9 +1,4 @@
-from abc import ABCMeta, abstractmethod
-
 from django.utils.translation import ugettext_lazy as _
-
-from corehq.apps.app_manager.dbaccessors import get_app
-from corehq.apps.app_manager.xform import XForm
 
 DATA_SOURCE_TYPE_CASE = 'case'
 DATA_SOURCE_TYPE_FORM = 'form'
@@ -60,58 +55,6 @@ def make_form_data_source_filter(xmlns, app_id):
             }
         ]
     }
-
-
-def get_app_data_source_meta(domain, app_id, data_source_type, data_source_id):
-    """
-    Get an AppDataSourceMeta object based on the expected domain, source type and ID
-    :param domain: the domain
-    :param data_source_type: must be "form" or "case"
-    :param data_source_id: for forms - the unique form ID, for cases the case type
-    :return: an AppDataSourceMeta object corresponding to the data source type and ID
-    """
-    assert data_source_type in APP_DATA_SOURCE_TYPE_VALUES
-    if data_source_type == DATA_SOURCE_TYPE_CASE:
-        return CaseDataSourceMeta(domain, app_id, data_source_type, data_source_id)
-    else:
-        return FormDataSourceMeta(domain, app_id, data_source_type, data_source_id)
-
-
-class AppDataSourceMeta(metaclass=ABCMeta):
-    """
-    Utility base class for interacting with forms/cases inside an app and data sources
-    """
-
-    def __init__(self, domain, app_id, data_source_type, data_source_id):
-        self.domain = domain
-        self.app = get_app(domain, app_id)
-        self.data_source_type = data_source_type
-        self.data_source_id = data_source_id
-
-    def get_doc_type(self):
-        return get_data_source_doc_type(self.data_source_type)
-
-    @abstractmethod
-    def get_filter(self):
-        pass
-
-
-class CaseDataSourceMeta(AppDataSourceMeta):
-
-    def get_filter(self):
-        return make_case_data_source_filter(self.data_source_id)
-
-
-class FormDataSourceMeta(AppDataSourceMeta):
-
-    def __init__(self, domain, app_id, data_source_type, data_source_id):
-        super().__init__(domain, app_id, data_source_type, data_source_id)
-        self.source_form = self.app.get_form(self.data_source_id)
-        self.source_xform = XForm(self.source_form.source)
-
-    def get_filter(self):
-        return make_form_data_source_filter(
-            self.source_xform.data_node.tag_xmlns, self.source_form.get_app().get_id)
 
 
 def make_form_question_indicator(question, column_id=None, data_type=None, root_doc=False):

--- a/corehq/apps/userreports/app_manager/data_source_meta.py
+++ b/corehq/apps/userreports/app_manager/data_source_meta.py
@@ -9,14 +9,6 @@ DATA_SOURCE_TYPE_CHOICES = (
     (DATA_SOURCE_TYPE_CASE, _("Cases")),
     (DATA_SOURCE_TYPE_FORM, _("Forms")),
 )
-DATA_SOURCE_DOC_TYPE_MAPPING = {
-    DATA_SOURCE_TYPE_CASE: 'CommCareCase',
-    DATA_SOURCE_TYPE_FORM: 'XFormInstance',
-}
-
-
-def get_data_source_doc_type(data_source_type):
-    return DATA_SOURCE_DOC_TYPE_MAPPING[data_source_type]
 
 
 def make_case_data_source_filter(case_type):

--- a/corehq/apps/userreports/app_manager/data_source_meta.py
+++ b/corehq/apps/userreports/app_manager/data_source_meta.py
@@ -1,14 +1,8 @@
-from django.utils.translation import ugettext_lazy as _
-
 DATA_SOURCE_TYPE_CASE = 'case'
 DATA_SOURCE_TYPE_FORM = 'form'
 DATA_SOURCE_TYPE_RAW = 'data_source'  # this is only used in report builder
 APP_DATA_SOURCE_TYPE_VALUES = (DATA_SOURCE_TYPE_CASE, DATA_SOURCE_TYPE_FORM)
 REPORT_BUILDER_DATA_SOURCE_TYPE_VALUES = (DATA_SOURCE_TYPE_CASE, DATA_SOURCE_TYPE_FORM, DATA_SOURCE_TYPE_RAW)
-DATA_SOURCE_TYPE_CHOICES = (
-    (DATA_SOURCE_TYPE_CASE, _("Cases")),
-    (DATA_SOURCE_TYPE_FORM, _("Forms")),
-)
 
 
 def make_case_data_source_filter(case_type):

--- a/corehq/apps/userreports/reports/builder/README.md
+++ b/corehq/apps/userreports/reports/builder/README.md
@@ -6,11 +6,11 @@ the JSON configuration "by hand."
 
 ## Populating the front end
 
-### `DataSourceBuilder.data_source_properties`
+### `ApplicationDataSourceHelper.data_source_properties`
 This dictionary represents the set of all possible form questions or metadata or case
 properties that could appear in a report data source.
 
-### `DataSourceBuilder.report_column_options`
+### `ApplicationDataSourceHelper.report_column_options`
 This dictionary represents the set of all possible indicators that could appear in a
 report. `report_column_options` are mostly derived from `data_source_properties`, but
 there are some indicators that can be displayed in a report that don't map directly to

--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -86,7 +86,7 @@ class ColumnOption(object):
         """
         raise NotImplementedError
 
-    def get_indicators(self, ui_aggregation, is_multiselect_chart_report=False):
+    def get_indicators(self, ui_aggregation):
         """
         Return the indicators corresponding to this column option.
         """
@@ -230,7 +230,7 @@ class MultiselectQuestionColumnOption(QuestionColumnOption):
         column_id = get_column_name(self._property.strip("/"))
         return make_multiselect_question_indicator(self._question_source, column_id)
 
-    def get_indicators(self, ui_aggregation, is_multiselect_chart_report=False):
+    def get_indicators(self, ui_aggregation):
         """
         Return the report config snippets that specify the data source indicator that will be used for
         aggregating this question, and the data source indicator for the multi-select question's choices.

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -285,13 +285,6 @@ class ReportBuilderDataSourceInterface(metaclass=ABCMeta):
     A data source could be an (app, form), (app, case_type) pair (see ApplicationDataSourceHelper),
     or it can be a real UCR data source (see UnmanagedDataSourceHelper)
     """
-
-    @property
-    @abstractmethod
-    def source_id(self):
-        """Case type or Form ID. Only applies to managed data sources."""
-        pass
-
     @property
     @abstractmethod
     def uses_managed_data_source(self):
@@ -349,6 +342,15 @@ class ReportBuilderDataSourceInterface(metaclass=ABCMeta):
     def report_column_options(self):
         pass
 
+
+class ManagedReportBuilderDataSourceHelper(ReportBuilderDataSourceInterface):
+    @property
+    @abstractmethod
+    def source_id(self):
+        """Case type or Form ID. Only applies to managed data sources."""
+        pass
+
+    @abstractmethod
     def indicators(self, columns, filters, is_multiselect_chart_report=False, as_dict=False):
         """Override if `uses_managed_data_source` is False
 
@@ -360,14 +362,17 @@ class ReportBuilderDataSourceInterface(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    @abstractmethod
     def get_datasource_constructor_kwargs(self, columns, filters, is_multiselect_chart_report=False, multiselect_field=None):
         """Override if `uses_managed_data_source` is False"""
         raise NotImplementedError
 
+    @abstractmethod
     def get_temp_datasource_constructor_kwargs(self, required_columns, required_filters):
         """Override if `uses_managed_data_source` is False"""
         raise NotImplementedError
 
+    @abstractmethod
     def all_possible_indicators(self, required_columns, required_filters):
         """
         Override if `uses_managed_data_source` is False
@@ -376,7 +381,6 @@ class ReportBuilderDataSourceInterface(metaclass=ABCMeta):
         provided columns and filters
         """
         raise NotImplementedError
-
 
 
 class UnmanagedDataSourceHelper(ReportBuilderDataSourceInterface):
@@ -428,7 +432,7 @@ class UnmanagedDataSourceHelper(ReportBuilderDataSourceInterface):
         return options
 
 
-class ApplicationDataSourceHelper(ReportBuilderDataSourceInterface):
+class ApplicationDataSourceHelper(ManagedReportBuilderDataSourceHelper):
     """
     A ReportBuilderDataSourceInterface that encapsulates an (app, form) or (app, case_type) pair.
     It also provides convenience methods for creating the underlying UCR data source associated

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1569,13 +1569,23 @@ class ConfigureListReportForm(ConfigureNewReportBase):
 
     @property
     def _report_columns(self):
+        return self._build_report_columns(
+            ui_aggregation_override=UI_AGG_GROUP_BY, is_aggregated_on_override=False
+        )
+
+    def _build_report_columns(self, ui_aggregation_override=None, is_aggregated_on_override=None):
         columns = []
         for i, conf in enumerate(self.cleaned_data['columns']):
+            ui_aggregation = conf['calculation'] if ui_aggregation_override is None else ui_aggregation_override
+            is_aggregated_on = is_aggregated_on_override
+            if is_aggregated_on_override is None:
+                is_aggregated_on = conf.get('calculation') == UI_AGG_GROUP_BY
             columns.extend(
                 self.ds_builder.report_column_options[conf['property']].to_column_dicts(
                     index=i,
                     display_text=conf.get('display_text', conf['property']),
-                    ui_aggregation=UI_AGG_GROUP_BY
+                    ui_aggregation=ui_aggregation,
+                    is_aggregated_on=is_aggregated_on,
                 )
             )
         return columns
@@ -1632,17 +1642,7 @@ class ConfigureTableReportForm(ConfigureListReportForm):
 
     @property
     def _report_columns(self):
-        columns = []
-        for i, conf in enumerate(self.cleaned_data['columns']):
-            column = self.ds_builder.report_column_options[conf['property']]
-            columns.extend(
-                column.to_column_dicts(
-                    index=i,
-                    display_text=conf['display_text'],
-                    ui_aggregation=conf['calculation'],
-                    is_aggregated_on=conf.get('calculation') == UI_AGG_GROUP_BY,
-                ))
-        return columns
+        return self._build_report_columns()
 
     @property
     @memoized

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -345,6 +345,10 @@ class ReportBuilderDataSourceInterface(metaclass=ABCMeta):
 
 class ManagedReportBuilderDataSourceHelper(ReportBuilderDataSourceInterface):
     @property
+    def uses_managed_data_source(self):
+        return True
+
+    @property
     @abstractmethod
     def source_id(self):
         """Case type or Form ID. Only applies to managed data sources."""
@@ -459,10 +463,6 @@ class ApplicationDataSourceHelper(ManagedReportBuilderDataSourceHelper):
     @property
     def source_id(self):
         return self._source_id
-
-    @property
-    def uses_managed_data_source(self):
-        return True
 
     @property
     @memoized
@@ -840,38 +840,6 @@ class ApplicationCaseDataSourceHelper(ApplicationDataSourceHelper):
     def data_source_name(self):
         today = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
         return "{} (v{}) {}".format(self.source_id, self.app.version, today)
-
-    def _ds_config_kwargs(self, indicators, is_multiselect_chart_report=False, multiselect_field=None):
-        if is_multiselect_chart_report:
-            base_item_expression = self.base_item_expression(True, multiselect_field)
-        else:
-            base_item_expression = self.base_item_expression(False)
-
-        return dict(
-            display_name=self.data_source_name,
-            referenced_doc_type=self.source_doc_type,
-            configured_filter=self.filter,
-            configured_indicators=indicators,
-            base_item_expression=base_item_expression,
-            meta=DataSourceMeta(build=DataSourceBuildInformation(
-                source_id=self.source_id,
-                app_id=self.app._id,
-                app_version=self.app.version,
-            ))
-        )
-
-    def get_temp_datasource_constructor_kwargs(self, required_columns, required_filters):
-        indicators = self.all_possible_indicators(required_columns, required_filters)
-        return self._ds_config_kwargs(indicators)
-
-    def get_datasource_constructor_kwargs(self, columns, filters,
-                                          is_multiselect_chart_report=False, multiselect_field=None):
-        indicators = self.indicators(
-            columns,
-            filters,
-            is_multiselect_chart_report
-        )
-        return self._ds_config_kwargs(indicators, is_multiselect_chart_report, multiselect_field)
 
 
 def get_data_source_interface(domain, app, source_type, source_id):

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -25,7 +25,7 @@ from corehq.apps.userreports.app_manager.data_source_meta import (
     APP_DATA_SOURCE_TYPE_VALUES,
     DATA_SOURCE_TYPE_RAW,
     REPORT_BUILDER_DATA_SOURCE_TYPE_VALUES,
-    DATA_SOURCE_TYPE_CASE, DATA_SOURCE_TYPE_FORM, get_data_source_doc_type,
+    DATA_SOURCE_TYPE_CASE, DATA_SOURCE_TYPE_FORM,
     make_case_data_source_filter, make_form_data_source_filter,
 )
 from corehq.apps.userreports.app_manager.helpers import clean_table_name
@@ -465,9 +465,10 @@ class ApplicationDataSourceHelper(ManagedReportBuilderDataSourceHelper):
         return self._source_id
 
     @property
-    @memoized
+    @abstractmethod
     def source_doc_type(self):
-        return get_data_source_doc_type(self.source_type)
+        """Return the doc_type the datasource.referenced_doc_type"""
+        raise NotImplementedError
 
     @property
     @abstractmethod
@@ -653,6 +654,10 @@ class ApplicationFormDataSourceHelper(ApplicationDataSourceHelper):
             }
 
     @property
+    def source_doc_type(self):
+        return 'XFormInstance'
+
+    @property
     @memoized
     def filter(self):
         return make_form_data_source_filter(
@@ -726,6 +731,10 @@ class ApplicationCaseDataSourceHelper(ApplicationDataSourceHelper):
     def base_item_expression(self, is_multiselect_chart_report, multiselect_field=None):
         assert not is_multiselect_chart_report
         return {}
+
+    @property
+    def source_doc_type(self):
+        return 'CommCareCase'
 
     @property
     @memoized

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -354,12 +354,6 @@ class ManagedReportBuilderDataSourceHelper(ReportBuilderDataSourceInterface):
     def uses_managed_data_source(self):
         return True
 
-    @property
-    @abstractmethod
-    def source_id(self):
-        """Case type or Form ID"""
-        pass
-
     @abstractmethod
     def indicators(self, columns, filters, as_dict=False):
         """Override if `uses_managed_data_source` is False
@@ -465,12 +459,9 @@ class ApplicationDataSourceHelper(ManagedReportBuilderDataSourceHelper):
         self.domain = domain
         self.app = app
         self.source_type = source_type
-        self._source_id = source_id
 
-    @property
-    def source_id(self):
-        """Case Type or Form ID"""
-        return self._source_id
+        # case type or form ID
+        self.source_id = source_id
 
     @property
     @abstractmethod

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -355,7 +355,7 @@ class ManagedReportBuilderDataSourceHelper(ReportBuilderDataSourceInterface):
         pass
 
     @abstractmethod
-    def indicators(self, columns, filters, is_multiselect_chart_report=False, as_dict=False):
+    def indicators(self, columns, filters, as_dict=False):
         """Override if `uses_managed_data_source` is False
 
         Return a list of indicators to be used in a data source configuration that supports the given columns and
@@ -481,7 +481,7 @@ class ApplicationDataSourceHelper(ManagedReportBuilderDataSourceHelper):
     def base_item_expression(self, is_multiselect_chart_report, multiselect_field=None):
         raise NotImplementedError
 
-    def indicators(self, columns, filters, is_multiselect_chart_report=False, as_dict=False):
+    def indicators(self, columns, filters, as_dict=False):
         """
         Return a list of indicators to be used in a data source configuration that supports the given columns and
         indicators.
@@ -495,7 +495,7 @@ class ApplicationDataSourceHelper(ManagedReportBuilderDataSourceHelper):
             # Property is only set if the column exists in report_column_options
             if column['property']:
                 column_option = self.report_column_options[column['property']]
-                for indicator in column_option.get_indicators(column['calculation'], is_multiselect_chart_report):
+                for indicator in column_option.get_indicators(column['calculation']):
                     # A column may have multiple indicators. e.g. "Group By" and "Count Per Choice" aggregations
                     # will use one indicator for the field's string value, and "Sum" and "Average" aggregations
                     # will use a second indicator for the field's numerical value. "column_id" includes the
@@ -584,11 +584,7 @@ class ApplicationDataSourceHelper(ManagedReportBuilderDataSourceHelper):
 
     def get_datasource_constructor_kwargs(self, columns, filters,
                                           is_multiselect_chart_report=False, multiselect_field=None):
-        indicators = self.indicators(
-            columns,
-            filters,
-            is_multiselect_chart_report
-        )
+        indicators = self.indicators(columns, filters)
         return self._ds_config_kwargs(indicators, is_multiselect_chart_report, multiselect_field)
 
 
@@ -1082,7 +1078,6 @@ class ConfigureNewReportBase(forms.Form):
                 indicators = self.ds_builder.indicators(
                     self._configured_columns,
                     self.cleaned_data['user_filters'] + self.cleaned_data['default_filters'],
-                    self._is_multiselect_chart_report,
                 )
                 if data_source.configured_indicators != indicators:
                     for property_name, value in self._get_data_source_configuration_kwargs().items():

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -300,7 +300,7 @@ class ReportBuilderDataSourceInterface(metaclass=ABCMeta):
 
         :return:
         """
-        pass
+        raise NotImplementedError
 
     @property
     @abstractmethod

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1,6 +1,6 @@
 import datetime
 import uuid
-from abc import ABCMeta, abstractproperty
+from abc import ABCMeta, abstractmethod
 from collections import OrderedDict, namedtuple
 
 from django import forms
@@ -286,7 +286,8 @@ class ReportBuilderDataSourceInterface(metaclass=ABCMeta):
     or it can be a real UCR data source (see UnmanagedDataSourceHelper)
     """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def uses_managed_data_source(self):
         """
         Whether this interface uses a managed data source.
@@ -300,7 +301,8 @@ class ReportBuilderDataSourceInterface(metaclass=ABCMeta):
         """
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def data_source_properties(self):
         """
         A dictionary containing the various properties that may be used as indicators
@@ -336,7 +338,8 @@ class ReportBuilderDataSourceInterface(metaclass=ABCMeta):
         """
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def report_column_options(self):
         pass
 

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -282,8 +282,8 @@ class ReportBuilderDataSourceInterface(metaclass=ABCMeta):
     """
     Abstract interface to a data source in report builder.
 
-    A data source could be an (app, form), (app, case_type) pair (see DataSourceBuilder),
-    or it can be a real UCR data soure (see ReportBuilderDataSourceReference)
+    A data source could be an (app, form), (app, case_type) pair (see ApplicationDataSourceHelper),
+    or it can be a real UCR data source (see UnmanagedDataSourceHelper)
     """
 
     @abstractproperty
@@ -341,7 +341,7 @@ class ReportBuilderDataSourceInterface(metaclass=ABCMeta):
         pass
 
 
-class ReportBuilderDataSourceReference(ReportBuilderDataSourceInterface):
+class UnmanagedDataSourceHelper(ReportBuilderDataSourceInterface):
     """
     A ReportBuilderDataSourceInterface that encapsulates an existing data source.
     """
@@ -390,13 +390,13 @@ class ReportBuilderDataSourceReference(ReportBuilderDataSourceInterface):
         return options
 
 
-class DataSourceBuilder(ReportBuilderDataSourceInterface):
+class ApplicationDataSourceHelper(ReportBuilderDataSourceInterface):
     """
     A ReportBuilderDataSourceInterface that encapsulates an (app, form) or (app, case_type) pair.
     It also provides convenience methods for creating the underlying UCR data source associated
     with the data.
 
-    When configuring a report, one can use DataSourceBuilder to determine some
+    When configuring a report, one can use ApplicationDataSourceHelper to determine some
     of the properties of the required report data source, such as:
         - referenced doc type
         - filter
@@ -773,9 +773,9 @@ class DataSourceBuilder(ReportBuilderDataSourceInterface):
 
 def get_data_source_interface(domain, app, source_type, source_id):
     if source_type in APP_DATA_SOURCE_TYPE_VALUES:
-        return DataSourceBuilder(domain, app, source_type, source_id)
+        return ApplicationDataSourceHelper(domain, app, source_type, source_id)
     else:
-        return ReportBuilderDataSourceReference(domain, app, source_type, source_id)
+        return UnmanagedDataSourceHelper(domain, app, source_type, source_id)
 
 
 class DataSourceForm(forms.Form):
@@ -947,7 +947,7 @@ class ConfigureNewReportBase(forms.Form):
     @property
     def _configured_columns(self):
         """
-        To be used by DataSourceBuilder.indicators()
+        To be used by ApplicationDataSourceHelper.indicators()
         """
         configured_columns = self.cleaned_data['columns']
         location = self.cleaned_data.get("location")

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -398,11 +398,7 @@ class UnmanagedDataSourceHelper(ReportBuilderDataSourceInterface):
         self.app = app
         self.source_type = source_type
         # source_id is the ID of a UCR data source
-        self._source_id = source_id
-
-    @property
-    def data_source_id(self):
-        return self._source_id
+        self.data_source_id = source_id
 
     @property
     def uses_managed_data_source(self):
@@ -411,7 +407,7 @@ class UnmanagedDataSourceHelper(ReportBuilderDataSourceInterface):
     @property
     @memoized
     def data_source(self):
-        return get_datasource_config_infer_type(self._source_id, self.domain)[0]
+        return get_datasource_config_infer_type(self.data_source_id, self.domain)[0]
 
     @property
     def data_source_properties(self):

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -294,9 +294,9 @@ class ReportBuilderDataSourceInterface(metaclass=ABCMeta):
         Whether this interface uses a managed data source.
 
         If true, the data source will be created / modified with the report, and the
-        temporary data source workflow will be enageld.
+        temporary data source workflow will be enabled.
 
-        If false, the data source is assumed to exist and be available as self.source_id.
+        If false, the data source is assumed to exist and be available as self.data_source_id.
 
         :return:
         """
@@ -346,6 +346,10 @@ class ReportBuilderDataSourceInterface(metaclass=ABCMeta):
 
 
 class ManagedReportBuilderDataSourceHelper(ReportBuilderDataSourceInterface):
+    """Abstract class that represents the interface required for building managed
+    data sources
+    """
+
     @property
     def uses_managed_data_source(self):
         return True
@@ -353,7 +357,7 @@ class ManagedReportBuilderDataSourceHelper(ReportBuilderDataSourceInterface):
     @property
     @abstractmethod
     def source_id(self):
-        """Case type or Form ID. Only applies to managed data sources."""
+        """Case type or Form ID"""
         pass
 
     @abstractmethod
@@ -400,7 +404,11 @@ class UnmanagedDataSourceHelper(ReportBuilderDataSourceInterface):
         self.app = app
         self.source_type = source_type
         # source_id is the ID of a UCR data source
-        self.source_id = source_id
+        self._source_id = source_id
+
+    @property
+    def data_source_id(self):
+        return self._source_id
 
     @property
     def uses_managed_data_source(self):
@@ -409,7 +417,7 @@ class UnmanagedDataSourceHelper(ReportBuilderDataSourceInterface):
     @property
     @memoized
     def data_source(self):
-        return get_datasource_config_infer_type(self.source_id, self.domain)[0]
+        return get_datasource_config_infer_type(self._source_id, self.domain)[0]
 
     @property
     def data_source_properties(self):
@@ -1114,7 +1122,7 @@ class ConfigureNewReportBase(forms.Form):
         if self.ds_builder.uses_managed_data_source:
             data_source_config_id = self._build_data_source()
         else:
-            data_source_config_id = self.ds_builder.source_id
+            data_source_config_id = self.ds_builder.data_source_id
         report = ReportConfiguration(
             domain=self.domain,
             config_id=data_source_config_id,
@@ -1171,7 +1179,7 @@ class ConfigureNewReportBase(forms.Form):
         """
         if not self.ds_builder.uses_managed_data_source:
             # if the data source interface doens't use a temp data source then the id is just the source_id
-            return self.ds_builder.source_id
+            return self.ds_builder.data_source_id
 
         filters = [f._asdict() for f in self.initial_user_filters + self.initial_default_filters]
         columns = [c._asdict() for c in self.initial_columns]

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -360,11 +360,11 @@ class ReportBuilderDataSourceInterface(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    def get_ds_config_kwargs(self, columns, filters, is_multiselect_chart_report=False, multiselect_field=None):
+    def get_datasource_constructor_kwargs(self, columns, filters, is_multiselect_chart_report=False, multiselect_field=None):
         """Override if `uses_managed_data_source` is False"""
         raise NotImplementedError
 
-    def get_temp_ds_config_kwargs(self, required_columns, required_filters):
+    def get_temp_datasource_constructor_kwargs(self, required_columns, required_filters):
         """Override if `uses_managed_data_source` is False"""
         raise NotImplementedError
 
@@ -799,12 +799,12 @@ class ApplicationDataSourceHelper(ReportBuilderDataSourceInterface):
             ))
         )
 
-    def get_temp_ds_config_kwargs(self, required_columns, required_filters):
+    def get_temp_datasource_constructor_kwargs(self, required_columns, required_filters):
         indicators = self.all_possible_indicators(required_columns, required_filters)
         return self._ds_config_kwargs(indicators)
 
-    def get_ds_config_kwargs(self, columns, filters,
-                             is_multiselect_chart_report=False, multiselect_field=None):
+    def get_datasource_constructor_kwargs(self, columns, filters,
+                                          is_multiselect_chart_report=False, multiselect_field=None):
         indicators = self.indicators(
             columns,
             filters,
@@ -1004,10 +1004,10 @@ class ConfigureNewReportBase(forms.Form):
     def _get_data_source_configuration_kwargs(self):
         filters = self.cleaned_data['user_filters'] + self.cleaned_data['default_filters']
         ms_field = self._report_aggregation_cols[0] if self._is_multiselect_chart_report else None
-        return self.ds_builder.get_ds_config_kwargs(self._configured_columns,
-                                                    filters,
-                                                    self._is_multiselect_chart_report,
-                                                    ms_field)
+        return self.ds_builder.get_datasource_constructor_kwargs(self._configured_columns,
+                                                                 filters,
+                                                                 self._is_multiselect_chart_report,
+                                                                 ms_field)
 
     def _build_data_source(self):
         data_source_config = DataSourceConfiguration(
@@ -1131,7 +1131,7 @@ class ConfigureNewReportBase(forms.Form):
         data_source_config = DataSourceConfiguration(
             domain=self.domain,
             table_id=clean_table_name(self.domain, uuid.uuid4().hex),
-            **self.ds_builder.get_temp_ds_config_kwargs(columns, filters)
+            **self.ds_builder.get_temp_datasource_constructor_kwargs(columns, filters)
         )
         data_source_config.validate()
         data_source_config.save()
@@ -1184,7 +1184,7 @@ class ConfigureNewReportBase(forms.Form):
 
         # rebuild the table
         if missing_columns:
-            temp_config = self.ds_builder.get_temp_ds_config_kwargs(self._configured_columns, filters)
+            temp_config = self.ds_builder.get_temp_datasource_constructor_kwargs(self._configured_columns, filters)
             data_source_config.configured_indicators = temp_config["configured_indicators"]
             data_source_config.configured_filter = temp_config["configured_filter"]
             data_source_config.base_item_expression = temp_config["base_item_expression"]

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -30,7 +30,7 @@ from corehq.apps.userreports.reports.builder.forms import (
     ConfigureListReportForm,
     ConfigureTableReportForm,
     ApplicationDataSourceHelper,
-    UnmanagedDataSourceHelper,
+    UnmanagedDataSourceHelper, ApplicationCaseDataSourceHelper,
 )
 from corehq.apps.userreports.tests.utils import get_simple_xform
 from corehq.util.test_utils import flag_enabled
@@ -109,7 +109,7 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
         self.assertEqual('First Name', name_prop.get_text())
 
     def test_builder_for_cases(self):
-        builder = ApplicationDataSourceHelper(self.domain, self.app, DATA_SOURCE_TYPE_CASE, self.case_type)
+        builder = ApplicationCaseDataSourceHelper(self.domain, self.app, DATA_SOURCE_TYPE_CASE, self.case_type)
         self.assertEqual('CommCareCase', builder.source_doc_type)
         expected_filter = {
             "operator": "eq",
@@ -135,7 +135,7 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
 
     @flag_enabled('SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER')
     def test_owner_as_location(self):
-        builder = ApplicationDataSourceHelper(self.domain, self.app, DATA_SOURCE_TYPE_CASE, self.case_type)
+        builder = ApplicationCaseDataSourceHelper(self.domain, self.app, DATA_SOURCE_TYPE_CASE, self.case_type)
 
         self.assertTrue(COMPUTED_OWNER_LOCATION_PROPERTY_ID in builder.data_source_properties)
         self.assertTrue(COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID in builder.data_source_properties)
@@ -447,7 +447,7 @@ class MultiselectQuestionTest(ReportBuilderDBTest):
                 'columns':
                     '['
                     '   {"property": "/data/first_name", "display_text": "first name", "calculation": "Group By"},'
-                    '   {"property": "/data/state", "display_text": "state", "calculation": "Count Per Choice"}'
+                    '   {"property": "/data/state", "display_text": "state", "calculation": "Count per Choice"}'
                     ']',
             }
         )

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -29,8 +29,8 @@ from corehq.apps.userreports.reports.builder.const import (
 from corehq.apps.userreports.reports.builder.forms import (
     ConfigureListReportForm,
     ConfigureTableReportForm,
-    DataSourceBuilder,
-    ReportBuilderDataSourceReference,
+    ApplicationDataSourceHelper,
+    UnmanagedDataSourceHelper,
 )
 from corehq.apps.userreports.tests.utils import get_simple_xform
 from corehq.util.test_utils import flag_enabled
@@ -67,10 +67,10 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
 
     def test_builder_bad_type(self):
         with self.assertRaises(AssertionError):
-            DataSourceBuilder(self.domain, self.app, 'invalid-type', self.form.unique_id)
+            ApplicationDataSourceHelper(self.domain, self.app, 'invalid-type', self.form.unique_id)
 
     def test_builder_for_forms(self):
-        builder = DataSourceBuilder(self.domain, self.app, DATA_SOURCE_TYPE_FORM, self.form.unique_id)
+        builder = ApplicationDataSourceHelper(self.domain, self.app, DATA_SOURCE_TYPE_FORM, self.form.unique_id)
         self.assertEqual('XFormInstance', builder.source_doc_type)
         expected_filter = {
             "type": "and",
@@ -109,7 +109,7 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
         self.assertEqual('First Name', name_prop.get_text())
 
     def test_builder_for_cases(self):
-        builder = DataSourceBuilder(self.domain, self.app, DATA_SOURCE_TYPE_CASE, self.case_type)
+        builder = ApplicationDataSourceHelper(self.domain, self.app, DATA_SOURCE_TYPE_CASE, self.case_type)
         self.assertEqual('CommCareCase', builder.source_doc_type)
         expected_filter = {
             "operator": "eq",
@@ -135,7 +135,7 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
 
     @flag_enabled('SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER')
     def test_owner_as_location(self):
-        builder = DataSourceBuilder(self.domain, self.app, DATA_SOURCE_TYPE_CASE, self.case_type)
+        builder = ApplicationDataSourceHelper(self.domain, self.app, DATA_SOURCE_TYPE_CASE, self.case_type)
 
         self.assertTrue(COMPUTED_OWNER_LOCATION_PROPERTY_ID in builder.data_source_properties)
         self.assertTrue(COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID in builder.data_source_properties)
@@ -166,7 +166,7 @@ class DataSourceReferenceTest(ReportBuilderDBTest):
     def test_reference_for_forms(self):
         form_data_source = get_form_data_source(self.app, self.form)
         form_data_source.save()
-        reference = ReportBuilderDataSourceReference(
+        reference = UnmanagedDataSourceHelper(
             self.domain, self.app, DATA_SOURCE_TYPE_RAW, form_data_source._id,
         )
         # todo: we should filter out some of these columns
@@ -190,7 +190,7 @@ class DataSourceReferenceTest(ReportBuilderDBTest):
     def test_reference_for_cases(self):
         case_data_source = get_case_data_source(self.app, self.case_type)
         case_data_source.save()
-        reference = ReportBuilderDataSourceReference(
+        reference = UnmanagedDataSourceHelper(
             self.domain, self.app, DATA_SOURCE_TYPE_RAW, case_data_source._id,
         )
         # todo: we should filter out some of these columns

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -29,8 +29,9 @@ from corehq.apps.userreports.reports.builder.const import (
 from corehq.apps.userreports.reports.builder.forms import (
     ConfigureListReportForm,
     ConfigureTableReportForm,
-    ApplicationDataSourceHelper,
-    UnmanagedDataSourceHelper, ApplicationCaseDataSourceHelper,
+    UnmanagedDataSourceHelper,
+    ApplicationFormDataSourceHelper,
+    ApplicationCaseDataSourceHelper,
 )
 from corehq.apps.userreports.tests.utils import get_simple_xform
 from corehq.util.test_utils import flag_enabled
@@ -67,10 +68,14 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
 
     def test_builder_bad_type(self):
         with self.assertRaises(AssertionError):
-            ApplicationDataSourceHelper(self.domain, self.app, 'invalid-type', self.form.unique_id)
+            ApplicationFormDataSourceHelper(self.domain, self.app, 'case', self.form.unique_id)
+
+    def test_builder_bad_type_case(self):
+        with self.assertRaises(AssertionError):
+            ApplicationCaseDataSourceHelper(self.domain, self.app, 'form', self.form.unique_id)
 
     def test_builder_for_forms(self):
-        builder = ApplicationDataSourceHelper(self.domain, self.app, DATA_SOURCE_TYPE_FORM, self.form.unique_id)
+        builder = ApplicationFormDataSourceHelper(self.domain, self.app, DATA_SOURCE_TYPE_FORM, self.form.unique_id)
         self.assertEqual('XFormInstance', builder.source_doc_type)
         expected_filter = {
             "type": "and",

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -697,7 +697,7 @@ def _get_form_type(report_type):
     if report_type == "list" or report_type is None:
         return ConfigureListReportForm
     if report_type == "table":
-            return ConfigureTableReportForm
+        return ConfigureTableReportForm
     if report_type == "map":
         return ConfigureMapReportForm
 


### PR DESCRIPTION
## Summary
Refactor of the classes used by Report Builder to create cleaner separation between the different modes (application form, application case, existing data source). I'm sure there is more that could be done but this seemed like enough for now.

This work is in preparation for building reports from Data Registries.

Best reviewed by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Covered by existing tests

### QA Plan
I've tested this locally building form, case and data source reports.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
