### PR TITLE
Report build times per app when over 30s

### DIFF
--- a/corehq/apps/app_manager/views/cli.py
+++ b/corehq/apps/app_manager/views/cli.py
@@ -4,12 +4,11 @@ from django.utils.text import slugify
 
 from couchdbkit.exceptions import DocTypeError, ResourceNotFound
 
-from corehq.util.metrics import metrics_histogram_timer
 from dimagi.ext.couchdbkit import Document
 from soil import FileDownload
 
 from corehq import toggles
-from corehq.apps.app_manager.views.utils import get_langs
+from corehq.apps.app_manager.views.utils import get_langs, report_build_time
 from corehq.apps.domain.decorators import api_auth
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqmedia.tasks import create_files_for_ccz
@@ -97,7 +96,7 @@ def direct_ccz(request, domain):
 
     lang, langs = get_langs(request, app)
 
-    with metrics_histogram_timer('commcare.app_build.live_preview', timing_buckets=(1, 10, 30, 60, 120, 240)):
+    with report_build_time(domain, app._id, 'live_preview'):
         return get_direct_ccz(domain, app, langs, version, include_multimedia, visit_scheduler_enabled)
 
 


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-1003
<!-- For non-invisible changes, describe user-facing effects. -->
Adds individual build time logging to datadog for apps that take longer than 30 seconds to build.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This is PRd into https://github.com/dimagi/commcare-hq/pull/30405 because it would otherwise conflict.  I'll hold off on merge of that then swap the base branch.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
