### PR TITLE
add missing instances to entries

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -44,6 +44,9 @@ class EntryInstances(PostProcessor):
             detail_ids.add(datum.detail_persistent)
             xpaths.add(datum.nodeset)
             xpaths.add(datum.function)
+        for query in entry.queries:
+            xpaths.update({data.ref for data in query.data})
+
         details = [details_by_id[detail_id] for detail_id in detail_ids if detail_id]
 
         entry_id = entry.command.id

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -54,8 +54,12 @@ class FormDatumMeta(namedtuple('FormDatumMeta', 'datum case_type requires_select
         return self.datum.function == 'uuid()'
 
     def __repr__(self):
-        return 'FormDataumMeta(datum=<SessionDatum(id={})>, case_type={}, requires_selection={}, action={})'.format(
-            self.datum.id, self.case_type, self.requires_selection, self.action
+        if isinstance(self.datum, RemoteRequestQuery):
+            datum = f"<RemoteRequestQuery(id={self.datum.url})>"
+        else:
+            datum = f"<SessionDatum(id={self.datum.id})>"
+        return 'FormDataumMeta(datum={}, case_type={}, requires_selection={}, action={})'.format(
+            datum, self.case_type, self.requires_selection, self.action
         )
 
 

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -468,6 +468,39 @@ class Assertion(XmlObject):
     text = NodeListField('text', Text)
 
 
+class QueryData(XmlObject):
+    ROOT_NAME = 'data'
+
+    key = StringField('@key')
+    ref = XPathField('@ref')
+
+
+class QueryPrompt(DisplayNode):
+    ROOT_NAME = 'prompt'
+
+    key = StringField('@key')
+    appearance = StringField('@appearance', required=False)
+    receive = StringField('@receive', required=False)
+    hidden = BooleanField('@hidden', required=False)
+    input_ = StringField('@input', required=False)
+    default_value = StringField('@default', required=False)
+    allow_blank_value = BooleanField('@allow_blank_value', required=False)
+
+    itemset = NodeField('itemset', Itemset)
+
+
+class RemoteRequestQuery(OrderedXmlObject, XmlObject):
+    ROOT_NAME = 'query'
+    ORDER = ('data', 'prompts')
+
+    url = StringField('@url')
+    storage_instance = StringField('@storage-instance')
+    template = StringField('@template')
+    data = NodeListField('data', QueryData)
+    prompts = NodeListField('prompt', QueryPrompt)
+    default_search = BooleanField("@default_search")
+
+
 class Entry(OrderedXmlObject, XmlObject):
     ROOT_NAME = 'entry'
     ORDER = ('form', 'command', 'instance', 'datums')
@@ -477,6 +510,7 @@ class Entry(OrderedXmlObject, XmlObject):
     instances = NodeListField('instance', Instance)
 
     datums = NodeListField('session/datum', SessionDatum)
+    queries = NodeListField('session/query', RemoteRequestQuery)
 
     stack = NodeField('stack', Stack)
 
@@ -516,45 +550,12 @@ class Entry(OrderedXmlObject, XmlObject):
             self.instances = sorted_instances
 
 
-class QueryData(XmlObject):
-    ROOT_NAME = 'data'
-
-    key = StringField('@key')
-    ref = XPathField('@ref')
-
-
-class QueryPrompt(DisplayNode):
-    ROOT_NAME = 'prompt'
-
-    key = StringField('@key')
-    appearance = StringField('@appearance', required=False)
-    receive = StringField('@receive', required=False)
-    hidden = BooleanField('@hidden', required=False)
-    input_ = StringField('@input', required=False)
-    default_value = StringField('@default', required=False)
-    allow_blank_value = BooleanField('@allow_blank_value', required=False)
-
-    itemset = NodeField('itemset', Itemset)
-
-
 class RemoteRequestPost(XmlObject):
     ROOT_NAME = 'post'
 
     url = StringField('@url')
     relevant = StringField('@relevant')
     data = NodeListField('data', QueryData)
-
-
-class RemoteRequestQuery(OrderedXmlObject, XmlObject):
-    ROOT_NAME = 'query'
-    ORDER = ('data', 'prompts')
-
-    url = StringField('@url')
-    storage_instance = StringField('@storage-instance')
-    template = StringField('@template')
-    data = NodeListField('data', QueryData)
-    prompts = NodeListField('prompt', QueryPrompt)
-    default_search = BooleanField("@default_search")
 
 
 class RemoteRequestSession(OrderedXmlObject, XmlObject):

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -369,6 +369,9 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         </partial>"""
         self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]/session/query")
 
+        # assert that session instance is added to the entry
+        self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='commcaresession']")
+
         # assert post is disabled
         self.assertXmlHasXpath(suite, "./remote-request[1]/post[@relevant='false()']")
 
@@ -401,6 +404,10 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
           </query>
         </partial>"""
         self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]/session/query[2]")
+
+        # assert that session and registry instances are added to the entry
+        self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='commcaresession']")
+        self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='registry']")
 
 
     def test_prompt_hint(self, *args):


### PR DESCRIPTION
## Summary
When using a query in the entry session we need to also add any instances that are used by the query.

## Feature Flag
DATA_REGISTRY

## Product Description
NA

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Updated

### QA Plan
None

### Safety story
Well tested code change

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
