### PR TITLE
Updated error UI in data dictionary

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -130,9 +130,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                         var activeCaseType = self.getActiveCaseType();
                         activeCaseType.properties(self.casePropertyList());
                     },
-                    error: function () {
-                        throw gettext("There was an error saving");
-                    },
+                    // Error handling is managed by SaveButton logic in main.js
                 });
             },
         });

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -9,8 +9,6 @@ from django.db.transaction import atomic
 from django.http import HttpResponse, JsonResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.html import format_html
-from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import View
 

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -143,11 +143,7 @@ def update_case_property(request, domain):
                 errors.append(error)
 
     if errors:
-        if len(errors) == 1:
-            message = errors[0]
-        else:
-            message = mark_safe("<ul>" + "".join(["<li>{}</li>".format(format_html(e)) for e in errors]) + "</ul>")
-        return JsonResponse({"status": "failed", "message": message}, status=400)
+        return JsonResponse({"status": "failed", "messages": errors}, status=400)
     else:
         return JsonResponse({"status": "success"})
 

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -9,6 +9,8 @@ from django.db.transaction import atomic
 from django.http import HttpResponse, JsonResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import View
 
@@ -141,7 +143,11 @@ def update_case_property(request, domain):
                 errors.append(error)
 
     if errors:
-        return JsonResponse({"status": "failed", "errors": errors}, status=400)
+        if len(errors) == 1:
+            message = errors[0]
+        else:
+            message = mark_safe("<ul>" + "".join(["<li>{}</li>".format(format_html(e)) for e in errors]) + "</ul>")
+        return JsonResponse({"status": "failed", "message": message}, status=400)
     else:
         return JsonResponse({"status": "success"})
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
@@ -215,7 +215,23 @@ hqDefine('hqwebapp/js/main', [
                         options.error = function (data) {
                             that.nextState = null;
                             that.setState('retry');
-                            var customError = ((data.responseJSON && data.responseJSON.message) ? data.responseJSON.message : data.responseText);
+                            var customError = "";
+                            if (data.responseJSON) {
+                                if (data.responseJSON.message) {
+                                    customError = data.responseJSON.message;
+                                } else if (data.responseJSON.messages && data.responseJSON.messages.length) {
+                                    if (data.responseJSON.messages.length === 1) {
+                                        customError = _.template("<%- m %>")({m: data.responseJSON.messages[0]});
+                                    } else {
+                                        customError = _.template("<ul><%= errors %></ul>")({
+                                            errors: data.responseJSON.messages.map(function (m) {
+                                                return _.template("<li><%- m %></li>")({m: m});
+                                            }).join(""),
+                                        });
+                                    }
+                                }
+                            }
+                            customError ||= data.responseText;
                             if (customError.indexOf('<head>') > -1) {
                                 // this is sending back a full html page, likely login, so no error message.
                                 customError = null;

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
@@ -215,7 +215,7 @@ hqDefine('hqwebapp/js/main', [
                         options.error = function (data) {
                             that.nextState = null;
                             that.setState('retry');
-                            var customError = "";
+                            var customError = data.responseText;
                             if (data.responseJSON) {
                                 if (data.responseJSON.message) {
                                     customError = data.responseJSON.message;
@@ -231,7 +231,6 @@ hqDefine('hqwebapp/js/main', [
                                     }
                                 }
                             }
-                            customError ||= data.responseText;
                             if (customError.indexOf('<head>') > -1) {
                                 // this is sending back a full html page, likely login, so no error message.
                                 customError = null;


### PR DESCRIPTION
## Summary
Part of [QA-3469](https://dimagi-dev.atlassian.net/browse/QA-3469)

This page uses the generic SaveButton error handling [here](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/main.js#L218-L223).

Previously, this resulted in dumping the stringified json response. This PR adds logic to pick out the error messages and format them as an HTML list if needed.

## Feature Flag
Data dictionary

## Product description
Before
![Screen Shot 2021-09-10 at 10 57 55 AM](https://user-images.githubusercontent.com/1486591/132874291-b4c5118f-ea97-4c30-8c0f-6b2621538dda.png)

After
![Screen Shot 2021-09-10 at 10 56 23 AM](https://user-images.githubusercontent.com/1486591/132874308-9b7a324c-2698-47ae-8b98-ec17afc00e91.png)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None for the error UI

### QA Plan

Not requesting QA

### Safety story
This is a pretty minor change to error display, isolated to a largely internal feature flag.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
