### PR TITLE
Remove duplicates from related case lookup in case search

### DIFF
--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -179,9 +179,8 @@ def get_related_cases(domain, app_id, case_types, cases):
     if child_case_types:
         results.extend(get_child_case_results(domain, cases, child_case_types))
 
-    initial_case_ids = {case.case_id for case in cases}
     return list({
-        case.case_id: case for case in results if case.case_id not in initial_case_ids
+        case.case_id: case for case in results
     }.values())
 
 

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -179,7 +179,10 @@ def get_related_cases(domain, app_id, case_types, cases):
     if child_case_types:
         results.extend(get_child_case_results(domain, cases, child_case_types))
 
-    return results
+    initial_case_ids = {case.case_id for case in cases}
+    return list({
+        case.case_id: case for case in results if case.case_id not in initial_case_ids
+    }.values())
 
 
 def get_related_case_relationships(app, case_type):

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -179,8 +179,9 @@ def get_related_cases(domain, app_id, case_types, cases):
     if child_case_types:
         results.extend(get_child_case_results(domain, cases, child_case_types))
 
+    initial_case_ids = {case.case_id for case in cases}
     return list({
-        case.case_id: case for case in results
+        case.case_id: case for case in results if case.case_id not in initial_case_ids
     }.values())
 
 

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -518,7 +518,7 @@ class TestCaseSearchLookups(TestCase):
         # d1 > c1
         # Search for case type 'c'
         # - initial results c1, c2
-        # - related lookups (parent, parent/parent) yield c1, a1, a1
+        # - related lookups (parent, parent/parent) yield a1, c1, a1
         # - child lookups yield c2, d1
         # - (future) extension lookups yield d1
         cases = [
@@ -540,7 +540,8 @@ class TestCaseSearchLookups(TestCase):
         cases = [CommCareCase.wrap(flatten_result(result)) for result in hits]
         self.assertEqual({case.case_id for case in cases}, {'c1', 'c2'})
 
-        with patch("corehq.apps.case_search.utils.get_related_case_relationships", return_value={"parent", "parent/parent"}), \
+        with patch("corehq.apps.case_search.utils.get_related_case_relationships",
+                   return_value={"parent", "parent/parent"}), \
              patch("corehq.apps.case_search.utils.get_child_case_types", return_value={"c", "d"}), \
              patch("corehq.apps.case_search.utils.get_app_cached"):
             cases = get_related_cases(self.domain, None, {"c"}, cases)

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -546,6 +546,7 @@ class TestCaseSearchLookups(TestCase):
             cases = get_related_cases(self.domain, None, {"c"}, cases)
 
         case_ids = Counter([case.case_id for case in cases])
+        self.assertEqual(set(case_ids), {"a1", "d1"})  # c1, c2 excluded since they are in the initial list
         self.assertEqual(max(case_ids.values()), 1, case_ids)  # no duplicates
 
     def _assert_related_case_ids(self, cases, paths, ids):

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -554,7 +554,8 @@ class TestCaseSearchLookups(TestCase):
         results = get_related_case_results(self.domain, cases, paths)
         result_ids = Counter([result['_id'] for result in results])
         self.assertEqual(ids, set(result_ids))
-        self.assertEqual(1, max(result_ids.values()), result_ids)  # no duplicates
+        if result_ids:
+            self.assertEqual(1, max(result_ids.values()), result_ids)  # no duplicates
 
     def test_multiple_case_types(self):
         cases = [

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -1,4 +1,5 @@
 import uuid
+from collections import Counter
 
 from datetime import date
 from django.test.testcases import SimpleTestCase
@@ -17,7 +18,7 @@ from corehq.apps.case_search.models import CaseSearchConfig
 from corehq.apps.case_search.utils import (
     CaseSearchCriteria,
     get_related_case_relationships,
-    get_related_case_results,
+    get_related_case_results, get_related_cases,
 )
 from corehq.apps.es.tests.utils import ElasticTestMixin, es_test
 from corehq.apps.es.case_search import (
@@ -509,9 +510,49 @@ class TestCaseSearchLookups(TestCase):
         self._assert_related_case_ids(cases, {"host", "parent"}, {"c2", "c4"})
         self._assert_related_case_ids(cases, {"host", "parent/parent"}, {"c4", "c1"})
 
+    def test_get_related_case_results_duplicates(self):
+        """Test that `get_related_cases` does not include any cases that are in the initial
+        set or are duplicates of others already found."""
+
+        # d1 :> c2 > c1 > a1
+        # d1 > c1
+        # Search for case type 'c'
+        # - initial results c1, c2
+        # - related lookups (parent, parent/parent) yield c1, a1, a1
+        # - child lookups yield c2, d1
+        # - (future) extension lookups yield d1
+        cases = [
+            {'_id': 'a1', 'case_type': 'a'},
+            {'_id': 'c1', 'case_type': 'c', 'index': {
+                'parent': ('a', 'a1'),
+            }},
+            {'_id': 'c2', 'case_type': 'c', 'index': {
+                'parent': ('c', 'c1'),
+            }},
+            {'_id': 'd1', 'case_type': 'd', 'index': {
+                'parent': ('c', 'c1'),
+                'host': ('c', 'c2'),
+            }},
+        ]
+        self._bootstrap_cases_in_es_for_domain(self.domain, cases)
+
+        hits = CaseSearchES().domain(self.domain).case_type("c").run().hits
+        cases = [CommCareCase.wrap(flatten_result(result)) for result in hits]
+        self.assertEqual({case.case_id for case in cases}, {'c1', 'c2'})
+
+        with patch("corehq.apps.case_search.utils.get_related_case_relationships", return_value={"parent", "parent/parent"}), \
+             patch("corehq.apps.case_search.utils.get_child_case_types", return_value={"c", "d"}), \
+             patch("corehq.apps.case_search.utils.get_app_cached"):
+            cases = get_related_cases(self.domain, None, {"c"}, cases)
+
+        case_ids = Counter([case.case_id for case in cases])
+        self.assertEqual(max(case_ids.values()), 1, case_ids)  # no duplicates
+
     def _assert_related_case_ids(self, cases, paths, ids):
         results = get_related_case_results(self.domain, cases, paths)
-        self.assertEqual(ids, {result['_id'] for result in results})
+        result_ids = Counter([result['_id'] for result in results])
+        self.assertEqual(ids, set(result_ids))
+        self.assertEqual(1, max(result_ids.values()), result_ids)  # no duplicates
 
     def test_multiple_case_types(self):
         cases = [


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-1252
## Summary
This is mostly relevant when searching across multiple case types however it is possible to create case hierarchies that result in duplicates.

Returning duplicates in the case search result set is bad because it can mean that XPath queries fail with an error like `cannot convert multiple nodes to a raw value. Refine path expression to match only one node.`

## Product Description
Prevent duplicate cases being returned in the case search results.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added

### QA Plan
None

### Safety story
Changes are isolated to case search and are well tested.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
