### PR TITLE
use alias decorator for location safe resources that intentionally do not apply restrictions

### DIFF
--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -208,6 +208,11 @@ def location_safe(view):
     return view
 
 
+# Use this decorator for views that need to be marked location safe but do not actually
+# apply location restrictions to the data they return. e.g. case search
+location_safe_bypass = location_safe
+
+
 def conditionally_location_safe(conditional_function):
     """Decorator to apply to a view function that verifies if something is location
     safe based on the arguments or kwarguments. That function should return

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -209,7 +209,8 @@ def location_safe(view):
 
 
 # Use this decorator for views that need to be marked location safe but do not actually
-# apply location restrictions to the data they return. e.g. case search
+# apply location restrictions to the data they return e.g. case search. This is generally only applicable to endpoints
+# whose client is expected to be the application engine (mobile / web apps).
 location_safe_bypass = location_safe
 
 

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -46,7 +46,7 @@ from corehq.apps.domain.decorators import (
     mobile_auth_or_formplayer,
 )
 from corehq.apps.domain.models import Domain
-from corehq.apps.locations.permissions import location_safe
+from corehq.apps.locations.permissions import location_safe, location_safe_bypass
 from corehq.apps.ota.decorators import require_mobile_access
 from corehq.apps.ota.rate_limiter import rate_limit_restore
 from corehq.apps.registry.helper import DataRegistryHelper
@@ -89,14 +89,14 @@ def restore(request, domain, app_id=None):
     return response
 
 
-@location_safe
+@location_safe_bypass
 @mobile_auth
 @check_domain_migration
 def search(request, domain):
     return app_aware_search(request, domain, None)
 
 
-@location_safe
+@location_safe_bypass
 @mobile_auth
 @check_domain_migration
 def app_aware_search(request, domain, app_id):
@@ -116,7 +116,7 @@ def app_aware_search(request, domain, app_id):
     return HttpResponse(fixtures, content_type="text/xml; charset=utf-8")
 
 
-@location_safe
+@location_safe_bypass
 @csrf_exempt
 @require_POST
 @mobile_auth
@@ -400,7 +400,7 @@ def recovery_measures(request, domain, build_id):
     return JsonResponse(response)
 
 
-@location_safe
+@location_safe_bypass
 @mobile_auth
 @require_GET
 def registry_case(request, domain, app_id):


### PR DESCRIPTION
## Summary
Using a different decorator communicates the intention more clearly.

See https://github.com/dimagi/commcare-hq/pull/30280#discussion_r696657712

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
NA

### QA Plan
None

### Safety story
Code if functionally equivalent

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
