### PR TITLE
Remove Couch: should_use_sql_backend and use_sql_backend

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -31,10 +31,7 @@ from corehq.form_processor.interfaces.dbaccessors import (
     FormAccessors,
 )
 from corehq.form_processor.signals import sql_case_post_save
-from corehq.form_processor.tests.utils import (
-    run_with_sql_backend,
-    set_case_property_directly,
-)
+from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.toggles import NAMESPACE_DOMAIN, RUN_AUTO_CASE_UPDATES_ON_SAVE
 from corehq.tests.locks import reentrant_redis_locks
 from corehq.util.context_managers import drop_connected_signals
@@ -517,6 +514,10 @@ class CaseRuleCriteriaTest(BaseCaseRuleTest):
             _save_case(self.domain, case)
             case = CaseAccessors(self.domain).get_case(case.case_id)
             self.assertTrue(rule.criteria_match(case, datetime(2017, 4, 15)))
+
+
+def set_case_property_directly(case, property_name, value):
+    case.case_json[property_name] = value
 
 
 class CaseRuleActionsTest(BaseCaseRuleTest):

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -330,7 +330,6 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
     usercase_enabled = BooleanProperty(default=False)
     hipaa_compliant = BooleanProperty(default=False)
     use_livequery = BooleanProperty(default=False)
-    use_sql_backend = BooleanProperty(default=False)
     first_domain_for_user = BooleanProperty(default=False)
 
     # CommConnect settings
@@ -639,7 +638,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
         return domain
 
     @classmethod
-    def get_or_create_with_name(cls, name, is_active=False, secure_submissions=True, use_sql_backend=False):
+    def get_or_create_with_name(cls, name, is_active=False, secure_submissions=True):
         result = cls.view("domain/domains", key=name, reduce=False, include_docs=True).first()
         if result:
             return result
@@ -650,7 +649,6 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
                 date_created=datetime.utcnow(),
                 secure_submissions=secure_submissions,
                 use_livequery=True,
-                use_sql_backend=use_sql_backend,
             )
             new_domain.save(**get_safe_write_kwargs())
             return new_domain

--- a/corehq/apps/domain/shortcuts.py
+++ b/corehq/apps/domain/shortcuts.py
@@ -1,6 +1,9 @@
 """
 Shortcuts for working with domains and users.
 """
+from django.contrib.auth.models import User
+
+from corehq.apps.domain.models import Domain
 
 
 def create_domain(name, active=True):
@@ -9,7 +12,8 @@ def create_domain(name, active=True):
                                           secure_submissions=False)
 
 
-def create_user(username, password, is_staff=False, is_superuser=False, is_active=True, password_hashed=False, **kwargs):
+def create_user(username, password, is_staff=False, is_superuser=False,
+                is_active=True, password_hashed=False, **kwargs):
     user = User()
     user.username = username.lower()
     for key, val in kwargs.items():
@@ -47,8 +51,3 @@ def _domain_to_change_meta(domain_obj):
         data_source_type=data_sources.SOURCE_COUCH,
         data_source_name=Domain.get_db().dbname,
     )
-
-
-from django.contrib.auth.models import User
-
-from corehq.apps.domain.models import Domain

--- a/corehq/apps/domain/shortcuts.py
+++ b/corehq/apps/domain/shortcuts.py
@@ -3,10 +3,10 @@ Shortcuts for working with domains and users.
 """
 
 
-def create_domain(name, active=True, use_sql_backend=False):
+def create_domain(name, active=True):
     """Create domain without secure submissions for tests"""
     return Domain.get_or_create_with_name(name=name, is_active=active,
-                                          secure_submissions=False, use_sql_backend=use_sql_backend)
+                                          secure_submissions=False)
 
 
 def create_user(username, password, is_staff=False, is_superuser=False, is_active=True, password_hashed=False, **kwargs):

--- a/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
+++ b/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
@@ -17,15 +17,6 @@
         Features can be enabled or disabled based on feature flags or privileges. This page
         is intended to provide a list of what features a domain has access to.
       </p>
-      {% if use_sql_backend %}
-        <div class="alert alert-warning" role="alert">
-          NOTE: This domain is using the SCALE backend which implies the following feature flags:
-          <ul>
-            <li>Use new backend export infrastructure</li>  <!-- not OLD_EXPORTS -->
-            <li>Use a SQLite backend for Touchforms</li>  <!-- TF_USES_SQLITE_BACKEND -->
-          </ul>
-        </div>
-      {% endif %}
     </div>
   </div>
 
@@ -163,10 +154,6 @@
         <th class="text-center text-nowrap">Enabled for domain?</th>
         </thead>
         <tbody>
-        <tr class="{% if use_sql_backend %}success{% else %}info{% endif %}">
-          <td>Using new SQL/scale backend</td>
-          <td class="text-center">{% if use_sql_backend %}<i class="fa fa-check"></i>{% endif %}</td>
-        </tr>
         <tr class="{% if use_livequery %}success{% else %}info{% endif %}">
           <td>Using LiveQuery sync algorithm</td>
           <td class="text-center">{% if use_livequery %}<i class="fa fa-check"></i>{% endif %}</td>

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -266,7 +266,6 @@ class FlagsAndPrivilegesView(BaseAdminProjectSettingsView):
         return {
             'toggles': self._get_toggles(),
             'use_livequery': self.domain_object.use_livequery,
-            'use_sql_backend': self.domain_object.use_sql_backend,
             'privileges': self._get_privileges(),
         }
 

--- a/corehq/apps/domain/views/tombstone.py
+++ b/corehq/apps/domain/views/tombstone.py
@@ -63,7 +63,6 @@ def create_tombstone(request):
             date_created=datetime.utcnow(),
             creating_user=request.couch_user.username,
             secure_submissions=True,
-            use_sql_backend=True,
             first_domain_for_user=False,
         )
         project.save()

--- a/corehq/apps/hqadmin/tests/test_stale_data_in_es.py
+++ b/corehq/apps/hqadmin/tests/test_stale_data_in_es.py
@@ -287,8 +287,7 @@ class TestStaleDataInESSQL(TestCase):
     @classmethod
     def setUpClass(cls):
         delete_all_cases()
-        cls.project = Domain.get_or_create_with_name(
-            cls.project_name, is_active=True, use_sql_backend=True)
+        cls.project = Domain.get_or_create_with_name(cls.project_name, is_active=True)
         cls.project.save()
         cls.elasticsearch = get_es_new()
         reset_es_index(XFORM_INDEX_INFO)

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -126,7 +126,6 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
             date_created=datetime.utcnow(),
             creating_user=current_user.username,
             secure_submissions=True,
-            use_sql_backend=True,
             first_domain_for_user=is_new_user
         )
 

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -149,11 +149,7 @@ def _get_forms_to_modify(domain, modified_forms, modified_cases, is_deletion):
         # all cases touched by this form are deleted
         return True
 
-    if is_deletion or Domain.get_by_name(domain).use_sql_backend:
-        all_forms = FormAccessors(domain).iter_forms(form_ids_to_modify)
-    else:
-        # accessor.iter_forms doesn't include deleted forms on the couch backend
-        all_forms = list(map(FormAccessors(domain).get_form, form_ids_to_modify))
+    all_forms = FormAccessors(domain).iter_forms(form_ids_to_modify)
     return [form.form_id for form in all_forms if _is_safe_to_modify(form)]
 
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/util.py
@@ -69,15 +69,12 @@ def bootstrap_case_from_xml(test_class, filename, case_id_override=None, domain=
 
 @contextmanager
 def create_case(domain, case_type, **kwargs):
+    assert should_use_sql_backend(domain), domain
     case = CaseFactory(domain).create_case(case_type=case_type, **kwargs)
-
     try:
         yield case
     finally:
-        if should_use_sql_backend(domain):
-            CaseAccessorSQL.hard_delete_cases(domain, [case.case_id])
-        else:
-            case.delete()
+        CaseAccessorSQL.hard_delete_cases(domain, [case.case_id])
 
 
 def _replace_ids_in_xform_xml(xml_data, case_id_override=None):

--- a/corehq/form_processor/tests/test_ledgers.py
+++ b/corehq/form_processor/tests/test_ledgers.py
@@ -12,7 +12,6 @@ from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import LedgerTransaction
 from corehq.form_processor.parsers.ledgers.helpers import UniqueLedgerReference
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_sql_backend, sharded
-from corehq.form_processor.utils.general import should_use_sql_backend
 
 from corehq.util.test_utils import softer_assert
 
@@ -190,18 +189,17 @@ class LedgerTests(TestCase):
         self.assertEqual(expected_balance, ledger.balance)
 
     def _assert_transactions(self, values, ignore_ordering=False):
-        if should_use_sql_backend(DOMAIN):
-            txs = LedgerAccessorSQL.get_ledger_transactions_for_case(self.case.case_id)
-            self.assertEqual(len(values), len(txs))
-            if ignore_ordering:
-                values = sorted(values, key=lambda v: (v.type, v.product_id))
-                txs = sorted(txs, key=lambda t: (t.type, t.entry_id))
-            for expected, tx in zip(values, txs):
-                self.assertEqual(expected.type, tx.type)
-                self.assertEqual(expected.product_id, tx.entry_id)
-                self.assertEqual('stock', tx.section_id)
-                self.assertEqual(expected.delta, tx.delta)
-                self.assertEqual(expected.updated_balance, tx.updated_balance)
+        txs = LedgerAccessorSQL.get_ledger_transactions_for_case(self.case.case_id)
+        self.assertEqual(len(values), len(txs))
+        if ignore_ordering:
+            values = sorted(values, key=lambda v: (v.type, v.product_id))
+            txs = sorted(txs, key=lambda t: (t.type, t.entry_id))
+        for expected, tx in zip(values, txs):
+            self.assertEqual(expected.type, tx.type)
+            self.assertEqual(expected.product_id, tx.entry_id)
+            self.assertEqual('stock', tx.section_id)
+            self.assertEqual(expected.delta, tx.delta)
+            self.assertEqual(expected.updated_balance, tx.updated_balance)
 
     def _expected_val(self, delta, updated_balance, type_=LedgerTransaction.TYPE_BALANCE, product_id=None):
         return TransactionValues(type_, product_id or self.product_a._id, delta, updated_balance)

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -22,7 +22,6 @@ from corehq.form_processor.backends.sql.dbaccessors import (
 from corehq.form_processor.backends.sql.processor import FormProcessorSQL
 from corehq.form_processor.interfaces.processor import ProcessedForms
 from corehq.form_processor.models import XFormInstanceSQL, CommCareCaseSQL, CaseTransaction, Attachment
-from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.sql_db.models import PartitionedModel
 from corehq.util.test_utils import unit_testing_only
 from couchforms.models import XFormInstance, all_known_formlike_doc_types
@@ -353,14 +352,6 @@ def create_form_for_test(
         form = FormAccessorSQL.get_form(form.form_id)
 
     return form
-
-
-@unit_testing_only
-def set_case_property_directly(case, property_name, value):
-    if should_use_sql_backend(case.domain):
-        case.case_json[property_name] = value
-    else:
-        setattr(case, property_name, value)
 
 
 def create_case(case) -> CommCareCaseSQL:

--- a/corehq/form_processor/utils/general.py
+++ b/corehq/form_processor/utils/general.py
@@ -1,29 +1,9 @@
-from django.conf import settings
-
-from corehq.toggles import TF_DOES_NOT_USE_SQLITE_BACKEND
-
-
 def should_use_sql_backend(domain_object_or_name):
-    if settings.ENTERPRISE_MODE or settings.UNIT_TESTING:
-        return True
-    domain_name, domain_object = _get_domain_name_and_object(domain_object_or_name)
-    return domain_object and domain_object.use_sql_backend
-
-
-def _get_domain_name_and_object(domain_object_or_name):
-    from corehq.apps.domain.models import Domain
-    if domain_object_or_name is None:
-        return None, None
-    elif isinstance(domain_object_or_name, Domain):
-        return domain_object_or_name.name, domain_object_or_name
-    elif getattr(settings, 'DB_ENABLED', True):
-        return domain_object_or_name, Domain.get_by_name(domain_object_or_name)
-    else:
-        return domain_object_or_name, None
+    return True
 
 
 def use_sqlite_backend(domain_name):
-    return not TF_DOES_NOT_USE_SQLITE_BACKEND.enabled(domain_name) or should_use_sql_backend(domain_name)
+    return True
 
 
 def is_commcarecase(obj):

--- a/corehq/motech/dhis2/tests/test_views.py
+++ b/corehq/motech/dhis2/tests/test_views.py
@@ -20,7 +20,7 @@ class BaseViewTest(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.domain = create_domain(DOMAIN, use_sql_backend=True)
+        cls.domain = create_domain(DOMAIN)
         cls.user = WebUser.create(DOMAIN, USERNAME, PASSWORD,
                                   created_by=None, created_via=None)
         cls.user.is_superuser = True
@@ -83,7 +83,7 @@ class TestDataSetMapUpdateView(BaseViewTest):
 
     def test_user_from_other_domain_404(self):
         other_domain = 'other-domain'
-        create_domain(other_domain, use_sql_backend=True)
+        create_domain(other_domain)
         user = WebUser.create(other_domain, 'other@user.com', PASSWORD,
                               created_by=None, created_via=None)
         self.addCleanup(user.delete, other_domain, None)

--- a/corehq/motech/fhir/tests/test_fhir_views.py
+++ b/corehq/motech/fhir/tests/test_fhir_views.py
@@ -33,7 +33,7 @@ class BaseFHIRViewTest(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.domain_obj = create_domain(DOMAIN, use_sql_backend=True)
+        cls.domain_obj = create_domain(DOMAIN)
         cls.user = WebUser.create(DOMAIN, USERNAME, PASSWORD,
                                   created_by=None, created_via=None)
         # ToDo: to be removed according to authentication updates by Smart-On-Fhir work

--- a/corehq/motech/repeaters/tests/test_payload_generators.py
+++ b/corehq/motech/repeaters/tests/test_payload_generators.py
@@ -150,5 +150,4 @@ def create_sql_domain(name):
         name,
         is_active=True,
         secure_submissions=False,
-        use_sql_backend=True,
     )

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1210,13 +1210,6 @@ CALL_CENTER_LOCATION_OWNERS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-TF_DOES_NOT_USE_SQLITE_BACKEND = StaticToggle(
-    'not_tf_sql_backend',
-    'Domains that do not use a SQLite backend for Touchforms',
-    TAG_INTERNAL,
-    [NAMESPACE_DOMAIN],
-)
-
 CUSTOM_APP_BASE_URL = StaticToggle(
     'custom_app_base_url',
     'Allow specifying a custom base URL for an application. Main use case is '

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -613,6 +613,7 @@ def create_test_case(domain, case_type, case_name, case_properties=None, drop_si
     from corehq.form_processor.utils.general import should_use_sql_backend
     from corehq.messaging.scheduling.scheduling_partitioned.dbaccessors import delete_schedule_instances_by_case_id
 
+    assert should_use_sql_backend(domain), domain
     case = create_and_save_a_case(domain, case_id or uuid.uuid4().hex, case_name,
         case_properties=case_properties, case_type=case_type, drop_signals=drop_signals,
         owner_id=owner_id, user_id=user_id)
@@ -621,10 +622,7 @@ def create_test_case(domain, case_type, case_name, case_properties=None, drop_si
     finally:
         delete_phone_numbers_for_owners([case.case_id])
         delete_schedule_instances_by_case_id(domain, case.case_id)
-        if should_use_sql_backend(domain):
-            CaseAccessorSQL.hard_delete_cases(domain, [case.case_id])
-        else:
-            case.delete()
+        CaseAccessorSQL.hard_delete_cases(domain, [case.case_id])
 
 
 create_test_case.__test__ = False


### PR DESCRIPTION
Remove some more uses of `should_use_sql_backend()`, and nearly completely remove `Domain.use_sql_backend`. The one exception is the field in the elastic mapping:

https://github.com/dimagi/commcare-hq/blob/efc36ab8f43f132f1bd840bbe8766122717046d9/corehq/pillows/mappings/domain_mapping.py#L257

Which I believe will require an elastic reindex to remove. It doesn't seem to be hurting anything to let it there. Thoughts welcome.

:tropical_fish: Review by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No new tests were added. Unused features are being removed. Tests that depended on those features were removed previously.

### QA Plan

No QA.

### Safety story

All domains in active environments are using the SQL backend, so everything removed in this PR, including code removed from tests, should be unused or unnecessary.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
