### PR TITLE
manage data registry permission checks

### DIFF
--- a/corehq/apps/registry/templates/registry/registry_list.html
+++ b/corehq/apps/registry/templates/registry/registry_list.html
@@ -33,12 +33,14 @@
           <span class="hq-help-template"
               data-content="{% blocktrans %}Data Registries allow sharing data between Project Spaces. Read more on the <a target='_blank' href='https://confluence.dimagi.com/display/USH/Data+Registry'>Help Site</a>.{% endblocktrans %}"
           ></span>
+        {% if allow_create %}
         <div class="pull-right">
           <button type="button" class="btn btn-primary" data-bind="openModal: 'create-registry-modal'">
             <i class="fa fa-plus"></i>
             {% trans "New Registry" %}
           </button>
         </div>
+        {% endif %}
         </h3>
       </div>
     </div>
@@ -160,7 +162,7 @@
     </div>
   </script>
 
-
+{% if allow_create %}
 <script type="text/html" id="create-registry-modal">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -245,4 +247,5 @@
       </div>
     </div>
 </script>
+{% endif %}
 {% endblock %}

--- a/corehq/apps/registry/tests/test_permissions.py
+++ b/corehq/apps/registry/tests/test_permissions.py
@@ -1,0 +1,36 @@
+from unittest.mock import Mock
+
+from django.test import SimpleTestCase
+from testil import eq
+
+from corehq.apps.registry.utils import RegistryPermissionCheck
+from corehq.apps.users.models import WebUser, DomainMembership, Permissions, PermissionInfo
+from corehq.util.test_utils import generate_cases
+
+
+class TestRegistryPermissions(SimpleTestCase):
+    pass
+
+
+@generate_cases([
+    (None, False, False, False),
+    ((), False, False, False),
+    (PermissionInfo.ALLOW_ALL, True, True, True),
+    (("test_reg",), False, True, True),
+    (("other",), False, True, False),
+], TestRegistryPermissions)
+def test_manage_registry_permission(self, allow, can_manage_all, can_manage_some, can_manage_specific):
+    domain = "domain"
+    membership = DomainMembership(domain=domain)
+
+    permissions = [PermissionInfo("manage_data_registry", allow)] if allow is not None else []
+    mock_role = Mock(permissions=Permissions.from_permission_list(permissions))
+    # prime membership.role memoize cache (avoids DB lookup)
+    setattr(membership, '_role_cache', {(): mock_role})
+
+    user = WebUser(domain_memberships=[membership])
+
+    checker = RegistryPermissionCheck(domain, user)
+    eq(checker.can_manage_all, can_manage_all)
+    eq(checker.can_manage_some, can_manage_some)
+    eq(checker.can_manage_registry("test_reg"), can_manage_specific)

--- a/corehq/apps/registry/utils.py
+++ b/corehq/apps/registry/utils.py
@@ -19,6 +19,7 @@ from corehq.apps.registry.signals import (
     data_registry_deleted,
 )
 from corehq.apps.users.decorators import require_permission_raw
+from corehq.apps.users.models import Permissions
 
 
 def _get_registry_or_404(domain, registry_slug):
@@ -32,7 +33,8 @@ class RegistryPermissionCheck:
     def __init__(self, domain, couch_user):
         self.domain = domain
         self.couch_user = couch_user
-        permissions = couch_user.get_role(domain, allow_enterprise=True).permissions
+        role = couch_user.get_role(domain, allow_enterprise=True)
+        permissions = role.permissions if role else Permissions()
         self.manageable_slugs = set(permissions.manage_data_registry_list)
 
         self.can_manage_all = permissions.manage_data_registry

--- a/corehq/apps/registry/utils.py
+++ b/corehq/apps/registry/utils.py
@@ -32,7 +32,7 @@ class RegistryPermissionCheck:
     def __init__(self, domain, couch_user):
         self.domain = domain
         self.couch_user = couch_user
-        permissions = couch_user.get_role(domain).permissions
+        permissions = couch_user.get_role(domain, allow_enterprise=True).permissions
         self.manageable_slugs = set(permissions.manage_data_registry_list)
 
         self.can_manage_all = permissions.manage_data_registry

--- a/corehq/apps/registry/views.py
+++ b/corehq/apps/registry/views.py
@@ -36,7 +36,7 @@ def data_registries(request, domain):
 
     context = {
         'domain': domain,
-        'allow_create': user_can_manage_all_registries(request, domain),
+        'allow_create': user_can_manage_all_registries(request.couch_user, domain),
         'owned_registries': owned,
         'invited_registries': invited,
         'available_case_types': list(get_data_dict_case_types(domain)),

--- a/corehq/apps/registry/views.py
+++ b/corehq/apps/registry/views.py
@@ -36,6 +36,7 @@ def data_registries(request, domain):
 
     context = {
         'domain': domain,
+        'allow_create': user_can_manage_all_registries(request, domain),
         'owned_registries': owned,
         'invited_registries': invited,
         'available_case_types': list(get_data_dict_case_types(domain)),

--- a/corehq/apps/registry/views.py
+++ b/corehq/apps/registry/views.py
@@ -13,17 +13,17 @@ from django.views.decorators.http import require_POST, require_GET
 from corehq import toggles
 from corehq.apps.accounting.models import BillingAccount
 from corehq.apps.data_dictionary.util import get_data_dict_case_types
-from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.decorators import use_multiselect, use_daterangepicker
 from corehq.apps.registry.models import DataRegistry, RegistryInvitation
-from corehq.apps.registry.utils import _get_registry_or_404, DataRegistryCrudHelper, DataRegistryAuditViewHelper
+from corehq.apps.registry.utils import _get_registry_or_404, DataRegistryCrudHelper, DataRegistryAuditViewHelper, \
+    manage_some_registries_required, manage_all_registries_required, user_can_manage_all_registries
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_user
 from dimagi.utils.parsing import ISO_DATE_FORMAT
 
 
-@domain_admin_required
+@manage_some_registries_required
 @require_GET
 @toggles.DATA_REGISTRY.required_decorator()
 def data_registries(request, domain):
@@ -85,7 +85,7 @@ def _registry_list_context(domain, registry):
     return context
 
 
-@domain_admin_required
+@manage_some_registries_required
 @require_GET
 @toggles.DATA_REGISTRY.required_decorator()
 @use_multiselect
@@ -143,7 +143,7 @@ def manage_registry(request, domain, registry_slug):
     return render(request, "registry/registry_edit.html", context)
 
 
-@domain_admin_required
+@manage_some_registries_required
 @require_POST
 def accept_registry_invitation(request, domain):
     registry_slug = request.POST.get('registry_slug')
@@ -152,7 +152,7 @@ def accept_registry_invitation(request, domain):
     return JsonResponse({"invitation": invitation.to_json()})
 
 
-@domain_admin_required
+@manage_some_registries_required
 @require_POST
 def reject_registry_invitation(request, domain):
     registry_slug = request.POST.get('registry_slug')
@@ -161,7 +161,7 @@ def reject_registry_invitation(request, domain):
     return JsonResponse({"invitation": invitation.to_json()})
 
 
-@domain_admin_required
+@manage_some_registries_required
 @require_POST
 def edit_registry_attr(request, domain, registry_slug, attr):
     helper = DataRegistryCrudHelper(domain, registry_slug, request.user)
@@ -194,7 +194,7 @@ def edit_registry_attr(request, domain, registry_slug, attr):
     return JsonResponse({attr: value})
 
 
-@domain_admin_required
+@manage_some_registries_required
 @require_POST
 def manage_invitations(request, domain, registry_slug):
     helper = DataRegistryCrudHelper(domain, registry_slug, request.user)
@@ -250,7 +250,7 @@ def manage_invitations(request, domain, registry_slug):
         })
 
 
-@domain_admin_required
+@manage_some_registries_required
 @require_POST
 def manage_grants(request, domain, registry_slug):
     helper = DataRegistryCrudHelper(domain, registry_slug, request.user)
@@ -300,7 +300,7 @@ def manage_grants(request, domain, registry_slug):
         })
 
 
-@domain_admin_required
+@manage_some_registries_required
 @require_POST
 def delete_registry(request, domain, registry_slug):
     helper = DataRegistryCrudHelper(domain, registry_slug, request.user)
@@ -318,7 +318,7 @@ def delete_registry(request, domain, registry_slug):
     return redirect("data_registries", domain=domain)
 
 
-@domain_admin_required
+@manage_all_registries_required
 @require_POST
 def create_registry(request, domain):
     name = request.POST.get("name")
@@ -345,7 +345,7 @@ def create_registry(request, domain):
     return redirect("manage_registry", domain=domain, registry_slug=registry.slug)
 
 
-@domain_admin_required
+@manage_all_registries_required
 @require_POST
 def validate_registry_name(request, domain):
     name = request.POST.get("name")
@@ -356,7 +356,7 @@ def validate_registry_name(request, domain):
     return JsonResponse({"result": not exists})
 
 
-@domain_admin_required
+@manage_some_registries_required
 @require_GET
 def registry_audit_logs(request, domain, registry_slug):
     helper = DataRegistryAuditViewHelper(domain, registry_slug)

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -2005,8 +2005,9 @@ def _get_feature_flag_items(domain, couch_user):
             'url': reverse('domain_report_dispatcher', args=[domain, 'project_link_report'])
         })
 
-    from corehq.apps.registry.utils import user_can_manage_some_registries
-    if toggles.DATA_REGISTRY.enabled(domain) and user_can_manage_some_registries(couch_user, domain):
+    from corehq.apps.registry.utils import RegistryPermissionCheck
+    permission_check = RegistryPermissionCheck(domain, couch_user)
+    if toggles.DATA_REGISTRY.enabled(domain) and permission_check.can_manage_some:
         feature_flag_items.append({
             'title': _('Data Registries'),
             'url': reverse('data_registries', args=[domain]),

--- a/corehq/tabs/tests.py
+++ b/corehq/tabs/tests.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from mock import patch
 
 from django.test import SimpleTestCase
 

--- a/corehq/tabs/tests.py
+++ b/corehq/tabs/tests.py
@@ -12,78 +12,75 @@ __test__ = {
 from corehq.util.test_utils import flag_enabled
 
 
+@patch('corehq.apps.users.models.CouchUser')
 class TestAccessToLinkedProjects(SimpleTestCase):
 
-    @patch('corehq.apps.domain.models.Domain')
-    def test_get_feature_flag_items_returns_none(self, mock_domain):
-
+    def test_get_feature_flag_items_returns_none(self, mock_user):
+        mock_user.is_domain_admin.return_value = True
         with patch('corehq.tabs.tabclasses.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
-            items = _get_feature_flag_items(mock_domain)
+            items = _get_feature_flag_items("domain", mock_user)
 
         self.assertFalse(items)
 
     @flag_enabled('LINKED_DOMAINS')
-    @patch('corehq.apps.domain.models.Domain')
-    def test_get_feature_flag_items_returns_some(self, mock_domain):
-
+    def test_get_feature_flag_items_returns_some(self, mock_user):
+        mock_user.is_domain_admin.return_value = True
         with patch('corehq.tabs.tabclasses.domain_has_privilege') as mock_domain_has_privilege, \
              patch('corehq.tabs.tabclasses.reverse') as mock_reverse:
             mock_domain_has_privilege.return_value = False
             mock_reverse.return_value = 'dummy_url'
-            items = _get_feature_flag_items(mock_domain)
+            items = _get_feature_flag_items("domain", mock_user)
 
         self.assertTrue(items)
 
     @flag_enabled('LINKED_DOMAINS')
-    @patch('corehq.apps.domain.models.Domain')
-    def test_get_feature_flag_items_returns_none_if_domain_has_release_management_privilege(self, mock_domain):
-
+    def test_get_feature_flag_items_returns_none_if_domain_has_release_management_privilege(self, mock_user):
+        mock_user.is_domain_admin.return_value = True
         with patch('corehq.tabs.tabclasses.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = True
-            items = _get_feature_flag_items(mock_domain)
+            items = _get_feature_flag_items("domain", mock_user)
 
         self.assertFalse(items)
 
 
 @patch('corehq.apps.users.models.CouchUser')
-@patch('corehq.apps.domain.models.Domain')
 class TestAccessToReleaseManagementTab(SimpleTestCase):
 
-    def test_get_release_management_items_returns_none(self, mock_domain, mock_user):
+    def test_get_release_management_items_returns_none(self, mock_user):
         mock_user.is_domain_admin.return_value = False
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
-            items = _get_release_management_items(mock_user, mock_domain)
+            items = _get_release_management_items(mock_user, "domain")
 
         self.assertFalse(items)
 
-    def test_get_release_management_items_returns_none_with_admin(self, mock_domain, mock_user):
+    def test_get_release_management_items_returns_none_with_admin(self, mock_user):
         mock_user.is_domain_admin.return_value = True
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
-            items = _get_release_management_items(mock_user, mock_domain)
+            items = _get_release_management_items(mock_user, "domain")
 
         self.assertFalse(items)
 
-    def test_get_release_management_items_returns_none_with_domain_privilege(self, mock_domain, mock_user):
+    def test_get_release_management_items_returns_none_with_domain_privilege(self, mock_user):
         mock_user.is_domain_admin.return_value = False
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = True
-            items = _get_release_management_items(mock_user, mock_domain)
+            items = _get_release_management_items(mock_user, "domain")
 
         self.assertFalse(items)
 
-    def test_get_release_management_items_returns_some(self, mock_domain, mock_user):
+    def test_get_release_management_items_returns_some(self, mock_user):
         mock_user.is_domain_admin.return_value = True
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege, \
              patch('corehq.tabs.tabclasses.reverse') as mock_reverse:
             mock_domain_has_privilege.return_value = True
             mock_reverse.return_value = 'dummy_url'
-            items = _get_release_management_items(mock_user, mock_domain)
+            items = _get_release_management_items(mock_user, "domain")
 
         self.assertTrue(items)


### PR DESCRIPTION
PR on top of https://github.com/dimagi/commcare-hq/pull/30350

## Summary
This adds permission checks in the Data Registry views.

## Feature Flag
DATA_REGISTRY

## Product Description
Support restriction of the Data Registry management views by role.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added

### QA Plan
Tested locally

### Safety story
Impact to FF feature

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
