### PR TITLE
Add tests for child and extension relationship

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/tests/data/case_relationship_tests.json
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/data/case_relationship_tests.json
@@ -964,6 +964,21 @@
         "outcome": [
             "L", "B", "C", "D", "E"
         ]
+    }, 
+    {
+        "name": "extension_and_child_relationship",
+        "owned": [
+            "parent"
+        ],
+        "subcases": [
+            ["child_and_extension", "parent"]
+        ],
+        "extensions": [
+            ["child_and_extension", "parent"]
+        ],
+        "outcome": [
+            "parent"
+        ]
     }
 
 ]


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Corresponding core PR: https://github.com/dimagi/commcare-core/pull/1031
Added a test for a scenario where both `child` and `extension` relationship is present between cases. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [ ] Risk label is set correctly
- [ ] All migrations are backwards compatible and won't block deploy
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
