### PR TITLE
Switched web apps success messaging from channel to event

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -141,18 +141,18 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         showWarning(message, $("#cloudcare-notifications"));
     });
 
-    FormplayerFrontend.getChannel().reply('showSuccess', function (successMessage) {
+    FormplayerFrontend.on('showSuccess', function (successMessage) {
         showSuccess(successMessage, $("#cloudcare-notifications"), 10000);
     });
 
-    FormplayerFrontend.getChannel().reply('handleNotification', function (notification) {
+    FormplayerFrontend.on('handleNotification', function (notification) {
         var type = notification.type;
         if (!type) {
             type = notification.error ? "error" : "success";
         }
 
         if (type === "success") {
-            FormplayerFrontend.getChannel().request('showSuccess', notification.message);
+            FormplayerFrontend.trigger('showSuccess', notification.message);
         } else if (type === "warning") {
             FormplayerFrontend.trigger('showWarning', notification.message);
         } else {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -24,7 +24,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
 
             // show any notifications from Formplayer
             if (menuResponse.notification && !_.isNull(menuResponse.notification.message)) {
-                FormplayerFrontend.getChannel().request("handleNotification", menuResponse.notification);
+                FormplayerFrontend.trigger("handleNotification", menuResponse.notification);
             }
 
             // If redirect was set, clear and go home.

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -94,7 +94,7 @@ hqDefine("cloudcare/js/formplayer/router", function () {
             response.appId = urlObject.appId;
 
              if (response.notification) {
-                FormplayerFrontend.getChannel().request("handleNotification", response.notification);
+                FormplayerFrontend.trigger("handleNotification", response.notification);
              }
 
             // When the response gets parsed, it will automatically trigger form

--- a/docs/web_apps.rst
+++ b/docs/web_apps.rst
@@ -178,7 +178,7 @@ Marionette `integrates with Backbone.Radio <https://marionettejs.com/docs/master
 
 Although you can namespace channels, web apps uses a single ``formplayer`` channel for all messages, which is accessed using ``FormplayerFrontend.getChannel()``. You'll see calls to get the channel and then call ``request`` to get at a variety of global-esque data, especially the current user. All of these requests are handled by ``reply`` callbacks defined in ``FormplayerFrontend``.
 
-``FormplayerFrontend`` also supports events, which behave similarly. Events are triggered directly on the ``FormplayerFrontend`` object, which defines ``on`` handlers. We tend to use events for navigation and do namespace some of them with ``:``, leading to events like ``menu:select``, ``menu:query``, and ``menu:show:detail``. Som ehelper events are not namespaces, such as ``showError`` and ``showSuccess``.
+``FormplayerFrontend`` also supports events, which behave similarly. Events are triggered directly on the ``FormplayerFrontend`` object, which defines ``on`` handlers. We tend to use events for navigation and do namespace some of them with ``:``, leading to events like ``menu:select``, ``menu:query``, and ``menu:show:detail``. Some helper events are not namespaced, such as ``showError`` and ``showSuccess``.
 
 Routing, URLs, and Middleware
 -----------------------------

--- a/docs/web_apps.rst
+++ b/docs/web_apps.rst
@@ -178,9 +178,7 @@ Marionette `integrates with Backbone.Radio <https://marionettejs.com/docs/master
 
 Although you can namespace channels, web apps uses a single ``formplayer`` channel for all messages, which is accessed using ``FormplayerFrontend.getChannel()``. You'll see calls to get the channel and then call ``request`` to get at a variety of global-esque data, especially the current user. All of these requests are handled by ``reply`` callbacks defined in ``FormplayerFrontend``.
 
-``FormplayerFrontend`` also supports events, which behave similarly. Events are triggered directly on the ``FormplayerFrontend`` object, which defines ``on`` handlers. We tend to use events for navigation and do namespace some of them with ``:``, leading to events like ``menu:select``, ``menu:query``, and ``menu:show:detail``.
-
-Counterintuitively, ``showError`` and ``showSuccess`` are implemented differently: ``showError`` is an event and ``showSuccess`` is a channel request.
+``FormplayerFrontend`` also supports events, which behave similarly. Events are triggered directly on the ``FormplayerFrontend`` object, which defines ``on`` handlers. We tend to use events for navigation and do namespace some of them with ``:``, leading to events like ``menu:select``, ``menu:query``, and ``menu:show:detail``. Som ehelper events are not namespaces, such as ``showError`` and ``showSuccess``.
 
 Routing, URLs, and Middleware
 -----------------------------


### PR DESCRIPTION
## Summary
https://github.com/dimagi/commcare-hq/pull/30065#discussion_r672625649

Minor refactor to make all kinds of notifications in web apps use events. Previously, success messages were using Backbone.Radio's channel feature, while errors and warnings were using events.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Little if any.

### QA Plan

Not requesting QA.

### Safety story
Not requesting QA, even though this touches the web apps UI, because this is such a small change - the event and channel APIs are quite similar. I tested locally that a success message (by reverting https://github.com/dimagi/formplayer/pull/968/) and an error message still appeared as expected.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
