### PR TITLE
always pass request to authenticate

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -146,7 +146,7 @@ def basicauth(realm=''):
         def wrapper(request, *args, **kwargs):
             uname, passwd = get_username_and_password_from_request(request)
             if uname and passwd:
-                user = authenticate(username=uname, password=passwd)
+                user = authenticate(username=uname, password=passwd, request=request)
                 if user is not None and user.is_active:
                     request.user = user
                     return view(request, *args, **kwargs)

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -83,10 +83,12 @@ class ProcessRegistrationView(JSONResponseMixin, View):
         raise Http404()
 
     def _create_new_account(self, reg_form, additional_hubspot_data=None):
-        activate_new_user_via_reg_form(reg_form, created_by=None, created_via=USER_CHANGE_VIA_WEB, ip=get_ip(self.request))
+        activate_new_user_via_reg_form(
+            reg_form, created_by=None, created_via=USER_CHANGE_VIA_WEB, ip=get_ip(self.request))
         new_user = authenticate(
             username=reg_form.cleaned_data['email'],
-            password=reg_form.cleaned_data['password']
+            password=reg_form.cleaned_data['password'],
+            request=self.request
         )
         web_user = WebUser.get_by_username(new_user.username, strict=True)
 

--- a/corehq/apps/users/views/web.py
+++ b/corehq/apps/users/views/web.py
@@ -153,7 +153,7 @@ class UserInvitationView(object):
                         _('You have been added to the "{}" project space.').format(self.domain)
                     )
                     authenticated = authenticate(username=form.cleaned_data["email"],
-                                                 password=form.cleaned_data["password"])
+                                                 password=form.cleaned_data["password"], request=request)
                     if authenticated is not None and authenticated.is_active:
                         login(request, authenticated)
                     track_workflow(request.POST['email'],


### PR DESCRIPTION
## Summary
Ticket: https://dimagi-dev.atlassian.net/browse/SAAS-12518.  We're seeing some login failures which contain no IP or other details, which strongly suggests that an empty `request` object is being passed to authenticate.  This should ensure that the request is always being passed.  Labelling this as high risk as it affects authentication and logins.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No new tests make sense here, as this is a change affecting the integration between units, not the units themselves -- The logging code is already tested, for example, and I don't think it's appropriate to create separate tests verifying that failed user signups log the offending IP (among other paths).

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
The specific flows that I know are affected are new user signup (coming to the application on your own, without a login) and accepting an application invite. This also seems to be used for submitting forms and listing applications from the phone, so I'd just like a general purpose smoke-test to make sure that a user can still log in, submit and view forms, and access apps from their phone.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Verified the 3 paths locally. Because the request objects were already present in the three modified methods, and because `authenticate` is a built-in django method, I think it is unlikely that just giving the request object to `authenticate` could cause an error. That said, I'm not necessarily convinced this will fix the reported issue with missing IP information.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
