### PR TITLE
Refactor ReportFixturesProvider to avoid loading apps and report configs twice

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -72,11 +72,15 @@ class ReportFixturesProvider(FixtureProvider):
         """
         Generates a report fixture for mobile that can be used by a report module
         """
-        if not self.uses_reports(restore_state):
+        if not self.should_sync(restore_state):
             return []
 
         restore_user = restore_state.restore_user
         apps = self._get_apps(restore_state, restore_user)
+        report_configs = self._get_report_configs(apps)
+        if not report_configs:
+            return []
+
         fixtures = []
 
         needed_versions = {
@@ -90,22 +94,18 @@ class ReportFixturesProvider(FixtureProvider):
             ReportFixturesProviderV2(report_data_cache)
         ]
 
-        report_configs = self._get_report_configs(apps)
         for provider in providers:
             fixtures.extend(provider(restore_state, restore_user, needed_versions, report_configs))
 
         return fixtures
 
-    def uses_reports(self, restore_state):
+    def should_sync(self, restore_state):
         restore_user = restore_state.restore_user
         if not toggles.MOBILE_UCR.enabled(restore_user.domain) or not _should_sync(restore_state):
             return False
 
         if toggles.PREVENT_MOBILE_UCR_SYNC.enabled(restore_user.domain):
             return False
-
-        apps = self._get_apps(restore_state, restore_user)
-        return bool(self._get_report_configs(apps))
 
     def _get_apps(self, restore_state, restore_user):
         app_aware_sync_app = restore_state.params.app

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -106,6 +106,8 @@ class ReportFixturesProvider(FixtureProvider):
 
         if toggles.PREVENT_MOBILE_UCR_SYNC.enabled(restore_user.domain):
             return False
+        
+        return True
 
     def _get_apps(self, restore_state, restore_user):
         app_aware_sync_app = restore_state.params.app


### PR DESCRIPTION
Related to https://dimagi-dev.atlassian.net/browse/USH-1229

## Summary
Minor refactor of `ReportFixturesProvider` to improve performance in Web Apps where all apps in the domain are loaded for each sync. Prior to this change the apps were loaded from CouchDB twice.

## Feature Flag
mobile_ucr

## Product Description
Performance improvement for sync involving mobile UCR reports in Web Apps

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Covered by existing tests

### QA Plan
None

### Safety story
Refactor covered by existing tests

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
