### PR TITLE
Added quickcache to get_apps_in_domain

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -246,6 +246,7 @@ def get_app(domain, app_id, wrap_cls=None, latest=False, target=None):
         raise Http404()
 
 
+@quickcache(['domain', 'include_remote'], timeout=24 * 60 * 60)
 def get_apps_in_domain(domain, include_remote=True):
     from .models import Application
     from corehq.apps.app_manager.util import get_correct_app_class

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -79,6 +79,7 @@ from corehq.apps.app_manager.dbaccessors import (
     domain_has_apps,
     get_app,
     get_app_languages,
+    get_apps_in_domain,
     get_build_by_version,
     get_build_ids,
     get_latest_build_doc,
@@ -4574,6 +4575,8 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
     def delete_app(self):
         domain_has_apps.clear(self.domain)
         get_app_languages.clear(self.domain)
+        get_apps_in_domain.clear(self.domain, True)
+        get_apps_in_domain.clear(self.domain, False)
         self.doc_type += '-Deleted'
         record = DeleteApplicationRecord(
             domain=self.domain,
@@ -4594,6 +4597,8 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
         get_all_case_properties.clear(self)
         get_usercase_properties.clear(self)
         get_app_languages.clear(self.domain)
+        get_apps_in_domain.clear(self.domain, True)
+        get_apps_in_domain.clear(self.domain, False)
 
         request = view_utils.get_request()
         user = getattr(request, 'couch_user', None)


### PR DESCRIPTION
## Summary
Minor contribution to performance problems in https://dimagi-dev.atlassian.net/browse/USH-1229

This gets called twice while generating report fixtures in `ReportFixturesProvider` and is taking 1.5 seconds for this domain. It isn't the biggest contributor to their sync times, but it's non-trivial and easy to address.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan

Not requesting QA.

### Safety story
This is a standard type of change that should be covered by restore tests.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
