### PR TITLE
Remove Couch: data_pipeline_audit, hqadmin

### DIFF
--- a/corehq/apps/data_pipeline_audit/dbacessors.py
+++ b/corehq/apps/data_pipeline_audit/dbacessors.py
@@ -2,19 +2,12 @@ from collections import Counter
 
 import dateutil
 
-from casexml.apps.case.models import CommCareCase
 from couchforms.const import DEVICE_LOG_XMLNS
-from couchforms.models import all_known_formlike_doc_types
 
 from corehq.apps import es
-from corehq.apps.domain.dbaccessors import (
-    get_doc_count_in_domain_by_type,
-    get_doc_ids_in_domain_by_type,
-)
 from corehq.apps.es import aggregations
 from corehq.form_processor.backends.sql.dbaccessors import doc_type_to_state
 from corehq.form_processor.models import CommCareCaseSQL, XFormInstanceSQL
-from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 
 
@@ -96,52 +89,6 @@ def get_es_user_counts_by_doc_type(domain):
 
 
 def get_primary_db_form_counts(domain, startdate=None, enddate=None):
-    if should_use_sql_backend(domain):
-        return _get_sql_forms_by_doc_type(domain, startdate, enddate)
-    else:
-        return _get_couch_forms_by_doc_type(domain)
-
-
-def get_primary_db_form_ids(domain, doc_type, startdate, enddate):
-    if should_use_sql_backend(domain):
-        return get_sql_form_ids(domain, doc_type, startdate, enddate)
-    else:
-        # date filtering not supported for couch
-        return set(get_doc_ids_in_domain_by_type(domain, doc_type, CommCareCase.get_db()))
-
-
-def get_primary_db_case_counts(domain, startdate=None, enddate=None):
-    if should_use_sql_backend(domain):
-        return _get_sql_cases_by_doc_type(domain, startdate, enddate)
-    else:
-        return _get_couch_cases_by_doc_type(domain)
-
-
-def get_primary_db_case_ids(domain, doc_type, startdate, enddate):
-    if should_use_sql_backend(domain):
-        return get_sql_case_ids(domain, doc_type, startdate, enddate)
-    else:
-        # date filtering not supported for couch
-        return set(get_doc_ids_in_domain_by_type(domain, doc_type, CommCareCase.get_db()))
-
-
-def _get_couch_forms_by_doc_type(domain):
-    return _get_couch_doc_counts(CommCareCase.get_db(), domain, all_known_formlike_doc_types())
-
-
-def _get_couch_cases_by_doc_type(domain):
-    return _get_couch_doc_counts(CommCareCase.get_db(), domain, ('CommCareCase', 'CommCareCase-Deleted'))
-
-
-def _get_couch_doc_counts(couch_db, domain, doc_types):
-    counter = Counter()
-    for doc_type in doc_types:
-        count = get_doc_count_in_domain_by_type(domain, doc_type, couch_db)
-        counter.update({doc_type: count})
-    return counter
-
-
-def _get_sql_forms_by_doc_type(domain, startdate=None, enddate=None):
     counter = Counter()
     for db_alias in get_db_aliases_for_partitioned_query():
         queryset = XFormInstanceSQL.objects.using(db_alias).filter(domain=domain)
@@ -159,7 +106,7 @@ def _get_sql_forms_by_doc_type(domain, startdate=None, enddate=None):
     return counter
 
 
-def _get_sql_cases_by_doc_type(domain, startdate=None, enddate=None):
+def get_primary_db_case_counts(domain, startdate=None, enddate=None):
     counter = Counter()
     for db_alias in get_db_aliases_for_partitioned_query():
         queryset = CommCareCaseSQL.objects.using(db_alias).filter(domain=domain)
@@ -173,7 +120,7 @@ def _get_sql_cases_by_doc_type(domain, startdate=None, enddate=None):
     return counter
 
 
-def get_sql_case_ids(domain, doc_type, startdate, enddate):
+def get_primary_db_case_ids(domain, doc_type, startdate, enddate):
     sql_ids = set()
     deleted = doc_type == 'CommCareCase-Deleted'
     for db_alias in get_db_aliases_for_partitioned_query():
@@ -190,7 +137,7 @@ def get_sql_case_ids(domain, doc_type, startdate, enddate):
     return sql_ids
 
 
-def get_sql_form_ids(domain, doc_type, startdate, enddate):
+def get_primary_db_form_ids(domain, doc_type, startdate, enddate):
     sql_ids = set()
     state = doc_type_to_state[doc_type]
     for db_alias in get_db_aliases_for_partitioned_query():

--- a/corehq/apps/data_pipeline_audit/management/commands/compare_doc_counts.py
+++ b/corehq/apps/data_pipeline_audit/management/commands/compare_doc_counts.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand
 
 from corehq.apps.data_pipeline_audit.tools import get_doc_counts_for_domain
-from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.util.markup import (
     CSVRowFormatter,
     SimpleTableWriter,
@@ -32,9 +31,8 @@ class Command(BaseCommand):
         writer = SimpleTableWriter(self.stdout, row_formatter)
         writer.write_headers(['Domain', 'Backend', 'Doc Type', 'Primary', 'ES'])
         for domain in domains:
-            backend = 'sql' if should_use_sql_backend(domain) else 'couch'
             rows = get_doc_counts_for_domain(domain)
-            writer.write_rows(((domain, backend) + row for row in rows))
+            writer.write_rows(((domain, 'sql') + row for row in rows))
 
 
 def _get_row_color(row):

--- a/corehq/apps/data_pipeline_audit/management/commands/compare_doc_ids.py
+++ b/corehq/apps/data_pipeline_audit/management/commands/compare_doc_ids.py
@@ -8,7 +8,6 @@ from itertools import zip_longest
 from corehq.util.argparse_types import date_type
 from couchforms.models import doc_types
 
-from corehq.apps.change_feed.document_types import CASE_DOC_TYPES
 from corehq.apps.data_pipeline_audit.dbacessors import (
     get_es_case_counts,
     get_es_case_ids,
@@ -24,7 +23,6 @@ from corehq.apps.users.dbaccessors import (
     get_mobile_user_ids,
 )
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.utils import should_use_sql_backend
 from corehq.util.markup import (
     CSVRowFormatter,
     SimpleTableWriter,
@@ -63,11 +61,6 @@ class Command(BaseCommand):
         enddate = options.get('end')
 
         form_doc_types = doc_types()
-
-        if startdate or enddate:
-            if doc_type in CASE_DOC_TYPES or doc_type in form_doc_types:
-                if not should_use_sql_backend(domain):
-                    raise CommandError("Date filtering not supported for Couch domains")
 
         if startdate and enddate and enddate <= startdate:
             raise CommandError("enddate must be after startdate")

--- a/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
+++ b/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
@@ -1,8 +1,7 @@
 import csv
-import itertools
-from collections import namedtuple
 
 from django.core.management import BaseCommand, CommandError
+from memoized import memoized
 
 from corehq.apps.change_feed import data_sources, topics
 from corehq.apps.change_feed.producer import producer
@@ -12,13 +11,11 @@ from corehq.toggles import DO_NOT_REPUBLISH_DOCS
 from pillowtop.feed.interface import ChangeMeta
 
 
-DocumentRecord = namedtuple('DocumentRecord', ['doc_id', 'doc_type', 'doc_subtype', 'domain'])
-
-
-CASE_DOC_TYPES = {'CommCareCase'}
-FORM_DOC_TYPES = {'XFormInstance', 'XFormArchived'}
-
-ALL_DOC_TYPES = set.union(CASE_DOC_TYPES, FORM_DOC_TYPES)
+DOC_TYPE_MAP = {
+    'CommCareCase': (topics.CASE_SQL, data_sources.CASE_SQL),
+    'XFormInstance': (topics.FORM_SQL, data_sources.FORM_SQL),
+    'XFormArchived': (topics.FORM_SQL, data_sources.FORM_SQL),
+}
 
 
 class Command(BaseCommand):
@@ -34,93 +31,42 @@ class Command(BaseCommand):
         parser.add_argument('--skip_domains', action='store_true')
 
     def handle(self, stale_data_in_es_file, delimiter, skip_domains, *args, **options):
-        data_rows = _get_data_rows(stale_data_in_es_file, delimiter=delimiter)
-        document_records = _get_document_records(data_rows)
-        form_records = []
-        case_records = []
-        for record in document_records:
-            if record.doc_type in CASE_DOC_TYPES:
-                case_records.append(record)
-            elif record.doc_type in FORM_DOC_TYPES:
-                form_records.append(record)
-            else:
-                assert False, f'Bad doc type {record.doc_type} should have been caught already below.'
-        _publish_cases(case_records, skip_domains=skip_domains)
-        _publish_forms(form_records, skip_domains=skip_domains)
+        changes = _iter_changes(stale_data_in_es_file, skip_domains, delimiter=delimiter)
+        for topic, meta in changes:
+            producer.send_change(topic, meta)
 
 
-def _get_data_rows(stale_data_in_es_file, delimiter):
+def _iter_changes(stale_data_in_es_file, skip_domains, delimiter):
     with open(stale_data_in_es_file, 'r') as f:
         csv_reader = csv.reader(f, **get_csv_args(delimiter))
         for csv_row in csv_reader:
             data_row = DataRow(*csv_row)
+            if skip_domains and should_not_republish_docs(data_row.domain):
+                continue
             # Skip the header row anywhere in the file.
             # The "anywhere in the file" part is useful
             # if you cat multiple stale_data_in_es_file files together.
             if data_row != HEADER_ROW:
-                yield data_row
+                try:
+                    topic, source = DOC_TYPE_MAP[data_row.doc_type]
+                except KeyError:
+                    raise CommandError(f"Found bad doc type {data_row.doc_type}. "
+                        "Did you use the right command to create the data?")
+                yield topic, _change_meta(data_row, source)
 
 
-def _get_document_records(data_rows):
-    for data_row in data_rows:
-        doc_id, doc_type, doc_subtype, domain = \
-            data_row.doc_id, data_row.doc_type, data_row.doc_subtype, data_row.domain
-        if doc_type not in ALL_DOC_TYPES:
-            raise CommandError(f"Found bad doc type {doc_type}. "
-                               "Did you use the right command to create the data?")
-        yield DocumentRecord(doc_id, doc_type, doc_subtype, domain)
+@memoized
+def should_not_republish_docs(domain):
+    return DO_NOT_REPUBLISH_DOCS.enabled(domain)
 
 
-def _publish_cases(case_records, skip_domains):
-    for domain, records in itertools.groupby(case_records, lambda r: r.domain):
-        if skip_domains and DO_NOT_REPUBLISH_DOCS.enabled(domain):
-            continue
-        _publish_cases_for_sql(domain, records)
-
-
-def _publish_forms(form_records, skip_domains):
-    for domain, records in itertools.groupby(form_records, lambda r: r.domain):
-        if skip_domains and DO_NOT_REPUBLISH_DOCS.enabled(domain):
-            continue
-        _publish_forms_for_sql(domain, records)
-
-
-def _publish_cases_for_sql(domain, case_records):
-    for record in case_records:
-        producer.send_change(
-            topics.CASE_SQL,
-            _change_meta_for_sql_case(domain, record.doc_id, record.doc_subtype)
-        )
-
-
-def _change_meta_for_sql_case(domain, case_id, case_type):
-    doc_type, = CASE_DOC_TYPES
+def _change_meta(data_row, source):
     return ChangeMeta(
-        document_id=case_id,
+        document_id=data_row.doc_id,
         data_source_type=data_sources.SOURCE_SQL,
-        data_source_name=data_sources.CASE_SQL,
-        document_type=doc_type,
-        document_subtype=case_type,
-        domain=domain,
-        is_deletion=False,
-    )
-
-
-def _publish_forms_for_sql(domain, form_records):
-    for record in form_records:
-        producer.send_change(
-            topics.FORM_SQL,
-            _change_meta_for_sql_form_record(domain, record)
-        )
-
-
-def _change_meta_for_sql_form_record(domain, form_record):
-    return ChangeMeta(
-        document_id=form_record.doc_id,
-        data_source_type=data_sources.SOURCE_SQL,
-        data_source_name=data_sources.FORM_SQL,
-        document_type=form_record.doc_type,
-        document_subtype=form_record.doc_subtype,
-        domain=domain,
+        data_source_name=source,
+        document_type=data_row.doc_type,
+        document_subtype=data_row.doc_subtype,
+        domain=data_row.domain,
         is_deletion=False,
     )

--- a/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
@@ -8,35 +8,27 @@ from django.core.management.base import BaseCommand, CommandError
 
 import dateutil
 
-from casexml.apps.case.models import CommCareCase
-from couchforms.models import XFormInstance
 from dimagi.utils.chunked import chunked
-from dimagi.utils.parsing import json_format_datetime
 from dimagi.utils.retry import retry_on
 
-from corehq.apps.domain.models import Domain
 from corehq.apps.es import CaseES, FormES
 from corehq.elastic import ES_EXPORT_INSTANCE
 from corehq.form_processor.backends.sql.dbaccessors import (
     CaseReindexAccessor,
     FormReindexAccessor,
 )
-from corehq.form_processor.utils import should_use_sql_backend
 from corehq.util.dates import iso_string_to_datetime
-from corehq.util.doc_processor.couch import resumable_view_iterator
 from corehq.util.doc_processor.progress import (
     ProcessorProgressLogger,
     ProgressManager,
 )
 from corehq.util.doc_processor.sql import resumable_sql_model_iterator
 from corehq.elastic import ESError
-from corehq.util.pagination import PaginationEventHandler
-from memoized import memoized
 
 
 CHUNK_SIZE = 1000
 
-RunConfig = namedtuple('RunConfig', ['iteration_key', 'domain', 'start_date', 'end_date', 'case_type', 'backend'])
+RunConfig = namedtuple('RunConfig', ['iteration_key', 'domain', 'start_date', 'end_date', 'case_type'])
 DataRow = namedtuple('DataRow', ['doc_id', 'doc_type', 'doc_subtype', 'domain', 'es_date', 'primary_date'])
 
 
@@ -60,6 +52,7 @@ def get_csv_args(delimiter):
 
 retry_on_es_timeout = retry_on(ESError, delays=[2**x for x in range(10)])
 
+
 class Command(BaseCommand):
     """
     Returns list of (doc_id, doc_type, doc_subtype, es_server_modified_on, primary_modified_on)
@@ -81,9 +74,6 @@ class Command(BaseCommand):
         parser.add_argument('data_models', nargs='+',
                             help='A list of data models to check. Valid options are "case" and "form".')
         parser.add_argument('--domain', default=ALL_DOMAINS)
-        parser.add_argument('--backed', choices=('couch', 'sql'),
-                            help='Limit to only domains on this backend. This is only applied if a domain name'
-                                 'is not specified.')
         parser.add_argument('--iteration_key', help='Unique slug to identify this run. Used to allow resuming.')
         parser.add_argument(
             '--start',
@@ -110,7 +100,6 @@ class Command(BaseCommand):
         end = dateutil.parser.parse(options['end']) if options['end'] else default_end
         case_type = options['case_type']
         iteration_key = options['iteration_key']
-        backend = options['backend'] if not domain else None
         if iteration_key:
             print(f'\nResuming previous run. Iteration Key:\n\t"{iteration_key}"\n', file=self.stderr)
         else:
@@ -120,15 +109,13 @@ class Command(BaseCommand):
                 f'-{start.isoformat() if start != default_start else ""}'
                 f'-{end.isoformat() if end != default_end else ""}'
                 f'-{case_type or ""}'
-                f'-{backend or ""}'
             )
             print(f'\nStarting new run. Iteration key:\n\t"{iteration_key}"\n', file=self.stderr)
 
-        run_config = RunConfig(iteration_key, domain, start, end, case_type, backend)
+        run_config = RunConfig(iteration_key, domain, start, end, case_type)
 
         if run_config.domain is ALL_DOMAINS:
-            backends = f'the "{backend}" backend' if backend else 'all backends'
-            print(f'Running for all domains on {backends}', file=self.stderr)
+            print('Running for all domains', file=self.stderr)
 
         csv_writer = csv.writer(self.stdout, **get_csv_args(delimiter))
 
@@ -150,7 +137,7 @@ class Command(BaseCommand):
 
                 for data_row in data_rows:
                     print_data_row(data_row)
-        except:
+        except:  # noqa: E722
             print(f'\nERROR: To resume the previous run add the "iteration_key" parameter to the command:\n'
                   f"\t--iteration_key '{iteration_key}'\n", file=self.stderr)
             raise
@@ -165,7 +152,7 @@ DATA_MODEL_HELPERS = {
 class CaseHelper:
     @classmethod
     def run(cls, run_config):
-        for chunk in _get_doc_chunks(cls, run_config):
+        for chunk in cls.get_sql_chunks(run_config):
             yield from cls._yield_missing_in_es(chunk)
 
     @staticmethod
@@ -182,18 +169,8 @@ class CaseHelper:
             matching_records = [
                 (case.case_id, case.type, case.server_modified_on, case.domain)
                 for case in chunk
-                if _should_use_sql_backend(case.domain)
             ]
             yield matching_records
-
-    @staticmethod
-    def get_couch_chunks(run_config):
-        if run_config.case_type and run_config is not ALL_DOMAINS \
-                and not _should_use_sql_backend(run_config.domain):
-            raise CommandError('Case type argument is not supported for couch domains!')
-        matching_records = CaseHelper._get_couch_case_data(run_config)
-        print("Processing cases in Couch, which doesn't support nice progress bar", file=sys.stderr)
-        yield from chunked(matching_records, CHUNK_SIZE)
 
     @staticmethod
     def _yield_missing_in_es(chunk):
@@ -204,25 +181,6 @@ class CaseHelper:
             if (es_modified_on, es_domain) != (modified_on, domain):
                 yield DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type, domain=domain,
                               es_date=es_modified_on, primary_date=modified_on)
-
-    @staticmethod
-    def _get_couch_case_data(run_config):
-        view_name = 'cases_by_server_date/by_server_modified_on'
-
-        keys = [[couch_domain] for couch_domain in _get_matching_couch_domains(run_config)]
-        if not keys:
-            return
-
-        iteration_key = f'couch_cases-{run_config.iteration_key}'
-        event_handler = ProgressEventHandler(iteration_key, 'unknown', sys.stderr)
-        iterable = resumable_view_iterator(
-            CommCareCase.get_db(), iteration_key, view_name, keys,
-            chunk_size=CHUNK_SIZE, view_event_handler=event_handler, full_row=True
-        )
-        for row in iterable:
-            case_id, domain, modified_on = row['id'], row['key'][0], iso_string_to_datetime(row['value'])
-            if run_config.start_date <= modified_on < run_config.end_date:
-                yield case_id, 'COUCH_TYPE_NOT_SUPPORTED', modified_on, domain
 
     @staticmethod
     @retry_on_es_timeout
@@ -239,7 +197,7 @@ class CaseHelper:
 class FormHelper:
     @classmethod
     def run(cls, run_config):
-        for chunk in _get_doc_chunks(cls, run_config):
+        for chunk in cls.get_sql_chunks(run_config):
             yield from cls._yield_missing_in_es(chunk)
 
     @staticmethod
@@ -255,61 +213,10 @@ class FormHelper:
             matching_records = [
                 (form.form_id, form.doc_type, form.xmlns, form.received_on, form.domain)
                 for form in chunk
-                if (
-                    _should_use_sql_backend(form.domain) and
-                    # Only check for "normal" and "archived" forms
-                    (form.is_normal or form.is_archived)
-                )
+                # Only check for "normal" and "archived" forms
+                if form.is_normal or form.is_archived
             ]
             yield matching_records
-
-    @staticmethod
-    def get_couch_chunks(run_config):
-        db = XFormInstance.get_db()
-        view_name = 'by_domain_doc_type_date/view'
-
-        keys = [
-            {
-                'startkey': [couch_domain, doc_type, json_format_datetime(run_config.start_date)],
-                'endkey': [couch_domain, doc_type, json_format_datetime(run_config.end_date)],
-            }
-            for couch_domain in _get_matching_couch_domains(run_config)
-            for doc_type in ['XFormArchived', 'XFormInstance']
-        ]
-        if not keys:
-            return
-
-        def _get_length():
-            length = 0
-            for key in keys:
-                result = db.view(view_name, reduce=True, **key).one()
-                if result:
-                    length += result['value']
-            return length
-
-        iteration_key = f'couch_forms-{run_config.iteration_key}'
-        iterable = resumable_view_iterator(
-            XFormInstance.get_db(), iteration_key, view_name, keys,
-            chunk_size=CHUNK_SIZE, full_row=True
-        )
-        progress = ProgressManager(
-            iterable,
-            total=_get_length(),
-            reset=False,
-            chunk_size=CHUNK_SIZE,
-            logger=ProcessorProgressLogger('[Couch Forms] ', sys.stderr)
-        )
-        with progress:
-            for chunk in chunked(iterable, CHUNK_SIZE):
-                records = []
-                for row in chunk:
-                    form_id = row['id']
-                    domain, doc_type, received_on = row['key']
-                    received_on = iso_string_to_datetime(received_on)
-                    assert run_config.domain in (domain, ALL_DOMAINS)
-                    records.append((form_id, doc_type, 'COUCH_XMLNS_NOT_SUPPORTED', received_on, domain))
-                yield records
-                progress.add(len(chunk))
 
     @staticmethod
     def _yield_missing_in_es(chunk):
@@ -330,39 +237,6 @@ class FormHelper:
         )
         return {_id: (iso_string_to_datetime(received_on), doc_type, domain)
                 for _id, received_on, doc_type, domain in results}
-
-
-def _get_doc_chunks(helper, run_config):
-    if not run_config.backend or run_config.backend == 'sql':
-        yield from helper.get_sql_chunks(run_config)
-    if not run_config.backend or run_config.backend == 'couch':
-        yield from helper.get_couch_chunks(run_config)
-
-
-@memoized
-def _should_use_sql_backend(domain):
-    return should_use_sql_backend(domain)
-
-
-@memoized
-def _get_matching_couch_domains(run_config):
-    if run_config.domain is ALL_DOMAINS:
-        return [domain.name for domain in Domain.get_all() if not _should_use_sql_backend(domain)]
-    elif _should_use_sql_backend(run_config.domain):
-        return []
-    else:
-        return [run_config.domain]
-
-
-class ProgressEventHandler(PaginationEventHandler):
-
-    def __init__(self, log_prefix, total, stream=None):
-        self.log_prefix = log_prefix
-        self.stream = stream
-        self.total = total
-
-    def page_end(self, total_emitted, duration, *args, **kwargs):
-        print(f'{self.log_prefix} Processed {total_emitted} of {self.total} in {duration}', file=self.stream)
 
 
 def _get_resumable_chunked_iterator(dbaccessor, iteration_key, log_prefix):

--- a/corehq/apps/hqadmin/tests/test_stale_data_in_es.py
+++ b/corehq/apps/hqadmin/tests/test_stale_data_in_es.py
@@ -37,7 +37,6 @@ class ExitEarlyException(Exception):
 @es_test
 class TestStaleDataInESSQL(TestCase):
 
-    use_sql_backend = True
     project_name = 'sql-project'
     case_type = 'patient'
     form_xmlns = None
@@ -88,9 +87,6 @@ class TestStaleDataInESSQL(TestCase):
                 )
 
         form, cases = self._submit_form(self.project.name, new_cases=4)
-        if not self.use_sql_backend:
-            # the couch view is sorted by case_id
-            cases = list(sorted(cases, key=lambda c: c.case_id))
 
         # process first 2 then raise exception
         self._assert_not_in_sync(call(2, expect_exception=ExitEarlyException), rows=[
@@ -292,7 +288,7 @@ class TestStaleDataInESSQL(TestCase):
     def setUpClass(cls):
         delete_all_cases()
         cls.project = Domain.get_or_create_with_name(
-            cls.project_name, is_active=True, use_sql_backend=cls.use_sql_backend)
+            cls.project_name, is_active=True, use_sql_backend=True)
         cls.project.save()
         cls.elasticsearch = get_es_new()
         reset_es_index(XFORM_INDEX_INFO)
@@ -311,12 +307,3 @@ class TestStaleDataInESSQL(TestCase):
         delete_all_cases()
         self._delete_forms_from_es(self.forms_to_delete_from_es)
         self._delete_cases_from_es(self.cases_to_delete_from_es)
-
-
-@es_test
-class TestStaleDataInESCouch(TestStaleDataInESSQL):
-
-    use_sql_backend = False
-    project_name = 'couch-project'
-    case_type = 'COUCH_TYPE_NOT_SUPPORTED'
-    form_xmlns = 'COUCH_XMLNS_NOT_SUPPORTED'


### PR DESCRIPTION
## Summary
Remove references to `should_use_sql_backend` and other Couch backend specific code from `data_pipeline_audit` and `hqadmin` apps. This mainly updates tests, but some non-test code has also been removed where it appears to be safe.

:tropical_fish: Review by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No new tests.

### QA Plan

No QA.

### Safety story

None of the removed code should be in use since all domains have been migrated to SQL.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
