### PR TITLE
fix pillow rewind command

### DIFF
--- a/corehq/apps/hqadmin/management/commands/fix_checkpoint_after_rewind.py
+++ b/corehq/apps/hqadmin/management/commands/fix_checkpoint_after_rewind.py
@@ -19,12 +19,13 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('pillow_name')
-        parser.add_argument('by_partition', default=False)
+        parser.add_argument('--by-partition', action='store_true')
 
-    def handle(self, pillow_name, by_partition, **options):
+    def handle(self, pillow_name, **options):
         confirm("Are you sure you want to reset the checkpoint for the '{}' pillow?".format(pillow_name))
         confirm("Have you stopped the pillow?")
 
+        by_partition = options['by_partition']
         pillow = get_pillow_by_name(pillow_name)
         if not pillow:
             raise CommandError("No pillow found with name: {}".format(pillow_name))


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The previous way this command was setup it was impossible to set `by_partition` to `False`, which was unfortunate because couch pillows do not have partitions, and those are the ones that get rewound by mistake. `by_partition` was setup as a required argument and there is no way to pass `False` to the script (since it was parsing the arguments as strings, so `'False'` is truthy). This makes the argument optional, not including leaves it `False`, as is expected, but it can be set to true by passing `--by-partition`.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested the argument locally, both possible values. Also, its a management command so low risk in general.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
