### PR TITLE
ensure 'commcare_project' is always present in user data for restore

### DIFF
--- a/corehq/apps/cloudcare/tests/test_session.py
+++ b/corehq/apps/cloudcare/tests/test_session.py
@@ -29,6 +29,7 @@ class SessionUtilsTest(TestCase):
         self.assertEqual('worker', data['username'])
         self.assertEqual(user._id, data['user_id'])
         self.assertTrue(isinstance(data['user_data'], dict))
+        self.assertTrue(data['user_data']['commcare_project'], 'cloudcare-tests')
 
     def test_default_user_data(self):
         user = CommCareUser(
@@ -77,6 +78,7 @@ class SessionUtilsTest(TestCase):
         self.assertEqual('web-user@example.com', data['username'])
         self.assertEqual(user._id, data['user_id'])
         self.assertTrue(isinstance(data['user_data'], dict))
+        self.assertTrue(data['user_data']['commcare_project'], 'cloudcare-tests')
 
     def test_load_session_data_for_commconnect_case(self):
         user = CommCareCase(

--- a/corehq/apps/cloudcare/tests/test_session.py
+++ b/corehq/apps/cloudcare/tests/test_session.py
@@ -53,6 +53,7 @@ class SessionUtilsTest(TestCase):
             Field(slug='word', label='A Word'),
         ])
         definition.save()
+        self.addCleanup(definition.delete)
         profile = CustomDataFieldsProfile(name='prof', fields={'word': 'supernova'}, definition=definition)
         profile.save()
         user = CommCareUser.create(
@@ -64,10 +65,10 @@ class SessionUtilsTest(TestCase):
             uuid=uuid.uuid4().hex,
             metadata={PROFILE_SLUG: profile.id},
         )
+        self.addCleanup(user.delete, None, None)
         user_data = get_user_contributions_to_touchforms_session('cloudcare-tests', user)['user_data']
         self.assertEqual(profile.id, user_data[PROFILE_SLUG])
         self.assertEqual('supernova', user_data['word'])
-        definition.delete()
 
     def test_load_session_data_for_web_user(self):
         user = WebUser(

--- a/corehq/apps/cloudcare/tests/test_session.py
+++ b/corehq/apps/cloudcare/tests/test_session.py
@@ -25,7 +25,7 @@ class SessionUtilsTest(TestCase):
             username='worker@cloudcare-tests.commcarehq.org',
             _id=uuid.uuid4().hex
         )
-        data = get_user_contributions_to_touchforms_session(user)
+        data = get_user_contributions_to_touchforms_session('cloudcare-tests', user)
         self.assertEqual('worker', data['username'])
         self.assertEqual(user._id, data['user_id'])
         self.assertTrue(isinstance(data['user_data'], dict))
@@ -36,12 +36,12 @@ class SessionUtilsTest(TestCase):
             username='worker@cloudcare-tests.commcarehq.org',
             _id=uuid.uuid4().hex
         )
-        user_data = get_user_contributions_to_touchforms_session(user)['user_data']
+        user_data = get_user_contributions_to_touchforms_session('cloudcare-tests', user)['user_data']
         for key in ['commcare_first_name', 'commcare_last_name', 'commcare_phone_number']:
             self.assertEqual(None, user_data[key])
         user.first_name = 'first'
         user.last_name = 'last'
-        user_data = get_user_contributions_to_touchforms_session(user)['user_data']
+        user_data = get_user_contributions_to_touchforms_session('cloudcare-tests', user)['user_data']
         self.assertEqual('first', user_data['commcare_first_name'])
         self.assertEqual('last', user_data['commcare_last_name'])
 
@@ -63,7 +63,7 @@ class SessionUtilsTest(TestCase):
             uuid=uuid.uuid4().hex,
             metadata={PROFILE_SLUG: profile.id},
         )
-        user_data = get_user_contributions_to_touchforms_session(user)['user_data']
+        user_data = get_user_contributions_to_touchforms_session('cloudcare-tests', user)['user_data']
         self.assertEqual(profile.id, user_data[PROFILE_SLUG])
         self.assertEqual('supernova', user_data['word'])
         definition.delete()
@@ -73,7 +73,7 @@ class SessionUtilsTest(TestCase):
             username='web-user@example.com',
             _id=uuid.uuid4().hex
         )
-        data = get_user_contributions_to_touchforms_session(user)
+        data = get_user_contributions_to_touchforms_session('cloudcare-tests', user)
         self.assertEqual('web-user@example.com', data['username'])
         self.assertEqual(user._id, data['user_id'])
         self.assertTrue(isinstance(data['user_data'], dict))
@@ -83,7 +83,7 @@ class SessionUtilsTest(TestCase):
             name='A case',
             _id=uuid.uuid4().hex
         )
-        data = get_user_contributions_to_touchforms_session(user)
+        data = get_user_contributions_to_touchforms_session('cloudcare-tests', user)
         self.assertEqual('A case', data['username'])
         self.assertEqual(user._id, data['user_id'])
         self.assertEqual({}, data['user_data'])

--- a/corehq/apps/cloudcare/touchforms_api.py
+++ b/corehq/apps/cloudcare/touchforms_api.py
@@ -21,7 +21,7 @@ class BaseSessionDataHelper(object):
             'app_version': '2.0',
             'domain': self.domain,
         }
-        session_data.update(get_user_contributions_to_touchforms_session(self.couch_user))
+        session_data.update(get_user_contributions_to_touchforms_session(self.domain, self.couch_user))
         return session_data
 
     def get_full_context(self, root_extras=None, session_extras=None):
@@ -101,12 +101,12 @@ class CaseSessionDataHelper(BaseSessionDataHelper):
         return session_var
 
 
-def get_user_contributions_to_touchforms_session(couch_user_or_commconnect_case):
+def get_user_contributions_to_touchforms_session(domain, couch_user_or_commconnect_case):
     return {
         'username': couch_user_or_commconnect_case.raw_username,
         'user_id': couch_user_or_commconnect_case.get_id,
         # This API is used by smsforms, so sometimes "couch_user" can be
         # a case, in which case there is no user_data.
-        'user_data': (couch_user_or_commconnect_case.user_session_data
+        'user_data': (couch_user_or_commconnect_case.get_user_session_data(domain)
             if isinstance(couch_user_or_commconnect_case, CouchUser) else {}),
     }

--- a/corehq/apps/custom_data_fields/models.py
+++ b/corehq/apps/custom_data_fields/models.py
@@ -12,6 +12,7 @@ CUSTOM_DATA_FIELD_PREFIX = "data-field"
 # If mobile-worker is demo, this will be set to value 'demo'
 COMMCARE_USER_TYPE_KEY = 'user_type'
 COMMCARE_USER_TYPE_DEMO = 'demo'
+COMMCARE_PROJECT = "commcare_project"
 
 # This stores the id of the user's CustomDataFieldsProfile, if any
 PROFILE_SLUG = "commcare_profile"

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1860,7 +1860,7 @@ class EditFormInstance(View):
         if not user:
             return _error(_('Could not find user for this submission.'))
 
-        edit_session_data = get_user_contributions_to_touchforms_session(user)
+        edit_session_data = get_user_contributions_to_touchforms_session(domain, user)
 
         # add usercase to session
         form = self._get_form_from_instance(instance)

--- a/corehq/apps/smsforms/tests/test_app.py
+++ b/corehq/apps/smsforms/tests/test_app.py
@@ -114,7 +114,12 @@ class TestStartSession(TestCase):
         expected_session_data = {
             'device_id': 'commconnect', 'app_version': '2.0', 'domain': self.domain,
             'username': self.recipient.raw_username, 'user_id': self.recipient.get_id,
-            'user_data': {'commcare_first_name': None, 'commcare_last_name': None, 'commcare_phone_number': None},
+            'user_data': {
+                'commcare_first_name': None,
+                'commcare_last_name': None,
+                'commcare_phone_number': None,
+                'commcare_project': self.domain,
+            },
             'app_id': None
         }
         xform_config_mock.assert_called_once_with(

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1070,12 +1070,12 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         self.first_name = data.pop(0)
         self.last_name = ' '.join(data)
 
-    @property
-    def user_session_data(self):
+    def get_user_session_data(self, domain):
         from corehq.apps.custom_data_fields.models import (
             SYSTEM_PREFIX,
             COMMCARE_USER_TYPE_KEY,
-            COMMCARE_USER_TYPE_DEMO
+            COMMCARE_USER_TYPE_DEMO,
+            COMMCARE_PROJECT
         )
 
         session_data = self.metadata
@@ -1084,6 +1084,9 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             session_data.update({
                 COMMCARE_USER_TYPE_KEY: COMMCARE_USER_TYPE_DEMO
             })
+
+        if COMMCARE_PROJECT not in session_data:
+            session_data[COMMCARE_PROJECT] = domain
 
         session_data.update({
             '{}_first_name'.format(SYSTEM_PREFIX): self.first_name,

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -96,7 +96,7 @@ class OTARestoreUser(object):
 
     @property
     def user_session_data(self):
-        return self._couch_user.user_session_data
+        return self._couch_user.get_user_session_data(self.domain)
 
     @property
     def date_joined(self):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
@@ -8,21 +8,6 @@ DUMMY_PASSWORD = "changeme"
 DUMMY_PROJECT = "domain"
 
 
-def dummy_user():
-    return MagicMock(
-        username=DUMMY_USERNAME,
-        password=DUMMY_PASSWORD,
-        user_id=DUMMY_ID,
-        date_joined=date(2016, 12, 12),
-        user_session_data={
-            'first_name': 'mclovin',
-            'last_name': None,
-            'phone_number': '555555',
-            'something': 'arbitrary',
-        }
-    )
-
-
 def dummy_user_xml(user=None):
     username = user.username if user else DUMMY_USERNAME
     password = user.password if user else DUMMY_PASSWORD


### PR DESCRIPTION
## Summary
This change ensures that the custom user data for a user always contains the 'commcare_project' key. For mobile users this value is set when creating the user but there is no such value for web users.

If the value is present in the user data it is assumed to be correct, if it is not present the domain from the request is used.

This will be used in future when Data Registries are in use with case search.

Can review by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Updated

### QA Plan
None

### Safety story
Minor change to custom user data in restore response

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
