### PR TITLE
do not process if ledger is deleted

### DIFF
--- a/corehq/pillows/ledger.py
+++ b/corehq/pillows/ledger.py
@@ -71,6 +71,9 @@ class LedgerProcessor(PillowProcessor):
     """
 
     def process_change(self, change):
+        if change.deleted:
+            return
+
         ledger = change.get_document()
         from corehq.apps.commtrack.models import CommtrackConfig
         commtrack_config = CommtrackConfig.for_domain(ledger['domain'])


### PR DESCRIPTION

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Deleted ledgers were causing pillow errors because they were returning null documents. There isn't cleanup necessary, just need to early exit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
