### PR TITLE
Remove unused pycco dependency

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -82,7 +82,6 @@ prometheus-client==0.7.1
 psycogreen~=1.0
 psycopg2>=2.8.4  # Python 3.8 support
 py-KISSmetrics==1.1.0
-Pycco==0.5.1
 pycryptodome>=3.6.6  # security update
 PyGithub==1.54.1
 Pygments==2.8.1

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -323,9 +323,7 @@ mako==1.1.3
 mando==0.6.4
     # via radon
 markdown==2.2.1
-    # via
-    #   -r base-requirements.in
-    #   pycco
+    # via -r base-requirements.in
 markupsafe==1.1.1
     # via
     #   jinja2
@@ -395,8 +393,6 @@ ptyprocess==0.6.0
     # via pexpect
 py-kissmetrics==1.1.0
     # via -r base-requirements.in
-pycco==0.5.1
-    # via -r base-requirements.in
 pycodestyle==2.7.0
     # via flake8
 pycparser==2.20
@@ -411,7 +407,6 @@ pygments==2.8.1
     # via
     #   -r base-requirements.in
     #   ipython
-    #   pycco
     #   sphinx
 pygooglechart==0.4.0
     # via -r base-requirements.in
@@ -429,8 +424,6 @@ pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
     # via twilio
-pystache==0.5.4
-    # via pycco
 python-dateutil==2.8.1
     # via
     #   -r base-requirements.in
@@ -560,8 +553,6 @@ six==1.15.0
     #   traitlets
     #   transifex-client
     #   twilio
-smartypants==2.0.1
-    # via pycco
 smmap==4.0.0
     # via gitdb
 sniffer==0.4.1

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -266,9 +266,7 @@ lxml==4.6.3
 mako==1.1.3
     # via alembic
 markdown==2.2.1
-    # via
-    #   -r base-requirements.in
-    #   pycco
+    # via -r base-requirements.in
 markdown-it-py==1.1.0
     # via
     #   mdit-py-plugins
@@ -318,8 +316,6 @@ psycopg2==2.8.6
     # via -r base-requirements.in
 py-kissmetrics==1.1.0
     # via -r base-requirements.in
-pycco==0.5.1
-    # via -r base-requirements.in
 pycparser==2.20
     # via cffi
 pycryptodome==3.9.9
@@ -329,7 +325,6 @@ pygithub==1.54.1
 pygments==2.8.1
     # via
     #   -r base-requirements.in
-    #   pycco
     #   sphinx
 pygooglechart==0.4.0
     # via -r base-requirements.in
@@ -345,8 +340,6 @@ pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
     # via twilio
-pystache==0.5.4
-    # via pycco
 python-dateutil==2.8.1
     # via
     #   -r base-requirements.in
@@ -452,8 +445,6 @@ six==1.15.0
     #   quickcache
     #   tenacity
     #   twilio
-smartypants==2.0.1
-    # via pycco
 snowballstemmer==2.1.0
     # via sphinx
 socketpool==0.5.3

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -272,9 +272,7 @@ lxml==4.6.3
 mako==1.1.3
     # via alembic
 markdown==2.2.1
-    # via
-    #   -r base-requirements.in
-    #   pycco
+    # via -r base-requirements.in
 markupsafe==1.1.1
     # via
     #   jinja2
@@ -330,8 +328,6 @@ pyasn1==0.4.8
     # via
     #   -r prod-requirements.in
     #   ndg-httpsclient
-pycco==0.5.1
-    # via -r base-requirements.in
 pycparser==2.20
     # via cffi
 pycryptodome==3.9.9
@@ -342,7 +338,6 @@ pygments==2.8.1
     # via
     #   -r base-requirements.in
     #   ipython
-    #   pycco
 pygooglechart==0.4.0
     # via -r base-requirements.in
 pyjwt==1.7.1
@@ -360,8 +355,6 @@ pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
     # via twilio
-pystache==0.5.4
-    # via pycco
 python-dateutil==2.8.1
     # via
     #   -r base-requirements.in
@@ -472,8 +465,6 @@ six==1.15.0
     #   tenacity
     #   traitlets
     #   twilio
-smartypants==2.0.1
-    # via pycco
 socketpool==0.5.3
     # via -r base-requirements.in
 sortedcontainers==2.3.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -254,9 +254,7 @@ lxml==4.6.3
 mako==1.1.3
     # via alembic
 markdown==2.2.1
-    # via
-    #   -r base-requirements.in
-    #   pycco
+    # via -r base-requirements.in
 markupsafe==1.1.1
     # via
     #   jinja2
@@ -296,8 +294,6 @@ psycopg2==2.8.6
     # via -r base-requirements.in
 py-kissmetrics==1.1.0
     # via -r base-requirements.in
-pycco==0.5.1
-    # via -r base-requirements.in
 pycparser==2.20
     # via cffi
 pycryptodome==3.9.9
@@ -305,9 +301,7 @@ pycryptodome==3.9.9
 pygithub==1.54.1
     # via -r base-requirements.in
 pygments==2.8.1
-    # via
-    #   -r base-requirements.in
-    #   pycco
+    # via -r base-requirements.in
 pygooglechart==0.4.0
     # via -r base-requirements.in
 pyjwt==1.7.1
@@ -322,8 +316,6 @@ pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
     # via twilio
-pystache==0.5.4
-    # via pycco
 python-dateutil==2.8.1
     # via
     #   -r base-requirements.in
@@ -430,8 +422,6 @@ six==1.15.0
     #   quickcache
     #   tenacity
     #   twilio
-smartypants==2.0.1
-    # via pycco
 socketpool==0.5.3
     # via -r base-requirements.in
 sortedcontainers==2.3.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -276,9 +276,7 @@ mako==1.1.3
 mando==0.6.4
     # via radon
 markdown==2.2.1
-    # via
-    #   -r base-requirements.in
-    #   pycco
+    # via -r base-requirements.in
 markupsafe==1.1.1
     # via
     #   jinja2
@@ -331,8 +329,6 @@ psycopg2==2.8.6
     #   sqlalchemy-postgres-copy
 py-kissmetrics==1.1.0
     # via -r base-requirements.in
-pycco==0.5.1
-    # via -r base-requirements.in
 pycparser==2.20
     # via cffi
 pycryptodome==3.9.9
@@ -340,9 +336,7 @@ pycryptodome==3.9.9
 pygithub==1.54.1
     # via -r base-requirements.in
 pygments==2.8.1
-    # via
-    #   -r base-requirements.in
-    #   pycco
+    # via -r base-requirements.in
 pygooglechart==0.4.0
     # via -r base-requirements.in
 pyjwt==1.7.1
@@ -357,8 +351,6 @@ pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
     # via twilio
-pystache==0.5.4
-    # via pycco
 python-dateutil==2.8.1
     # via
     #   -r base-requirements.in
@@ -474,8 +466,6 @@ six==1.15.0
     #   sqlalchemy-postgres-copy
     #   tenacity
     #   twilio
-smartypants==2.0.1
-    # via pycco
 socketpool==0.5.3
     # via -r base-requirements.in
 sortedcontainers==2.3.0


### PR DESCRIPTION
The only thing that ever used it was removed in https://github.com/dimagi/commcare-hq/pull/20548

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None.

### QA Plan

None.

### Safety story

Removing an unused dependency.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
