### PR TITLE
Cs/sc 1697 new custom recipient

### DIFF
--- a/custom/abt/messaging/custom_recipients.py
+++ b/custom/abt/messaging/custom_recipients.py
@@ -2,7 +2,7 @@ from corehq.apps.users.models import CommCareUser
 from corehq.apps.locations.models import SQLLocation
 
 
-def abt_case_owner_location_parent_old_framework(handler, reminder):
+def abt_mobile_worker_case_owner_location_parent_old_framework(handler, reminder):
     case = reminder.case
     if not case:
         return None
@@ -26,7 +26,7 @@ def abt_case_owner_location_parent_old_framework(handler, reminder):
     return [parent_location]
 
 
-def abt_case_owner_location_parent_new_framework(case_schedule_instance):
+def abt_mobile_worker_case_owner_location_parent_new_framework(case_schedule_instance):
     # Get the case owner, which we always expect to be a mobile worker in
     # this one-off feature
     owner = case_schedule_instance.case_owner
@@ -42,7 +42,7 @@ def abt_case_owner_location_parent_new_framework(case_schedule_instance):
     return owner_location.parent
 
 
-def abt_case_owner_location_parent_location_old_framework(handler, reminder):
+def abt_location_case_owner_parent_location_old_framework(handler, reminder):
     case = reminder.case
     if not case:
         return None
@@ -59,7 +59,7 @@ def abt_case_owner_location_parent_location_old_framework(handler, reminder):
     return [parent_location]
 
 
-def abt_case_owner_location_parent_location_new_framework(case_schedule_instance):
+def abt_location_case_owner_parent_location_new_framework(case_schedule_instance):
     # Get the case owner, which is expected to be a location
     owner_location = case_schedule_instance.case_owner
     if not isinstance(owner_location, SQLLocation):

--- a/custom/abt/messaging/custom_recipients.py
+++ b/custom/abt/messaging/custom_recipients.py
@@ -1,4 +1,5 @@
 from corehq.apps.users.models import CommCareUser
+from corehq.apps.locations.models import SQLLocation
 
 
 def abt_case_owner_location_parent_old_framework(handler, reminder):
@@ -35,6 +36,17 @@ def abt_case_owner_location_parent_new_framework(case_schedule_instance):
     # Get the case owner's location
     owner_location = owner.sql_location
     if not owner_location:
+        return None
+
+    # Get that location's parent location
+    return owner_location.parent
+
+
+def abt_case_owner_location_parent_location(case_schedule_instance):
+    # Get the case owner, which we always expect to be a mobile worker in
+    # this one-off feature
+    owner_location = case_schedule_instance.case_owner
+    if not isinstance(owner_location, SQLLocation):
         return None
 
     # Get that location's parent location

--- a/custom/abt/messaging/custom_recipients.py
+++ b/custom/abt/messaging/custom_recipients.py
@@ -42,9 +42,25 @@ def abt_case_owner_location_parent_new_framework(case_schedule_instance):
     return owner_location.parent
 
 
-def abt_case_owner_location_parent_location(case_schedule_instance):
-    # Get the case owner, which we always expect to be a mobile worker in
-    # this one-off feature
+def abt_case_owner_location_parent_location_old_framework(handler, reminder):
+    case = reminder.case
+    if not case:
+        return None
+
+    owner_location = reminder.case_owner
+    if not isinstance(owner_location, SQLLocation):
+        return None
+
+    # Get that owner location's parent location
+    parent_location = owner_location.parent
+    if not parent_location:
+        return None
+
+    return [parent_location]
+
+
+def abt_case_owner_location_parent_location_new_framework(case_schedule_instance):
+    # Get the case owner, which is expected to be a location
     owner_location = case_schedule_instance.case_owner
     if not isinstance(owner_location, SQLLocation):
         return None

--- a/custom/abt/tests/test_custom_recipients.py
+++ b/custom/abt/tests/test_custom_recipients.py
@@ -54,7 +54,7 @@ class CustomRecipientTest(TestCase):
         self.domain_obj.delete()
 
     @run_with_all_backends
-    def test_recipient_case_owner_location_parent(self):
+    def test_recipient_case_owner_parent_location(self):
         with create_test_case(self.domain, 'test-case', 'test-name', owner_id=self.user.get_id) as case:
             self.assertEqual(case.owner_id, self.user.get_id)
 
@@ -78,6 +78,27 @@ class CustomRecipientTest(TestCase):
             # Remove child location
             self.user.unset_location()
             self.assertIsNone(instance().recipient)
+
+            # Remove case
+            self.assertIsNone(instance(case_id='does-not-exist').recipient)
+
+    @run_with_all_backends
+    def test_recipient_case_owner_location_parent_location(self):
+        with create_test_case(self.domain, 'test-case', 'test-name', owner_id=self.child_location.location_id) as case:
+            self.assertEqual(case.owner_id, self.child_location.location_id)
+
+            def instance(case_id=''):
+                # recipient is memoized
+                return CaseTimedScheduleInstance(
+                    domain=self.domain,
+                    case_id=case_id or case.case_id,
+                    recipient_type='CustomRecipient',
+                    recipient_id='CASE_OWNER_LOCATION_PARENT_LOCATION'
+                )
+
+            # Test the recipient is returned correctly
+            self.assertTrue(isinstance(instance().recipient, SQLLocation))
+            self.assertEqual(instance().recipient.pk, self.parent_location.pk)
 
             # Remove case
             self.assertIsNone(instance(case_id='does-not-exist').recipient)

--- a/custom/abt/tests/test_custom_recipients.py
+++ b/custom/abt/tests/test_custom_recipients.py
@@ -64,7 +64,7 @@ class CustomRecipientTest(TestCase):
                     domain=self.domain,
                     case_id=case_id or case.case_id,
                     recipient_type='CustomRecipient',
-                    recipient_id='CASE_OWNER_LOCATION_PARENT'
+                    recipient_id='CASE_OWNER_PARENT_LOCATION'
                 )
 
             # Test the recipient is returned correctly

--- a/custom/abt/tests/test_custom_recipients.py
+++ b/custom/abt/tests/test_custom_recipients.py
@@ -54,7 +54,7 @@ class CustomRecipientTest(TestCase):
         self.domain_obj.delete()
 
     @run_with_all_backends
-    def test_recipient_case_owner_parent_location(self):
+    def test_recipient_mobile_worker_case_owner_location_parent(self):
         with create_test_case(self.domain, 'test-case', 'test-name', owner_id=self.user.get_id) as case:
             self.assertEqual(case.owner_id, self.user.get_id)
 
@@ -64,7 +64,7 @@ class CustomRecipientTest(TestCase):
                     domain=self.domain,
                     case_id=case_id or case.case_id,
                     recipient_type='CustomRecipient',
-                    recipient_id='CASE_OWNER_PARENT_LOCATION'
+                    recipient_id='MOBILE_WORKER_CASE_OWNER_LOCATION_PARENT'
                 )
 
             # Test the recipient is returned correctly
@@ -83,7 +83,7 @@ class CustomRecipientTest(TestCase):
             self.assertIsNone(instance(case_id='does-not-exist').recipient)
 
     @run_with_all_backends
-    def test_recipient_case_owner_location_parent_location(self):
+    def test_recipient_location_case_owner_parent_location(self):
         with create_test_case(self.domain, 'test-case', 'test-name', owner_id=self.child_location.location_id) as case:
             self.assertEqual(case.owner_id, self.child_location.location_id)
 
@@ -93,7 +93,7 @@ class CustomRecipientTest(TestCase):
                     domain=self.domain,
                     case_id=case_id or case.case_id,
                     recipient_type='CustomRecipient',
-                    recipient_id='CASE_OWNER_LOCATION_PARENT_LOCATION'
+                    recipient_id='LOCATION_CASE_OWNER_PARENT_LOCATION'
                 )
 
             # Test the recipient is returned correctly

--- a/settings.py
+++ b/settings.py
@@ -727,8 +727,8 @@ AVAILABLE_CUSTOM_REMINDER_RECIPIENTS = {
     'CASE_OWNER_PARENT_LOCATION':
         ['custom.abt.messaging.custom_recipients.abt_case_owner_location_parent_old_framework',
          "Abt: The case owner's location's parent location"],
-    'for ':
-        ['custom.abt.messaging.custom_recipients.abt_case_owner_location_parent_location',
+    'CASE_OWNER_LOCATION_PARENT_LOCATION':
+        ['custom.abt.messaging.custom_recipients.abt_case_owner_location_parent_location_old_framework',
          "Abt: The case owner location's parent location"],
 }
 
@@ -746,7 +746,7 @@ AVAILABLE_CUSTOM_SCHEDULING_RECIPIENTS = {
         ['custom.abt.messaging.custom_recipients.abt_case_owner_location_parent_new_framework',
          "Abt: The case owner's location's parent location"],
     'CASE_OWNER_LOCATION_PARENT_LOCATION':
-        ['custom.abt.messaging.custom_recipients.abt_case_owner_location_parent_location',
+        ['custom.abt.messaging.custom_recipients.abt_case_owner_location_parent_location_new_framework',
          "Abt: The case owner location's parent location"],
 }
 

--- a/settings.py
+++ b/settings.py
@@ -724,9 +724,12 @@ AVAILABLE_CUSTOM_REMINDER_RECIPIENTS = {
     'HOST_CASE_OWNER_LOCATION_PARENT':
         ['corehq.apps.reminders.custom_recipients.host_case_owner_location_parent',
          "Custom: Extension Case -> Host Case -> Owner (which is a location) -> Parent location"],
-    'CASE_OWNER_LOCATION_PARENT':
+    'CASE_OWNER_PARENT_LOCATION':
         ['custom.abt.messaging.custom_recipients.abt_case_owner_location_parent_old_framework',
          "Abt: The case owner's location's parent location"],
+    'for ':
+        ['custom.abt.messaging.custom_recipients.abt_case_owner_location_parent_location',
+         "Abt: The case owner location's parent location"],
 }
 
 
@@ -739,9 +742,12 @@ AVAILABLE_CUSTOM_SCHEDULING_RECIPIENTS = {
     'HOST_CASE_OWNER_LOCATION_PARENT':
         ['corehq.messaging.scheduling.custom_recipients.host_case_owner_location_parent',
          "Custom: Extension Case -> Host Case -> Owner (which is a location) -> Parent location"],
-    'CASE_OWNER_LOCATION_PARENT':
+    'CASE_OWNER_PARENT_LOCATION':
         ['custom.abt.messaging.custom_recipients.abt_case_owner_location_parent_new_framework',
          "Abt: The case owner's location's parent location"],
+    'CASE_OWNER_LOCATION_PARENT_LOCATION':
+        ['custom.abt.messaging.custom_recipients.abt_case_owner_location_parent_location',
+         "Abt: The case owner location's parent location"],
 }
 
 LOCAL_AVAILABLE_CUSTOM_RULE_CRITERIA = {}

--- a/settings.py
+++ b/settings.py
@@ -724,11 +724,11 @@ AVAILABLE_CUSTOM_REMINDER_RECIPIENTS = {
     'HOST_CASE_OWNER_LOCATION_PARENT':
         ['corehq.apps.reminders.custom_recipients.host_case_owner_location_parent',
          "Custom: Extension Case -> Host Case -> Owner (which is a location) -> Parent location"],
-    'CASE_OWNER_PARENT_LOCATION':
-        ['custom.abt.messaging.custom_recipients.abt_case_owner_location_parent_old_framework',
+    'MOBILE_WORKER_CASE_OWNER_LOCATION_PARENT':
+        ['custom.abt.messaging.custom_recipients.abt_mobile_worker_case_owner_location_parent_old_framework',
          "Abt: The case owner's location's parent location"],
-    'CASE_OWNER_LOCATION_PARENT_LOCATION':
-        ['custom.abt.messaging.custom_recipients.abt_case_owner_location_parent_location_old_framework',
+    'LOCATION_CASE_OWNER_PARENT_LOCATION':
+        ['custom.abt.messaging.custom_recipients.abt_location_case_owner_parent_location_old_framework',
          "Abt: The case owner location's parent location"],
 }
 
@@ -742,11 +742,11 @@ AVAILABLE_CUSTOM_SCHEDULING_RECIPIENTS = {
     'HOST_CASE_OWNER_LOCATION_PARENT':
         ['corehq.messaging.scheduling.custom_recipients.host_case_owner_location_parent',
          "Custom: Extension Case -> Host Case -> Owner (which is a location) -> Parent location"],
-    'CASE_OWNER_PARENT_LOCATION':
-        ['custom.abt.messaging.custom_recipients.abt_case_owner_location_parent_new_framework',
+    'MOBILE_WORKER_CASE_OWNER_LOCATION_PARENT':
+        ['custom.abt.messaging.custom_recipients.abt_mobile_worker_case_owner_location_parent_new_framework',
          "Abt: The case owner's location's parent location"],
-    'CASE_OWNER_LOCATION_PARENT_LOCATION':
-        ['custom.abt.messaging.custom_recipients.abt_case_owner_location_parent_location_new_framework',
+    'LOCATION_CASE_OWNER_PARENT_LOCATION':
+        ['custom.abt.messaging.custom_recipients.abt_location_case_owner_parent_location_new_framework',
          "Abt: The case owner location's parent location"],
 }
 


### PR DESCRIPTION
## Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-1679)

A new custom recipient (`LOCATION_CASE_OWNER_PARENT_LOCATION`) is to be added for VectorLink. See full description of what it needs to do in ticket, but here's the summary:
The recipient needs to be the location's (location X1) parent location assuming the location (X1) owns cases. 
Currently there's a custom recipient (`CASE_OWNER_LOCATION_PARENT`) type that assumes the mobile worker owns the cases and the recipient would be the mobile worker's location's parent location.

Note: 
I renamed the existing custom recipient (`CASE_OWNER_LOCATION_PARENT`) to `MOBILE_WORKER_CASE_OWNER_LOCATION_PARENT` in an effort to make it more distinguishable from the new recipient, `LOCATION_CASE_OWNER_PARENT_LOCATION`. Please feel free to suggest better naming.

## Feature Flag
Not specific to any one

## Product Description
A new type of custom recipient option is available, ie `Abt: The case owner location's parent location`

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Unit test for new recipient

### Safety story
- Local testing done
- Successful end-2-end test on staging 

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
