### PR TITLE
update referrer case forwarder to maintain case transfer history

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
@@ -164,10 +164,12 @@ class CaseBlock(object):
             else:
                 # can this be a hierarchical structure? if yes, how to decode?
                 updates[tag] = node.text
+
+        if case.get("date_modified"):
+            fields['date_modified'] = string_to_datetime(case.get("date_modified")).replace(tzinfo=None)
+
         return cls(
             case_id=case.get("case_id"),
-            date_modified=string_to_datetime(
-                case.get("date_modified")).replace(tzinfo=None),
             user_id=case.get("user_id"),
             index=dict(index_tuple(x) for x in case.find(NS + "index") or []),
             **fields

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -379,8 +379,8 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
             # addition of the history properties
             previous_source_domain = original_case_json.get('cchq_referral_source_domain')
             previous_source_case_id = original_case_json.get('cchq_referral_source_case_id')
-            domain_history.append(f"_unknown_ {previous_source_domain}")
-            id_history.append(f"_unknown_ {previous_source_case_id}")
+            domain_history = ["_unknown_", previous_source_domain]
+            id_history = ["_unknown_", previous_source_case_id]
 
         case.case_json['cchq_referral_domain_history'] = ' '.join(domain_history + [self.repeater.domain])
         case.case_json['cchq_referral_case_id_history'] = ' '.join(id_history + [original_case_id])

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -311,8 +311,8 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
             'case_block': case_blocks,
             'time': json_format_datetime(datetime.utcnow()),
             'uid': uuid4().hex,
-            'username': self.repeater.connection_settings.username,
-            'user_id': CouchUser.get_by_username(self.repeater.connection_settings.username).user_id,
+            'username': self.submission_username(),
+            'user_id': self.submission_user_id(),
             'device_id': "ReferCaseRepeater",
         })
 
@@ -330,12 +330,13 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
                 else:
                     raise ReferralError(f'case {original_id} included without referenced case {index.referenced_id}')
             config = case_type_configs[case.type]
+            original_case_json = case.case_json.copy()
             if config.use_blacklist:
                 self._update_case_properties_with_blacklist(case, config)
             else:
                 self._update_case_properties_with_whitelist(case, config)
             self._set_constant_properties(case, config)
-            self._set_referral_properties(case, original_id)
+            self._set_referral_properties(case, original_id, original_case_json)
             case_blocks.append(case.to_xml(V2).decode('utf-8'))
         case_blocks = ''.join(case_blocks)
         return case_blocks
@@ -364,11 +365,23 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
         for name, value in config.constant_properties:
             case.case_json[name] = value
 
-    def _set_referral_properties(self, case, original_case_id):
+    def _set_referral_properties(self, case, original_case_id, original_case_json):
         # make sure new case is open
         case.closed = False
         case.case_json['cchq_referral_source_domain'] = self.repeater.domain
         case.case_json['cchq_referral_source_case_id'] = original_case_id
+
+        domain_history = original_case_json.get('cchq_referral_domain_history', '').split()
+        case.case_json['cchq_referral_domain_history'] = ' '.join(domain_history + [self.repeater.domain])
+
+        id_history = original_case_json.get('cchq_referral_case_id_history', '').split()
+        case.case_json['cchq_referral_case_id_history'] = ' '.join(id_history + [original_case_id])
+
+    def submission_username(self):
+        return self.repeater.connection_settings.username
+
+    def submission_user_id(self):
+        return CouchUser.get_by_username(self.submission_username).user_id
 
 
 class AppStructureGenerator(BasePayloadGenerator):

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -372,9 +372,17 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
         case.case_json['cchq_referral_source_case_id'] = original_case_id
 
         domain_history = original_case_json.get('cchq_referral_domain_history', '').split()
-        case.case_json['cchq_referral_domain_history'] = ' '.join(domain_history + [self.repeater.domain])
-
         id_history = original_case_json.get('cchq_referral_case_id_history', '').split()
+
+        if 'cchq_referral_source_domain' in original_case_json and not domain_history:
+            # bootstrap for cases that have already been transferred at least once prior to
+            # addition of the history properties
+            previous_source_domain = original_case_json.get('cchq_referral_source_domain')
+            previous_source_case_id = original_case_json.get('cchq_referral_source_case_id')
+            domain_history.append(f"_unknown_ {previous_source_domain}")
+            id_history.append(f"_unknown_ {previous_source_case_id}")
+
+        case.case_json['cchq_referral_domain_history'] = ' '.join(domain_history + [self.repeater.domain])
         case.case_json['cchq_referral_case_id_history'] = ' '.join(id_history + [original_case_id])
 
     def submission_username(self):

--- a/corehq/motech/repeaters/tests/test_refer_case_repeater.py
+++ b/corehq/motech/repeaters/tests/test_refer_case_repeater.py
@@ -1,10 +1,20 @@
-from django.test import SimpleTestCase
+import uuid
+from http.client import responses
+from unittest.mock import patch, Mock
+from xml.etree import cElementTree as ElementTree
 
+from django.test import SimpleTestCase
+from testil import eq
+
+from casexml.apps.case.mock import CaseBlock
+from casexml.apps.case.xml import V2_NAMESPACE
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCaseSQL
 from corehq.motech.repeater_helpers import RepeaterResponse
 from corehq.motech.repeaters.models import ReferCaseRepeater
+from corehq.motech.repeaters.repeater_generators import ReferCasePayloadGenerator
 from corehq.util.test_utils import generate_cases
 from couchforms.openrosa_response import ResponseNature
-from http.client import responses
 
 SUCCESS = f"""
     <OpenRosaResponse xmlns="http://openrosa.org/http/response">
@@ -46,3 +56,64 @@ def test_get_response(self, status_code, text, expected_response):
     self.assertEqual(response.status_code, expected_response.status_code)
     self.assertEqual(response.reason, expected_response.reason)
     self.assertEqual(response.retry, expected_response.retry)
+
+
+def test_refer_case_payload_generator_no_previous_transfer():
+    _test_refer_case_payload_generator({}, _get_referral_props("1", "source_domain"))
+
+
+def test_refer_case_payload_generator_one_previous_transfer():
+    _test_refer_case_payload_generator(
+        _get_referral_props("a", "domainA"),
+        _get_referral_props("a 1", "domainA source_domain"),
+    )
+
+
+def test_refer_case_payload_generator_multiple_previous_transfer():
+    _test_refer_case_payload_generator(
+        _get_referral_props("a b", "domainA domainB"),
+        _get_referral_props("a b 1", "domainA domainB source_domain"),
+    )
+
+
+def _test_refer_case_payload_generator(initial_case_properties, expected_referral_props):
+    domain = "source_domain"
+    repeater = ReferCaseRepeater(domain=domain)
+    generator = ReferCasePayloadGenerator(repeater)
+    generator.submission_user_id = Mock(return_value='user1')
+    generator.submission_username = Mock(return_value='user1')
+    transfer_case = CommCareCaseSQL(
+        type="transfer",
+        case_json={
+            "cases_to_forward": "case1",
+            "new_owner": "owner1",
+            "case_types": "patient",
+            "patient_whitelist": "copy_this"
+        }
+    )
+    copy_value = uuid.uuid4().hex
+    properties = {"copy_this": copy_value}
+    properties.update(initial_case_properties or {})
+    target_case = CommCareCaseSQL(
+        case_id="1",
+        type="patient",
+        case_json=properties
+    )
+    with patch.object(CaseAccessors, "get_cases", return_value=[target_case]):
+        form = generator.get_payload(None, transfer_case)
+        formxml = ElementTree.fromstring(form)
+        case = CaseBlock.from_xml(formxml.find("{%s}case" % V2_NAMESPACE))
+        expected_update = {
+            "cchq_referral_source_domain": domain,
+            "cchq_referral_source_case_id": "1",
+            "copy_this": copy_value
+        }
+        expected_update.update(expected_referral_props)
+        eq(case.update, expected_update)
+
+
+def _get_referral_props(case_id_history, domain_history):
+    return {
+        "cchq_referral_case_id_history": case_id_history,
+        "cchq_referral_domain_history": domain_history,
+    }

--- a/corehq/motech/repeaters/tests/test_refer_case_repeater.py
+++ b/corehq/motech/repeaters/tests/test_refer_case_repeater.py
@@ -62,6 +62,15 @@ def test_refer_case_payload_generator_no_previous_transfer():
     _test_refer_case_payload_generator({}, _get_referral_props("1", "source_domain"))
 
 
+def test_refer_case_payload_generator_previous_transfer_prior_to_history():
+    initial_props = {
+        "cchq_referral_source_domain": "a",
+        "cchq_referral_source_case_id": "2",
+    }
+    expected_history_props = _get_referral_props("_unknown_ 2 1", "_unknown_ a source_domain")
+    _test_refer_case_payload_generator(initial_props, expected_history_props)
+
+
 def test_refer_case_payload_generator_one_previous_transfer():
     _test_refer_case_payload_generator(
         _get_referral_props("a", "domainA"),


### PR DESCRIPTION
## Summary
This is a change to the `ReferCaseRepeater` to add two new case properties to transferred cases. These two new properties will help to keep track of where cases come from and make it easier to see the history of a case.

**cchq_referral_domain_history**
- space separated list of domains that this case has been transferred from
- Ordered from first to last: “x y z”, x was first domain, y next, z last (before the current domain)

**cchq_referral_case_id_history**
- space separated list of case IDs that this case has had in the past
- This is ordered in the same way as the domain history so domain_history[x] can be paired with case_id_history[x]

Docs: https://docs.google.com/document/d/1aT3oqEmi-T6HHX2p61wbEB41FM_tnzTWmbyhXLQPaZ8/edit#

## Feature Flag
REFER_CASE_REPEATER

## Product Description
Make it easier to track the history of 'transferred' cases.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added

### QA Plan
None

### Safety story
Changes to USH feature. Tested.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
