### PR TITLE
wrap celery result sequence

### DIFF
--- a/corehq/apps/hqadmin/migrations/0020_celery_results_sequence.py
+++ b/corehq/apps/hqadmin/migrations/0020_celery_results_sequence.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hqadmin', '0019_celery_taskmeta_sequence')
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            "ALTER SEQUENCE IF EXISTS django_celery_results_taskresult_id_seq MAXVALUE 2147483647 CYCLE"
+        ),
+    ]


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12419

Same idea as https://github.com/dimagi/commcare-hq/pull/30210

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

This PR can't be reverted after deploy without thinking about it further. The consideration is that we are close to the upper limit already.
