### PR TITLE
improve performance of building CCZ for app preview & CLI

### DIFF
--- a/corehq/apps/app_manager/management/commands/benchmark_direct_ccz.py
+++ b/corehq/apps/app_manager/management/commands/benchmark_direct_ccz.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
 
 def _code_to_benchmark(domain, app_id):
     app = get_app(domain, app_id)
-    get_direct_ccz(domain, app, None, None)
+    get_direct_ccz(domain, app, None)
 
 
 @profile_dump('direct_ccz.prof')

--- a/corehq/apps/app_manager/views/cli.py
+++ b/corehq/apps/app_manager/views/cli.py
@@ -1,3 +1,4 @@
+from django.http import JsonResponse
 from django.template.loader import render_to_string
 from django.utils.text import slugify
 
@@ -5,7 +6,6 @@ from couchdbkit.exceptions import DocTypeError, ResourceNotFound
 
 from corehq.util.metrics import metrics_histogram_timer
 from dimagi.ext.couchdbkit import Document
-from dimagi.utils.web import json_response
 from soil import FileDownload
 
 from corehq import toggles
@@ -36,7 +36,7 @@ def list_apps(request, domain):
                                              params={'app_id': app.get_id})
         }
     applications = Domain.get_by_name(domain).applications()
-    return json_response({
+    return JsonResponse({
         'status': 'success',
         'applications': list(map(app_to_json, applications)),
     })
@@ -55,7 +55,7 @@ def direct_ccz(request, domain):
     """
 
     def error(msg, code=400):
-        return json_response({'status': 'error', 'message': msg}, status_code=code)
+        return JsonResponse({'status': 'error', 'message': msg}, status_code=code)
 
     def get_app(app_id, version, latest):
         if version:
@@ -115,7 +115,7 @@ def get_direct_ccz(domain, app, lang, langs, version=None, include_multimedia=Fa
             'langs': langs,
             'visit_scheduler_enabled': visit_scheduler_enabled,
         })
-        return json_response(
+        return JsonResponse(
             {'error_html': error_html},
             status_code=400,
         )
@@ -132,5 +132,5 @@ def get_direct_ccz(domain, app, lang, langs, version=None, include_multimedia=Fa
             filename='{}.ccz'.format(slugify(app.name)),
         )
     except Exception as e:
-        return json_response({'status': 'error', 'message': str(e)}, status_code=400)
+        return JsonResponse({'status': 'error', 'message': str(e)}, status_code=400)
     return FileDownload.get(download.download_id).toHttpResponse()

--- a/corehq/apps/app_manager/views/cli.py
+++ b/corehq/apps/app_manager/views/cli.py
@@ -98,10 +98,10 @@ def direct_ccz(request, domain):
     lang, langs = get_langs(request, app)
 
     with metrics_histogram_timer('commcare.app_build.live_preview', timing_buckets=(1, 10, 30, 60, 120, 240)):
-        return get_direct_ccz(domain, app, lang, langs, version, include_multimedia, visit_scheduler_enabled)
+        return get_direct_ccz(domain, app, langs, version, include_multimedia, visit_scheduler_enabled)
 
 
-def get_direct_ccz(domain, app, lang, langs, version=None, include_multimedia=False, visit_scheduler_enabled=False):
+def get_direct_ccz(domain, app, langs, version=None, include_multimedia=False, visit_scheduler_enabled=False):
     if not app.copy_of:
         errors = app.validate_app()
     else:


### PR DESCRIPTION
## Summary
Part 1 of https://dimagi-dev.atlassian.net/browse/USH-1225

This replaces the call to "build_application_zip"  with "create_files_for_ccz". This has the advantage of being able to pass the app in directly instead of re-fetching it. This in itself improves performance but beyond that using the same app object has the added benefit of re-using the cached properties on the app, in particular "create_all_files".

## Product Description
Improve performance of app installation for app preview.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
None

### QA Plan
Tested app preview locally, both a successful app build and also a build with errors.

### Safety story
Changes to how Formplayer fetches CCZ files for app preview. The changes have been tested locally.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
