### PR TITLE
[fix] do not invoice paused subscriptions with $0 invoices

### DIFF
--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -101,7 +101,9 @@ class DomainInvoiceFactory(object):
                 & Q(date_end__gt=F('date_start'))
             ),
             subscriber=self.subscriber,
-            date_start__lte=self.date_end
+            date_start__lte=self.date_end,
+        ).exclude(
+            plan_version__plan__edition=SoftwarePlanEdition.PAUSED,
         ).order_by('date_start', 'date_end').all()
         return list(subscriptions)
 

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -365,8 +365,7 @@ class CustomerAccountInvoiceFactory(object):
 
     def create_invoice(self):
         for sub in self.account.subscription_set.filter(do_not_invoice=False):
-            if not sub.plan_version.plan.edition == SoftwarePlanEdition.COMMUNITY \
-                    and should_create_invoice(sub, sub.subscriber.domain, self.date_start, self.date_end):
+            if should_create_invoice(sub, sub.subscriber.domain, self.date_start, self.date_end):
                 self.subscriptions[sub.plan_version].append(sub)
         if not self.subscriptions:
             return
@@ -430,6 +429,11 @@ class CustomerAccountInvoiceFactory(object):
 
 
 def should_create_invoice(subscription, domain, invoice_start, invoice_end):
+    if subscription.plan_version.plan.edition in [
+        SoftwarePlanEdition.COMMUNITY,
+        SoftwarePlanEdition.PAUSED,
+    ]:
+        return False
     if not domain_exists(domain) and deleted_domain_exists(domain):
         # domain has been deleted, ignore
         return False

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -365,7 +365,8 @@ class CustomerAccountInvoiceFactory(object):
 
     def create_invoice(self):
         for sub in self.account.subscription_set.filter(do_not_invoice=False):
-            if should_create_invoice(sub, sub.subscriber.domain, self.date_start, self.date_end):
+            if (not sub.plan_version.plan.edition == SoftwarePlanEdition.COMMUNITY
+                    and should_create_invoice(sub, sub.subscriber.domain, self.date_start, self.date_end)):
                 self.subscriptions[sub.plan_version].append(sub)
         if not self.subscriptions:
             return
@@ -429,10 +430,7 @@ class CustomerAccountInvoiceFactory(object):
 
 
 def should_create_invoice(subscription, domain, invoice_start, invoice_end):
-    if subscription.plan_version.plan.edition in [
-        SoftwarePlanEdition.COMMUNITY,
-        SoftwarePlanEdition.PAUSED,
-    ]:
+    if subscription.plan_version.plan.edition == SoftwarePlanEdition.PAUSED:
         return False
     if not domain_exists(domain) and deleted_domain_exists(domain):
         # domain has been deleted, ignore

--- a/corehq/apps/accounting/tests/test_invoice_factory.py
+++ b/corehq/apps/accounting/tests/test_invoice_factory.py
@@ -125,6 +125,21 @@ class TestDomainInvoiceFactory(BaseAccountingTest):
         community_ranges = self.invoice_factory._get_community_ranges(subscriptions)
         self.assertEqual(community_ranges, [(self.invoice_start, self.invoice_end + datetime.timedelta(days=1))])
 
+    def test_paused_plan_generates_no_invoice(self):
+        """
+        Ensure that paused plans do not generate invoices.
+        """
+        paused_plan = generator.subscribable_plan_version(
+            edition=SoftwarePlanEdition.PAUSED
+        )
+        Subscription.new_domain_subscription(
+            self.account, self.domain.name, paused_plan,
+            date_start=self.invoice_start,
+            date_end=self.invoice_end + datetime.timedelta(days=1),
+
+        )
+        self.assertListEqual(self.invoice_factory._get_subscriptions(), [])
+
 
 class TestInvoicingMethods(BaseAccountingTest):
 

--- a/corehq/apps/accounting/tests/test_invoice_factory.py
+++ b/corehq/apps/accounting/tests/test_invoice_factory.py
@@ -185,6 +185,28 @@ class TestInvoicingMethods(BaseAccountingTest):
         ))
         trial_domain.delete()
 
+    def test_should_not_invoice_paused_plan(self):
+        """
+        Ensure that paused plans do not generate a CustomerInvoice
+        """
+        paused_domain = generator.arbitrary_domain()
+        self.addCleanup(paused_domain.delete)
+        paused_plan = generator.subscribable_plan_version(
+            edition=SoftwarePlanEdition.PAUSED
+        )
+        paused_plan.plan.is_customer_software_plan = True
+        subscription = Subscription.new_domain_subscription(
+            self.account, paused_domain.name, paused_plan,
+            date_start=self.invoice_start,
+
+        )
+        self.assertFalse(should_create_invoice(
+            subscription=subscription,
+            domain=subscription.subscriber.domain,
+            invoice_start=self.invoice_start,
+            invoice_end=self.invoice_end
+        ))
+
     def test_should_not_invoice_without_subscription_charges(self):
         feature_charge_domain = generator.arbitrary_domain()
         subscription = Subscription.new_domain_subscription(


### PR DESCRIPTION
## Summary
Don't send out invoices for paused subscriptions (which always result in $0 invoices anyway).

Related ticket:
https://dimagi-dev.atlassian.net/browse/SS-206

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Yes, and new tests added

### QA Plan
Tests are very much sufficient

### Safety story
Lots of tests. Simple, clear changes

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
