### PR TITLE
Data registry schema for form designer

### DIFF
--- a/corehq/apps/app_manager/app_schemas/casedb_schema.py
+++ b/corehq/apps/app_manager/app_schemas/casedb_schema.py
@@ -17,7 +17,7 @@ def get_casedb_schema(form):
 
     subsets = []
     if not form.get_module().search_config.data_registry:
-        subsets.extend(_get_case_schema(app, form))
+        subsets.extend(_get_case_schema_subsets(app, form))
 
     if is_usercase_in_use(app.domain):
         subsets.append({
@@ -47,7 +47,7 @@ def get_registry_schema(form):
 
     subsets = []
     if data_registry:
-        subsets.extend(_get_case_schema(app, form, hashtag='#registry_case/'))
+        subsets.extend(_get_case_schema_subsets(app, form, hashtag='#registry_case/'))
 
     return {
         "id": "registry",
@@ -59,7 +59,7 @@ def get_registry_schema(form):
     }
 
 
-def _get_case_schema(app, form, hashtag='#case/'):
+def _get_case_schema_subsets(app, form, hashtag='#case/'):
     base_case_type = form.get_module().case_type if form.requires_case() else None
     builder = ParentCasePropertyBuilder.for_app(app, ['case_name'], include_parent_properties=False)
     related = builder.get_parent_type_map(None)

--- a/corehq/apps/app_manager/app_schemas/session_schema.py
+++ b/corehq/apps/app_manager/app_schemas/session_schema.py
@@ -14,7 +14,7 @@ def get_session_schema(form):
     datums = EntriesHelper(app).get_datums_meta_for_form_generic(form)
     datums = [
         d for d in datums
-        if not d.is_new_case_id and d.case_type and d.requires_selection
+        if d.requires_selection and d.case_type and not d.is_new_case_id
     ]
     if len(datums):
         session_var = datums[-1].datum.id

--- a/corehq/apps/app_manager/app_schemas/session_schema.py
+++ b/corehq/apps/app_manager/app_schemas/session_schema.py
@@ -8,6 +8,8 @@ def get_session_schema(form):
     """
     from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
     app = form.get_app()
+    module = form.get_module()
+    data_registry = module.search_config.data_registry
     structure = {}
     datums = EntriesHelper(app).get_datums_meta_for_form_generic(form)
     datums = [
@@ -21,8 +23,8 @@ def get_session_schema(form):
             "structure": {
                 session_var: {
                     "reference": {
-                        "hashtag": "#case",
-                        "source": "casedb",
+                        "hashtag": '#registry_case' if data_registry else "#case",
+                        "source": "registry" if data_registry else "casedb",
                         "subset": "case",
                         "key": "@case_id",
                     },

--- a/corehq/apps/app_manager/app_schemas/tests/test_schema.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_schema.py
@@ -6,7 +6,7 @@ from django.test import SimpleTestCase
 from mock import MagicMock, patch
 
 from corehq.apps.app_manager import util as util
-from corehq.apps.app_manager.app_schemas.casedb_schema import get_casedb_schema
+from corehq.apps.app_manager.app_schemas.casedb_schema import get_casedb_schema, get_registry_schema
 from corehq.apps.app_manager.app_schemas.session_schema import (
     get_session_schema,
 )
@@ -300,6 +300,48 @@ class SchemaTest(SimpleTestCase):
                     "phone_number": {},
                 },
             })
+
+    def test_get_casedb_schema_with_form_from_registry(self):
+        village = self.add_form("village")
+        module = village.get_module()
+        module.search_config.data_registry = "my-registry"
+        self.factory.form_requires_case(
+            village,
+            case_type=self.factory.app.get_module(0).case_type,
+            update={'foo': '/data/question1'}
+        )
+        schema = get_casedb_schema(village)
+        self.assertEqual(len(schema["subsets"]), 0, schema["subsets"])
+
+    def test_get_registry_schema_with_form_from_registry(self):
+        village = self.add_form("village")
+        module = village.get_module()
+        module.search_config.data_registry = "my-registry"
+        self.factory.form_requires_case(
+            village,
+            case_type=self.factory.app.get_module(0).case_type,
+            update={'foo': '/data/question1'}
+        )
+
+        schema = get_registry_schema(village)
+        self.assert_has_kv_pairs(schema, {
+            "id": "registry",
+            "uri": "jr://instance/remote",
+            "name": "registry_case",
+            "path": "/results/case",
+            "structure": {},
+        })
+
+        self.assertEqual(len(schema["subsets"]), 1, schema["subsets"])
+        self.assert_has_kv_pairs(schema["subsets"][0], {
+            'id': 'case',
+            'name': 'village',
+            'structure': {
+                'case_name': {"description": ""},
+                'foo': {"description": ""},
+            },
+            'related': None,
+        })
 
     # -- helpers --
 

--- a/corehq/apps/app_manager/app_schemas/tests/test_schema.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_schema.py
@@ -301,6 +301,27 @@ class SchemaTest(SimpleTestCase):
                 },
             })
 
+    def test_get_session_schema_for_simple_module_with_case_from_registry(self):
+        module, form = self.factory.new_basic_module('village', 'village')
+        module.search_config.data_registry = "my-registry"
+        self.factory.form_requires_case(form)
+        schema = get_session_schema(form)
+        self.assertDictEqual(schema["structure"], {
+            "data": {
+                "merge": True,
+                "structure": {
+                    "case_id": {
+                        "reference": {
+                            "hashtag": "#registry_case",
+                            "source": "registry",
+                            "subset": "case",
+                            "key": "@case_id",
+                        },
+                    },
+                },
+            },
+        })
+
     def test_get_casedb_schema_with_form_from_registry(self):
         village = self.add_form("village")
         module = village.get_module()

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -126,6 +126,7 @@ INSTANCE_KWARGS_BY_ID = {
     'ledgerdb': dict(id='ledgerdb', src='jr://instance/ledgerdb'),
     'casedb': dict(id='casedb', src='jr://instance/casedb'),
     'commcaresession': dict(id='commcaresession', src='jr://instance/session'),
+    'registry': dict(id='registry', src='jr://instance/remote'),
 }
 
 

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -33,6 +33,7 @@ from corehq.apps.app_manager.xpath import (
     interpolate_xpath,
     session_var,
 )
+from corehq.apps.case_search.models import CASE_SEARCH_REGISTRY_ID_KEY
 from corehq.util.timer import time_method
 from corehq.util.view_utils import absolute_reverse
 
@@ -489,7 +490,7 @@ class EntriesHelper(object):
                 data=[
                     QueryData(key='case_type', ref=f"'{datum['case_type']}'"),
                     QueryData(key='case_id', ref=session_var(datum['session_var'])),
-                    QueryData(key='registry', ref=f"'{module.search_config.data_registry}'")
+                    QueryData(key=CASE_SEARCH_REGISTRY_ID_KEY, ref=f"'{module.search_config.data_registry}'")
                 ],
                 default_search='true',
             ),

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -200,7 +200,7 @@ class RemoteRequestFactory(object):
             datums.append(
                 QueryData(
                     key=CASE_SEARCH_REGISTRY_ID_KEY,
-                    ref=self.module.search_config.data_registry,
+                    ref=f"'{self.module.search_config.data_registry}'",
                 )
             )
         return datums

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -373,7 +373,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
 
         expected_data = """
         <partial>
-          <data key="commcare_registry" ref="myregistry"/>
+          <data key="commcare_registry" ref="'myregistry'"/>
         </partial>
         """
         self.assertXmlPartialEqual(expected_data, suite, "./remote-request[1]/session/query/data[@key='commcare_registry']")

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -363,7 +363,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
           <query url="http://localhost:8000/a/test_domain/phone/registry_case/123/" storage-instance="registry" template="case" default_search="true">
             <data key="case_type" ref="'case'"/>
             <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
-            <data key="registry" ref="'myregistry'"/>
+            <data key="commcare_registry" ref="'myregistry'"/>
           </query>
         </partial>"""
         self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]/session/query")

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -20,7 +20,7 @@ from corehq.apps.analytics.tasks import (
     send_hubspot_form,
 )
 from corehq.apps.app_manager import add_ons
-from corehq.apps.app_manager.app_schemas.casedb_schema import get_casedb_schema
+from corehq.apps.app_manager.app_schemas.casedb_schema import get_casedb_schema, get_registry_schema
 from corehq.apps.app_manager.app_schemas.session_schema import (
     get_session_schema,
 )
@@ -190,6 +190,8 @@ def get_form_data_schema(request, domain, app_id, form_unique_id):
         data.append(get_session_schema(form))
         if form.requires_case() or is_usercase_in_use(domain):
             data.append(get_casedb_schema(form))
+        if form.requires_case() and form.get_module().search_config.data_registry:
+            data.append(get_registry_schema(form))
     except AppManagerException as e:
         notify_exception(request, message=str(e))
         return HttpResponseBadRequest(

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -195,6 +195,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
     Get context items that are used by both basic and advanced modules.
     '''
     item_lists = item_lists_by_app(app) if app.enable_search_prompt_appearance else []
+    case_types = set(module.search_config.additional_case_types) | {module.case_type}
     context = {
         'details': _get_module_details_context(request, app, module, case_property_builder),
         'case_list_form_options': _case_list_form_options(app, module, lang),
@@ -205,6 +206,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
         'data_registries': [
             (registry.slug, registry.name) for registry in
             DataRegistry.objects.accessible_to_domain(app.domain)
+            if set(registry.wrapped_schema.case_types) & case_types
         ],
         'js_options': {
             'fixture_columns_by_type': _get_fixture_columns_by_type(app.domain),

--- a/corehq/apps/ota/tests/test_registry_case_details.py
+++ b/corehq/apps/ota/tests/test_registry_case_details.py
@@ -45,7 +45,7 @@ class RegistryCaseDetailsTests(TestCase):
 
     def test_get_case_details(self):
         response_content = self._make_request({
-            "registry": self.registry.slug, "case_id": self.case.case_id, "case_type": "patient",
+            "commcare_registry": self.registry.slug, "case_id": self.case.case_id, "case_type": "patient",
         }, 200)
         self.assertEqual(CaseDBFixture(self.case).fixture.decode('utf8'), response_content)
         self.assertEqual(1, RegistryAuditLog.objects.filter(
@@ -57,12 +57,12 @@ class RegistryCaseDetailsTests(TestCase):
 
     def test_get_case_details_missing_case(self):
         self._make_request({
-            "registry": self.registry.slug, "case_id": "missing", "case_type": "patient",
+            "commcare_registry": self.registry.slug, "case_id": "missing", "case_type": "patient",
         }, 404)
 
     def test_get_case_details_missing_registry(self):
         self._make_request({
-            "registry": "not-a-registry", "case_id": self.case.case_id, "case_type": "patient",
+            "commcare_registry": "not-a-registry", "case_id": self.case.case_id, "case_type": "patient",
         }, 404)
 
     def _make_request(self, params, expected_response_code):
@@ -73,9 +73,9 @@ class RegistryCaseDetailsTests(TestCase):
 
 
 @generate_cases([
-    ({}, "'case_id', 'case_type', 'registry' are required parameters"),
-    ({"case_id": "a"}, "'case_type', 'registry' are required parameters"),
-    ({"case_id": "a", "case_type": "b"}, "'registry' is a required parameter"),
+    ({}, "'case_id', 'case_type', 'commcare_registry' are required parameters"),
+    ({"case_id": "a"}, "'case_type', 'commcare_registry' are required parameters"),
+    ({"case_id": "a", "case_type": "b"}, "'commcare_registry' is a required parameter"),
 ], RegistryCaseDetailsTests)
 def test_required_params(self, params, message):
     content = self._make_request(params, 400)

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -406,12 +406,12 @@ def recovery_measures(request, domain, build_id):
 def registry_case(request, domain, app_id):
     case_id = request.GET.get("case_id")
     case_type = request.GET.get("case_type")
-    registry = request.GET.get("registry")
+    registry = request.GET.get("commcare_registry")
 
     missing = [
         name
         for name, value in zip(
-            ["case_id", "case_type", "registry"],
+            ["case_id", "case_type", "commcare_registry"],
             [case_id, case_type, registry]
         )
         if not value


### PR DESCRIPTION
## Summary
Changes to make it easier to use the case data loaded from a data registry in a form. This changes the app schema used by Vellum so that referencing case properties in the form will generate the correct instance expressions.

Spec: https://docs.google.com/document/d/1FCSxVBoBG8LnmogMwei1nb6eC74eUhs7HWuJmBg6i3k/edit#
Jira: https://dimagi-dev.atlassian.net/browse/USH-1233

## Feature Flag
DATA_REGISTRY

## Product Description
Support drag and drop case property references in Form Builder for cases loaded from a data registry.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
