### PR TITLE
Add bulk export action for Form exports and bulk delete for form, case, daily saved exports and feeds

### DIFF
--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -44,7 +44,6 @@ hqDefine("export/js/export_list", [
         options.formname = options.formname || '';
         assertProperties.assert(options, [
             'addedToBulk',
-            'addedToBulk2',
             'can_edit',
             'deleteUrl',
             'description',
@@ -413,7 +412,7 @@ hqDefine("export/js/export_list", [
             return true;
         };
 
-        // Bulk export handling
+        // Bulk action handling
         self.selectAll = function () {
             _.each(self.exports(), function (e) { e.addedToBulk(true); });
         };
@@ -435,17 +434,15 @@ hqDefine("export/js/export_list", [
             return true;
         };
 
-        //Bulk Delete Handling - TESTTTTT Delete2
-        //just copying most of the funcs from above
+        self.bulkDeleteList = ko.computed(function () {
+            return _.filter(self.exports(), function (e) {return e.addedToBulk();})
+        });
 
-        self.selectDeleteAll = function () {
-            _.each(self.exports(), function (e) { e.addedToBulk2(true); });
-        };
-        self.selectDeleteNone = function () {
-            _.each(self.exports(), function (e) { e.addedToBulk2(false); });
-        };
-        self.bulkDeleteCount = ko.computed(function () {
-            return _.filter(self.exports(), function (e) { return e.addedToBulk2(); }).length;
+        self.multipleBulkSelected = ko.computed(function () {
+            if(self.bulkDeleteList().length > 1){
+                return true
+            };
+            return false;
         });
 
         self.BulkExportDelete = function (observable, event) {
@@ -455,7 +452,7 @@ hqDefine("export/js/export_list", [
                     $(event.currentTarget).closest('form').submit();
                 }, 250);
             } else {
-                _.each(_.filter(self.exports(), function (e) {return e.addedToBulk2();}),
+                _.each(_.filter(self.exports(), function (e) {return e.addedToBulk();}),
                    function (e) { $.ajax({
                                     method: 'POST',
                                     url: e.deleteUrl(),

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -44,6 +44,7 @@ hqDefine("export/js/export_list", [
         options.formname = options.formname || '';
         assertProperties.assert(options, [
             'addedToBulk',
+            'addedToBulk2',
             'can_edit',
             'deleteUrl',
             'description',
@@ -432,6 +433,36 @@ hqDefine("export/js/export_list", [
             })));
 
             return true;
+        };
+
+        //Bulk Delete Handling - TESTTTTT Delete2
+        //just copying most of the funcs from above
+
+        self.selectDeleteAll = function () {
+            _.each(self.exports(), function (e) { e.addedToBulk2(true); });
+        };
+        self.selectDeleteNone = function () {
+            _.each(self.exports(), function (e) { e.addedToBulk2(false); });
+        };
+        self.bulkDeleteCount = ko.computed(function () {
+            return _.filter(self.exports(), function (e) { return e.addedToBulk2(); }).length;
+        });
+
+        self.BulkExportDelete = function (observable, event) {
+            if (options.isOData) {
+                kissmetricsAnalytics.track.event("[BI Integration] Deleted Feed");
+                setTimeout(function () {
+                    $(event.currentTarget).closest('form').submit();
+                }, 250);
+            } else {
+                _.each(_.filter(self.exports(), function (e) {return e.addedToBulk2();}),
+                   function (e) { $.ajax({
+                                    method: 'POST',
+                                    url: e.deleteUrl(),
+                                  });
+                   });
+            }
+            location.reload(); //there's probably a better way to do it that I'm not seeing
         };
 
         // HTML elements from filter form - admittedly it's not very knockout-y to manipulate these directly

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -189,15 +189,15 @@ hqDefine("export/js/export_list", [
 
         //button hover text
         self.popoverText = "";
-        if(self.isOData() || self.isFeed()){
+        if (self.isOData() || self.isFeed()) {
             self.popoverText = "All of the selected feeds will be deleted.";
         }
-        else{
+        else {
             self.popoverText = "All of the selected exports will be deleted.";
         }
 
         $('#bulk-delete-text').tooltip({
-            trigger : 'hover',
+            trigger: 'hover',
             placement: 'top',
             title: gettext(self.popoverText),
         });
@@ -444,8 +444,8 @@ hqDefine("export/js/export_list", [
         };
 
         // Bulk action handling
-         self.bulkDeleteList = ko.computed(function () {
-            return _.filter(self.exports(), function (e) {return e.addedToBulk();})
+        self.bulkDeleteList = ko.computed(function () {
+            return _.filter(self.exports(), function (e) {return e.addedToBulk();});
         });
         self.bulkExportDownloadCount = ko.computed(function () {
             return self.bulkDeleteList().length;
@@ -463,35 +463,35 @@ hqDefine("export/js/export_list", [
         };
 
         self.multiple = ko.computed(function () {
-            if(self.bulkDeleteList().length > 1) { return "s"}
-            return ""
+            if (self.bulkDeleteList().length > 1) { return "s"; }
+            return "";
         });
         self.plural = ko.computed(function () {
-            if(self.bulkDeleteList().length > 1) { return "these"}
-            return "this"
+            if (self.bulkDeleteList().length > 1) { return "these"; }
+            return "this";
         });
 
         self.BulkExportDelete = function (observable, event) {
-            count = self.bulkExportDownloadCount;
+            var count = self.bulkExportDownloadCount;
             //probably a better fix for this
-            for(let i = 0; i < self.panels().length; i++){
-                panel = self.panels()[i];
+            for (let i = 0; i < self.panels().length; i++) {
+                var panel = self.panels()[i];
                 panel.isLoadingPanel(true);
                 panel.isNotBulkDeleting(false);
             }
-            bulkDelete = function () {
-                selected = _.filter(self.exports(), function (e) {return e.addedToBulk();});
-                deleteArray = [];
+            var bulkDelete = function () {
+                var selected = _.filter(self.exports(), function (e) { return e.addedToBulk() });
+                var deleteArray = [];
                 selected.forEach(function (item, i) {
                     var attr = {};
                     attr["domain"] = item.domain();
                     attr["type"] = item.type();
                     attr["id"] = item.id();
-                    if (attr["id"] != selected[0].id()){
+                    if (attr["id"] !== selected[0].id()) {
                         deleteArray.push(attr);
                     }
                 });
-                deleteList = JSON.stringify(deleteArray);
+                var deleteList = JSON.stringify(deleteArray);
                 $.ajax({
                     method: 'POST',
                     url: selected[0].deleteUrl(),
@@ -501,9 +501,12 @@ hqDefine("export/js/export_list", [
                     },
                     success: function (url) {
                         window.location.href = url;
-                    }
+                    },
+                    error: function () {
+                        location.reload();
+                    },
                 });
-            }
+            };
             if (options.isOData) {
                 kissmetricsAnalytics.track.event("[BI Integration] Deleted Feed");
                 setTimeout(function () {

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -187,22 +187,6 @@ hqDefine("export/js/export_list", [
             });
         };
 
-        var tooltipText = "";
-        if (self.isOData() || self.isFeed()) {
-            tooltipText = "All of the selected feeds will be deleted.";
-        } else {
-            tooltipText = "All of the selected exports will be deleted.";
-        }
-
-        $(function () {
-            $('[data-toggle="tooltip-bulkExport"]').attr('title',
-                "All of the selected exports will be collected for download to a single Excel file, with each export as a separate sheet.").tooltip();
-        });
-
-        $(function () {
-            $('[data-toggle="tooltip-bulkDelete"]').attr('title', tooltipText).tooltip({trigger: 'hover'});
-        });
-
         return self;
     };
 
@@ -457,6 +441,23 @@ hqDefine("export/js/export_list", [
 
             return true;
         };
+
+        var tooltipText = "";
+        if (self.isOData || self.isFeed) {
+            tooltipText = gettext("All of the selected feeds will be deleted.");
+        } else {
+            tooltipText = gettext("All of the selected exports will be deleted.");
+        }
+
+        $(function () {
+            $('[data-toggle="tooltip-bulkExport"]').attr('title',
+                gettext("All of the selected exports will be collected for download to a " +
+                "single Excel file, with each export as a separate sheet.")).tooltip();
+        });
+
+        $(function () {
+            $('[data-toggle="tooltip-bulkDelete"]').attr('title', tooltipText).tooltip({trigger: 'hover'});
+        });
 
         self.isMultiple = ko.computed(function () {
             if (self.bulkDeleteList().length > 1) { return true; }

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -187,6 +187,26 @@ hqDefine("export/js/export_list", [
             });
         };
 
+        //button hover text
+        self.popoverText = "";
+        if(self.isOData() || self.isFeed()){
+            self.popoverText = "All of the selected feeds will be deleted.";
+        }
+        else{
+            self.popoverText = "All of the selected exports will be deleted.";
+        }
+
+        $('#bulk-delete-text').tooltip({
+            trigger : 'hover',
+            placement: 'top',
+            title: gettext(self.popoverText),
+        });
+
+        $('#bulk-export-text').tooltip({
+            placement: 'top',
+            title: gettext("All of the selected exports will be collected for download to a single Excel file, with each export as a separate sheet."),
+        });
+
         return self;
     };
 

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -298,6 +298,7 @@ hqDefine("export/js/export_list", [
 
         // Loading/error handling UI
         self.loadingErrorMessage = ko.observable('');
+        self.isNotBulkDeleting = ko.observable(true);
         self.isLoadingPanel = ko.observable(true);
         self.isLoadingPage = ko.observable(false);
         self.hasError = ko.observable(false);
@@ -452,6 +453,12 @@ hqDefine("export/js/export_list", [
 
         self.BulkExportDelete = function (observable, event) {
             count = self.bulkExportDownloadCount;
+            //probably a better fix for this
+            for(let i = 0; i < self.panels().length; i++){
+                panel = self.panels()[i];
+                panel.isLoadingPanel(true);
+                panel.isNotBulkDeleting(false);
+            }
             bulkDelete = function () {
                 selected = _.filter(self.exports(), function (e) {return e.addedToBulk();});
                 deleteArray = [];

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -187,30 +187,21 @@ hqDefine("export/js/export_list", [
             });
         };
 
-        //button hover text
-        function tooltipStyle(color, margin) {
-            $('.tooltip-inner').css({'background-color': color, 'color': 'black', 'margin-right': margin})
-            $('.tooltip.top .tooltip-arrow').css({'border-top-color': color});
-        }
-
-        var popoverText = "";
+        var tooltipText = "";
         if (self.isOData() || self.isFeed()) {
-            popoverText = "All of the selected feeds will be deleted.";
-        }
-        else {
-            popoverText = "All of the selected exports will be deleted.";
+            tooltipText = "All of the selected feeds will be deleted.";
+        } else {
+            tooltipText = "All of the selected exports will be deleted.";
         }
 
-        $('#bulk-delete-text').tooltip({
-            trigger: 'hover',
-            placement: 'top',
-            title: gettext(popoverText),
-        }).mouseover(function() {tooltipStyle('#f2dede', '0px')});
+        $(function () {
+            $('[data-toggle="tooltip-bulkExport"]').attr('title',
+                "All of the selected exports will be collected for download to a single Excel file, with each export as a separate sheet.").tooltip();
+        });
 
-        $('#bulk-export-text').tooltip({
-            placement: 'top',
-            title: gettext("All of the selected exports will be collected for download to a single Excel file, with each export as a separate sheet."),
-        }).mouseover(function() {tooltipStyle('#d9edf7', '10px')});
+        $(function () {
+            $('[data-toggle="tooltip-bulkDelete"]').attr('title', tooltipText).tooltip({trigger: 'hover'});
+        });
 
         return self;
     };
@@ -467,13 +458,9 @@ hqDefine("export/js/export_list", [
             return true;
         };
 
-        self.multiple = ko.computed(function () {
-            if (self.bulkDeleteList().length > 1) { return "s"; }
-            return "";
-        });
-        self.plural = ko.computed(function () {
-            if (self.bulkDeleteList().length > 1) { return "these"; }
-            return "this";
+        self.isMultiple = ko.computed(function () {
+            if (self.bulkDeleteList().length > 1) { return true; }
+            return false;
         });
 
         self.BulkExportDelete = function (observable, event) {
@@ -482,7 +469,7 @@ hqDefine("export/js/export_list", [
             var bulkDelete = function () {
                 var selected = _.filter(self.exports(), function (e) { return e.addedToBulk(); });
                 var deleteArray = [];
-                selected.forEach(function (item, i) {
+                selected.forEach(function (item) {
                     var attr = {};
                     attr["domain"] = item.domain();
                     attr["type"] = item.type();

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -44,9 +44,11 @@ hqDefine("export/js/export_list", [
         options.formname = options.formname || '';
         assertProperties.assert(options, [
             'addedToBulk',
+            'additionalODataUrls',
             'can_edit',
             'deleteUrl',
             'description',
+            'domain',
             'downloadUrl',
             'showDetDownload',
             'detSchemaUrl',
@@ -59,10 +61,10 @@ hqDefine("export/js/export_list", [
             'isDeid',
             'lastBuildDuration',
             'name',
+            'odataUrl',
             'owner_username',
             'sharing',
-            'odataUrl',
-            'additionalODataUrls',
+            'type',
         ], [
             'case_type',
             'isAutoRebuildEnabled',
@@ -309,6 +311,14 @@ hqDefine("export/js/export_list", [
             return !self.isLoadingPanel() && !self.hasError() && self.exports().length;
         });
 
+        //Bulk Action selection
+        self.selectAll = function () {
+            _.each(self.exports(), function (e) { e.addedToBulk(true); });
+        };
+        self.selectNone = function () {
+            _.each(self.exports(), function (e) { e.addedToBulk(false); });
+        };
+
         self.totalItems = ko.observable(0);
         self.itemsPerPage = ko.observable();
         self.goToPage = function (page) {
@@ -413,14 +423,11 @@ hqDefine("export/js/export_list", [
         };
 
         // Bulk action handling
-        self.selectAll = function () {
-            _.each(self.exports(), function (e) { e.addedToBulk(true); });
-        };
-        self.selectNone = function () {
-            _.each(self.exports(), function (e) { e.addedToBulk(false); });
-        };
+         self.bulkDeleteList = ko.computed(function () {
+            return _.filter(self.exports(), function (e) {return e.addedToBulk();})
+        });
         self.bulkExportDownloadCount = ko.computed(function () {
-            return _.filter(self.exports(), function (e) { return e.addedToBulk(); }).length;
+            return self.bulkDeleteList().length;
         });
         self.bulkExportList = ko.observable('');
         self.submitBulkExportDownload = function () {
@@ -434,32 +441,50 @@ hqDefine("export/js/export_list", [
             return true;
         };
 
-        self.bulkDeleteList = ko.computed(function () {
-            return _.filter(self.exports(), function (e) {return e.addedToBulk();})
+        self.multiple = ko.computed(function () {
+            if(self.bulkDeleteList().length > 1) { return "s"}
+            return ""
         });
-
-        self.multipleBulkSelected = ko.computed(function () {
-            if(self.bulkDeleteList().length > 1){
-                return true
-            };
-            return false;
+        self.plural = ko.computed(function () {
+            if(self.bulkDeleteList().length > 1) { return "these"}
+            return "this"
         });
 
         self.BulkExportDelete = function (observable, event) {
+            count = self.bulkExportDownloadCount;
+            bulkDelete = function () {
+                selected = _.filter(self.exports(), function (e) {return e.addedToBulk();});
+                deleteArray = [];
+                selected.forEach(function (item, i) {
+                    var attr = {};
+                    attr["domain"] = item.domain();
+                    attr["type"] = item.type();
+                    attr["id"] = item.id();
+                    if (attr["id"] != selected[0].id()){
+                        deleteArray.push(attr);
+                    }
+                });
+                deleteList = JSON.stringify(deleteArray);
+                $.ajax({
+                    method: 'POST',
+                    url: selected[0].deleteUrl(),
+                    data: {
+                        "count": count,
+                        "deleteList": deleteList,
+                    },
+                    success: function (url) {
+                        window.location.href = url;
+                    }
+                });
+            }
             if (options.isOData) {
                 kissmetricsAnalytics.track.event("[BI Integration] Deleted Feed");
                 setTimeout(function () {
-                    $(event.currentTarget).closest('form').submit();
+                    bulkDelete();
                 }, 250);
             } else {
-                _.each(_.filter(self.exports(), function (e) {return e.addedToBulk();}),
-                   function (e) { $.ajax({
-                                    method: 'POST',
-                                    url: e.deleteUrl(),
-                                  });
-                   });
+                bulkDelete();
             }
-            location.reload(); //there's probably a better way to do it that I'm not seeing
         };
 
         // HTML elements from filter form - admittedly it's not very knockout-y to manipulate these directly

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -188,24 +188,29 @@ hqDefine("export/js/export_list", [
         };
 
         //button hover text
-        self.popoverText = "";
+        function tooltipStyle(color, margin) {
+            $('.tooltip-inner').css({'background-color': color, 'color': 'black', 'margin-right': margin})
+            $('.tooltip.top .tooltip-arrow').css({'border-top-color': color});
+        }
+
+        var popoverText = "";
         if (self.isOData() || self.isFeed()) {
-            self.popoverText = "All of the selected feeds will be deleted.";
+            popoverText = "All of the selected feeds will be deleted.";
         }
         else {
-            self.popoverText = "All of the selected exports will be deleted.";
+            popoverText = "All of the selected exports will be deleted.";
         }
 
         $('#bulk-delete-text').tooltip({
             trigger: 'hover',
             placement: 'top',
-            title: gettext(self.popoverText),
-        });
+            title: gettext(popoverText),
+        }).mouseover(function() {tooltipStyle('#f2dede', '0px')});
 
         $('#bulk-export-text').tooltip({
             placement: 'top',
             title: gettext("All of the selected exports will be collected for download to a single Excel file, with each export as a separate sheet."),
-        });
+        }).mouseover(function() {tooltipStyle('#d9edf7', '10px')});
 
         return self;
     };
@@ -318,7 +323,7 @@ hqDefine("export/js/export_list", [
 
         // Loading/error handling UI
         self.loadingErrorMessage = ko.observable('');
-        self.isNotBulkDeleting = ko.observable(true);
+        self.isBulkDeleting = ko.observable(false);
         self.isLoadingPanel = ko.observable(true);
         self.isLoadingPage = ko.observable(false);
         self.hasError = ko.observable(false);
@@ -473,14 +478,9 @@ hqDefine("export/js/export_list", [
 
         self.BulkExportDelete = function (observable, event) {
             var count = self.bulkExportDownloadCount;
-            //probably a better fix for this
-            for (let i = 0; i < self.panels().length; i++) {
-                var panel = self.panels()[i];
-                panel.isLoadingPanel(true);
-                panel.isNotBulkDeleting(false);
-            }
+            self.panels().forEach(panel => panel.isBulkDeleting(true));
             var bulkDelete = function () {
-                var selected = _.filter(self.exports(), function (e) { return e.addedToBulk() });
+                var selected = _.filter(self.exports(), function (e) { return e.addedToBulk(); });
                 var deleteArray = [];
                 selected.forEach(function (item, i) {
                     var attr = {};

--- a/corehq/apps/export/templates/export/dialogs/bulk_delete_custom_export_dialog.html
+++ b/corehq/apps/export/templates/export/dialogs/bulk_delete_custom_export_dialog.html
@@ -3,25 +3,46 @@
 <div data-bind="attr: {id: 'bulk-delete-export-modal'}" class="modal fade">
   <div class="modal-dialog">
     <div class="modal-content">
-      <div class="modal-header">
+      <div class="modal-header" style="color:black;">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <h4 class="modal-title">
-          {% blocktrans %}
-              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Selected Exports
-            {% endblocktrans %}
-        </h4>
-      </div>
-      <div class="modal-body">
-        <p>
-          <div data-bind="if: !multipleBulkSelected()">
+          <div data-bind="if: isOData || isFeed">
             {% blocktrans %}
-              Are you sure you want to permanently delete this <strong>1 export</strong>:
+              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Selected Feeds
             {% endblocktrans %}
           </div>
-          <div data-bind="if: multipleBulkSelected()">
+          <div data-bind="if: !isOData && !isFeed">
             {% blocktrans %}
-              Are you sure you want to permanently delete these <strong><span data-bind="text: bulkExportDownloadCount()"></span> exports</strong>:
+              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Selected Exports
             {% endblocktrans %}
+          </div>
+        </h4>
+      </div>
+      <div class="modal-body" style="color:black;">
+        <p>
+          <div data-bind="if: !multipleBulkSelected()">
+            <div data-bind="if: isOData || isFeed">
+              {% blocktrans %}
+                Are you sure you want to permanently delete this <strong>1 feed</strong>:
+              {% endblocktrans %}
+            </div>
+            <div data-bind="if: !isOData && !isFeed">
+              {% blocktrans %}
+                Are you sure you want to permanently delete this <strong>1 export</strong>:
+              {% endblocktrans %}
+            </div>
+          </div>
+          <div data-bind="if: multipleBulkSelected()">
+            <div data-bind="if: isOData || isFeed">
+              {% blocktrans %}
+                Are you sure you want to permanently delete these <strong><span data-bind="text: bulkExportDownloadCount()"></span> feeds</strong>:
+              {% endblocktrans %}
+            </div>
+            <div data-bind="if: !isOData && !isFeed">
+              {% blocktrans %}
+                Are you sure you want to permanently delete these <strong><span data-bind="text: bulkExportDownloadCount()"></span> exports</strong>:
+              {% endblocktrans %}
+            </div>
           </div>
           <br>
             <ul data-bind="foreach: bulkDeleteList()">
@@ -31,10 +52,18 @@
       </div>
       <div class="modal-footer">
         <button class="btn btn-danger" data-bind="click: BulkExportDelete" data-dismiss="modal">
-          <i class="fa fa-remove"></i>
-          {% blocktrans %}
-            Delete <span data-bind="text: bulkExportDownloadCount()"></span> Exports
-          {% endblocktrans %}
+          <div data-bind="if: isOData || isFeed">
+            <i class="fa fa-remove"></i>
+            {% blocktrans %}
+              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Selected Feeds
+            {% endblocktrans %}
+          </div>
+          <div data-bind="if: !isOData && !isFeed">
+            <i class="fa fa-remove"></i>
+            {% blocktrans %}
+              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Selected Exports
+            {% endblocktrans %}
+          </div>
         </button>
         <a href="#" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</a>
       </div>

--- a/corehq/apps/export/templates/export/dialogs/bulk_delete_custom_export_dialog.html
+++ b/corehq/apps/export/templates/export/dialogs/bulk_delete_custom_export_dialog.html
@@ -1,0 +1,30 @@
+{% load hq_shared_tags %}
+{% load i18n %}
+<div data-bind="attr: {id: 'bulk-delete-export-modal'}" class="modal fade">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">
+          {% blocktrans %}
+              Delete selected exports?
+            {% endblocktrans %}
+        </h4>
+      </div>
+      <div class="modal-body">
+        <p>
+            {% blocktrans %}
+              Scrollable list of exports here?
+            {% endblocktrans %}
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-danger" data-bind="click: BulkExportDelete" data-dismiss="modal">
+          <i class="fa fa-remove"></i>
+          {% trans "Delete" %}
+        </button>
+        <a href="#" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/corehq/apps/export/templates/export/dialogs/bulk_delete_custom_export_dialog.html
+++ b/corehq/apps/export/templates/export/dialogs/bulk_delete_custom_export_dialog.html
@@ -7,21 +7,34 @@
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <h4 class="modal-title">
           {% blocktrans %}
-              Delete selected exports?
+              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Selected Exports
             {% endblocktrans %}
         </h4>
       </div>
       <div class="modal-body">
         <p>
+          <div data-bind="if: !multipleBulkSelected()">
             {% blocktrans %}
-              Scrollable list of exports here?
+              Are you sure you want to permanently delete this <strong>1 export</strong>:
             {% endblocktrans %}
+          </div>
+          <div data-bind="if: multipleBulkSelected()">
+            {% blocktrans %}
+              Are you sure you want to permanently delete these <strong><span data-bind="text: bulkExportDownloadCount()"></span> exports</strong>:
+            {% endblocktrans %}
+          </div>
+          <br>
+            <ul data-bind="foreach: bulkDeleteList()">
+              <li data-bind="text: name"></li>
+            </ul>
         </p>
       </div>
       <div class="modal-footer">
         <button class="btn btn-danger" data-bind="click: BulkExportDelete" data-dismiss="modal">
           <i class="fa fa-remove"></i>
-          {% trans "Delete" %}
+          {% blocktrans %}
+            Delete <span data-bind="text: bulkExportDownloadCount()"></span> Exports
+          {% endblocktrans %}
         </button>
         <a href="#" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</a>
       </div>

--- a/corehq/apps/export/templates/export/dialogs/bulk_delete_custom_export_dialog.html
+++ b/corehq/apps/export/templates/export/dialogs/bulk_delete_custom_export_dialog.html
@@ -8,41 +8,29 @@
         <h4 class="modal-title">
           <div data-bind="if: isOData || isFeed">
             {% blocktrans %}
-              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Selected Feeds
+              Delete <span data-bind="text: bulkDeleteList().length"></span> Selected Feed<span data-bind="text: multiple()"></span>
             {% endblocktrans %}
           </div>
           <div data-bind="if: !isOData && !isFeed">
             {% blocktrans %}
-              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Selected Exports
+              Delete <span data-bind="text: bulkDeleteList().length"></span> Selected Export<span data-bind="text: multiple()"></span>
             {% endblocktrans %}
           </div>
         </h4>
       </div>
       <div class="modal-body" style="color:black;">
         <p>
-          <div data-bind="if: !multipleBulkSelected()">
-            <div data-bind="if: isOData || isFeed">
-              {% blocktrans %}
-                Are you sure you want to permanently delete this <strong>1 feed</strong>:
-              {% endblocktrans %}
-            </div>
-            <div data-bind="if: !isOData && !isFeed">
-              {% blocktrans %}
-                Are you sure you want to permanently delete this <strong>1 export</strong>:
-              {% endblocktrans %}
-            </div>
+          <div data-bind="if: isOData || isFeed">
+            {% blocktrans %}
+              Are you sure you want to permanently delete <span data-bind="text: plural()"></span>
+              <strong><span data-bind="text: bulkExportDownloadCount()"></span> feed<span data-bind="text: multiple()"></span> </strong>:
+            {% endblocktrans %}
           </div>
-          <div data-bind="if: multipleBulkSelected()">
-            <div data-bind="if: isOData || isFeed">
-              {% blocktrans %}
-                Are you sure you want to permanently delete these <strong><span data-bind="text: bulkExportDownloadCount()"></span> feeds</strong>:
-              {% endblocktrans %}
-            </div>
-            <div data-bind="if: !isOData && !isFeed">
-              {% blocktrans %}
-                Are you sure you want to permanently delete these <strong><span data-bind="text: bulkExportDownloadCount()"></span> exports</strong>:
-              {% endblocktrans %}
-            </div>
+          <div data-bind="if: !isOData && !isFeed">
+            {% blocktrans %}
+              Are you sure you want to permanently delete <span data-bind="text: plural()"></span>
+              <strong><span data-bind="text: bulkExportDownloadCount()"></span> export<span data-bind="text: multiple()"></span> </strong>:
+            {% endblocktrans %}
           </div>
           <br>
             <ul data-bind="foreach: bulkDeleteList()">
@@ -55,13 +43,13 @@
           <div data-bind="if: isOData || isFeed">
             <i class="fa fa-remove"></i>
             {% blocktrans %}
-              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Selected Feeds
+              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Selected Feed<span data-bind="text: multiple()"></span>
             {% endblocktrans %}
           </div>
           <div data-bind="if: !isOData && !isFeed">
             <i class="fa fa-remove"></i>
             {% blocktrans %}
-              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Selected Exports
+              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Selected Export<span data-bind="text: multiple()"></span>
             {% endblocktrans %}
           </div>
         </button>

--- a/corehq/apps/export/templates/export/dialogs/bulk_delete_custom_export_dialog.html
+++ b/corehq/apps/export/templates/export/dialogs/bulk_delete_custom_export_dialog.html
@@ -8,12 +8,12 @@
         <h4 class="modal-title">
           <div data-bind="if: isOData || isFeed">
             {% blocktrans %}
-              Delete <span data-bind="text: bulkDeleteList().length"></span> Selected Feed<span data-bind="text: multiple()"></span>
+              Delete <span data-bind="text: bulkDeleteList().length"></span> Feed<span data-bind="text: multiple()"></span>
             {% endblocktrans %}
           </div>
           <div data-bind="if: !isOData && !isFeed">
             {% blocktrans %}
-              Delete <span data-bind="text: bulkDeleteList().length"></span> Selected Export<span data-bind="text: multiple()"></span>
+              Delete <span data-bind="text: bulkDeleteList().length"></span> Export<span data-bind="text: multiple()"></span>
             {% endblocktrans %}
           </div>
         </h4>
@@ -43,13 +43,13 @@
           <div data-bind="if: isOData || isFeed">
             <i class="fa fa-remove"></i>
             {% blocktrans %}
-              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Selected Feed<span data-bind="text: multiple()"></span>
+              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Feed<span data-bind="text: multiple()"></span>
             {% endblocktrans %}
           </div>
           <div data-bind="if: !isOData && !isFeed">
             <i class="fa fa-remove"></i>
             {% blocktrans %}
-              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Selected Export<span data-bind="text: multiple()"></span>
+              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Export<span data-bind="text: multiple()"></span>
             {% endblocktrans %}
           </div>
         </button>

--- a/corehq/apps/export/templates/export/dialogs/bulk_delete_custom_export_dialog.html
+++ b/corehq/apps/export/templates/export/dialogs/bulk_delete_custom_export_dialog.html
@@ -23,13 +23,13 @@
           <div data-bind="if: isOData || isFeed">
             {% blocktrans %}
               Are you sure you want to permanently delete <span data-bind="text: plural()"></span>
-              <strong><span data-bind="text: bulkExportDownloadCount()"></span> feed<span data-bind="text: multiple()"></span> </strong>:
+              <strong><span data-bind="text: bulkExportDownloadCount()"></span> feed<span data-bind="text: multiple()"></span></strong>?
             {% endblocktrans %}
           </div>
           <div data-bind="if: !isOData && !isFeed">
             {% blocktrans %}
               Are you sure you want to permanently delete <span data-bind="text: plural()"></span>
-              <strong><span data-bind="text: bulkExportDownloadCount()"></span> export<span data-bind="text: multiple()"></span> </strong>:
+              <strong><span data-bind="text: bulkExportDownloadCount()"></span> export<span data-bind="text: multiple()"></span></strong>?
             {% endblocktrans %}
           </div>
           <br>

--- a/corehq/apps/export/templates/export/dialogs/bulk_delete_custom_export_dialog.html
+++ b/corehq/apps/export/templates/export/dialogs/bulk_delete_custom_export_dialog.html
@@ -6,32 +6,54 @@
       <div class="modal-header" style="color:black;">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <h4 class="modal-title">
-          <div data-bind="if: isOData || isFeed">
-            {% blocktrans %}
-              Delete <span data-bind="text: bulkDeleteList().length"></span> Feed<span data-bind="text: multiple()"></span>
-            {% endblocktrans %}
-          </div>
-          <div data-bind="if: !isOData && !isFeed">
-            {% blocktrans %}
-              Delete <span data-bind="text: bulkDeleteList().length"></span> Export<span data-bind="text: multiple()"></span>
-            {% endblocktrans %}
-          </div>
+          <!-- ko if: isOData || isFeed -->
+            <!-- ko if: isMultiple -->
+              {% blocktrans %}
+                Delete <!-- ko text: bulkExportDownloadCount() --><!-- /ko --> Feeds
+              {% endblocktrans %}
+            <!-- /ko -->
+            <!-- ko if: !isMultiple() -->
+              {% trans "Delete 1 Feed" %}
+            <!-- /ko -->
+          <!-- /ko -->
+          <!-- ko if: !isOData && !isFeed -->
+            <!-- ko if: isMultiple -->
+              {% blocktrans %}
+                Delete <!-- ko text: bulkExportDownloadCount() --><!-- /ko --> Exports
+              {% endblocktrans %}
+            <!-- /ko -->
+            <!-- ko if: !isMultiple() -->
+              {% trans "Delete 1 Export" %}
+            <!-- /ko -->
+          <!-- /ko -->
         </h4>
       </div>
       <div class="modal-body" style="color:black;">
         <p>
-          <div data-bind="if: isOData || isFeed">
-            {% blocktrans %}
-              Are you sure you want to permanently delete <span data-bind="text: plural()"></span>
-              <strong><span data-bind="text: bulkExportDownloadCount()"></span> feed<span data-bind="text: multiple()"></span></strong>?
-            {% endblocktrans %}
-          </div>
-          <div data-bind="if: !isOData && !isFeed">
-            {% blocktrans %}
-              Are you sure you want to permanently delete <span data-bind="text: plural()"></span>
-              <strong><span data-bind="text: bulkExportDownloadCount()"></span> export<span data-bind="text: multiple()"></span></strong>?
-            {% endblocktrans %}
-          </div>
+          <!-- ko if: isOData || isFeed -->
+            <!-- ko if: isMultiple -->
+              {% blocktrans %}
+                Are you sure you want to permanently delete these <strong><!-- ko text: bulkExportDownloadCount() --><!-- /ko --> feeds</strong>?
+              {% endblocktrans %}
+            <!-- /ko -->
+            <!-- ko if: !isMultiple() -->
+              {% blocktrans %}
+                Are you sure you want to permanently delete this <strong>1 feed</strong>?
+              {% endblocktrans %}
+            <!-- /ko -->
+          <!-- /ko -->
+          <!-- ko if: !isOData && !isFeed -->
+            <!-- ko if: isMultiple -->
+              {% blocktrans %}
+                Are you sure you want to permanently delete these <strong><!-- ko text: bulkExportDownloadCount() --><!-- /ko --> exports</strong>?
+              {% endblocktrans %}
+            <!-- /ko -->
+            <!-- ko if: !isMultiple() -->
+              {% blocktrans %}
+                Are you sure you want to permanently delete this <strong>1 export</strong>?
+              {% endblocktrans %}
+            <!-- /ko -->
+          <!-- /ko -->
           <br>
             <ul data-bind="foreach: bulkDeleteList()">
               <li data-bind="text: name"></li>
@@ -40,18 +62,27 @@
       </div>
       <div class="modal-footer">
         <button class="btn btn-danger" data-bind="click: BulkExportDelete" data-dismiss="modal">
-          <div data-bind="if: isOData || isFeed">
-            <i class="fa fa-remove"></i>
-            {% blocktrans %}
-              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Feed<span data-bind="text: multiple()"></span>
-            {% endblocktrans %}
-          </div>
-          <div data-bind="if: !isOData && !isFeed">
-            <i class="fa fa-remove"></i>
-            {% blocktrans %}
-              Delete <span data-bind="text: bulkExportDownloadCount()"></span> Export<span data-bind="text: multiple()"></span>
-            {% endblocktrans %}
-          </div>
+          <i class="fa fa-remove"></i>
+          <!-- ko if: isOData || isFeed -->
+            <!-- ko if: isMultiple -->
+              {% blocktrans %}
+                Delete <!-- ko text: bulkExportDownloadCount() --><!-- /ko --> Feeds
+              {% endblocktrans %}
+            <!-- /ko -->
+            <!-- ko if: !isMultiple() -->
+              {% trans "Delete 1 Feed" %}
+            <!-- /ko -->
+          <!-- /ko -->
+          <!-- ko if: !isOData && !isFeed -->
+            <!-- ko if: isMultiple -->
+              {% blocktrans %}
+                Delete <!-- ko text: bulkExportDownloadCount() --><!-- /ko --> Exports
+              {% endblocktrans %}
+            <!-- /ko -->
+            <!-- ko if: !isMultiple() -->
+              {% trans "Delete 1 Export" %}
+            <!-- /ko -->
+          <!-- /ko -->
         </button>
         <a href="#" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</a>
       </div>

--- a/corehq/apps/export/templates/export/partials/delete_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partials/delete_bulk_notice.html
@@ -1,0 +1,26 @@
+{% load i18n %}
+<div class="alert alert-info"
+   data-bind="visible: bulkDeleteCount()">
+  <div class="row">
+    <div class="col-sm-3 col-lg-2">
+      <input name="delete_list" type="hidden"/>
+      <a class="btn btn-danger btn-lg"
+         data-toggle="modal"
+         data-bind="attr: {
+                      href: '#bulk-delete-export-modal'
+                    }">
+        <i class="fa fa-remove"></i>
+        <span>{% trans 'Bulk Delete' %}
+        (<span data-bind="text: bulkDeleteCount()"></span>)</span>
+      </a>
+      {% include "export/dialogs/bulk_delete_custom_export_dialog.html" %}
+    </div>
+    <div class="col-sm-9 col-lg-10">
+      <p style="margin-top: 13px;">
+        {% blocktrans %}
+          Delete selected exports.
+        {% endblocktrans %}
+      </p>
+    </div>
+  </div>
+</div>

--- a/corehq/apps/export/templates/export/partials/delete_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partials/delete_bulk_notice.html
@@ -1,25 +1,27 @@
 {% load i18n %}
-<div class="alert alert-info"
-   data-bind="visible: bulkDeleteCount()">
+
+<div class="alert alert-danger"
+     data-bind="visible: bulkExportDownloadCount()"
+     style="overflow: hidden">
   <div class="row">
-    <div class="col-sm-3 col-lg-2">
-      <input name="delete_list" type="hidden"/>
-      <a class="btn btn-danger btn-lg"
-         data-toggle="modal"
-         data-bind="attr: {
-                      href: '#bulk-delete-export-modal'
-                    }">
-        <i class="fa fa-remove"></i>
-        <span>{% trans 'Bulk Delete' %}
-        (<span data-bind="text: bulkDeleteCount()"></span>)</span>
-      </a>
-      {% include "export/dialogs/bulk_delete_custom_export_dialog.html" %}
-    </div>
-    <div class="col-sm-9 col-lg-10">
-      <p style="margin-top: 13px;">
+    <div class="col-sm-5 col-lg-7">
+      <p style="margin-top: 15px">
         {% blocktrans %}
-          Delete selected exports.
+          All of the selected exports will be deleted.
         {% endblocktrans %}
+      </p>
+    </div>
+    <div class="col-sm-4 col-lg-5" style="float:right; height: 48px">
+      <input name="delete_list" type="hidden"/>
+      <p style="float:right">
+        <a class="btn btn-danger btn-lg"
+           data-toggle="modal"
+           data-bind="attr: {
+                        href: '#bulk-delete-export-modal'
+                      }">
+          <span>{% trans 'Delete Selected Exports' %}</span>
+        </a>
+        {% include "export/dialogs/bulk_delete_custom_export_dialog.html" %}
       </p>
     </div>
   </div>

--- a/corehq/apps/export/templates/export/partials/delete_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partials/delete_bulk_notice.html
@@ -5,9 +5,14 @@
      style="overflow: hidden">
   <div class="row">
     <div class="col-sm-5 col-lg-7">
-      <p style="margin-top: 15px">
+      <p style="margin-top: 15px" data-bind="if: !isOData && !isFeed">
         {% blocktrans %}
           All of the selected exports will be deleted.
+        {% endblocktrans %}
+      </p>
+      <p style="margin-top: 15px" data-bind="if: isOData || isFeed">
+        {% blocktrans %}
+          All of the selected feeds will be deleted.
         {% endblocktrans %}
       </p>
     </div>
@@ -19,7 +24,8 @@
            data-bind="attr: {
                         href: '#bulk-delete-export-modal'
                       }">
-          <span>{% trans 'Delete Selected Exports' %}</span>
+          <span data-bind="if: !isOData && !isFeed">{% trans 'Delete Selected Exports' %}</span>
+          <span data-bind="if: isOData || isFeed">{% trans 'Delete Selected Feeds' %}</span>
         </a>
         {% include "export/dialogs/bulk_delete_custom_export_dialog.html" %}
       </p>

--- a/corehq/apps/export/templates/export/partials/delete_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partials/delete_bulk_notice.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 <div data-bind="visible: bulkExportDownloadCount()">
-  <div style="float:right;" id="bulk-delete-text">
+  <div style="float:right;" class="tooltip-bulkDelete" data-container=".tooltip-bulkDelete"
+       data-toggle="tooltip-bulkDelete" data-placement="top">
     <input name="delete_list" type="hidden"/>
     <p style="float:right">
       <a class="btn btn-danger btn-primary"
@@ -8,10 +9,37 @@
          data-bind="attr: {
                       href: '#bulk-delete-export-modal'
                     }">
-        <span data-bind="if: !isOData && !isFeed">{% trans 'Delete Selected Exports' %}</span>
-        <span data-bind="if: isOData || isFeed">{% trans 'Delete Selected Feeds' %}</span>
+        <!-- ko if: isOData || isFeed -->
+          <!-- ko if: isMultiple -->
+            {% trans "Delete Selected Feeds" %}
+          <!-- /ko -->
+          <!-- ko if: !isMultiple() -->
+            {% trans "Delete Selected Feed" %}
+          <!-- /ko -->
+        <!-- /ko -->
+        <!-- ko if: !isOData && !isFeed -->
+          <!-- ko if: isMultiple -->
+            {% trans "Delete Selected Exports" %}
+          <!-- /ko -->
+          <!-- ko if: !isMultiple() -->
+            {% trans "Delete Selected Export" %}
+          <!-- /ko -->
+        <!-- /ko -->
       </a>
       {% include "export/dialogs/bulk_delete_custom_export_dialog.html" %}
     </p>
   </div>
 </div>
+
+<style>
+.tooltip-bulkDelete .tooltip .tooltip-inner {
+  background-color: #f2dede;
+  position: relative;
+  color: black;
+  min-width: 235px
+}
+
+.tooltip-bulkDelete .tooltip.top .tooltip-arrow {
+  border-top-color: #f2dede;
+}
+</style>

--- a/corehq/apps/export/templates/export/partials/delete_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partials/delete_bulk_notice.html
@@ -1,34 +1,17 @@
 {% load i18n %}
-
-<div class="alert alert-danger"
-     data-bind="visible: bulkExportDownloadCount()"
-     style="overflow: hidden">
-  <div class="row">
-    <div class="col-sm-5 col-lg-7">
-      <p style="margin-top: 15px" data-bind="if: !isOData && !isFeed">
-        {% blocktrans %}
-          All of the selected exports will be deleted.
-        {% endblocktrans %}
-      </p>
-      <p style="margin-top: 15px" data-bind="if: isOData || isFeed">
-        {% blocktrans %}
-          All of the selected feeds will be deleted.
-        {% endblocktrans %}
-      </p>
-    </div>
-    <div class="col-sm-4 col-lg-5" style="float:right; height: 48px">
-      <input name="delete_list" type="hidden"/>
-      <p style="float:right">
-        <a class="btn btn-danger btn-lg"
-           data-toggle="modal"
-           data-bind="attr: {
-                        href: '#bulk-delete-export-modal'
-                      }">
-          <span data-bind="if: !isOData && !isFeed">{% trans 'Delete Selected Exports' %}</span>
-          <span data-bind="if: isOData || isFeed">{% trans 'Delete Selected Feeds' %}</span>
-        </a>
-        {% include "export/dialogs/bulk_delete_custom_export_dialog.html" %}
-      </p>
-    </div>
+<div data-bind="visible: bulkExportDownloadCount()">
+  <div style="float:right;" id="bulk-delete-text">
+    <input name="delete_list" type="hidden"/>
+    <p style="float:right">
+      <a class="btn btn-danger btn-primary"
+         data-toggle="modal"
+         data-bind="attr: {
+                      href: '#bulk-delete-export-modal'
+                    }">
+        <span data-bind="if: !isOData && !isFeed">{% trans 'Delete Selected Exports' %}</span>
+        <span data-bind="if: isOData || isFeed">{% trans 'Delete Selected Feeds' %}</span>
+      </a>
+      {% include "export/dialogs/bulk_delete_custom_export_dialog.html" %}
+    </p>
   </div>
 </div>

--- a/corehq/apps/export/templates/export/partials/delete_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partials/delete_bulk_notice.html
@@ -1,7 +1,6 @@
 {% load i18n %}
 <div data-bind="visible: bulkExportDownloadCount()">
-  <div style="float:right;" class="tooltip-bulkDelete" data-container=".tooltip-bulkDelete"
-       data-toggle="tooltip-bulkDelete" data-placement="top">
+  <div class="pull-right" data-toggle="tooltip-bulkDelete" data-placement="top">
     <input name="delete_list" type="hidden"/>
     <p style="float:right">
       <a class="btn btn-danger btn-primary"
@@ -30,16 +29,3 @@
     </p>
   </div>
 </div>
-
-<style>
-.tooltip-bulkDelete .tooltip .tooltip-inner {
-  background-color: #f2dede;
-  position: relative;
-  color: black;
-  min-width: 235px
-}
-
-.tooltip-bulkDelete .tooltip.top .tooltip-arrow {
-  border-top-color: #f2dede;
-}
-</style>

--- a/corehq/apps/export/templates/export/partials/export_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partials/export_bulk_notice.html
@@ -7,11 +7,10 @@
         action="{{ bulk_download_url }}">
     {% csrf_token %}
     <div class="row">
-      <div class="col-sm-5 col-lg-4">
+      <div class="col-sm-4 col-lg-3">
         <input name="export_list" type="hidden" data-bind="value: bulkExportList" />
         <button type="submit"
-                class="btn btn-primary btn-lg"
-                style="width: 100%;">
+                class="btn btn-primary btn-lg">
           {% trans 'Bulk Export' %}
           (<span data-bind="text: bulkExportDownloadCount()"></span>)
         </button>

--- a/corehq/apps/export/templates/export/partials/export_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partials/export_bulk_notice.html
@@ -1,12 +1,13 @@
 {% load i18n %}
 <div class="alert alert-info"
-     data-bind="visible: bulkExportDownloadCount()">
+     data-bind="visible: bulkExportDownloadCount()"
+     style="float:left; width:48%; margin-right:10px">
   <form class="form form-inline" method="post"
         data-bind="submit: submitBulkExportDownload"
         action="{{ bulk_download_url }}">
     {% csrf_token %}
     <div class="row">
-      <div class="col-sm-3 col-lg-2">
+      <div class="col-sm-5 col-lg-4">
         <input name="export_list" type="hidden" data-bind="value: bulkExportList" />
         <button type="submit"
                 class="btn btn-primary btn-lg"
@@ -15,8 +16,8 @@
           (<span data-bind="text: bulkExportDownloadCount()"></span>)
         </button>
       </div>
-      <div class="col-sm-9 col-lg-10">
-        <p style="margin-top: 13px;">
+      <div class="col-sm-5 col-lg-8">
+        <p style="margin-top: 7px;">
           {% blocktrans %}
             All of the selected exports will be collected for download
             to a single Excel file, with each export as a separate sheet.

--- a/corehq/apps/export/templates/export/partials/export_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partials/export_bulk_notice.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <div data-bind="visible: bulkExportDownloadCount()"
-     style="float:right; margin-left:10px">
+     style="float:right; margin-left:10px; margin-bottom:8px">
   <form class="form form-inline" method="post"
         data-bind="submit: submitBulkExportDownload"
         action="{{ bulk_download_url }}">

--- a/corehq/apps/export/templates/export/partials/export_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partials/export_bulk_notice.html
@@ -1,14 +1,14 @@
 {% load i18n %}
 <div data-bind="visible: bulkExportDownloadCount()"
-     style="float:right; margin-left:10px; margin-bottom:8px">
+     style="float:right; margin-left:8px; margin-bottom:8px">
   <form class="form form-inline" method="post"
         data-bind="submit: submitBulkExportDownload"
         action="{{ bulk_download_url }}">
     {% csrf_token %}
-    <div style="min-width:110px;" data-toggle="tooltip-bulkExport" data-container=".tooltip-bulkExport" data-placement="top">
+    <div style="min-width:110px;" data-toggle="tooltip-bulkExport" data-container=".tooltip-bulk-export" data-placement="top">
       <input name="export_list" type="hidden" data-bind="value: bulkExportList" />
       <button type="submit"
-              class="btn btn-primary tooltip-bulkExport"
+              class="btn btn-primary tooltip-bulk-export"
               style="width: 100%;">
         {% trans 'Bulk Export' %}
         (<!-- ko text: bulkExportDownloadCount() --><!-- /ko -->)
@@ -18,15 +18,7 @@
 </div>
 
 <style>
-.tooltip-bulkExport .tooltip .tooltip-inner {
-  background-color: #d9edf7;
+.tooltip-bulk-export .tooltip .tooltip-inner {
   margin-right: 10px;
-  position: relative;
-  color: black;
-  min-width: 325px
-}
-
-.tooltip-bulkExport .tooltip.top .tooltip-arrow {
-  border-top-color: #d9edf7;
 }
 </style>

--- a/corehq/apps/export/templates/export/partials/export_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partials/export_bulk_notice.html
@@ -5,14 +5,28 @@
         data-bind="submit: submitBulkExportDownload"
         action="{{ bulk_download_url }}">
     {% csrf_token %}
-    <div style="min-width:110px;" id="bulk-export-text">
+    <div style="min-width:110px;" data-toggle="tooltip-bulkExport" data-container=".tooltip-bulkExport" data-placement="top">
       <input name="export_list" type="hidden" data-bind="value: bulkExportList" />
       <button type="submit"
-              class="btn btn-primary"
+              class="btn btn-primary tooltip-bulkExport"
               style="width: 100%;">
         {% trans 'Bulk Export' %}
-        (<span data-bind="text: bulkExportDownloadCount()"></span>)
+        (<!-- ko text: bulkExportDownloadCount() --><!-- /ko -->)
       </button>
     </div>
   </form>
 </div>
+
+<style>
+.tooltip-bulkExport .tooltip .tooltip-inner {
+  background-color: #d9edf7;
+  margin-right: 10px;
+  position: relative;
+  color: black;
+  min-width: 325px
+}
+
+.tooltip-bulkExport .tooltip.top .tooltip-arrow {
+  border-top-color: #d9edf7;
+}
+</style>

--- a/corehq/apps/export/templates/export/partials/export_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partials/export_bulk_notice.html
@@ -1,29 +1,18 @@
 {% load i18n %}
-<div class="alert alert-info"
-     data-bind="visible: bulkExportDownloadCount()"
-     style="float:left; width:48%; margin-right:10px">
+<div data-bind="visible: bulkExportDownloadCount()"
+     style="float:right; margin-left:10px">
   <form class="form form-inline" method="post"
         data-bind="submit: submitBulkExportDownload"
         action="{{ bulk_download_url }}">
     {% csrf_token %}
-    <div class="row">
-      <div class="col-sm-6 col-lg-3" style="min-width:165px;">
-        <input name="export_list" type="hidden" data-bind="value: bulkExportList" />
-        <button type="submit"
-                class="btn btn-primary btn-lg"
-                style="width: 100%;">
-          {% trans 'Bulk Export' %}
-          (<span data-bind="text: bulkExportDownloadCount()"></span>)
-        </button>
-      </div>
-      <div class="col-sm-6 col-lg-8">
-        <p style="margin-top: 7px;">
-          {% blocktrans %}
-            All of the selected exports will be collected for download
-            to a single Excel file, with each export as a separate sheet.
-          {% endblocktrans %}
-        </p>
-      </div>
+    <div style="min-width:130px;" id="bulk-export-text">
+      <input name="export_list" type="hidden" data-bind="value: bulkExportList" />
+      <button type="submit"
+              class="btn btn-primary"
+              style="width: 100%;">
+        {% trans 'Bulk Export' %}
+        (<span data-bind="text: bulkExportDownloadCount()"></span>)
+      </button>
     </div>
   </form>
 </div>

--- a/corehq/apps/export/templates/export/partials/export_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partials/export_bulk_notice.html
@@ -7,15 +7,16 @@
         action="{{ bulk_download_url }}">
     {% csrf_token %}
     <div class="row">
-      <div class="col-sm-4 col-lg-3">
+      <div class="col-sm-6 col-lg-3" style="min-width:155px;">
         <input name="export_list" type="hidden" data-bind="value: bulkExportList" />
         <button type="submit"
-                class="btn btn-primary btn-lg">
+                class="btn btn-primary btn-lg"
+                style="width: 100%;">
           {% trans 'Bulk Export' %}
           (<span data-bind="text: bulkExportDownloadCount()"></span>)
         </button>
       </div>
-      <div class="col-sm-5 col-lg-8">
+      <div class="col-sm-6 col-lg-8">
         <p style="margin-top: 7px;">
           {% blocktrans %}
             All of the selected exports will be collected for download

--- a/corehq/apps/export/templates/export/partials/export_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partials/export_bulk_notice.html
@@ -5,7 +5,7 @@
         data-bind="submit: submitBulkExportDownload"
         action="{{ bulk_download_url }}">
     {% csrf_token %}
-    <div style="min-width:130px;" id="bulk-export-text">
+    <div style="min-width:110px;" id="bulk-export-text">
       <input name="export_list" type="hidden" data-bind="value: bulkExportList" />
       <button type="submit"
               class="btn btn-primary"

--- a/corehq/apps/export/templates/export/partials/export_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partials/export_bulk_notice.html
@@ -7,7 +7,7 @@
         action="{{ bulk_download_url }}">
     {% csrf_token %}
     <div class="row">
-      <div class="col-sm-6 col-lg-3" style="min-width:155px;">
+      <div class="col-sm-6 col-lg-3" style="min-width:165px;">
         <input name="export_list" type="hidden" data-bind="value: bulkExportList" />
         <button type="submit"
                 class="btn btn-primary btn-lg"

--- a/corehq/apps/export/templates/export/partials/export_list_controller.html
+++ b/corehq/apps/export/templates/export/partials/export_list_controller.html
@@ -39,6 +39,7 @@
 
 <div id="export-list" class="ko-template">
   {% include 'export/partials/export_bulk_notice.html' %}
+  {% include 'export/partials/delete_bulk_notice.html' %}
   <div data-bind="foreach: panels">
     <div class="panel panel-default">
       <div class="panel-heading" data-bind="text: header"></div>

--- a/corehq/apps/export/templates/export/partials/export_list_controller.html
+++ b/corehq/apps/export/templates/export/partials/export_list_controller.html
@@ -38,9 +38,13 @@
 {% endif %}
 
 <div id="export-list" class="ko-template">
-  {% include 'export/partials/export_bulk_notice.html' %}
-  {% include 'export/partials/delete_bulk_notice.html' %}
-  <div data-bind="foreach: panels">
+  <div class="container-fluid" style="padding-left: 0; padding-right: 0">
+    {% if allow_bulk_export %} {# form exports only #}
+      {% include 'export/partials/export_bulk_notice.html' %}
+    {% endif %}
+    {% include 'export/partials/delete_bulk_notice.html' %}
+  </div>
+  <div data-bind="foreach: panels" style="display: inline">
     <div class="panel panel-default">
       <div class="panel-heading" data-bind="text: header"></div>
       <div class="panel-body">

--- a/corehq/apps/export/templates/export/partials/export_list_controller.html
+++ b/corehq/apps/export/templates/export/partials/export_list_controller.html
@@ -42,7 +42,9 @@
     {% if allow_bulk_export %} {# form exports only #}
       {% include 'export/partials/export_bulk_notice.html' %}
     {% endif %}
-    {% include 'export/partials/delete_bulk_notice.html' %}
+    {% if has_edit_permissions %}
+      {% include 'export/partials/delete_bulk_notice.html' %}
+    {% endif %}
   </div>
   <div data-bind="foreach: panels" style="display: inline">
     <div class="panel panel-default">

--- a/corehq/apps/export/templates/export/partials/loading_exports.html
+++ b/corehq/apps/export/templates/export/partials/loading_exports.html
@@ -14,6 +14,11 @@
   {% trans "Loading exports..." %}
 </div>
 
+<div class="alert alert-info" data-bind="visible: isBulkDeleting">
+  <i class="fa fa-refresh fa-spin"></i>
+  {% trans "Deleting exports..." %}
+</div>
+
 <div class="help-block" data-bind="visible: showEmpty">
   {% if is_deid %}
     {% blocktrans %}

--- a/corehq/apps/export/templates/export/partials/loading_exports.html
+++ b/corehq/apps/export/templates/export/partials/loading_exports.html
@@ -16,7 +16,22 @@
 
 <div class="alert alert-info" data-bind="visible: isBulkDeleting">
   <i class="fa fa-refresh fa-spin"></i>
-  {% trans "Deleting exports..." %}
+  <!-- ko if: $parent.isOData || $parent.isFeed -->
+    <!-- ko if: $parent.isMultiple -->
+      {% trans "Deleting feeds..." %}
+    <!-- /ko -->
+    <!-- ko if: !$parent.isMultiple() -->
+      {% trans "Deleting feed..." %}
+    <!-- /ko -->
+  <!-- /ko -->
+  <!-- ko if: !$parent.isOData && !$parent.isFeed -->
+    <!-- ko if: $parent.isMultiple() -->
+      {% trans "Deleting exports..." %}
+    <!-- /ko -->
+    <!-- ko if: !$parent.isMultiple() -->
+      {% trans "Deleting export..." %}
+    <!-- /ko -->
+  <!-- /ko -->
 </div>
 
 <div class="help-block" data-bind="visible: showEmpty">

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -64,6 +64,28 @@
       <th class="col-sm-1">
         {% trans 'Delete' %}
       </th>
+
+
+      <!-- copied from bulk export section -->
+
+      {%  if allow_bulk_export %} {# form exports only #}
+      <th class="col-sm-1">
+        {% blocktrans %}Bulk Delete{% endblocktrans %}
+        <br>
+        <button type="button"
+                class="btn btn-xs btn-default"
+                data-bind="click: $root.selectDeleteAll">
+          {% trans 'All' %}
+        </button>
+        {% trans 'or' %}
+        <button type="button"
+                class="btn btn-xs btn-default"
+                data-bind="click: $root.selectDeleteNone">
+          {% trans 'None' %}
+        </button>
+      </th>
+    {% endif %}
+
     {% endif %}
 
     {% if request|toggle_enabled:"EXPORT_OWNERSHIP" %}
@@ -697,6 +719,19 @@
           </div>
           <div data-bind="visible: owner_username !== 'unknown',
                           text: owner_username"></div>
+        </div>
+      </td>
+    {% endif %}
+
+    <!-- copied from other checkbox list -->
+    <!-- need isLocationSafeForUser check? -->
+    {% if allow_bulk_export %}
+      <td>
+        <div class="checkbox checkbox-table-cell">
+          <label>
+            <input type="checkbox"
+                   data-bind="checked: addedToBulk2" />
+          </label>
         </div>
       </td>
     {% endif %}

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -7,6 +7,21 @@
        data-bind="visible: exports().length">
   <thead>
     <tr>
+      <th class="col-sm-1">
+        {% blocktrans %}Select{% endblocktrans %}
+        <br>
+        <button type="button"
+                class="btn btn-xs btn-default"
+                data-bind="click: $root.selectAll">
+          {% trans 'All' %}
+        </button>
+        {%trans 'or'%}
+        <button type="button"
+                class="btn btn-xs btn-default"
+                data-bind="click: $root.selectNone">
+          {% trans 'None' %}
+        </button>
+      </th>
       <th class="col-sm-4">
         {% trans 'Name' %}
       </th>
@@ -27,24 +42,6 @@
       {% endif %}
     </th>
 
-    {%  if allow_bulk_export %} {# form exports only #}
-      <th class="col-sm-1">
-        {% blocktrans %}Bulk {{ export_type_caps }}{% endblocktrans %}
-        <br>
-        <button type="button"
-                class="btn btn-xs btn-default"
-                data-bind="click: $root.selectAll">
-          {% trans 'All' %}
-        </button>
-        {% trans 'or' %}
-        <button type="button"
-                class="btn btn-xs btn-default"
-                data-bind="click: $root.selectNone">
-          {% trans 'None' %}
-        </button>
-      </th>
-    {% endif %}
-
     {% if is_daily_saved_export %}
       <th class="col-sm-1">{% trans "Enable/Disable" %}</th>
     {% endif %}
@@ -64,28 +61,6 @@
       <th class="col-sm-1">
         {% trans 'Delete' %}
       </th>
-
-
-      <!-- copied from bulk export section -->
-
-      {%  if allow_bulk_export %} {# form exports only #}
-      <th class="col-sm-1">
-        {% blocktrans %}Bulk Delete{% endblocktrans %}
-        <br>
-        <button type="button"
-                class="btn btn-xs btn-default"
-                data-bind="click: $root.selectDeleteAll">
-          {% trans 'All' %}
-        </button>
-        {% trans 'or' %}
-        <button type="button"
-                class="btn btn-xs btn-default"
-                data-bind="click: $root.selectDeleteNone">
-          {% trans 'None' %}
-        </button>
-      </th>
-    {% endif %}
-
     {% endif %}
 
     {% if request|toggle_enabled:"EXPORT_OWNERSHIP" %}
@@ -103,6 +78,15 @@
   </thead>
   <tbody data-bind="foreach: exports()">
     <tr>
+    <!-- need isLocationSafeForUser check? -->
+      <td>
+        <div class="checkbox checkbox-table-cell">
+          <label>
+            <input type="checkbox"
+                   data-bind="checked: addedToBulk" />
+          </label>
+        </div>
+      </td>
       <td>
         <h4 data-bind="css: {'text-muted': hasEmailedExport && !isAutoRebuildEnabled()}">
           <inline-edit params="value: name,
@@ -548,17 +532,6 @@
       </a>
     </td>
 
-    {% if allow_bulk_export %}
-      <td>
-        <div class="checkbox checkbox-table-cell">
-          <label>
-            <input type="checkbox"
-                   data-bind="checked: addedToBulk" />
-          </label>
-        </div>
-      </td>
-    {% endif %}
-
     {% if is_daily_saved_export %}
       <td>
         <!-- ko if: isLocationSafeForUser() -->
@@ -723,18 +696,6 @@
       </td>
     {% endif %}
 
-    <!-- copied from other checkbox list -->
-    <!-- need isLocationSafeForUser check? -->
-    {% if allow_bulk_export %}
-      <td>
-        <div class="checkbox checkbox-table-cell">
-          <label>
-            <input type="checkbox"
-                   data-bind="checked: addedToBulk2" />
-          </label>
-        </div>
-      </td>
-    {% endif %}
     </tr>
   </tbody>
 </table>

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -78,7 +78,6 @@
   </thead>
   <tbody data-bind="foreach: exports()">
     <tr>
-    <!-- need isLocationSafeForUser check? -->
       <td>
         <div class="checkbox checkbox-table-cell">
           <label>

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -4,7 +4,7 @@
 {% load humanize %}
 
 <table class="table table-striped"
-       data-bind="visible: exports().length && isNotBulkDeleting">
+       data-bind="visible: exports().length && !isBulkDeleting()">
   <thead>
     <tr>
       {% if has_edit_permissions or allow_bulk_export %}

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -4,7 +4,7 @@
 {% load humanize %}
 
 <table class="table table-striped"
-       data-bind="visible: exports().length">
+       data-bind="visible: exports().length && isNotBulkDeleting">
   <thead>
     <tr>
       <th class="col-sm-1">

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -7,21 +7,23 @@
        data-bind="visible: exports().length && isNotBulkDeleting">
   <thead>
     <tr>
-      <th class="col-sm-1">
-        {% blocktrans %}Select{% endblocktrans %}
-        <br>
-        <button type="button"
-                class="btn btn-xs btn-default"
-                data-bind="click: selectAll">
-          {% trans 'All' %}
-        </button>
-        {%trans 'or'%}
-        <button type="button"
-                class="btn btn-xs btn-default"
-                data-bind="click: selectNone">
-          {% trans 'None' %}
-        </button>
-      </th>
+      {% if has_edit_permissions or allow_bulk_export %}
+        <th class="col-sm-1">
+          {% blocktrans %}Select{% endblocktrans %}
+          <br>
+          <button type="button"
+                  class="btn btn-xs btn-default"
+                  data-bind="click: selectAll">
+            {% trans 'All' %}
+          </button>
+          {%trans 'or'%}
+          <button type="button"
+                  class="btn btn-xs btn-default"
+                  data-bind="click: selectNone">
+            {% trans 'None' %}
+          </button>
+        </th>
+      {% endif %}
       <th class="col-sm-4">
         {% trans 'Name' %}
       </th>
@@ -78,6 +80,7 @@
   </thead>
   <tbody data-bind="foreach: exports()">
     <tr>
+    {% if has_edit_permissions or allow_bulk_export %}
       <td>
         <div class="checkbox checkbox-table-cell">
           <label>
@@ -86,6 +89,7 @@
           </label>
         </div>
       </td>
+    {% endif %}
       <td>
         <h4 data-bind="css: {'text-muted': hasEmailedExport && !isAutoRebuildEnabled()}">
           <inline-edit params="value: name,

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -12,13 +12,13 @@
         <br>
         <button type="button"
                 class="btn btn-xs btn-default"
-                data-bind="click: $root.selectAll">
+                data-bind="click: selectAll">
           {% trans 'All' %}
         </button>
         {%trans 'or'%}
         <button type="button"
                 class="btn btn-xs btn-default"
-                data-bind="click: $root.selectNone">
+                data-bind="click: selectNone">
           {% trans 'None' %}
         </button>
       </th>

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -236,7 +236,6 @@ class ExportListHelper(object):
             'emailedExport': self._get_daily_saved_export_metadata(export),
             'odataUrl': self._get_odata_url(export),
             'additionalODataUrls': self._get_additional_odata_urls(export),
-            'addedToBulk2': False,
         }
 
     def _get_additional_odata_urls(self, export):

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -236,6 +236,7 @@ class ExportListHelper(object):
             'emailedExport': self._get_daily_saved_export_metadata(export),
             'odataUrl': self._get_odata_url(export),
             'additionalODataUrls': self._get_additional_odata_urls(export),
+            'addedToBulk2': False,
         }
 
     def _get_additional_odata_urls(self, export):

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -224,6 +224,8 @@ class ExportListHelper(object):
             'formname': formname,
             'deleteUrl': reverse(DeleteNewCustomExportView.urlname,
                                  args=(self.domain, export.type, export.get_id)),
+            'domain': self.domain,
+            'type': export.type,
             'downloadUrl': reverse(self._download_view(export).urlname, args=(self.domain, export.get_id)),
             'showDetDownload': export.show_det_config_download,
             'detSchemaUrl': reverse(DownloadDETSchemaView.urlname,

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -368,7 +368,6 @@ class DeleteNewCustomExportView(BaseExportView):
         count = request.POST.get("count")
         if count:
             deletelist = json.loads(request.POST.get("deleteList"))
-            print(self.kwargs.get('export_type'))
             self.export_type = self.kwargs.get('export_type')
             export = self.export_instance
             export.delete()

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -3,7 +3,7 @@ import json
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import SuspiciousOperation
-from django.http import Http404, HttpResponseRedirect, JsonResponse
+from django.http import Http404, HttpResponseRedirect, HttpResponse, JsonResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
@@ -228,6 +228,8 @@ class BaseExportView(BaseProjectDataView):
                 return json_response({
                     'redirect': url,
                 })
+            if request.POST.get("count"):
+                return HttpResponse(url)
             return HttpResponseRedirect(url)
 
     @memoized
@@ -363,14 +365,39 @@ class DeleteNewCustomExportView(BaseExportView):
             raise Http404()
 
     def commit(self, request):
-        self.export_type = self.kwargs.get('export_type')
-        export = self.export_instance
-        export.delete()
-        messages.success(
-            request,
-            format_html(_("Export <strong>{}</strong> was deleted."), export.name)
-        )
-        return export._id
+        count = request.POST.get("count")
+        if count:
+            deletelist = json.loads(request.POST.get("deleteList"))
+            print(self.kwargs.get('export_type'))
+            self.export_type = self.kwargs.get('export_type')
+            export = self.export_instance
+            export.delete()
+            for item in deletelist:
+                bulkexport = self.export_instance_cls.get(item["id"])
+                bulkexport.delete()
+
+            if self.export_instance.is_odata_config or self.export_instance.export_format == "html":
+                delete = "feed"
+            else:
+                delete = "export"
+            if int(count) > 1:
+                message = format_html(_("<strong>{}</strong> {}{} were deleted."), count, delete, "s")
+            else:
+                message = format_html(_("<strong>{}</strong> {}{} was deleted."), count, delete, "")
+            messages.success(
+                request,
+                message
+            )
+            return export._id
+        else:
+            self.export_type = self.kwargs.get('export_type')
+            export = self.export_instance
+            export.delete()
+            messages.success(
+                request,
+                format_html(_("Export <strong>{}</strong> was deleted."), export.name)
+            )
+            return export._id
 
     @property
     @memoized


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Added a bulk selection column for users to choose which exports/feeds to export/delete (they can mark individually or select/deselect all). Bulk deleting will show a confirmation modal that lists the exports/feeds marked for deletion. 

Current view: 
![image-20210716-200831](https://user-images.githubusercontent.com/33491742/134370633-b4222cee-1e23-4bac-9615-ea467a5da0ca.png)

New:

Bulk selector column on the left
<img width="1286" alt="Screen Shot 2021-09-22 at 10 59 19 AM" src="https://user-images.githubusercontent.com/33491742/134370757-0cf1ddaf-eee0-4e81-b94d-37ba2d1d8ff9.png">

Selecting exports/feeds make the bulk action buttons visible + hover text descriptions of each action
<img width="1480" alt="Screen Shot 2021-09-22 at 6 13 09 PM" src="https://user-images.githubusercontent.com/33491742/134429161-6346c522-9d62-475f-88f3-05f59caf73c4.png">

<img width="1482" alt="Screen Shot 2021-09-22 at 6 13 13 PM" src="https://user-images.githubusercontent.com/33491742/134429175-29cdb163-a3d3-4b10-8db7-a0569473b367.png">

Bulk delete popup
<img width="726" alt="Screen Shot 2021-09-22 at 11 00 23 AM" src="https://user-images.githubusercontent.com/33491742/134371006-8b16e9b8-9cd4-4ec9-898d-bb784276d1a5.png">



## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

https://dimagi-dev.atlassian.net/browse/SS-176
https://dimagi-dev.atlassian.net/browse/SS-199
https://dimagi-dev.atlassian.net/browse/SS-200
https://dimagi-dev.atlassian.net/browse/SS-201

UI design was proposed/finalized by USH. 
Bulk export was already functional before, just changed in appearance.
Bulk delete was built on top of the existing deletion function by passing in an array of exports/feeds to delete instead. 

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
TBD

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

https://dimagi-dev.atlassian.net/browse/QA-3417 (passed)

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This feature is limited to the exports/feeds pages describe in the tickets above.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
