### PR TITLE
fix wording of data registry role permission

### DIFF
--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -347,7 +347,7 @@ hqDefine('users/js/roles',[
                         self.viewRegistryContentsPermission,
                         {
                             permissionText: gettext("View Registry Data"),
-                            listHeading: gettext("Select which registries the role access:"),
+                            listHeading: gettext("Select which registries the role can access:"),
                         }
                     ),
                 ];


### PR DESCRIPTION
## Summary
Text change to registry permission.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan
None

### Safety story
Text change to FF permission

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
