### PR TITLE
Disable quickcache for couchforms analytics tests

### DIFF
--- a/corehq/ex-submodules/couchforms/tests/test_analytics.py
+++ b/corehq/ex-submodules/couchforms/tests/test_analytics.py
@@ -163,7 +163,7 @@ class CouchformsESAnalyticsTest(TestCase):
         with trap_extra_setup(ConnectionError):
             cls.elasticsearch = get_es_new()
             initialize_index_and_mapping(cls.elasticsearch, XFORM_INDEX_INFO)
-            cls.forms = [create_form_and_sync_to_es(cls.now), create_form_and_sync_to_es(cls.now-cls._60_days)]
+            cls.forms = [create_form_and_sync_to_es(cls.now), create_form_and_sync_to_es(cls.now - cls._60_days)]
 
         cls.elasticsearch.indices.refresh(XFORM_INDEX_INFO.index)
 

--- a/corehq/ex-submodules/couchforms/tests/test_analytics.py
+++ b/corehq/ex-submodules/couchforms/tests/test_analytics.py
@@ -27,10 +27,16 @@ from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_s
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
-from corehq.util.test_utils import DocTestMixin, get_form_ready_to_save, trap_extra_setup
+from corehq.util.test_utils import (
+    DocTestMixin,
+    disable_quickcache,
+    get_form_ready_to_save,
+    trap_extra_setup,
+)
 
 
 @es_test
+@disable_quickcache
 @run_with_sql_backend
 class ExportsFormsAnalyticsTest(TestCase, DocTestMixin):
     maxDiff = None
@@ -125,6 +131,7 @@ TEST_ES_META = {
 }
 
 
+@disable_quickcache
 @run_with_sql_backend
 class CouchformsESAnalyticsTest(TestCase):
     domain = 'hqadmin-es-accessor'

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -819,3 +819,18 @@ def require_db_context(fn):
         if not isinstance(Domain.get_db(), mock.Mock):
             return fn(*args, **kwargs)
     return inner
+
+
+def disable_quickcache(test_case=None):
+    """A patch/decorator that disables quickcache
+
+    :param test_case: Optional test class or function. The patch is
+    applied as a decorator to this object if provided.
+    :returns: A `mock.patch` object that disables the cache when started
+    and re-enables it when stopped OR a decorated test case when
+    `test_case` is provided.
+    """
+    def call(self, *args, **kw):
+        return self.fn(*args, **kw)
+    patch = mock.patch("quickcache.quickcache_helper.QuickCacheHelper.__call__", call)
+    return patch if test_case is None else patch(test_case)


### PR DESCRIPTION
## Summary

Adds a testing utility to disable quickcache and uses it to fix some tests that were failing due to caching affecting later test runs.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Added.

### QA Plan

None.

### Safety story

Changes affect tests only.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
