### PR TITLE
Remove unused dev dependencies

### DIFF
--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -15,8 +15,6 @@ Sphinx~=4.1.2
 sphinx-rtd-theme~=0.5.2
 docutils==0.16
 sphinxcontrib-django~=0.5
-recommonmark
-graphviz==0.16
 
 # linting/formatting
 flake8

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -62,8 +62,6 @@ colorama==0.4.3
     #   sniffer
 commcaretranslationchecker==0.9.7
     # via -r base-requirements.in
-commonmark==0.9.1
-    # via recommonmark
 concurrent-log-handler==0.9.12
     # via -r base-requirements.in
 contextlib2==0.6.0.post1
@@ -196,7 +194,6 @@ dnspython==1.15.0
 docutils==0.16
     # via
     #   -r dev-requirements.in
-    #   recommonmark
     #   sphinx
     #   sphinx-rtd-theme
 dropbox==9.3.0
@@ -244,8 +241,6 @@ gitdb==4.0.7
 gitpython==3.1.14
     # via transifex-client
 gnureadline==8.0.0
-    # via -r dev-requirements.in
-graphviz==0.16
     # via -r dev-requirements.in
 greenlet==0.4.17
     # via
@@ -481,8 +476,6 @@ radon==5.0.1
     # via -r test-requirements.in
 rcssmin==1.0.6
     # via django-compressor
-recommonmark==0.7.1
-    # via -r dev-requirements.in
 redis==3.5.3
     # via
     #   -r base-requirements.in
@@ -584,7 +577,6 @@ soupsieve==2.0.1
 sphinx==4.1.2
     # via
     #   -r dev-requirements.in
-    #   recommonmark
     #   sphinx-rtd-theme
 sphinx-rtd-theme==0.5.2
     # via -r dev-requirements.in


### PR DESCRIPTION
Remove unused dev dependencies

- `graphviz` (previous usage unknown, added in #16066)
- `recommonmark` (usage removed in #30044)

Closes: #30260

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests, all code already removed.

### QA Plan

No QA.

### Safety story

These removals do not affect any code and are safe to deploy.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
