### PR TITLE
Replace 'master' with 'upstream' in linked project app manager context

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases/app_view_release_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/app_view_release_manager.js
@@ -10,7 +10,7 @@ hqDefine("app_manager/js/releases/app_view_release_manager", function () {
         recipient_contacts: initial_page_data('sms_contacts'),
         download_modal_id: '#download-zip-modal',
         latestReleasedVersion: initial_page_data('latestReleasedVersion'),
-        masterBriefs: initial_page_data('master_briefs'),
+        upstreamBriefs: initial_page_data('upstream_briefs'),
         upstreamUrl: initial_page_data('upstream_url'),
     };
     var el = $('#releases-table');

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -47,7 +47,7 @@ hqDefine('app_manager/js/releases/releases', function () {
             if (self.doc_type() !== "LinkedApplication") {
                 return "";
             }
-            var brief = releasesMain.masterBriefsById[self.upstream_app_id()] || {};
+            var brief = releasesMain.upstreamBriefsById[self.upstream_app_id()] || {};
             return brief.name || gettext("Unknown App");
         });
 
@@ -250,7 +250,7 @@ hqDefine('app_manager/js/releases/releases', function () {
         self.latestReleasedVersion = ko.observable(self.options.latestReleasedVersion);
         self.lastAppVersion = ko.observable();
         self.buildComment = ko.observable();
-        self.masterBriefsById = _.indexBy(self.options.masterBriefs, '_id');
+        self.upstreamBriefsById = _.indexBy(self.options.upstreamBriefs, '_id');
         self.upstreamUrl = self.options.upstreamUrl;
 
         self.download_modal = $(self.options.download_modal_id);

--- a/corehq/apps/app_manager/templates/app_manager/app_view_release_manager.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view_release_manager.html
@@ -31,8 +31,8 @@
   {% initial_page_data 'build_profiles' app.build_profiles %}
   {% initial_page_data 'latest_version_for_build_profiles' latest_version_for_build_profiles %}
   {% initial_page_data 'latestReleasedVersion' latest_released_version %}
-  {% initial_page_data 'master_briefs' master_briefs %}{# linked apps only #}
-  {% initial_page_data 'multiple_masters' multiple_masters %}{# linked apps only #}
+  {% initial_page_data 'upstream_briefs' upstream_briefs %}{# linked apps only #}
+  {% initial_page_data 'multiple_upstreams' multiple_upstreams %}{# linked apps only #}
   {% initial_page_data 'practice_users' practice_users %}
   {% initial_page_data 'enable_practice_users' app.enable_practice_users %}
   {% initial_page_data 'intro_only' intro_only %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -198,10 +198,10 @@
     {% if is_linked_app %}
       <div class="tab-pane" id="linked-app">
         <div class="panel panel-appmanager panel-appmanager-form">
-          <form action="{% url "pull_master_app" domain app.id %}" method="POST">
+          <form action="{% url "pull_upstream_app" domain app.id %}" method="POST">
             {% csrf_token %}
             <legend>
-              {% trans "Update from master application" %}
+              {% trans "Update from upstream application" %}
             </legend>
             <div class="panel-body">
               <p>
@@ -222,7 +222,7 @@
                   <div class="form-group">
                     <div class="{% css_field_class %}">
                       <select name="master_app_id" class="form-control hqwebapp-select2"
-                              data-placeholder="{% trans_html_attr "Select a master app to pull" %}">
+                              data-placeholder="{% trans_html_attr "Select an upstream app to pull" %}">
                         <option value="">{% trans "Select a master app to pull" %}</option>
                         {% for brief in master_briefs %}
                           {# Poor readability because any whitespace within the option will also appear in the title attribute and therefore on hover #}

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -218,15 +218,15 @@
                 {% endif %}
               </p>
               <div class="form-horizontal">
-                {% if multiple_masters %}
+                {% if multiple_upstreams %}
                   <div class="form-group">
                     <div class="{% css_field_class %}">
                       <select name="master_app_id" class="form-control hqwebapp-select2"
                               data-placeholder="{% trans_html_attr "Select an upstream app to pull" %}">
-                        <option value="">{% trans "Select a master app to pull" %}</option>
-                        {% for brief in master_briefs %}
+                        <option value="">{% trans "Select an upstream app to pull" %}</option>
+                        {% for brief in upstream_briefs %}
                           {# Poor readability because any whitespace within the option will also appear in the title attribute and therefore on hover #}
-                          <option value="{{ brief.id }}">{{ brief.name }}{% for id, version in master_versions_by_id.items %}{% if id == brief.id %} ({% blocktrans with v=version %}version {{ v }}{% endblocktrans %}){% endif %}{% endfor %}</option>
+                          <option value="{{ brief.id }}">{{ brief.name }}{% for id, version in upstream_versions_by_id.items %}{% if id == brief.id %} ({% blocktrans with v=version %}version {{ v }}{% endblocktrans %}){% endif %}{% endfor %}</option>
                         {% endfor %}
                       </select>
                     </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -221,7 +221,7 @@
                 {% if multiple_upstreams %}
                   <div class="form-group">
                     <div class="{% css_field_class %}">
-                      <select name="master_app_id" class="form-control hqwebapp-select2"
+                      <select name="upstream_app_id" class="form-control hqwebapp-select2"
                               data-placeholder="{% trans_html_attr "Select an upstream app to pull" %}">
                         <option value="">{% trans "Select an upstream app to pull" %}</option>
                         {% for brief in upstream_briefs %}
@@ -232,7 +232,7 @@
                     </div>
                   </div>
                 {% else %}
-                  <input name="master_app_id" type="hidden" value="{{ upstream_brief.get_id }}" />
+                  <input name="upstream_app_id" type="hidden" value="{{ upstream_brief.get_id }}" />
                 {% endif %}
                 <div class="form-group">
                   <div class="{% css_field_class %}">

--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -66,7 +66,7 @@ from corehq.apps.app_manager.views import (
     overwrite_module_case_list,
     paginate_releases,
     patch_xform,
-    pull_master_app,
+    pull_upstream_app,
     rearrange,
     release_build,
     revert_to_copy,
@@ -169,7 +169,7 @@ urlpatterns = [
     url(r'^new_form/(?P<app_id>[\w-]+)/(?P<module_unique_id>[\w-]+)/$',
         new_form, name='new_form'),
     url(r'^drop_usercase/(?P<app_id>[\w-]+)/$', drop_usercase, name='drop_usercase'),
-    url(r'^pull_master/(?P<app_id>[\w-]+)/$', pull_master_app, name='pull_master_app'),
+    url(r'^pull_upstream_app/(?P<app_id>[\w-]+)/$', pull_upstream_app, name='pull_upstream_app'),
     url(r'^pull_missing_multimedia/(?P<app_id>[\w-]+)/$', pull_missing_multimedia,
         name='pull_missing_multimedia'),
 

--- a/corehq/apps/app_manager/views/__init__.py
+++ b/corehq/apps/app_manager/views/__init__.py
@@ -23,7 +23,7 @@ from corehq.apps.app_manager.views.apps import (
     get_app_ui_translations,
     import_app,
     new_app,
-    pull_master_app,
+    pull_upstream_app,
     rearrange,
     undo_delete_app,
     view_app,

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -333,7 +333,7 @@ def _get_upstream_url(app, user, upstream_app_id=None):
     Get the upstream url if the user has access
     :param user: couch_user from a request
     """
-    if app.domain_link:
+    if not app.domain_link:
         return None
 
     is_member_of_local_domain = user.is_member_of(app.domain_link.master_domain) and not app.domain_link.is_remote

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -98,7 +98,7 @@ from corehq.apps.hqwebapp.forms import AppTranslationsBulkUploadForm
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.linked_domain.applications import create_linked_app
-from corehq.apps.linked_domain.dbaccessors import is_master_linked_domain
+from corehq.apps.linked_domain.dbaccessors import is_active_upstream_domain
 from corehq.apps.linked_domain.exceptions import RemoteRequestError
 from corehq.apps.translations.models import Translation
 from corehq.apps.users.dbaccessors import (
@@ -390,7 +390,7 @@ def get_apps_base_context(request, domain, app):
         )
 
         disable_report_modules = (
-            is_master_linked_domain(domain)
+            is_active_upstream_domain(domain)
             and not toggles.MOBILE_UCR_LINKED_DOMAIN.enabled(domain)
         )
 

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -1007,10 +1007,10 @@ def drop_usercase(request, domain, app_id):
 
 
 @require_can_edit_apps
-def pull_master_app(request, domain, app_id):
+def pull_upstream_app(request, domain, app_id):
     master_app_id = request.POST.get('master_app_id')
     if not master_app_id:
-        messages.error(request, _("Please select a master app."))
+        messages.error(request, _("Please select an upstream app."))
         return HttpResponseRedirect(reverse_util('app_settings', params={}, args=[domain, app_id]))
 
     async_update = request.POST.get('notify') == 'on'

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -309,7 +309,7 @@ def get_app_view_context(request, app):
                 brief for brief in app.get_master_app_briefs() if brief.id in upstream_versions_by_id
             ]
         except RemoteRequestError:
-            messages.error(request, "Unable to reach remote master server. Please try again later.")
+            messages.error(request, "Unable to reach remote upstream server. Please try again later.")
             upstream_versions_by_id = {}
             upstream_briefs = []
         upstream_brief = {}

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -1010,24 +1010,24 @@ def drop_usercase(request, domain, app_id):
 
 @require_can_edit_apps
 def pull_upstream_app(request, domain, app_id):
-    master_app_id = request.POST.get('master_app_id')
-    if not master_app_id:
+    upstream_app_id = request.POST.get('upstream_app_id')
+    if not upstream_app_id:
         messages.error(request, _("Please select an upstream app."))
         return HttpResponseRedirect(reverse_util('app_settings', params={}, args=[domain, app_id]))
 
     async_update = request.POST.get('notify') == 'on'
     if async_update:
-        update_linked_app_and_notify_task.delay(domain, app_id, master_app_id,
+        update_linked_app_and_notify_task.delay(domain, app_id, upstream_app_id,
                                                 request.couch_user.get_id, request.couch_user.email)
         messages.success(request,
                          _('Your request has been submitted. We will notify you via email once completed.'))
     else:
         app = get_current_app(domain, app_id)
         try:
-            update_linked_app(app, master_app_id, request.couch_user.get_id)
+            update_linked_app(app, upstream_app_id, request.couch_user.get_id)
         except AppLinkError as e:
             messages.error(request, str(e))
             return HttpResponseRedirect(reverse_util('app_settings', params={}, args=[domain, app_id]))
         messages.success(request, _('Your linked application was successfully updated to the latest version.'))
-    track_workflow(request.couch_user.username, "Linked domain: master app pulled")
+    track_workflow(request.couch_user.username, "Linked domain: upstream app pulled")
     return HttpResponseRedirect(reverse_util('app_settings', params={}, args=[domain, app_id]))

--- a/corehq/apps/hqmedia/README.rst
+++ b/corehq/apps/hqmedia/README.rst
@@ -59,7 +59,7 @@ The version is updated (set to the latest app version) in the following situatio
 Linked apps
 """""""""""
 
-Linked apps, when pulled, copy the multimedia map directly from the master app, so all the attributes of each item will match those in the master app. Because linked apps are always pulled from a released version of a master app, each item should have a version set.
+Linked apps, when pulled, copy the multimedia map directly from the upstream app, so all the attributes of each item will match those in the upstream app. Because linked apps are always pulled from a released version of an upstream app, each item should have a version set.
 
 media_suite.xml
 ###############

--- a/corehq/apps/hqmedia/view_helpers.py
+++ b/corehq/apps/hqmedia/view_helpers.py
@@ -87,7 +87,7 @@ def update_multimedia_paths(app, paths):
                 if update_count:
                     success_counts[form.unique_id] += update_count
 
-    # Update app's master map of multimedia
+    # Update app's upstream map of multimedia
     for old_path, new_path in paths.items():
         if old_path in app.multimedia_map:  # path will not be present if file is missing from app
             app.multimedia_map.update({

--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -42,11 +42,6 @@ def get_linked_domains(domain, include_deleted=False):
     return list(manager.filter(master_domain=domain).all())
 
 
-@quickcache(['domain'], timeout=60 * 60)
-def is_master_linked_domain(domain):
-    return DomainLink.objects.filter(master_domain=domain).exists()
-
-
 def get_actions_in_domain_link_history(link):
     return DomainLinkHistory.objects.filter(link=link).annotate(row_number=RawSQL(
         'row_number() OVER (PARTITION BY model, model_detail ORDER BY date DESC)',

--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -82,13 +82,11 @@ class DomainLink(models.Model):
             get_linked_domains,
             is_active_downstream_domain,
             is_active_upstream_domain,
-            is_master_linked_domain,
         )
         get_upstream_domain_link.clear(self.linked_domain)
         is_active_downstream_domain.clear(self.linked_domain)
 
         get_linked_domains.clear(self.master_domain)
-        is_master_linked_domain.clear(self.master_domain)
         is_active_upstream_domain.clear(self.master_domain)
 
     @classmethod


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-170)

Noticed while doing other work, so just a quick PR to address referencing 'master' in this context. Made sure pulling an app update still worked locally.

Update: Ended up making a few more changes than initially expected, but still relatively small (there are still plenty of references to master that could be replaced with upstream). 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
