### PR TITLE
Added logic to block endpoints for forms in shadow menus

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/endpoints.py
+++ b/corehq/apps/app_manager/suite_xml/sections/endpoints.py
@@ -32,9 +32,10 @@ class SessionEndpointContributor(SuiteContributorByModule):
         endpoints = []
         if module.session_endpoint_id:
             endpoints.append(self._make_session_endpoint(module))
-        for form in module.get_suite_forms():
-            if form.session_endpoint_id:
-                endpoints.append(self._make_session_endpoint(module, form))
+        if module.module_type != "shadow":
+            for form in module.get_suite_forms():
+                if form.session_endpoint_id:
+                    endpoints.append(self._make_session_endpoint(module, form))
         return endpoints
 
     def _make_session_endpoint(self, module, form=None):


### PR DESCRIPTION
PR into https://github.com/dimagi/commcare-hq/pull/30002

This might fix https://dimagi-dev.atlassian.net/browse/QA-3376

There isn't a way to specify an endpoint for a form in a shadow menu - instead, duplicate endpoints get created that navigate via the shadow menu instead of the source menu.

I could see there being a use case for an endpoint for a form in a shadow menu, since then the shadow menu would be the one that shows up in breadcrumbs, but for now I'm inclined to just disallow them.