### PR TITLE
Remove pickles from export celery tasks

### DIFF
--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -289,7 +289,7 @@ def get_export_writer(export_instances, temp_path, allow_pagination=True):
     return writer
 
 
-def get_export_download(domain, export_ids, exports_type, username, filters, owner_id, filename=None):
+def get_export_download(domain, export_ids, exports_type, username, es_filters, owner_id, filename=None):
     from corehq.apps.export.tasks import populate_export_download_task
 
     download = DownloadBase()
@@ -298,7 +298,7 @@ def get_export_download(domain, export_ids, exports_type, username, filters, own
         export_ids,
         exports_type,
         username,
-        filters,
+        es_filters,
         download.download_id,
         owner_id,
         filename=filename
@@ -306,29 +306,35 @@ def get_export_download(domain, export_ids, exports_type, username, filters, own
     return download
 
 
-def get_export_file(export_instances, filters, temp_path, progress_tracker=None):
+def get_export_file(export_instances, es_filters, temp_path, progress_tracker=None):
     """
     Return an export file for the given ExportInstance and list of filters
     """
     writer = get_export_writer(export_instances, temp_path)
     with writer.open(export_instances):
         for export_instance in export_instances:
-            docs = get_export_documents(export_instance, filters)
+            docs = get_export_documents(export_instance, es_filters, are_filters_es_formatted=True)
             write_export_instance(writer, export_instance, docs, progress_tracker)
 
     return ExportFile(writer.path, writer.format)
 
 
-def get_export_documents(export_instance, filters):
+def get_export_documents(export_instance, filters, are_filters_es_formatted=False):
     # Pull doc ids from elasticsearch and stream to disk
-    query = get_export_query(export_instance, filters)
+    query = get_export_query(export_instance, filters, are_filters_es_formatted)
     return iter_es_docs_from_query(query)
 
 
-def get_export_query(export_instance, filters):
+def get_export_query(export_instance, filters, are_filters_es_formatted=False):
+    """
+    :param filters: either a list of ExportFilter objects, or a list of json serializable dicts
+    :param are_filters_es_formatted: used to determine if filters are already json serializable dicts
+    :return:
+    """
     query = _get_base_query(export_instance)
-    for filter in filters:
-        query = query.filter(filter.to_es_filter())
+    for f in filters:
+        es_filter = f if are_filters_es_formatted else f.to_es_filter()
+        query = query.filter(es_filter)
     return query
 
 
@@ -442,9 +448,10 @@ def rebuild_export(export_instance, progress_tracker):
     """
     Rebuild the given daily saved ExportInstance
     """
-    filters = export_instance.get_filters()
+    filters = export_instance.get_filters() or []
+    es_filters = [f.to_es_filter() for f in filters]
     with TransientTempfile() as temp_path:
-        export_file = get_export_file([export_instance], filters or [], temp_path, progress_tracker)
+        export_file = get_export_file([export_instance], es_filters, temp_path, progress_tracker)
         with export_file as payload:
             save_export_payload(export_instance, payload)
 

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -104,7 +104,7 @@ def populate_export_download_task(domain, export_ids, exports_type, username,
     email_requests.delete()
 
 
-@task(serializer='pickle', queue=SAVED_EXPORTS_QUEUE, ignore_result=False, acks_late=True)
+@task(queue=SAVED_EXPORTS_QUEUE, ignore_result=False, acks_late=True)
 def _start_export_task(export_instance_id):
     export_instance = get_properly_wrapped_export_instance(export_instance_id)
     rebuild_export(export_instance, progress_tracker=_start_export_task)

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -205,9 +205,11 @@ def _cached_add_inferred_export_properties(sender, domain, case_type, properties
     inferred_schema.save()
 
 
-@task(serializer='pickle', queue='background_queue', bind=True)
-def generate_schema_for_all_builds(self, schema_cls, domain, app_id, identifier):
-    schema_cls.generate_schema_from_builds(
+@task(queue='background_queue', bind=True)
+def generate_schema_for_all_builds(self, export_type, domain, app_id, identifier):
+    from .views.utils import GenerateSchemaFromAllBuildsView
+    export_cls = GenerateSchemaFromAllBuildsView.export_cls(export_type)
+    export_cls.generate_schema_from_builds(
         domain,
         app_id,
         identifier,

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -39,9 +39,9 @@ from .system_properties import MAIN_CASE_TABLE_PROPERTIES
 logger = logging.getLogger('export_migration')
 
 
-@task(serializer='pickle', queue=EXPORT_DOWNLOAD_QUEUE)
+@task(queue=EXPORT_DOWNLOAD_QUEUE)
 def populate_export_download_task(domain, export_ids, exports_type, username,
-                                  filters, download_id, owner_id,
+                                  es_filters, download_id, owner_id,
                                   filename=None, expiry=10 * 60):
     """
     :param expiry:  Time period for the export to be available for download in minutes
@@ -63,7 +63,7 @@ def populate_export_download_task(domain, export_ids, exports_type, username,
     with TransientTempfile() as temp_path, metrics_track_errors('populate_export_download_task'):
         export_file = get_export_file(
             export_instances,
-            filters,
+            es_filters,
             temp_path,
             # We don't have a great way to calculate progress if it's a bulk download,
             # so only track the progress for single instance exports.

--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -312,6 +312,7 @@ def prepare_custom_export(request, domain):
             'error': _("Form did not validate."),
         })
     export_filters = filter_form.get_export_filters(request, filter_form_data)
+    export_es_filters = [f.to_es_filter() for f in export_filters]
 
     export_specs = json.loads(request.POST.get('exports'))
     export_ids = [spec['export_id'] for spec in export_specs]
@@ -336,7 +337,7 @@ def prepare_custom_export(request, domain):
         export_ids,
         view_helper.model,
         request.couch_user.username,
-        filters=export_filters,
+        es_filters=export_es_filters,
         owner_id=request.couch_user.get_id,
         filename=filename,
     )

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -256,8 +256,9 @@ class ODataFeedMixin(object):
 class GenerateSchemaFromAllBuildsView(LoginAndDomainMixin, View):
     urlname = 'build_full_schema'
 
-    def export_cls(self, type_):
-        return CaseExportDataSchema if type_ == CASE_EXPORT else FormExportDataSchema
+    @staticmethod
+    def export_cls(export_type):
+        return CaseExportDataSchema if export_type == CASE_EXPORT else FormExportDataSchema
 
     def get(self, request, *args, **kwargs):
         download_id = request.GET.get('download_id')
@@ -279,11 +280,11 @@ class GenerateSchemaFromAllBuildsView(LoginAndDomainMixin, View):
         })
 
     def post(self, request, *args, **kwargs):
-        type_ = request.POST.get('type')
-        assert type_ in [CASE_EXPORT, FORM_EXPORT], 'Unrecogized export type {}'.format(type_)
+        export_type = request.POST.get('type')
+        assert export_type in [CASE_EXPORT, FORM_EXPORT], 'Unrecogized export type {}'.format(export_type)
         download = DownloadBase()
         download.set_task(generate_schema_for_all_builds.delay(
-            self.export_cls(type_),
+            export_type,
             request.domain,
             request.POST.get('app_id'),
             request.POST.get('identifier'),


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11385)

This is part of a series of PRs aimed at removing pickling from celery tasks, and instead relying on the default json serialization. This is due to celery maintainers not prioritizing support for serialization formats other than json. 

**Review commit by commit**

The `populate_export_download_task` was expecting a list of `ExportFilter` objects. These objects already had a method `to_es_filter` that converted these filters to a json compatible format, and it turns out the task only needed this format of the filter so the conversion could be done prior to calling the celery task. 

The `_start_export_task` was an easy one that was already passing an id and could be changed to json serialization without further consideration. 

In the case of the `generate_schema_for_all_builds` task, a string was being mapped to a class prior to calling the celery task, but could instead be mapped on the celery side. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Did not add any automated tests. 
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested what I could, but planning to test more on staging.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
