### PR TITLE
Disable Couch branch of run_with_all_backends

### DIFF
--- a/corehq/apps/callcenter/tests/test_indicators.py
+++ b/corehq/apps/callcenter/tests/test_indicators.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 from django.core import cache
 from django.db import DEFAULT_DB_ALIAS
 from django.test import TestCase
-from django.test.utils import override_settings
 
 from mock import patch
 
@@ -35,7 +34,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.groups.models import Group
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends, sharded
+from corehq.form_processor.tests.utils import run_with_sql_backend, sharded
 from corehq.sql_db.connections import connection_manager, override_engine
 from corehq.sql_db.tests.utils import temporary_database
 
@@ -84,7 +83,8 @@ def get_indicators(prefix, values, case_type=None, is_legacy=False, limit_ranges
 StaticIndicators = namedtuple('StaticIndicators', 'name, values, is_legacy, infix')
 
 
-def expected_standard_indicators(no_data=False, include_legacy=True, include_totals=True, case_types=None, limit_ranges=None):
+def expected_standard_indicators(
+        no_data=False, include_legacy=True, include_totals=True, case_types=None, limit_ranges=None):
     case_types = case_types if case_types is not None else ['person', 'dog']
     expected = {}
     expected_values = []
@@ -98,7 +98,7 @@ def expected_standard_indicators(no_data=False, include_legacy=True, include_tot
         ])
 
     if 'dog' in case_types:
-        expected_values.extend ([
+        expected_values.extend([
             StaticIndicators('cases_total', [3, 3, 3, 5], False, 'dog'),
             StaticIndicators('cases_opened', [0, 0, 0, 5], False, 'dog'),
             StaticIndicators('cases_closed', [0, 0, 0, 2], False, 'dog'),
@@ -106,7 +106,7 @@ def expected_standard_indicators(no_data=False, include_legacy=True, include_tot
         ])
 
     if 'person' in case_types:
-        expected_values.extend ([
+        expected_values.extend([
             StaticIndicators('cases_total', [1, 1, 3, 0], False, 'person'),
             StaticIndicators('cases_opened', [0, 1, 3, 0], False, 'person'),
             StaticIndicators('cases_closed', [0, 0, 2, 0], False, 'person'),
@@ -128,6 +128,7 @@ def expected_standard_indicators(no_data=False, include_legacy=True, include_tot
     return expected
 
 
+@run_with_sql_backend
 class BaseCCTests(TestCase):
     domain_name = None
 
@@ -436,14 +437,6 @@ class CallCenterTests(BaseCCTests):
         self.assertEqual(indicator_set.get_data(), {})
 
 
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
-class CallCenterTestsSQL(CallCenterTests):
-    """Run all tests in ``CallCenterTests`` with SQL backend
-    """
-    domain_name = "cc_test_sql"
-    pass
-
-
 class CallCenterSupervisorGroupTest(BaseCCTests):
     domain_name = 'cc_supervisor'
 
@@ -476,7 +469,6 @@ class CallCenterSupervisorGroupTest(BaseCCTests):
         self.domain.delete()
         super(CallCenterSupervisorGroupTest, self).tearDown()
 
-    @run_with_all_backends
     @patch('corehq.apps.callcenter.indicator_sets.get_case_types_for_domain_es',
            return_value={'person', 'dog', CASE_TYPE})
     def test_users_assigned_via_group(self, mock):
@@ -533,7 +525,6 @@ class CallCenterCaseSharingTest(BaseCCTests):
         clear_data(self.domain.name)
         self.domain.delete()
 
-    @run_with_all_backends
     @patch('corehq.apps.callcenter.indicator_sets.get_case_types_for_domain_es',
            return_value={'person', 'dog', CASE_TYPE})
     def test_cases_owned_by_group(self, mock):
@@ -577,7 +568,6 @@ class CallCenterTestOpenedClosed(BaseCCTests):
         clear_data(self.domain.name)
         self.domain.delete()
 
-    @run_with_all_backends
     @patch('corehq.apps.callcenter.indicator_sets.get_case_types_for_domain_es',
            return_value={'person', 'dog', CASE_TYPE})
     def test_opened_closed(self, mock):
@@ -601,6 +591,7 @@ class CallCenterTestOpenedClosed(BaseCCTests):
         self._test_indicators(self.user, indicator_set.get_data(), expected)
 
 
+@sharded
 class TestSavingToUCRDatabase(BaseCCTests):
     domain_name = 'callcenterucrtest'
 
@@ -639,8 +630,3 @@ class TestSavingToUCRDatabase(BaseCCTests):
                 custom_cache=locmem_cache
             )
             self._test_indicators(self.cc_user, indicator_set.get_data(), expected_standard_indicators())
-
-
-@sharded
-class TestSavingToUCRDatabaseSQL(TestSavingToUCRDatabase):
-    pass

--- a/corehq/apps/ota/tests/test_claim.py
+++ b/corehq/apps/ota/tests/test_claim.py
@@ -11,7 +11,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.ota.utils import get_restore_user
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.form_processor.exceptions import CaseNotFound
 
 DOMAIN = 'test_domain'
@@ -25,6 +25,7 @@ def index_to_dict(instance):
     return {k: str(getattr(instance, k)) for k in keys}
 
 
+@run_with_sql_backend
 class CaseClaimTests(TestCase):
 
     def setUp(self):
@@ -68,7 +69,6 @@ class CaseClaimTests(TestCase):
             'relationship': 'extension',
         }])
 
-    @run_with_all_backends
     def test_claim_case(self):
         """
         claim_case should create an extension case
@@ -77,7 +77,6 @@ class CaseClaimTests(TestCase):
                               host_type=self.host_case_type, host_name=self.host_case_name)
         self.assert_claim(claim_id=claim_id)
 
-    @run_with_all_backends
     def test_claim_case_id_only(self):
         """
         claim_case should look up host case details if only ID is passed
@@ -85,7 +84,6 @@ class CaseClaimTests(TestCase):
         claim_id = claim_case(DOMAIN, self.restore_user, self.host_case_id)
         self.assert_claim(claim_id=claim_id)
 
-    @run_with_all_backends
     def test_first_claim_one(self):
         """
         get_first_claim should return one claim
@@ -95,7 +93,6 @@ class CaseClaimTests(TestCase):
         claim = get_first_claim(DOMAIN, self.user.user_id, self.host_case_id)
         self.assert_claim(claim, claim_id)
 
-    @run_with_all_backends
     def test_first_claim_none(self):
         """
         get_first_claim should return None if not found
@@ -103,7 +100,6 @@ class CaseClaimTests(TestCase):
         claim = get_first_claim(DOMAIN, self.user.user_id, self.host_case_id)
         self.assertIsNone(claim)
 
-    @run_with_all_backends
     def test_closed_claim(self):
         """
         get_first_claim should return None if claim case is closed
@@ -114,7 +110,6 @@ class CaseClaimTests(TestCase):
         first_claim = get_first_claim(DOMAIN, self.user.user_id, self.host_case_id)
         self.assertIsNone(first_claim)
 
-    @run_with_all_backends
     def test_claim_case_other_domain(self):
         malicious_domain = 'malicious_domain'
         domain_obj = create_domain(malicious_domain)

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -26,7 +26,7 @@ from corehq.apps.es.tests.utils import ElasticTestMixin, es_test
 from corehq.apps.users.models import CommCareUser
 from corehq.elastic import get_es_new
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.pillows.case_search import CaseSearchReindexerFactory, domains_needing_search_index
 from corehq.pillows.mappings.case_search_mapping import (
     CASE_SEARCH_INDEX,
@@ -305,6 +305,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
 
 
 @es_test
+@run_with_sql_backend
 class CaseClaimEndpointTests(TestCase):
     def setUp(self):
         self.domain = create_domain(DOMAIN)
@@ -335,7 +336,6 @@ class CaseClaimEndpointTests(TestCase):
         cache = get_redis_default_cache()
         cache.clear()
 
-    @run_with_all_backends
     def test_claim_case(self):
         """
         A claim case request should create an extension case
@@ -353,7 +353,6 @@ class CaseClaimEndpointTests(TestCase):
         self.assertEqual(claim.owner_id, self.user.get_id)
         self.assertEqual(claim.name, CASE_NAME)
 
-    @run_with_all_backends
     def test_duplicate_client_claim(self):
         """
         Server should not allow the same client to claim the same case more than once
@@ -369,7 +368,6 @@ class CaseClaimEndpointTests(TestCase):
         self.assertEqual(response.status_code, 409)
         self.assertEqual(response.content.decode('utf-8'), 'You have already claimed that case')
 
-    @run_with_all_backends
     def test_duplicate_user_claim(self):
         """
         Server should not allow the same user to claim the same case more than once
@@ -388,7 +386,6 @@ class CaseClaimEndpointTests(TestCase):
         self.assertEqual(response.content.decode('utf-8'), 'You have already claimed that case')
 
     @flaky
-    @run_with_all_backends
     def test_claim_restore_as(self):
         """Server should assign cases to the correct user
         """
@@ -447,7 +444,6 @@ class CaseClaimEndpointTests(TestCase):
         claim_cases = CaseAccessors(DOMAIN).get_cases(claim_ids)
         self.assertIn(another_user._id, [case.owner_id for case in claim_cases])
 
-    @run_with_all_backends
     def test_search_endpoint(self):
         self.maxDiff = None
         client = Client()

--- a/corehq/apps/userreports/tests/test_indicators.py
+++ b/corehq/apps/userreports/tests/test_indicators.py
@@ -23,7 +23,7 @@ from corehq.form_processor.parsers.ledgers.helpers import (
     StockReportHelper,
     StockTransactionHelper,
 )
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.form_processor.utils import get_simple_wrapped_form
 from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.form_processor.utils.xform import TestFormMetadata
@@ -599,6 +599,7 @@ class DueListDateIndicatorTest(SimpleTestCase):
         )
 
 
+@run_with_sql_backend
 class TestGetValuesByProduct(TestCase):
     domain_name = 'test-domain'
     case_id = 'case1'
@@ -676,7 +677,6 @@ class TestGetValuesByProduct(TestCase):
         StockTransaction.objects.all().delete()
         super(TestGetValuesByProduct, self).tearDown()
 
-    @run_with_all_backends
     def test_get_soh_values_by_product(self):
         values = get_values_by_product(
             self.domain_name, self.case_id, 'soh', ['coke', 'surge', 'new_coke']
@@ -685,7 +685,6 @@ class TestGetValuesByProduct(TestCase):
         self.assertEqual(values.get('surge'), 85)
         self.assertEqual(values.get('new_coke'), None)
 
-    @run_with_all_backends
     def test_get_consumption_by_product(self):
         values = get_values_by_product(
             self.domain_name, self.case_id, 'consumption', ['coke', 'surge', 'new_coke']

--- a/corehq/apps/users/tests/test_user_model.py
+++ b/corehq/apps/users/tests/test_user_model.py
@@ -14,7 +14,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser, DeviceAppMeta, WebUser
 from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
-    run_with_all_backends,
+    run_with_sql_backend,
 )
 from corehq.form_processor.utils import (
     TestFormMetadata,
@@ -25,6 +25,7 @@ from corehq.util.test_utils import softer_assert
 from corehq.apps.users.models import MAX_LOGIN_ATTEMPTS
 
 
+@run_with_sql_backend
 class UserModelTest(TestCase):
 
     def setUp(self):
@@ -60,7 +61,6 @@ class UserModelTest(TestCase):
             created_via=None,
         )
 
-    @run_with_all_backends
     def test_get_form_ids(self):
         form_ids = list(self.user._get_form_ids())
         self.assertEqual(len(form_ids), 1)

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_case_history.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_case_history.py
@@ -4,9 +4,10 @@ from casexml.apps.case.mock import CaseFactory, CaseStructure
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 from casexml.apps.case.util import get_case_history
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import run_with_sql_backend
 
 
+@run_with_sql_backend
 class TestCaseHistory(TestCase):
     def setUp(self):
         self.domain = "isildur"
@@ -18,7 +19,6 @@ class TestCaseHistory(TestCase):
         delete_all_xforms()
         delete_all_cases()
 
-    @run_with_all_backends
     def test_case_history(self):
         self.factory.create_or_update_case(
             CaseStructure(

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_get_case_property_changes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_get_case_property_changes.py
@@ -12,9 +12,10 @@ from casexml.apps.case.util import (
 )
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import RebuildWithReason
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import run_with_sql_backend
 
 
+@run_with_sql_backend
 class TestCasePropertyChanged(TestCase):
     def setUp(self):
         self.domain = "isildur"
@@ -26,7 +27,6 @@ class TestCasePropertyChanged(TestCase):
         delete_all_xforms()
         delete_all_cases()
 
-    @run_with_all_backends
     def test_date_case_property_changed(self):
         updated_on = datetime(2015, 5, 3, 12, 11)
         # submit 2 updates
@@ -56,7 +56,6 @@ class TestCasePropertyChanged(TestCase):
             get_datetime_case_property_changed(case, "abc", "updated")
         )
 
-    @run_with_all_backends
     def test_multiple_cases_in_update(self):
         day_1 = datetime(2015, 5, 1, 12, 11)
         day_2 = datetime(2015, 5, 2, 12, 11)
@@ -100,7 +99,6 @@ class TestCasePropertyChanged(TestCase):
             get_datetime_case_property_changed(case, "relevant_property", "updated")
         )
 
-    @run_with_all_backends
     def test_owner_id_changed(self):
         changes, _ = get_paged_changes_to_case_property(self.case, 'owner_id')
         self.assertEqual(len(changes), 1)
@@ -122,7 +120,6 @@ class TestCasePropertyChanged(TestCase):
         self.assertEqual(changes[0].new_value, 'new_owner')
         self.assertEqual(changes[1].new_value, 'owner')
 
-    @run_with_all_backends
     def test_name_changed(self):
         self.factory.create_or_update_case(
             CaseStructure(
@@ -139,7 +136,6 @@ class TestCasePropertyChanged(TestCase):
         self.assertEqual(changes[0].new_value, 'Strider')
         self.assertEqual(changes[1].new_value, 'Aragorn')
 
-    @run_with_all_backends
     def test_blank_change(self):
         self.factory.create_or_update_case(
             CaseStructure(
@@ -156,7 +152,6 @@ class TestCasePropertyChanged(TestCase):
         self.assertEqual(changes[0].new_value, '')
         self.assertEqual(changes[1].new_value, 'Narsil')
 
-    @run_with_all_backends
     def test_case_rebuild(self):
         # Cases with rebuild actions were failing because rebuild actions have no form
         # https://manage.dimagi.com/default.asp?276216#1494409

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -33,7 +33,7 @@ from corehq.form_processor.interfaces.dbaccessors import (
 )
 from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
-    run_with_all_backends,
+    run_with_sql_backend,
 )
 from corehq.motech.models import ConnectionSettings
 from corehq.motech.repeaters.const import (
@@ -86,6 +86,7 @@ XFORM_XML_TEMPLATE = """<?xml version='1.0' ?>
 """
 
 
+@run_with_sql_backend
 class BaseRepeaterTest(TestCase, DomainSubscriptionMixin):
     domain = 'base-domain'
 
@@ -185,14 +186,12 @@ class RepeaterTest(BaseRepeaterTest):
     def repeat_records(self):
         return super(RepeaterTest, self).repeat_records(self.domain)
 
-    @run_with_all_backends
     def test_skip_device_logs(self):
         devicelog_xml = XFORM_XML_TEMPLATE.format(DEVICE_LOG_XMLNS, USER_ID, '1234', '')
         self.post_xml(devicelog_xml, self.domain)
         for repeat_record in self.repeat_records():
             self.assertNotEqual(repeat_record.payload_id, '1234')
 
-    @run_with_all_backends
     def test_skip_duplicates(self):
         """
         Ensure that submitting a duplicate form does not create extra RepeatRecords
@@ -203,7 +202,6 @@ class RepeaterTest(BaseRepeaterTest):
         self.assertTrue(form.is_duplicate)
         self.assertEqual(len(self.repeat_records()), 2)
 
-    @run_with_all_backends
     def test_repeater_failed_sends(self):
         """
         This tests records that fail are requeued later
@@ -236,7 +234,6 @@ class RepeaterTest(BaseRepeaterTest):
         )
         self.assertEqual(len(repeat_records), 2)
 
-    @run_with_all_backends
     def test_update_failure_next_check(self):
         now = datetime.utcnow()
         record = RepeatRecord(
@@ -251,7 +248,6 @@ class RepeaterTest(BaseRepeaterTest):
         self.assertTrue(record.last_checked > now)
         self.assertEqual(record.next_check, record.last_checked + MIN_RETRY_WAIT)
 
-    @run_with_all_backends
     def test_repeater_successful_send(self):
 
         repeat_records = self.repeat_records()
@@ -289,7 +285,6 @@ class RepeaterTest(BaseRepeaterTest):
         self.post_xml(self.update_xform_xml, self.domain)
         self.assertEqual(len(self.repeat_records()), 2)
 
-    @run_with_all_backends
     def test_check_repeat_records(self):
         self.assertEqual(len(self.repeat_records()), 2)
         self.assertEqual(self.initial_fire_call_count, 2)
@@ -298,7 +293,6 @@ class RepeaterTest(BaseRepeaterTest):
             check_repeaters()
             self.assertEqual(mock_fire.call_count, 0)
 
-    @run_with_all_backends
     def test_repeat_record_status_check(self):
         self.assertEqual(len(self.repeat_records()), 2)
 
@@ -330,7 +324,6 @@ class RepeaterTest(BaseRepeaterTest):
             for repeat_record in self.repeat_records():
                 self.assertEqual(repeat_record.state, RECORD_SUCCESS_STATE)
 
-    @run_with_all_backends
     def test_retry_process_repeat_record_locking(self):
         self.assertEqual(len(self.repeat_records()), 2)
 
@@ -347,7 +340,6 @@ class RepeaterTest(BaseRepeaterTest):
             check_repeaters()
             self.assertEqual(mock_process.delay.call_count, 2)
 
-    @run_with_all_backends
     def test_automatic_cancel_repeat_record(self):
         repeat_record = self.case_repeater.register(CaseAccessors(self.domain).get_case(CASE_ID))
         self.assertEqual(1, repeat_record.overall_tries)
@@ -390,7 +382,6 @@ class FormPayloadGeneratorTest(BaseRepeaterTest, TestXmlMixin):
         delete_all_repeat_records()
         super().tearDown()
 
-    @run_with_all_backends
     def test_get_payload(self):
         self.post_xml(self.xform_xml, self.domain)
         payload_doc = FormAccessors(self.domain).get_form(self.instance_id)
@@ -425,7 +416,6 @@ class FormRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         delete_all_repeat_records()
         super(FormRepeaterTest, self).tearDown()
 
-    @run_with_all_backends
     def test_payload(self):
         self.post_xml(self.xform_xml, self.domain)
         repeat_records = self.repeat_records(self.domain).all()
@@ -461,7 +451,6 @@ class ShortFormRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         delete_all_repeat_records()
         super().tearDown()
 
-    @run_with_all_backends
     def test_payload(self):
         form = self.post_xml(self.xform_xml, self.domain).xform
         repeat_records = self.repeat_records(self.domain).all()
@@ -495,7 +484,6 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         self.connx.delete()
         super().tearDown()
 
-    @run_with_all_backends
     def test_case_close_format(self):
         # create a case
         self.post_xml(self.xform_xml, self.domain)
@@ -510,7 +498,6 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         self.assertXmlHasXpath(close_payload, '//*[local-name()="case"]')
         self.assertXmlHasXpath(close_payload, '//*[local-name()="close"]')
 
-    @run_with_all_backends
     def test_excluded_case_types_are_not_forwarded(self):
         self.repeater.white_listed_case_types = ['planet']
         self.repeater.save()
@@ -531,7 +518,6 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         CaseFactory(self.domain).post_case_blocks([non_white_listed_case])
         self.assertEqual(1, len(self.repeat_records(self.domain).all()))
 
-    @run_with_all_backends
     def test_black_listed_user_cases_do_not_forward(self):
         self.repeater.black_listed_users = ['black_listed_user']
         self.repeater.save()
@@ -629,7 +615,6 @@ class RepeaterFailureTest(BaseRepeaterTest):
         delete_all_repeat_records()
         super().tearDown()
 
-    @run_with_all_backends
     def test_get_payload_exception(self):
         repeat_record = self.repeater.register(CaseAccessors(self.domain).get_case(CASE_ID))
         with self.assertRaises(Exception):
@@ -639,7 +624,6 @@ class RepeaterFailureTest(BaseRepeaterTest):
         self.assertEqual(repeat_record.failure_reason, 'Boom!')
         self.assertFalse(repeat_record.succeeded)
 
-    @run_with_all_backends
     def test_failure(self):
         repeat_record = self.repeater.register(CaseAccessors(self.domain).get_case(CASE_ID))
         with patch('corehq.motech.repeaters.models.simple_post', side_effect=RequestException('Boom!')):
@@ -648,7 +632,6 @@ class RepeaterFailureTest(BaseRepeaterTest):
         self.assertEqual(repeat_record.failure_reason, 'Boom!')
         self.assertFalse(repeat_record.succeeded)
 
-    @run_with_all_backends
     def test_unexpected_failure(self):
         repeat_record = self.repeater.register(CaseAccessors(self.domain).get_case(CASE_ID))
         with patch('corehq.motech.repeaters.models.simple_post', side_effect=Exception('Boom!')):
@@ -657,7 +640,6 @@ class RepeaterFailureTest(BaseRepeaterTest):
         self.assertEqual(repeat_record.failure_reason, 'Internal Server Error')
         self.assertFalse(repeat_record.succeeded)
 
-    @run_with_all_backends
     def test_success(self):
         repeat_record = self.repeater.register(CaseAccessors(self.domain).get_case(CASE_ID))
         repeat_record = RepeatRecord.get(repeat_record.record_id)
@@ -704,7 +686,6 @@ class IgnoreDocumentTest(BaseRepeaterTest):
         FormProcessorTestUtils.delete_all_cases_forms_ledgers(self.domain)
         delete_all_repeat_records()
 
-    @run_with_all_backends
     def test_ignore_document(self):
         """
         When get_payload raises IgnoreDocument, fire should call update_success
@@ -781,7 +762,6 @@ class TestRepeaterFormat(BaseRepeaterTest):
         with self.assertRaises(DuplicateFormatException):
             RegisterGenerator.get_collection(CaseRepeater).add_new_format(NewCaseGenerator, is_default=True)
 
-    @run_with_all_backends
     def test_new_format_payload(self):
         repeat_record = self.repeater.register(CaseAccessors(self.domain).get_case(CASE_ID))
         with patch('corehq.motech.repeaters.models.simple_post') as mock_post, \
@@ -809,7 +789,7 @@ class TestRepeaterFormat(BaseRepeaterTest):
         ).generator, self.new_generator)
 
 
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
+@run_with_sql_backend
 class UserRepeaterTest(TestCase, DomainSubscriptionMixin):
 
     @classmethod
@@ -886,7 +866,7 @@ class UserRepeaterTest(TestCase, DomainSubscriptionMixin):
         )
 
 
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
+@run_with_sql_backend
 class LocationRepeaterTest(TestCase, DomainSubscriptionMixin):
 
     @classmethod
@@ -997,7 +977,6 @@ class TestRepeaterPause(BaseRepeaterTest):
         delete_all_repeat_records()
         super(TestRepeaterPause, self).tearDown()
 
-    @run_with_all_backends
     def test_trigger_when_paused(self):
         # not paused
         with patch.object(RepeatRecord, 'fire') as mock_fire:
@@ -1050,7 +1029,6 @@ class TestRepeaterDeleted(BaseRepeaterTest):
         delete_all_repeat_records()
         super().tearDown()
 
-    @run_with_all_backends
     def test_trigger_when_deleted(self):
         self.repeater.retire()
 
@@ -1060,7 +1038,6 @@ class TestRepeaterDeleted(BaseRepeaterTest):
             self.assertEqual(mock_fire.call_count, 0)
             self.assertEqual(self.repeat_record.doc_type, "RepeatRecord-Deleted")
 
-    @run_with_all_backends
     def test_paused_then_deleted(self):
         self.repeater.pause()
         self.repeater.retire()


### PR DESCRIPTION
Should have done this first, if only I had thought about it first. Hopefully this will reduce the time to run all tests.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No new tests.

### QA Plan

No QA.

### Safety story

None of the removed code should be in use since all domains have been migrated to SQL.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
