### PR TITLE
Disable pact form submission signal

### DIFF
--- a/custom/_legacy/pact/signals.py
+++ b/custom/_legacy/pact/signals.py
@@ -31,5 +31,5 @@ def process_dots_submission(sender, xform, **kwargs):
         notify_exception(None, message="Error processing PACT DOT submission due to an unknown error: %s\n\tTraceback: %s" % (ex, tb))
 
 #xform_saved.connect(process_dots_submission)
-successful_form_received.connect(process_dots_submission)
-
+# Signal disabled since forms and cases were migrated from Couch to SQL
+#successful_form_received.connect(process_dots_submission)


### PR DESCRIPTION
## Summary
This signal updates Couch forms when they are submitted. It is no longer useful since the domain has been migrated to SQL.

Additional context: https://dimagi-dev.atlassian.net/browse/SUPPORT-9925

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

None.

### Safety story

Only affects legacy custom code.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
