### PR TITLE
data registry permission checks data

### DIFF
--- a/corehq/apps/ota/tests/test_registry_case_details.py
+++ b/corehq/apps/ota/tests/test_registry_case_details.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from defusedxml import ElementTree
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -6,6 +8,7 @@ from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseIndex
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.registry.helper import DataRegistryHelper
 from corehq.apps.registry.models import RegistryAuditLog
 from corehq.apps.registry.tests.utils import create_registry_for_test
 from corehq.apps.users.models import CommCareUser
@@ -95,7 +98,8 @@ class RegistryCaseDetailsTests(TestCase):
         }, 404)
 
     def _make_request(self, params, expected_response_code):
-        response = self.client.get(reverse('registry_case', args=[self.domain, self.app.get_id]), data=params)
+        with patch.object(DataRegistryHelper, 'check_access', return_value=True):
+            response = self.client.get(reverse('registry_case', args=[self.domain, self.app.get_id]), data=params)
         content = response.content
         self.assertEqual(response.status_code, expected_response_code, content)
         return content.decode('utf8')

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -9,6 +9,7 @@ from django.http import (
     HttpResponseBadRequest,
     JsonResponse,
     HttpResponseNotFound,
+    HttpResponseForbidden,
 )
 from django.utils.translation import ugettext as _, ngettext
 from django.views.decorators.csrf import csrf_exempt
@@ -423,8 +424,11 @@ def registry_case(request, domain, app_id):
             len(missing)
         ).format(params="', '".join(missing)))
 
-    app = get_app_cached(domain, app_id)
     helper = DataRegistryHelper(domain, registry_slug=registry)
+    if not helper.check_access(request.couch_user):
+        return HttpResponseForbidden()
+
+    app = get_app_cached(domain, app_id)
     try:
         case = helper.get_case(case_id, case_type, request.user, app)
     except RegistryNotFound:

--- a/corehq/apps/registry/fixtures.py
+++ b/corehq/apps/registry/fixtures.py
@@ -7,6 +7,7 @@ from corehq.apps.app_manager.util import module_offers_search
 from corehq.apps.domain.models import Domain
 from corehq.apps.registry.helper import DataRegistryHelper
 from corehq.apps.registry.models import DataRegistry
+from corehq.apps.registry.utils import RegistryPermissionCheck
 
 
 class RegistryFixtureProvider(FixtureProvider):
@@ -27,10 +28,11 @@ class RegistryFixtureProvider(FixtureProvider):
         if not registry_slugs:
             return []
 
-        # TODO: apply user level permissions
+        permission_check = _get_permission_checker(restore_state)
         available_registries = {
             registry.slug: registry
             for registry in DataRegistry.objects.visible_to_domain(restore_state.domain)
+            if permission_check.can_view_registry_data(registry.slug)
         }
         needed_registries = [
             available_registries[slug] for slug in registry_slugs
@@ -60,6 +62,11 @@ def _get_apps(restore_state):
         apps = get_apps_in_domain(restore_state.domain, include_remote=False)
 
     return apps
+
+
+def _get_permission_checker(restore_state):
+    couch_user = restore_state.restore_user._couch_user
+    return RegistryPermissionCheck(restore_state.domain, couch_user)
 
 
 def _get_registry_list_fixture(registries):

--- a/corehq/apps/registry/helper.py
+++ b/corehq/apps/registry/helper.py
@@ -1,5 +1,6 @@
 from corehq.apps.registry.exceptions import RegistryNotFound, RegistryAccessException
 from corehq.apps.registry.models import DataRegistry
+from corehq.apps.registry.utils import RegistryPermissionCheck
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.util.timer import TimingContext
@@ -19,6 +20,10 @@ class DataRegistryHelper:
         else:
             self.registry_slug = registry_slug
             self._registry = None
+
+    def check_access(self, couch_user):
+        checker = RegistryPermissionCheck(self.current_domain, couch_user)
+        return checker.can_view_registry_data(self.registry_slug)
 
     @property
     def registry(self):

--- a/corehq/apps/registry/tests/test_fixtures.py
+++ b/corehq/apps/registry/tests/test_fixtures.py
@@ -68,7 +68,24 @@ class RegistryFixtureProviderTests(TestCase, TestXmlMixin):
         self.assertEqual([], fixtures)
 
     @flag_enabled("DATA_REGISTRY")
-    def test_fixture_provider(self):
+    @patch("corehq.apps.registry.fixtures._get_permission_checker")
+    def test_fixture_provider_no_permission(self, _get_permission_checker):
+        _get_permission_checker().can_view_registry_data.return_value = False
+        fixtures = call_fixture_generator(
+            registry_fixture_generator, self.restore_user, project=self.domain_obj
+        )
+        self.assertEqual(1, len(fixtures))
+        expected_list_fixture = f"""
+        <fixture id="registry:list">
+           <registry_list>
+           </registry_list>
+        </fixture>"""
+        self.assertXmlEqual(expected_list_fixture, ElementTree.tostring(fixtures[0], encoding='utf-8'))
+
+    @flag_enabled("DATA_REGISTRY")
+    @patch("corehq.apps.registry.fixtures._get_permission_checker")
+    def test_fixture_provider(self, _get_permission_checker):
+        _get_permission_checker().can_view_registry_data.return_value = True
         list_fixture, domains_fixture = call_fixture_generator(
             registry_fixture_generator, self.restore_user, project=self.domain_obj
         )

--- a/corehq/apps/registry/tests/test_fixtures.py
+++ b/corehq/apps/registry/tests/test_fixtures.py
@@ -75,10 +75,9 @@ class RegistryFixtureProviderTests(TestCase, TestXmlMixin):
             registry_fixture_generator, self.restore_user, project=self.domain_obj
         )
         self.assertEqual(1, len(fixtures))
-        expected_list_fixture = f"""
+        expected_list_fixture = """
         <fixture id="registry:list">
-           <registry_list>
-           </registry_list>
+           <registry_list></registry_list>
         </fixture>"""
         self.assertXmlEqual(expected_list_fixture, ElementTree.tostring(fixtures[0], encoding='utf-8'))
 

--- a/corehq/apps/registry/utils.py
+++ b/corehq/apps/registry/utils.py
@@ -34,14 +34,20 @@ class RegistryPermissionCheck:
         self.domain = domain
         self.couch_user = couch_user
         role = couch_user.get_role(domain, allow_enterprise=True)
-        permissions = role.permissions if role else Permissions()
-        self.manageable_slugs = set(permissions.manage_data_registry_list)
+        self._permissions = role.permissions if role else Permissions()
+        self.manageable_slugs = set(self._permissions.manage_data_registry_list)
 
-        self.can_manage_all = permissions.manage_data_registry
+        self.can_manage_all = self._permissions.manage_data_registry
         self.can_manage_some = self.can_manage_all or bool(self.manageable_slugs)
 
     def can_manage_registry(self, slug):
         return self.can_manage_all or slug in self.manageable_slugs
+
+    def can_view_registry_data(self, slug):
+        return (
+            self._permissions.view_data_registry_contents or
+            slug in self._permissions.view_data_registry_contents_list
+        )
 
     @staticmethod
     def user_can_manage_some(couch_user, domain):

--- a/corehq/apps/registry/utils.py
+++ b/corehq/apps/registry/utils.py
@@ -45,8 +45,8 @@ class RegistryPermissionCheck:
 
     def can_view_registry_data(self, slug):
         return (
-            self._permissions.view_data_registry_contents or
-            slug in self._permissions.view_data_registry_contents_list
+            self._permissions.view_data_registry_contents
+            or slug in self._permissions.view_data_registry_contents_list
         )
 
     @staticmethod


### PR DESCRIPTION
PR into https://github.com/dimagi/commcare-hq/pull/30369

## Summary
Check user level permissions for data access:
* in registry case view
* in registry fixture generator and only include data for registries the user has access to

## Feature Flag
DATA_REGISTRY

## Product Description
Check user permissions in data registry fixture

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Updated

### QA Plan
None

### Safety story
FF feature

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
