### PR TITLE
remove superuser management from web user edit form

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -247,19 +247,6 @@ class UpdateUserRoleForm(BaseUpdateUserForm):
             self.initial['role'] = current_role
 
 
-class UpdateUserPermissionForm(forms.Form):
-    superuser = forms.BooleanField(label=ugettext_lazy('System Super User'), required=False)
-
-    def update_user_permission(self, couch_user=None, editable_user=None, is_superuser=None):
-        is_update_successful = False
-        if editable_user and couch_user.is_superuser:
-            editable_user.is_superuser = is_superuser
-            editable_user.save()
-            is_update_successful = True
-
-        return is_update_successful
-
-
 class BaseUserInfoForm(forms.Form):
     first_name = forms.CharField(label=ugettext_lazy('First Name'), max_length=30, required=False)
     last_name = forms.CharField(label=ugettext_lazy('Last Name'), max_length=30, required=False)

--- a/corehq/apps/users/templates/users/edit_web_user.html
+++ b/corehq/apps/users/templates/users/edit_web_user.html
@@ -77,24 +77,6 @@
       </fieldset>
     </form>
   {% endif %}
-  {% if update_permissions and not request.is_view_only %}
-    <hr />
-    <form class="form form-horizontal" name="user_permissions" method="post">
-      {% csrf_token %}
-      <input type="hidden" name="form_type" value="update-user-permissions" />
-      <fieldset>
-
-        <legend>{% blocktrans with couch_user.human_friendly_name as friendly_name %}Change {{ friendly_name }}'s Staff Permissions{% endblocktrans %}</legend>
-        {% crispy form_user_update_permissions %}
-
-        <div class="form-actions">
-          <div class="col-sm-offset-3 col-md-offset-2 col-sm-9 col-md-8 col-lg-6">
-            <button type="submit" class="btn btn-primary">{% trans 'Update Permissions' %}</button>
-          </div>
-        </div>
-      </fieldset>
-    </form>
-  {% endif %}
 
   {% if update_form %}
     <hr />


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12582

Remove the redundant form to mark user as superuser from web user edit view.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally that page still works

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
