### PR TITLE
Add toggle to preview removing CBC ciphers

### DIFF
--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -9,12 +9,13 @@ from datetime import timedelta
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.exceptions import MiddlewareNotUsed
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.urls import reverse
 from django.contrib.auth.views import LogoutView
 from django.utils.deprecation import MiddlewareMixin
 from sentry_sdk import add_breadcrumb
 
+from corehq import toggles
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import legacy_domain_re
 from corehq.const import OPENROSA_DEFAULT_VERSION
@@ -342,6 +343,13 @@ def flag_cbc_middleware(get_response):
 
     def middleware(request):
         cipher_suite = request.META.get('HTTP_X_AMZN_TLS_CIPHER_SUITE')
+
+        if toggles.REJECT_REQUESTS_USING_CBC_CIPHER_SUITES.enabled_for_request(request):
+
+            if cipher_suite in ('ECDHE-ECDSA-AES128-SHA256', 'ECDHE-RSA-AES128-SHA256', 'ECDHE-ECDSA-AES256-SHA384', 'ECDHE-RSA-AES256-SHA384'):
+                response = HttpResponseBadRequest()
+                response['x-amzn-tls-cipher-suite'] = cipher_suite
+                return response
 
         response = get_response(request)
 

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -336,3 +336,18 @@ def get_view_func(view_fn, view_kwargs):
         return view_fn.view_class
 
     return view_fn
+
+
+def flag_cbc_middleware(get_response):
+
+    def middleware(request):
+        cipher_suite = request.META.get('HTTP_X_AMZN_TLS_CIPHER_SUITE')
+
+        response = get_response(request)
+
+        if cipher_suite:
+            response['x-amzn-tls-cipher-suite'] = cipher_suite
+
+        return response
+
+    return middleware

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -2112,3 +2112,10 @@ DO_NOT_REPUBLISH_DOCS = StaticToggle(
     TAG_INTERNAL,
     namespaces=[NAMESPACE_DOMAIN],
 )
+
+REJECT_REQUESTS_USING_CBC_CIPHER_SUITES = StaticToggle(
+    'reject_requests_using_cbc_cipher_suites',
+    'Responds with a 400 if the x-amzn-tls-cipher-suite is set to one of the four CBC cipher suites to be removed',
+    TAG_INTERNAL,
+    namespaces=[NAMESPACE_DOMAIN, NAMESPACE_USER],
+)

--- a/settings.py
+++ b/settings.py
@@ -167,6 +167,7 @@ MIDDLEWARE = [
     'no_exceptions.middleware.NoExceptionsMiddleware',
     'corehq.apps.locations.middleware.LocationAccessMiddleware',
     'corehq.apps.cloudcare.middleware.CloudcareMiddleware',
+    'corehq.middleware.flag_cbc_middleware',
 ]
 
 X_FRAME_OPTIONS = 'DENY'


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12091

## Feature Flag
`REJECT_REQUESTS_USING_CBC_CIPHER_SUITES`

## Product Description
This adds a flag that we can use when working with specific projects to debug whether they will have issue after switching. This PR should be reverted after we make the change.

For this to work we also need to enable the "[TLS version and cipher headers](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html)" flag on the ALB. I've tested this on staging

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
This just adds a header (for debugging) to the response, and everything else is behind a flag.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
