### PR TITLE
Renamed 'steps' to 'selections' in CloudcareURL

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -368,17 +368,15 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         }
 
         var urlObject = Util.currentUrlToObject();
-        var selections = urlObject.steps;
-        var appId = urlObject.appId;
 
         $debug.html('');
         cloudCareDebugger = new CloudCareDebugger({
             baseUrl: user.formplayer_url,
-            selections: selections,
+            selections: urlObject.selections,
             username: user.username,
             restoreAs: user.restoreAs,
             domain: user.domain,
-            appId: appId,
+            appId: urlObject.appId,
             tabs: [
                 TabIDs.EVAL_XPATH,
             ],

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -86,8 +86,8 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
                             );
                         }
                         var urlObject = Util.currentUrlToObject();
-                        if (urlObject.steps) {
-                            urlObject.steps.pop();
+                        if (urlObject.selections) {
+                            urlObject.selections.pop();
                             Util.setUrlToObject(urlObject);
                         }
                         defer.reject();
@@ -100,7 +100,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
                     "domain": user.domain,
                     "app_id": params.appId,
                     "locale": displayOptions.language,
-                    "selections": params.steps,
+                    "selections": params.selections,
                     "offset": params.page * casesPerPage,
                     "search_text": params.search,
                     "menu_session_id": params.sessionId,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -55,7 +55,7 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
 
             if (response.selections) {
                 var urlObject = Util.currentUrlToObject();
-                urlObject.setSteps(response.selections);
+                urlObject.setSelections(response.selections);
                 Util.setUrlToObject(urlObject);
             }
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -67,7 +67,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
     var selectDetail = function (caseId, detailIndex, isPersistent) {
         var urlObject = Util.currentUrlToObject();
         if (!isPersistent) {
-            urlObject.addStep(caseId);
+            urlObject.addSelection(caseId);
         }
         var fetchingDetails = FormplayerFrontend.getChannel().request("entity:get:details", urlObject, isPersistent);
         $.when(fetchingDetails).done(function (detailResponse) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -329,11 +329,11 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
         caseListAction: function (e) {
             var index = $(e.currentTarget).data().index,
-                step = "action " + index;
-            if (step === this.redoLast) {
+                selection = "action " + index;
+            if (selection === this.redoLast) {
                 FormplayerFrontend.trigger("menu:select");
             } else {
-                FormplayerFrontend.trigger("menu:select", step);
+                FormplayerFrontend.trigger("menu:select", selection);
             }
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -148,7 +148,7 @@ hqDefine("cloudcare/js/formplayer/router", function () {
             urlObject.setQueryData(undefined, false);
             urlObject.setForceManualAction(true);
         } else {
-            urlObject.addStep(index);
+            urlObject.addSelection(index);
             urlObject.setForceManualAction(false);
         }
         Util.setUrlToObject(urlObject);
@@ -227,11 +227,11 @@ hqDefine("cloudcare/js/formplayer/router", function () {
     FormplayerFrontend.on("breadcrumbSelect", function (index) {
         FormplayerFrontend.trigger("clearForm");
         var urlObject = Util.currentUrlToObject();
-        urlObject.spliceSteps(index);
+        urlObject.spliceSelections(index);
         Util.setUrlToObject(urlObject);
         var options = {
             'appId': urlObject.appId,
-            'steps': urlObject.steps,
+            'selections': urlObject.selections,
             'queryData': urlObject.queryData,
         };
         hqImport("cloudcare/js/formplayer/menus/controller").selectMenu(options);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -159,7 +159,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
         this.appId = options.appId;
         this.copyOf = options.copyOf;
         this.sessionId = options.sessionId;
-        this.steps = options.steps;
+        this.selections = options.selections;
         this.page = options.page;
         this.search = options.search;
         this.casesPerPage = options.casesPerPage;
@@ -168,19 +168,19 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
         this.sortIndex = options.sortIndex;
         this.forceManualAction = options.forceManualAction;
 
-        this.setSteps = function (steps) {
-            this.steps = steps;
+        this.setSelections = function (selections) {
+            this.selections = selections;
         };
 
-        this.addStep = function (step) {
-            if (!this.steps) {
-                this.steps = [];
+        this.addSelection = function (selection) {
+            if (!this.selections) {
+                this.selections = [];
             }
 
-            // Steps only deal with strings, because formplayer will send them back as strings
-            this.steps.push(String(step));
+            // Selections only deal with strings, because formplayer will send them back as strings
+            this.selections.push(String(selection));
 
-            // clear out pagination and search when we take a step
+            // clear out pagination and search when we navigate
             this.page = null;
             this.search = null;
         };
@@ -210,11 +210,11 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             if (!this.queryData) {
                 this.queryData = {};
             }
-            var steps = hqImport("cloudcare/js/formplayer/utils/util").currentUrlToObject().steps;
+            var selections = hqImport("cloudcare/js/formplayer/utils/util").currentUrlToObject().selections;
             this.queryData[sessionStorage.queryKey] = {
                 inputs: queryDict,
                 execute: execute,
-                selections: steps,
+                selections: selections,
             };
             this.page = null;
             this.search = null;
@@ -226,7 +226,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
 
         this.clearExceptApp = function () {
             this.sessionId = null;
-            this.steps = null;
+            this.selections = null;
             this.page = null;
             this.sortIndex = null;
             this.search = null;
@@ -242,19 +242,19 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             this.forceManualAction = null;
         };
 
-        this.spliceSteps = function (index) {
+        this.spliceSelections = function (index) {
             // null out the session if we clicked the root (home)
             if (index === 0) {
-                this.steps = null;
+                this.selections = null;
                 this.sessionId = null;
             } else {
-                this.steps = this.steps.splice(0, index);
-                var stepsKey = this.steps.join(",");
+                this.selections = this.selections.splice(0, index);
+                var key = this.selections.join(",");
                 // Query data is necessary to formplayer navigation, so keep it,
-                // but only for the steps that are still relevant to the session.
+                // but only for the selections that are still relevant to the session.
                 this.queryData = _.pick(this.queryData, function (value) {
                     var valueKey = value.selections.join(",");
-                    return stepsKey.startsWith(valueKey) && stepsKey !== valueKey;
+                    return key.startsWith(valueKey) && key !== valueKey;
                 });
             }
             this.page = null;
@@ -271,7 +271,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             appId: self.appId,
             copyOf: self.copyOf,
             sessionId: self.sessionId,
-            steps: self.steps,
+            selections: self.selections,
             page: self.page,
             search: self.search,
             queryData: self.queryData || {},    // formplayer can't handle a null
@@ -288,7 +288,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             'appId': data.appId,
             'copyOf': data.copyOf,
             'sessionId': data.sessionId,
-            'steps': data.steps,
+            'selections': data.selections,
             'page': data.page,
             'search': data.search,
             'queryData': data.queryData,

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -9,11 +9,11 @@ def should_show_preview_app(request, app, username):
     return not app.is_remote_app()
 
 
-def _webapps_url(domain, app_id, steps):
+def _webapps_url(domain, app_id, selections):
     url = reverse('formplayer_main', args=[domain])
     query_dict = {
         'appId': app_id,
-        'steps': steps,
+        'selections': selections,
         'page': None,
         'search': None,
     }
@@ -22,12 +22,12 @@ def _webapps_url(domain, app_id, steps):
 
 
 def webapps_module_form_case(domain, app_id, module_id, form_id, case_id):
-    return _webapps_url(domain, app_id, steps=[module_id, form_id, case_id])
+    return _webapps_url(domain, app_id, selections=[module_id, form_id, case_id])
 
 
 def webapps_module_case_form(domain, app_id, module_id, case_id, form_id):
-    return _webapps_url(domain, app_id, steps=[module_id, case_id, form_id])
+    return _webapps_url(domain, app_id, selections=[module_id, case_id, form_id])
 
 
 def webapps_module(domain, app_id, module_id):
-    return _webapps_url(domain, app_id, steps=[module_id])
+    return _webapps_url(domain, app_id, selections=[module_id])

--- a/docs/web_apps.rst
+++ b/docs/web_apps.rst
@@ -169,7 +169,7 @@ Marionette's `regions <https://marionettejs.com/docs/master/marionette.region.ht
 
 We rarely touch the region-handling code, which defines the high-level structure of the page: the "main" region, the progress bar, breadcrumbs, and the restore as banner. The persistent case tile also has a region. Most web apps development happens within the ``main`` region.
 
-It is sometimes useful to know how the breadcrumbs work. The breadcrumbs are tightly tied to formplayer's selections-based navigation. See `Navigation and replaying of sessions <https://github.com/dimagi/commcare-hq/blob/master/docs/formplayer.rst#navigation-and-replaying-of-sessions>`_ for an overview and examples. The breadcrumbs use this same selections array, which corresponds to the "steps" attribute of ``CloudcareURL``, with one breadcrumb for each selection.
+It is sometimes useful to know how the breadcrumbs work. The breadcrumbs are tightly tied to formplayer's selections-based navigation. See `Navigation and replaying of sessions <https://github.com/dimagi/commcare-hq/blob/master/docs/formplayer.rst#navigation-and-replaying-of-sessions>`_ for an overview and examples. The breadcrumbs use this same selections array, which is also an attribute of ``CloudcareURL``, with one breadcrumb for each selection.
 
 Backbone.Radio and Events
 -------------------------


### PR DESCRIPTION
## Summary
Improve consistency between web apps and formplayer code.

## Product Description
Noting that this will cause web apps URLs to break:
* It should not affect most users working normally in web apps. If a user has a browser window open from pre-deploy, that code will continue to use `steps` until the user reloads the page.
* If a user is working in web apps - say they're on a case list screen - and refreshes the page, they'll get sent back to the app's home screen without an error, since they'll get the new code that references `selections` but their URL will use `steps`.
* Any web apps URLs copied from the browser pre-deploy will not work, they'll send the user to the app's first screen instead of the screen specified in the URL. Web apps URLs are already pretty short-lived and fragile.

I'm following up on this with the product team to verify this is okay.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Little if any.

### QA Plan

There's a formplayer regression happening tonight as part of https://dimagi-dev.atlassian.net/browse/QA-3278, so I'm planning to piggyback on that.

### Safety story
This changes a scattering of code in a high-risk area, although it's a pretty mechanical change.

This also touches the pact reports, but those are already broken.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
