### PR TITLE
Correct order of patched parameters

### DIFF
--- a/corehq/tabs/tests.py
+++ b/corehq/tabs/tests.py
@@ -50,7 +50,7 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
 
     @patch('corehq.apps.users.models.CouchUser')
     @patch('corehq.apps.domain.models.Domain')
-    def test_get_release_management_items_returns_none(self, mock_user, mock_domain):
+    def test_get_release_management_items_returns_none(self, mock_domain, mock_user):
         mock_user.is_domain_admin.return_value = False
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
@@ -61,7 +61,7 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
 
     @patch('corehq.apps.users.models.CouchUser')
     @patch('corehq.apps.domain.models.Domain')
-    def test_get_release_management_items_returns_none_with_admin(self, mock_user, mock_domain):
+    def test_get_release_management_items_returns_none_with_admin(self, mock_domain, mock_user):
         mock_user.is_domain_admin.return_value = True
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
@@ -72,7 +72,7 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
 
     @patch('corehq.apps.users.models.CouchUser')
     @patch('corehq.apps.domain.models.Domain')
-    def test_get_release_management_items_returns_none_with_domain_privilege(self, mock_user, mock_domain):
+    def test_get_release_management_items_returns_none_with_domain_privilege(self, mock_domain, mock_user):
         mock_user.is_domain_admin.return_value = False
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
@@ -83,7 +83,7 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
 
     @patch('corehq.apps.users.models.CouchUser')
     @patch('corehq.apps.domain.models.Domain')
-    def test_get_release_management_items_returns_some(self, mock_user, mock_domain):
+    def test_get_release_management_items_returns_some(self, mock_domain, mock_user):
         mock_user.is_domain_admin.return_value = True
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege, \

--- a/corehq/tabs/tests.py
+++ b/corehq/tabs/tests.py
@@ -46,10 +46,10 @@ class TestAccessToLinkedProjects(SimpleTestCase):
         self.assertFalse(items)
 
 
+@patch('corehq.apps.users.models.CouchUser')
+@patch('corehq.apps.domain.models.Domain')
 class TestAccessToReleaseManagementTab(SimpleTestCase):
 
-    @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.domain.models.Domain')
     def test_get_release_management_items_returns_none(self, mock_domain, mock_user):
         mock_user.is_domain_admin.return_value = False
 
@@ -59,8 +59,6 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
 
         self.assertFalse(items)
 
-    @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.domain.models.Domain')
     def test_get_release_management_items_returns_none_with_admin(self, mock_domain, mock_user):
         mock_user.is_domain_admin.return_value = True
 
@@ -70,8 +68,6 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
 
         self.assertFalse(items)
 
-    @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.domain.models.Domain')
     def test_get_release_management_items_returns_none_with_domain_privilege(self, mock_domain, mock_user):
         mock_user.is_domain_admin.return_value = False
 
@@ -81,8 +77,6 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
 
         self.assertFalse(items)
 
-    @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.domain.models.Domain')
     def test_get_release_management_items_returns_some(self, mock_domain, mock_user):
         mock_user.is_domain_admin.return_value = True
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
While reading [patch docs](https://docs.python.org/3/library/unittest.mock.html), I came across this:
> When you nest patch decorators the mocks are passed in to the decorated function in the same order they applied (the normal Python order that decorators are applied). This means from the bottom up...

which was not my understanding of python decorators, and I remembered tests I wrote that could potentially be impacted by this. Fortunately, both objects are just mocks, so we are still mocking the correct method `is_domain_admin`, just on a mocked domain rather than a mocked user. This is why tests still passed. This is mostly a change to be semantically correct.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
This is just a change to automated tests.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Very safe. Just changes how mocks are arranged in an already existing automated test.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
