### PR TITLE
Do not show deleted linked models in the linked content table

### DIFF
--- a/corehq/apps/linked_domain/tests/test_view_helpers.py
+++ b/corehq/apps/linked_domain/tests/test_view_helpers.py
@@ -266,31 +266,15 @@ class TestBuildIndividualViewModels(TestCase):
         actual_view_model = build_app_view_model(app)
         self.assertEqual(expected_view_model, actual_view_model)
 
-    def test_build_app_view_model_with_none_returns_unknown(self):
+    def test_build_app_view_model_with_none_returns_none(self):
         app = None
-        expected_view_model = {
-            'type': 'app',
-            'name': 'Application (Unknown App)',
-            'detail': None,
-            'last_update': None,
-            'can_update': False
-        }
-
         actual_view_model = build_app_view_model(app)
-        self.assertEqual(expected_view_model, actual_view_model)
+        self.assertIsNone(actual_view_model)
 
-    def test_build_app_view_model_with_empty_dict_returns_unknown(self):
+    def test_build_app_view_model_with_empty_dict_returns_none(self):
         app = {}
-        expected_view_model = {
-            'type': 'app',
-            'name': 'Application (Unknown App)',
-            'detail': None,
-            'last_update': None,
-            'can_update': False
-        }
-
         actual_view_model = build_app_view_model(app)
-        self.assertEqual(expected_view_model, actual_view_model)
+        self.assertIsNone(actual_view_model)
 
     def test_build_fixture_view_model_returns_match(self):
         fixture = _create_fixture(self.domain, tag="test-table", should_save=False)
@@ -305,31 +289,15 @@ class TestBuildIndividualViewModels(TestCase):
         actual_view_model = build_fixture_view_model(fixture)
         self.assertEqual(expected_view_model, actual_view_model)
 
-    def test_build_fixture_view_model_with_none_returns_unknown(self):
+    def test_build_fixture_view_model_with_none_returns_none(self):
         fixture = None
-        expected_view_model = {
-            'type': 'fixture',
-            'name': 'Lookup Table (Unknown Table)',
-            'detail': None,
-            'last_update': None,
-            'can_update': False
-        }
-
         actual_view_model = build_fixture_view_model(fixture)
-        self.assertEqual(expected_view_model, actual_view_model)
+        self.assertIsNone(actual_view_model)
 
     def test_build_fixture_view_model_with_empty_returns_none(self):
         fixture = {}
-        expected_view_model = {
-            'type': 'fixture',
-            'name': 'Lookup Table (Unknown Table)',
-            'detail': None,
-            'last_update': None,
-            'can_update': False
-        }
-
         actual_view_model = build_fixture_view_model(fixture)
-        self.assertEqual(expected_view_model, actual_view_model)
+        self.assertIsNone(actual_view_model)
 
     def test_build_report_view_model(self):
         report = _create_report(self.domain, title='report-test', should_save=False)
@@ -345,31 +313,15 @@ class TestBuildIndividualViewModels(TestCase):
         actual_view_model = build_report_view_model(report)
         self.assertEqual(expected_view_model, actual_view_model)
 
-    def test_build_report_view_model_with_none_returns_unknown(self):
+    def test_build_report_view_model_with_none_returns_none(self):
         report = None
-        expected_view_model = {
-            'type': 'report',
-            'name': 'Report (Unknown Report)',
-            'detail': None,
-            'last_update': None,
-            'can_update': False
-        }
-
         actual_view_model = build_report_view_model(report)
-        self.assertEqual(expected_view_model, actual_view_model)
+        self.assertIsNone(actual_view_model)
 
-    def test_build_report_view_model_with_empty_returns_unknown(self):
+    def test_build_report_view_model_with_empty_returns_none(self):
         report = {}
-        expected_view_model = {
-            'type': 'report',
-            'name': 'Report (Unknown Report)',
-            'detail': None,
-            'last_update': None,
-            'can_update': False
-        }
-
         actual_view_model = build_report_view_model(report)
-        self.assertEqual(expected_view_model, actual_view_model)
+        self.assertIsNone(actual_view_model)
 
     def test_build_keyword_view_model_returns_match(self):
         keyword = _create_keyword(self.domain, name='keyword-test', should_save=False)
@@ -386,31 +338,15 @@ class TestBuildIndividualViewModels(TestCase):
         actual_view_model = build_keyword_view_model(keyword)
         self.assertEqual(expected_view_model, actual_view_model)
 
-    def test_build_keyword_view_model_with_none_returns_unknown(self):
+    def test_build_keyword_view_model_with_none_returns_none(self):
         keyword = None
-        expected_view_model = {
-            'type': 'keyword',
-            'name': 'Keyword (Deleted Keyword)',
-            'detail': None,
-            'last_update': None,
-            'can_update': False
-        }
-
         actual_view_model = build_keyword_view_model(keyword)
-        self.assertEqual(expected_view_model, actual_view_model)
+        self.assertIsNone(actual_view_model)
 
-    def test_build_keyword_view_model_with_empty_returns_unknown(self):
+    def test_build_keyword_view_model_with_empty_returns_none(self):
         keyword = {}
-        expected_view_model = {
-            'type': 'keyword',
-            'name': 'Keyword (Deleted Keyword)',
-            'detail': None,
-            'last_update': None,
-            'can_update': False
-        }
-
         actual_view_model = build_keyword_view_model(keyword)
-        self.assertEqual(expected_view_model, actual_view_model)
+        self.assertIsNone(actual_view_model)
 
 
 class TestBuildFeatureFlagViewModels(TestCase):

--- a/corehq/apps/linked_domain/view_helpers.py
+++ b/corehq/apps/linked_domain/view_helpers.py
@@ -91,87 +91,52 @@ def get_keywords(domain):
 
 
 def build_app_view_model(app, last_update=None):
-    can_update = False
-    name = _('Unknown App')
-    detail = None
+    if not app:
+        return None
 
-    if app:
-        can_update = True
-        name = app.name
-        detail = AppLinkDetail(app_id=app._id).to_json()
-
-    view_model = build_linked_data_view_model(
+    return build_linked_data_view_model(
         model_type=MODEL_APP,
-        name=f"{LINKED_MODELS_MAP[MODEL_APP]} ({name})",
-        detail=detail,
+        name=f"{LINKED_MODELS_MAP[MODEL_APP]} ({app.name})",
+        detail=AppLinkDetail(app_id=app._id).to_json(),
         last_update=last_update,
-        can_update=can_update
     )
-
-    return view_model
 
 
 def build_fixture_view_model(fixture, last_update=None):
-    can_update = False
-    name = _('Unknown Table')
-    detail = None
+    if not fixture:
+        return None
 
-    if fixture:
-        can_update = fixture.is_global
-        name = fixture.tag
-        detail = FixtureLinkDetail(tag=fixture.tag).to_json()
-
-    view_model = build_linked_data_view_model(
+    return build_linked_data_view_model(
         model_type=MODEL_FIXTURE,
-        name=f"{LINKED_MODELS_MAP[MODEL_FIXTURE]} ({name})",
-        detail=detail,
+        name=f"{LINKED_MODELS_MAP[MODEL_FIXTURE]} ({fixture.tag})",
+        detail=FixtureLinkDetail(tag=fixture.tag).to_json(),
         last_update=last_update,
-        can_update=can_update
+        can_update=fixture.is_global,
     )
-
-    return view_model
 
 
 def build_report_view_model(report, last_update=None):
-    can_update = False
-    name = _("Unknown Report")
-    detail = None
+    if not report:
+        return None
 
-    if report:
-        can_update = True
-        name = report.title
-        detail = ReportLinkDetail(report_id=report.get_id).to_json()
-
-    view_model = build_linked_data_view_model(
+    return build_linked_data_view_model(
         model_type=MODEL_REPORT,
-        name=f"{LINKED_MODELS_MAP[MODEL_REPORT]} ({name})",
-        detail=detail,
+        name=f"{LINKED_MODELS_MAP[MODEL_REPORT]} ({report.title})",
+        detail=ReportLinkDetail(report_id=report.get_id).to_json(),
         last_update=last_update,
-        can_update=can_update
     )
-
-    return view_model
 
 
 def build_keyword_view_model(keyword, last_update=None):
-    can_update = False
-    name = _("Deleted Keyword")
-    detail = None
+    if not keyword:
+        return None
 
-    if keyword:
-        can_update = True
-        name = keyword.keyword
-        detail = KeywordLinkDetail(keyword_id=str(keyword.id)).to_json()
-
-    view_model = build_linked_data_view_model(
+    return build_linked_data_view_model(
         model_type=MODEL_KEYWORD,
-        name=f"{LINKED_MODELS_MAP[MODEL_KEYWORD]} ({name})",
-        detail=detail,
+        name=f"{LINKED_MODELS_MAP[MODEL_KEYWORD]} ({keyword.keyword})",
+        detail=KeywordLinkDetail(keyword_id=str(keyword.id)).to_json(),
         last_update=last_update,
-        can_update=can_update
     )
-
-    return view_model
 
 
 def build_feature_flag_view_models(domain, ignore_models=None):
@@ -364,9 +329,9 @@ def build_pullable_view_models_from_data_models(domain, upstream_link, apps, fix
                 detail=action.model_detail,
                 last_update=last_update,
             )
-
-        if view_model['type'] not in dict(SUPERUSER_DATA_MODELS).keys() or is_superuser:
-            linked_data_view_models.append(view_model)
+        if view_model:
+            if view_model['type'] not in dict(SUPERUSER_DATA_MODELS).keys() or is_superuser:
+                linked_data_view_models.append(view_model)
 
     # Add data models that have never been pulled into the downstream domain before
     # ignoring any models we have already added via domain history


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-216)

We currently show deleted linked data models in the linked content table. An example is a deleted app would display as "Application (Unknown App)" and not be updatable. 

It is worth noting that I unintentionally modified the behavior, which prior to my changes a few months ago was to display [the app_id pulled from the link action](https://github.com/dimagi/commcare-hq/pull/19381/files#diff-07657c6e5232742251036eb16896a92f0163cb70dbee4d0addd7f920cf3de913R104-R113). The alternative would be to revert to that behavior, however I can't think of a reason why the user would want to see deleted data models that can't be updated on a page dedicated to updating data models.

If anyone feels differently, I could look into adding a toggle to display deleted models as well. Otherwise the new behavior would be to not display deleted data models. This does not impact past events displaying in the linked project space history report. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
