### PR TITLE
add reconciliation tasks and command to fetch results

### DIFF
--- a/corehq/apps/hqadmin/management/commands/fetch_reconciliation_records.py
+++ b/corehq/apps/hqadmin/management/commands/fetch_reconciliation_records.py
@@ -1,0 +1,26 @@
+from django.core.management.base import BaseCommand, CommandError
+from corehq.blobs import CODES, get_blob_db
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument('data_type')
+        parser.add_argument('date')
+
+    def handle(self, data_type, date, **options):
+        blob_db = get_blob_db()
+        if data_type == 'form':
+            parent_id = 'reconcile_es_forms'
+        elif data_type == 'case':
+            parent_id = 'reconcile_es_cases'
+        else:
+            raise CommandError('data_type must be either form or case')
+        key = f'{parent_id}_{date}'
+        blob = blob_db.get(
+            key=key,
+            type_code=CODES.tempfile
+        )
+        data = blob.read().decode('utf-8')
+        self.stdout.write(data)
+

--- a/corehq/apps/hqadmin/management/commands/fetch_reconciliation_records.py
+++ b/corehq/apps/hqadmin/management/commands/fetch_reconciliation_records.py
@@ -23,4 +23,3 @@ class Command(BaseCommand):
         )
         data = blob.read().decode('utf-8')
         self.stdout.write(data)
-

--- a/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
+++ b/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
         parser.add_argument('--delimiter', default='\t', choices=('\t', ','))
         parser.add_arument('--skip_domains', action='store_true')
 
-    def handle(self, stale_data_in_es_file, delimiter, *args, **options):
+    def handle(self, stale_data_in_es_file, delimiter, skip_domains, *args, **options):
         data_rows = _get_data_rows(stale_data_in_es_file, delimiter=delimiter)
         document_records = _get_document_records(data_rows)
         form_records = []

--- a/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
+++ b/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('stale_data_in_es_file')
         parser.add_argument('--delimiter', default='\t', choices=('\t', ','))
-        parser.add_arument('--skip_domains', action='store_true')
+        parser.add_argument('--skip_domains', action='store_true')
 
     def handle(self, stale_data_in_es_file, delimiter, skip_domains, *args, **options):
         data_rows = _get_data_rows(stale_data_in_es_file, delimiter=delimiter)

--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -230,7 +230,7 @@ def count_es_forms_past_window():
         'es_forms_past_window',
         start=start,
         end=end,
-        publish=False
+        republish=False
     )
 
 
@@ -247,20 +247,20 @@ def count_es_cases_past_window():
         'es_cases_past_window',
         start=start,
         end=end,
-        publish=False
+        republish=False
     )
 
 
 def _reconcile_es_data(data_type, metric, blob_parent_id, start=None, end=None, republish=True):
+    today = date.today()
     if not start:
-        today = date.today()
         two_days_ago = today - timedelta(days=2)
         start = two_days_ago.isoformat()
     with TransientTempfile() as file_path:
         with open(file_path, 'w') as output_file:
             call_command('stale_data_in_es', data_type, start=start, end=end, stdout=output_file)
         with open(file_path, 'r') as f:
-            reader = csv.reader(f)
+            reader = csv.reader(f, delimiter='\t')
             # ignore the headers
             next(reader)
             counts_by_domain = defaultdict(int)

--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -27,7 +27,7 @@ from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.blobs import CODES, get_blob_db
 from corehq.elastic import get_es_new
 from corehq.util.celery_utils import periodic_task_when_true
-from corehq.util.metrics import metrics_gauge
+from corehq.util.metrics import metrics_counter, metrics_gauge
 from corehq.util.soft_assert import soft_assert
 
 from .utils import check_for_rewind
@@ -226,7 +226,7 @@ def _reconcile_es_data(data_type, metric, blob_parent_id):
         line_count = sum(1 for line in f)
         # ignore the headers
         stale_docs = line_count - 1
-        metrics_gauge(metric, stale_docs)
+        metrics_counter(metric, stale_docs)
     call_command('republish_doc_changes', file_name)
     with open(file_name, 'rb') as f:
         blob_db = get_blob_db()

--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -1,5 +1,6 @@
 import csv
 import io
+from collections import defaultdict
 from datetime import date, timedelta
 from tempfile import NamedTemporaryFile
 
@@ -234,7 +235,7 @@ def count_es_forms_past_window():
 
 
 @periodic_task(queue='background_queue', run_every=crontab(minute="0", hour="6"))
-def count_es_forms_past_window():
+def count_es_cases_past_window():
     today = date.today()
     two_days_ago = today - timedelta(days=2)
     four_days_ago = today - timedelta(days=4)
@@ -267,7 +268,7 @@ def _reconcile_es_data(data_type, metric, blob_parent_id, start=None, end=None, 
             domain = line[3]
             counts_by_domain[domain] += 1
         if counts_by_domain:
-            for domain, count in by_domain.items():
+            for domain, count in counts_by_domain.items():
                 metrics_counter(metric, count, tags={'domain': domain})
         else:
             metrics_counter(metric, 0)

--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -222,8 +222,8 @@ def count_es_forms_past_window():
     today = date.today()
     two_days_ago = today - timedelta(days=2)
     four_days_ago = today - timedelta(days=4)
-    start = two_days_ago.isoformat()
-    end = four_days_ago.isoformat()
+    start = four_days_ago.isoformat()
+    end = two_days_ago.isoformat()
     _reconcile_es_data(
         'form',
         'commcare.elasticsearch.stale_forms_past_window',
@@ -239,8 +239,8 @@ def count_es_cases_past_window():
     today = date.today()
     two_days_ago = today - timedelta(days=2)
     four_days_ago = today - timedelta(days=4)
-    start = two_days_ago.isoformat()
-    end = four_days_ago.isoformat()
+    start = four_days_ago.isoformat()
+    end = two_days_ago.isoformat()
     _reconcile_es_data(
         'case',
         'commcare.elasticsearch.stale_cases_past_window',

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -2113,3 +2113,10 @@ CASE_IMPORT_DATA_DICTIONARY_VALIDATION = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
     help_link="https://confluence.dimagi.com/display/saas/Validate+data+per+data+dictionary+definitions+during+case+import",
 )
+
+DO_NOT_REPUBLISH_DOCS = StaticToggle(
+    'do_not_republish_docs',
+    'Prevents automatic attempts to repair stale ES docs in this domain',
+    TAG_INTERNAL,
+    namespaces=[NAMESPACE_DOMAIN],
+)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
After a large number of ES consistency issues over the past year, I wanted to take a different approach. This creates a nightly task to check the last 2 days of form and case data in ES for stale or inconsistent data. It should be fast (checking 3 months of data took about 4 hours), and gives us two chances to catch stale data in case there is an issue the first night.

I used the existing commands we have to keep things simple, and logged stats in datadog so that we would still be able to tell if there were higher than usual data issues, even if we fix them immediately. Similarly, I stored the output of the stale data command in the blob db for 30 days to aid in investigation if we do see a spike. The last bit is a management command to fetch those stored results.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Isolated celery task using existing commands so quite safe.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
