### PR TITLE
Add support for batch size in Auditcare Migration command

### DIFF
--- a/corehq/apps/auditcare/couch_to_sql.py
+++ b/corehq/apps/auditcare/couch_to_sql.py
@@ -28,7 +28,6 @@ ACCESS_LOOKUP = {
     "login_failed": ACCESS_FAILED,
 }
 
-COUCH_QUERY_LIMIT = 1000
 
 IGNORED_DOC_TYPES = {"ModelActionAudit"}
 

--- a/corehq/apps/auditcare/couch_to_sql.py
+++ b/corehq/apps/auditcare/couch_to_sql.py
@@ -33,7 +33,7 @@ COUCH_QUERY_LIMIT = 1000
 IGNORED_DOC_TYPES = {"ModelActionAudit"}
 
 
-def copy_events_to_sql(start_time, end_time):
+def copy_events_to_sql(start_time, end_time, batch_size):
     util = AuditCareMigrationUtil()
     logger.info(f"Starting batch: {start_time} - {end_time}")
     key = get_migration_key(start_time, end_time)
@@ -46,7 +46,7 @@ def copy_events_to_sql(start_time, end_time):
     count, other_doc_type_count = util.get_existing_count(key)
     try:
         while not break_query:
-            events_info = get_events_from_couch(next_start_key, end_key, last_doc_id)
+            events_info = get_events_from_couch(next_start_key, end_key, batch_size, last_doc_id)
             next_start_key = events_info['next_start_key']
             NavigationEventAudit.objects.bulk_create(events_info['navigation_events'], ignore_conflicts=True)
             AccessAudit.objects.bulk_create(events_info['audit_events'], ignore_conflicts=True)
@@ -78,7 +78,7 @@ def get_migration_key(start_time, end_time):
     return get_formatted_datetime_string(start_time) + '_' + get_formatted_datetime_string(end_time)
 
 
-def get_events_from_couch(start_key, end_key, start_doc_id=None):
+def get_events_from_couch(start_key, end_key, batch_size, start_doc_id=None):
     navigation_objects = []
     access_objects = []
     records_returned = 0
@@ -87,7 +87,7 @@ def get_events_from_couch(start_key, end_key, start_doc_id=None):
     access_couch_ids = []
     other_doc_type_count = 0
     processed_doc_id = start_doc_id
-    couch_docs = _get_couch_docs(start_key, end_key, start_doc_id)
+    couch_docs = _get_couch_docs(start_key, end_key, batch_size, start_doc_id)
     for result in couch_docs:
         next_start_key = result['key']
         records_returned += 1
@@ -138,7 +138,7 @@ def get_events_from_couch(start_key, end_key, start_doc_id=None):
     )
 
     res_obj.update({
-        "break_query": records_returned < COUCH_QUERY_LIMIT or not next_start_key,
+        "break_query": records_returned < batch_size or not next_start_key,
         "next_start_key": next_start_key,
         "last_doc_id": processed_doc_id,
         "other_doc_type_count": other_doc_type_count
@@ -147,7 +147,7 @@ def get_events_from_couch(start_key, end_key, start_doc_id=None):
 
 
 @retry_on_couch_error
-def _get_couch_docs(start_key, end_key, start_doc_id=None):
+def _get_couch_docs(start_key, end_key, batch_size, start_doc_id=None):
     db = get_db("auditcare")
     if start_doc_id:
         kwargs = {"startkey_docid": start_doc_id, "skip": 1}
@@ -170,7 +170,7 @@ def _get_couch_docs(start_key, end_key, start_doc_id=None):
         reduce=False,
         include_docs=True,
         descending=True,
-        limit=COUCH_QUERY_LIMIT,
+        limit=batch_size,
         **kwargs
     )
     return list(result)

--- a/corehq/apps/auditcare/management/commands/copy_events_to_sql.py
+++ b/corehq/apps/auditcare/management/commands/copy_events_to_sql.py
@@ -56,7 +56,13 @@ class Command(BaseCommand):
                 if not batches:
                     print("No batches to process")
                     return
-                batched_processes = [gevent.spawn(copy_events_to_sql, *batch) for batch in batches]
+                batched_processes = [
+                    gevent.spawn(
+                        copy_events_to_sql,
+                        *batch,
+                        batch_size=batch_size
+                    ) for batch in batches
+                ]
                 gevent.joinall([*batched_processes])
         except MissingStartTimeError as e:
             message = f"Error in copy_events_to_sql while generating batches\n{e}"

--- a/corehq/apps/auditcare/management/commands/copy_events_to_sql.py
+++ b/corehq/apps/auditcare/management/commands/copy_events_to_sql.py
@@ -31,10 +31,17 @@ class Command(BaseCommand):
             choices=[True, False],
             help="Will try to process batches that have been errored"
         )
+        parser.add_argument(
+            '--batch_size',
+            default=1000,
+            type=int,
+            help="Number of documents to query from couch"
+        )
 
     def handle(self, **options):
         workers = options['workers']
         batch_by = options['batch_by']
+        batch_size = options['batch_size']
         util = AuditCareMigrationUtil()
         batches = []
         try:

--- a/corehq/apps/auditcare/tests/test_auditcare_migration.py
+++ b/corehq/apps/auditcare/tests/test_auditcare_migration.py
@@ -210,14 +210,13 @@ class TestCopyEventsToSQL(AuditcareTest):
             self.assertEqual(AccessAudit.objects.first().path, "/a/delmar/login/")
 
         NavigationEventAudit(event_date=datetime(2021, 2, 1, 4), path="just/a/checkpoint").save()
-        copy_events_to_sql(start_time=datetime(2021, 2, 1, 5), end_time=datetime(2021, 2, 1, 1, 59))
+        copy_events_to_sql(start_time=datetime(2021, 2, 1, 5), end_time=datetime(2021, 2, 1, 1, 59), batch_size=10)
         _assert()
 
         # Re-copying should have no effect
-        copy_events_to_sql(start_time=datetime(2021, 2, 1, 5), end_time=datetime(2021, 2, 1, 2))
+        copy_events_to_sql(start_time=datetime(2021, 2, 1, 5), end_time=datetime(2021, 2, 1, 2), batch_size=10)
         _assert()
 
-    @patch('corehq.apps.auditcare.couch_to_sql.COUCH_QUERY_LIMIT', 2)
     def test_copy_with_small_couch_query_limit(self):
         def _assert():
             self.assertEqual(NavigationEventAudit.objects.count(), 4)
@@ -232,5 +231,5 @@ class TestCopyEventsToSQL(AuditcareTest):
             self.assertEqual(AccessAudit.objects.count(), 1)
             self.assertEqual(AccessAudit.objects.first().path, "/a/delmar/login/")
 
-        copy_events_to_sql(start_time=datetime(2021, 2, 2), end_time=datetime(2020, 12, 31))
+        copy_events_to_sql(start_time=datetime(2021, 2, 2), end_time=datetime(2020, 12, 31), batch_size=2)
         _assert()


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Allow the command to take custom batch size while starting the migrations
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Changes are live on staging and the tests ran successfully after the change.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
