### PR TITLE
Remove the API key display from django admin

### DIFF
--- a/corehq/apps/users/admin.py
+++ b/corehq/apps/users/admin.py
@@ -22,8 +22,12 @@ admin.site.register(PartialDigest, DDPartialDigestAdmin)
 
 class ApiKeyInline(admin.TabularInline):
     model = HQApiKey
-    readonly_fields = ['key', 'created']
-    extra = 1
+    readonly_fields = ('created',)
+    exclude = ('key',)
+    extra = 0
+
+    def has_add_permission(self, request, obj):
+        return False
 
 
 class CustomUserAdmin(UserAdmin):
@@ -42,6 +46,9 @@ admin.site.register(User, CustomUserAdmin)
 class HQApiKeyAdmin(admin.ModelAdmin):
     list_display = ['user', 'name', 'created', 'domain']
     list_filter = ['created', 'domain']
+
+    readonly_fields = ('created',)
+    exclude = ('key',)
 
 
 admin.site.register(HQApiKey, HQApiKeyAdmin)


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12408


## Product Description
See JIRA ticket for description/discussion

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests involved

### QA Plan

No QA needed

### Safety story
Local testing was performed to ensure that both the API Key and User displays no longer show the API key. Testing was also done to make sure that these admins can still be used to make changes to the key entry beyond the key's value (such as the name). Also verified that keys can still be added and deleted as normal through the application.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
