### PR TITLE
prevent creating roles with duplicate names

### DIFF
--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -362,12 +362,10 @@ hqDefine('users/js/roles',[
         self.roleError = ko.observable("");
         self.setRoleError = function (form, error) {
             self.roleError(error);
-            $(form).find('.modal-footer').addClass('has-error');
             $(form).find('[type="submit"]').enableButton();
         };
         self.clearRoleError = function (form) {
             self.roleError("");
-            $(form).find('.modal-footer').removeClass('has-error');
         };
         self.clearRoleForm = function (_, event) {
             self.clearRoleError($(event.target).parents('form'));

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -364,15 +364,15 @@ hqDefine('users/js/roles',[
             self.roleError(error);
             $(form).find('[type="submit"]').enableButton();
         };
-        self.clearRoleError = function (form) {
+        self.clearRoleError = function () {
             self.roleError("");
         };
-        self.clearRoleForm = function (unused, event) {
-            self.clearRoleError($(event.target).parents('form'));
+        self.clearRoleForm = function () {
+            self.clearRoleError();
             self.unsetRoleBeingEdited();
         };
         self.submitNewRole = function (form) {
-            self.clearRoleError(form);
+            self.clearRoleError();
             $.ajax({
                 method: 'POST',
                 url: o.saveUrl,

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -323,7 +323,7 @@ hqDefine('users/js/roles',[
             roleCopy.modalTitle = title;
             self.roleBeingEdited(roleCopy);
         };
-        self.unsetRoleBeingEdited = function () {
+        self.unsetRoleBeingEdited = function (_, event) {
             self.roleBeingEdited(undefined);
         };
         self.setRoleBeingDeleted = function (role) {
@@ -359,8 +359,22 @@ hqDefine('users/js/roles',[
                 };
             },
         };
-        self.submitNewRole = function () {
-            // moved saveOptions inline
+        self.roleError = ko.observable("");
+        self.setRoleError = function(form, error) {
+            self.roleError(error);
+            $(form).find('.modal-footer').addClass('has-error')
+            $(form).find('[type="submit"]').enableButton();
+        };
+        self.clearRoleError = function(form) {
+            self.roleError("");
+            $(form).find('.modal-footer').removeClass('has-error')
+        }
+        self.clearRoleForm = function(_, event) {
+            self.clearRoleError($(event.target).parents('form'));
+            self.unsetRoleBeingEdited();
+        }
+        self.submitNewRole = function (form) {
+            self.clearRoleError(form);
             $.ajax({
                 method: 'POST',
                 url: o.saveUrl,
@@ -371,7 +385,11 @@ hqDefine('users/js/roles',[
                     self.unsetRoleBeingEdited();
                 },
                 error: function (response) {
-                    alertUser.alert_user(response.responseJSON.message, 'danger');
+                    var message = gettext("An error occurred, please try again.");
+                    if (response.responseJSON && response.responseJSON.message) {
+                        message = response.responseJSON.message;
+                    }
+                    self.setRoleError(form, message);
                 }
             });
         };

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -360,19 +360,19 @@ hqDefine('users/js/roles',[
             },
         };
         self.roleError = ko.observable("");
-        self.setRoleError = function(form, error) {
+        self.setRoleError = function (form, error) {
             self.roleError(error);
-            $(form).find('.modal-footer').addClass('has-error')
+            $(form).find('.modal-footer').addClass('has-error');
             $(form).find('[type="submit"]').enableButton();
         };
-        self.clearRoleError = function(form) {
+        self.clearRoleError = function (form) {
             self.roleError("");
-            $(form).find('.modal-footer').removeClass('has-error')
-        }
-        self.clearRoleForm = function(_, event) {
+            $(form).find('.modal-footer').removeClass('has-error');
+        };
+        self.clearRoleForm = function (_, event) {
             self.clearRoleError($(event.target).parents('form'));
             self.unsetRoleBeingEdited();
-        }
+        };
         self.submitNewRole = function (form) {
             self.clearRoleError(form);
             $.ajax({

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -367,7 +367,7 @@ hqDefine('users/js/roles',[
         self.clearRoleError = function (form) {
             self.roleError("");
         };
-        self.clearRoleForm = function (_, event) {
+        self.clearRoleForm = function (unused, event) {
             self.clearRoleError($(event.target).parents('form'));
             self.unsetRoleBeingEdited();
         };

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -394,7 +394,7 @@
           </div>
         </div>
 
-        <div class="modal-footer">
+        <div class="modal-footer" data-bind="css: {'has-error': $root.roleError }">
           {% if can_edit_roles %}
             <button type="button"
                     class="btn btn-default"

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -398,13 +398,14 @@
           {% if can_edit_roles %}
             <button type="button"
                     class="btn btn-default"
-                    data-bind="click: $root.unsetRoleBeingEdited">
+                    data-bind="click: $root.clearRoleForm">
               {% trans "Cancel" %}
             </button>
             <button type="submit"
                     class="btn btn-primary disable-on-submit">
               {% trans "Save" %}
             </button>
+            <span class='help-block' data-bind="text: $root.roleError"></span>
           {% else %}
             <button type="button"
                     class="btn btn-default"

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -875,8 +875,8 @@ def _update_role_from_view(domain, role_data):
 
     name = role_data["name"]
     if not role.id:
-        if UserRole.objects.filter(domain=domain, name=name).exists():
-            raise ValueError(_("Role with name '{name}' already exists").format(name=name))
+        if UserRole.objects.filter(domain=domain, name__iexact=name).exists():
+            raise ValueError(_("A role with the same name already exists"))
 
     role.domain = domain
     role.name = name

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -873,8 +873,13 @@ def _update_role_from_view(domain, role_data):
     else:
         role = UserRole()
 
+    name = role_data["name"]
+    if not role.id:
+        if UserRole.objects.filter(domain=domain, name=name).exists():
+            raise ValueError(_("Role with name '{name}' already exists").format(name=name))
+
     role.domain = domain
-    role.name = role_data["name"]
+    role.name = name
     role.default_landing_page = landing_page
     role.is_non_admin_editable = role_data["is_non_admin_editable"]
     role.save()

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -875,7 +875,7 @@ def _update_role_from_view(domain, role_data):
 
     name = role_data["name"]
     if not role.id:
-        if UserRole.objects.filter(domain=domain, name__iexact=name).exists():
+        if name.lower() == 'admin' or UserRole.objects.filter(domain=domain, name__iexact=name).exists():
             raise ValueError(_("A role with the same name already exists"))
 
     role.domain = domain


### PR DESCRIPTION
## Summary
When I was doing the couch to SQL migration for roles I noticed a number of domains that had roles with duplicate names. Having roles with duplicate names is not great since the role name is all that's displayed in the role selection dropdowns:

![image](https://user-images.githubusercontent.com/249606/131342871-da854d63-5379-4272-b2f2-275cca1e06ed.png)

This change does not enforce the uniqueness at the DB level since that would require updating existing duplicates. Instead this only prevents creating new roles with duplicate names. Duplicates can still be created by editing an existing role to use a duplicate name. I decided to do this to prevent blocking users from updating existing role permissions even if it has a duplicate name but that decision is open for challenge.

The error is presented to the user underneath the save button:
![image](https://user-images.githubusercontent.com/249606/131347728-b30c73cb-ac42-4074-b81b-9b007f42e942.png)


## Product Description
Prevent creating new roles with duplicate names (per domain)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
None

### QA Plan
Staging: https://dimagi-dev.atlassian.net/browse/QA-3459

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
