### PR TITLE
Rc/show hide inactive mobile

### DIFF
--- a/corehq/apps/users/static/users/js/enterprise_users.js
+++ b/corehq/apps/users/static/users/js/enterprise_users.js
@@ -23,6 +23,7 @@ hqDefine("users/js/enterprise_users", [
             profile: null,
             loginAsUser: null,
             loginAsUserCount: 0,
+            inactiveMobileCount: 0,
         });
 
         // Only varies for mobile users
@@ -31,19 +32,35 @@ hqDefine("users/js/enterprise_users", [
         // Only relevant for web users
         self.expanded = ko.observable(false);
 
+        self.showInactive = ko.observable(false);
+
         return self;
     };
 
     var enterpriseUsersList = function (options) {
+
         var self = webUsersList(options);
+
         self.toggleLoginAsUsers = function (webUser) {
             webUser.expanded(!webUser.expanded());
             _.each(self.users(), function (user) {
-                if (user.loginAsUser === webUser.username) {
-                    user.visible(webUser.expanded());
+                console.log(user);
+                self.showHideDeactivated(webUser);
+                if (user.loginAsUser === webUser.username && user.is_active) {
+                    user.visible(webUser.expanded() && !self.showDeactivated());
                 }
             });
         };
+
+        self.showDeactivated = ko.observable(false);
+
+        self.showHideDeactivated = function (webUser) {
+            _.each(self.users(), function (user) {
+                if (user.loginAsUser === webUser.username && !user.is_active) {
+                    user.visible(webUser.expanded() && self.showDeactivated());
+                }
+            });
+        }
 
         return self;
     };

--- a/corehq/apps/users/static/users/js/enterprise_users.js
+++ b/corehq/apps/users/static/users/js/enterprise_users.js
@@ -44,19 +44,18 @@ hqDefine("users/js/enterprise_users", [
             webUser.expanded(!webUser.expanded());
             _.each(self.users(), function (user) {
                 if (user.loginAsUser === webUser.username) {
-                    if (!self.showDeactivated()) {
-                        user.visible(webUser.expanded() && user.is_active);
-                    }
-                    if (self.showDeactivated()) {
-                        user.visible(webUser.expanded() && !user.is_active);
-                    }
+                    user.visible(webUser.expanded() && user.is_active !== self.showDeactivated());
                 }
             });
         };
 
         self.showDeactivated = ko.observable(false);
 
-        self.showHideDeactivated = function () {
+        self.toggleDeactivatedText = ko.computed(function () {
+            return self.showDeactivated() ? "Hide Deactivated Mobile Workers" : "Show Deactivated Mobile Workers";
+        }, this);
+
+        self.toggleDeactivated = function () {
             _.each(self.users(), function (user) {
                 if (!user.loginAsUser) {
                     user.expanded(false);
@@ -72,7 +71,7 @@ hqDefine("users/js/enterprise_users", [
         };
 
         self.showDeactivated.subscribe(function () {
-            self.showHideDeactivated();
+            self.toggleDeactivated();
         });
 
         return self;

--- a/corehq/apps/users/static/users/js/enterprise_users.js
+++ b/corehq/apps/users/static/users/js/enterprise_users.js
@@ -62,16 +62,14 @@ hqDefine("users/js/enterprise_users", [
                     user.expanded(false);
                     if (self.showDeactivated()) {
                         user.visible(user.inactiveMobileCount > 0);
-                    }
-                    else {
+                    } else {
                         user.visible(true);
                     }
-                }
-                else {
+                } else {
                     user.visible(false);
                 }
             });
-        }
+        };
 
         self.showDeactivated.subscribe(function () {
             self.showHideDeactivated();

--- a/corehq/apps/users/static/users/js/enterprise_users.js
+++ b/corehq/apps/users/static/users/js/enterprise_users.js
@@ -1,5 +1,3 @@
-const { isError } = require("underscore");
-
 /**
  * This file controls the UI for the enterprise users page.
  * This page is based on the main "Current Users" panel on
@@ -29,7 +27,7 @@ hqDefine("users/js/enterprise_users", [
         });
 
         // Only varies for mobile users
-        self.visible = ko.observable(self.loginAsUser === null);
+        self.visible = ko.observable(!self.loginAsUser);
 
         // Only relevant for web users
         self.expanded = ko.observable(false);

--- a/corehq/apps/users/templates/users/enterprise_users.html
+++ b/corehq/apps/users/templates/users/enterprise_users.html
@@ -16,14 +16,19 @@
           <h3 class="panel-title" style="padding-top: 7px;">{% trans 'Users' %}</h3>
         </div>
         <div class="col-sm-6">
-          <search-box data-apply-bindings="false"
-                      params="value: query,
-                              action: function() { goToPage(1); },
-                              placeholder: '{% trans_html_attr "Search Users..." %}'"></search-box>
+            <button type="button" class="btn btn-default pull-right "
+                    data-bind="visible: !showDeactivated(), click: function() { showDeactivated(true); }"
+                    >
+              {% trans 'Show Deactivated Mobile Workers' %}
+            </button>
+            <button type="button" class="btn btn-default pull-right"
+                    data-bind="visible: showDeactivated(),
+                    click: function() { showDeactivated(false); }"
+                    >
+              {% trans 'Hide Deactivated Mobile Workers' %}
+            </button>
         </div>
       </div>
-    </div>
-    <div class="panel-body">
       <div class="alert alert-danger" data-bind="visible: error, text: error"></div>
       <div data-bind="visible: showLoadingSpinner">
         <i class="fa fa-spin fa-spinner"></i>
@@ -58,7 +63,8 @@
               "></i>
               <i class="fa fa-link" data-bind="visible: loginAsUser" style="margin-left: 15px;"></i>
               <span data-bind="attr: {style: (loginAsUserCount || loginAsUser ? 'margin-left: 1px' : 'margin-left: 15px;')}, text: username"></span>
-              <span class="label label-success" data-bind="text: loginAsUserCount"></span>
+              <span class="label label-success" data-bind="text: loginAsUserCount, visible: loginAsUserCount > 0, "></span>
+              <span class="label label-success" data-bind="text: inactiveMobileCount, visible: inactiveMobileCount > 0,"></span>
             </td>
             <td data-bind="text: name">
             </td>

--- a/corehq/apps/users/templates/users/enterprise_users.html
+++ b/corehq/apps/users/templates/users/enterprise_users.html
@@ -59,12 +59,12 @@
               <i class="clickable fa" data-bind="
                 click: $root.toggleLoginAsUsers,
                 css: {'fa-plus-square': !expanded(), 'fa-minus-square': expanded()},
-                visible: loginAsUserCount > 0,
+                visible: !$root.showDeactivated() ? loginAsUserCount > 0 : inactiveMobileCount > 0,
               "></i>
               <i class="fa fa-link" data-bind="visible: loginAsUser" style="margin-left: 15px;"></i>
               <span data-bind="attr: {style: (loginAsUserCount || loginAsUser ? 'margin-left: 1px' : 'margin-left: 15px;')}, text: username"></span>
-              <span class="label label-success" data-bind="text: loginAsUserCount, visible: loginAsUserCount > 0, "></span>
-              <span class="label label-success" data-bind="text: inactiveMobileCount, visible: inactiveMobileCount > 0,"></span>
+              <span class="label label-success" data-bind="text: loginAsUserCount, visible: !$root.showDeactivated() && loginAsUserCount > 0, "></span>
+              <span class="label label-warning" data-bind="text: inactiveMobileCount, visible: $root.showDeactivated() && inactiveMobileCount > 0,"></span>
             </td>
             <td data-bind="text: name">
             </td>

--- a/corehq/apps/users/templates/users/enterprise_users.html
+++ b/corehq/apps/users/templates/users/enterprise_users.html
@@ -11,9 +11,15 @@
 
   <div class="panel panel-default ko-template" id="web-users-panel">
     <div class="panel-heading">
+      <h3 class="panel-title" style="padding-top: 7px;">{% trans 'Users' %}</h3>
+    </div>
+    <div class="panel-body">
       <div class="row">
         <div class="col-sm-6">
-          <h3 class="panel-title" style="padding-top: 7px;">{% trans 'Users' %}</h3>
+          <search-box data-apply-bindings="false"
+                      params="value: query,
+                              action: function() { goToPage(1); },
+                              placeholder: '{% trans_html_attr "Search Users..." %}'"></search-box>
         </div>
         <div class="col-sm-6">
             <button type="button" class="btn btn-default pull-right "

--- a/corehq/apps/users/templates/users/enterprise_users.html
+++ b/corehq/apps/users/templates/users/enterprise_users.html
@@ -23,16 +23,10 @@
         </div>
         <div class="col-sm-6">
             <button type="button" class="btn btn-default pull-right "
-                    data-bind="visible: !showDeactivated(), click: function() { showDeactivated(true); }"
+                    data-bind="text: {% trans 'toggleDeactivatedText' %}, click: function() { showDeactivated(!showDeactivated()); }"
                     >
-              {% trans 'Show Deactivated Mobile Workers' %}
             </button>
-            <button type="button" class="btn btn-default pull-right"
-                    data-bind="visible: showDeactivated(),
-                    click: function() { showDeactivated(false); }"
-                    >
-              {% trans 'Hide Deactivated Mobile Workers' %}
-            </button>
+            <button type="button" value="yargh"></button>
         </div>
       </div>
       <div class="alert alert-danger" data-bind="visible: error, text: error"></div>

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -697,10 +697,10 @@ def paginate_enterprise_users(request, domain):
     for hit in mobile_result.hits:
         login_as_user = {data['key']: data['value'] for data in hit['user_data_es']}.get('login_as_user')
         mobile_users[login_as_user].append(CommCareUser.wrap(hit))
-    loginAsUserCount = len(list(filter(lambda m: m['is_active'], mobile_users[web_user.username])))
     users = []
     allowed_domains = set(domains) - {domain}
     for web_user in web_users:
+        loginAsUserCount = len(list(filter(lambda m: m['is_active'], mobile_users[web_user.username])))
         other_domains = [m.domain for m in web_user.domain_memberships if m.domain in allowed_domains]
         users.append({
             **_format_enterprise_user(domain, web_user),


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[USH-1167](https://dimagi-dev.atlassian.net/browse/USH-1167)
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When `Show Deactivated Mobile Workers` is clicked only web users that have inactive linked mobile workers are shown with their mobile workers that are inactive.
Clicking  `Hide Deactivated Mobile Workers` shows all web users and their mobile workers that are active.
## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
No QA plan for this
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally. Changes confined to EUM feature flag.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
