### PR TITLE
use dict instead of wrapped fixture item

### DIFF
--- a/corehq/apps/fixtures/dbaccessors.py
+++ b/corehq/apps/fixtures/dbaccessors.py
@@ -57,7 +57,7 @@ def delete_fixture_items_for_data_type(domain, data_type_id):
     ])
 
 
-def iter_fixture_items_for_data_type(domain, data_type_id):
+def iter_fixture_items_for_data_type(domain, data_type_id, wrap=True):
     from corehq.apps.fixtures.models import FixtureDataItem
     for row in paginate_view(
             FixtureDataItem.get_db(),
@@ -68,7 +68,10 @@ def iter_fixture_items_for_data_type(domain, data_type_id):
             reduce=False,
             include_docs=True
     ):
-        yield FixtureDataItem.wrap(row['doc'])
+        if wrap:
+            yield FixtureDataItem.wrap(row['doc'])
+        else:
+            yield row['doc']
 
 
 def count_fixture_items(domain, data_type_id):

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from functools import partial
-from operator import attrgetter
+from operator import itemgetter
 from xml.etree import cElementTree as ElementTree
 
 from casexml.apps.phone.fixtures import FixtureProvider
@@ -9,11 +9,13 @@ from casexml.apps.phone.utils import (
     get_or_cache_global_fixture,
 )
 from corehq.apps.fixtures.dbaccessors import iter_fixture_items_for_data_type
+from corehq.apps.fixtures.exceptions import FixtureTypeCheckError
 from corehq.apps.fixtures.models import FIXTURE_BUCKET, FixtureDataType
 from corehq.apps.products.fixtures import product_fixture_generator_json
 from corehq.apps.programs.fixtures import program_fixture_generator_json
 from corehq.util.metrics import metrics_histogram
-from .utils import get_index_schema_node
+from corehq.util.xml_utils import serialize
+from .utils import clean_fixture_field_name, get_index_schema_node
 
 
 def item_lists_by_domain(domain):
@@ -114,7 +116,7 @@ class ItemListsProvider(FixtureProvider):
 
     def _get_global_items(self, global_types, domain):
         def get_items_by_type(data_type):
-            for item in iter_fixture_items_for_data_type(domain, data_type._id):
+            for item in iter_fixture_items_for_data_type(domain, data_type._id, wrap=False):
                 self._set_cached_type(item, data_type)
                 yield item
 
@@ -124,7 +126,7 @@ class ItemListsProvider(FixtureProvider):
         user_items_count = 0
         items_by_type = defaultdict(list)
         for item in restore_user.get_fixture_data_items():
-            data_type = user_types.get(item.data_type_id)
+            data_type = user_types.get(item['data_type_id'])
             if data_type:
                 self._set_cached_type(item, data_type)
                 items_by_type[data_type].append(item)
@@ -132,18 +134,18 @@ class ItemListsProvider(FixtureProvider):
 
         def get_items_by_type(data_type):
             return sorted(items_by_type.get(data_type, []),
-                          key=attrgetter('sort_key'))
+                          key=itemgetter('sort_key'))
 
         return self._get_fixtures(user_types, get_items_by_type, restore_user.user_id), user_items_count
 
     def _set_cached_type(self, item, data_type):
         # set the cached version used by the object so that it doesn't
         # have to do another db trip later
-        item._data_type = data_type
+        item['_data_type'] = data_type
 
     def _get_fixtures(self, data_types, get_items_by_type, user_id):
         fixtures = []
-        for data_type in sorted(data_types.values(), key=attrgetter('tag')):
+        for data_type in sorted(data_types.values(), key=itemgetter('tag')):
             if data_type.is_indexed:
                 fixtures.append(self._get_schema_element(data_type))
             items = get_items_by_type(data_type)
@@ -161,13 +163,41 @@ class ItemListsProvider(FixtureProvider):
         item_list_element = ElementTree.Element('%s_list' % data_type.tag)
         fixture_element.append(item_list_element)
         for item in items:
-            item_list_element.append(item.to_xml())
+            item_list_element.append(self.to_xml(item))
         return fixture_element
 
     def _get_schema_element(self, data_type):
         attrs_to_index = [field.field_name for field in data_type.fields if field.is_indexed]
         fixture_id = ':'.join((self.id, data_type.tag))
         return get_index_schema_node(fixture_id, attrs_to_index)
+
+    @staticmethod
+    def to_xml(item):
+        xData = ElementTree.Element(item['_data_type'].tag)
+        for attribute in item['_data_type'].item_attributes:
+            try:
+                xData.attrib[attribute] = serialize(item['item_attributes'][attribute])
+            except KeyError as e:
+                # This should never occur, buf if it does, the OTA restore on mobile will fail and
+                # this error would have been raised and email-logged.
+                raise FixtureTypeCheckError(
+                    "Table with tag %s has an item with id %s that doesn't have an attribute as defined in its types definition"
+                    % (item['_data_type'].tag, item['_id'])
+                )
+        for field in item['_data_type'].fields:
+            escaped_field_name = clean_fixture_field_name(field.field_name)
+            if field.field_name not in item['fields']:
+                xField = ElementTree.SubElement(xData, escaped_field_name)
+                xField.text = ""
+            else:
+                for field_with_attr in item['fields'][field.field_name]['field_list']:
+                    xField = ElementTree.SubElement(xData, escaped_field_name)
+                    xField.text = serialize(field_with_attr['field_value'])
+                    for attribute in field_with_attr['properties']:
+                        val = field_with_attr['properties'][attribute]
+                        xField.attrib[attribute] = serialize(val)
+
+        return xData
 
 
 item_lists = ItemListsProvider()

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -191,7 +191,7 @@ class ItemListsProvider(FixtureProvider):
                 )
         for field in item['_data_type'].fields:
             escaped_field_name = clean_fixture_field_name(field.field_name)
-            if field.field_name not in item['fields']:
+            if field.field_name not in item.get('fields', {}):
                 xField = ElementTree.SubElement(xData, escaped_field_name)
                 xField.text = ""
             else:

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -348,6 +348,11 @@ class FixtureDataItem(Document):
 
     @classmethod
     def by_user(cls, user, include_docs=True):
+        """
+        This method returns all fixture data items owned by the user, their location, or their group.
+
+        :param include_docs: whether to return the fixture data item dicts or just a set of ids
+        """
         group_ids = Group.by_user_id(user.user_id, wrap=False)
         loc_ids = user.sql_location.path if user.sql_location else []
 
@@ -364,7 +369,7 @@ class FixtureDataItem(Document):
                 wrapper=lambda r: r['value'],
             )
         )
-        if wrap:
+        if include_docs:
             results = cls.get_db().view('_all_docs', keys=list(fixture_ids), include_docs=True)
 
             # sort the results into those corresponding to real documents

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -299,33 +299,6 @@ class FixtureDataItem(Document):
         if fields:
             raise FixtureTypeCheckError("fields %s from fixture data %s not in fixture data type" % (', '.join(fields), self.get_id))
 
-    def to_xml(self):
-        xData = ElementTree.Element(self.data_type.tag)
-        for attribute in self.data_type.item_attributes:
-            try:
-                xData.attrib[attribute] = serialize(self.item_attributes[attribute])
-            except KeyError as e:
-                # This should never occur, buf if it does, the OTA restore on mobile will fail and
-                # this error would have been raised and email-logged.
-                raise FixtureTypeCheckError(
-                    "Table with tag %s has an item with id %s that doesn't have an attribute as defined in its types definition"
-                    % (self.data_type.tag, self.get_id)
-                )
-        for field in self.data_type.fields:
-            escaped_field_name = clean_fixture_field_name(field.field_name)
-            if field.field_name not in self.fields:
-                xField = ElementTree.SubElement(xData, escaped_field_name)
-                xField.text = ""
-            else:
-                for field_with_attr in self.fields[field.field_name].field_list:
-                    xField = ElementTree.SubElement(xData, escaped_field_name)
-                    xField.text = serialize(field_with_attr.field_value)
-                    for attribute in field_with_attr.properties:
-                        val = field_with_attr.properties[attribute]
-                        xField.attrib[attribute] = serialize(val)
-
-        return xData
-
     def get_groups(self, wrap=True):
         group_ids = get_owner_ids_by_type(self.domain, 'group', self.get_id)
         if wrap:

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -374,7 +374,7 @@ class FixtureDataItem(Document):
         return SQLLocation.objects.filter(location_id__in=loc_ids)
 
     @classmethod
-    def by_user(cls, user, wrap=True):
+    def by_user(cls, user, include_docs=True):
         group_ids = Group.by_user_id(user.user_id, wrap=False)
         loc_ids = user.sql_location.path if user.sql_location else []
 
@@ -401,7 +401,7 @@ class FixtureDataItem(Document):
 
             for result in results:
                 if result.get('doc'):
-                    docs.append(cls.wrap(result['doc']))
+                    docs.append(result['doc'])
                 elif result.get('error'):
                     assert result['error'] == 'not_found'
                     deleted_fixture_ids.add(result['key'])

--- a/corehq/apps/fixtures/tests/test_field_names.py
+++ b/corehq/apps/fixtures/tests/test_field_names.py
@@ -11,6 +11,7 @@ from corehq.apps.fixtures.models import (
     FixtureItemField,
     FixtureTypeField,
 )
+from corehq.apps.fixtures.fixturegenerators import item_lists
 from corehq.apps.fixtures.utils import is_identifier_invalid
 
 
@@ -113,6 +114,8 @@ class FieldNameCleanTest(TestCase):
         self.data_item.delete()
 
     def test_cleaner(self):
+        item_dict = self.data_item.to_json()
+        item_dict['_data_type'] = self.data_item.data_type
         check_xml_line_by_line(self, """
         <dirty_fields>
             <will_crash>yep</will_crash>
@@ -121,7 +124,7 @@ class FieldNameCleanTest(TestCase):
             <_with_>so fail</_with_>
             <_crazy___combo__d>just why</_crazy___combo__d>
         </dirty_fields>
-        """, ElementTree.tostring(self.data_item.to_xml(), encoding='utf-8'))
+        """, ElementTree.tostring(item_lists.to_xml(item_dict), encoding='utf-8'))
 
 
 class FieldNameValidationTest(SimpleTestCase):

--- a/corehq/apps/fixtures/tests/test_fixture_data.py
+++ b/corehq/apps/fixtures/tests/test_fixture_data.py
@@ -122,6 +122,8 @@ class FixtureDataTest(TestCase):
         super(FixtureDataTest, self).tearDown()
 
     def test_xml(self):
+        item_dict = self.data_item.to_json()
+        item_dict['_data_type'] = self.data_item.data_type
         check_xml_line_by_line(self, """
         <district>
             <state_name>Delhi_state</state_name>
@@ -129,7 +131,7 @@ class FixtureDataTest(TestCase):
             <district_name lang="eng">Delhi_in_ENG</district_name>
             <district_id>Delhi_id</district_id>
         </district>
-        """, ElementTree.tostring(self.data_item.to_xml(), encoding='utf-8'))
+        """, ElementTree.tostring(fixturegenerators.item_lists.to_xml(item_dict), encoding='utf-8'))
 
     def test_ownership(self):
         self.assertItemsEqual([self.data_item.get_id], FixtureDataItem.by_user(self.user, wrap=False))

--- a/corehq/apps/fixtures/tests/test_fixture_data.py
+++ b/corehq/apps/fixtures/tests/test_fixture_data.py
@@ -134,7 +134,7 @@ class FixtureDataTest(TestCase):
         """, ElementTree.tostring(fixturegenerators.item_lists.to_xml(item_dict), encoding='utf-8'))
 
     def test_ownership(self):
-        self.assertItemsEqual([self.data_item.get_id], FixtureDataItem.by_user(self.user, wrap=False))
+        self.assertItemsEqual([self.data_item.get_id], FixtureDataItem.by_user(self.user, include_docs=False))
         self.assertItemsEqual([self.user.get_id], self.data_item.get_all_users(wrap=False))
 
         fixture, = call_fixture_generator(self.user.to_ota_restore_user())

--- a/corehq/apps/fixtures/tests/test_location_ownership.py
+++ b/corehq/apps/fixtures/tests/test_location_ownership.py
@@ -89,7 +89,7 @@ class TestLocationOwnership(LocationHierarchyTestCase):
 
     @staticmethod
     def _get_value(fixture_item, field_name):
-        return fixture_item.fields[field_name].field_list[0].field_value
+        return fixture_item['fields'][field_name]['field_list'][0]['field_value']
 
     def test_sees_fixture_at_own_location(self):
         fixture_items = FixtureDataItem.by_user(self.suffolk_user)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This changes our fixture restore code to not wrap `FixtureDataItem`s. For domains with large fixtures, they form the dominant part of restore memory usage. This is in large part due to the fact that we are not able to effectively chunk user fixtures (those where we need to look up ownership of the individual rows). That will likely be much easier when fixtures are in SQL, but in the mean time this provides a fair amount of relief. Wrapping is expensive in both time and memory, and this provides significant improvement in both places.

For a specific user with ~600k fixture rows and ~7k cases (such that almost all restore time was in fixtures), I compared this code to `master`. Memory usage on the restore went from 3.5GB to 1.6GB and time went from 183 seconds to 50 seconds. Notably memory usage on restores seems to be mostly influenced by fixtures, as similar restores in the domain with over 100k cases, but fewer fixture rows had far less memory usage, although longer timing, so this should pull down memory peaks for these domains regardless of casedb size.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Both the xml serialization function, and the larger fixture generator have automated testing, unmodified in this PR. Restores more generally are also well tested.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
I plan to put this on staging, for some added sanity checks.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
