### PR TITLE
Fix multiselect knockout binding bug

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -161,8 +161,8 @@ hqDefine('hqwebapp/js/multiselect_utils', [
         },
         update: function (element, valueAccessor) {
             var properties = valueAccessor();
-            // have to access the observable to get the `update` method to fire on changes
             if (properties.options) {
+                // have to access the observable to get the `update` method to fire on changes to options
                 ko.unwrap(properties.options());
             }
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -142,34 +142,38 @@ hqDefine('hqwebapp/js/multiselect_utils', [
 
     /*
      * A custom binding for setting multiselect properties in knockout content.
-     * This binding does not handle dynamic properties, but could be extended to do so.
-     * For a list of available options, see http://loudev.com/ under Options
+     * The only dynamic part of this binding are the options
+     * For a list of configurable properties, see http://loudev.com/ under Options
      */
-    ko.bindingHandlers.multiselect = {
+    ko.bindingHandlers.multiselectProperties = {
         init: function (element, valueAccessor) {
-            var options = valueAccessor();
+            var properties = valueAccessor();
             multiselect_utils.createFullMultiselectWidget(
                 element,
-                options.selectableHeaderTitle || gettext("Items"),
-                options.selectedHeaderTitle || gettext("Selected items"),
-                options.searchItemTitle || gettext("Search items")
+                properties.selectableHeaderTitle || gettext("Items"),
+                properties.selectedHeaderTitle || gettext("Selected items"),
+                properties.searchItemTitle || gettext("Search items")
             );
-        },
-    };
-
-    /*
-    * A custom binding for dynamically updating select options when using the multiselect binding
-    * Replace the `options` binding with `multiselectOptions`, and the binding will take care of the rest
-    */
-    ko.bindingHandlers.multiselectOptions = {
-        init: function (element, valueAccessor) {
-            // add the `options` binding to the element, valueAccessor() should return an observable
-            ko.applyBindingsToNode(element, {options: valueAccessor()});
+            if (properties.options) {
+                // add the `options` binding to the element, valueAccessor() should return an observable
+                ko.applyBindingsToNode(element, {options: properties.options});
+            }
         },
         update: function (element, valueAccessor) {
+            var properties = valueAccessor();
             // have to access the observable to get the `update` method to fire on changes
-            ko.unwrap(valueAccessor());
-            $(element).multiSelect('refresh');
+            if (properties.options) {
+                ko.unwrap(properties.options());
+            }
+
+            // multiSelect('refresh') breaks existing click handlers, so the alternative is to destroy and rebuild
+            $(element).multiSelect('destroy');
+            multiselect_utils.createFullMultiselectWidget(
+                element,
+                properties.selectableHeaderTitle || gettext("Items"),
+                properties.selectedHeaderTitle || gettext("Selected items"),
+                properties.searchItemTitle || gettext("Search items")
+            );
         },
     };
 

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -253,6 +253,7 @@ hqDefine("linked_domain/js/domain_links", [
             selectableHeaderTitle: gettext("All project spaces"),
             selectedHeaderTitle: gettext("Project spaces to push to"),
             searchItemTitle: gettext("Search project spaces"),
+            options: self.localDownstreamDomains,
         };
 
         self.canPush = ko.computed(function () {

--- a/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/tabs/push_release_content_tab.html
@@ -19,7 +19,7 @@
         <div class="col-sm-9 col-md-10 controls">
           <select multiple class="form-control"
                   data-bind="selectedOptions: modelsToPush,
-                             multiselect: {
+                             multiselectProperties: {
                                  selectableHeaderTitle: '{% trans_html_attr "All content" %}',
                                  selectedHeaderTitle: '{% trans_html_attr "Content to push" %}',
                                  searchItemTitle: '{% trans_html_attr "Search content" %}',
@@ -36,9 +36,7 @@
         </label>
         <div class="col-sm-9 col-md-10 controls">
           <select multiple class="form-control"
-                  data-bind="selectedOptions: domainsToPush,
-                             multiselect: multiselectProperties,
-                             multiselectOptions: localDownstreamDomains">
+                  data-bind="selectedOptions: domainsToPush, multiselectProperties: multiselectProperties">
           </select>
         </div>
       </div>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-12571)

My most recent change in `multiselect_utils.js` was an attempt to add a custom knockout binding in addition to the existing custom `multiselect` binding to update `<select>` options dynamically. I created the `multiselectOptions` binding which achieved the dynamic updates, but introduced a bug in that the "Add All" and "Remove All" buttons that are part of the bootstrap multiselect element were no longer functioning properly, as observed in the ticket linked above.

Upon further investigation, I've pinned this down to the `$(element).multiSelect('refresh');` line. I'm not sure why, but the `refresh` call does not achieve the result I want, and instead removes the existing click handlers for the Add All and Remove All buttons added within `multiselect_utils.js`. The alternative approach is to rebuild the entire multiselect view, which while more resource intensive, is relatively safe because this only occurs when the view is first loaded, and when domain links are added/removed.

I consolidated the 2 existing custom bindings into one for 2 reasons:
- this made rebuilding the multiselect widget a bit easier since I had access to all of the multiselect properties
- I think it makes more sense to have one binding. The reason I had 2 is because having a binding named `multiselect` seemed to conflict with an existing bootstrap binding _or something like that_. Basically, I could only pass properties specified in the bootstrap multiselect widget and not custom properties like `options`. Renaming the custom binding solved this issue for me, and as far as I can tell, linked domains is the only place we use the custom knockout binding. Everywhere else uses `multiselect_utils.js` directly. @orangejenny does that sound right?

Last but not least, I was about to refactor the creation of the multiselect widget a bit, and move the default property values (selectableHeaderTitle, selectedHeaderTitle, etc) into the create method. However this would change the method signature for creating a multiselect widget, and I don't want to hold up this bug fix with a refactor that likely needs more attention/QA. I will do so on a separate PR.

Longer PR description than expected. Thanks for bearing with me.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested. Will test on staging as well.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
