### PR TITLE
data registry suite file changes for loading case data into forms

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -13,7 +13,6 @@ from corehq.apps.app_manager.exceptions import (
 from corehq.apps.app_manager.suite_xml.contributors import (
     SuiteContributorByModule,
 )
-from corehq.apps.app_manager.suite_xml.sections.remote_requests import REGISTRY_INSTANCE
 from corehq.apps.app_manager.suite_xml.utils import (
     get_form_locale_id,
     get_select_chain_meta,
@@ -477,6 +476,7 @@ class EntriesHelper(object):
         return datums
 
     def get_data_registry_query_datum(self, datum, module):
+        from corehq.apps.app_manager.suite_xml.sections.remote_requests import REGISTRY_INSTANCE
         return FormDatumMeta(
             datum=RemoteRequestQuery(
                 url=absolute_reverse('registry_case', args=[self.app.domain]),

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -476,6 +476,10 @@ class EntriesHelper(object):
         return datums
 
     def get_data_registry_query_datum(self, datum, module):
+        """When a data registry is the source of the search results we can't assume that the case
+        the user selected is in the user's casedb so we have to get the data directly from HQ before
+        entering the form. This data is then available in the 'registry' instance (``instance('registry')``)
+        """
         from corehq.apps.app_manager.suite_xml.sections.remote_requests import REGISTRY_INSTANCE
         return FormDatumMeta(
             datum=RemoteRequestQuery(

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -77,9 +77,13 @@ class RemoteRequestFactory(object):
                 ),
             ],
         }
-        relevant = self.module.search_config.get_relevant()
-        if relevant:
-            kwargs["relevant"] = relevant
+        if self.module.search_config.data_registry:
+            # Disable claim request for data registry
+            kwargs["relevant"] = "false()"
+        else:
+            relevant = self.module.search_config.get_relevant()
+            if relevant:
+                kwargs["relevant"] = relevant
         return RemoteRequestPost(**kwargs)
 
     def _build_command(self):

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -39,7 +39,12 @@ from corehq.apps.case_search.models import (
 from corehq.util.timer import time_method
 from corehq.util.view_utils import absolute_reverse
 
-RESULTS_INSTANCE = 'results'  # The name of the instance where search results are stored
+# The name of the instance where search results are stored
+RESULTS_INSTANCE = 'results'
+
+# The name of the instance where search results are stored when querying a data registry
+REGISTRY_INSTANCE = 'registry'
+
 SESSION_INSTANCE = 'commcaresession'
 
 

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -41,7 +41,8 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         self.app._id = '123'
         self.app.build_spec = BuildSpec(version='2.35.0', build_number=1)
         self.module = self.app.add_module(Module.new_module("Untitled Module", None))
-        self.app.new_form(0, "Untitled Form", None)
+        self.form = self.app.new_form(0, "Untitled Form", None)
+        self.form.requires = 'case'
         self.module.case_type = 'case'
 
         # chosen xpath just used to reference more instances - not considered valid to use in apps
@@ -349,15 +350,30 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             suite = self.app.create_suite()
         self.assertXmlPartialEqual(self.get_xml('search_config_blacklisted_owners'), suite, "./remote-request[1]")
 
+    @flag_enabled('USH_CASE_CLAIM_UPDATES')
     def test_search_data_registry(self, *args):
         self.module.search_config.data_registry = "myregistry"
         suite = self.app.create_suite()
-        expected = """
+
+        expected_entry_query = """
+        <partial>
+          <query url="http://localhost:8000/a/test_domain/phone/registry_case/" storage-instance="registry" template="case" default_search="true">
+            <data key="case_type" ref="'case'"/>
+            <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
+            <data key="registry" ref="'myregistry'"/>
+          </query>
+        </partial>"""
+        self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]/session/query")
+
+        # assert post is disabled
+        self.assertXmlHasXpath(suite, "./remote-request[1]/post[@relevant='false()']")
+
+        expected_data = """
         <partial>
           <data key="commcare_registry" ref="myregistry"/>
         </partial>
         """
-        self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/data[@key='commcare_registry']")
+        self.assertXmlPartialEqual(expected_data, suite, "./remote-request[1]/session/query/data[@key='commcare_registry']")
 
     def test_prompt_hint(self, *args):
         self.module.search_config.properties[0].hint = {'en': 'Search against name'}


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-1230

## Summary
Additional suite file changes when using data registries for case search:

1. Disable case claim request
2. Add a `query` to the form entry session

Spec: https://docs.google.com/document/d/1FCSxVBoBG8LnmogMwei1nb6eC74eUhs7HWuJmBg6i3k/edit#heading=h.oij9d37sohxx

## Feature Flag
DATA_REGISTRY

## Product Description
Application XML changes to support loading data from data registries into forms.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Updated

### QA Plan
None

### Safety story
Currently unused feature

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
