### PR TITLE
Registry Case Search

### DIFF
--- a/corehq/apps/case_search/const.py
+++ b/corehq/apps/case_search/const.py
@@ -14,6 +14,7 @@ CASE_SEARCH_MAX_RESULTS = 500
 
 # Added to each case response when case searches are performed
 RELEVANCE_SCORE = "commcare_search_score"
+COMMCARE_PROJECT = "commcare_project"
 # Added to secondary results in case search to filter them out of the case list
 IS_RELATED_CASE = "commcare_is_related_case"
 EXCLUDE_RELATED_CASES_FILTER = "[not(commcare_is_related_case=true())]"

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -20,70 +20,100 @@ from corehq.apps.registry.tests.utils import (
 from corehq.form_processor.tests.utils import run_with_sql_backend
 
 
+def case(name, type_, properties):
+    return CaseBlock(
+        case_id=str(uuid.uuid4()),
+        case_type=type_,
+        case_name=name,
+        create=True,
+        update=properties,
+    )
+
+
 @es_test
 @run_with_sql_backend
 class TestCaseSearchRegistry(TestCase):
 
-    # TODO convert to setUpClass
-    def setUp(self):
-        self.user = create_user("admin", "123")
-        self.domain_1 = "jane-the-virgin"
-        self.setup_domain(self.domain_1, [
-            ("Jane", {"family": "Villanueva"}),
-            ("Xiomara", {"family": "Villanueva"}),
-            ("Alba", {"family": "Villanueva"}),
-            ("Rogelio", {"family": "de la Vega"}),
-            ("Jane", {"family": "Ramos"}),
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = create_user("admin", "123")
+        cls.domain_1 = "jane-the-virgin"
+        cls.setup_domain(cls.domain_1, [
+            case("Jane", 'person', {"family": "Villanueva"}),
+            case("Xiomara", 'person', {"family": "Villanueva"}),
+            case("Alba", 'person', {"family": "Villanueva"}),
+            case("Rogelio", 'person', {"family": "de la Vega"}),
+            case("Jane", 'person', {"family": "Ramos"}),
         ])
-        self.domain_2 = "jane-eyre"
-        self.setup_domain(self.domain_2, [
-            ("Jane", {"family": "Eyre"}),
-            ("Sarah", {"family": "Reed"}),
-            ("John", {"family": "Reed"}),
-            ("Eliza", {"family": "Reed"}),
-            ("Georgiana", {"family": "Reed"}),
+        cls.domain_2 = "jane-eyre"
+        cls.setup_domain(cls.domain_2, [
+            case("Jane", 'person', {"family": "Eyre"}),
+            case("Sarah", 'person', {"family": "Reed"}),
+            case("John", 'person', {"family": "Reed"}),
+            case("Eliza", 'person', {"family": "Reed"}),
+            case("Georgiana", 'person', {"family": "Reed"}),
         ])
-        self.domain_3 = "janes-addiction"
-        self.setup_domain(self.domain_3, [
-            ("Jane", {}),
-            ("Perry", {"family": "Farrell"}),
-            ("Dave", {"family": "Navarro"}),
-            ("Stephen", {"family": "Perkins"}),
-            ("Chris", {"family": "Chaney"}),
+        cls.domain_3 = "janes-addiction"
+        cls.setup_domain(cls.domain_3, [
+            case("Jane", 'person', {"family": "Villanueva"}),
+            case("Perry", 'person', {"family": "Farrell"}),
+            case("Dave", 'person', {"family": "Navarro"}),
+            case("Stephen", 'person', {"family": "Perkins"}),
+            case("Chris", 'person', {"family": "Chaney"}),
         ])
 
-        self.registry_slug = create_registry_for_test(
-            self.user,
-            self.domain_1,
+        cls.registry_slug = create_registry_for_test(
+            cls.user,
+            cls.domain_1,
             invitations=[
-                Invitation(self.domain_2),
-                Invitation(self.domain_3),
+                Invitation(cls.domain_2),
+                Invitation(cls.domain_3),
             ],
             grants=[
-                Grant(self.domain_1, [self.domain_2, self.domain_3]),
-                Grant(self.domain_2, [self.domain_1]),
-                Grant(self.domain_3, []),
+                Grant(cls.domain_1, [cls.domain_2]),
+                Grant(cls.domain_2, [cls.domain_1]),
+                Grant(cls.domain_3, [cls.domain_1]),
             ],
             name="reg1",
         ).slug
 
-    def setup_domain(self, domain, cases):
+    @classmethod
+    def setup_domain(cls, domain, cases):
         CaseSearchConfig.objects.create(pk=domain, enabled=True)
-        case_search_es_setup(domain, [
-            CaseBlock(
-                case_id=str(uuid.uuid4()),
-                case_type='person',
-                case_name=name,
-                create=True,
-                update=properties,
-            ) for name, properties in cases
-        ])
+        case_search_es_setup(domain, cases)
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         case_search_es_teardown()
+        super().tearDownClass()
 
-    def test_query_multiple_domains(self):
+    def test_query_all_domains_in_registry(self):
+        # Domain 1 has access to all three domains
         results = RegistryCaseSearchCriteria(self.domain_1, ['person'], {
+            "name": "Jane",
+        }, self.registry_slug).search_es.values_list("name", "domain")
+        self.assertItemsEqual([
+            ("Jane", self.domain_1),
+            ("Jane", self.domain_1),
+            ("Jane", self.domain_2),
+            ("Jane", self.domain_3),
+        ], results)
+
+    def test_case_property_query(self):
+        results = RegistryCaseSearchCriteria(self.domain_1, ['person'], {
+            "family": "Villanueva",
+        }, self.registry_slug).search_es.values_list("name", "domain")
+        self.assertItemsEqual([
+            ("Jane", self.domain_1),
+            ("Xiomara", self.domain_1),
+            ("Alba", self.domain_1),
+            ("Jane", self.domain_3),
+        ], results)
+
+    def test_subset_of_domains_accessible(self):
+        # Domain 2 has access only to domains 1 and itself
+        results = RegistryCaseSearchCriteria(self.domain_2, ['person'], {
             "name": "Jane",
         }, self.registry_slug).search_es.values_list("name", "domain")
         self.assertItemsEqual([
@@ -92,8 +122,14 @@ class TestCaseSearchRegistry(TestCase):
             ("Jane", self.domain_2),
         ], results)
 
-    def test_invalid_registry(self):
-        pass
+    def test_in_registry_but_no_grants(self):
+        # Domain 3 has access only to its own cases
+        results = RegistryCaseSearchCriteria(self.domain_3, ['person'], {
+            "name": "Jane",
+        }, self.registry_slug).search_es.values_list("name", "domain")
+        self.assertItemsEqual([
+            ("Jane", self.domain_3),
+        ], results)
 
     def test_case_type_not_in_registry(self):
         pass

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -1,0 +1,84 @@
+import uuid
+
+from django.test import TestCase
+
+from casexml.apps.case.mock import CaseBlock
+
+from corehq.apps.case_search.models import CaseSearchConfig
+from corehq.apps.domain.shortcuts import create_user
+from corehq.apps.es.tests.utils import (
+    case_search_es_setup,
+    case_search_es_teardown,
+    es_test,
+)
+from corehq.apps.registry.tests.utils import (
+    Grant,
+    Invitation,
+    create_registry_for_test,
+)
+from corehq.form_processor.tests.utils import run_with_sql_backend
+
+
+@es_test
+@run_with_sql_backend
+class TestCaseSearchRegistry(TestCase):
+
+    # TODO convert to setUpClass
+    def setUp(self):
+        self.user = create_user("admin", "123")
+        self.domain_1 = "jane-the-virgin"
+        self.setup_domain(self.domain_1, [
+            ("Jane", {"family": "Villanueva"}),
+            ("Xiomara", {"family": "Villanueva"}),
+            ("Alba", {"family": "Villanueva"}),
+            ("Rogelio", {"family": "de la Vega"}),
+            ("Jane", {"family": "Ramos"}),
+        ])
+        self.domain_2 = "jane-eyre"
+        self.setup_domain(self.domain_2, [
+            ("Jane", {"family": "Eyre"}),
+            ("Sarah", {"family": "Reed"}),
+            ("John", {"family": "Reed"}),
+            ("Eliza", {"family": "Reed"}),
+            ("Georgiana", {"family": "Reed"}),
+        ])
+        self.domain_3 = "janes-addiction"
+        self.setup_domain(self.domain_3, [
+            ("Perry", {"family": "Farrell"}),
+            ("Dave", {"family": "Navarro"}),
+            ("Stephen", {"family": "Perkins"}),
+            ("Chris", {"family": "Chaney"}),
+        ])
+
+        create_registry_for_test(
+            self.user,
+            self.domain_1,
+            invitations=[
+                Invitation(self.domain_2),
+                Invitation(self.domain_3),
+            ],
+            grants=[
+                Grant(self.domain_1, [self.domain_2, self.domain_3]),
+                Grant(self.domain_2, [self.domain_1]),
+                Grant(self.domain_3, []),
+            ],
+            name="reg1",
+        )
+
+    def setup_domain(self, domain, cases):
+        CaseSearchConfig.objects.create(pk=domain, enabled=True)
+        case_search_es_setup(domain, [
+            CaseBlock(
+                case_id=str(uuid.uuid4()),
+                case_type='person',
+                case_name=name,
+                create=True,
+                update=properties,
+            ) for name, properties in cases
+        ])
+
+    def tearDown(self):
+        case_search_es_teardown()
+
+    def test(self):
+        print("running")

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -12,11 +12,11 @@ from corehq.apps.app_manager.models import (
     DetailColumn,
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
-from corehq.apps.case_search.models import CaseSearchConfig
-from corehq.apps.case_search.utils import (
-    CaseSearchCriteria,
-    get_case_search_results,
+from corehq.apps.case_search.models import (
+    CASE_SEARCH_REGISTRY_ID_KEY,
+    CaseSearchConfig,
 )
+from corehq.apps.case_search.utils import get_case_search_results
 from corehq.apps.domain.shortcuts import create_user
 from corehq.apps.es.tests.utils import (
     case_search_es_setup,
@@ -149,7 +149,7 @@ class TestCaseSearchRegistry(TestCase):
     def _run_query(self, domain, case_types, criteria, registry_slug):
         results = get_case_search_results(domain, {
             'case_type': case_types,
-            'registry_slug': registry_slug,
+            CASE_SEARCH_REGISTRY_ID_KEY: registry_slug,
             **criteria
         })
         return [(case.name, case.domain) for case in results]
@@ -250,7 +250,7 @@ class TestCaseSearchRegistry(TestCase):
     def test_includes_project_property(self):
         results = get_case_search_results(
             self.domain_1,
-            {"case_type": ["person"], "name": "Jane", "registry_slug": self.registry_slug},
+            {"case_type": ["person"], "name": "Jane", CASE_SEARCH_REGISTRY_ID_KEY: self.registry_slug},
         )
         self.assertItemsEqual([
             ("Jane", self.domain_1, self.domain_1),
@@ -268,8 +268,8 @@ class TestCaseSearchRegistry(TestCase):
                 self.domain_1,
                 {
                     "case_type": ["creative_work"],
-                    "name": "Jane Eyre", # from domain 2
-                    "registry_slug": self.registry_slug
+                    "name": "Jane Eyre",  # from domain 2
+                    CASE_SEARCH_REGISTRY_ID_KEY: self.registry_slug
                 },
                 "mock_app_id",
             )

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -118,8 +118,12 @@ class TestCaseSearchRegistry(TestCase):
         super().tearDownClass()
 
     def _run_query(self, domain, case_types, criteria, registry_slug):
-        search = CaseSearchCriteria.from_registry(domain, case_types, criteria, registry_slug)
-        return search.search_es.values_list("name", "domain")
+        results = get_case_search_results(domain, {
+            'case_type': case_types,
+            'registry_slug': registry_slug,
+            **criteria
+        })
+        return [(case.name, case.domain) for case in results]
 
     def test_query_all_domains_in_registry(self):
         # Domain 1 has access to all three domains
@@ -213,8 +217,6 @@ class TestCaseSearchRegistry(TestCase):
         self.assertItemsEqual([
             ("Jane Eyre", self.domain_2),
         ], results)
-
-    # get_case_search_results tests below:
 
     def test_includes_project_property(self):
         results = get_case_search_results(

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -174,6 +174,17 @@ class TestCaseSearchRegistry(TestCase):
             ("Jennie Snyder Urman", self.domain_1),
         ], results)
 
+    def test_access_related_case_type_not_in_registry(self):
+        # "creative_work" case types are in the registry, but not their parents - "creator"
+        # domain 1 can access a domain 2 case even while referencing an inaccessible case type property
+        # TODO is this the correct behavior?  Same question for xpath queries
+        results = (RegistryCaseSearchCriteria(self.domain_1, ['creative_work'], {
+            "parent/name": "Charlotte Brontë"
+        }, self.registry_slug).search_es.values_list("name", "domain"))
+        self.assertItemsEqual([
+            ("Jane Eyre", self.domain_2),
+        ], results)
+
     def test_includes_project_property(self):
         # TODO insert 'commcare_project'
         pass

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from casexml.apps.case.mock import CaseBlock, IndexAttrs
 
 from corehq.apps.case_search.models import CaseSearchConfig
-from corehq.apps.case_search.utils import RegistryCaseSearchCriteria
+from corehq.apps.case_search.utils import CaseSearchCriteria
 from corehq.apps.domain.shortcuts import create_user
 from corehq.apps.es.tests.utils import (
     case_search_es_setup,
@@ -115,7 +115,7 @@ class TestCaseSearchRegistry(TestCase):
         super().tearDownClass()
 
     def _run_query(self, domain, case_types, criteria, registry_slug):
-        search = RegistryCaseSearchCriteria(domain, case_types, criteria, registry_slug)
+        search = CaseSearchCriteria.from_registry(domain, case_types, criteria, registry_slug)
         return search.search_es.values_list("name", "domain")
 
     def test_query_all_domains_in_registry(self):

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -5,7 +5,10 @@ from django.test import TestCase
 from casexml.apps.case.mock import CaseBlock, IndexAttrs
 
 from corehq.apps.case_search.models import CaseSearchConfig
-from corehq.apps.case_search.utils import CaseSearchCriteria
+from corehq.apps.case_search.utils import (
+    CaseSearchCriteria,
+    get_case_search_results,
+)
 from corehq.apps.domain.shortcuts import create_user
 from corehq.apps.es.tests.utils import (
     case_search_es_setup,
@@ -211,9 +214,22 @@ class TestCaseSearchRegistry(TestCase):
             ("Jane Eyre", self.domain_2),
         ], results)
 
+    # get_case_search_results tests below:
+
     def test_includes_project_property(self):
-        # TODO insert 'commcare_project'
-        pass
+        results = get_case_search_results(
+            self.domain_1,
+            {"case_type": ["person"], "name": "Jane", "registry_slug": self.registry_slug},
+        )
+        self.assertItemsEqual([
+            ("Jane", self.domain_1, self.domain_1),
+            ("Jane", self.domain_1, self.domain_1),
+            ("Jane", self.domain_2, self.domain_2),
+            ("Jane", self.domain_3, self.domain_3),
+        ], [
+            (case.name, case.domain, case.get_case_property('commcare_project'))
+            for case in results
+        ])
 
     def test_related_cases_included(self):
         pass

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -131,6 +131,15 @@ class TestCaseSearchRegistry(TestCase):
             ("Jane", self.domain_3),
         ], results)
 
+    def test_invalid_registry_can_access_own_cases(self):
+        results = RegistryCaseSearchCriteria(self.domain_1, ['person'], {
+            "name": "Jane",
+        }, "fake-registry").search_es.values_list("name", "domain")
+        self.assertItemsEqual([
+            ("Jane", self.domain_1),
+            ("Jane", self.domain_1),
+        ], results)
+
     def test_case_type_not_in_registry(self):
         pass
 

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -31,6 +31,7 @@ from corehq.apps.es.case_search import (
     case_property_range_query,
     flatten_result,
 )
+from corehq.apps.registry.exceptions import RegistryNotFound
 from corehq.apps.registry.helper import DataRegistryHelper
 
 
@@ -231,7 +232,11 @@ class RegistryCaseSearchCriteria(BaseCaseSearchCriteria):
 
     def __init__(self, domain, case_types, criteria, registry_slug):
         self._registry_helper = DataRegistryHelper(domain, registry_slug=registry_slug)
-        domains = self._registry_helper.visible_domains
+        try:
+            domains = self._registry_helper.visible_domains
+        except RegistryNotFound:
+            # This is a valid use-case, don't fail hard
+            domains = [domain]
         super().__init__(domain, case_types, criteria, query_domains=domains)
 
 

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -21,6 +21,7 @@ from corehq.apps.case_search.filter_dsl import (
 )
 from corehq.apps.case_search.models import (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
+    CASE_SEARCH_REGISTRY_ID_KEY,
     CASE_SEARCH_XPATH_QUERY_KEY,
     SEARCH_QUERY_CUSTOM_VALUE,
     UNSEARCHABLE_KEYS,
@@ -49,7 +50,7 @@ def get_case_search_results(domain, criteria, app_id=None):
     except KeyError:
         raise CaseSearchUserError(_('Search request must specify case type'))
 
-    registry_slug = criteria.pop('registry_slug', None)
+    registry_slug = criteria.pop(CASE_SEARCH_REGISTRY_ID_KEY, None)
     if registry_slug:
         query_domains = _get_registry_visible_domains(domain, case_types, registry_slug)
         helper = _RegistryQueryHelper(domain, query_domains)

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -24,6 +24,7 @@ from corehq.apps.case_search.models import (
 )
 from corehq.apps.case_search.utils import (
     CaseSearchCriteria,
+    _QueryHelper,
     get_related_case_relationships,
     get_related_case_results,
     get_related_cases,
@@ -566,14 +567,14 @@ class TestCaseSearchLookups(TestCase):
                    return_value={"parent", "parent/parent"}), \
              patch("corehq.apps.case_search.utils.get_child_case_types", return_value={"c", "d"}), \
              patch("corehq.apps.case_search.utils.get_app_cached"):
-            cases = get_related_cases(self.domain, None, {"c"}, cases)
+            cases = get_related_cases(_QueryHelper(self.domain), None, {"c"}, cases)
 
         case_ids = Counter([case.case_id for case in cases])
         self.assertEqual(set(case_ids), {"a1", "d1"})  # c1, c2 excluded since they are in the initial list
         self.assertEqual(max(case_ids.values()), 1, case_ids)  # no duplicates
 
     def _assert_related_case_ids(self, cases, paths, ids):
-        results = get_related_case_results(self.domain, cases, paths)
+        results = get_related_case_results(_QueryHelper(self.domain), cases, paths)
         result_ids = Counter([result['_id'] for result in results])
         self.assertEqual(ids, set(result_ids))
         if result_ids:

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -63,7 +63,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
             "query": {
                 "bool": {
                     "filter": [
-                        {'term': {'domain.exact': 'swashbucklers'}},
+                        {'terms': {'domain.exact': ['swashbucklers']}},
                         {"terms": {"type.exact": ["case_type"]}},
                         {"term": {"closed": False}},
                         {
@@ -159,7 +159,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
             "query": {
                 "bool": {
                     "filter": [
-                        {'term': {'domain.exact': 'swashbucklers'}},
+                        {'terms': {'domain.exact': ['swashbucklers']}},
                         {"terms": {"type.exact": ["case_type"]}},
                         {"term": {"closed": False}},
                         {"match_all": {}}

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -69,26 +69,12 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
                         {
                             "bool": {
                                 "must_not": {
-                                    "term": {
-                                        "owner_id": "id1"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "bool": {
-                                "must_not": {
-                                    "term": {
-                                        "owner_id": "id2"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "bool": {
-                                "must_not": {
-                                    "term": {
-                                        "owner_id": "id3,id4"
+                                    "terms": {
+                                        "owner_id": [
+                                            "id1",
+                                            "id2",
+                                            "id3,id4"
+                                        ]
                                     }
                                 }
                             }

--- a/corehq/apps/registry/tests/utils.py
+++ b/corehq/apps/registry/tests/utils.py
@@ -7,9 +7,10 @@ from corehq.apps.registry.models import DataRegistry
 
 
 @nottest
-def create_registry_for_test(user, domain, invitations=None, grants=None, name=None):
+def create_registry_for_test(user, domain, invitations=None, grants=None, name=None, case_types=None):
     name = name or uuid.uuid4().hex
-    registry = DataRegistry.create(user, domain=domain, name=name)
+    schema = [{"case_type": case_type} for case_type in case_types]
+    registry = DataRegistry.create(user, domain=domain, name=name, schema=schema)
     for invite in (invitations or []):
         invitation = registry.invitations.create(domain=invite.domain)
         if invite.accepted:

--- a/corehq/apps/registry/tests/utils.py
+++ b/corehq/apps/registry/tests/utils.py
@@ -9,7 +9,7 @@ from corehq.apps.registry.models import DataRegistry
 @nottest
 def create_registry_for_test(user, domain, invitations=None, grants=None, name=None, case_types=None):
     name = name or uuid.uuid4().hex
-    schema = [{"case_type": case_type} for case_type in case_types]
+    schema = [{"case_type": case_type} for case_type in case_types or []]
     registry = DataRegistry.create(user, domain=domain, name=name, schema=schema)
     for invite in (invitations or []):
         invitation = registry.invitations.create(domain=invite.domain)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-1130

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Enable Data Registries

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Add case search backend for searching registries

![image](https://user-images.githubusercontent.com/2367539/133133227-d761eba2-d97b-4b1c-9076-6f3be4a68eb1.png)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

I added new tests for registries, plus `test_case_search_endpoint` and `test_case_search_es` both cover the normal code paths.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
