### PR TITLE
Remove tornado dependency, required by flower

### DIFF
--- a/requirements/prod-requirements.in
+++ b/requirements/prod-requirements.in
@@ -3,7 +3,6 @@
 pip>=10.0.0
 
 flower==0.9.2
-tornado<5.0
 setproctitle==1.2.2
 uWSGI==2.0.19.1
 ipython==7.16.1

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -500,9 +500,7 @@ text-unidecode==1.3
 tinys3==0.1.12
     # via -r base-requirements.in
 tornado==4.5.3
-    # via
-    #   -r prod-requirements.in
-    #   flower
+    # via flower
 traitlets==4.3.3
     # via ipython
 tropo-webapi-python==0.1.3


### PR DESCRIPTION
Flower's dependency graph includes tornado, and our pin should be unnecessary.

The version of flower we are using (0.9.2) ~apparently [requires `tornado>=5.0.0,<7.0.0`](https://github.com/mher/flower/blob/0.9/requirements/default.txt)~ [requires `tornado>=4.2.0`](https://github.com/mher/flower/blob/v0.9.2/requirements/default.txt), but we had issues in the past when we tried to upgrade (see https://github.com/dimagi/commcare-hq/pull/29440). We should be cautious (test on staging) when upgrading tornado, and possibly also upgrade flower to a more recent version at the same time. Note that this PR does not upgrade tornado.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

None.

### Safety story

This simply defers the version tornado requirement to flower. Nothing else changed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
