### PR TITLE
Allow text input for superusers when adding downstream domains

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select2_knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select2_knockout_bindings.ko.js
@@ -77,7 +77,7 @@ hqDefine("hqwebapp/js/select2_knockout_bindings.ko", [
 
         self.update = function (element, valueAccessor, allBindings) {
             var $el = $(element),
-                newValue = ko.unwrap(allBindings().value) || $el.val();
+                newValue = ko.unwrap(allBindings().value);
 
             ko.bindingHandlers.select2.updateSelect2Source(element, valueAccessor);
 

--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -9,7 +9,6 @@ from django.utils.translation import ugettext as _
 
 import jsonobject
 
-from corehq.apps.domain.dbaccessors import domain_exists
 from corehq.apps.linked_domain.const import ALL_LINKED_MODELS
 from corehq.apps.linked_domain.exceptions import DomainLinkError
 
@@ -94,11 +93,6 @@ class DomainLink(models.Model):
 
     @classmethod
     def link_domains(cls, linked_domain, master_domain, remote_details=None):
-        if not domain_exists(linked_domain):
-            raise DomainLinkError(
-                _(f"The domain {linked_domain} does not exist. Make sure the name is correct and this domain "
-                  "hasn't been deleted.")
-            )
         existing_links = cls.all_objects.filter(linked_domain=linked_domain)
         active_links_with_other_domains = [
             domain_link for domain_link in existing_links

--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -102,7 +102,7 @@ class DomainLink(models.Model):
             already_linked_domain = active_links_with_other_domains[0].master_domain
             raise DomainLinkError(
                 _('{} is already a downstream project space of {}.\nYou must remove the existing link before '
-                  'creating this new link.'.format(linked_domain, already_linked_domain))
+                  'creating this new link.').format(linked_domain, already_linked_domain)
             )
 
         deleted_existing_links = [

--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -101,8 +101,8 @@ class DomainLink(models.Model):
         if active_links_with_other_domains:
             already_linked_domain = active_links_with_other_domains[0].master_domain
             raise DomainLinkError(
-                _(f'{linked_domain} is already a downstream project space of {already_linked_domain}.\n'
-                  'You must remove the existing link before creating this new link.')
+                _('{} is already a downstream project space of {}.\nYou must remove the existing link before '
+                  'creating this new link.'.format(linked_domain, already_linked_domain))
             )
 
         deleted_existing_links = [

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -368,7 +368,7 @@ hqDefine("linked_domain/js/domain_links", [
                     self.parent.goToPage(1);
                 } else {
                     var errorMessage = _.template(
-                        gettext('Unable to link project spaces. <%- error %>\nYou must remove the existing link before creating this new link.')
+                        gettext('Unable to link project spaces. <%- error %>')
                     )({error: response.message});
                     alertUser.alert_user(errorMessage, 'danger');
                 }

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -353,17 +353,16 @@ hqDefine("linked_domain/js/domain_links", [
         var self = {};
         self.parent = data.parent;
         self.availableDomains = ko.observableArray(data.availableDomains.sort());
-        self.value = ko.observable();
+        self.domainToAdd = ko.observable();
 
         self.addDownstreamDomain = function (viewModel) {
             _private.RMI("create_domain_link", {
-                "downstream_domain": viewModel.value(),
+                "downstream_domain": viewModel.domainToAdd(),
             }).done(function (response) {
                 if (response.success) {
                     self.availableDomains(_.filter(self.availableDomains(), function (item) {
-                        return item !== viewModel.value();
+                        return item !== viewModel.domainToAdd();
                     }));
-                    self.value(null);
                     self.parent.domain_links.unshift(DomainLink(response.domain_link));
                     self.parent.goToPage(1);
                 } else {
@@ -372,6 +371,7 @@ hqDefine("linked_domain/js/domain_links", [
                     )({error: response.message});
                     alertUser.alert_user(errorMessage, 'danger');
                 }
+                self.domainToAdd(null);
             }).fail(function () {
                 alertUser.alert_user(gettext('Unable to link project spaces.\nPlease try again, or report an issue if the problem persists.'), 'danger');
             });

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -75,7 +75,11 @@
         <div class="modal-body">
           <div class="ko-model">
             <label >{% trans 'Project Space:' %}</label>
-            <select class="form-control" data-bind="select2: availableDomains, value: value"></select>
+            {% if is_superuser %}
+              <select class="form-control" data-bind="autocompleteSelect2: availableDomains, value: value"></select>
+            {% else %}
+              <select class="form-control" data-bind="select2: availableDomains, value: value"></select>
+            {% endif %}
           </div>
         </div>
         <div class="modal-footer">

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -76,9 +76,9 @@
           <div class="ko-model">
             <label >{% trans 'Project Space:' %}</label>
             {% if is_superuser %}
-              <select class="form-control" data-bind="autocompleteSelect2: availableDomains, value: value"></select>
+              <select class="form-control" data-bind="autocompleteSelect2: availableDomains, value: domainToAdd"></select>
             {% else %}
-              <select class="form-control" data-bind="select2: availableDomains, value: value"></select>
+              <select class="form-control" data-bind="select2: availableDomains, value: domainToAdd"></select>
             {% endif %}
           </div>
         </div>

--- a/corehq/apps/linked_domain/tests/test_link_domains.py
+++ b/corehq/apps/linked_domain/tests/test_link_domains.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from django.test import TestCase
 
 from corehq.apps.linked_domain.exceptions import DomainLinkError
@@ -8,28 +6,9 @@ from corehq.apps.linked_domain.models import DomainLink
 
 class LinkedDomainTests(TestCase):
 
-    def setUp(self):
-        self.domain_exists_patcher = patch('corehq.apps.linked_domain.models.domain_exists')
-        self.mock_domain_exists = self.domain_exists_patcher.start()
-        self.mock_domain_exists.return_value = True
-
     def tearDown(self):
         DomainLink.all_objects.all().delete()
-        self.domain_exists_patcher.stop()
         super(LinkedDomainTests, self).tearDown()
-
-    def test_non_existent_domain_raises_exception(self):
-        self.mock_domain_exists.return_value = False
-
-        with self.assertRaises(DomainLinkError):
-            DomainLink.link_domains('downstream', 'upstream')
-
-    def test_existent_domain_does_not_raise_exception(self):
-        # defaults to true
-        try:
-            DomainLink.link_domains('downstream', 'upstream')
-        except DomainLinkError:
-            self.fail("link_domains() should not raise a DomainLinkError exception.")
 
     def test_linking_existing(self):
         link = DomainLink.link_domains('linked', 'master')

--- a/corehq/apps/linked_domain/tests/test_link_domains.py
+++ b/corehq/apps/linked_domain/tests/test_link_domains.py
@@ -11,6 +11,7 @@ class LinkedDomainTests(TestCase):
     def setUp(self):
         self.domain_exists_patcher = patch('corehq.apps.linked_domain.models.domain_exists')
         self.mock_domain_exists = self.domain_exists_patcher.start()
+        self.mock_domain_exists.return_value = True
 
     def tearDown(self):
         DomainLink.all_objects.all().delete()
@@ -24,7 +25,7 @@ class LinkedDomainTests(TestCase):
             DomainLink.link_domains('downstream', 'upstream')
 
     def test_existent_domain_does_not_raise_exception(self):
-        self.mock_domain_exists.return_value = True
+        # defaults to true
         try:
             DomainLink.link_domains('downstream', 'upstream')
         except DomainLinkError:

--- a/corehq/apps/linked_domain/tests/test_link_domains.py
+++ b/corehq/apps/linked_domain/tests/test_link_domains.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import TestCase
 
 from corehq.apps.linked_domain.exceptions import DomainLinkError
@@ -5,9 +7,28 @@ from corehq.apps.linked_domain.models import DomainLink
 
 
 class LinkedDomainTests(TestCase):
+
+    def setUp(self):
+        self.domain_exists_patcher = patch('corehq.apps.linked_domain.models.domain_exists')
+        self.mock_domain_exists = self.domain_exists_patcher.start()
+
     def tearDown(self):
         DomainLink.all_objects.all().delete()
+        self.domain_exists_patcher.stop()
         super(LinkedDomainTests, self).tearDown()
+
+    def test_non_existent_domain_raises_exception(self):
+        self.mock_domain_exists.return_value = False
+
+        with self.assertRaises(DomainLinkError):
+            DomainLink.link_domains('downstream', 'upstream')
+
+    def test_existent_domain_does_not_raise_exception(self):
+        self.mock_domain_exists.return_value = True
+        try:
+            DomainLink.link_domains('downstream', 'upstream')
+        except DomainLinkError:
+            self.fail("link_domains() should not raise a DomainLinkError exception.")
 
     def test_linking_existing(self):
         link = DomainLink.link_domains('linked', 'master')

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -392,14 +392,16 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
         if not domain_exists(domain_to_link):
             return {
                 'success': False,
-                'message': ugettext(f"The project space {domain_to_link} does not exist. Make sure the name is "
-                                    f"correct and this domain hasn't been deleted.")
+                'message': ugettext("The project space {} does not exist. Make sure the name is "
+                                    "correct and this domain hasn't been deleted.".format(domain_to_link))
             }
 
         if DomainLink.objects.filter(master_domain=self.domain, linked_domain=domain_to_link):
             return {
                 'success': False,
-                'message': ugettext(f"The project space {domain_to_link} is already linked to this project space.")
+                'message': ugettext(
+                    "The project space {} is already linked to this project space.".format(domain_to_link)
+                )
             }
 
         try:

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -25,6 +25,7 @@ from corehq.apps.app_manager.dbaccessors import (
 from corehq.apps.app_manager.decorators import require_can_edit_apps
 from corehq.apps.app_manager.util import is_linked_app
 from corehq.apps.case_search.models import CaseSearchConfig
+from corehq.apps.domain.dbaccessors import domain_exists
 from corehq.apps.domain.decorators import (
     domain_admin_required,
     login_or_api_key,
@@ -388,6 +389,13 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
     @allow_remote_invocation
     def create_domain_link(self, in_data):
         domain_to_link = in_data['downstream_domain']
+        if not domain_exists(domain_to_link):
+            return {
+                'success': False,
+                'message': ugettext(f"The domain {domain_to_link} does not exist. Make sure the name is correct "
+                                    "and this domain hasn't been deleted.")
+            }
+
         try:
             domain_link = DomainLink.link_domains(domain_to_link, self.domain)
         except DomainLinkError as e:

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -392,8 +392,14 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
         if not domain_exists(domain_to_link):
             return {
                 'success': False,
-                'message': ugettext(f"The domain {domain_to_link} does not exist. Make sure the name is correct "
-                                    "and this domain hasn't been deleted.")
+                'message': ugettext(f"The project space {domain_to_link} does not exist. Make sure the name is "
+                                    f"correct and this domain hasn't been deleted.")
+            }
+
+        if DomainLink.objects.filter(master_domain=self.domain, linked_domain=domain_to_link):
+            return {
+                'success': False,
+                'message': ugettext(f"The project space {domain_to_link} is already linked to this project space.")
             }
 
         try:

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -305,6 +305,7 @@ class DomainLinkView(BaseAdminProjectSettingsView):
             'domain': self.domain,
             'timezone': timezone.localize(datetime.utcnow()).tzname(),
             'has_release_management_privilege': domain_has_privilege(self.domain, RELEASE_MANAGEMENT),
+            'is_superuser': is_superuser,
             'view_data': {
                 'is_downstream_domain': bool(master_link),
                 'upstream_domains': upstream_domain_urls,

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -393,15 +393,15 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
             return {
                 'success': False,
                 'message': ugettext("The project space {} does not exist. Make sure the name is "
-                                    "correct and this domain hasn't been deleted.".format(domain_to_link))
+                                    "correct and this domain hasn't been deleted.").format(domain_to_link)
             }
 
         if DomainLink.objects.filter(master_domain=self.domain, linked_domain=domain_to_link):
             return {
                 'success': False,
                 'message': ugettext(
-                    "The project space {} is already linked to this project space.".format(domain_to_link)
-                )
+                    "The project space {} is already linked to this project space."
+                ).format(domain_to_link)
             }
 
         try:

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -382,9 +382,9 @@ def link_keywords(request, domain):
     if successes:
         messages.success(
             request,
-            _("Successfully linked and copied to {}. ".format(', '.join(successes))))
+            _("Successfully linked and copied to {}. ").format(', '.join(successes)))
     if failures:
-        messages.error(request, _("Errors occurred for {}.".format(', '.join(failures))))
+        messages.error(request, _("Errors occurred for {}.").format(', '.join(failures)))
 
     return HttpResponseRedirect(
         reverse(KeywordsListView.urlname, args=[from_domain])

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -382,9 +382,9 @@ def link_keywords(request, domain):
     if successes:
         messages.success(
             request,
-            _(f"Successfully linked and copied to {', '.join(successes)}. "))
+            _("Successfully linked and copied to {}. ".format(', '.join(successes))))
     if failures:
-        messages.error(request, _(f"Errors occurred for {', '.join(failures)}."))
+        messages.error(request, _("Errors occurred for {}.".format(', '.join(failures))))
 
     return HttpResponseRedirect(
         reverse(KeywordsListView.urlname, args=[from_domain])


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-213)

Recent changes to linked domains have been more restrictive in that only domains with an enterprise account can be linked to. In order for this to work for USH,  a superuser must still have the ability to link to any domain via text input (similar to how the app manager workflow has been). This allows superusers to type in any domain, and will raise an exception if that domain does not exist. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added a couple of tests to ensure an exception is raised if a domain does not exist (and not raised if it does exist).

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
[QA Ticket](https://dimagi-dev.atlassian.net/browse/QA-3500)
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested. Will test on staging as well and will go through QA. This only impacts those on the release_management privilege, which is currently SaaS enterprise partners.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
