### PR TITLE
Added case search filter to exclude related cases

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -32,6 +32,7 @@ from corehq.apps.app_manager.xpath import (
     InstanceXpath,
     interpolate_xpath,
 )
+from corehq.apps.case_search.const import EXCLUDE_RELATED_CASES_FILTER
 from corehq.apps.case_search.models import (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
     CASE_SEARCH_REGISTRY_ID_KEY,
@@ -166,7 +167,7 @@ class RemoteRequestFactory(object):
                     additional_types, instance_name=RESULTS_INSTANCE)
             if self.module.search_config.search_filter:
                 nodeset = f"{nodeset}[{interpolate_xpath(self.module.search_config.search_filter)}]"
-        nodeset += "[not(commcare_is_related_case=true())]"
+        nodeset += EXCLUDE_RELATED_CASES_FILTER
 
         return [SessionDatum(
             id=self.module.search_config.case_session_var,

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -166,7 +166,7 @@ class RemoteRequestFactory(object):
                     additional_types, instance_name=RESULTS_INSTANCE)
             if self.module.search_config.search_filter:
                 nodeset = f"{nodeset}[{interpolate_xpath(self.module.search_config.search_filter)}]"
-        nodeset += "[not(commcare_related_case=true())]"
+        nodeset += "[not(commcare_is_related_case=true())]"
 
         return [SessionDatum(
             id=self.module.search_config.case_session_var,

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -166,6 +166,7 @@ class RemoteRequestFactory(object):
                     additional_types, instance_name=RESULTS_INSTANCE)
             if self.module.search_config.search_filter:
                 nodeset = f"{nodeset}[{interpolate_xpath(self.module.search_config.search_filter)}]"
+        nodeset += "[not(commcare_related_case=true())]"
 
         return [SessionDatum(
             id=self.module.search_config.case_session_var,

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -43,7 +43,7 @@
         </prompt>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name]"
+             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_related_case=true())]"
              value="./@case_id"
              detail-confirm="{module_id}_search_long"
              detail-select="{module_id}_search_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -43,7 +43,7 @@
         </prompt>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_related_case=true())]"
+             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_is_related_case=true())]"
              value="./@case_id"
              detail-confirm="{module_id}_search_long"
              detail-select="{module_id}_search_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
@@ -41,7 +41,7 @@
         </prompt>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_related_case=true())]"
+             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_is_related_case=true())]"
              value="./@case_id"
              detail-confirm="m0_case_long"
              detail-select="m0_case_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
@@ -41,7 +41,7 @@
         </prompt>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name]"
+             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_related_case=true())]"
              value="./@case_id"
              detail-confirm="m0_case_long"
              detail-select="m0_case_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
@@ -32,7 +32,7 @@
         </prompt>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][not(commcare_related_case=true())]"
+             nodeset="instance('results')/results/case[@case_type='case'][not(commcare_is_related_case=true())]"
              value="./@case_id"
              detail-confirm="m0_search_long"
              detail-select="m0_search_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
@@ -32,7 +32,7 @@
         </prompt>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case']"
+             nodeset="instance('results')/results/case[@case_type='case'][not(commcare_related_case=true())]"
              value="./@case_id"
              detail-confirm="m0_search_long"
              detail-select="m0_search_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
@@ -27,7 +27,7 @@
         <data key="name" ref="instance('locations')/locations/location[@id=123]/@type"/>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][not(commcare_related_case=true())]"
+             nodeset="instance('results')/results/case[@case_type='case'][not(commcare_is_related_case=true())]"
              value="./@case_id"
              detail-confirm="m0_search_long"
              detail-select="m0_search_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
@@ -27,7 +27,7 @@
         <data key="name" ref="instance('locations')/locations/location[@id=123]/@type"/>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case']"
+             nodeset="instance('results')/results/case[@case_type='case'][not(commcare_related_case=true())]"
              value="./@case_id"
              detail-confirm="m0_search_long"
              detail-select="m0_search_short"/>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -220,7 +220,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         suite = parse_normalize(suite, to_string=False)
         ref_path = './remote-request[1]/session/datum/@nodeset'
         self.assertEqual(
-            "instance('{}')/{}/case[@case_type='{}'][{}]".format(
+            "instance('{}')/{}/case[@case_type='{}'][{}][not(commcare_related_case=true())]".format(
                 RESULTS_INSTANCE,
                 RESULTS_INSTANCE,
                 self.module.case_type,
@@ -237,12 +237,13 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         suite = parse_normalize(suite_xml, to_string=False)
         ref_path = './remote-request[1]/session/datum/@nodeset'
         self.assertEqual(
-            "instance('{}')/{}/case[@case_type='{}' or @case_type='{}'][{}]".format(
+            "instance('{}')/{}/case[@case_type='{}' or @case_type='{}'][{}][{}]".format(
                 RESULTS_INSTANCE,
                 RESULTS_INSTANCE,
                 self.module.case_type,
                 another_case_type,
-                self.module.search_config.search_filter
+                self.module.search_config.search_filter,
+                "not(commcare_related_case=true())",
             ),
             suite.xpath(ref_path)[0]
         )

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -220,7 +220,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         suite = parse_normalize(suite, to_string=False)
         ref_path = './remote-request[1]/session/datum/@nodeset'
         self.assertEqual(
-            "instance('{}')/{}/case[@case_type='{}'][{}][not(commcare_related_case=true())]".format(
+            "instance('{}')/{}/case[@case_type='{}'][{}][not(commcare_is_related_case=true())]".format(
                 RESULTS_INSTANCE,
                 RESULTS_INSTANCE,
                 self.module.case_type,
@@ -243,7 +243,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 self.module.case_type,
                 another_case_type,
                 self.module.search_config.search_filter,
-                "not(commcare_related_case=true())",
+                "not(commcare_is_related_case=true())",
             ),
             suite.xpath(ref_path)[0]
         )

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -27,6 +27,7 @@ from corehq.apps.app_manager.tests.util import (
     patch_get_xform_resource_overrides,
 )
 from corehq.apps.builds.models import BuildSpec
+from corehq.apps.case_search.const import EXCLUDE_RELATED_CASES_FILTER
 from corehq.util.test_utils import flag_enabled
 
 DOMAIN = 'test_domain'
@@ -220,11 +221,12 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         suite = parse_normalize(suite, to_string=False)
         ref_path = './remote-request[1]/session/datum/@nodeset'
         self.assertEqual(
-            "instance('{}')/{}/case[@case_type='{}'][{}][not(commcare_is_related_case=true())]".format(
+            "instance('{}')/{}/case[@case_type='{}'][{}]{}".format(
                 RESULTS_INSTANCE,
                 RESULTS_INSTANCE,
                 self.module.case_type,
-                search_filter
+                search_filter,
+                EXCLUDE_RELATED_CASES_FILTER
             ),
             suite.xpath(ref_path)[0]
         )
@@ -237,13 +239,13 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         suite = parse_normalize(suite_xml, to_string=False)
         ref_path = './remote-request[1]/session/datum/@nodeset'
         self.assertEqual(
-            "instance('{}')/{}/case[@case_type='{}' or @case_type='{}'][{}][{}]".format(
+            "instance('{}')/{}/case[@case_type='{}' or @case_type='{}'][{}]{}".format(
                 RESULTS_INSTANCE,
                 RESULTS_INSTANCE,
                 self.module.case_type,
                 another_case_type,
                 self.module.search_config.search_filter,
-                "not(commcare_is_related_case=true())",
+                EXCLUDE_RELATED_CASES_FILTER
             ),
             suite.xpath(ref_path)[0]
         )

--- a/corehq/apps/case_search/const.py
+++ b/corehq/apps/case_search/const.py
@@ -16,6 +16,7 @@ CASE_SEARCH_MAX_RESULTS = 500
 RELEVANCE_SCORE = "commcare_search_score"
 # Added to secondary results in case search to filter them out of the case list
 IS_RELATED_CASE = "commcare_is_related_case"
+EXCLUDE_RELATED_CASES_FILTER = "[not(commcare_is_related_case=true())]"
 
 # Added to each case on the index for debugging when a case was added to ES
 INDEXED_ON = '@indexed_on'


### PR DESCRIPTION
## Summary
Part of https://dimagi-dev.atlassian.net/browse/USH-1252

## Feature Flag
Case search & claim

## Product Description
Prevents invalid results from showing up in case search. Unlikely to be relevant for non-USH projects.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Tests included.

### QA Plan

Not requesting QA for this piece. Tested locally that I can still build apps and use case search.

### Safety story
Has decent test coverage, adds a filter that will be ignored until the other part of this ticket is done.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
