### PR TITLE
Remove pickling from celery tasks in sms app

### DIFF
--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -754,8 +754,8 @@ def create_billable_for_sms(msg, delay=True):
     try:
         from corehq.apps.sms.tasks import store_billable
         if delay:
-            store_billable.delay(msg)
+            store_billable.delay(msg.couch_id)
         else:
-            store_billable(msg)
+            store_billable(msg.couch_id)
     except Exception as e:
         log_smsbillables_error("Errors Creating SMS Billable: %s" % e)

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -317,7 +317,7 @@ class SMS(SMSBase):
         try:
             publish_sms_saved(self)
         except Exception:
-            publish_sms_change.delay(self)
+            publish_sms_change.delay(self.id)
 
     def requeue(self):
         if self.processed or self.direction != OUTGOING:

--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -501,17 +501,7 @@ def clear_case_caches(case):
     is_case_contact_active.clear(case.domain, case.case_id)
 
 
-@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, acks_late=True,
-                default_retry_delay=5 * 60, max_retries=10, bind=True)
-def sync_case_phone_number(self, case):
-    try:
-        clear_case_caches(case)
-        _sync_case_phone_number(case)
-    except Exception as e:
-        self.retry(exc=e)
-
-
-def _sync_case_phone_number(contact_case):
+def sync_case_phone_number(contact_case):
     phone_info = contact_case.get_phone_info()
 
     with CriticalSection([contact_case.phone_sync_key], timeout=5 * 60):

--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -601,9 +601,10 @@ def _sync_user_phone_numbers(couch_user_id):
                     pass
 
 
-@no_result_task(serializer='pickle', queue='background_queue', acks_late=True,
+@no_result_task(queue='background_queue', acks_late=True,
                 default_retry_delay=5 * 60, max_retries=10, bind=True)
-def publish_sms_change(self, sms):
+def publish_sms_change(self, sms_id):
+    sms = SMS.objects.get(sms_id)
     try:
         publish_sms_saved(sms)
     except Exception as e:

--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -457,14 +457,15 @@ def send_to_sms_queue(queued_sms):
     process_sms.apply_async([queued_sms.pk])
 
 
-@no_result_task(serializer='pickle', queue='background_queue', default_retry_delay=60 * 60,
+@no_result_task(queue='background_queue', default_retry_delay=60 * 60,
                 max_retries=23, bind=True)
-def store_billable(self, msg):
+def store_billable(self, msg_couch_id):
     """
     Creates billable in db that contains price of the message
     default_retry_delay/max_retries are set based on twilio support numbers:
     Most messages will have a price within 2 hours of delivery, all within 24 hours max
     """
+    msg = SMS.objects.get(couch_id=msg_couch_id)
     if not isinstance(msg, SMS):
         raise Exception("Expected msg to be an SMS")
 

--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -364,7 +364,7 @@ class OutboundDailyCounter(object):
         return True
 
 
-@no_result_task(serializer='pickle', queue="sms_queue", acks_late=True)
+@no_result_task(queue="sms_queue", acks_late=True)
 def process_sms(queued_sms_pk):
     """
     queued_sms_pk - pk of a QueuedSMS entry
@@ -488,7 +488,7 @@ def store_billable(self, msg):
             self.retry(exc=e)
 
 
-@no_result_task(serializer='pickle', queue='background_queue', acks_late=True)
+@no_result_task(queue='background_queue', acks_late=True)
 def delete_phone_numbers_for_owners(owner_ids):
     for p in PhoneNumber.objects.filter(owner_id__in=owner_ids):
         # Clear cache and delete
@@ -565,7 +565,7 @@ def _sync_case_phone_number(contact_case):
         phone_number.save()
 
 
-@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, acks_late=True,
+@no_result_task(queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, acks_late=True,
                 default_retry_delay=5 * 60, max_retries=10, bind=True)
 def sync_user_phone_numbers(self, couch_user_id):
     if not settings.USE_PHONE_ENTRIES:

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -71,7 +71,7 @@ def update_messaging_for_case(domain, case_id, case):
     if case is None or case.is_deleted:
         clear_messaging_for_case(domain, case_id)
     elif settings.USE_PHONE_ENTRIES:
-        sms_tasks._sync_case_phone_number(case)
+        sms_tasks.sync_case_phone_number(case)
 
 
 def clear_messaging_for_case(domain, case_id):

--- a/docs/messaging/contacts.rst
+++ b/docs/messaging/contacts.rst
@@ -46,7 +46,7 @@ be granted two-way phone number status to the case who registers it first.
 
 If a two-way phone number can be granted for the case, a `corehq.apps.sms.models.PhoneNumber <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/sms/models.py>`_
 entry with verified set to True is created for it. This happens automatically by running celery task
-`corehq.apps.sms.tasks.sync_case_phone_number <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/sms/tasks.py>`_
+`run_case_update_rules_on_save <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_interfaces/tasks.py#L202>`_
 for a case each time a case is saved.
 
 Future State


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11385)

Part of a series of PRs aimed at replacing pickling with the default json serialization for celery tasks so that we can upgrade celery.

There were some typical cases where it appeared safe to remove pickling in favor of json as the arguments were already json serializable. A couple of cases required passing the db object id instead of the object itself, and in one case the task is no longer used and can be removed (woohoo). I updated the docs that referenced this task as well.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Can't locally test these sms tasks. Will look into on staging.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
