### PR TITLE
Update build_domain_link_view_model method

### DIFF
--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -142,7 +142,7 @@ hqDefine("linked_domain/js/domain_links", [
         self.query = ko.observable();
         self.filteredDomainLinks = ko.observableArray([]);
         self.matchesQuery = function (domainLink) {
-            return !self.query() || domainLink.linked_domain().toLowerCase().indexOf(self.query().toLowerCase()) !== -1;
+            return !self.query() || domainLink.downstreamDomain().toLowerCase().indexOf(self.query().toLowerCase()) !== -1;
         };
         self.filter = function () {
             self.filteredDomainLinks(_.filter(self.domain_links(), self.matchesQuery));
@@ -175,8 +175,8 @@ hqDefine("linked_domain/js/domain_links", [
 
         self.createRemoteReportLink = function (reportId) {
             _private.RMI("create_remote_report_link", {
-                "master_domain": self.upstreamLink.master_domain,
-                "linked_domain": self.upstreamLink.linked_domain(),
+                "master_domain": self.upstreamLink.upstreamDomain,
+                "linked_domain": self.upstreamLink.downstreamDomain(),
                 "report_id": reportId,
             }).done(function (data) {
                 if (data.success) {
@@ -195,11 +195,11 @@ hqDefine("linked_domain/js/domain_links", [
 
         self.deleteLink = function (link) {
             _private.RMI("delete_domain_link", {
-                "linked_domain": link.linked_domain(),
+                "linked_domain": link.downstreamDomain(),
             }).done(function () {
                 self.domain_links.remove(link);
                 var availableDomains = self.addDownstreamDomainViewModel.availableDomains();
-                availableDomains.push(link.linked_domain());
+                availableDomains.push(link.downstreamDomain());
                 self.addDownstreamDomainViewModel.availableDomains(availableDomains.sort());
                 self.goToPage(self.currentPage);
             }).fail(function () {
@@ -220,9 +220,9 @@ hqDefine("linked_domain/js/domain_links", [
 
     var DomainLink = function (link) {
         var self = {};
-        self.linked_domain = ko.observable(link.linked_domain);
-        self.is_remote = link.is_remote;
-        self.master_domain = link.master_domain;
+        self.downstreamDomain = ko.observable(link.downstream_domain);
+        self.isRemote = link.is_remote;
+        self.upstreamDomain = link.upstream_domain;
         self.lastUpdate = link.last_update;
         self.upstreamUrl = link.upstream_url;
         self.downstreamUrl = link.downstream_url;
@@ -242,8 +242,8 @@ hqDefine("linked_domain/js/domain_links", [
 
         self.localDownstreamDomains = ko.computed(function () {
             return self.parent.domain_links().reduce(function (result, link) {
-                if (!link.is_remote) {
-                    return result.concat(link.linked_domain());
+                if (!link.isRemote) {
+                    return result.concat(link.downstreamDomain());
                 }
                 return result;
             }, []);
@@ -326,8 +326,8 @@ hqDefine("linked_domain/js/domain_links", [
 
         self.createLink = function () {
             _private.RMI("create_remote_report_link", {
-                "master_domain": upstreamLink.master_domain,
-                "linked_domain": upstreamLink.linked_domain(),
+                "master_domain": upstreamLink.upstreamDomain,
+                "linked_domain": upstreamLink.downstreamDomain(),
                 "report_id": self.id,
             }).done(function (data) {
                 if (data.success) {

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/manage_downstream_domains.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/manage_downstream_domains.html
@@ -40,7 +40,7 @@
           </thead>
           <tbody data-bind="foreach: paginatedDomainLinks">
           <tr>
-            <td><a data-bind="attr: {'href': downstreamUrl}, text: linked_domain"></a></td>
+            <td><a data-bind="attr: {'href': downstreamUrl}, text: downstreamDomain"></a></td>
             <td data-bind="text: lastUpdate"></td>
             <td>
               <button type="button" class="btn btn-danger" data-toggle="modal" data-bind="attr: {'data-target': '#remove-link-modal-' + $index()}">
@@ -57,7 +57,7 @@
                     <div class="modal-body">
                       <h4>
                         {% blocktrans trimmed %}
-                          Are you sure you want to remove the downstream link to <b data-bind="text: linked_domain"></b>?
+                          Are you sure you want to remove the downstream link to <b data-bind="text: downstreamDomain"></b>?
                         {% endblocktrans %}
                       </h4>
                       <p>

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/pull_content.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/pull_content.html
@@ -5,7 +5,7 @@
   <div data-bind="if: domainLink">
     <p>
       {% blocktrans trimmed %}
-        This project space is linked to the upstream project space <a data-bind="attr: {'href': domainLink.upstreamUrl}, text: domainLink.master_domain"></a>.<br/>
+        This project space is linked to the upstream project space <a data-bind="attr: {'href': domainLink.upstreamUrl}, text: domainLink.upstreamDomain"></a>.<br/>
         The content below can be synced with the existing content in the upstream project space.<br/>
         <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about pulling content with Linked Project Spaces.
       {% endblocktrans %}
@@ -52,7 +52,7 @@
                       </h4>
                       <p>
                         {% blocktrans trimmed %}
-                          This will pull <!-- ko text: name --><!-- /ko --> from the upstream project space <b data-bind="text: $parent.domainLink.master_domain"></b>, overwriting the existing <!-- ko text: name --><!-- /ko -->.<br/>
+                          This will pull <!-- ko text: name --><!-- /ko --> from the upstream project space <b data-bind="text: $parent.domainLink.upstreamDomain"></b>, overwriting the existing <!-- ko text: name --><!-- /ko -->.<br/>
                           <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about pulling content from an upstream project space into a downstream project space.
                         {% endblocktrans %}
                       </p>

--- a/corehq/apps/linked_domain/view_helpers.py
+++ b/corehq/apps/linked_domain/view_helpers.py
@@ -34,8 +34,8 @@ from corehq.apps.userreports.models import ReportConfiguration
 
 def build_domain_link_view_model(link, timezone):
     return {
-        'linked_domain': link.linked_domain,
-        'master_domain': link.master_domain,
+        'downstream_domain': link.linked_domain,
+        'upstream_domain': link.master_domain,
         'upstream_url': link.upstream_url,
         'downstream_url': link.downstream_url,
         'is_remote': link.is_remote,


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-170)

The domain link view model still uses `master_domain` and `linked_domain` which gets used down the chain in JS as well. I updated the view model to use `upstream_domain` and `downstream_domain` instead, and while updating the JS side, I "JSified" variable names to be lowerCamelCase in that particular view model.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated test coverage. This is just updating variable names across python and JS, which is certainly prone to errors, but from what I've tested locally this looks safe. 
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested each page.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
