### PR TITLE
Tag related cases as such in case search results

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -32,6 +32,7 @@ from corehq.apps.app_manager.xpath import (
     InstanceXpath,
     interpolate_xpath,
 )
+from corehq.apps.case_search.const import EXCLUDE_RELATED_CASES_FILTER
 from corehq.apps.case_search.models import (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
     CASE_SEARCH_REGISTRY_ID_KEY,
@@ -166,7 +167,7 @@ class RemoteRequestFactory(object):
                     additional_types, instance_name=RESULTS_INSTANCE)
             if self.module.search_config.search_filter:
                 nodeset = f"{nodeset}[{interpolate_xpath(self.module.search_config.search_filter)}]"
-        nodeset += "[not(commcare_is_related_case=true())]"
+        nodeset += EXCLUDE_RELATED_CASES_FILTER
 
         return [SessionDatum(
             id=self.module.search_config.case_session_var,

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -166,7 +166,7 @@ class RemoteRequestFactory(object):
                     additional_types, instance_name=RESULTS_INSTANCE)
             if self.module.search_config.search_filter:
                 nodeset = f"{nodeset}[{interpolate_xpath(self.module.search_config.search_filter)}]"
-        nodeset += "[not(commcare_related_case=true())]"
+        nodeset += "[not(commcare_is_related_case=true())]"
 
         return [SessionDatum(
             id=self.module.search_config.case_session_var,

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -166,6 +166,7 @@ class RemoteRequestFactory(object):
                     additional_types, instance_name=RESULTS_INSTANCE)
             if self.module.search_config.search_filter:
                 nodeset = f"{nodeset}[{interpolate_xpath(self.module.search_config.search_filter)}]"
+        nodeset += "[not(commcare_related_case=true())]"
 
         return [SessionDatum(
             id=self.module.search_config.case_session_var,

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -43,7 +43,7 @@
         </prompt>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name]"
+             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_related_case=true())]"
              value="./@case_id"
              detail-confirm="{module_id}_search_long"
              detail-select="{module_id}_search_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -43,7 +43,7 @@
         </prompt>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_related_case=true())]"
+             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_is_related_case=true())]"
              value="./@case_id"
              detail-confirm="{module_id}_search_long"
              detail-select="{module_id}_search_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
@@ -41,7 +41,7 @@
         </prompt>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_related_case=true())]"
+             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_is_related_case=true())]"
              value="./@case_id"
              detail-confirm="m0_case_long"
              detail-select="m0_case_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
@@ -41,7 +41,7 @@
         </prompt>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name]"
+             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_related_case=true())]"
              value="./@case_id"
              detail-confirm="m0_case_long"
              detail-select="m0_case_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
@@ -32,7 +32,7 @@
         </prompt>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][not(commcare_related_case=true())]"
+             nodeset="instance('results')/results/case[@case_type='case'][not(commcare_is_related_case=true())]"
              value="./@case_id"
              detail-confirm="m0_search_long"
              detail-select="m0_search_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
@@ -32,7 +32,7 @@
         </prompt>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case']"
+             nodeset="instance('results')/results/case[@case_type='case'][not(commcare_related_case=true())]"
              value="./@case_id"
              detail-confirm="m0_search_long"
              detail-select="m0_search_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
@@ -27,7 +27,7 @@
         <data key="name" ref="instance('locations')/locations/location[@id=123]/@type"/>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][not(commcare_related_case=true())]"
+             nodeset="instance('results')/results/case[@case_type='case'][not(commcare_is_related_case=true())]"
              value="./@case_id"
              detail-confirm="m0_search_long"
              detail-select="m0_search_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
@@ -27,7 +27,7 @@
         <data key="name" ref="instance('locations')/locations/location[@id=123]/@type"/>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case']"
+             nodeset="instance('results')/results/case[@case_type='case'][not(commcare_related_case=true())]"
              value="./@case_id"
              detail-confirm="m0_search_long"
              detail-select="m0_search_short"/>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -220,7 +220,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         suite = parse_normalize(suite, to_string=False)
         ref_path = './remote-request[1]/session/datum/@nodeset'
         self.assertEqual(
-            "instance('{}')/{}/case[@case_type='{}'][{}]".format(
+            "instance('{}')/{}/case[@case_type='{}'][{}][not(commcare_related_case=true())]".format(
                 RESULTS_INSTANCE,
                 RESULTS_INSTANCE,
                 self.module.case_type,
@@ -237,12 +237,13 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         suite = parse_normalize(suite_xml, to_string=False)
         ref_path = './remote-request[1]/session/datum/@nodeset'
         self.assertEqual(
-            "instance('{}')/{}/case[@case_type='{}' or @case_type='{}'][{}]".format(
+            "instance('{}')/{}/case[@case_type='{}' or @case_type='{}'][{}][{}]".format(
                 RESULTS_INSTANCE,
                 RESULTS_INSTANCE,
                 self.module.case_type,
                 another_case_type,
-                self.module.search_config.search_filter
+                self.module.search_config.search_filter,
+                "not(commcare_related_case=true())",
             ),
             suite.xpath(ref_path)[0]
         )

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -220,7 +220,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         suite = parse_normalize(suite, to_string=False)
         ref_path = './remote-request[1]/session/datum/@nodeset'
         self.assertEqual(
-            "instance('{}')/{}/case[@case_type='{}'][{}][not(commcare_related_case=true())]".format(
+            "instance('{}')/{}/case[@case_type='{}'][{}][not(commcare_is_related_case=true())]".format(
                 RESULTS_INSTANCE,
                 RESULTS_INSTANCE,
                 self.module.case_type,
@@ -243,7 +243,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 self.module.case_type,
                 another_case_type,
                 self.module.search_config.search_filter,
-                "not(commcare_related_case=true())",
+                "not(commcare_is_related_case=true())",
             ),
             suite.xpath(ref_path)[0]
         )

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -27,6 +27,7 @@ from corehq.apps.app_manager.tests.util import (
     patch_get_xform_resource_overrides,
 )
 from corehq.apps.builds.models import BuildSpec
+from corehq.apps.case_search.const import EXCLUDE_RELATED_CASES_FILTER
 from corehq.util.test_utils import flag_enabled
 
 DOMAIN = 'test_domain'
@@ -220,11 +221,12 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         suite = parse_normalize(suite, to_string=False)
         ref_path = './remote-request[1]/session/datum/@nodeset'
         self.assertEqual(
-            "instance('{}')/{}/case[@case_type='{}'][{}][not(commcare_is_related_case=true())]".format(
+            "instance('{}')/{}/case[@case_type='{}'][{}]{}".format(
                 RESULTS_INSTANCE,
                 RESULTS_INSTANCE,
                 self.module.case_type,
-                search_filter
+                search_filter,
+                EXCLUDE_RELATED_CASES_FILTER
             ),
             suite.xpath(ref_path)[0]
         )
@@ -237,13 +239,13 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         suite = parse_normalize(suite_xml, to_string=False)
         ref_path = './remote-request[1]/session/datum/@nodeset'
         self.assertEqual(
-            "instance('{}')/{}/case[@case_type='{}' or @case_type='{}'][{}][{}]".format(
+            "instance('{}')/{}/case[@case_type='{}' or @case_type='{}'][{}]{}".format(
                 RESULTS_INSTANCE,
                 RESULTS_INSTANCE,
                 self.module.case_type,
                 another_case_type,
                 self.module.search_config.search_filter,
-                "not(commcare_is_related_case=true())",
+                EXCLUDE_RELATED_CASES_FILTER
             ),
             suite.xpath(ref_path)[0]
         )

--- a/corehq/apps/case_search/const.py
+++ b/corehq/apps/case_search/const.py
@@ -16,6 +16,7 @@ CASE_SEARCH_MAX_RESULTS = 500
 RELEVANCE_SCORE = "commcare_search_score"
 # Added to secondary results in case search to filter them out of the case list
 IS_RELATED_CASE = "commcare_is_related_case"
+EXCLUDE_RELATED_CASES_FILTER = "[not(commcare_is_related_case=true())]"
 
 # Added to each case on the index for debugging when a case was added to ES
 INDEXED_ON = '@indexed_on'

--- a/corehq/apps/case_search/const.py
+++ b/corehq/apps/case_search/const.py
@@ -14,6 +14,8 @@ CASE_SEARCH_MAX_RESULTS = 500
 
 # Added to each case response when case searches are performed
 RELEVANCE_SCORE = "commcare_search_score"
+# Added to secondary results in case search to filter them out of the case list
+IS_RELATED_CASE = "commcare_is_related_case"
 
 # Added to each case on the index for debugging when a case was added to ES
 INDEXED_ON = '@indexed_on'

--- a/corehq/apps/case_search/exceptions.py
+++ b/corehq/apps/case_search/exceptions.py
@@ -4,3 +4,7 @@ class CaseSearchException(Exception):
 
 class CaseSearchNotEnabledException(CaseSearchException):
     pass
+
+
+class CaseSearchUserError(CaseSearchException):
+    pass

--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -12,6 +12,7 @@ from corehq.apps.app_manager.models import (
     DetailColumn,
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
+from corehq.apps.case_search.const import IS_RELATED_CASE
 from corehq.apps.case_search.models import CaseSearchConfig
 from corehq.apps.domain.shortcuts import create_user
 from corehq.apps.es.tests.utils import (
@@ -81,6 +82,13 @@ class TestCaseSearchEndpoint(TestCase):
     def test_app_aware_related_cases(self):
         with mock.patch('corehq.apps.case_search.utils.get_app_cached', new=lambda _, __: self.factory.app):
             res = get_case_search_results(self.domain, {'case_type': 'person'}, 'fake_app_id')
-        self.assertItemsEqual(["Jane", "Xiomara", "Alba", "Rogelio", "Jane", "Villanueva"], [
-            case.name for case in res
+        self.assertItemsEqual([
+            (case.name, case.get_case_property(IS_RELATED_CASE)) for case in res
+        ], [
+            ("Jane", None),
+            ("Xiomara", None),
+            ("Alba", None),
+            ("Rogelio", None),
+            ("Jane", None),
+            ("Villanueva", "true"),
         ])

--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -2,8 +2,16 @@ import uuid
 
 from django.test import TestCase
 
-from casexml.apps.case.mock import CaseBlock
+import mock
 
+from casexml.apps.case.mock import CaseBlock, IndexAttrs
+
+from corehq.apps.app_manager.models import (
+    CaseSearch,
+    CaseSearchProperty,
+    DetailColumn,
+)
+from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.case_search.models import CaseSearchConfig
 from corehq.apps.domain.shortcuts import create_user
 from corehq.apps.es.tests.utils import (
@@ -21,31 +29,58 @@ from ..utils import get_case_search_results
 class TestCaseSearchEndpoint(TestCase):
     domain = "TestCaseSearchEndpoint"
 
-    # TODO convert to setUpClass after it stabilizes
-    def setUp(self):
-        self.user = create_user("admin", "123")
-        CaseSearchConfig.objects.create(domain=self.domain, enabled=True)
-        case_search_es_setup(self.domain, [
-            CaseBlock(
-                case_id=str(uuid.uuid4()),
-                case_type='person',
-                case_name=name,
-                create=True,
-                update=properties,
-            ) for name, properties in [
-                ("Jane", {"family": "Villanueva"}),
-                ("Xiomara", {"family": "Villanueva"}),
-                ("Alba", {"family": "Villanueva"}),
-                ("Rogelio", {"family": "de la Vega"}),
-                ("Jane", {"family": "Ramos"}),
-            ]
-        ])
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = create_user("admin", "123")
+        CaseSearchConfig.objects.create(domain=cls.domain, enabled=True)
+        household_1 = str(uuid.uuid4())
+        case_blocks = [CaseBlock(
+            case_id=household_1,
+            case_type='household',
+            case_name="Villanueva",
+            create=True,
+        )]
+        case_blocks.extend([CaseBlock(
+            case_id=str(uuid.uuid4()),
+            case_type='person',
+            case_name=name,
+            create=True,
+            update=properties,
+            index={'parent': IndexAttrs('household', household_id, 'child')} if household_id else None,
+        ) for name, properties, household_id in [
+            ("Jane", {"family": "Villanueva"}, household_1),
+            ("Xiomara", {"family": "Villanueva"}, household_1),
+            ("Alba", {"family": "Villanueva"}, household_1),
+            ("Rogelio", {"family": "de la Vega"}, household_1),
+            ("Jane", {"family": "Ramos"}, None),
+        ]])
+        case_search_es_setup(cls.domain, case_blocks)
 
-    def tearDown(self):
+        cls.factory = AppFactory(domain=cls.domain)
+        module, form = cls.factory.new_basic_module('person', 'person')
+        module.search_config = CaseSearch(
+            properties=[CaseSearchProperty(name='name')]
+        )
+        module.case_details.short.columns = [
+            DetailColumn(format='plain', field=field, header={'en': field}, model='person')
+            for field in ['name', 'parent/name']
+        ]
+
+    @classmethod
+    def tearDownClass(cls):
         case_search_es_teardown()
+        super().tearDownClass()
 
-    def test_no_filter(self):
+    def test_basic(self):
         res = get_case_search_results(self.domain, {'case_type': 'person'})
         self.assertItemsEqual(["Jane", "Xiomara", "Alba", "Rogelio", "Jane"], [
+            case.name for case in res
+        ])
+
+    def test_app_aware_related_cases(self):
+        with mock.patch('corehq.apps.case_search.utils.get_app_cached', new=lambda _, __: self.factory.app):
+            res = get_case_search_results(self.domain, {'case_type': 'person'}, 'fake_app_id')
+        self.assertItemsEqual(["Jane", "Xiomara", "Alba", "Rogelio", "Jane", "Villanueva"], [
             case.name for case in res
         ])

--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -1,0 +1,51 @@
+import uuid
+
+from django.test import TestCase
+
+from casexml.apps.case.mock import CaseBlock
+
+from corehq.apps.case_search.models import CaseSearchConfig
+from corehq.apps.domain.shortcuts import create_user
+from corehq.apps.es.tests.utils import (
+    case_search_es_setup,
+    case_search_es_teardown,
+    es_test,
+)
+from corehq.form_processor.tests.utils import run_with_sql_backend
+
+from ..utils import get_case_search_results
+
+
+@es_test
+@run_with_sql_backend
+class TestCaseSearchEndpoint(TestCase):
+    domain = "TestCaseSearchEndpoint"
+
+    # TODO convert to setUpClass after it stabilizes
+    def setUp(self):
+        self.user = create_user("admin", "123")
+        CaseSearchConfig.objects.create(domain=self.domain, enabled=True)
+        case_search_es_setup(self.domain, [
+            CaseBlock(
+                case_id=str(uuid.uuid4()),
+                case_type='person',
+                case_name=name,
+                create=True,
+                update=properties,
+            ) for name, properties in [
+                ("Jane", {"family": "Villanueva"}),
+                ("Xiomara", {"family": "Villanueva"}),
+                ("Alba", {"family": "Villanueva"}),
+                ("Rogelio", {"family": "de la Vega"}),
+                ("Jane", {"family": "Ramos"}),
+            ]
+        ])
+
+    def tearDown(self):
+        case_search_es_teardown()
+
+    def test_no_filter(self):
+        res = get_case_search_results(self.domain, {'case_type': 'person'})
+        self.assertItemsEqual(["Jane", "Xiomara", "Alba", "Rogelio", "Jane"], [
+            case.name for case in res
+        ])

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -266,7 +266,7 @@ def get_related_case_results(domain, cases, paths):
                 indices = [case.get_index(identifier) for case in current_cases]
                 related_case_ids = {i.referenced_id for i in indices if i}
                 results = CaseSearchES().domain(domain).case_ids(related_case_ids).run().hits
-                current_cases = [CommCareCase.wrap(flatten_result(result)) for result in results]
+                current_cases = [CommCareCase.wrap(flatten_result(result, is_related_case=True)) for result in results]
                 results_cache[fragment] = current_cases
 
     results = []
@@ -297,4 +297,4 @@ def get_child_case_results(domain, parent_cases, case_types):
     parent_case_ids = {c.case_id for c in parent_cases}
     query = CaseSearchES().domain(domain).case_type(case_types).get_child_cases(parent_case_ids, "parent")
     results = query.run().hits
-    return [CommCareCase.wrap(flatten_result(result)) for result in results]
+    return [CommCareCase.wrap(flatten_result(result, is_related_case=True)) for result in results]

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -1,9 +1,18 @@
 import re
+
 from django.utils.translation import ugettext as _
 
 from casexml.apps.case.models import CommCareCase
+from dimagi.utils.logging import notify_exception
+
 from corehq.apps.app_manager.dbaccessors import get_app_cached
 from corehq.apps.app_manager.util import module_offers_search
+from corehq.apps.case_search.const import CASE_SEARCH_MAX_RESULTS
+from corehq.apps.case_search.exceptions import CaseSearchUserError
+from corehq.apps.case_search.filter_dsl import (
+    CaseFilterError,
+    TooManyRelatedCasesError,
+)
 from corehq.apps.case_search.models import (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
     CASE_SEARCH_XPATH_QUERY_KEY,
@@ -13,8 +22,41 @@ from corehq.apps.case_search.models import (
     FuzzyProperties,
 )
 from corehq.apps.es.case_search import CaseSearchES, flatten_result
-from corehq.apps.case_search.const import CASE_SEARCH_MAX_RESULTS
-from corehq.apps.case_search.filter_dsl import CaseFilterError
+
+
+def get_case_search_results(domain, criteria, app_id=None):
+    try:
+        # could be a list or a single string
+        case_type = criteria.pop('case_type')
+        case_types = case_type if isinstance(case_type, list) else [case_type]
+    except KeyError:
+        raise CaseSearchUserError(_('Search request must specify case type'))
+
+    try:
+        case_search_criteria = CaseSearchCriteria(domain, case_types, criteria)
+    except TooManyRelatedCasesError:
+        raise CaseSearchUserError(_('Search has too many results. Please try a more specific search.'))
+    except CaseFilterError as e:
+        # This is an app building error, notify so we can track
+        notify_exception(None, str(e), details=dict(
+            exception_type=type(e),
+        ))
+        raise CaseSearchUserError(str(e))
+    search_es = case_search_criteria.search_es
+
+    try:
+        hits = search_es.run().raw_hits
+    except Exception as e:
+        notify_exception(None, str(e), details=dict(
+            exception_type=type(e),
+        ))
+        raise
+
+    # Even if it's a SQL domain, we just need to render the hits as cases, so CommCareCase.wrap will be fine
+    cases = [CommCareCase.wrap(flatten_result(result, include_score=True)) for result in hits]
+    if app_id:
+        cases.extend(get_related_cases(domain, app_id, case_types, cases))
+    return cases
 
 
 class CaseSearchCriteria(object):

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -266,7 +266,8 @@ def get_related_case_results(domain, cases, paths):
                 indices = [case.get_index(identifier) for case in current_cases]
                 related_case_ids = {i.referenced_id for i in indices if i}
                 results = CaseSearchES().domain(domain).case_ids(related_case_ids).run().hits
-                current_cases = [CommCareCase.wrap(flatten_result(result, is_related_case=True)) for result in results]
+                current_cases = [CommCareCase.wrap(flatten_result(result, is_related_case=True))
+                                 for result in results]
                 results_cache[fragment] = current_cases
 
     results = []

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -18,6 +18,7 @@ from corehq.apps.case_search.const import (
     CASE_PROPERTIES_PATH,
     IDENTIFIER,
     INDICES_PATH,
+    IS_RELATED_CASE,
     REFERENCED_ID,
     RELEVANCE_SCORE,
     SPECIAL_CASE_PROPERTIES,
@@ -285,7 +286,7 @@ def indexed_on(gt=None, gte=None, lt=None, lte=None):
     return filters.date_range('@indexed_on', gt, gte, lt, lte)
 
 
-def flatten_result(hit, include_score=False):
+def flatten_result(hit, include_score=False, is_related_case=False):
     """Flattens a result from CaseSearchES into the format that Case serializers
     expect
 
@@ -299,6 +300,8 @@ def flatten_result(hit, include_score=False):
 
     if include_score:
         result[RELEVANCE_SCORE] = hit['_score']
+    if is_related_case:
+        result[IS_RELATED_CASE] = "true"
     case_properties = result.pop(CASE_PROPERTIES_PATH, [])
     for case_property in case_properties:
         key = case_property.get('key')

--- a/corehq/apps/es/tests/utils.py
+++ b/corehq/apps/es/tests/utils.py
@@ -6,7 +6,10 @@ from nose.tools import nottest
 from pillowtop.es_utils import initialize_index_and_mapping
 from pillowtop.tests.utils import TEST_INDEX_INFO
 
-from corehq.elastic import get_es_new, send_to_elasticsearch, ES_META
+from corehq.elastic import ES_META, get_es_new, send_to_elasticsearch
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
+from corehq.pillows.case_search import transform_case_for_elasticsearch
+from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
 from corehq.util.test_utils import trap_extra_setup
 
@@ -76,3 +79,18 @@ def populate_es_index(models, index_name, doc_prep_fn=lambda doc: doc):
 
 def populate_user_index(users):
     populate_es_index(users, 'users')
+
+
+def case_search_es_setup(domain, case_blocks):
+    """Submits caseblocks, creating the cases, then sends them to ES"""
+    from corehq.apps.hqcase.utils import submit_case_blocks
+    _, cases = submit_case_blocks([cb.as_text() for cb in case_blocks], domain=domain)
+    order = {cb.case_id: index for index, cb in enumerate(case_blocks)}
+    # send cases to ES in the same order they were passed in
+    cases = sorted(cases, key=lambda case: order[case.case_id])
+    populate_es_index(cases, 'case_search', transform_case_for_elasticsearch)
+
+
+def case_search_es_teardown():
+    FormProcessorTestUtils.delete_all_cases()
+    ensure_index_deleted(CASE_SEARCH_INDEX_INFO.index)

--- a/corehq/apps/es/tests/utils.py
+++ b/corehq/apps/es/tests/utils.py
@@ -84,7 +84,8 @@ def populate_user_index(users):
 def case_search_es_setup(domain, case_blocks):
     """Submits caseblocks, creating the cases, then sends them to ES"""
     from corehq.apps.hqcase.utils import submit_case_blocks
-    _, cases = submit_case_blocks([cb.as_text() for cb in case_blocks], domain=domain)
+    xform, cases = submit_case_blocks([cb.as_text() for cb in case_blocks], domain=domain)
+    assert not xform.is_error, xform
     order = {cb.case_id: index for index, cb in enumerate(case_blocks)}
     # send cases to ES in the same order they were passed in
     cases = sorted(cases, key=lambda case: order[case.case_id])

--- a/corehq/apps/es/tests/utils.py
+++ b/corehq/apps/es/tests/utils.py
@@ -87,7 +87,8 @@ def case_search_es_setup(domain, case_blocks):
     xform, cases = submit_case_blocks([cb.as_text() for cb in case_blocks], domain=domain)
     assert not xform.is_error, xform
     order = {cb.case_id: index for index, cb in enumerate(case_blocks)}
-    # send cases to ES in the same order they were passed in
+    # send cases to ES in the same order they were passed in so `indexed_on`
+    # order is predictable for TestCaseListAPI.test_pagination and others
     cases = sorted(cases, key=lambda case: order[case.case_id])
     populate_es_index(cases, 'case_search', transform_case_for_elasticsearch)
 

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -6,24 +6,18 @@ from django.http import QueryDict
 from django.test import TestCase
 
 from casexml.apps.case.mock import CaseBlock, IndexAttrs
-from pillowtop.es_utils import initialize_index_and_mapping
 
 from corehq import privileges
-from corehq.apps.es.tests.utils import es_test
-from corehq.elastic import get_es_new, send_to_elasticsearch
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_sql_backend
-from corehq.pillows.case_search import transform_case_for_elasticsearch
-from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
-from corehq.util.elastic import ensure_index_deleted
-from corehq.util.test_utils import (
-    generate_cases,
-    privilege_enabled,
-    trap_extra_setup,
+from corehq.apps.es.tests.utils import (
+    case_search_es_setup,
+    case_search_es_teardown,
+    es_test,
 )
+from corehq.form_processor.tests.utils import run_with_sql_backend
+from corehq.util.test_utils import generate_cases, privilege_enabled
 
 from ..api.core import UserError
 from ..api.get_list import MAX_PAGE_SIZE, get_list
-from ..utils import submit_case_blocks
 
 GOOD_GUYS_ID = str(uuid.uuid4())
 BAD_GUYS_ID = str(uuid.uuid4())
@@ -38,19 +32,10 @@ class TestCaseListAPI(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.cases = cls._mk_cases()
-        cls.es = get_es_new()
-        with trap_extra_setup(ConnectionError):
-            initialize_index_and_mapping(cls.es, CASE_SEARCH_INDEX_INFO)
-        for case in cls.cases:
-            send_to_elasticsearch(
-                'case_search',
-                transform_case_for_elasticsearch(case.to_json())
-            )
-        cls.es.indices.refresh(CASE_SEARCH_INDEX_INFO.index)
+        case_search_es_setup(cls.domain, cls._get_case_blocks())
 
-    @classmethod
-    def _mk_cases(cls):
+    @staticmethod
+    def _get_case_blocks():
         case_blocks = []
         for team_id, name in [(GOOD_GUYS_ID, 'good_guys'), (BAD_GUYS_ID, 'bad_guys')]:
             case_blocks.append(CaseBlock(
@@ -84,17 +69,11 @@ class TestCaseListAPI(TestCase):
             date_opened += datetime.timedelta(days=1)
 
         case_blocks[-1].close = True  # close Ned Pepper
-
-        _, cases = submit_case_blocks([cb.as_text() for cb in case_blocks], domain=cls.domain)
-
-        # preserve ordering so inserted_at date lines up right in ES
-        order = {cb.external_id: index for index, cb in enumerate(case_blocks)}
-        return sorted(cases, key=lambda case: order[case.external_id])
+        return case_blocks
 
     @classmethod
     def tearDownClass(cls):
-        FormProcessorTestUtils.delete_all_cases()
-        ensure_index_deleted(CASE_SEARCH_INDEX_INFO.index)
+        case_search_es_teardown()
         super().tearDownClass()
 
     def test_pagination(self):

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -38,15 +38,14 @@ from corehq.apps.app_manager.dbaccessors import (
 )
 from corehq.apps.app_manager.models import GlobalAppConfig
 from corehq.apps.builds.utils import get_default_build_spec
-from corehq.apps.case_search.filter_dsl import CaseFilterError, TooManyRelatedCasesError
-from corehq.apps.case_search.utils import CaseSearchCriteria, get_related_cases
+from corehq.apps.case_search.exceptions import CaseSearchUserError
+from corehq.apps.case_search.utils import get_case_search_results
 from corehq.apps.domain.decorators import (
     check_domain_migration,
     mobile_auth,
     mobile_auth_or_formplayer,
 )
 from corehq.apps.domain.models import Domain
-from corehq.apps.es.case_search import flatten_result
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.ota.decorators import require_mobile_access
 from corehq.apps.ota.rate_limiter import rate_limit_restore
@@ -107,42 +106,12 @@ def app_aware_search(request, domain, app_id):
         Multiple values can be specified for a param, which will be searched with OR operator
 
     Returns results as a fixture with the same structure as a casedb instance.
-
-
     """
     criteria = {k: v[0] if len(v) == 1 else v for k, v in request.GET.lists()}
     try:
-        # could be a list or a single string
-        case_type = criteria.pop('case_type')
-        case_types = case_type if isinstance(case_type, list) else [case_type]
-    except KeyError:
-        return HttpResponse('Search request must specify case type', status=400)
-
-    try:
-        case_search_criteria = CaseSearchCriteria(domain, case_types, criteria)
-    except TooManyRelatedCasesError:
-        return HttpResponse(_('Search has too many results. Please try a more specific search.'), status=400)
-    except CaseFilterError as e:
-        # This is an app building error, notify so we can track
-        notify_exception(request, str(e), details=dict(
-            exception_type=type(e),
-        ))
+        cases = get_case_search_results(domain, criteria, app_id)
+    except CaseSearchUserError as e:
         return HttpResponse(str(e), status=400)
-    search_es = case_search_criteria.search_es
-
-    try:
-        hits = search_es.run().raw_hits
-    except Exception as e:
-        notify_exception(request, str(e), details=dict(
-            exception_type=type(e),
-        ))
-        return HttpResponse(status=500)
-
-    # Even if it's a SQL domain, we just need to render the hits as cases, so CommCareCase.wrap will be fine
-    cases = [CommCareCase.wrap(flatten_result(result, include_score=True)) for result in hits]
-    if app_id:
-        cases.extend(get_related_cases(domain, app_id, case_types, cases))
-
     fixtures = CaseDBFixture(cases).fixture
     return HttpResponse(fixtures, content_type="text/xml; charset=utf-8")
 

--- a/corehq/apps/users/tests/test_dbaccessors.py
+++ b/corehq/apps/users/tests/test_dbaccessors.py
@@ -113,11 +113,7 @@ class AllCommCareUsersTest(TestCase):
         super(AllCommCareUsersTest, cls).tearDownClass()
 
     def test_get_users_by_filters(self):
-        populate_user_index([
-            self.ccuser_1.to_json(),
-            self.ccuser_2.to_json(),
-            self.web_user.to_json(),
-        ])
+        populate_user_index([self.ccuser_1, self.ccuser_2, self.web_user])
 
         def usernames(users):
             return [u.username for u in users]

--- a/corehq/apps/users/tests/test_web_user_download.py
+++ b/corehq/apps/users/tests/test_web_user_download.py
@@ -92,12 +92,7 @@ class TestDownloadWebUsers(TestCase):
             role=cls.other_role.get_qualified_id()
         )
 
-        populate_user_index([
-            cls.user1.to_json(),
-            cls.user2.to_json(),
-            cls.user10.to_json(),
-            cls.user11.to_json(),
-        ])
+        populate_user_index([cls.user1, cls.user2, cls.user10, cls.user11])
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
## Summary
Accompanies https://github.com/dimagi/commcare-hq/pull/30323
from https://dimagi-dev.atlassian.net/browse/USH-1252
First two commits are cherry-picked from a WIP branch I have locally, but make these tests easier to set up.

## Feature Flag
Case search & claim

## Product Description
Prevents invalid results from showing up in case search. Unlikely to be relevant for non-USH projects.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
The components are tested individually, this adds tests for the piece as a whole

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This is reasonably well-tested, and doesn't actually change much

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
