### PR TITLE
Temporary emails are now rejected by hubspot

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -644,7 +644,7 @@ def track_periodic_data():
 
 
 def _email_is_valid(email):
-    if not email:
+    if not email or _is_suspicious_email(email):
         return False
 
     try:
@@ -654,6 +654,19 @@ def _email_is_valid(email):
         return False
 
     return True
+
+
+# These domains provide disposable email addresses which attract scammers
+# AWS Guard Duty triggers alerts for these domains. The below list is likely incomplete --
+# if a Guard Duty alert is triggered for a domain not seen below, please add it
+SUSPICIOUS_DOMAINS = [
+    'mailna.me',
+    'mozej.com'
+]
+
+
+def _is_suspicious_email(email):
+    return any(email.endswith(domain) for domain in SUSPICIOUS_DOMAINS)
 
 
 def submit_data_to_hub_and_kiss(submit_json):

--- a/corehq/apps/analytics/tests/test_tasks.py
+++ b/corehq/apps/analytics/tests/test_tasks.py
@@ -1,0 +1,16 @@
+from django.test import SimpleTestCase
+from ..tasks import _email_is_valid
+
+
+class TestEmailValidation(SimpleTestCase):
+    def test_mozej_dot_com_is_invalid(self):
+        self.assertFalse(_email_is_valid('test@mozej.com'))
+
+    def test_mailna_dot_me_is_invalid(self):
+        self.assertFalse(_email_is_valid('test@mailna.me'))
+
+    def test_generic_email_is_valid(self):
+        self.assertTrue(_email_is_valid('test@google.com'))
+
+    def test_malformed_email_is_not_valid(self):
+        self.assertFalse(_email_is_valid('bob'))


### PR DESCRIPTION
## Summary
[This](https://dimagi-dev.atlassian.net/browse/SAAS-12594) is roughly the ticket that inspired this ticket, with [this](https://dimagi-dev.atlassian.net/browse/SAAS-12584) being what the alerts look like for a triggered warning.  The issue is that AWS maintains a list of suspicious domains, which we trigger an alert for while making sure that email domains are resolvable. As it seems we need to maintain this resolvable check, the next best approach was to maintain our own mirror version of suspicious domains.

Note that this isn't ideal -- AWS has its own list, which could change independently of what we store here.

A more complete solution probably involves spreading this 'invalid email' logic throughout the codebase. In particular, a user should not be able to sign up with one of these domains. I'm not sure if that's in scope for this ticket, or something we should spin off on its own.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

New test suite created in _test_tasks_

### QA Plan

No QA needed.

### Safety story
The unit tests cover my concerns here. This task was already rejecting malformed emails, and this essentially just turns suspicious domains into malformed emails.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
