### PR TITLE
Updated default login as permission checkbox to be disabled when user…

### DIFF
--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -267,7 +267,15 @@
                 {% trans "Login-As Default User" %}
               </label>
               <div class="col-sm-8 controls">
-                <div class="form-check">
+                {# Placeholder disabled checkbox when not using limited login as #}
+                <div class="form-check" data-bind="visible: permissions.login_as_all_users() || !permissions.limited_login_as()">
+                  <input type="checkbox" disabled="disabled" data-bind="checked: permissions.login_as_all_users()" />
+                  <label for="default-login-as-checkbox">
+                    {% trans "Allow the user to login as the default user in Web Apps." %}
+                  </label>
+                </div>
+                {# Real checkbox #}
+                <div class="form-check" data-bind="visible: !permissions.login_as_all_users() && permissions.limited_login_as()">
                   <input type="checkbox"
                          id="default-login-as-checkbox"
                          data-bind="checked: permissions.access_default_login_as_user,


### PR DESCRIPTION
… can't login as

## Summary
https://dimagi-dev.atlassian.net/browse/QA-3390

![Screen Shot 2021-08-13 at 9 57 59 AM](https://user-images.githubusercontent.com/1486591/129368290-d3fb69e0-b01f-465b-8ec1-40e8a6e44433.png)

Disable the login as default user checkbox when the one above it is disabled, because allowing login as the default user only makes sense if you're using limited login as. If login as all users is on, the user will already have access to the default login as user. If login as all users is off and limited login as is also off, the user can't login as at all, so it's misleading to be able to check a box that says they can login as the default user.

The behavior is now that the default login as user checkbox is:
* editable only when limited login as is checked
* disabled and unchecked when limited login as is not checked
* disabled and checked when login as all users is checked

## Feature Flag
USH: Limit allowed users for login as

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None for this UI

### QA Plan
Asking QA to verify.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
