### PR TITLE
Remove @sharded test duplication

### DIFF
--- a/corehq/apps/receiverwrapper/tests/test_auth.py
+++ b/corehq/apps/receiverwrapper/tests/test_auth.py
@@ -287,6 +287,7 @@ class InsecureAuthCouchOnlyTest(TestCase, AuthTestMixin, _AuthTestsCouchOnly):
         super(InsecureAuthCouchOnlyTest, self).tearDown()
 
 
+@sharded
 class AuthTest(TestCase, AuthTestMixin, _AuthTestsBothBackends):
 
     domain = 'my-crazy-domain'
@@ -305,6 +306,7 @@ class AuthTest(TestCase, AuthTestMixin, _AuthTestsBothBackends):
         super(AuthTest, self).tearDown()
 
 
+@sharded
 class InsecureAuthTest(TestCase, AuthTestMixin, _AuthTestsBothBackends):
 
     domain = 'my-crazy-insecure-domain'
@@ -321,13 +323,3 @@ class InsecureAuthTest(TestCase, AuthTestMixin, _AuthTestsBothBackends):
     def tearDown(self):
         self.user.delete(self.domain, deleted_by=None)
         super(InsecureAuthTest, self).tearDown()
-
-
-@sharded
-class AuthTestSQL(AuthTest):
-    pass
-
-
-@sharded
-class InsecureAuthTestSQL(InsecureAuthTest):
-    pass

--- a/corehq/apps/reports/tests/commtrack/test_datasources.py
+++ b/corehq/apps/reports/tests/commtrack/test_datasources.py
@@ -11,6 +11,7 @@ from corehq.form_processor.interfaces.supply import SupplyInterface
 from corehq.form_processor.tests.utils import sharded
 
 
+@sharded
 class StockStatusDataSourceTests(TestCase):
 
     @classmethod
@@ -99,8 +100,3 @@ class StockStatusDataSourceTests(TestCase):
                 'product_name': self.product.name,
                 'resupply_quantity_needed': None}]
         )
-
-
-@sharded
-class StockStatusDataSourceSQLTests(StockStatusDataSourceTests):
-    pass

--- a/corehq/apps/reports/tests/test_readable_formdata.py
+++ b/corehq/apps/reports/tests/test_readable_formdata.py
@@ -343,6 +343,7 @@ class ReadableFormdataTest(SimpleTestCase):
         self._test_corpus('top_level_refless_group')
 
 
+@sharded
 class ReadableFormTest(TestCase):
 
     def setUp(self):
@@ -454,8 +455,3 @@ class ReadableFormTest(TestCase):
             '/data/cups_of_tea[3]/details_of_cup/secret': 'mg',
         }
         self.assertDictEqual({k: v['value'] for k, v in question_response_map.items()}, expected_response_map)
-
-
-@sharded
-class ReadableFormSQLTest(ReadableFormTest):
-    pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -12,6 +12,7 @@ from corehq.util.test_utils import flag_enabled
 from corehq.apps.users.dbaccessors import delete_all_users
 
 
+@sharded
 class AutoCloseExtensionsTest(TestCase):
 
     @classmethod
@@ -290,8 +291,3 @@ class AutoCloseExtensionsTest(TestCase):
         self.assertEqual(1, len(cases[self.host_id].get_closing_transactions()))
         self.assertEqual(1, len(cases[self.extension_ids[0]].get_closing_transactions()))
         self.assertEqual(1, len(cases[self.extension_ids[1]].get_closing_transactions()))
-
-
-@sharded
-class AutoCloseExtensionsTestSQL(AutoCloseExtensionsTest):
-    pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_db_accessors.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_db_accessors.py
@@ -10,6 +10,7 @@ from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
 from django.test import TestCase
 
 
+@sharded
 class TestExtensionCaseIds(TestCase):
 
     def setUp(self):
@@ -153,10 +154,6 @@ class TestExtensionCaseIds(TestCase):
 
 
 @sharded
-class TestExtensionCaseIdsSQL(TestExtensionCaseIds):
-    pass
-
-
 class TestIndexedCaseIds(TestCase):
 
     def setUp(self):
@@ -186,11 +183,6 @@ class TestIndexedCaseIds(TestCase):
         )
         returned_cases = CaseAccessors(self.domain).get_indexed_case_ids([extension_id])
         self.assertItemsEqual(returned_cases, [host_id])
-
-
-@sharded
-class TestIndexedCaseIdsSQL(TestIndexedCaseIds):
-    pass
 
 
 class TestReverseIndexedCases(TestCase):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_domains.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_domains.py
@@ -71,6 +71,7 @@ ALICE_DOMAIN = 'domain1'
 EVE_DOMAIN = 'domain2'
 
 
+@sharded
 class DomainTest(TestCase):
 
     def tearDown(self):
@@ -86,8 +87,3 @@ class DomainTest(TestCase):
 
         result_alice_update = submit_form_locally(ALICE_UPDATE_XML, ALICE_DOMAIN)
         self.assertEqual(result_alice_update.case.dynamic_case_properties()['plan_to_buy_gun'], 'no')
-
-
-@sharded
-class DomainTestSQL(DomainTest):
-    pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
 import os
-from django.test.utils import override_settings
 from casexml.apps.case.tests.util import delete_all_cases
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
@@ -14,7 +13,7 @@ class CaseExclusionTest(TestCase):
     """
     Tests the exclusion of device logs from case processing
     """
-    
+
     def setUp(self):
         super(CaseExclusionTest, self).setUp()
         delete_all_cases()

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
@@ -9,6 +9,7 @@ from corehq.form_processor.tests.utils import sharded
 TEST_DOMAIN = 'test-domain'
 
 
+@sharded
 class CaseExclusionTest(TestCase):
     """
     Tests the exclusion of device logs from case processing
@@ -39,8 +40,3 @@ class CaseExclusionTest(TestCase):
         result = submit_form_locally(xml_data, TEST_DOMAIN)
         self.assertEqual(['case_in_form'], CaseAccessors(TEST_DOMAIN).get_case_ids_in_domain())
         self.assertEqual("form case", result.case.name)
-
-
-@sharded
-class CaseExclusionTestSQL(CaseExclusionTest):
-    pass

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
@@ -2,7 +2,6 @@ import re
 import uuid
 from xml.etree import cElementTree as ElementTree
 import datetime
-from django.test.utils import override_settings
 from casexml.apps.case.mock import CaseBlock, CaseBlockError, IndexAttrs, ChildIndexAttrs
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
@@ -86,7 +85,6 @@ class IndexTest(TestCase):
                 [CaseBlock.deprecated_init(create=True, case_id=prereq, user_id=self.user.user_id).as_xml()],
                 domain=self.project.name
             )
-
 
         # Step 1. Create a case with index <mom>
         create_index = CaseBlock.deprecated_init(
@@ -280,7 +278,7 @@ class CaseBlockIndexRelationshipTests(SimpleTestCase):
         CaseBlock index relationship should only allow valid values
         """
         with self.assertRaisesRegex(CaseBlockError,
-                                     'Valid values for an index relationship are "child" and "extension"'):
+                                    'Valid values for an index relationship are "child" and "extension"'):
             CaseBlock.deprecated_init(
                 case_id='abcdef',
                 case_type='at_risk',

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
@@ -55,6 +55,7 @@ class IndexSimpleTest(SimpleTestCase):
         self.assertRaises(ValueError, self.case.remove_index_by_ref_id, 'i2')
 
 
+@sharded
 class IndexTest(TestCase):
     CASE_ID = 'test-index-case'
     MOTHER_CASE_ID = 'text-index-mother-case'
@@ -183,11 +184,6 @@ class IndexTest(TestCase):
         }
         form, cases = post_case_blocks([create_index.as_xml()], domain=self.project.name)
         self.assertEqual(cases[0].indices[0].relationship, 'child')
-
-
-@sharded
-class IndexTestSQL(IndexTest):
-    pass
 
 
 class CaseBlockIndexRelationshipTests(SimpleTestCase):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_strict_datetimes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_strict_datetimes.py
@@ -24,6 +24,7 @@ CASE_BLOCK = """
 """.format(case_id=CASE_ID)
 
 
+@sharded
 class StrictDatetimesTest(TestCase):
 
     @classmethod
@@ -39,11 +40,6 @@ class StrictDatetimesTest(TestCase):
             with self.interface.casedb_cache(domain=self.domain) as case_db:
                 with self.assertRaises(PhoneDateValueError):
                     process_cases_with_casedb(xforms, case_db)
-
-
-@sharded
-class StrictDatetimesTestSQL(StrictDatetimesTest):
-    pass
 
 
 def _make_form_from_case_blocks(case_blocks):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -187,6 +187,7 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
         self.assertTrue(invalidate.called)
 
 
+@sharded
 class AsyncRestoreTest(BaseAsyncRestoreTest):
 
     @flag_enabled('ASYNC_RESTORE')
@@ -270,11 +271,6 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
 
         self._restore_config(is_async=True, overwrite_cache=True).get_payload()
         self.assertTrue(invalidate.called)
-
-
-@sharded
-class AsyncRestoreTestSQL(AsyncRestoreTest):
-    pass
 
 
 class TestAsyncRestoreResponse(TestXmlMixin, SimpleTestCase):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
@@ -11,7 +11,6 @@ from casexml.apps.phone.exceptions import InvalidDomainError, InvalidOwnerIdErro
 from casexml.apps.phone.models import OwnershipCleanlinessFlag
 from casexml.apps.phone.tests.test_sync_mode import DeprecatedBaseSyncTest
 from corehq.form_processor.tests.utils import sharded
-from six.moves import range
 
 
 @sharded
@@ -574,8 +573,15 @@ class GetCaseFootprintInfoTest(TestCase):
     def test_simple_footprint(self):
         """ should only return open cases from user """
         case = CaseStructure(case_id=uuid.uuid4().hex, attrs={'owner_id': self.owner_id, 'create': True})
-        closed_case = CaseStructure(case_id=uuid.uuid4().hex, attrs={'owner_id': self.owner_id, 'close': True, 'create': True})
-        other_case = CaseStructure(case_id=uuid.uuid4().hex, attrs={'owner_id': self.other_owner_id, 'create': True})
+        closed_case = CaseStructure(case_id=uuid.uuid4().hex, attrs={
+            'owner_id': self.owner_id,
+            'close': True,
+            'create': True,
+        })
+        other_case = CaseStructure(case_id=uuid.uuid4().hex, attrs={
+            'owner_id': self.other_owner_id,
+            'create': True,
+        })
         self.factory.create_or_update_cases([case, other_case, closed_case])
 
         footprint_info = get_case_footprint_info(self.domain, self.owner_id)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
@@ -14,6 +14,7 @@ from corehq.form_processor.tests.utils import sharded
 from six.moves import range
 
 
+@sharded
 @override_settings(TESTS_SHOULD_TRACK_CLEANLINESS=None)
 class OwnerCleanlinessTest(DeprecatedBaseSyncTest):
 
@@ -523,10 +524,6 @@ class OwnerCleanlinessTest(DeprecatedBaseSyncTest):
 
 
 @sharded
-class OwnerCleanlinessTestSQL(OwnerCleanlinessTest):
-    pass
-
-
 class SetCleanlinessFlagsTest(TestCase):
 
     def test_set_bad_domains(self):
@@ -540,11 +537,6 @@ class SetCleanlinessFlagsTest(TestCase):
         for invalid_owner in test_cases:
             with self.assertRaises(InvalidOwnerIdError):
                 set_cleanliness_flags('whatever', invalid_owner)
-
-
-@sharded
-class SetCleanlinessFlagsTestSQL(SetCleanlinessFlagsTest):
-    pass
 
 
 class CleanlinessUtilitiesTest(SimpleTestCase):
@@ -564,6 +556,7 @@ class CleanlinessUtilitiesTest(SimpleTestCase):
         self.assertEqual(set(back), set(range(5)))
 
 
+@sharded
 class GetCaseFootprintInfoTest(TestCase):
 
     @classmethod
@@ -709,10 +702,6 @@ class GetCaseFootprintInfoTest(TestCase):
 
 
 @sharded
-class GetCaseFootprintInfoTestSQL(GetCaseFootprintInfoTest):
-    pass
-
-
 class GetDependentCasesTest(TestCase):
 
     @classmethod
@@ -796,8 +785,3 @@ class GetDependentCasesTest(TestCase):
                          get_dependent_case_info(self.domain, [child.case_id]).extension_ids)
         self.assertEqual(set([]),
                          get_dependent_case_info(self.domain, [parent.case_id]).extension_ids)
-
-
-@sharded
-class GetDependentCasesTestSQL(GetDependentCasesTest):
-    pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
@@ -101,6 +101,7 @@ class TestSequenceMeta(type):
         return type.__new__(mcs, name, bases, dict)
 
 
+@sharded
 class IndexTreeTest(BaseSyncTest, metaclass=TestSequenceMeta):
     """Fetch all testcases from data/case_relationship_tests.json and run them
 
@@ -180,14 +181,5 @@ class IndexTreeTest(BaseSyncTest, metaclass=TestSequenceMeta):
 
 
 @sharded
-class IndexTreeTestSQL(IndexTreeTest):
-    pass
-
-
 class LiveQueryIndexTreeTest(IndexTreeTest):
     restore_options = {'case_sync': LIVEQUERY}
-
-
-@sharded
-class LiveQueryIndexTreeTestSQL(LiveQueryIndexTreeTest):
-    pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
@@ -47,6 +47,7 @@ class TestLiveQuery(TestCase):
             device.sync(case_sync=CLEAN_OWNERS)
 
 
+@sharded
 class TestNewSyncSpecifics(TestCase):
 
     @classmethod
@@ -110,8 +111,3 @@ class TestNewSyncSpecifics(TestCase):
             CaseStructure(case_id=child_id, attrs={'owner_id': 'different'}),
             CaseStructure(case_id=parent_id, attrs={'owner_id': 'different'}),
         ], form_extras={'last_sync_token': sync_log._id})
-
-
-@sharded
-class TestNewSyncSpecificsSQL(TestNewSyncSpecifics):
-    pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
@@ -1,8 +1,6 @@
 from xml.etree import cElementTree as ElementTree
 from django.test import TestCase
 from corehq.blobs import get_blob_db
-from casexml.apps.phone.fixtures import generator
-from casexml.apps.phone.tests.utils import create_restore_user
 from casexml.apps.phone.utils import MockDevice
 from corehq.apps.domain.models import Domain
 from corehq.apps.fixtures.models import (

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
@@ -21,6 +21,7 @@ SA_PROVINCES = 'sa_provinces'
 FR_PROVINCES = 'fr_provinces'
 
 
+@sharded
 class OtaFixtureTest(TestCase):
 
     @classmethod
@@ -82,11 +83,6 @@ class OtaFixtureTest(TestCase):
         self.assertIn('<fixture ', restore)
         restore_without_fixture = device.sync(skip_fixtures=True).payload.decode('utf-8')
         self.assertNotIn('<fixture ', restore_without_fixture)
-
-
-@sharded
-class OtaFixtureTestSQL(OtaFixtureTest):
-    pass
 
 
 def _get_group_fixture(user_id, groups):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
@@ -1,5 +1,4 @@
 from django.test import TestCase
-from django.test.utils import override_settings
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.phone.checksum import EMPTY_HASH, CaseStateHash
 from casexml.apps.case.xml import V1

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
@@ -12,6 +12,7 @@ from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.form_processor.tests.utils import sharded
 
 
+@sharded
 class StateHashTest(TestCase):
 
     @classmethod
@@ -79,8 +80,3 @@ class StateHashTest(TestCase):
             self.assertEqual(set(e.case_ids), {"abc123", "123abc"})
         else:
             self.fail("Call to generate a payload with a bad hash should fail!")
-
-
-@sharded
-class StateHashTestSQL(StateHashTest):
-    pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
@@ -12,6 +12,7 @@ from couchforms.models import XFormInstance
 from corehq.form_processor.tests.utils import sharded
 
 
+@sharded
 class SyncLogAssertionTest(TestCase):
 
     def test_update_dependent_case(self):
@@ -53,8 +54,3 @@ class SyncLogAssertionTest(TestCase):
             # before this test was added, the following call raised a ValueError on legacy logs.
             sync_log.update_phone_lists(xform, [parent_case])
             self.assertIn(dependent_case_state, sync_log.test_only_get_dependent_cases_on_phone())
-
-
-@sharded
-class SyncLogAssertionTestSQL(SyncLogAssertionTest):
-    pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
@@ -48,7 +48,10 @@ class SyncLogAssertionTest(TestCase):
         dependent_case_state = CaseState(case_id="d1", indices=[])
         xform_id = uuid.uuid4().hex
         xform = XFormInstance(_id=xform_id)
-        form_actions = [CommCareCaseAction(action_type=CASE_ACTION_UPDATE, updated_known_properties={'owner_id': 'user2'})]
+        form_actions = [CommCareCaseAction(
+            action_type=CASE_ACTION_UPDATE,
+            updated_known_properties={'owner_id': 'user2'},
+        )]
         with patch.object(CommCareCase, 'get_actions_for_form', return_value=form_actions):
             parent_case = CommCareCase(_id='d1')
             # before this test was added, the following call raised a ValueError on legacy logs.

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -2,7 +2,6 @@ import os
 import uuid
 from datetime import datetime
 from xml.etree import cElementTree as ElementTree
-from django.test.utils import override_settings
 from django.test import TestCase
 from mock import patch
 
@@ -31,7 +30,6 @@ from casexml.apps.phone.models import (
     get_properly_wrapped_sync_log,
     LOG_FORMAT_LIVEQUERY,
     LOG_FORMAT_SIMPLIFIED,
-    SimplifiedSyncLog,
 )
 from casexml.apps.phone.restore import (
     CachedResponse,
@@ -43,7 +41,6 @@ from casexml.apps.phone.restore import (
 )
 from casexml.apps.case.xml import V2, V1
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
-from six.moves import range
 
 USERNAME = "syncguy"
 OTHER_USERNAME = "ferrel"

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -148,6 +148,7 @@ class DeprecatedBaseSyncTest(BaseSyncTest):
         }
 
 
+@sharded
 class SyncTokenUpdateTest(BaseSyncTest):
     """
     Tests sync token updates on submission related to the list of cases
@@ -770,19 +771,11 @@ class SyncTokenUpdateTest(BaseSyncTest):
 
 
 @sharded
-class SyncTokenUpdateTestSQL(SyncTokenUpdateTest):
-    pass
-
-
 class LiveQuerySyncTokenUpdateTest(SyncTokenUpdateTest):
     restore_options = {'case_sync': LIVEQUERY}
 
 
 @sharded
-class LiveQuerySyncTokenUpdateTestSQL(LiveQuerySyncTokenUpdateTest):
-    pass
-
-
 class SyncDeletedCasesTest(BaseSyncTest):
 
     def test_deleted_case_doesnt_sync(self):
@@ -812,19 +805,11 @@ class SyncDeletedCasesTest(BaseSyncTest):
 
 
 @sharded
-class SyncDeletedCasesTestSQL(SyncDeletedCasesTest):
-    pass
-
-
 class LiveQuerySyncDeletedCasesTest(SyncDeletedCasesTest):
     restore_options = {'case_sync': LIVEQUERY}
 
 
 @sharded
-class LiveQuerySyncDeletedCasesTestSQL(LiveQuerySyncDeletedCasesTest):
-    pass
-
-
 class ExtensionCasesSyncTokenUpdates(BaseSyncTest):
     """Makes sure the extension case trees are propertly updated
     """
@@ -1053,19 +1038,11 @@ class ExtensionCasesSyncTokenUpdates(BaseSyncTest):
 
 
 @sharded
-class ExtensionCasesSyncTokenUpdatesSQL(ExtensionCasesSyncTokenUpdates):
-    pass
-
-
 class LiveQueryExtensionCasesSyncTokenUpdates(ExtensionCasesSyncTokenUpdates):
     restore_options = {'case_sync': LIVEQUERY}
 
 
 @sharded
-class LiveQueryExtensionCasesSyncTokenUpdatesSQL(LiveQueryExtensionCasesSyncTokenUpdates):
-    pass
-
-
 class ExtensionCasesFirstSync(BaseSyncTest):
 
     def setUp(self):
@@ -1096,19 +1073,11 @@ class ExtensionCasesFirstSync(BaseSyncTest):
 
 
 @sharded
-class ExtensionCasesFirstSyncSQL(ExtensionCasesFirstSync):
-    pass
-
-
 class LiveQueryExtensionCasesFirstSync(ExtensionCasesFirstSync):
     restore_options = {'case_sync': LIVEQUERY}
 
 
 @sharded
-class LiveQueryExtensionCasesFirstSyncSQL(LiveQueryExtensionCasesFirstSync):
-    pass
-
-
 class ChangingOwnershipTest(BaseSyncTest):
 
     def test_remove_user_from_group(self):
@@ -1167,19 +1136,11 @@ class ChangingOwnershipTest(BaseSyncTest):
 
 
 @sharded
-class ChangingOwnershipTestSQL(ChangingOwnershipTest):
-    pass
-
-
 class LiveQueryChangingOwnershipTest(ChangingOwnershipTest):
     restore_options = {'case_sync': LIVEQUERY}
 
 
 @sharded
-class LiveQueryChangingOwnershipTestSQL(LiveQueryChangingOwnershipTest):
-    pass
-
-
 @patch('casexml.apps.phone.restore.INITIAL_SYNC_CACHE_THRESHOLD', 0)
 class SyncTokenCachingTest(BaseSyncTest):
 
@@ -1280,19 +1241,11 @@ class SyncTokenCachingTest(BaseSyncTest):
 
 
 @sharded
-class SyncTokenCachingTestSQL(SyncTokenCachingTest):
-    pass
-
-
 class LiveQuerySyncTokenCachingTest(SyncTokenCachingTest):
     restore_options = {'case_sync': LIVEQUERY}
 
 
 @sharded
-class LiveQuerySyncTokenCachingTestSQL(LiveQuerySyncTokenCachingTest):
-    pass
-
-
 class MultiUserSyncTest(BaseSyncTest):
     """
     Tests the interaction of two users in sync mode doing various things
@@ -1835,19 +1788,11 @@ class MultiUserSyncTest(BaseSyncTest):
 
 
 @sharded
-class MultiUserSyncTestSQL(MultiUserSyncTest):
-    pass
-
-
 class LiveQueryMultiUserSyncTest(MultiUserSyncTest):
     restore_options = {'case_sync': LIVEQUERY}
 
 
 @sharded
-class LiveQueryMultiUserSyncTestSQL(LiveQueryMultiUserSyncTest):
-    pass
-
-
 class SteadyStateExtensionSyncTest(BaseSyncTest):
     """
     Test that doing multiple clean syncs with extensions does what we think it will
@@ -1997,19 +1942,11 @@ class SteadyStateExtensionSyncTest(BaseSyncTest):
 
 
 @sharded
-class SteadyStateExtensionSyncTestSQL(SteadyStateExtensionSyncTest):
-    pass
-
-
 class LiveQuerySteadyStateExtensionSyncTest(SteadyStateExtensionSyncTest):
     restore_options = {'case_sync': LIVEQUERY}
 
 
 @sharded
-class LiveQuerySteadyStateExtensionSyncTestSQL(LiveQuerySteadyStateExtensionSyncTest):
-    pass
-
-
 class SyncTokenReprocessingTest(BaseSyncTest):
     """
     Tests sync token logic for fixing itself when it gets into a bad state.
@@ -2039,19 +1976,11 @@ class SyncTokenReprocessingTest(BaseSyncTest):
 
 
 @sharded
-class SyncTokenReprocessingTestSQL(SyncTokenReprocessingTest):
-    pass
-
-
 class LiveQuerySyncTokenReprocessingTest(SyncTokenReprocessingTest):
     restore_options = {'case_sync': LIVEQUERY}
 
 
 @sharded
-class LiveQuerySyncTokenReprocessingTestSQL(LiveQuerySyncTokenReprocessingTest):
-    pass
-
-
 class LooseSyncTokenValidationTest(BaseSyncTest):
 
     def test_submission_with_bad_log_toggle_enabled(self):
@@ -2076,19 +2005,11 @@ class LooseSyncTokenValidationTest(BaseSyncTest):
 
 
 @sharded
-class LooseSyncTokenValidationTestSQL(LooseSyncTokenValidationTest):
-    pass
-
-
 class LiveQueryLooseSyncTokenValidationTest(LooseSyncTokenValidationTest):
     restore_options = {'case_sync': LIVEQUERY}
 
 
 @sharded
-class LiveQueryLooseSyncTokenValidationTestSQL(LiveQueryLooseSyncTokenValidationTest):
-    pass
-
-
 class IndexSyncTest(BaseSyncTest):
 
     def test_sync_index_between_open_owned_cases(self):
@@ -2122,14 +2043,5 @@ class IndexSyncTest(BaseSyncTest):
 
 
 @sharded
-class IndexSyncTestSQL(IndexSyncTest):
-    pass
-
-
 class LiveQueryIndexSyncTest(IndexSyncTest):
     restore_options = {'case_sync': LIVEQUERY}
-
-
-@sharded
-class LiveQueryIndexSyncTestSQL(LiveQueryIndexSyncTest):
-    pass

--- a/corehq/ex-submodules/casexml/apps/stock/tests/test_consumption_for_case.py
+++ b/corehq/ex-submodules/casexml/apps/stock/tests/test_consumption_for_case.py
@@ -5,6 +5,7 @@ from casexml.apps.stock.tests.base import StockTestBase
 from corehq.form_processor.tests.utils import sharded
 
 
+@sharded
 class ConsumptionCaseTest(StockTestBase):
 
     def testNoConsumption(self):
@@ -42,8 +43,3 @@ class ConsumptionCaseTest(StockTestBase):
                 default_monthly_consumption_function=_ten
             )
         ))
-
-
-@sharded
-class ConsumptionCaseTestSQL(ConsumptionCaseTest):
-    pass

--- a/corehq/ex-submodules/couchforms/tests/test_archive.py
+++ b/corehq/ex-submodules/couchforms/tests/test_archive.py
@@ -17,6 +17,7 @@ from couchforms.models import UnfinishedArchiveStub
 from testapps.test_pillowtop.utils import capture_kafka_changes_context
 
 
+@sharded
 class TestFormArchiving(TestCase, TestFileMixin):
     file_path = ('data', 'sample_xforms')
     root = os.path.dirname(__file__)
@@ -426,10 +427,6 @@ class TestFormArchiving(TestCase, TestFileMixin):
         xform.unarchive()
         self.assertEqual(1, archive_counter)
         self.assertEqual(1, restore_counter)
-
-
-@sharded
-class TestFormArchivingSQL(TestFormArchiving):
 
     @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def testPublishChanges(self):

--- a/corehq/ex-submodules/couchforms/tests/test_auth.py
+++ b/corehq/ex-submodules/couchforms/tests/test_auth.py
@@ -8,6 +8,7 @@ import os
 from corehq.form_processor.tests.utils import sharded
 
 
+@sharded
 class AuthTest(TestCase, TestFileMixin):
     file_path = ('data', 'posts')
     root = os.path.dirname(__file__)
@@ -17,8 +18,3 @@ class AuthTest(TestCase, TestFileMixin):
 
         result = submit_form_locally(xml_data, 'test-domain', auth_context=DefaultAuthContext())
         self.assertEqual(result.xform.auth_context, {'doc_type': 'DefaultAuthContext'})
-
-
-@sharded
-class AuthTestSQL(AuthTest):
-    pass

--- a/corehq/ex-submodules/couchforms/tests/test_devicelogs.py
+++ b/corehq/ex-submodules/couchforms/tests/test_devicelogs.py
@@ -10,6 +10,7 @@ from phonelog.models import UserEntry, DeviceReportEntry, UserErrorEntry, ForceC
 from phonelog.utils import _get_logs
 
 
+@sharded
 class DeviceLogTest(TestCase, TestFileMixin):
     file_path = ('data', 'devicelogs')
     root = os.path.dirname(__file__)
@@ -109,11 +110,6 @@ class DeviceLogTest(TestCase, TestFileMixin):
     def test_subreports_that_shouldnt_fail(self):
         xml = self.get_xml('subreports_that_shouldnt_fail')
         submit_form_locally(xml, 'test-domain')
-
-
-@sharded
-class DeviceLogTestSQL(DeviceLogTest):
-    pass
 
 
 class TestDeviceLogUtils(SimpleTestCase, TestFileMixin):

--- a/corehq/ex-submodules/couchforms/tests/test_errors.py
+++ b/corehq/ex-submodules/couchforms/tests/test_errors.py
@@ -5,6 +5,7 @@ from corehq.form_processor.tests.utils import sharded
 from corehq.util.test_utils import softer_assert
 
 
+@sharded
 class CaseProcessingErrorsTest(TestCase):
 
     def test_no_case_id(self):
@@ -66,8 +67,3 @@ class CaseProcessingErrorsTest(TestCase):
         )
         self.assertTrue(result.xform.is_error)
         self.assertEqual(result.xform.problem, 'UsesReferrals: Sorry, referrals are no longer supported!')
-
-
-@sharded
-class CaseProcessingErrorsTestSQL(CaseProcessingErrorsTest):
-    pass

--- a/corehq/ex-submodules/couchforms/tests/test_namespaces.py
+++ b/corehq/ex-submodules/couchforms/tests/test_namespaces.py
@@ -7,6 +7,7 @@ from corehq.form_processor.tests.utils import sharded
 from corehq.util.test_utils import TestFileMixin
 
 
+@sharded
 class TestNamespaces(TestCase, TestFileMixin):
     file_path = ('data', 'posts')
     root = os.path.dirname(__file__)
@@ -29,8 +30,3 @@ class TestNamespaces(TestCase, TestFileMixin):
         self._assert_xmlns('gc', xform, 'form/parent/childwithelement/grandchild')
         self._assert_xmlns('lcwo', xform, 'form/parent/lastchildwithout')
         self._assert_xmlns('nothing here either', xform, 'form/lastempty')
-
-
-@sharded
-class TestNamespacesSQL(TestNamespaces):
-    pass

--- a/corehq/ex-submodules/couchforms/tests/test_xml.py
+++ b/corehq/ex-submodules/couchforms/tests/test_xml.py
@@ -7,6 +7,7 @@ from corehq.form_processor.tests.utils import sharded
 from corehq.util.test_utils import TestFileMixin
 
 
+@sharded
 class XMLElementTest(TestCase, TestFileMixin):
     file_path = ('data',)
     root = os.path.dirname(__file__)
@@ -29,8 +30,3 @@ class XMLElementTest(TestCase, TestFileMixin):
             self.assertEqual(value, xform.form_data['test'])
             elem = xform.get_xml_element()
             self.assertEqual(value, elem.find('{http://commcarehq.org/couchforms-tests}test').text)
-
-
-@sharded
-class XMLElementTestSQL(XMLElementTest):
-    pass

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -416,6 +416,7 @@ class FormAccessorTestsSQL(TestCase):
         FormAccessorSQL.set_archived_state(form, False, user_id)
 
 
+@sharded
 class FormAccessorsTests(TestCase, TestXmlMixin):
 
     def tearDown(self):
@@ -534,11 +535,6 @@ class FormAccessorsTests(TestCase, TestXmlMixin):
         updates = {'eight': 'ocho'}
         errors = FormProcessorInterface(DOMAIN).update_responses(xform, updates, 'user1')
         self.assertEqual(['eight'], errors)
-
-
-@sharded
-class FormAccessorsTestsSQL(FormAccessorsTests):
-    pass
 
 
 class DeleteAttachmentsFSDBTests(TestCase):

--- a/corehq/form_processor/tests/test_gdpr_scrub_user_from_forms.py
+++ b/corehq/form_processor/tests/test_gdpr_scrub_user_from_forms.py
@@ -52,14 +52,15 @@ class UpdateFormTests(TestCase):
         self.assertXMLEqual(EXPECTED_FORM_XML, actual_form_xml)
 
 
-class GDPRScrubUserFromFormsCouchTests(TestCase):
+@sharded
+class GDPRScrubUserFromFormsTests(TestCase):
     def setUp(self):
-        super(GDPRScrubUserFromFormsCouchTests, self).setUp()
+        super(GDPRScrubUserFromFormsTests, self).setUp()
         self.db = TemporaryFilesystemBlobDB()
 
     def tearDown(self):
         self.db.close()
-        super(GDPRScrubUserFromFormsCouchTests, self).tearDown()
+        super(GDPRScrubUserFromFormsTests, self).tearDown()
 
     def test_modify_attachment_xml_and_metadata_couch(self):
         form = get_simple_wrapped_form(uuid.uuid4().hex,
@@ -78,8 +79,3 @@ class GDPRScrubUserFromFormsCouchTests(TestCase):
         self.assertEqual(len(refetched_form.history), 1)
         self.assertEqual(refetched_form.history[0].operation, "gdpr_scrub")
         self.assertEqual(refetched_form.metadata.username, NEW_USERNAME)
-
-
-@sharded
-class GDPRScrubUserFromFormsSqlTests(GDPRScrubUserFromFormsCouchTests):
-    pass

--- a/corehq/form_processor/tests/test_kafka.py
+++ b/corehq/form_processor/tests/test_kafka.py
@@ -12,6 +12,7 @@ from pillowtop.processors.sample import TestProcessor
 from testapps.test_pillowtop.utils import process_pillow_changes
 
 
+@sharded
 class KafkaPublishingTest(TestCase):
 
     domain = 'kafka-publishing-test'
@@ -84,8 +85,3 @@ class KafkaPublishingTest(TestCase):
         change_meta = self.processor.changes_seen[0].metadata
         self.assertEqual(case.case_id, change_meta.document_id)
         self.assertTrue(change_meta.is_deletion)
-
-
-@sharded
-class KafkaPublishingTestSQL(KafkaPublishingTest):
-    pass

--- a/corehq/form_processor/tests/test_ledgers.py
+++ b/corehq/form_processor/tests/test_ledgers.py
@@ -94,10 +94,11 @@ class LedgerTests(TestCase):
             ))
             balance = self.interface.ledger_db.get_current_ledger_value(
                 UniqueLedgerReference(
-                case_id=self.case.case_id,
-                section_id='stock',
-                entry_id=prod_id
-            ))
+                    case_id=self.case.case_id,
+                    section_id='stock',
+                    entry_id=prod_id
+                )
+            )
             self.assertEqual(expected_balance, balance)
 
         self._assert_transactions(expected_transactions, ignore_ordering=True)

--- a/corehq/form_processor/tests/test_ledgers.py
+++ b/corehq/form_processor/tests/test_ledgers.py
@@ -20,6 +20,7 @@ DOMAIN = 'ledger-tests'
 TransactionValues = namedtuple('TransactionValues', ['type', 'product_id', 'delta', 'updated_balance'])
 
 
+@sharded
 @run_with_sql_backend
 class LedgerTests(TestCase):
 
@@ -204,10 +205,7 @@ class LedgerTests(TestCase):
     def _expected_val(self, delta, updated_balance, type_=LedgerTransaction.TYPE_BALANCE, product_id=None):
         return TransactionValues(type_, product_id or self.product_a._id, delta, updated_balance)
 
-
-@sharded
-@softer_assert()
-class LedgerTestsSQL(LedgerTests):
+    @softer_assert()
     def test_edit_form_that_removes_ledgers(self):
         from corehq.apps.commtrack.tests.util import get_single_balance_block
         form_id = uuid.uuid4().hex
@@ -243,6 +241,7 @@ class LedgerTestsSQL(LedgerTests):
 
         self._assert_transactions([])
 
+    @softer_assert()
     def test_edit_form_with_ledgers(self):
         from corehq.apps.commtrack.tests.util import get_single_balance_block
         form_id = uuid.uuid4().hex


### PR DESCRIPTION
All tests decorated with @sharded run in both sharded and unsharded test runners. Previously it was necessary to create an extra @sharded subclass when tests also needed to run against both Couch and SQL backends, but no more.

Hopefully this will reduce test run times by a bit. Update: doesn't seem to have made much difference. :disappointed: Still a good change though.

:tropical_fish: Review by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Nothing other than tests was modified.

### QA Plan

No QA.

### Safety story

Nothing other than tests was modified.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
