### PR TITLE
Fixed pact imports

### DIFF
--- a/custom/_legacy/pact/reports/__init__.py
+++ b/custom/_legacy/pact/reports/__init__.py
@@ -48,7 +48,7 @@ class PactDrilldownReportMixin(object):
         return False
 
 
-from pact.reports import patient_list, dot, patient, chw_list, chw
+from pact.reports import patient, chw_list
 
 CUSTOM_REPORTS = (
     ("PACT Reports", (


### PR DESCRIPTION
## Summary
Followup for https://github.com/dimagi/commcare-hq/pull/30233/ which deleted these modules.

https://sentry.io/organizations/dimagi/issues/2597746117/

## Feature Flag
This is specific to the pact domain(s), which are currently 500ing.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan
No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
