### PR TITLE
Smart linking MVP: Allow app id in URL to be an upstream app id

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -74,7 +74,6 @@ from corehq.apps.hqwebapp.decorators import (
     waf_allow,
 )
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import can_use_restore_as
-from corehq.apps.linked_domain.applications import get_downstream_app_id_map
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.formdetails import readable
 from corehq.apps.users.decorators import require_can_login_as
@@ -593,6 +592,7 @@ def session_endpoint(request, domain, app_id, endpoint_id):
         # These links can be used for cross-domain web apps workflows, where a link jumps to the
         # same screen but in another domain's corresponding app. This works if both the source and
         # target apps are downstream apps that share an upstream app - the link references the upstream app.
+        from corehq.apps.linked_domain.applications import get_downstream_app_id_map
         id_map = get_downstream_app_id_map(domain)
         if app_id in id_map.keys():
             build = _fetch_build(domain, request.couch_user.username, id_map[app_id])

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -590,7 +590,7 @@ def session_endpoint(request, domain, app_id, endpoint_id):
 
     build = _fetch_build(domain, request.couch_user.username, app_id)
     if not build:
-        id_map = get_downstream_app_id_map(domain, use_upstream_app_id=True)
+        id_map = get_downstream_app_id_map(domain)
         if app_id in id_map.keys():
             build = _fetch_build(domain, request.couch_user.username, id_map[app_id])
         if not build:

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -594,7 +594,7 @@ def session_endpoint(request, domain, app_id, endpoint_id):
         # target apps are downstream apps that share an upstream app - the link references the upstream app.
         from corehq.apps.linked_domain.applications import get_downstream_app_id_map
         id_map = get_downstream_app_id_map(domain)
-        if app_id in id_map.keys():
+        if app_id in id_map:
             build = _fetch_build(domain, request.couch_user.username, id_map[app_id])
         if not build:
             return _fail(_("Could not find application."))

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -590,6 +590,9 @@ def session_endpoint(request, domain, app_id, endpoint_id):
 
     build = _fetch_build(domain, request.couch_user.username, app_id)
     if not build:
+        # These links can be used for cross-domain web apps workflows, where a link jumps to the
+        # same screen but in another domain's corresponding app. This works if both the source and
+        # target apps are downstream apps that share an upstream app - the link references the upstream app.
         id_map = get_downstream_app_id_map(domain)
         if app_id in id_map.keys():
             build = _fetch_build(domain, request.couch_user.username, id_map[app_id])

--- a/corehq/apps/linked_domain/applications.py
+++ b/corehq/apps/linked_domain/applications.py
@@ -55,7 +55,7 @@ def get_downstream_app_id(downstream_domain, upstream_app_id, use_upstream_app_i
     :param use_upstream_app_id: whether to search for downstream app based on upstream_app_id or family_id
     DEPRECATED: family_id is deprecated and will be removed. If calling this method, try to use upstream_app_id
     """
-    downstream_ids = _get_downstream_app_id_map(
+    downstream_ids = get_downstream_app_id_map(
         downstream_domain,
         use_upstream_app_id=use_upstream_app_id
     )[upstream_app_id]
@@ -67,7 +67,7 @@ def get_downstream_app_id(downstream_domain, upstream_app_id, use_upstream_app_i
 
 
 def get_upstream_app_ids(downstream_domain):
-    return list(_get_downstream_app_id_map(downstream_domain))
+    return list(get_downstream_app_id_map(downstream_domain))
 
 
 @quickcache(
@@ -75,7 +75,7 @@ def get_upstream_app_ids(downstream_domain):
     skip_arg=lambda *args, **kwargs: settings.UNIT_TESTING,
     timeout=5 * 60
 )
-def _get_downstream_app_id_map(downstream_domain, use_upstream_app_id=False):
+def get_downstream_app_id_map(downstream_domain, use_upstream_app_id=False):
     """
     :param downstream_domain: domain name
     :param use_upstream_app_id: whether to search for downstream app based on upstream_app_id or family_id

--- a/corehq/apps/linked_domain/applications.py
+++ b/corehq/apps/linked_domain/applications.py
@@ -67,7 +67,7 @@ def get_downstream_app_id(downstream_domain, upstream_app_id, use_upstream_app_i
 
 
 def get_upstream_app_ids(downstream_domain):
-    return list(get_downstream_app_id_map(downstream_domain))
+    return list(get_downstream_app_id_map(downstream_domain, use_upstream_app_id=False))
 
 
 @quickcache(
@@ -75,7 +75,7 @@ def get_upstream_app_ids(downstream_domain):
     skip_arg=lambda *args, **kwargs: settings.UNIT_TESTING,
     timeout=5 * 60
 )
-def get_downstream_app_id_map(downstream_domain, use_upstream_app_id=False):
+def get_downstream_app_id_map(downstream_domain, use_upstream_app_id=True):
     """
     :param downstream_domain: domain name
     :param use_upstream_app_id: whether to search for downstream app based on upstream_app_id or family_id
@@ -137,7 +137,7 @@ def link_app(linked_app, master_domain, master_id, remote_details=None):
         except RemoteRequestError:
             raise AppLinkError('Error fetching multimedia from remote server. Please try again later.')
 
-    _get_downstream_app_id_map.clear(linked_app.domain)
+    get_downstream_app_id_map.clear(linked_app.domain)
     return linked_app
 
 


### PR DESCRIPTION
PR into https://github.com/dimagi/commcare-hq/pull/30002

For cross-jurisdictional web apps workflows, we'll want to link from one app into the corresponding app in another domain. To accomplish this, if a smart link can't find the app in the URL, assume it's an upstream app id, and link to the downstream app in the current domain.

This will potentially fail if the same upstream app has multiple downstream copies in a single domain.