### PR TITLE
[User History] log phone number removal from UI

### DIFF
--- a/corehq/apps/settings/tests/test_views.py
+++ b/corehq/apps/settings/tests/test_views.py
@@ -1,7 +1,12 @@
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
+from django.urls import reverse
 from unittest.mock import Mock, patch
 
+from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.settings.views import EnableMobilePrivilegesView
+from corehq.apps.users.audit.change_messages import UserChangeMessage
+from corehq.apps.users.models import WebUser, UserHistory
+from corehq.const import USER_CHANGE_VIA_WEB
 
 
 class EnableMobilePrivilegesViewTests(SimpleTestCase):
@@ -20,3 +25,35 @@ class EnableMobilePrivilegesViewTests(SimpleTestCase):
             context = view.get(mock_request)
 
         self.assertTrue(isinstance(context['qrcode_64'], str))
+
+
+class TestMyAccountSettingsView(TestCase):
+    domain_name = 'test'
+
+    def setUp(self):
+        super().setUp()
+        self.domain = create_domain(self.domain_name)
+        self.couch_user = WebUser.create(None, "test", "foobar", None, None)
+        self.couch_user.add_domain_membership(self.domain_name, is_admin=True)
+        self.couch_user.save()
+
+        self.url = reverse('my_account_settings')
+        self.client.login(username='test', password='foobar')
+
+    def tearDown(self):
+        self.couch_user.delete(self.domain_name, deleted_by=None)
+        self.domain.delete()
+        super().tearDown()
+
+    def test_process_delete_phone_number(self):
+        phone_number = "9999999999"
+        self.client.post(
+            self.url,
+            {"form_type": "delete-phone-number", "phone_number": phone_number}
+        )
+
+        user_history_log = UserHistory.objects.get(user_id=self.couch_user.get_id)
+        self.assertEqual(user_history_log.message, UserChangeMessage.phone_number_removed(phone_number))
+        self.assertEqual(user_history_log.changed_by, self.couch_user.get_id)
+        self.assertIsNone(user_history_log.domain)
+        self.assertEqual(user_history_log.details['changed_via'], USER_CHANGE_VIA_WEB)

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -202,6 +202,14 @@ class MyAccountSettingsView(BaseMyAccountView):
 
     def process_delete_phone_number(self):
         self.request.couch_user.delete_phone_number(self.phone_number)
+        log_user_change(
+            domain=None,
+            couch_user=self.request.couch_user,
+            changed_by_user=self.request.couch_user,
+            changed_via=USER_CHANGE_VIA_WEB,
+            message=UserChangeMessage.phone_number_removed(self.phone_number),
+            domain_required_for_log=False,
+        )
         messages.success(self.request, _("Phone number deleted."))
         return HttpResponseRedirect(reverse(MyAccountSettingsView.urlname))
 

--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -4,11 +4,13 @@ from django.test import TestCase
 from django.urls import reverse
 
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.audit.change_messages import UserChangeMessage
 from corehq.apps.users.dbaccessors import delete_all_users
-from corehq.apps.users.models import CouchUser, WebUser, Permissions
+from corehq.apps.users.models import CouchUser, WebUser, Permissions, CommCareUser, UserHistory
 from corehq.apps.users.models import UserRole
 from corehq.apps.users.views import _update_role_from_view
 from corehq.apps.users.views.mobile.users import MobileWorkerListView
+from corehq.const import USER_CHANGE_VIA_WEB
 from corehq.util.test_utils import generate_cases
 
 
@@ -143,3 +145,49 @@ class TestUpdateRoleFromView(TestCase):
         role_data["default_landing_page"] = "bad value"
         with self.assertRaises(ValueError):
             _update_role_from_view(self.domain, role_data)
+
+
+class TestDeletePhoneNumberView(TestCase):
+    domain = 'test'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.webuser_username = f"webuser@{cls.domain}.commcarehq.org"
+        cls.dummy_password = "******"
+        cls.project = create_domain(cls.domain)
+        cls.web_user = WebUser.create(cls.domain, cls.webuser_username, cls.dummy_password,
+                                      None, None)
+        cls.web_user.set_role(cls.domain, 'admin')
+        cls.web_user.save()
+        cls.commcare_user = CommCareUser.create(cls.domain, "test-user", cls.dummy_password, None, None)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.commcare_user.delete(cls.domain, deleted_by=None)
+        cls.web_user.delete(cls.domain, deleted_by=None)
+        cls.project.delete()
+        super().tearDownClass()
+
+    def setUp(self):
+        self.client.login(username=self.webuser_username, password=self.dummy_password)
+
+    def test_no_phone_number(self):
+        response = self.client.post(
+            reverse('delete_phone_number', args=[self.domain, self.commcare_user.get_id]),
+            {'phone_number': ''}
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_phone_number(self):
+        phone_number = '99999999'
+        self.client.post(
+            reverse('delete_phone_number', args=[self.domain, self.commcare_user.get_id]),
+            {'phone_number': phone_number}
+        )
+
+        user_history_log = UserHistory.objects.get(user_id=self.commcare_user.get_id)
+        self.assertEqual(user_history_log.message, UserChangeMessage.phone_number_removed(phone_number))
+        self.assertEqual(user_history_log.changed_by, self.web_user.get_id)
+        self.assertEqual(user_history_log.domain, self.domain)
+        self.assertEqual(user_history_log.details['changed_via'], USER_CHANGE_VIA_WEB)

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1229,6 +1229,13 @@ def delete_phone_number(request, domain, couch_user_id):
         raise Http404('Must include phone number in request.')
 
     user.delete_phone_number(phone_number)
+    log_user_change(
+        domain=request.domain,
+        couch_user=user,
+        changed_by_user=request.couch_user,
+        changed_via=USER_CHANGE_VIA_WEB,
+        message=UserChangeMessage.phone_number_removed(phone_number)
+    )
     from corehq.apps.users.views.mobile import EditCommCareUserView
     redirect = reverse(EditCommCareUserView.urlname, args=[domain, couch_user_id])
     return HttpResponseRedirect(redirect)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/QA-3476
This got flagged during QA. We were not tracking phone number removals from UI.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-3476

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally and works okay

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
