### PR TITLE
Add config option for case searching a registry

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2133,6 +2133,7 @@ class CaseSearch(DocumentSchema):
     default_properties = SchemaListProperty(DefaultCaseSearchProperty)
     blacklisted_owner_ids_expression = StringProperty()
     additional_case_types = ListProperty(str)
+    data_registry_id = StringProperty()
 
     @property
     def case_session_var(self):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2133,7 +2133,7 @@ class CaseSearch(DocumentSchema):
     default_properties = SchemaListProperty(DefaultCaseSearchProperty)
     blacklisted_owner_ids_expression = StringProperty()
     additional_case_types = ListProperty(str)
-    data_registry_id = StringProperty()
+    data_registry = StringProperty()
 
     @property
     def case_session_var(self):

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -168,7 +168,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
     var searchConfigKeys = [
         'autoLaunch', 'blacklistedOwnerIdsExpression', 'defaultSearch', 'searchAgainLabel',
         'searchButtonDisplayCondition', 'searchLabel', 'searchFilter', 'searchDefaultRelevant',
-        'searchAdditionalRelevant',
+        'searchAdditionalRelevant', 'dataRegistryId',
     ];
     var searchConfigModel = function (options, lang, searchFilterObservable, saveButton) {
         hqImport("hqwebapp/js/assert_properties").assertRequired(options, searchConfigKeys);
@@ -223,6 +223,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 search_default_relevant: self.searchDefaultRelevant(),
                 search_additional_relevant: self.searchAdditionalRelevant(),
                 search_button_display_condition: self.searchButtonDisplayCondition(),
+                data_registry_id: self.dataRegistryId(),
                 search_label: self.searchLabel(),
                 search_label_image:
                     $("#case_search-search_label_media_media_image input[type=hidden][name='case_search-search_label_media_media_image']").val() || null,

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -168,7 +168,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
     var searchConfigKeys = [
         'autoLaunch', 'blacklistedOwnerIdsExpression', 'defaultSearch', 'searchAgainLabel',
         'searchButtonDisplayCondition', 'searchLabel', 'searchFilter', 'searchDefaultRelevant',
-        'searchAdditionalRelevant', 'dataRegistryId',
+        'searchAdditionalRelevant', 'dataRegistry',
     ];
     var searchConfigModel = function (options, lang, searchFilterObservable, saveButton) {
         hqImport("hqwebapp/js/assert_properties").assertRequired(options, searchConfigKeys);
@@ -223,7 +223,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 search_default_relevant: self.searchDefaultRelevant(),
                 search_additional_relevant: self.searchAdditionalRelevant(),
                 search_button_display_condition: self.searchButtonDisplayCondition(),
-                data_registry_id: self.dataRegistryId(),
+                data_registry: self.dataRegistry(),
                 search_label: self.searchLabel(),
                 search_label_image:
                     $("#case_search-search_label_media_media_image input[type=hidden][name='case_search-search_label_media_media_image']").val() || null,

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -47,6 +47,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
                     searchAgainLabel: options.search_again_label,
                     searchFilter: options.search_filter,
                     blacklistedOwnerIdsExpression: options.blacklisted_owner_ids_expression,
+                    dataRegistryId: options.data_registry_id,
                 });
 
                 var $list_home = $("#" + detail.type + "-detail-screen-config-tab");

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -47,7 +47,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
                     searchAgainLabel: options.search_again_label,
                     searchFilter: options.search_filter,
                     blacklistedOwnerIdsExpression: options.blacklisted_owner_ids_expression,
-                    dataRegistryId: options.data_registry_id,
+                    dataRegistry: options.data_registry,
                 });
 
                 var $list_home = $("#" + detail.type + "-detail-screen-config-tab");

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -162,28 +162,23 @@ class RemoteRequestFactory(object):
     @cached_property
     def _remote_request_query_datums(self):
         default_query_datums = [
-            QueryData(
-                key='case_type',
-                ref="'{}'".format(self.module.case_type)
-            ),
+            QueryData(key='case_type', ref=f"'{self.module.case_type}'"),
         ]
-        additional_types = list(set(self.module.search_config.additional_case_types) - {self.module.case_type})
-        for type in additional_types:
+
+        additional_types = set(self.module.search_config.additional_case_types) - {self.module.case_type}
+        for case_type in additional_types:
             default_query_datums.append(
-                QueryData(
-                    key='case_type',
-                    ref="'{}'".format(type)
-                )
+                QueryData(key='case_type', ref=f"'{case_type}'")
             )
         extra_query_datums = [
-            QueryData(key="{}".format(c.property), ref="{}".format(c.defaultValue))
+            QueryData(key=c.property, ref=c.defaultValue)
             for c in self.module.search_config.default_properties
         ]
         if self.module.search_config.blacklisted_owner_ids_expression:
             extra_query_datums.append(
                 QueryData(
                     key=CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
-                    ref="{}".format(self.module.search_config.blacklisted_owner_ids_expression)
+                    ref=self.module.search_config.blacklisted_owner_ids_expression,
                 )
             )
         return default_query_datums + extra_query_datums

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -27,8 +27,15 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
     Text,
 )
 from corehq.apps.app_manager.util import module_offers_search
-from corehq.apps.app_manager.xpath import CaseTypeXpath, InstanceXpath, interpolate_xpath
-from corehq.apps.case_search.models import CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY
+from corehq.apps.app_manager.xpath import (
+    CaseTypeXpath,
+    InstanceXpath,
+    interpolate_xpath,
+)
+from corehq.apps.case_search.models import (
+    CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
+    CASE_SEARCH_REGISTRY_ID_KEY,
+)
 from corehq.util.timer import time_method
 from corehq.util.view_utils import absolute_reverse
 
@@ -176,6 +183,13 @@ class RemoteRequestFactory(object):
                 QueryData(
                     key=CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
                     ref=self.module.search_config.blacklisted_owner_ids_expression,
+                )
+            )
+        if self.module.search_config.data_registry_id:
+            datums.append(
+                QueryData(
+                    key=CASE_SEARCH_REGISTRY_ID_KEY,
+                    ref=self.module.search_config.data_registry_id,
                 )
             )
         return datums

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -161,27 +161,27 @@ class RemoteRequestFactory(object):
 
     @cached_property
     def _remote_request_query_datums(self):
-        default_query_datums = [
+        datums = [
             QueryData(key='case_type', ref=f"'{self.module.case_type}'"),
         ]
 
         additional_types = set(self.module.search_config.additional_case_types) - {self.module.case_type}
         for case_type in additional_types:
-            default_query_datums.append(
+            datums.append(
                 QueryData(key='case_type', ref=f"'{case_type}'")
             )
-        extra_query_datums = [
+        datums.extend(
             QueryData(key=c.property, ref=c.defaultValue)
             for c in self.module.search_config.default_properties
-        ]
+        )
         if self.module.search_config.blacklisted_owner_ids_expression:
-            extra_query_datums.append(
+            datums.append(
                 QueryData(
                     key=CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
                     ref=self.module.search_config.blacklisted_owner_ids_expression,
                 )
             )
-        return default_query_datums + extra_query_datums
+        return datums
 
     def _build_query_prompts(self):
         prompts = []

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -91,7 +91,7 @@ class RemoteRequestFactory(object):
         ]
 
         xpaths = {QuerySessionXPath(self.module.search_config.case_session_var).instance()}
-        xpaths.update(datum.ref for datum in self._get_remote_request_query_datums())
+        xpaths.update(datum.ref for datum in self._remote_request_query_datums)
         xpaths.add(self.module.search_config.get_relevant())
         xpaths.add(self.module.search_config.search_filter)
         xpaths.update(prop.default_value for prop in self.module.search_config.properties)
@@ -128,7 +128,7 @@ class RemoteRequestFactory(object):
                 url=absolute_reverse('app_aware_remote_search', args=[self.app.domain, self.app._id]),
                 storage_instance=RESULTS_INSTANCE,
                 template='case',
-                data=self._get_remote_request_query_datums(),
+                data=self._remote_request_query_datums,
                 prompts=self._build_query_prompts(),
                 default_search=self.module.search_config.default_search,
             )
@@ -159,7 +159,8 @@ class RemoteRequestFactory(object):
             detail_confirm=self._details_helper.get_detail_id_safe(self.module, long_detail_id),
         )]
 
-    def _get_remote_request_query_datums(self):
+    @cached_property
+    def _remote_request_query_datums(self):
         default_query_datums = [
             QueryData(
                 key='case_type',

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -161,15 +161,12 @@ class RemoteRequestFactory(object):
 
     @cached_property
     def _remote_request_query_datums(self):
+        additional_types = set(self.module.search_config.additional_case_types) - {self.module.case_type}
         datums = [
-            QueryData(key='case_type', ref=f"'{self.module.case_type}'"),
+            QueryData(key='case_type', ref=f"'{case_type}'")
+            for case_type in [self.module.case_type] + list(additional_types)
         ]
 
-        additional_types = set(self.module.search_config.additional_case_types) - {self.module.case_type}
-        for case_type in additional_types:
-            datums.append(
-                QueryData(key='case_type', ref=f"'{case_type}'")
-            )
         datums.extend(
             QueryData(key=c.property, ref=c.defaultValue)
             for c in self.module.search_config.default_properties

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -185,11 +185,11 @@ class RemoteRequestFactory(object):
                     ref=self.module.search_config.blacklisted_owner_ids_expression,
                 )
             )
-        if self.module.search_config.data_registry_id:
+        if self.module.search_config.data_registry:
             datums.append(
                 QueryData(
                     key=CASE_SEARCH_REGISTRY_ID_KEY,
-                    ref=self.module.search_config.data_registry_id,
+                    ref=self.module.search_config.data_registry,
                 )
             )
         return datums

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -147,6 +147,8 @@
               {% include "app_manager/partials/nav_menu_media.html" with qualifier='case_search-search_again_label_media_' ICON_LABEL="Search Again Icon" AUDIO_LABEL="Search Again Audio" %}
             <!-- /ko -->
           </div>
+          {% endif %}
+          {% if request|toggle_enabled:'DATA_REGISTRY' %}
           <div class="form-group">
               <label for="data-registry-id" class="{% css_label_class %} control-label">
                   {% trans "Registry ID" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -147,6 +147,16 @@
               {% include "app_manager/partials/nav_menu_media.html" with qualifier='case_search-search_again_label_media_' ICON_LABEL="Search Again Icon" AUDIO_LABEL="Search Again Audio" %}
             <!-- /ko -->
           </div>
+          <div class="form-group">
+              <label for="data-registry-id" class="{% css_label_class %} control-label">
+                  {% trans "Registry ID" %}
+                  <span class="hq-help-template" data-title="{% trans "Registry ID" %}"
+                        data-content="{% trans_html_attr "Enter the ID of a case registry.  Users with access will see results from the registry when performing this search." %}">
+              </label>
+              <div class="{% css_field_class %}">
+                  <input class="form-control" type="text" id="data-registry-id" data-bind="value: dataRegistryId"/>
+              </div>
+          </div>
           {% endif %}
           <div class="form-group" data-bind="slideVisible: !autoLaunch()">
             <label for="search-display-condition" class="control-label {% css_label_class %}">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -151,12 +151,17 @@
           {% if request|toggle_enabled:'DATA_REGISTRY' %}
           <div class="form-group">
               <label for="data-registry-id" class="{% css_label_class %} control-label">
-                  {% trans "Registry ID" %}
-                  <span class="hq-help-template" data-title="{% trans "Registry ID" %}"
+                  {% trans "Data Registry ID" %}
+                  <span class="hq-help-template" data-title="{% trans "Data Registry ID" %}"
                         data-content="{% trans_html_attr "Enter the ID of a case registry.  Users with access will see results from the registry when performing this search." %}">
               </label>
               <div class="{% css_field_class %}">
-                  <input class="form-control" type="text" id="data-registry-id" data-bind="value: dataRegistryId"/>
+                  <select class="form-control" id="data-registry-id" data-bind="value: dataRegistryId">
+                      <option value/>
+                      {% for value, name in data_registries %}
+                          <option value="{{ value }}">{{ name }}</option>
+                      {% endfor %}
+                  </select>
               </div>
           </div>
           {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -150,13 +150,13 @@
           {% endif %}
           {% if request|toggle_enabled:'DATA_REGISTRY' %}
           <div class="form-group">
-              <label for="data-registry-id" class="{% css_label_class %} control-label">
+              <label for="data-registry" class="{% css_label_class %} control-label">
                   {% trans "Data Registry ID" %}
                   <span class="hq-help-template" data-title="{% trans "Data Registry ID" %}"
                         data-content="{% trans_html_attr "Enter the ID of a case registry.  Users with access will see results from the registry when performing this search." %}">
               </label>
               <div class="{% css_field_class %}">
-                  <select class="form-control" id="data-registry-id" data-bind="value: dataRegistryId">
+                  <select class="form-control" id="data-registry" data-bind="value: dataRegistry">
                       <option value/>
                       {% for value, name in data_registries %}
                           <option value="{{ value }}">{{ name }}</option>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -151,9 +151,9 @@
           {% if request|toggle_enabled:'DATA_REGISTRY' %}
           <div class="form-group">
               <label for="data-registry" class="{% css_label_class %} control-label">
-                  {% trans "Data Registry ID" %}
-                  <span class="hq-help-template" data-title="{% trans "Data Registry ID" %}"
-                        data-content="{% trans_html_attr "Enter the ID of a case registry.  Users with access will see results from the registry when performing this search." %}">
+                  {% trans "Data Registry" %}
+                  <span class="hq-help-template" data-title="{% trans "Data Registry" %}"
+                        data-content="{% trans_html_attr "Select a Data Registry to use for searching.  Users with access will see results from the registry when performing this search." %}">
               </label>
               <div class="{% css_field_class %}">
                   <select class="form-control" id="data-registry" data-bind="value: dataRegistry">

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -349,6 +349,16 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             suite = self.app.create_suite()
         self.assertXmlPartialEqual(self.get_xml('search_config_blacklisted_owners'), suite, "./remote-request[1]")
 
+    def test_search_data_registry(self, *args):
+        self.module.search_config.data_registry_id = "myregistry"
+        suite = self.app.create_suite()
+        expected = """
+        <partial>
+          <data key="commcare_registry" ref="myregistry"/>
+        </partial>
+        """
+        self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/data[@key='commcare_registry']")
+
     def test_prompt_hint(self, *args):
         self.module.search_config.properties[0].hint = {'en': 'Search against name'}
         suite = self.app.create_suite()

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -350,7 +350,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         self.assertXmlPartialEqual(self.get_xml('search_config_blacklisted_owners'), suite, "./remote-request[1]")
 
     def test_search_data_registry(self, *args):
-        self.module.search_config.data_registry_id = "myregistry"
+        self.module.search_config.data_registry = "myregistry"
         suite = self.app.create_suite()
         expected = """
         <partial>

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -231,6 +231,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
                 module.search_config.search_label.label if hasattr(module, 'search_config') else "",
             'search_again_label':
                 module.search_config.search_again_label.label if hasattr(module, 'search_config') else "",
+            'data_registry_id': module.search_config.data_registry_id,
         },
     }
     if toggles.CASE_DETAIL_PRINT.enabled(app.domain):
@@ -1209,6 +1210,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
                 auto_launch=bool(search_properties.get('auto_launch')),
                 default_search=bool(search_properties.get('default_search')),
                 search_filter=search_properties.get('search_filter', ""),
+                data_registry_id=search_properties.get('data_registry_id', ""),
                 search_button_display_condition=search_properties.get('search_button_display_condition', ""),
                 blacklisted_owner_ids_expression=search_properties.get('blacklisted_owner_ids_expression', ""),
                 default_properties=[

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -114,6 +114,7 @@ from corehq.apps.hqmedia.models import (
 )
 from corehq.apps.hqmedia.views import ProcessDetailPrintTemplateUploadView
 from corehq.apps.hqwebapp.decorators import waf_allow
+from corehq.apps.registry.models import DataRegistry
 from corehq.apps.reports.analytics.esaccessors import (
     get_case_types_for_domain_es
 )
@@ -201,6 +202,10 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
         'shadow_parent': _get_shadow_parent(app, module),
         'case_types': {m.case_type for m in app.modules if m.case_type},
         'session_endpoints_enabled': toggles.SESSION_ENDPOINTS.enabled(app.domain),
+        'data_registries': [
+            (registry.pk, registry.name) for registry in
+            DataRegistry.objects.accessible_to_domain(app.domain)
+        ],
         'js_options': {
             'fixture_columns_by_type': _get_fixture_columns_by_type(app.domain),
             'is_search_enabled': case_search_enabled_for_domain(app.domain),

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -203,7 +203,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
         'case_types': {m.case_type for m in app.modules if m.case_type},
         'session_endpoints_enabled': toggles.SESSION_ENDPOINTS.enabled(app.domain),
         'data_registries': [
-            (registry.pk, registry.name) for registry in
+            (registry.slug, registry.name) for registry in
             DataRegistry.objects.accessible_to_domain(app.domain)
         ],
         'js_options': {
@@ -236,7 +236,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
                 module.search_config.search_label.label if hasattr(module, 'search_config') else "",
             'search_again_label':
                 module.search_config.search_again_label.label if hasattr(module, 'search_config') else "",
-            'data_registry_id': module.search_config.data_registry_id,
+            'data_registry': module.search_config.data_registry,
         },
     }
     if toggles.CASE_DETAIL_PRINT.enabled(app.domain):
@@ -1215,7 +1215,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
                 auto_launch=bool(search_properties.get('auto_launch')),
                 default_search=bool(search_properties.get('default_search')),
                 search_filter=search_properties.get('search_filter', ""),
-                data_registry_id=search_properties.get('data_registry_id', ""),
+                data_registry=search_properties.get('data_registry', ""),
                 search_button_display_condition=search_properties.get('search_button_display_condition', ""),
                 blacklisted_owner_ids_expression=search_properties.get('blacklisted_owner_ids_expression', ""),
                 default_properties=[

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -15,6 +15,7 @@ FUZZY_PROPERTIES = "fuzzy_properties"
 SEARCH_QUERY_CUSTOM_VALUE = 'commcare_custom_value'
 CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY = 'commcare_blacklisted_owner_ids'
 CASE_SEARCH_XPATH_QUERY_KEY = '_xpath_query'
+CASE_SEARCH_REGISTRY_ID_KEY = 'commcare_registry'
 UNSEARCHABLE_KEYS = (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
     'owner_id',

--- a/corehq/apps/registry/models.py
+++ b/corehq/apps/registry/models.py
@@ -68,6 +68,9 @@ class DataRegistry(models.Model):
     class Meta:
         unique_together = ('domain', 'slug')
 
+    def __repr__(self):
+        return f"DataRegistry(domain='{self.domain}', slug='{self.slug}')"
+
     @classmethod
     @transaction.atomic
     def create(cls, user, domain, name):
@@ -149,6 +152,9 @@ class RegistryInvitation(models.Model):
     class Meta:
         unique_together = ("registry", "domain")
 
+    def __repr__(self):
+        return f"RegistryInvitation(domain='{self.domain}', status='{self.status}')"
+
     @transaction.atomic
     def accept(self, user):
         self.status = self.STATUS_ACCEPTED
@@ -171,6 +177,9 @@ class RegistryGrant(models.Model):
     from_domain = models.CharField(max_length=255)
     to_domains = ArrayField(models.CharField(max_length=255))
 
+    def __repr__(self):
+        return f"RegistryGrant(from_domain='{self.from_domain}', to_domains='{self.to_domains}')"
+
 
 class RegistryPermission(models.Model):
     """This model controls which users in a domain can access the data registry."""
@@ -180,6 +189,9 @@ class RegistryPermission(models.Model):
 
     class Meta:
         unique_together = ('registry', 'domain')
+
+    def __repr__(self):
+        return f"RegistryPermission(domain='{self.domain}', read_only_group_id='{self.read_only_group_id}')"
 
 
 class RegistryAuditLog(models.Model):

--- a/corehq/apps/registry/models.py
+++ b/corehq/apps/registry/models.py
@@ -69,7 +69,7 @@ class DataRegistry(models.Model):
         unique_together = ('domain', 'slug')
 
     def __repr__(self):
-        return f"DataRegistry(domain='{self.domain}', slug='{self.slug}')"
+        return f"DataRegistry(id='{self.id}', domain='{self.domain}', slug='{self.slug}')"
 
     @classmethod
     @transaction.atomic
@@ -153,7 +153,8 @@ class RegistryInvitation(models.Model):
         unique_together = ("registry", "domain")
 
     def __repr__(self):
-        return f"RegistryInvitation(domain='{self.domain}', status='{self.status}')"
+        return (f"RegistryInvitation(registry_id='{self.registry_id}', "
+                f"domain='{self.domain}', status='{self.status}')")
 
     @transaction.atomic
     def accept(self, user):
@@ -178,7 +179,8 @@ class RegistryGrant(models.Model):
     to_domains = ArrayField(models.CharField(max_length=255))
 
     def __repr__(self):
-        return f"RegistryGrant(from_domain='{self.from_domain}', to_domains='{self.to_domains}')"
+        return (f"RegistryGrant(registry_id='{self.registry_id}', "
+                f"from_domain='{self.from_domain}', to_domains='{self.to_domains}')")
 
 
 class RegistryPermission(models.Model):
@@ -191,7 +193,8 @@ class RegistryPermission(models.Model):
         unique_together = ('registry', 'domain')
 
     def __repr__(self):
-        return f"RegistryPermission(domain='{self.domain}', read_only_group_id='{self.read_only_group_id}')"
+        return (f"RegistryPermission(registry_id='{self.registry_id}', "
+                f"domain='{self.domain}', read_only_group_id='{self.read_only_group_id}')")
 
 
 class RegistryAuditLog(models.Model):


### PR DESCRIPTION
## Summary
https://docs.google.com/document/d/1h1chIrRkDtnPVQzFJHuB7JbZq8S4HNQf2dBA8z_MCkg/edit#
This doesn't actually do anything yet, but since the config is behind the data registry feature flag it should be okay to merge in this incomplete state.  So far it adds a config box to the UI, saves it, and updates the suite file.

Here's what the `__repr__`s look like for some sample data:
```python
DataRegistry(id='1', domain='florida-covid', slug='florida-covid-registry')
RegistryGrant(registry_id='1', from_domain='florida-covid-mdc', to_domains='['florida-covid', 'florida-covid-jax']')
RegistryInvitation(registry_id='1', domain='florida-covid-mdc', status='accepted')
RegistryPermission(registry_id='1', domain='florida-covid-jax', read_only_group_id='f3fbb3313a65f33038cdeabcd2003df9')
```

## Feature Flag
Data registry

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
![image](https://user-images.githubusercontent.com/2367539/129935949-38bd2585-5339-4975-8017-5bcc155b3831.png)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
