### PR TITLE
Fixed import and version in time_restore command

### DIFF
--- a/corehq/apps/ota/management/commands/time_restore.py
+++ b/corehq/apps/ota/management/commands/time_restore.py
@@ -3,7 +3,7 @@ import datetime
 from django.core.management.base import BaseCommand
 
 import csv
-from couchdbkit.resource import ResourceNotFound
+from couchdbkit import ResourceNotFound
 from lxml import etree
 
 from corehq.apps.app_manager.dbaccessors import get_current_app_doc
@@ -54,7 +54,7 @@ def _get_headers_and_rows(domain, users, app_id):
     rows = []
     for user in users:
         response, timing_context = get_restore_response(
-            domain, user, app_id=app_id,
+            domain, user, app_id=app_id, version="2.0"
         )
         timing_dict = timing_context.to_dict()
         xml_payload = etree.fromstring(b''.join(response.streaming_content))


### PR DESCRIPTION
## Summary
Minor updates to a management command.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
