### PR TITLE
Refactor get_<model> methods in linked domains to be more explicit

### DIFF
--- a/corehq/apps/linked_domain/view_helpers.py
+++ b/corehq/apps/linked_domain/view_helpers.py
@@ -93,16 +93,21 @@ def get_upstream_and_downstream_reports(domain):
     return upstream_list, downstream_list
 
 
-def get_keywords(domain):
-    master_list = {}
-    linked_list = {}
+def get_upstream_and_downstream_keywords(domain):
+    """
+    Return 2 lists of keywords
+    The upstream_list contains keywords that originated in the specified domain
+    The downstream_list contains keywords that have been pulled from a domain upstream of the specified domain
+    """
+    upstream_list = {}
+    downstream_list = {}
     keywords = Keyword.objects.filter(domain=domain)
     for keyword in keywords:
         if keyword.upstream_id:
-            linked_list[str(keyword.id)] = keyword
+            downstream_list[str(keyword.id)] = keyword
         else:
-            master_list[str(keyword.id)] = keyword
-    return master_list, linked_list
+            upstream_list[str(keyword.id)] = keyword
+    return upstream_list, downstream_list
 
 
 def build_app_view_model(app, last_update=None):

--- a/corehq/apps/linked_domain/view_helpers.py
+++ b/corehq/apps/linked_domain/view_helpers.py
@@ -76,16 +76,21 @@ def get_fixtures_for_domain(domain):
     return {f.tag: f for f in fixtures if f.is_global}
 
 
-def get_reports(domain):
-    master_list = {}
-    linked_list = {}
+def get_upstream_and_downstream_reports(domain):
+    """
+    Return 2 lists of reports
+    The upstream_list contains reports that originated in the specified domain
+    The downstream_list contains reports that have been pulled from a domain upstream of the specified domain
+    """
+    upstream_list = {}
+    downstream_list = {}
     reports = get_report_configs_for_domain(domain)
     for report in reports:
         if report.report_meta.master_id:
-            linked_list[report.get_id] = report
+            downstream_list[report.get_id] = report
         else:
-            master_list[report.get_id] = report
-    return master_list, linked_list
+            upstream_list[report.get_id] = report
+    return upstream_list, downstream_list
 
 
 def get_keywords(domain):

--- a/corehq/apps/linked_domain/view_helpers.py
+++ b/corehq/apps/linked_domain/view_helpers.py
@@ -43,16 +43,21 @@ def build_domain_link_view_model(link, timezone):
     }
 
 
-def get_apps(domain):
-    master_list = {}
-    linked_list = {}
+def get_upstream_and_downstream_apps(domain):
+    """
+    Return 2 lists of app_briefs
+    The upstream_list contains apps that originated in the specified domain
+    The downstream_list contains apps that have been pulled from a domain upstream of the specified domain
+    """
+    upstream_list = {}
+    downstream_list = {}
     briefs = get_brief_apps_in_domain(domain, include_remote=False)
     for brief in briefs:
         if is_linked_app(brief):
-            linked_list[brief._id] = brief
+            downstream_list[brief._id] = brief
         else:
-            master_list[brief._id] = brief
-    return master_list, linked_list
+            upstream_list[brief._id] = brief
+    return upstream_list, downstream_list
 
 
 def get_fixtures(domain, master_link):

--- a/corehq/apps/linked_domain/view_helpers.py
+++ b/corehq/apps/linked_domain/view_helpers.py
@@ -60,10 +60,15 @@ def get_upstream_and_downstream_apps(domain):
     return upstream_list, downstream_list
 
 
-def get_fixtures(domain, master_link):
-    master_list = get_fixtures_for_domain(domain)
-    linked_list = get_fixtures_for_domain(master_link.master_domain) if master_link else {}
-    return master_list, linked_list
+def get_upstream_and_downstream_fixtures(domain, upstream_link):
+    """
+    Return 2 lists of fixtures
+    The upstream_list contains fixtures that originated in the specified domain
+    The downstream_list contains fixtures that have been pulled from a domain upstream of the specified domain
+    """
+    upstream_list = get_fixtures_for_domain(domain)
+    downstream_list = get_fixtures_for_domain(upstream_link.master_domain) if upstream_link else {}
+    return upstream_list, downstream_list
 
 
 def get_fixtures_for_domain(domain):

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -87,7 +87,7 @@ from corehq.apps.linked_domain.view_helpers import (
     build_pullable_view_models_from_data_models,
     build_view_models_from_data_models,
     get_upstream_and_downstream_apps,
-    get_fixtures,
+    get_upstream_and_downstream_fixtures,
     get_keywords,
     get_reports,
 )
@@ -269,19 +269,20 @@ class DomainLinkView(BaseAdminProjectSettingsView):
         upstream_link = get_upstream_domain_link(self.domain)
         linked_domains = [build_domain_link_view_model(link, timezone) for link in get_linked_domains(self.domain)]
         upstream_apps, downstream_apps = get_upstream_and_downstream_apps(self.domain)
-        master_fixtures, linked_fixtures = get_fixtures(self.domain, upstream_link)
+        upstream_fixtures, downstream_fixtures = get_upstream_and_downstream_fixtures(self.domain, upstream_link)
         master_reports, linked_reports = get_reports(self.domain)
         master_keywords, linked_keywords = get_keywords(self.domain)
 
         is_superuser = self.request.couch_user.is_superuser
         timezone = get_timezone_for_request()
         view_models_to_pull = build_pullable_view_models_from_data_models(
-            self.domain, upstream_link, downstream_apps, linked_fixtures, linked_reports, linked_keywords,
+            self.domain, upstream_link, downstream_apps, downstream_fixtures, linked_reports, linked_keywords,
             timezone, is_superuser=is_superuser
         )
 
         view_models_to_push = build_view_models_from_data_models(
-            self.domain, upstream_apps, master_fixtures, master_reports, master_keywords, is_superuser=is_superuser
+            self.domain, upstream_apps, upstream_fixtures, master_reports, master_keywords,
+            is_superuser=is_superuser
         )
 
         account = BillingAccount.get_account_by_domain(self.request.domain)

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -86,7 +86,7 @@ from corehq.apps.linked_domain.view_helpers import (
     build_domain_link_view_model,
     build_pullable_view_models_from_data_models,
     build_view_models_from_data_models,
-    get_apps,
+    get_upstream_and_downstream_apps,
     get_fixtures,
     get_keywords,
     get_reports,
@@ -268,7 +268,7 @@ class DomainLinkView(BaseAdminProjectSettingsView):
         timezone = get_timezone_for_request()
         upstream_link = get_upstream_domain_link(self.domain)
         linked_domains = [build_domain_link_view_model(link, timezone) for link in get_linked_domains(self.domain)]
-        master_apps, linked_apps = get_apps(self.domain)
+        upstream_apps, downstream_apps = get_upstream_and_downstream_apps(self.domain)
         master_fixtures, linked_fixtures = get_fixtures(self.domain, upstream_link)
         master_reports, linked_reports = get_reports(self.domain)
         master_keywords, linked_keywords = get_keywords(self.domain)
@@ -276,12 +276,12 @@ class DomainLinkView(BaseAdminProjectSettingsView):
         is_superuser = self.request.couch_user.is_superuser
         timezone = get_timezone_for_request()
         view_models_to_pull = build_pullable_view_models_from_data_models(
-            self.domain, upstream_link, linked_apps, linked_fixtures, linked_reports, linked_keywords, timezone,
-            is_superuser=is_superuser
+            self.domain, upstream_link, downstream_apps, linked_fixtures, linked_reports, linked_keywords,
+            timezone, is_superuser=is_superuser
         )
 
         view_models_to_push = build_view_models_from_data_models(
-            self.domain, master_apps, master_fixtures, master_reports, master_keywords, is_superuser=is_superuser
+            self.domain, upstream_apps, master_fixtures, master_reports, master_keywords, is_superuser=is_superuser
         )
 
         account = BillingAccount.get_account_by_domain(self.request.domain)

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -88,7 +88,7 @@ from corehq.apps.linked_domain.view_helpers import (
     build_view_models_from_data_models,
     get_upstream_and_downstream_apps,
     get_upstream_and_downstream_fixtures,
-    get_keywords,
+    get_upstream_and_downstream_keywords,
     get_upstream_and_downstream_reports,
 )
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
@@ -271,17 +271,17 @@ class DomainLinkView(BaseAdminProjectSettingsView):
         upstream_apps, downstream_apps = get_upstream_and_downstream_apps(self.domain)
         upstream_fixtures, downstream_fixtures = get_upstream_and_downstream_fixtures(self.domain, upstream_link)
         upstream_reports, downstream_reports = get_upstream_and_downstream_reports(self.domain)
-        master_keywords, linked_keywords = get_keywords(self.domain)
+        upstream_keywords, downstream_keywords = get_upstream_and_downstream_keywords(self.domain)
 
         is_superuser = self.request.couch_user.is_superuser
         timezone = get_timezone_for_request()
         view_models_to_pull = build_pullable_view_models_from_data_models(
-            self.domain, upstream_link, downstream_apps, downstream_fixtures, downstream_reports, linked_keywords,
-            timezone, is_superuser=is_superuser
+            self.domain, upstream_link, downstream_apps, downstream_fixtures, downstream_reports,
+            downstream_keywords, timezone, is_superuser=is_superuser
         )
 
         view_models_to_push = build_view_models_from_data_models(
-            self.domain, upstream_apps, upstream_fixtures, upstream_reports, master_keywords,
+            self.domain, upstream_apps, upstream_fixtures, upstream_reports, upstream_keywords,
             is_superuser=is_superuser
         )
 

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -89,7 +89,7 @@ from corehq.apps.linked_domain.view_helpers import (
     get_upstream_and_downstream_apps,
     get_upstream_and_downstream_fixtures,
     get_keywords,
-    get_reports,
+    get_upstream_and_downstream_reports,
 )
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
 from corehq.apps.reports.dispatcher import ReleaseManagementReportDispatcher
@@ -270,18 +270,18 @@ class DomainLinkView(BaseAdminProjectSettingsView):
         linked_domains = [build_domain_link_view_model(link, timezone) for link in get_linked_domains(self.domain)]
         upstream_apps, downstream_apps = get_upstream_and_downstream_apps(self.domain)
         upstream_fixtures, downstream_fixtures = get_upstream_and_downstream_fixtures(self.domain, upstream_link)
-        master_reports, linked_reports = get_reports(self.domain)
+        upstream_reports, downstream_reports = get_upstream_and_downstream_reports(self.domain)
         master_keywords, linked_keywords = get_keywords(self.domain)
 
         is_superuser = self.request.couch_user.is_superuser
         timezone = get_timezone_for_request()
         view_models_to_pull = build_pullable_view_models_from_data_models(
-            self.domain, upstream_link, downstream_apps, downstream_fixtures, linked_reports, linked_keywords,
+            self.domain, upstream_link, downstream_apps, downstream_fixtures, downstream_reports, linked_keywords,
             timezone, is_superuser=is_superuser
         )
 
         view_models_to_push = build_view_models_from_data_models(
-            self.domain, upstream_apps, upstream_fixtures, master_reports, master_keywords,
+            self.domain, upstream_apps, upstream_fixtures, upstream_reports, master_keywords,
             is_superuser=is_superuser
         )
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-170)

The method names (`get_apps`, `get_reports`, etc) have been bugging me for awhile since they are very vague and potentially misleading. In the process of updating those method names, I changed some master/linked references to upstream/downstream, and just made sure variable naming was aligned in tests as well.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Good test coverage on these methods and the change was harmless.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Briefly locally tested for obvious issues. Because of the automated testing, I'm confident I don't need to test individual data models pull upstream and downstream lists correctly.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
