### PR TITLE
Added build error for session endpoints to menus using display-only forms

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -368,6 +368,12 @@ class ModuleBaseValidator(object):
                     'module': self.get_module_info(),
                 })
 
+        if self.module.put_in_root and self.module.session_endpoint_id:
+            errors.append({
+                'type': 'endpoint to display only forms',
+                'module': self.get_module_info(),
+            })
+
         return errors
 
     def validate_detail_columns(self, columns):

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -77,6 +77,12 @@
                 to a menu using "Display only forms," which makes that menu an invalid choice.
               {% endblocktrans %}
               {% include "app_manager/partials/form_error_message.html" %}
+            {% case "endpoint to display only forms" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                uses "Display only forms" and also has a Session Endpoint ID.
+                Session endpoints cannot be used with "Display only forms."
+              {% endblocktrans %}
             {% case "no ref detail" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}
                 <a href="{{ module_url }}">{{ module_name }}</a>


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/QA-3389

These menus don't have their own "screen" so it doesn't make sense to point an endpoint at them anyway. We have a [similar error](https://github.com/dimagi/commcare-hq/blob/2f0dd9178b3b7c92f7accf0495abe8b18a23e423/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html#L74-L78) for form linking.

## Feature Flag
Session endpoints

## Product Description
Adding a session endpoint to a menu will now not let you make a build. Previously, you could create a build but the endpoint wouldn't work.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

yes

### QA Plan

Not requesting QA.

### Safety story
Small footprint, tested locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
