### PR TITLE
Updated feature flag page to sort items

### DIFF
--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -36,7 +36,7 @@ hqDefine('toggle_ui/js/edit-flag', [
                 last_used = config.last_used || {},
                 service_type = config.service_type || {};
             self.items.removeAll();
-            _(items).each(function (item) {
+            _.each(_.sortBy(items), function (item) {
                 var fields = item.split(':'),
                     namespace = fields.length > 1 ? fields[0] : 'user',
                     value = fields.length > 1 ? fields[1] : fields[0];


### PR DESCRIPTION
## Summary
This was bugging me.

## Product Description
This page is now sorted:
![Screen Shot 2021-08-25 at 5 21 32 PM](https://user-images.githubusercontent.com/1486591/130866421-337b3dba-3894-4fff-bac7-9552cc141714.png)


## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
