### PR TITLE
ensure feature flag is set when inviting a domain to a data registry

### DIFF
--- a/corehq/apps/registry/utils.py
+++ b/corehq/apps/registry/utils.py
@@ -2,6 +2,7 @@ from django.db import transaction
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 
+from corehq import toggles
 from corehq.apps.registry.models import DataRegistry, RegistryInvitation, RegistryGrant
 from corehq.apps.registry.signals import (
     data_registry_activated,
@@ -72,6 +73,7 @@ class DataRegistryCrudHelper:
         if created:
             self.registry.logger.invitation_added(self.user, invitation)
             data_registry_invitation_created.send(sender=DataRegistry, registry=self.registry, invitation=invitation)
+            toggles.DATA_REGISTRY.set(domain, True, namespace=toggles.NAMESPACE_DOMAIN)
         return invitation, created
 
     @transaction.atomic


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-3495

## Summary
ensure feature flag is set when inviting a domain to a data registry

## Feature Flag
DATA_REGISTRY

## Product Description
Enable the Data Registry feature flag when a domain is invited to a DR.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
