### PR TITLE
Fix race condition in Auditcare migration

### DIFF
--- a/corehq/apps/auditcare/couch_to_sql.py
+++ b/corehq/apps/auditcare/couch_to_sql.py
@@ -159,6 +159,7 @@ def _get_couch_docs(start_key, end_key, start_doc_id=None):
         # Records matching end_key will be start_key of another batch and may cause race conditions
         # We are adding 1 to end_key to avoid querying them.
         assert len(start_key) == 6, start_key
+        assert len(end_key) == 6, end_key
         start_key[5] += 1
         end_key[5] += 1
         kwargs = {}

--- a/corehq/apps/auditcare/tests/test_auditcare_migration.py
+++ b/corehq/apps/auditcare/tests/test_auditcare_migration.py
@@ -75,6 +75,7 @@ class TestAuditcareMigrationUtil(TestCase):
         # generation should stop
         batches = self.util.generate_batches(5, 'd')
         expected_batches = [
+            [datetime(2013, 1, 1), datetime(2012, 12, 31)]
             [datetime(2013, 1, 3), datetime(2013, 1, 2)],
             [datetime(2013, 1, 2), datetime(2013, 1, 1)],
         ]

--- a/corehq/apps/auditcare/tests/test_auditcare_migration.py
+++ b/corehq/apps/auditcare/tests/test_auditcare_migration.py
@@ -75,9 +75,9 @@ class TestAuditcareMigrationUtil(TestCase):
         # generation should stop
         batches = self.util.generate_batches(5, 'd')
         expected_batches = [
-            [datetime(2013, 1, 1), datetime(2012, 12, 31)]
             [datetime(2013, 1, 3), datetime(2013, 1, 2)],
             [datetime(2013, 1, 2), datetime(2013, 1, 1)],
+            [datetime(2013, 1, 1), datetime(2012, 12, 31)],
         ]
         self.assertEqual(batches, expected_batches)
 

--- a/corehq/apps/auditcare/tests/test_auditcare_migration.py
+++ b/corehq/apps/auditcare/tests/test_auditcare_migration.py
@@ -209,7 +209,7 @@ class TestCopyEventsToSQL(AuditcareTest):
             self.assertEqual(AccessAudit.objects.first().path, "/a/delmar/login/")
 
         NavigationEventAudit(event_date=datetime(2021, 2, 1, 4), path="just/a/checkpoint").save()
-        copy_events_to_sql(start_time=datetime(2021, 2, 1, 5), end_time=datetime(2021, 2, 1, 2))
+        copy_events_to_sql(start_time=datetime(2021, 2, 1, 5), end_time=datetime(2021, 2, 1, 1, 59))
         _assert()
 
         # Re-copying should have no effect
@@ -231,5 +231,5 @@ class TestCopyEventsToSQL(AuditcareTest):
             self.assertEqual(AccessAudit.objects.count(), 1)
             self.assertEqual(AccessAudit.objects.first().path, "/a/delmar/login/")
 
-        copy_events_to_sql(start_time=datetime(2021, 2, 2), end_time=datetime(2021, 1, 1))
+        copy_events_to_sql(start_time=datetime(2021, 2, 2), end_time=datetime(2020, 12, 31))
         _assert()

--- a/corehq/apps/auditcare/utils/migration.py
+++ b/corehq/apps/auditcare/utils/migration.py
@@ -9,7 +9,7 @@ from dimagi.utils.dates import force_to_datetime
 from corehq.apps.auditcare.models import AuditcareMigrationMeta
 from corehq.apps.auditcare.utils.export import get_sql_start_date
 
-CUTOFF_TIME = datetime(2013, 1, 1)
+CUTOFF_TIME = datetime(2012, 12, 31)
 CACHE_TTL = 14 * 24 * 60 * 60  # 14 days
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
A part of https://dimagi-dev.atlassian.net/browse/SAAS-12241
While running the migration command on India env we figured out that a race condition is observed when a batch is finishing and the next one is starting and they try to insert the Auditcare docs in SQL at the same time and the bulk insert command fails because of trying to insert duplicate couch_id.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The changes have been verified on staging and all records were getting copied. And they are very much secluded from rest of the HQ.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
