### PR TITLE
Add support to query by view in evaluate_couch_model_for_sql

### DIFF
--- a/corehq/apps/cleanup/management/commands/evaluate_couch_model_for_sql.py
+++ b/corehq/apps/cleanup/management/commands/evaluate_couch_model_for_sql.py
@@ -2,16 +2,19 @@ import logging
 import os
 from pathlib import Path
 
-import jinja2
-from couchdbkit.ext.django import schema
 from django.core.management.base import BaseCommand
 from django.utils.dateparse import parse_date, parse_datetime
 
-from corehq.dbaccessors.couchapps.all_docs import get_doc_ids_by_class
-from corehq.util.couchdb_management import couch_config
+import jinja2
+from couchdbkit.ext.django import schema
+from requests.exceptions import HTTPError
+
 from dimagi.ext import jsonobject
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.modules import to_function
+
+from corehq.dbaccessors.couchapps.all_docs import get_doc_ids_by_class
+from corehq.util.couchdb_management import couch_config
 
 logger = logging.getLogger(__name__)
 

--- a/corehq/apps/cleanup/management/commands/evaluate_couch_model_for_sql.py
+++ b/corehq/apps/cleanup/management/commands/evaluate_couch_model_for_sql.py
@@ -68,7 +68,11 @@ class Command(BaseCommand):
             self.couch_class = to_function(self.models_path)
             self.class_name = self.models_path.split(".")[-1]
 
-        doc_ids = get_doc_ids_by_class(self.couch_class)
+        try:
+            doc_ids = get_doc_ids_by_class(self.couch_class)
+        except HTTPError:
+            view_name = input("Unable to query model. Please enter view to query: ")
+            doc_ids = self.couch_class.get_db().view(view_name).all()
         print("Found {} {} docs\n".format(len(doc_ids), self.class_name))
 
         for doc in iter_docs(self.couch_class.get_db(), doc_ids):


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Found out during investigating - https://dimagi-dev.atlassian.net/browse/SAAS-12155

We were unable to generate the SQL model for CaseRepeaters because `get_doc_ids_by_class ` was failing. So as a workaround we decided that whenever it fails we will ask the user to provide a view name that can be queried to get some docs.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The changes does not affect any live part of HQ and command has been tested on local
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
