### PR TITLE
Resolve some doc warnings

### DIFF
--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -389,7 +389,7 @@ Dict expressions
 
 
 "Add Hours" expressions
-''''''''''''''''''''''
+'''''''''''''''''''''''
 
 .. autoclass:: corehq.apps.userreports.expressions.date_specs.AddHoursExpressionSpec
 
@@ -2049,7 +2049,7 @@ Please note that the columns used in distinct on clause should also be present
 in the sort expression as the first set of columns in the same order.
 
 Pick distinct by a single column
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Sort expression should have column1 and then other columns if needed
 
 .. code:: json
@@ -2072,7 +2072,7 @@ and distinct on would be
    ["column1"]
 
 Pick distinct result based on two columns
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Sort expression should have column1 and column2 in same order,
 More columns can be added after these if needed

--- a/docs/js-guide/module-history.md
+++ b/docs/js-guide/module-history.md
@@ -43,7 +43,7 @@ It essentially has two parts.
 Putting those together, it looks something like this:
 
 ```javascript
-MYNAMESPACE.myModule = (function () {
+MYNAMESPACE.myModule = function () {
     // things inside here are private
     var myPrivateGreeting = "Hello";
     // unless you put them in the return object
@@ -52,9 +52,9 @@ MYNAMESPACE.myModule = (function () {
     };
     return {
         sayHi: sayHi,
-        favoriteColor: “blue”,
+        favoriteColor: "blue",
     };
-}());
+}();
 ```
 
 This uses a pattern so common in JavaScript that it has its own
@@ -89,7 +89,7 @@ var sayHi = function (name) {
 // also a global
 myModule = {
     sayHi: sayHi,
-    favoriteColor: “blue”,
+    favoriteColor: "blue",
 };
 ```
 
@@ -139,7 +139,7 @@ hqDefine('myapp/js/myModule', function () {
     };
     return {
         sayHi: sayHi,
-        favoriteColor: “blue”,
+        favoriteColor: "blue",
     };
 });
 ```

--- a/docs/overview/architecture.rst
+++ b/docs/overview/architecture.rst
@@ -38,6 +38,7 @@ The diagram below shows this synchronous processing:
 2. The form is received by CommCare and once the request has been authenticated and authorized it is fully processed
    before responding with a success or error response.
 3. The data is persisted to the various backend data sources.
+
   1. This SQL database is used for authentication and authorization.
   2. A set of partitioned SQL databases form the primary data store for form and case data.
   3. Once processing is complete a metadata record is published to the change log for each data model
@@ -46,6 +47,7 @@ The diagram below shows this synchronous processing:
      database in (b).
   5. If this submission is from a mobile device the sync record for the device is updated to allow efficient
      synchronization when the mobile device next makes a sync request.
+
 4. A successful response is sent to the sender.
 
 Asynchronous data pipeline
@@ -62,17 +64,22 @@ CommCare offers.
    request processing as described above.
 2. A pool of ETL workers (a.k.a. pillows) subscribe to Kafka and receive the metadata records from the partitions
    they are subscribed to.
+
   a. Each ETL worker subscribes to a unique set of partitions.
   b. Since each worker is independent of the others the rate of processing can vary between workers or can get
      delayed due to errors or other external factors.
   c. The impact of this is that data liveness in the secondary database may vary based on the specific components
      in the pipeline. I.e. two cases which got updated in the same form may be updated in Elasticsearch at different
      times due to variations in the processing delay between pillow workers.
+
 3. The ETL workers fetch the data record from the primary database.
+
   a. For forms and cases this data comes from PostgreSQL
   b. For users and applications this data comes from CouchDB
+
 4. If the data model is a form then the form XML is also retrieved from object storage. This data together with the
    record from the primary database are used to produce the final output which is written to the secondary databases.
+
   a. In the case of UCRs there may be other data that is fetched during the processing stage e.g. locations, users.
 
 Change Processors (Pillows)

--- a/docs/overview/platform.rst
+++ b/docs/overview/platform.rst
@@ -27,7 +27,7 @@ management provides a staging-to-deploy pipeline, profile-based releases for dif
 incremental rollout and distribution for different regions.
 
 Android Mobile App Runner and Web App Engine
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Applications developed in the end user programming (EUP) content builder are deployed to users and then executed
 within the CommCare application engine, which is built on a shared Java codebase.  The application configurations
@@ -169,7 +169,7 @@ UCRs may also be used to send report data to the mobile devices. This data can t
 a report or graph.
 
 Messaging Layer
---------------
+---------------
 
 CommCare Messaging integrates with a SMS gateway purchased and maintained by the client as the processing layer for
 SMS messages. This layer manages the pipeline from a Case transaction to matching business logic rules to message

--- a/docs/web_apps.rst
+++ b/docs/web_apps.rst
@@ -85,11 +85,9 @@ This is written in knockout, and it's probably the oldest code in this area.
 
 Major files to be aware of:
 
-* `form_ui.js
-* <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js>`_ defines ``Question`` and ``Container``, the major abstractions used by form definitions. ``Container`` is the base abstraction for groups and for forms themselves.
+* `form_ui.js <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js>`_ defines ``Question`` and ``Container``, the major abstractions used by form definitions. ``Container`` is the base abstraction for groups and for forms themselves.
 * `entries.js <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js>`_ defines ``Entry`` and its many subclasses, the widgets for entering data. The class hierarchy of entries has a few levels. There's generally a class for each question type: ``SingleSelectEntry``, ``TimeEntry``, etc. Appearance attributes can also have their own classes, such as ``ComboboxEntry`` and ``GeoPointEntry``.
-* `web_form_session.js
-* <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js>`_ defines the interaction for filling out a form. Web apps sends a request to formplayer every time a question is answered, so the session manages a lot of asynchronous requests, using a task queue. The session also handles loading forms, loading incomplete forms, and within-form actions like changing the form's language.
+* `web_form_session.js <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js>`_ defines the interaction for filling out a form. Web apps sends a request to formplayer every time a question is answered, so the session manages a lot of asynchronous requests, using a task queue. The session also handles loading forms, loading incomplete forms, and within-form actions like changing the form's language.
 
 Form entry has a fair amount of test coverage. There are entry-specific tests and also tests for web_form_session.
 


### PR DESCRIPTION
[ci skip]

## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
When running `make html` locally, there are lots of warnings, so this is an attempt to resolve at least a few of those low hanging fruit warnings.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Just docs.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
