### PR TITLE
Add some caching to the app build

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2452,6 +2452,7 @@ class ModuleDetailsMixin(object):
         for case_list in (self.case_list, self.referral_list):
             case_list.rename_lang(old_lang, new_lang)
 
+    @memoized
     def get_details(self):
         details = [
             ('case_short', self.case_details.short, True),
@@ -3158,6 +3159,7 @@ class AdvancedModule(ModuleBase):
         detail.instance_name = RESULTS_INSTANCE
         return detail
 
+    @memoized
     def get_details(self):
         details = [
             ('case_short', self.case_details.short, True),
@@ -3627,6 +3629,7 @@ class ReportModule(ModuleBase):
         module.get_or_create_unique_id()
         return module
 
+    @memoized
     def get_details(self):
         from corehq.apps.app_manager.suite_xml.features.mobile_ucr import ReportModuleSuiteHelper
         return ReportModuleSuiteHelper(self).get_details()

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -179,7 +179,7 @@ def get_all_instances_referenced_in_xpaths(app, xpaths):
     instance_re = r"""instance\(['"]([\w\-:]+)['"]\)"""
     instances = set()
     unknown_instance_ids = set()
-    for xpath in xpaths:
+    for xpath in set(xpaths):
         if not xpath:
             continue
 

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -611,11 +611,7 @@ def get_detail_column_infos_for_tabs_with_sorting(detail):
 
 
 def get_instances_for_module(app, module, detail_section_elements):
-    """
-    This method is used by CloudCare when filtering cases.
-    """
-    modules = list(app.get_modules())
-    helper = DetailsHelper(app, modules)
+    helper = DetailsHelper(app)
     details = detail_section_elements
     detail_mapping = {detail.id: detail for detail in details}
     details_by_id = detail_mapping

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -16,9 +16,6 @@ from corehq.apps.app_manager.suite_xml.contributors import SectionContributor
 from corehq.apps.app_manager.suite_xml.features.scheduler import (
     schedule_detail_variables,
 )
-from corehq.apps.app_manager.suite_xml.post_process.instances import (
-    get_all_instances_referenced_in_xpaths,
-)
 from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
 from corehq.apps.app_manager.suite_xml.xml_models import (
     Action,
@@ -608,24 +605,6 @@ def get_detail_column_infos_for_tabs_with_sorting(detail):
             ])
 
     return columns
-
-
-def get_instances_for_module(app, module, detail_section_elements):
-    helper = DetailsHelper(app)
-    details = detail_section_elements
-    detail_mapping = {detail.id: detail for detail in details}
-    details_by_id = detail_mapping
-    detail_ids = [helper.get_detail_id_safe(module, detail_type)
-                  for detail_type, detail, enabled in module.get_details()
-                  if enabled]
-    detail_ids = [_f for _f in detail_ids if _f]
-    xpaths = set()
-
-    for detail_id in detail_ids:
-        xpaths.update(details_by_id[detail_id].get_all_xpaths())
-
-    instances, _ = get_all_instances_referenced_in_xpaths(app, xpaths)
-    return instances
 
 
 class CaseTileHelper(object):

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -1102,11 +1102,8 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
 
         app = Application.new_app('domain', "Untitled Application")
 
-        report_module = app.add_module(ReportModule.new_module('Reports', None))
-        report_module.unique_id = 'report_module'
         report = get_sample_report_config()
         report._id = 'd3ff18cd83adf4550b35db8d391f6008'
-
         report_app_config = ReportAppConfig(
             report_id=report._id,
             header={'en': 'CommBugz'},
@@ -1122,6 +1119,8 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             },
         )
         report_app_config._report = report
+        report_module = app.add_module(ReportModule.new_module('Reports', None))
+        report_module.unique_id = 'report_module'
         report_module.report_configs = [report_app_config]
         report_module._loaded = True
         self.assertXmlPartialEqual(
@@ -1140,36 +1139,40 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         report_module.media_image = {
             'en': 'jr://file/commcare/image/module0_en.png',
         }
+        report_module.get_details.reset_cache(report_module)
+        actual_suite = app.create_suite()
         self.assertXmlPartialEqual(
             self.get_xml('reports_module_menu_multimedia'),
-            app.create_suite(),
+            actual_suite,
             "./menu",
         )
 
         self.assertXmlPartialEqual(
             self.get_xml('reports_module_select_detail'),
-            app.create_suite(),
+            actual_suite,
             "./detail[@id='reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.select']",
         )
         self.assertXmlPartialEqual(
             self.get_xml('reports_module_summary_detail_use_xpath_description'),
-            app.create_suite(),
+            actual_suite,
             "./detail[@id='reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.summary']",
         )
         self.assertXmlPartialEqual(
             self.get_xml('reports_module_data_detail'),
-            app.create_suite(),
+            actual_suite,
             "./detail/detail[@id='reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.data']",
         )
 
         report_app_config.show_data_table = False
+        report_module.get_details.reset_cache(report_module)
         self.assertXmlPartialEqual(
             self.get_xml('reports_module_summary_detail_hide_data_table'),
             app.create_suite(),
             "./detail[@id='reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.summary']",
         )
-        report_app_config.show_data_table = True
 
+        report_app_config.show_data_table = True
+        report_module.get_details.reset_cache(report_module)
         self.assertXmlPartialEqual(
             self.get_xml('reports_module_data_entry'),
             app.create_suite(),
@@ -1181,6 +1184,7 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         )
 
         report_app_config.use_xpath_description = False
+        report_module.get_details.reset_cache(report_module)
         self.assertXmlPartialEqual(
             self.get_xml('reports_module_summary_detail_use_localized_description'),
             app.create_suite(),
@@ -1218,6 +1222,7 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 'translations': translation_format,
             }
             report_app_config._report = ReportConfiguration.wrap(report_app_config._report._doc)
+            report_module.get_details.reset_cache(report_module)
             self.assertXmlPartialEqual(
                 self.get_xml(expected_output),
                 app.create_suite(),


### PR DESCRIPTION
## Summary
https://docs.google.com/document/d/1e99ZRsQAxDb1JQIr727JmaDmgCSnqJfWzEKi6_65oGI/edit#
I did an analysis of where build time is spent (see doc above), and these are some pretty straightforward targets for caching.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
App builds are pretty heavily tested

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
I tested this locally, though the app was admittedly simpler than most.  I'm largely relying on my understanding of the code and in the (extensive) test suite.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
