### PR TITLE
simplify UCR data source form & helper

### DIFF
--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -15,6 +15,7 @@ from couchforms.analytics import get_exports_by_form
 from corehq.apps.app_manager.analytics import get_exports_by_application
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.app_manager.dbaccessors import get_app, get_apps_in_domain
+from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.reports.analytics.esaccessors import (
     get_case_types_for_domain_es,
 )
@@ -85,7 +86,7 @@ class ApplicationDataSourceUIHelper(object):
 
         self.application_field = forms.ChoiceField(label=_('Application'), widget=forms.Select())
         if len(source_choices) > 1:
-            self.source_type_field = forms.ChoiceField(label=_('Type of Data'),
+            self.source_type_field = forms.ChoiceField(label=_('Forms or Cases'),
                                                        choices=source_choices,
                                                        widget=forms.Select(choices=source_choices))
         else:
@@ -94,6 +95,7 @@ class ApplicationDataSourceUIHelper(object):
                                                        initial=source_choices[0][0])
 
         self.source_field = forms.ChoiceField(label=_('Data Source'), widget=forms.Select())
+        self.source_field.label = '<span data-bind="text: labelMap[sourceType()]"></span>'
 
     def bootstrap(self, domain):
         self.all_sources = get_app_sources(domain)
@@ -148,6 +150,20 @@ class ApplicationDataSourceUIHelper(object):
         fields['application'] = self.application_field
         fields['source'] = self.source_field
         return fields
+
+    def get_crispy_fields(self):
+        help_texts = {
+            "source_type": _(
+                "<strong>Form</strong>: Display data from form submissions.<br/>"
+                "<strong>Case</strong>: Display data from your cases. You must be using case management for this "
+                "option."),
+            "application": _("Which application should the data come from?"),
+            "source": _("Choose the case type or form from which to retrieve data for this report."),
+        }
+        return [
+            hqcrispy.FieldWithHelpBubble(name, help_bubble_text=help_text)
+            for name, help_text in help_texts.items()
+        ]
 
     def get_app_source(self, data_dict):
         return ApplicationDataSource(data_dict['application'], data_dict['source_type'], data_dict['source'])

--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -76,28 +76,20 @@ class ApplicationDataSourceUIHelper(object):
     See usages for examples.
     """
 
-    def __init__(self, enable_cases=True, enable_forms=True, enable_raw=False):
+    def __init__(self, enable_raw=False):
         self.all_sources = {}
-        self.enable_cases = enable_cases
-        self.enable_forms = enable_forms
         self.enable_raw = enable_raw
-        source_choices = []
-        if enable_cases:
-            source_choices.append((DATA_SOURCE_TYPE_CASE, _("Case")))
-        if enable_forms:
-            source_choices.append((DATA_SOURCE_TYPE_FORM, _("Form")))
+        source_choices = [
+            (DATA_SOURCE_TYPE_CASE, _("Case")),
+            (DATA_SOURCE_TYPE_FORM, _("Form"))
+        ]
         if enable_raw:
             source_choices.append((DATA_SOURCE_TYPE_RAW, _("Data Source")))
 
         self.application_field = forms.ChoiceField(label=_('Application'), widget=forms.Select())
-        if len(source_choices) > 1:
-            self.source_type_field = forms.ChoiceField(label=_('Forms or Cases'),
-                                                       choices=source_choices,
-                                                       widget=forms.Select(choices=source_choices))
-        else:
-            self.source_type_field = forms.ChoiceField(choices=source_choices,
-                                                       widget=forms.HiddenInput(),
-                                                       initial=source_choices[0][0])
+        self.source_type_field = forms.ChoiceField(label=_('Forms or Cases'),
+                                                   choices=source_choices,
+                                                   widget=forms.Select(choices=source_choices))
 
         self.source_field = forms.ChoiceField(label=_('Data Source'), widget=forms.Select())
         self.source_field.label = '<span data-bind="text: labelMap[sourceType()]"></span>'
@@ -115,16 +107,14 @@ class ApplicationDataSourceUIHelper(object):
             # it's weird/annoying that you have to manually sync these
             field.widget.choices.extend(choices)
 
-        if self.enable_cases:
-            _add_choices(
-                self.source_field,
-                [(ct['value'], ct['text']) for app in self.all_sources.values() for ct in app['case']]
-            )
-        if self.enable_forms:
-            _add_choices(
-                self.source_field,
-                [(ct['value'], ct['text']) for app in self.all_sources.values() for ct in app['form']]
-            )
+        _add_choices(
+            self.source_field,
+            [(ct['value'], ct['text']) for app in self.all_sources.values() for ct in app['case']]
+        )
+        _add_choices(
+            self.source_field,
+            [(ct['value'], ct['text']) for app in self.all_sources.values() for ct in app['form']]
+        )
         if self.enable_raw:
             available_data_sources = get_datasources_for_domain(domain, include_static=True,
                                                                 include_aggregate=AGGREGATE_UCRS.enabled(domain))

--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -61,7 +61,12 @@ class ApplicationDataSourceUIHelper(object):
             $("#FORM").koApplyBindings({
                 application: ko.observable(""),
                 sourceType: ko.observable(""),
-                sourcesMap: {{ sources_map|JSON }}
+                sourcesMap: {{ sources_map|JSON }},
+                labelMap: {
+                    'case': gettext('Case'),
+                    'form': gettext('Form'),
+                    'data_source': gettext('Data Source'),
+                },
             });
         });
 

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -877,34 +877,14 @@ class DataSourceForm(forms.Form):
             enable_raw=SHOW_RAW_DATA_SOURCES_IN_REPORT_BUILDER.enabled(self.domain)
 
         )
-        self.app_source_helper.source_type_field.label = _('Forms or Cases')
-        self.app_source_helper.source_field.label = '<span data-bind="text: labelMap[sourceType()]"></span>'
         self.app_source_helper.bootstrap(self.domain)
-        report_source_fields = self.app_source_helper.get_fields()
-        report_source_help_texts = {
-            "source_type": _(
-                "<strong>Form</strong>: Display data from form submissions.<br/>"
-                "<strong>Case</strong>: Display data from your cases. You must be using case management for this "
-                "option."),
-            "application": _("Which application should the data come from?"),
-            "source": _("Choose the case type or form from which to retrieve data for this report."),
-        }
-        self.fields.update(report_source_fields)
+        self.fields.update(self.app_source_helper.get_fields())
 
         self.helper = FormHelper()
         self.helper.form_class = "form form-horizontal"
         self.helper.form_id = "report-builder-form"
         self.helper.label_class = 'col-sm-3 col-md-2 col-lg-2'
         self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
-
-        report_source_crispy_fields = []
-        for k in report_source_fields.keys():
-            if k in report_source_help_texts:
-                report_source_crispy_fields.append(hqcrispy.FieldWithHelpBubble(
-                    k, help_bubble_text=report_source_help_texts[k]
-                ))
-            else:
-                report_source_crispy_fields.append(k)
 
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
@@ -918,7 +898,7 @@ class DataSourceForm(forms.Form):
                 )
             ),
             crispy.Fieldset(
-                _('Data'), *report_source_crispy_fields
+                _('Data'), *self.app_source_helper.get_crispy_fields()
             ),
             hqcrispy.FormActions(
                 StrictButton(

--- a/corehq/apps/userreports/static/userreports/js/data_source_from_app.js
+++ b/corehq/apps/userreports/static/userreports/js/data_source_from_app.js
@@ -1,9 +1,6 @@
 hqDefine('userreports/js/data_source_from_app', function () {
     $(function () {
-        $("#data-source-config").koApplyBindings({
-            application: ko.observable(""),
-            sourceType: ko.observable(""),
-            sourcesMap: hqImport("hqwebapp/js/initial_page_data").get("sources_map"),
-        });
+        let dataModel = hqImport("userreports/js/data_source_select_model");
+        $("#data-source-config").koApplyBindings(dataModel);
     });
 });

--- a/corehq/apps/userreports/static/userreports/js/data_source_select.js
+++ b/corehq/apps/userreports/static/userreports/js/data_source_select.js
@@ -1,17 +1,7 @@
-
 hqDefine("userreports/js/data_source_select", function () {
     $(function () {
-        var dataSourceSelector = {
-            application: ko.observable(""),
-            sourceType: ko.observable(""),
-            sourcesMap: hqImport("hqwebapp/js/initial_page_data").get("sources_map"),
-            labelMap: {
-                'case': gettext('Case'),
-                'form': gettext('Form'),
-                'data_source': gettext('Data Source'),
-            },
-        };
-        $("#report-builder-form").koApplyBindings(dataSourceSelector);
+        let dataModel = hqImport("userreports/js/data_source_select_model");
+        $("#report-builder-form").koApplyBindings(dataModel);
         $('#js-next-data-source').click(function () {
             hqImport('userreports/js/report_analytix').track.event('Data Source Next', hqImport('hqwebapp/js/main').capitalize(dataSourceSelector.sourceType()));
             hqImport('analytix/js/kissmetrix').track.event("RBv2 - Data Source");

--- a/corehq/apps/userreports/static/userreports/js/data_source_select_model.js
+++ b/corehq/apps/userreports/static/userreports/js/data_source_select_model.js
@@ -1,0 +1,12 @@
+hqDefine("userreports/js/data_source_select_model", function () {
+    return {
+        application: ko.observable(""),
+        sourceType: ko.observable(""),
+        sourcesMap: hqImport("hqwebapp/js/initial_page_data").get("sources_map"),
+        labelMap: {
+            'case': gettext('Case'),
+            'form': gettext('Form'),
+            'data_source': gettext('Data Source'),
+        },
+    };
+});

--- a/corehq/apps/userreports/templates/userreports/data_source_from_app.html
+++ b/corehq/apps/userreports/templates/userreports/data_source_from_app.html
@@ -1,10 +1,14 @@
 {% extends "userreports/userreports_base.html" %}
 {% load i18n %}
+{% load compress %}
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 
 {% block js %}{{ block.super }}
-  <script src="{% static "userreports/js/data_source_from_app.js" %}"></script>
+  {% compress js %}
+  <script src="{% static 'userreports/js/data_source_select_model.js' %}"></script>
+  <script src="{% static 'userreports/js/data_source_from_app.js' %}"></script>
+  {% endcompress %}
 {% endblock %}
 
 {% block page_content %}

--- a/corehq/apps/userreports/templates/userreports/reportbuilder/data_source_select.html
+++ b/corehq/apps/userreports/templates/userreports/reportbuilder/data_source_select.html
@@ -1,5 +1,6 @@
 {% extends "userreports/base_report_builder.html" %}
 {% load i18n %}
+{% load compress %}
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
@@ -8,7 +9,10 @@
 {% endblock %}
 
 {% block js %}{{ block.super }}
+  {% compress js %}
+  <script src="{% static 'userreports/js/data_source_select_model.js' %}"></script>
   <script src="{% static 'userreports/js/data_source_select.js' %}"></script>
+  {% endcompress %}
 {% endblock %}
 
 {% block page_title %}{% trans "Step 1 of 2 - Select Data Source" %}{% endblock page_title %}

--- a/corehq/apps/userreports/ui/forms.py
+++ b/corehq/apps/userreports/ui/forms.py
@@ -260,8 +260,7 @@ class ConfigurableDataSourceFromAppForm(forms.Form):
         super(ConfigurableDataSourceFromAppForm, self).__init__(*args, **kwargs)
         self.app_source_helper = ApplicationDataSourceUIHelper()
         self.app_source_helper.bootstrap(domain)
-        report_source_fields = self.app_source_helper.get_fields()
-        self.fields.update(report_source_fields)
+        self.fields.update(self.app_source_helper.get_fields())
         self.helper = FormHelper()
         self.helper.form_id = "data-source-config"
 

--- a/corehq/apps/userreports/ui/forms.py
+++ b/corehq/apps/userreports/ui/forms.py
@@ -274,7 +274,7 @@ class ConfigurableDataSourceFromAppForm(forms.Form):
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
                 _("Create Data Source from Application"),
-                *list(report_source_fields)
+                *self.app_source_helper.get_crispy_fields()
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(


### PR DESCRIPTION
## Summary
Refactor to make both usages of `ApplicationDataSourceUIHelper` consistent with each other.

The only functional change is that the advanced UI "Create Data Source from Application" now uses the same form and JS model. There are 2 differences, minor text change and help bubbles.

Can review by commit. 

## Product Description
NA

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
None

### QA Plan
Tested both UIs locally

### Safety story
Minor changes to advanced UI, no changes to Report Builder UI

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
