### PR TITLE
serial task and kill if modified

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1098,7 +1098,8 @@ class ConfigureNewReportBase(forms.Form):
                     for property_name, value in self._get_data_source_configuration_kwargs().items():
                         setattr(data_source, property_name, value)
                     data_source.save()
-                    tasks.rebuild_indicators.delay(data_source._id, source='report_builder_update')
+                    now = datetime.datetime.utcnow()
+                    tasks.rebuild_indicators.delay(data_source._id, source='report_builder_update', trigger_time=now)
 
     def create_report(self):
         """

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -89,7 +89,7 @@ def _build_indicators(config, document_store, relevant_ids):
             adapter.best_effort_save(doc)
 
 
-@serial_task('{indicator_config_id}', default_retry_delay=60 * 10, timeout=3 * 60 * 60, max_retries=5, queue=UCR_CELERY_QUEUE, ignore_result=True)
+@serial_task('{indicator_config_id}', default_retry_delay=60 * 10, timeout=3 * 60 * 60, max_retries=20, queue=UCR_CELERY_QUEUE, ignore_result=True)
 def rebuild_indicators(indicator_config_id, initiated_by=None, limit=-1, source=None, engine_id=None, diffs=None, trigger_time=None):
     config = _get_config_by_id(indicator_config_id)
     if trigger_time is not None and trigger_time < config.last_modified:

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -92,7 +92,7 @@ def _build_indicators(config, document_store, relevant_ids):
 @serial_task('{indicator_config_id}', default_retry_delay=60 * 10, timeout=3 * 60 * 60, max_retries=5, queue=UCR_CELERY_QUEUE, ignore_result=True)
 def rebuild_indicators(indicator_config_id, initiated_by=None, limit=-1, source=None, engine_id=None, diffs=None, trigger_time=None):
     config = _get_config_by_id(indicator_config_id)
-    if trigger_time is not None and trigger_time > config.last_modified:
+    if trigger_time is not None and trigger_time < config.last_modified:
         return
 
     success = _('Your UCR table {} has finished rebuilding in {}').format(config.table_id, config.domain)

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -89,9 +89,12 @@ def _build_indicators(config, document_store, relevant_ids):
             adapter.best_effort_save(doc)
 
 
-@task(serializer='pickle', queue=UCR_CELERY_QUEUE, ignore_result=True)
-def rebuild_indicators(indicator_config_id, initiated_by=None, limit=-1, source=None, engine_id=None, diffs=None):
+@serial_task('{indicator_config_id}', default_retry_delay=60 * 10, timeout=3 * 60 * 60, max_retries=5, queue=UCR_CELERY_QUEUE, ignore_result=True)
+def rebuild_indicators(indicator_config_id, initiated_by=None, limit=-1, source=None, engine_id=None, diffs=None, trigger_time=None):
     config = _get_config_by_id(indicator_config_id)
+    if trigger_time is not None and trigger_time > config.last_modified:
+        return
+
     success = _('Your UCR table {} has finished rebuilding in {}').format(config.table_id, config.domain)
     failure = _('There was an error rebuilding Your UCR table {} in {}.').format(config.table_id, config.domain)
     send = False


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12510

I am not totally sold on this approach, but I think it may be a step in the right direction and am curious what people think. The PR includes two separate parts.

The first is simply to make this task a serial task with the lock keyed on the data source id so that we will never have two rebuilds running at the same time for the same data source. This is nice both because thats a dangerous situation, having them both modifying the data source, and because it ensures no large data source will monopolize the queue.

The second change is to more directly deal with the issue in the ticket (someone kicking off rebuilds repeatedly that each ran for hours). It makes it so that the automated rebuilds kicked off by the report builder will early exit if the data source has been changed since it was kicked off. This will hopefully mean that when someone kicks off multiple in quick succession (with repeated saving), only the last will actually run.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
