### PR TITLE
Upgrade js-xpath to 0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "ui-select": "npm:ui-select#0.13.2",
         "underscore": "1.13.1",
         "url-polyfill": "1.1.10",
-        "xpath": "dimagi/js-xpath#v0.0.5",
+        "xpath": "dimagi/js-xpath#v0.0.6",
         "zxcvbn": "4.4.2"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6516,9 +6516,9 @@ xdg-basedir@^3.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
   integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
 
-xpath@dimagi/js-xpath#v0.0.5:
-  version "0.0.4"
-  resolved "https://codeload.github.com/dimagi/js-xpath/tar.gz/e65fd5396f2392c5099fb5d8e979f0e98eedc0c5"
+xpath@dimagi/js-xpath#v0.0.6:
+  version "0.0.6"
+  resolved "https://codeload.github.com/dimagi/js-xpath/tar.gz/a23afb724cd65088cb04c97ae7e5ecc2b425270e"
   dependencies:
     biginteger "^1.0.3"
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12550

Due to a mishap with previous version bump, I created a new js-xpath release that we should point to. You can see on the [previous PR](https://github.com/dimagi/commcare-hq/pull/30235), the js-xpath version references the 0.0.5 tag, but still has a version of 0.0.4. This fixes that misalignment. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
