### PR TITLE
Adapt repeater helpers tests to SQL backend

### DIFF
--- a/corehq/motech/fhir/tests/test_repeater_helpers.py
+++ b/corehq/motech/fhir/tests/test_repeater_helpers.py
@@ -211,15 +211,12 @@ class TestGetInfoResourcesListSubCases(TestCase, DomainSubscriptionMixin):
             case_trigger_infos,
             resource_types_by_case_type,
         )
-        self.assertEqual(resource, {
-            'id': self.parent_case_id,
-            'name': [
-                {'text': 'Ted'},
-                {'given': ['Theodore', 'John'], 'family': 'Kaczynski'},
-                {'given': ['Unabomber']},
-            ],
-            'resourceType': 'Patient',
-        })
+        self.assertIn({'text': 'Ted'}, resource['name'])
+        self.assertIn(
+            {'given': ['Theodore', 'John'], 'family': 'Kaczynski'},
+            resource['name'],
+        )
+        self.assertIn({'given': ['Unabomber']}, resource['name'])
 
 
 @run_with_sql_backend

--- a/corehq/motech/fhir/tests/test_repeater_helpers.py
+++ b/corehq/motech/fhir/tests/test_repeater_helpers.py
@@ -6,14 +6,13 @@ from uuid import uuid4
 
 from django.test import TestCase
 
-from casexml.apps.case.models import CommCareCase
-from casexml.apps.case.sharedmodels import CommCareCaseIndex
-
 from corehq.apps.accounting.models import SoftwarePlanEdition
 from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
 from corehq.apps.accounting.utils import clear_plan_version_cache
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.form_processor.models import CommCareCaseSQL, CommCareCaseIndexSQL
+from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.motech.const import (
     COMMCARE_DATA_TYPE_DECIMAL,
     COMMCARE_DATA_TYPE_TEXT,
@@ -32,6 +31,7 @@ from ..repeater_helpers import get_info_resource_list, send_resources
 DOMAIN = ''.join([random.choice(string.ascii_lowercase) for __ in range(20)])
 
 
+@run_with_sql_backend
 class TestGetInfoResourcesListOneCase(TestCase, DomainSubscriptionMixin):
 
     @classmethod
@@ -64,8 +64,8 @@ class TestGetInfoResourcesListOneCase(TestCase, DomainSubscriptionMixin):
     def setUp(self):
         now = datetime.utcnow()
         self.case_id = str(uuid4())
-        self.case = CommCareCase(
-            _id=self.case_id,
+        self.case = CommCareCaseSQL(
+            case_id=self.case_id,
             domain=DOMAIN,
             type='person',
             name='Ted',
@@ -93,6 +93,7 @@ class TestGetInfoResourcesListOneCase(TestCase, DomainSubscriptionMixin):
         })
 
 
+@run_with_sql_backend
 class TestGetInfoResourcesListSubCases(TestCase, DomainSubscriptionMixin):
 
     @classmethod
@@ -148,8 +149,8 @@ class TestGetInfoResourcesListSubCases(TestCase, DomainSubscriptionMixin):
     def setUp(self):
         now = datetime.utcnow()
         self.parent_case_id = str(uuid4())
-        self.parent_case = CommCareCase(
-            _id=self.parent_case_id,
+        self.parent_case = CommCareCaseSQL(
+            case_id=self.parent_case_id,
             domain=DOMAIN,
             type='person',
             name='Ted',
@@ -159,39 +160,43 @@ class TestGetInfoResourcesListSubCases(TestCase, DomainSubscriptionMixin):
         )
         self.parent_case.save()
 
-        self.child_case_1 = CommCareCase(
+        self.child_case_1 = CommCareCaseSQL(
             case_id='111111111',
             domain=DOMAIN,
             type='person_name',
             name='Theodore',
-            given_names='Theodore John',
-            family_name='Kaczynski',
-            indices=[CommCareCaseIndex(
-                identifier='parent',
-                referenced_type='person',
-                referenced_id=self.parent_case_id,
-            )],
+            case_json={
+                'given_names': 'Theodore John',
+                'family_name': 'Kaczynski',
+            },
             owner_id=str(uuid4()),
             modified_on=now,
             server_modified_on=now,
         )
         self.child_case_1.save()
-        self.child_case_2 = CommCareCase(
+        add_case_index(
+            self.child_case_1,
+            identifier='parent',
+            referenced_type='person',
+            referenced_id=self.parent_case_id,
+        )
+        self.child_case_2 = CommCareCaseSQL(
             case_id='222222222',
             domain=DOMAIN,
             type='person_name',
             name='Unabomber',
-            given_names='Unabomber',
-            indices=[CommCareCaseIndex(
-                identifier='parent',
-                referenced_type='person',
-                referenced_id=self.parent_case_id,
-            )],
+            case_json={'given_names': 'Unabomber'},
             owner_id=str(uuid4()),
             modified_on=now,
             server_modified_on=now,
         )
         self.child_case_2.save()
+        add_case_index(
+            self.child_case_2,
+            identifier='parent',
+            referenced_type='person',
+            referenced_id=self.parent_case_id,
+        )
 
     def tearDown(self):
         self.child_case_1.delete()
@@ -217,6 +222,7 @@ class TestGetInfoResourcesListSubCases(TestCase, DomainSubscriptionMixin):
         })
 
 
+@run_with_sql_backend
 class TestGetInfoResourcesListResources(TestCase, DomainSubscriptionMixin):
     """
     Demonstrates building multiple resources using subcases.
@@ -327,8 +333,8 @@ class TestGetInfoResourcesListResources(TestCase, DomainSubscriptionMixin):
         now = datetime.utcnow()
         owner_id = str(uuid4())
         self.parent_case_id = str(uuid4())
-        self.parent_case = CommCareCase(
-            _id=self.parent_case_id,
+        self.parent_case = CommCareCaseSQL(
+            case_id=self.parent_case_id,
             domain=DOMAIN,
             type='person',
             name='Beth',
@@ -339,21 +345,22 @@ class TestGetInfoResourcesListResources(TestCase, DomainSubscriptionMixin):
         self.parent_case.save()
 
         self.child_case_id = str(uuid4())
-        self.child_case = CommCareCase(
-            _id=self.child_case_id,
+        self.child_case = CommCareCaseSQL(
+            case_id=self.child_case_id,
             domain=DOMAIN,
             type='vitals',
-            temperature=36.1,
-            indices=[CommCareCaseIndex(
-                identifier='parent',
-                referenced_type='person',
-                referenced_id=self.parent_case_id,
-            )],
+            case_json={'temperature': 36.1},
             owner_id=owner_id,
             modified_on=now,
             server_modified_on=now,
         )
         self.child_case.save()
+        add_case_index(
+            self.child_case,
+            identifier='parent',
+            referenced_type='person',
+            referenced_id=self.parent_case_id,
+        )
 
     def tearDown(self):
         self.child_case.delete()
@@ -407,6 +414,7 @@ class TestGetInfoResourcesListResources(TestCase, DomainSubscriptionMixin):
         }])
 
 
+@run_with_sql_backend
 class TestWhenToBundle(TestCase):
 
     def setUp(self):
@@ -474,3 +482,12 @@ class TestWhenToBundle(TestCase):
 
         # Bundles are POSTed to API root
         self.assertEqual(response, "POSTed to endpoint '/'")
+
+
+def add_case_index(child_case, **props):
+    child_case.index_set.add(CommCareCaseIndexSQL(
+        case=child_case,
+        domain=DOMAIN,
+        relationship_id=CommCareCaseIndexSQL.CHILD,
+        **props
+    ), bulk=False)


### PR DESCRIPTION
I'm getting a local test failure related to item ordering. It is unclear whether item order is important in this case or not.
```
FAIL: corehq.motech.fhir.tests.test_repeater_helpers:TestGetInfoResourcesListSubCases.test_get_info_resource_list
----------------------------------------------------------------------
Traceback (most recent call last):
  File "corehq/motech/fhir/tests/test_repeater_helpers.py", line 221, in test_get_info_resource_list
    'resourceType': 'Patient',
AssertionError: {'name': [{'text': 'Ted'}, {'given': ['Unab[134 chars]ent'} != {'id': 'ad98bc1f-3ba7-46c6-95e5-35dcf28f3f4[134 chars]ent'}
  {'id': 'ad98bc1f-3ba7-46c6-95e5-35dcf28f3f45',
   'name': [{'text': 'Ted'},
-           {'given': ['Unabomber']},
-           {'family': 'Kaczynski', 'given': ['Theodore', 'John']}],
?                                                                 -

+           {'family': 'Kaczynski', 'given': ['Theodore', 'John']},
+           {'given': ['Unabomber']}],
   'resourceType': 'Patient'}
```

Code that may need to be changed:

https://github.com/dimagi/commcare-hq/blob/2547c253bafae4a017b7cdfae5b0819f2b845455/corehq/motech/fhir/tests/test_repeater_helpers.py#L216-L220

Is the order if items in the `"name"` list important, or is it reasonable to swap the last two items to make the test pass?

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No new tests added.

### QA Plan

No QA.

### Safety story

All code changed is test code.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
