### PR TITLE
update instructions for removed once off migrations

### DIFF
--- a/corehq/util/django_migrations.py
+++ b/corehq/util/django_migrations.py
@@ -145,7 +145,7 @@ def run_management_command_or_exit(command_name, *args, required_commit=None, cu
 
                 commcare-cloud <env> fab setup_limited_release --set code_branch={required_commit}
 
-                commcare-cloud <env> django-manage --release <release created by previous command> {command_name}
+                commcare-cloud <env> django-manage --release <release created by previous command> migrate_multi
 
                 commcare-cloud <env> deploy commcare
             """)


### PR DESCRIPTION
## Summary
Running `migrate_multi` will apply the migration and also record that the migration has been done which will unblock the deploy.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
NA

### QA Plan
NA

### Safety story
Change to text only.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
