### PR TITLE
Move "Product Description" to top of PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,7 @@
-## Summary
+## Product Description
+<!-- For non-invisible changes, describe user-facing effects. -->
+
+## Technical Summary
 <!--
     Provide a link to the ticket or document which prompted this change,
     Describe the rationale and design decisions.
@@ -6,9 +9,6 @@
 
 ## Feature Flag
 <!-- If this is specific to a feature flag, which one? -->
-
-## Product Description
-<!-- For non-invisible changes, describe user-facing effects. -->
 
 ## Safety Assurance
 


### PR DESCRIPTION
The "product description" is always the first thing I want to convey to a reviewer, technical or not.