### PR TITLE
Repair translations

### DIFF
--- a/corehq/apps/enterprise/templates/enterprise/enterprise_permissions.html
+++ b/corehq/apps/enterprise/templates/enterprise/enterprise_permissions.html
@@ -7,13 +7,13 @@
 
 {% block page_content %}
   <p class="lead">
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       Enterprise Permissions
     {% endblocktrans %}
   </p>
 
   <p class="help-block">
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       Give web users who have access to a controlling project space the same level of access to your other project spaces.
       Such users will neither get email invitations to join these project spaces, nor will they appear as members in those project spaces.
     {% endblocktrans %}
@@ -29,7 +29,7 @@
     </form>
   {% else %}
     <p class="help-block">
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         To turn on enterprise permissions, select the controlling project space.
       {% endblocktrans %}
     </p>
@@ -61,11 +61,11 @@
     <div class="col-sm-6">
       <p class="help-block">
         {% if source_domain %}
-          {% blocktrans %}
+          {% blocktrans trimmed %}
             Web users in <strong>{{ source_domain }}</strong> will also have permissions in the following project spaces.
           {% endblocktrans %}
         {% else %}
-          {% blocktrans %}
+          {% blocktrans trimmed %}
             Web users in the controlling project space will also have permissions in the following project spaces.
           {% endblocktrans %}
         {% endif %}
@@ -75,11 +75,11 @@
     <div class="col-sm-6">
       <p class="help-block">
         {% if source_domain %}
-          {% blocktrans %}
+          {% blocktrans trimmed %}
             Web users in <strong>{{ source_domain }}</strong> will <strong>not</strong> have permissions in the following project spaces.
           {% endblocktrans %}
         {% else %}
-          {% blocktrans %}
+          {% blocktrans trimmed %}
             Web users in the controlling project space will <strong>not</strong> have permissions in the following project spaces.
           {% endblocktrans %}
         {% endif %}

--- a/corehq/apps/enterprise/templates/enterprise/partials/enterprise_permissions_table.html
+++ b/corehq/apps/enterprise/templates/enterprise/partials/enterprise_permissions_table.html
@@ -33,7 +33,7 @@
   </table>
 {% else %}
   <div class="alert alert-info">
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       No project spaces found.
     {% endblocktrans %}
   </div>

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -382,7 +382,7 @@ def add_enterprise_permissions_domain(request, domain, target_domain):
 
     redirect = reverse("enterprise_permissions", args=[domain])
     if target_domain not in config.account.get_domains():
-        messages.error(request, _("Could not add {}}.").format(target_domain))
+        messages.error(request, _("Could not add {}.").format(target_domain))
         return HttpResponseRedirect(redirect)
 
     if target_domain not in config.domains:

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/manage_downstream_domains_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/manage_downstream_domains_tab.html
@@ -5,7 +5,7 @@
   <div data-bind="if: domain_links().length">
     <h3>{% trans "Manage Downstream Project Spaces" %}</h3>
     <p>
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         This project space is an upstream project space for the project spaces listed below.<br/>
         <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about Linked Project Spaces.
       {% endblocktrans %}
@@ -56,12 +56,12 @@
                     </div>
                     <div class="modal-body">
                       <h4>
-                        {% blocktrans %}
+                        {% blocktrans trimmed %}
                           Are you sure you want to remove the downstream link to <b data-bind="text: linked_domain"></b>?
                         {% endblocktrans %}
                       </h4>
                       <p>
-                        {% blocktrans %}
+                        {% blocktrans trimmed %}
                           <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about what happens when downstream project space links are removed.
                         {% endblocktrans %}
                       </p>

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/pull_release_content_tab.html
@@ -4,7 +4,7 @@
 <div id="ko-tabs-pull-content" data-bind="with: $root.pullReleaseContentViewModel">
   <div data-bind="if: domainLink">
     <p>
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         This project space is linked to the upstream project space <a data-bind="attr: {'href': domainLink.upstreamUrl}, text: domainLink.master_domain"></a>.<br/>
         The content below can be synced with the existing content in the upstream project space.<br/>
         <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about pulling content with Linked Project Spaces.
@@ -46,12 +46,12 @@
                     </div>
                     <div class="modal-body">
                       <h4>
-                        {% blocktrans %}
+                        {% blocktrans trimmed %}
                           Are you sure you want to overwrite <b data-bind="text: name"></b>?
                         {% endblocktrans %}
                       </h4>
                       <p>
-                        {% blocktrans %}
+                        {% blocktrans trimmed %}
                           This will pull <!-- ko text: name --><!-- /ko --> from the upstream project space <b data-bind="text: $parent.domainLink.master_domain"></b>, overwriting the existing <!-- ko text: name --><!-- /ko -->.<br/>
                           <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about pulling content from an upstream project space into a downstream project space.
                         {% endblocktrans %}

--- a/hqscripts/management/commands/makemessages.py
+++ b/hqscripts/management/commands/makemessages.py
@@ -1,0 +1,23 @@
+from django.core.management.commands import makemessages
+
+
+class Command(makemessages.Command):
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument('--no-fuzzy', action='store_true', help='Remove fuzzy strings.')
+
+    def handle(self, *args, **options):
+        no_fuzzy = options['no_fuzzy']
+        if no_fuzzy:
+            # The underlying parser only passes custom msgattrib_options if '--no-obsolete' is true,
+            # so we have to do a bit of hacking here
+            no_obsolete = options['no_obsolete']
+            if no_obsolete:
+                # If we are removing obsolete messages already, just add in removing fuzzy messages
+                self.msgattrib_options += ['--no-fuzzy']
+            else:
+                # Otherwise, we need to fake obsolete messages while only actually removing fuzzy messages
+                options['no_obsolete'] = True
+                self.msgattrib_options = ['--no-fuzzy']
+
+        super().handle(*args, **options)

--- a/scripts/update-translations.sh
+++ b/scripts/update-translations.sh
@@ -10,6 +10,30 @@ function abort () {
     exit 1
 }
 
+function help () {
+    echo "Update Translations"
+    echo
+    echo "Syntax: scripts/updateTranslations [-h|--no-fuzzy|--no-obsolete]"
+    echo "options:"
+    echo " --no-fuzzy   Remove fuzzy translations"
+    echo " --no-obsolte Remove obsolete translations"
+    echo " -h|--help    Print this help"
+    echo
+}
+
+while getopts ":h-:" option; do
+    if [ "$option" = "-" ]; then
+        option="${OPTARG%%=*}"
+    fi
+
+    case $option in
+        h | help )
+            help
+            exit;;
+    esac
+done
+
+
 has_local_changes=`git diff-index HEAD` && true
 if [[ $has_local_changes ]]
 then
@@ -42,10 +66,10 @@ echo "Pulling translations from transifex"
 tx pull -f
 
 echo "Gathering all translation strings.  Note that this will probably take a while"
-./manage.py makemessages --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs/_build' --no-obsolete --no-fuzzy
+./manage.py makemessages --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs/_build' $@
 
 echo "Gathering javascript translation strings.  This will also probably take a while"
-./manage.py makemessages -d djangojs --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs' --no-obsolete --no-fuzzy
+./manage.py makemessages -d djangojs --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs' $@
 
 set +e   # Temporarily disable strict mode so we can respond any failure
 echo "Compiling translation files."

--- a/scripts/update-translations.sh
+++ b/scripts/update-translations.sh
@@ -42,10 +42,10 @@ echo "Pulling translations from transifex"
 tx pull -f
 
 echo "Gathering all translation strings.  Note that this will probably take a while"
-./manage.py makemessages --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs/_build'
+./manage.py makemessages --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs/_build' --no-obsolete --no-fuzzy
 
 echo "Gathering javascript translation strings.  This will also probably take a while"
-./manage.py makemessages -d djangojs --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs'
+./manage.py makemessages -d djangojs --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs' --no-obsolete --no-fuzzy
 
 set +e   # Temporarily disable strict mode so we can respond any failure
 echo "Compiling translation files."


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12577. This ticket aims to first make translations work, then fix them more thoroughly in a later ticket. The issue is being caused by translations containing a newline character being paired with a Portuguese translation which does not. Because none of the new translations actually needed the newline character, it was possible to repair translations simply by switching new instances of `blocktrans` with `blocktrans trimmed`.

However, this is mostly the simplest fix we could do -- while gettext would reject translating:
`\nMy English String` with `My Portuguese String`, it is perfectly happy to translate `My English String` with `My Portuguese String`, so there may still be incorrect translations generated (that would have been generated with the previous process, also).

I believe that one of the main ways that this specific Portuguese string ('Relatorio Semanal aos Coordinadores do Distrito e os NEDs') is being pulled in, is that the translation system looks at previous 'obsolete' and 'fuzzy' translations, and uses those to infer new translations. Since it doesn't appear we use either of these types of translations, I thought it was best to modify our process to generate translations without fuzzy or obsolete translations.

One thing to keep in mind: 'Obsolete' translations can occur when a translation is committed, then the code it translates is reverted. If that code is later re-introduced, any previous translations will have to be re-done. Without this change, re-introduced code would pick up the old translations.

UPDATE: Modified _update_translations.sh_ to no longer automatically remove fuzzy and obsolete strings. Instead, it just passes through whatever arguments it receives, allowing the user to pass `--no-obsolete` and `--no-fuzzy` if that is the desired behavior. These extra translations should definitely be cleaned up now, but it's probably safer to not use these options every time we deploy.

Note: There is no reason for that Portuguese string to be in non-Portuguese translation files. A future ticket should handle removing all instances of this from non-Portuguese files.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests

### QA Plan

The changes here would potentially affect visible whitespace for strings. As I think it would be difficult for QA to pick up on which strings should look which way, I think QA is unnecessary, and am relying on local testing.

### Safety story
I've run the translation processes locally (commenting out the commit code), and had @gherceg verify that the changes don't affect whitespace for the templates he was familiar with.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
