### PR TITLE
include docs stale in case_search index when finding stale cases

### DIFF
--- a/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
@@ -184,7 +184,7 @@ class CaseHelper:
             if (es_modified_on, es_domain) != (modified_on, domain):
                 yield DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type, domain=domain,
                               es_date=es_modified_on, primary_date=modified_on)
-            else:
+            elif domain in domains_needing_search_index():
                 es_modified_on, es_domain = case_search_es_modified_on_by_ids.get(case_id, (None, None))
                 if (es_modified_on, es_domain) != (modified_on, domain):
                     yield DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type, domain=domain,

--- a/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
@@ -11,12 +11,13 @@ import dateutil
 from dimagi.utils.chunked import chunked
 from dimagi.utils.retry import retry_on
 
-from corehq.apps.es import CaseES, FormES
+from corehq.apps.es import CaseES, CaseSearchES, FormES
 from corehq.elastic import ES_EXPORT_INSTANCE
 from corehq.form_processor.backends.sql.dbaccessors import (
     CaseReindexAccessor,
     FormReindexAccessor,
 )
+from corehq.pillows.case_search import domains_needing_search_index
 from corehq.util.dates import iso_string_to_datetime
 from corehq.util.doc_processor.progress import (
     ProcessorProgressLogger,
@@ -150,6 +151,7 @@ DATA_MODEL_HELPERS = {
 
 
 class CaseHelper:
+
     @classmethod
     def run(cls, run_config):
         for chunk in cls.get_sql_chunks(run_config):
@@ -174,13 +176,19 @@ class CaseHelper:
 
     @staticmethod
     def _yield_missing_in_es(chunk):
-        case_ids = [val[0] for val in chunk]
+        case_ids, case_search_ids = CaseHelper._get_ids_from_chunk(chunk)
         es_modified_on_by_ids = CaseHelper._get_es_modified_dates(case_ids)
+        case_search_es_modified_on_by_ids = CaseHelper._get_case_search_es_modified_dates(case_search_ids)
         for case_id, case_type, modified_on, domain in chunk:
             es_modified_on, es_domain = es_modified_on_by_ids.get(case_id, (None, None))
             if (es_modified_on, es_domain) != (modified_on, domain):
                 yield DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type, domain=domain,
                               es_date=es_modified_on, primary_date=modified_on)
+            else:
+                es_modified_on, es_domain = case_search_es_modified_on_by_ids.get(case_id, (None, None))
+                if (es_modified_on, es_domain) != (modified_on, domain):
+                    yield DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type, domain=domain,
+                                  es_date=es_modified_on, primary_date=modified_on)
 
     @staticmethod
     @retry_on_es_timeout
@@ -192,6 +200,27 @@ class CaseHelper:
         )
         return {_id: (iso_string_to_datetime(server_modified_on), domain)
                 for _id, server_modified_on, domain in results}
+
+    @staticmethod
+    @retry_on_es_timeout
+    def _get_case_search_es_modified_dates(case_ids):
+        results = (
+            CaseSearchES(es_instance_alias=ES_EXPORT_INSTANCE)
+            .case_ids(case_ids)
+            .values_list('_id', 'server_modified_on', 'domain')
+        )
+        return {_id: (iso_string_to_datetime(server_modified_on), domain)
+                for _id, server_modified_on, domain in results}
+
+    @staticmethod
+    def _get_ids_from_chunk(chunk):
+        case_ids = []
+        case_search_ids = []
+        for val in chunk:
+            case_ids.append(val[0])
+            if val[3] in domains_needing_search_index():
+                case_search_ids.append(val[0])
+        return case_ids, case_search_ids
 
 
 class FormHelper:

--- a/corehq/apps/hqadmin/tests/test_stale_data_in_es.py
+++ b/corehq/apps/hqadmin/tests/test_stale_data_in_es.py
@@ -24,6 +24,7 @@ from corehq.form_processor.utils.xform import (
 from corehq.pillows.case import transform_case_for_elasticsearch
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
+from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
 from corehq.pillows.xform import transform_xform_for_elasticsearch
 from corehq.util.elastic import reset_es_index
 from corehq.util.es import elasticsearch
@@ -293,6 +294,7 @@ class TestStaleDataInESSQL(TestCase):
         cls.elasticsearch = get_es_new()
         reset_es_index(XFORM_INDEX_INFO)
         reset_es_index(CASE_INDEX_INFO)
+        reset_es_index(CASE_SEARCH_INDEX_INFO)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12391
This adds checking the case search index, for domains that need it, to our existing reconciliation tasks.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Invisible task with no user impact if it fails.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
