### PR TITLE
moves keyboard focus to newly created repeat group

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -437,7 +437,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
             if (repeat) {
                 repeat.trigger('focus');
             }
-        }
+        };
 
         var styles = _.has(json, 'style') && json.style && json.style.raw ? json.style.raw.split(/\s+/) : [];
         self.collapsible = _.contains(styles, Const.COLLAPSIBLE);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -432,6 +432,13 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
             self.domain_meta = parseMeta(json.datatype, json.style);
         }
 
+        self.focusNewRepeat = function () {
+            var repeat = $('.repetition');
+            if (repeat) {
+                repeat.trigger('focus');
+            }
+        }
+
         var styles = _.has(json, 'style') && json.style && json.style.raw ? json.style.raw.split(/\s+/) : [];
         self.collapsible = _.contains(styles, Const.COLLAPSIBLE);
         self.showChildren = ko.observable(!self.collapsible || _.contains(styles, Const.COLLAPSIBLE_OPEN));
@@ -512,6 +519,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         self.newRepeat = function () {
             $.publish('formplayer.' + Const.NEW_REPEAT, self);
             $.publish('formplayer.dirty');
+            $('.add').trigger('blur');
         };
 
         self.getTranslation = function (translationKey, defaultTranslation) {

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -2,7 +2,8 @@
 {% load hq_shared_tags %}
 
 <script type="text/html" id="sub-group-fullform-ko-template">
-  <div class="gr" data-bind="
+  <div tabindex="-1" class ="gr" data-bind="
+        class: isRepetition ? 'repetition' : '',
         css: {
           'gr-no-children': $data.children().length === 0,
           'gr-has-no-questions': _.all($data.children(), function(d) { return d.type() !== 'question' }),
@@ -55,7 +56,8 @@
       <div data-bind="if: showChildren()">
         <fieldset>
         <legend aria-hidden="true" class="sr-only">{% trans "Question Group" %}</legend>
-          <div class="children" data-bind="slideVisible: showChildren(), template: { name: childTemplate, foreach: $data.children }, css: {'panel-body': collapsible}"/>
+          <div class="children" data-bind="slideVisible: showChildren(), template: { name: childTemplate, foreach: $data.children,
+            afterRender: focusNewRepeat }, css: {'panel-body': collapsible}"/>
         </fieldset>
       </div>
   </div>
@@ -284,7 +286,6 @@
               data-bind="click: newRepeat, text: getTranslation('repeat.dialog.add.new', '{% trans_html_attr 'Add new repeat' %}')"
               id="repeat-add-new" />
     </div>
-
   </div>
 </script>
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When a repeat group is added keyboard focus is applied to the newly created repeat group. Previously focus remained on the `Add new repeat` button and repeat groups rendered above were skipped for screen readers.

<img width="200" alt="Screen Shot 2021-09-15 at 11 10 44 AM" src="https://user-images.githubusercontent.com/42388648/133480000-a275bec1-020b-49d3-b8a2-fe0727d38c85.png"> <img width="200" alt="Screen Shot 2021-09-15 at 11 12 05 AM" src="https://user-images.githubusercontent.com/42388648/133480017-4de8c6d4-01fd-4f1d-b34b-7984dde27de8.png">

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
[QA-3541](https://dimagi-dev.atlassian.net/browse/QA-3541)
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
