### PR TITLE
show superusers status in admin user lookup

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -14,11 +14,12 @@
       <div class="alert alert-warning" role="alert">{% trans "This account is disabled." %}</div>
     {% endif %}
     <dl>
-      <dt>{% trans "ID" %}</dt>
-      <dd>{{ web_user.get_id }}
+      <div><b>{% trans "ID" %}:</b>
+        {{ web_user.get_id }}
         <small><a href="{% url 'raw_doc' %}?id={{ web_user.get_id }}">{% trans "couch doc" %}</a></small> |
         <small><a href="{% url 'doc_in_es' %}?id={{ web_user.get_id }}">{% trans "elasticsearch lookup" %}</a></small>
-      </dd>
+      </div>
+      <div><b>{% trans "Is Superuser" %}:</b> {{ web_user.is_superuser }}</div>
     </dl>
     <div class="btn-toolbar">
       <a class="btn btn-default" href="{{ audit_report_url }}?username={{ web_user.username|urlencode }}">View User Audit Report</a>


### PR DESCRIPTION
## Summary
Minor update to admin user lookup view to show superuser status:

![image](https://user-images.githubusercontent.com/249606/132706876-eedd8937-0616-4e34-8ccc-c80d87cb7514.png)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
None

### QA Plan
None

### Safety story
Admin view only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
