### PR TITLE
Add checkbox toggle for SMS billable report visibility in the accounting UI + remove "show" filter in sms detailed reports

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -236,14 +236,6 @@ class BillingAccountBasicForm(forms.Form):
                     data_initial=json.dumps(self.initial.get('enterprise_admin_emails')),
                 )
             )
-            #eventually hide this w visible: is_customer_billing_account
-            additional_fields.append(hqcrispy.B3MultiField(
-                "SMS Billable Report Visible",
-                hqcrispy.MultiInlineField(
-                    'is_sms_billable_report_visible',
-                    data_bind="checked: is_sms_billable_report_visible",
-                ),
-            ))
             additional_fields.append(
                 crispy.Div(
                     crispy.Field(

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -108,6 +108,11 @@ class BillingAccountBasicForm(forms.Form):
         required=False,
         initial=False
     )
+    is_sms_billable_report_visible = forms.BooleanField(
+        label=ugettext_lazy("SMS Billable Report Visible"),
+        required=False,
+        initial=False
+    )
     enterprise_admin_emails = forms.CharField(
         label="Enterprise Admin Emails",
         required=False,
@@ -174,6 +179,7 @@ class BillingAccountBasicForm(forms.Form):
                 'email_list': contact_info.email_list,
                 'is_active': account.is_active,
                 'is_customer_billing_account': account.is_customer_billing_account,
+                'is_sms_billable_report_visible': account.is_sms_billable_report_visible,
                 'enterprise_admin_emails': account.enterprise_admin_emails,
                 'enterprise_restricted_signup_domains': ','.join(account.enterprise_restricted_signup_domains),
                 'invoicing_plan': account.invoicing_plan,
@@ -225,6 +231,13 @@ class BillingAccountBasicForm(forms.Form):
                         'enterprise_admin_emails',
                         css_class='input-xxlarge accounting-email-select2',
                         data_initial=json.dumps(self.initial.get('enterprise_admin_emails')),
+                    ),
+                    hqcrispy.B3MultiField(
+                        "SMS Billable Report Visible",
+                        hqcrispy.MultiInlineField(
+                            'is_sms_billable_report_visible',
+                            data_bind="checked: is_sms_billable_report_visible",
+                        )
                     ),
                     data_bind='visible: is_customer_billing_account',
                     data_initial=json.dumps(self.initial.get('enterprise_admin_emails')),
@@ -400,6 +413,7 @@ class BillingAccountBasicForm(forms.Form):
         account.name = self.cleaned_data['name']
         account.is_active = self.cleaned_data['is_active']
         account.is_customer_billing_account = self.cleaned_data['is_customer_billing_account']
+        account.is_sms_billable_report_visible = self.cleaned_data['is_sms_billable_report_visible']
         account.enterprise_admin_emails = self.cleaned_data['enterprise_admin_emails']
         account.enterprise_restricted_signup_domains = self.cleaned_data['enterprise_restricted_signup_domains']
         account.invoicing_plan = self.cleaned_data['invoicing_plan']

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -232,16 +232,19 @@ class BillingAccountBasicForm(forms.Form):
                         css_class='input-xxlarge accounting-email-select2',
                         data_initial=json.dumps(self.initial.get('enterprise_admin_emails')),
                     ),
-                    hqcrispy.B3MultiField(
-                        "SMS Billable Report Visible",
-                        hqcrispy.MultiInlineField(
-                            'is_sms_billable_report_visible',
-                            data_bind="checked: is_sms_billable_report_visible",
-                        )
-                    ),
                     data_bind='visible: is_customer_billing_account',
                     data_initial=json.dumps(self.initial.get('enterprise_admin_emails')),
                 )
+            )
+            additional_fields.append(
+                hqcrispy.B3MultiField(
+                    "SMS Billable Report Visible",
+                    hqcrispy.MultiInlineField(
+                        'is_sms_billable_report_visible',
+                        data_bind="checked: is_sms_billable_report_visible",
+                    ),
+                    data_bind='visible: is_customer_billing_account',
+                ),
             )
             additional_fields.append(
                 crispy.Div(

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -108,6 +108,11 @@ class BillingAccountBasicForm(forms.Form):
         required=False,
         initial=False
     )
+    is_sms_billable_report_visible = forms.BooleanField(
+        label=ugettext_lazy("SMS Billable Report Visible"),
+        required=False,
+        initial=False
+    )
     enterprise_admin_emails = forms.CharField(
         label="Enterprise Admin Emails",
         required=False,
@@ -174,6 +179,7 @@ class BillingAccountBasicForm(forms.Form):
                 'email_list': contact_info.email_list,
                 'is_active': account.is_active,
                 'is_customer_billing_account': account.is_customer_billing_account,
+                'is_sms_billable_report_visible': account.is_sms_billable_report_visible,
                 'enterprise_admin_emails': account.enterprise_admin_emails,
                 'enterprise_restricted_signup_domains': ','.join(account.enterprise_restricted_signup_domains),
                 'invoicing_plan': account.invoicing_plan,
@@ -230,6 +236,14 @@ class BillingAccountBasicForm(forms.Form):
                     data_initial=json.dumps(self.initial.get('enterprise_admin_emails')),
                 )
             )
+            #eventually hide this w visible: is_customer_billing_account
+            additional_fields.append(hqcrispy.B3MultiField(
+                "SMS Billable Report Visible",
+                hqcrispy.MultiInlineField(
+                    'is_sms_billable_report_visible',
+                    data_bind="checked: is_sms_billable_report_visible",
+                ),
+            ))
             additional_fields.append(
                 crispy.Div(
                     crispy.Field(
@@ -400,6 +414,7 @@ class BillingAccountBasicForm(forms.Form):
         account.name = self.cleaned_data['name']
         account.is_active = self.cleaned_data['is_active']
         account.is_customer_billing_account = self.cleaned_data['is_customer_billing_account']
+        account.is_sms_billable_report_visible = self.cleaned_data['is_sms_billable_report_visible']
         account.enterprise_admin_emails = self.cleaned_data['enterprise_admin_emails']
         account.enterprise_restricted_signup_domains = self.cleaned_data['enterprise_restricted_signup_domains']
         account.invoicing_plan = self.cleaned_data['invoicing_plan']

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -109,7 +109,7 @@ class BillingAccountBasicForm(forms.Form):
         initial=False
     )
     is_sms_billable_report_visible = forms.BooleanField(
-        label=ugettext_lazy("SMS Billable Report Visible"),
+        label="",
         required=False,
         initial=False
     )

--- a/corehq/apps/accounting/migrations/0057_add_sms_report_toggle.py
+++ b/corehq/apps/accounting/migrations/0057_add_sms_report_toggle.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0056_add_release_management'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='billingaccount',
+            name='is_sms_billable_report_visible',
+            field=models.BooleanField(default=False),
+        ),
+    ]
+

--- a/corehq/apps/accounting/migrations/0057_add_sms_report_toggle.py
+++ b/corehq/apps/accounting/migrations/0057_add_sms_report_toggle.py
@@ -1,5 +1,6 @@
 from django.db import migrations, models
 
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -13,4 +14,3 @@ class Migration(migrations.Migration):
             field=models.BooleanField(default=False),
         ),
     ]
-

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -383,6 +383,7 @@ class BillingAccount(ValidateModelMixin, models.Model):
     )
     is_active = models.BooleanField(default=True)
     is_customer_billing_account = models.BooleanField(default=False, db_index=True)
+    is_sms_billable_report_visible = models.BooleanField(default=False)
     enterprise_admin_emails = ArrayField(models.EmailField(), default=list, blank=True)
     enterprise_restricted_signup_domains = ArrayField(models.CharField(max_length=128), default=list, blank=True)
     invoicing_plan = models.CharField(
@@ -583,6 +584,12 @@ class BillingAccount(ValidateModelMixin, models.Model):
             render_to_string('accounting/email/invoice_autopay_setup.html', context),
             text_content=strip_tags(render_to_string('accounting/email/invoice_autopay_setup.html', context)),
         )
+
+    def _is_sms_billable_report_visible(domain):
+        account = BillingAccount.get_account_by_domain(domain)
+        if account.is_sms_billable_report_visible:
+            return True
+        return False
 
 
 class BillingContactInfo(models.Model):

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -585,11 +585,10 @@ class BillingAccount(ValidateModelMixin, models.Model):
             text_content=strip_tags(render_to_string('accounting/email/invoice_autopay_setup.html', context)),
         )
 
-    def _is_sms_billable_report_visible(domain):
+    @staticmethod
+    def should_show_sms_billable_report(domain):
         account = BillingAccount.get_account_by_domain(domain)
-        if account.is_sms_billable_report_visible:
-            return True
-        return False
+        return account.is_sms_billable_report_visible
 
 
 class BillingContactInfo(models.Model):

--- a/corehq/apps/accounting/static/accounting/js/billing_account_form.js
+++ b/corehq/apps/accounting/static/accounting/js/billing_account_form.js
@@ -9,12 +9,13 @@ hqDefine('accounting/js/billing_account_form', [
     ko,
     initialPageData
 ) {
-    var billingAccountFormModel = function (isActive, isCustomerBillingAccount, enterpriseAdminEmails) {
+    var billingAccountFormModel = function (isActive, isCustomerBillingAccount, enterpriseAdminEmails, isSMSBillableReportVisible) {
         'use strict';
         var self = {};
 
         self.is_active = ko.observable(isActive);
         self.is_customer_billing_account = ko.observable(isCustomerBillingAccount);
+        self.is_sms_billable_report_visible = ko.observable(isSMSBillableReportVisible);
         self.enterprise_admin_emails = ko.observable(enterpriseAdminEmails);
         self.showActiveAccounts = ko.computed(function () {
             return !self.is_active();
@@ -25,7 +26,8 @@ hqDefine('accounting/js/billing_account_form', [
 
     $(function () {
         var baForm = billingAccountFormModel(initialPageData.get('account_form_is_active'),
-            initialPageData.get('is_customer_billing_account'), initialPageData.get('enterprise_admin_emails'));
+            initialPageData.get('is_customer_billing_account'), initialPageData.get('enterprise_admin_emails'),
+            initialPageData.get('is_sms_billable_report_visible'));
         $('#account-form').koApplyBindings(baForm);
 
         $("#show_emails").click(function () {

--- a/corehq/apps/accounting/static/accounting/js/billing_account_form.js
+++ b/corehq/apps/accounting/static/accounting/js/billing_account_form.js
@@ -9,13 +9,13 @@ hqDefine('accounting/js/billing_account_form', [
     ko,
     initialPageData
 ) {
-    var billingAccountFormModel = function (isActive, isCustomerBillingAccount, enterpriseAdminEmails, isSMSBillableReportVisible) {
+    var billingAccountFormModel = function (isActive, isCustomerBillingAccount, enterpriseAdminEmails, isSmsBillableReportVisible) {
         'use strict';
         var self = {};
 
         self.is_active = ko.observable(isActive);
         self.is_customer_billing_account = ko.observable(isCustomerBillingAccount);
-        self.is_sms_billable_report_visible = ko.observable(isSMSBillableReportVisible);
+        self.is_sms_billable_report_visible = ko.observable(isSmsBillableReportVisible);
         self.enterprise_admin_emails = ko.observable(enterpriseAdminEmails);
         self.showActiveAccounts = ko.computed(function () {
             return !self.is_active();

--- a/corehq/apps/accounting/templates/accounting/accounts.html
+++ b/corehq/apps/accounting/templates/accounting/accounts.html
@@ -9,6 +9,7 @@
   {% initial_page_data 'account_form_is_active' basic_form.is_active.value %}
   {% initial_page_data 'is_customer_billing_account' basic_form.is_customer_billing_account.value %}
   {% initial_page_data 'enterprise_admin_emails' basic_form.enterprise_admin_emails.value %}
+  {% initial_page_data 'is_sms_billable_report_visible' basic_form.is_sms_billable_report_visible.value %}
 
   <ul class="nav nav-tabs sticky-tabs" id="user-settings-tabs">
     <li><a href="#account" data-toggle="tab">{% trans "Account" %}</a></li>

--- a/corehq/apps/enterprise/dispatcher.py
+++ b/corehq/apps/enterprise/dispatcher.py
@@ -3,7 +3,8 @@ from django.utils.decorators import method_decorator
 
 from corehq.apps.reports.dispatcher import ReportDispatcher
 from corehq.apps.enterprise.decorators import require_enterprise_admin
-
+from corehq.apps.accounting.models import BillingAccount
+from corehq.apps.hqwebapp.views import not_found
 
 class EnterpriseReportDispatcher(ReportDispatcher):
     prefix = 'enterprise_interface'
@@ -12,4 +13,6 @@ class EnterpriseReportDispatcher(ReportDispatcher):
     @method_decorator(login_and_domain_required)
     @method_decorator(require_enterprise_admin)
     def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
+        if BillingAccount._is_sms_billable_report_visible(args[0]):
+            return super().dispatch(request, *args, **kwargs)
+        return not_found(request)

--- a/corehq/apps/enterprise/dispatcher.py
+++ b/corehq/apps/enterprise/dispatcher.py
@@ -1,10 +1,11 @@
-from corehq.apps.domain.decorators import login_and_domain_required
 from django.utils.decorators import method_decorator
 
-from corehq.apps.reports.dispatcher import ReportDispatcher
-from corehq.apps.enterprise.decorators import require_enterprise_admin
 from corehq.apps.accounting.models import BillingAccount
+from corehq.apps.domain.decorators import login_and_domain_required
+from corehq.apps.enterprise.decorators import require_enterprise_admin
 from corehq.apps.hqwebapp.views import not_found
+from corehq.apps.reports.dispatcher import ReportDispatcher
+
 
 class EnterpriseReportDispatcher(ReportDispatcher):
     prefix = 'enterprise_interface'
@@ -13,6 +14,6 @@ class EnterpriseReportDispatcher(ReportDispatcher):
     @method_decorator(login_and_domain_required)
     @method_decorator(require_enterprise_admin)
     def dispatch(self, request, *args, **kwargs):
-        if BillingAccount._is_sms_billable_report_visible(args[0]):
+        if BillingAccount.should_show_sms_billable_report(args[0]):
             return super().dispatch(request, *args, **kwargs)
         return not_found(request)

--- a/corehq/apps/enterprise/interface.py
+++ b/corehq/apps/enterprise/interface.py
@@ -10,7 +10,6 @@ from corehq.apps.smsbillables.filters import (
     DateSentFilter,
     GatewayTypeFilter,
     HasGatewayFeeFilter,
-    ShowBillablesFilter,
 )
 from corehq.apps.enterprise.filters import EnterpriseDomainFilter
 from corehq.apps.accounting.models import (
@@ -40,7 +39,6 @@ class EnterpriseSMSBillablesReport(GenericTabularReport):
     fields = [
         DateSentFilter,
         DateCreatedFilter,
-        ShowBillablesFilter,
         EnterpriseDomainFilter,
         HasGatewayFeeFilter,
         GatewayTypeFilter,
@@ -89,10 +87,6 @@ class EnterpriseSMSBillablesReport(GenericTabularReport):
                 {
                     'name': DateCreatedFilter.optional_filter_slug(),
                     'value': DateCreatedFilter.optional_filter_string_value(self.request)
-                },
-                {
-                    'name': ShowBillablesFilter.slug,
-                    'value': ShowBillablesFilter.get_value(self.request, self.domain)
                 },
                 {
                     'name': EnterpriseDomainFilter.slug,
@@ -157,12 +151,6 @@ class EnterpriseSMSBillablesReport(GenericTabularReport):
                 DateCreatedFilter.get_start_date(self.request), DateCreatedFilter.get_end_date(self.request)
             )
             selected_billables = SmsBillable.filter_selected_billables_by_date(selected_billables, date_span)
-        show_billables = ShowBillablesFilter.get_value(
-            self.request, self.domain)
-        if show_billables:
-            selected_billables = SmsBillable.filter_selected_billables_show_billables(
-                selected_billables, show_billables
-            )
         domain = EnterpriseDomainFilter.get_value(self.request, self.domain)
         if domain:
             selected_billables = selected_billables.filter(

--- a/corehq/apps/enterprise/tests/test_interface.py
+++ b/corehq/apps/enterprise/tests/test_interface.py
@@ -56,36 +56,6 @@ class TestEnterpriseSMSBillablesReport(TestCase):
 
         self.assertEqual(len(results), 2)
 
-    def test_sms_billables_show_billables_true(self):
-        self.create_smsbillable(datetime(2021, 7, 12), True)
-        self.create_smsbillable(datetime(2021, 7, 1), True)
-        self.create_smsbillable(datetime(2021, 7, 5), False)
-
-        report = self.create_interface(
-            date_sent_startdate='2021-06-30',
-            date_sent_enddate='2021-07-30',
-            show_billables='valid'
-        )
-
-        results = report.get_all_rows
-
-        self.assertEqual(len(results), 2)
-
-    def test_sms_billables_show_billables_false(self):
-        self.create_smsbillable(datetime(2021, 7, 12), True)
-        self.create_smsbillable(datetime(2021, 7, 1), True)
-        self.create_smsbillable(datetime(2021, 7, 5), False)
-
-        report = self.create_interface(
-            date_sent_startdate='2021-06-30',
-            date_sent_enddate='2021-07-30',
-            show_billables='invalid'
-        )
-
-        results = report.get_all_rows
-
-        self.assertEqual(len(results), 1)
-
     def test_sms_billables_has_gateway_fee(self):
         gateway_fee = Decimal('8.9')
         self.create_smsbillable(datetime(2021, 7, 12), True, None)

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1,3 +1,4 @@
+from corehq.apps.enterprise.dispatcher import EnterpriseReportDispatcher
 from django.conf import settings
 from django.http import Http404
 from django.urls import reverse
@@ -13,7 +14,8 @@ from corehq import privileges, toggles
 from corehq.apps.accounting.dispatcher import (
     AccountingAdminInterfaceDispatcher,
 )
-from corehq.apps.accounting.models import Invoice, Subscription
+from corehq.apps.accounting.models import Invoice, Subscription, BillingAccount
+#from corehq.apps.accounting.forms import BillingAccountBasicForm
 from corehq.apps.accounting.utils import (
     domain_has_privilege,
     domain_is_on_trial,
@@ -1624,6 +1626,10 @@ class EnterpriseSettingsTab(UITab):
                 })
 
         items.append((_('Manage Enterprise'), enterprise_views))
+
+        if BillingAccount._is_sms_billable_report_visible(self.domain):
+            items.extend(EnterpriseReportDispatcher.navigation_sections(
+                request=self._request, domain=self.domain))
 
         return items
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1626,7 +1626,7 @@ class EnterpriseSettingsTab(UITab):
 
         items.append((_('Manage Enterprise'), enterprise_views))
 
-        if BillingAccount._is_sms_billable_report_visible(self.domain):
+        if BillingAccount.should_show_sms_billable_report(self.domain):
             items.extend(EnterpriseReportDispatcher.navigation_sections(
                 request=self._request, domain=self.domain))
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -15,7 +15,6 @@ from corehq.apps.accounting.dispatcher import (
     AccountingAdminInterfaceDispatcher,
 )
 from corehq.apps.accounting.models import Invoice, Subscription, BillingAccount
-#from corehq.apps.accounting.forms import BillingAccountBasicForm
 from corehq.apps.accounting.utils import (
     domain_has_privilege,
     domain_is_on_trial,


### PR DESCRIPTION
## Summary

Added a checkbox in the accounting UI that toggles a new `BillingAccount` property `is_sms_billable_report_visible` that determines whether to show the "SMS Detailed Report" tab item in the enterprise console. When unchecked, the url for the sms billable reports page will show a 404 error if accessed, since the report shouldn't be accessible/exist for certain accounts. 

The "show" filter field in the SMS detailed reports page has been removed so that users can only look at valid SMS by default.

Jira:
https://dimagi-dev.atlassian.net/browse/SS-194
https://dimagi-dev.atlassian.net/browse/SS-196

![checkbox](https://user-images.githubusercontent.com/33491742/130670217-47f560b9-5ff1-45d8-8122-5325e3f4537f.png)


## Product Description

The "show" filter field was removed. 
Before
![before](https://user-images.githubusercontent.com/33491742/130670216-0869bc40-f118-4cf3-879d-8cea59c6bfa6.png)
After
![after](https://user-images.githubusercontent.com/33491742/130670215-0500e442-aeec-4690-82d9-72b5b14280a1.png)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan

https://dimagi-dev.atlassian.net/browse/QA-3394 (Passed)

### Safety story

The toggle essentially just hides/unhides the report. 

### Rollback instructions

- [ ] This PR can be reverted after deploy with no further considerations 

This PR includes a migration that needs to be rolled back if the PR is reverted. 