### PR TITLE
Remove SQL-backend test decorators

### DIFF
--- a/corehq/apps/api/tests/case_resources.py
+++ b/corehq/apps/api/tests/case_resources.py
@@ -15,7 +15,6 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.users.models import WebUser
 from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.apps.es.tests.utils import ElasticTestMixin
-from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.pillows.case import transform_case_for_elasticsearch
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.util.elastic import reset_es_index
@@ -110,7 +109,6 @@ class TestCommCareCaseResource(APIResourceTest):
         api_case = api_cases[0]
         self.assertEqual(api_case['server_date_modified'], json_format_datetime(backend_case.server_modified_on))
 
-    @run_with_all_backends
     def test_parent_and_child_cases(self):
         # Create cases
         parent_case_id = uuid.uuid4().hex

--- a/corehq/apps/api/tests/form_resources.py
+++ b/corehq/apps/api/tests/form_resources.py
@@ -15,7 +15,6 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.es.tests.utils import es_test
 from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.apps.es.tests.utils import ElasticTestMixin
-from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
 from corehq.pillows.reportxform import transform_xform_for_report_forms_index
 from corehq.pillows.xform import transform_xform_for_elasticsearch
@@ -42,7 +41,6 @@ class TestXFormInstanceResource(APIResourceTest):
         reset_es_index(XFORM_INDEX_INFO)
         initialize_index_and_mapping(self.es, XFORM_INDEX_INFO)
 
-    @run_with_all_backends
     def test_fetching_xform_cases(self):
 
         # Create an xform that touches a case

--- a/corehq/apps/api/tests/ucr_resources.py
+++ b/corehq/apps/api/tests/ucr_resources.py
@@ -18,12 +18,10 @@ from corehq.apps.userreports.models import (
 from corehq.apps.userreports.tasks import rebuild_indicators
 from corehq.apps.users.models import WebUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend
 
 from .utils import APIResourceTest
 
 
-@run_with_sql_backend
 class TestSimpleReportConfigurationResource(APIResourceTest):
     resource = v0_5.SimpleReportConfigurationResource
     api_name = "v0.5"
@@ -150,7 +148,6 @@ class TestSimpleReportConfigurationResource(APIResourceTest):
         self.assertEqual(response.status_code, 403)  # 403 is "Forbidden"
 
 
-@run_with_sql_backend
 class TestConfigurableReportDataResource(APIResourceTest):
     resource = v0_5.ConfigurableReportDataResource
     api_name = "v0.5"

--- a/corehq/apps/callcenter/tests/test_indicators.py
+++ b/corehq/apps/callcenter/tests/test_indicators.py
@@ -34,7 +34,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.groups.models import Group
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend, sharded
+from corehq.form_processor.tests.utils import sharded
 from corehq.sql_db.connections import connection_manager, override_engine
 from corehq.sql_db.tests.utils import temporary_database
 
@@ -128,7 +128,6 @@ def expected_standard_indicators(
     return expected
 
 
-@run_with_sql_backend
 class BaseCCTests(TestCase):
     domain_name = None
 

--- a/corehq/apps/callcenter/tests/test_utils.py
+++ b/corehq/apps/callcenter/tests/test_utils.py
@@ -44,7 +44,6 @@ from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
     FormAccessors,
 )
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.pillows.mappings.domain_mapping import DOMAIN_INDEX_INFO
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.elastic import ensure_index_deleted
@@ -53,7 +52,6 @@ TEST_DOMAIN = 'cc-util-test'
 CASE_TYPE = 'cc-flw'
 
 
-@run_with_sql_backend
 class CallCenterUtilsTests(TestCase):
     @classmethod
     def setUpClass(cls):
@@ -223,7 +221,6 @@ class CallCenterUtilsTests(TestCase):
         return CaseAccessors(TEST_DOMAIN).get_case_by_domain_hq_user_id(user_id or self.user._id, CASE_TYPE)
 
 
-@run_with_sql_backend
 class CallCenterUtilsUsercaseTests(TestCase):
     @classmethod
     def setUpClass(cls):
@@ -519,7 +516,6 @@ def _create_domain(name, cc_enabled, cc_use_fixtures, cc_case_type, cc_case_owne
         )
 
 
-@run_with_sql_backend
 class CallCenterDomainMockTest(TestCase):
 
     _call_center_domain_mock = mock.patch(

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -26,13 +26,11 @@ from corehq.apps.locations.models import LocationType
 from corehq.apps.locations.tests.util import restrict_user_by_location
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.util.test_utils import flag_enabled, flag_disabled
 from corehq.util.timezones.conversions import PhoneTime
 from corehq.util.workbook_reading import make_worksheet
 
 
-@run_with_sql_backend
 class ImporterTest(TestCase):
 
     def setUp(self):

--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -20,13 +20,11 @@ from corehq.apps.es.tests.utils import (
     case_search_es_teardown,
     es_test,
 )
-from corehq.form_processor.tests.utils import run_with_sql_backend
 
 from ..utils import get_case_search_results
 
 
 @es_test
-@run_with_sql_backend
 class TestCaseSearchEndpoint(TestCase):
     domain = "TestCaseSearchEndpoint"
 

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -28,7 +28,6 @@ from corehq.apps.registry.tests.utils import (
     Invitation,
     create_registry_for_test,
 )
-from corehq.form_processor.tests.utils import run_with_sql_backend
 
 
 def case(name, type_, properties):
@@ -82,7 +81,6 @@ patch_get_app_cached = mock.patch('corehq.apps.case_search.utils.get_app_cached'
 
 
 @es_test
-@run_with_sql_backend
 class TestCaseSearchRegistry(TestCase):
 
     @classmethod

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -13,7 +13,7 @@ from corehq.apps.case_search.filter_dsl import (
 from corehq.apps.es import CaseSearchES
 from corehq.apps.es.tests.utils import ElasticTestMixin, es_test
 from corehq.elastic import get_es_new, send_to_elasticsearch
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_sql_backend
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.pillows.case_search import transform_case_for_elasticsearch
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
@@ -356,7 +356,6 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
 
 
 @es_test
-@run_with_sql_backend
 class TestFilterDslLookups(ElasticTestMixin, TestCase):
     maxDiff = None
 

--- a/corehq/apps/commtrack/tests/test_dbaccessors.py
+++ b/corehq/apps/commtrack/tests/test_dbaccessors.py
@@ -4,10 +4,8 @@ from casexml.apps.case.tests.util import delete_all_cases
 
 from corehq.apps.commtrack.tests.util import bootstrap_domain, make_loc
 from corehq.form_processor.interfaces.supply import SupplyInterface
-from corehq.form_processor.tests.utils import run_with_sql_backend
 
 
-@run_with_sql_backend
 class SupplyPointDBAccessorsTest(TestCase):
 
     def setUp(self):

--- a/corehq/apps/commtrack/tests/test_locations.py
+++ b/corehq/apps/commtrack/tests/test_locations.py
@@ -9,7 +9,6 @@ from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.supply import SupplyInterface
-from corehq.form_processor.tests.utils import run_with_sql_backend
 
 
 def _count_locations(domain):
@@ -20,7 +19,6 @@ def _count_root_locations(domain):
     return SQLLocation.active_objects.root_nodes().filter(domain=domain).count()
 
 
-@run_with_sql_backend
 class LocationsTest(TestCase):
     domain = 'westworld'
 

--- a/corehq/apps/commtrack/tests/test_rebuild.py
+++ b/corehq/apps/commtrack/tests/test_rebuild.py
@@ -13,7 +13,6 @@ from corehq.form_processor.interfaces.dbaccessors import (
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import RebuildWithReason
 from corehq.form_processor.parsers.ledgers.helpers import UniqueLedgerReference
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.util.test_utils import softer_assert
 
 LEDGER_BLOCKS_SIMPLE = """
@@ -37,7 +36,6 @@ LEDGER_BLOCKS_INFERRED = """
 """
 
 
-@run_with_sql_backend
 class RebuildStockStateTest(TestCase):
 
     def setUp(self):

--- a/corehq/apps/commtrack/tests/test_sms_reporting.py
+++ b/corehq/apps/commtrack/tests/test_sms_reporting.py
@@ -11,10 +11,8 @@ from corehq.apps.sms.tests.util import setup_default_sms_test_backend
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.form_processor.exceptions import LedgerValueNotFound
 from corehq.form_processor.backends.sql.dbaccessors import FormAccessorSQL, LedgerAccessorSQL
-from corehq.form_processor.tests.utils import run_with_sql_backend
 
 
-@run_with_sql_backend
 class SMSTests(TestCase):
     user_definitions = [util.ROAMING_USER, util.FIXED_USER]
 

--- a/corehq/apps/commtrack/tests/test_stock_report.py
+++ b/corehq/apps/commtrack/tests/test_stock_report.py
@@ -17,7 +17,6 @@ from corehq.form_processor.parsers.ledgers.helpers import (
     StockReportHelper,
     StockTransactionHelper,
 )
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.form_processor.utils import get_simple_wrapped_form
 from corehq.form_processor.utils.xform import TestFormMetadata
 
@@ -31,7 +30,6 @@ def _get_name_for_domain():
     )
 
 
-@run_with_sql_backend
 class StockReportDomainTest(TestCase):
     def create_report(self, transactions=None, tag=None, date=None):
         form = get_simple_wrapped_form(uuid.uuid4().hex, metadata=TestFormMetadata(domain=self.domain))

--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -31,7 +31,6 @@ from corehq.form_processor.interfaces.dbaccessors import (
     FormAccessors,
 )
 from corehq.form_processor.signals import sql_case_post_save
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.toggles import NAMESPACE_DOMAIN, RUN_AUTO_CASE_UPDATES_ON_SAVE
 from corehq.tests.locks import reentrant_redis_locks
 from corehq.util.context_managers import drop_connected_signals
@@ -96,7 +95,6 @@ def _create_empty_rule(domain, case_type='person', active=True, deleted=False):
     )
 
 
-@run_with_sql_backend
 class BaseCaseRuleTest(TestCase):
     domain = 'case-rule-test'
 

--- a/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
+++ b/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
@@ -26,7 +26,6 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.hqcase.utils import update_case
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.messaging.scheduling.const import (
     VISIT_WINDOW_DUE_DATE,
     VISIT_WINDOW_END,
@@ -89,7 +88,6 @@ def get_visit_scheduler_module_and_form_for_test():
     return module, form
 
 
-@run_with_sql_backend
 class CaseRuleSchedulingIntegrationTest(TestCase):
     domain = 'case-rule-scheduling-test'
 
@@ -1316,7 +1314,6 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
             self.assertTrue(instance.active)
 
 
-@run_with_sql_backend
 class VisitSchedulerIntegrationHelperTestCase(TestCase):
     domain = 'visit-scheduler-integration-helper'
 

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -6,7 +6,7 @@ from io import BytesIO
 
 from django.contrib.auth.models import User
 from django.core.management import call_command
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from dateutil.relativedelta import relativedelta
 from mock import patch
@@ -327,11 +327,9 @@ class TestDeleteDomain(TestCase):
         self.assertEqual(len(CaseAccessors(self.domain.name).get_case_ids_in_domain()), 0)
         self.assertEqual(len(CaseAccessors(self.domain2.name).get_case_ids_in_domain()), 1)
 
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_case_deletion_sql(self):
         self._test_case_deletion()
 
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_form_deletion(self):
         form_states = [state_tuple[0] for state_tuple in XFormInstanceSQL.STATES]
 
@@ -1046,7 +1044,6 @@ class TestHardDeleteSQLFormsAndCases(TestCase):
         call_command('hard_delete_forms_and_cases_in_domain', self.domain.name, noinput=True)
         super(TestHardDeleteSQLFormsAndCases, self).tearDown()
 
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_hard_delete_forms(self):
         for domain_name in [self.domain.name, self.domain2.name]:
             create_form_for_test(domain_name)
@@ -1069,7 +1066,6 @@ class TestHardDeleteSQLFormsAndCases(TestCase):
         self.assertEqual(len(FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain.name)), 0)
         self.assertEqual(len(FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain2.name)), 0)
 
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_hard_delete_forms_none_to_delete(self):
         for domain_name in [self.domain.name, self.domain2.name]:
             create_form_for_test(domain_name)
@@ -1092,7 +1088,6 @@ class TestHardDeleteSQLFormsAndCases(TestCase):
         self.assertEqual(len(FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain.name)), 2)
         self.assertEqual(len(FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain2.name)), 0)
 
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_hard_delete_cases(self):
         for domain_name in [self.domain.name, self.domain2.name]:
             CaseFactory(domain_name).create_case()
@@ -1114,7 +1109,6 @@ class TestHardDeleteSQLFormsAndCases(TestCase):
         self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain.name)), 0)
         self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain2.name)), 0)
 
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_hard_delete_cases_none_to_delete(self):
         for domain_name in [self.domain.name, self.domain2.name]:
             CaseFactory(domain_name).create_case()

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -39,10 +39,7 @@ from corehq.apps.es.case_search import (
 )
 from corehq.apps.es.tests.utils import ElasticTestMixin, es_test
 from corehq.elastic import SIZE_LIMIT, get_es_new
-from corehq.form_processor.tests.utils import (
-    FormProcessorTestUtils,
-    run_with_sql_backend,
-)
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.pillows.case_search import CaseSearchReindexerFactory
 from corehq.pillows.mappings.case_search_mapping import (
     CASE_SEARCH_INDEX,
@@ -268,7 +265,6 @@ class TestCaseSearchES(ElasticTestMixin, SimpleTestCase):
 
 
 @es_test
-@run_with_sql_backend
 class TestCaseSearchLookups(TestCase):
 
     def setUp(self):

--- a/corehq/apps/hqcase/tests/test_bugs.py
+++ b/corehq/apps/hqcase/tests/test_bugs.py
@@ -11,10 +11,8 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import format_username
-from corehq.form_processor.tests.utils import run_with_sql_backend
 
 
-@run_with_sql_backend
 class OtaRestoreBugTest(TestCase):
 
     def setUp(self):

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -13,7 +13,6 @@ from corehq.apps.es.tests.utils import (
     case_search_es_teardown,
     es_test,
 )
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.util.test_utils import generate_cases, privilege_enabled
 
 from ..api.core import UserError
@@ -24,7 +23,6 @@ BAD_GUYS_ID = str(uuid.uuid4())
 
 
 @es_test
-@run_with_sql_backend
 @privilege_enabled(privileges.API_ACCESS)
 class TestCaseListAPI(TestCase):
     domain = 'testcaselistapi'

--- a/corehq/apps/hqcase/tests/test_dbaccessors.py
+++ b/corehq/apps/hqcase/tests/test_dbaccessors.py
@@ -9,7 +9,7 @@ from pillowtop.es_utils import initialize_index_and_mapping
 from corehq.apps.es.tests.utils import es_test
 from corehq.apps.hqcase.analytics import get_number_of_cases_in_domain
 from corehq.elastic import get_es_new
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_sql_backend
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.pillows.mappings.domain_mapping import DOMAIN_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
@@ -23,7 +23,6 @@ TEST_ES_META = {
 
 
 @es_test
-@run_with_sql_backend
 class ESAccessorsTest(TestCase):
     domain = 'hqadmin-es-accessor'
 

--- a/corehq/apps/hqcase/tests/test_explode_cases.py
+++ b/corehq/apps/hqcase/tests/test_explode_cases.py
@@ -20,11 +20,9 @@ from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
     LedgerAccessors,
 )
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.util.test_utils import flag_enabled
 
 
-@run_with_sql_backend
 class ExplodeCasesDbTest(TestCase):
 
     @classmethod
@@ -127,7 +125,6 @@ class ExplodeCasesDbTest(TestCase):
             self.assertTrue(child.indices[0].referenced_id in parent_cases)
 
 
-@run_with_sql_backend
 class ExplodeExtensionsDBTest(BaseSyncTest):
 
     def setUp(self):
@@ -213,7 +210,6 @@ class ExplodeExtensionsDBTest(BaseSyncTest):
 
 
 @flag_enabled('NON_COMMTRACK_LEDGERS')
-@run_with_sql_backend
 class ExplodeLedgersTest(BaseSyncTest):
     def setUp(self):
         super(ExplodeLedgersTest, self).setUp()

--- a/corehq/apps/hqcase/tests/test_loadtest_users.py
+++ b/corehq/apps/hqcase/tests/test_loadtest_users.py
@@ -10,11 +10,9 @@ from casexml.apps.phone.restore import RestoreConfig, RestoreParams
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.toggles import ENABLE_LOADTEST_USERS
 
 
-@run_with_sql_backend
 class LoadtestUserTest(TestCase):
 
     @classmethod

--- a/corehq/apps/hqcase/tests/test_serialization.py
+++ b/corehq/apps/hqcase/tests/test_serialization.py
@@ -11,7 +11,6 @@ from corehq.apps.es.case_search import CaseSearchES
 from corehq.apps.es.tests.utils import es_test
 from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.pillows.case_search import transform_case_for_elasticsearch
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
@@ -22,7 +21,6 @@ from ..utils import submit_case_blocks
 
 
 @es_test
-@run_with_sql_backend
 class TestAPISerialization(TestCase):
     domain = 'test-update-cases'
     maxDiff = None

--- a/corehq/apps/ivr/tests/util.py
+++ b/corehq/apps/ivr/tests/util.py
@@ -2,7 +2,6 @@ from django.test import TestCase
 
 from corehq.apps.ivr.models import Call
 from corehq.apps.sms.models import INCOMING
-from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.util.test_utils import create_test_case
 
 
@@ -53,7 +52,6 @@ class LogCallTestCase(TestCase):
         return create_test_case(self.domain, 'contact', 'test',
             case_properties=case_properties, drop_signals=False)
 
-    @run_with_all_backends
     def test_log_call(self):
         with self.create_case() as case:
             if self.__class__ == LogCallTestCase:

--- a/corehq/apps/locations/tests/test_change_administrative_status.py
+++ b/corehq/apps/locations/tests/test_change_administrative_status.py
@@ -19,13 +19,11 @@ from django.test import TestCase
 
 from corehq.apps.commtrack.tests.util import bootstrap_domain
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend
 
 from ..models import SQLLocation
 from .util import setup_locations_and_types
 
 
-@run_with_sql_backend
 class TestChangeStatus(TestCase):
     domain = 'test-change-administrative'
     location_type_names = ['state', 'county', 'city']

--- a/corehq/apps/locations/tests/test_location_groups.py
+++ b/corehq/apps/locations/tests/test_location_groups.py
@@ -8,14 +8,12 @@ from corehq.apps.commtrack.tests.util import bootstrap_location_types
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.groups.exceptions import CantSaveException
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.util.test_utils import flag_enabled
 
 from ..fixtures import location_fixture_generator
 from .util import make_loc
 
 
-@run_with_sql_backend
 class LocationGroupBase(TestCase):
 
     @classmethod

--- a/corehq/apps/locations/tests/test_permissions.py
+++ b/corehq/apps/locations/tests/test_permissions.py
@@ -15,7 +15,6 @@ from corehq.apps.es.fake.users_fake import UserESFake
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.apps.users.views.mobile import users as user_views
-from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.form_processor.utils.xform import (
     TestFormMetadata,
     get_simple_wrapped_form,
@@ -58,20 +57,16 @@ class TestNewFormEditRestrictions(LocationHierarchyTestCase):
         cls.extra_teardown()
         super(TestNewFormEditRestrictions, cls).tearDownClass()
 
-    @run_with_all_backends
     def test_can_edit_form_in_county(self):
         self.assertCanEdit(self.middlesex_web_user, self.cambridge_form)
 
-    @run_with_all_backends
     def test_cant_edit_out_of_county(self):
         self.assertCannotEdit(self.middlesex_web_user, self.boston_form)
 
-    @run_with_all_backends
     def test_can_edit_any_form(self):
         self.assertCanEdit(self.massachusetts_web_user, self.cambridge_form)
         self.assertCanEdit(self.massachusetts_web_user, self.boston_form)
 
-    @run_with_all_backends
     def test_project_admin_can_edit_anything(self):
         self.project_admin.get_domain_membership(self.domain).is_admin = True
         self.project_admin.save()
@@ -79,7 +74,6 @@ class TestNewFormEditRestrictions(LocationHierarchyTestCase):
         self.assertCanEdit(self.project_admin, self.cambridge_form)
         self.assertCanEdit(self.project_admin, self.boston_form)
 
-    @run_with_all_backends
     def test_unassigned_web_user_cant_edit_anything(self):
         self.assertCannotEdit(self.locationless_web_user, self.cambridge_form)
         self.assertCannotEdit(self.locationless_web_user, self.boston_form)

--- a/corehq/apps/ota/tests/test_claim.py
+++ b/corehq/apps/ota/tests/test_claim.py
@@ -11,7 +11,6 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.ota.utils import get_restore_user
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.form_processor.exceptions import CaseNotFound
 
 DOMAIN = 'test_domain'
@@ -25,7 +24,6 @@ def index_to_dict(instance):
     return {k: str(getattr(instance, k)) for k in keys}
 
 
-@run_with_sql_backend
 class CaseClaimTests(TestCase):
 
     def setUp(self):

--- a/corehq/apps/ota/tests/test_registry_case_details.py
+++ b/corehq/apps/ota/tests/test_registry_case_details.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from defusedxml import ElementTree
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 
 from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseIndex
@@ -16,7 +16,6 @@ from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL, Form
 from corehq.util.test_utils import generate_cases
 
 
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class RegistryCaseDetailsTests(TestCase):
     domain = 'registry-case-details'
 

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -26,7 +26,6 @@ from corehq.apps.es.tests.utils import ElasticTestMixin, es_test
 from corehq.apps.users.models import CommCareUser
 from corehq.elastic import get_es_new
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.pillows.case_search import CaseSearchReindexerFactory, domains_needing_search_index
 from corehq.pillows.mappings.case_search_mapping import (
     CASE_SEARCH_INDEX,
@@ -49,7 +48,6 @@ DATE_PATTERN = r'\d{4}-\d{2}-\d{2}'
 
 
 @es_test
-@run_with_sql_backend
 class CaseSearchTests(ElasticTestMixin, TestCase):
     def setUp(self):
         super(CaseSearchTests, self).setUp()
@@ -292,7 +290,6 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
 
 
 @es_test
-@run_with_sql_backend
 class CaseClaimEndpointTests(TestCase):
     def setUp(self):
         self.domain = create_domain(DOMAIN)

--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -3,7 +3,6 @@ from django.test import TestCase
 from casexml.apps.phone.models import OTARestoreCommCareUser, OTARestoreWebUser
 
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.apps.locations.tests.util import LocationHierarchyTestCase
 from corehq.apps.ota.utils import get_restore_user, is_permitted_to_restore
 from corehq.apps.users.dbaccessors import delete_all_users
@@ -11,7 +10,6 @@ from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.apps.users.util import format_username
 
 
-@run_with_sql_backend
 class RestorePermissionsTest(LocationHierarchyTestCase):
     domain = 'goats'
     other_domain = 'sheep'
@@ -217,7 +215,6 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
         self.assertRegex(message, 'not in allowed locations')
 
 
-@run_with_sql_backend
 class GetRestoreUserTest(TestCase):
 
     domain = 'goats'

--- a/corehq/apps/receiverwrapper/tests/test_submissions.py
+++ b/corehq/apps/receiverwrapper/tests/test_submissions.py
@@ -13,11 +13,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors, CaseAccessors
-from corehq.form_processor.tests.utils import (
-    FormProcessorTestUtils,
-    run_with_sql_backend,
-    sharded,
-)
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
 from corehq.util.json import CommCareJSONEncoder
 from corehq.util.test_utils import TestFileMixin, softer_assert
 
@@ -25,7 +21,6 @@ from corehq.util.test_utils import TestFileMixin, softer_assert
 from couchforms.exceptions import InvalidSubmissionFileExtensionError
 
 
-@run_with_sql_backend
 class BaseSubmissionTest(TestCase):
     def setUp(self):
         super(BaseSubmissionTest, self).setUp()
@@ -287,7 +282,6 @@ class NormalModeSubmissionTest(BaseSubmissionTest):
         self.assertTrue(notification.called)
 
 
-@run_with_sql_backend
 class SubmissionSQLTransactionsTest(TestCase, TestFileMixin):
     root = os.path.dirname(__file__)
     file_path = ('data',)

--- a/corehq/apps/registry/tests/test_helper.py
+++ b/corehq/apps/registry/tests/test_helper.py
@@ -11,7 +11,7 @@ from corehq.apps.registry.schema import RegistrySchemaBuilder
 from corehq.apps.registry.tests.utils import create_registry_for_test
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.exceptions import CaseNotFound
-from corehq.form_processor.tests.utils import run_with_sql_backend, FormProcessorTestUtils
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 
 
 class TestDataRegistryHelper(SimpleTestCase):
@@ -64,7 +64,6 @@ class TestDataRegistryHelper(SimpleTestCase):
         self.log_data_access.not_called()
 
 
-@run_with_sql_backend
 class TestGetCaseHierarchy(TestCase):
     domain = 'data-registry-case-hierarchy'
 

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -61,7 +61,6 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CaseTransaction, CommCareCaseSQL
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.pillows.case import transform_case_for_elasticsearch
 from corehq.pillows.mappings.case_mapping import CASE_INDEX, CASE_INDEX_INFO
@@ -76,7 +75,6 @@ from corehq.util.test_utils import make_es_ready_form, trap_extra_setup
 
 
 @es_test
-@run_with_sql_backend
 class BaseESAccessorsTest(TestCase):
     es_index_info = None
 
@@ -862,7 +860,6 @@ class TestFormESAccessors(BaseESAccessorsTest):
 
 
 @es_test
-@run_with_sql_backend
 class TestUserESAccessors(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/corehq/apps/sms/tests/opt_tests.py
+++ b/corehq/apps/sms/tests/opt_tests.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 
 from corehq.apps.accounting.models import SoftwarePlanEdition
-from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
 from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
 from corehq.apps.accounting.utils import clear_plan_version_cache
 from corehq.apps.domain.models import Domain

--- a/corehq/apps/sms/tests/opt_tests.py
+++ b/corehq/apps/sms/tests/opt_tests.py
@@ -13,10 +13,7 @@ from corehq.apps.sms.tests.util import (
     delete_domain_phone_numbers,
     setup_default_sms_test_backend,
 )
-from corehq.form_processor.tests.utils import (
-    FormProcessorTestUtils,
-    run_with_all_backends,
-)
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 
 
 class OptTestCase(DomainSubscriptionMixin, TestCase):
@@ -65,7 +62,6 @@ class OptTestCase(DomainSubscriptionMixin, TestCase):
     def get_last_sms(self, phone_number):
         return SMS.objects.filter(domain=self.domain, phone_number=phone_number).order_by('-date')[0]
 
-    @run_with_all_backends
     def test_opt_out_and_opt_in(self):
         self.assertEqual(PhoneBlacklist.objects.count(), 0)
 
@@ -97,7 +93,6 @@ class OptTestCase(DomainSubscriptionMixin, TestCase):
         self.assertEqual(sms.direction, 'O')
         self.assertEqual(sms.text, get_message(MSG_OPTED_IN, context=('STOP',)))
 
-    @run_with_all_backends
     def test_sending_to_opted_out_number(self):
         self.assertEqual(PhoneBlacklist.objects.count(), 0)
 

--- a/corehq/apps/sms/tests/test_backends.py
+++ b/corehq/apps/sms/tests/test_backends.py
@@ -36,7 +36,6 @@ from corehq.apps.sms.tasks import (
 )
 from corehq.apps.sms.tests.util import BaseSMSTest, delete_domain_phone_numbers
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.messaging.smsbackends.airtel_tcl.models import AirtelTCLBackend
 from corehq.messaging.smsbackends.apposit.models import SQLAppositBackend
 from corehq.messaging.smsbackends.grapevine.models import SQLGrapevineBackend
@@ -395,7 +394,6 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
         self._test_outbound_backend(self.infobip_backend, 'infobip test', infobip_send)
         self._test_outbound_backend(self.pinpoint_backend, 'pinpoint test', pinpoint_send)
 
-    @run_with_all_backends
     def test_unicel_inbound_sms(self):
         self._simulate_inbound_request(
             '/unicel/in/%s/' % self.unicel_backend.inbound_api_key,
@@ -406,7 +404,6 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
 
         self._verify_inbound_request(self.unicel_backend.get_api_id(), 'unicel test')
 
-    @run_with_all_backends
     def test_telerivet_inbound_sms(self):
         additional_params = {
             'event': 'incoming_message',
@@ -419,7 +416,6 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
 
         self._verify_inbound_request(self.telerivet_backend.get_api_id(), 'telerivet test')
 
-    @run_with_all_backends
     @override_settings(SIMPLE_API_KEYS={'grapevine-test': 'grapevine-api-key'})
     def test_grapevine_inbound_sms(self):
         xml = """
@@ -436,7 +432,6 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
 
         self._verify_inbound_request(self.grapevine_backend.get_api_id(), 'grapevine test')
 
-    @run_with_all_backends
     def test_turn_inbound_sms(self):
         url = '/turn/sms/%s' % self.turn_backend.inbound_api_key
         payload = {"messages": [
@@ -455,7 +450,6 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
         self._verify_inbound_request(self.turn_backend.get_api_id(), 'turn test',
             backend_couch_id=self.turn_backend.couch_id)
 
-    @run_with_all_backends
     def test_twilio_inbound_sms(self):
         url = '/twilio/sms/%s' % self.twilio_backend.inbound_api_key
         self._simulate_inbound_request(url, phone_param='From',
@@ -464,7 +458,6 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
         self._verify_inbound_request(self.twilio_backend.get_api_id(), 'twilio test',
             backend_couch_id=self.twilio_backend.couch_id)
 
-    @run_with_all_backends
     def test_twilio_401_response(self):
         start_count = SMS.objects.count()
 
@@ -476,7 +469,6 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
 
         self.assertEqual(start_count, end_count)
 
-    @run_with_all_backends
     def test_sislog_inbound_sms(self):
         self._simulate_inbound_request(
             '/sislog/in/%s/' % self.sislog_backend.inbound_api_key,
@@ -487,7 +479,6 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
 
         self._verify_inbound_request(self.sislog_backend.get_api_id(), 'sislog test')
 
-    @run_with_all_backends
     def test_yo_inbound_sms(self):
         self._simulate_inbound_request(
             '/yo/sms/%s/' % self.yo_backend.inbound_api_key,
@@ -498,7 +489,6 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
 
         self._verify_inbound_request(self.yo_backend.get_api_id(), 'yo test')
 
-    @run_with_all_backends
     def test_smsgh_inbound_sms(self):
         self._simulate_inbound_request(
             '/smsgh/sms/{}/'.format(self.smsgh_backend.inbound_api_key),
@@ -509,7 +499,6 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
 
         self._verify_inbound_request('SMSGH', 'smsgh test')
 
-    @run_with_all_backends
     def test_apposit_inbound_sms(self):
         self._simulate_inbound_request_with_payload(
             '/apposit/in/%s/' % self.apposit_backend.inbound_api_key,
@@ -522,7 +511,6 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
         self._verify_inbound_request('APPOSIT', 'apposit test',
             backend_couch_id=self.apposit_backend.couch_id)
 
-    @run_with_all_backends
     def test_push_inbound_sms(self):
         xml = """<?xml version="1.0" encoding="UTF-8"?>
         <bspostevent>
@@ -537,7 +525,6 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
         self._verify_inbound_request(self.push_backend.get_api_id(), 'push test',
             backend_couch_id=self.push_backend.couch_id)
 
-    @run_with_all_backends
     def test_trumpia_inbound_sms(self):
         text = 'trumpia test'
         xml = urlencode({"xml":
@@ -561,7 +548,6 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
             backend_couch_id=self.trumpia_backend.couch_id,
         )
 
-    @run_with_all_backends
     def test_infobip_inbound_sms(self):
         url = '/infobip/sms/%s' % self.infobip_backend.inbound_api_key
         payload = {
@@ -581,7 +567,6 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
         self._verify_inbound_request(self.infobip_backend.get_api_id(), 'infobip test',
             backend_couch_id=self.infobip_backend.couch_id)
 
-    @run_with_all_backends
     def test_pinpoint_inbound_sms(self):
         url = '/pinpoint/sms/%s' % self.pinpoint_backend.inbound_api_key
         payload = {

--- a/corehq/apps/sms/tests/test_chat.py
+++ b/corehq/apps/sms/tests/test_chat.py
@@ -11,7 +11,6 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.sms.models import INCOMING, OUTGOING, SMS, SQLLastReadMessage
 from corehq.apps.sms.views import ChatMessageHistory
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.util.test_utils import create_test_case, softer_assert
 
 
@@ -221,7 +220,6 @@ class ChatHistoryTestCase(TestCase):
     def create_contact2(self):
         return create_test_case('another-domain', 'contact', 'test-case2', case_id=self.contact2_id)
 
-    @run_with_all_backends
     def test_contact(self):
         with self.create_contact1() as contact1, self.create_contact2() as contact2:
             with self.patch_contact_id(contact1.case_id):
@@ -230,7 +228,6 @@ class ChatHistoryTestCase(TestCase):
             with self.patch_contact_id(contact2.case_id):
                 self.assertIsNone(self.new_view.contact)
 
-    @run_with_all_backends
     def test_contact_name(self):
         with self.create_contact1() as contact1:
             self.set_custom_case_username(None)
@@ -317,7 +314,6 @@ class ChatHistoryTestCase(TestCase):
         self.assertEqual(lrm.message_id, sms.couch_id)
         self.assertEqual(lrm.message_timestamp, sms.date)
 
-    @run_with_all_backends
     def test_get_response_data(self):
         with self.create_contact1() as contact1:
             with self.patch_contact_id(contact1.case_id):
@@ -363,7 +359,6 @@ class ChatHistoryTestCase(TestCase):
 
                 self.set_survey_filter_option(False, False)
 
-    @run_with_all_backends
     def test_update_last_read_message(self):
         SQLLastReadMessage.objects.all().delete()
         self.assertEqual(self.get_last_read_message_count(), 0)

--- a/corehq/apps/sms/tests/test_phone_numbers.py
+++ b/corehq/apps/sms/tests/test_phone_numbers.py
@@ -20,7 +20,6 @@ from corehq.apps.sms.tests.util import delete_domain_phone_numbers
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.apps.users.tasks import tag_cases_as_deleted_and_remove_indices
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.form_processor.utils import is_commcarecase
 from corehq.messaging.smsbackends.test.models import SQLTestSMSBackend
 from corehq.util.test_utils import create_test_case
@@ -129,7 +128,6 @@ class CaseContactPhoneNumberTestCase(TestCase):
         if pk:
             self.assertEqual(v.pk, pk)
 
-    @run_with_all_backends
     def test_case_phone_number_updates(self):
         extra_number = PhoneNumber.objects.create(
             domain=self.domain,
@@ -180,7 +178,6 @@ class CaseContactPhoneNumberTestCase(TestCase):
 
         self.assertEqual(PhoneNumber.get_two_way_number('999123'), extra_number)
 
-    @run_with_all_backends
     def test_close_case(self):
         extra_number = PhoneNumber.objects.create(
             domain=self.domain,
@@ -205,7 +202,6 @@ class CaseContactPhoneNumberTestCase(TestCase):
 
         self.assertEqual(PhoneNumber.get_two_way_number('999123'), extra_number)
 
-    @run_with_all_backends
     def test_case_soft_delete(self):
         extra_number = PhoneNumber.objects.create(
             domain=self.domain,
@@ -230,7 +226,6 @@ class CaseContactPhoneNumberTestCase(TestCase):
 
         self.assertEqual(PhoneNumber.get_two_way_number('999123'), extra_number)
 
-    @run_with_all_backends
     def test_case_zero_phone_number(self):
         extra_number = PhoneNumber.objects.create(
             domain=self.domain,
@@ -255,7 +250,6 @@ class CaseContactPhoneNumberTestCase(TestCase):
 
         self.assertEqual(PhoneNumber.get_two_way_number('999123'), extra_number)
 
-    @run_with_all_backends
     def test_invalid_phone_format(self):
         extra_number = PhoneNumber.objects.create(
             domain=self.domain,
@@ -280,7 +274,6 @@ class CaseContactPhoneNumberTestCase(TestCase):
 
         self.assertEqual(PhoneNumber.get_two_way_number('999123'), extra_number)
 
-    @run_with_all_backends
     def test_phone_number_already_in_use(self):
         self.assertEqual(PhoneNumber.count_by_domain(self.domain), 0)
 
@@ -305,7 +298,6 @@ class CaseContactPhoneNumberTestCase(TestCase):
             self.assertPhoneNumberDetails(case1, '99987658765', None, None, True, False, True)
             self.assertPhoneNumberDetails(case2, '99987658765', None, None, False, False, False)
 
-    @run_with_all_backends
     def test_multiple_entries(self):
         extra_number = PhoneNumber.objects.create(
             domain=self.domain,
@@ -379,7 +371,6 @@ class SQLPhoneNumberTestCase(TestCase):
         number.backend_id = '  '
         self.assertEqual(number.backend, backend1)
 
-    @run_with_all_backends
     def test_case_owner(self):
         with create_test_case(self.domain, 'participant', 'test') as case:
             number = PhoneNumber(owner_doc_type='CommCareCase', owner_id=case.case_id)
@@ -640,7 +631,6 @@ class SQLPhoneNumberTestCase(TestCase):
             drop_signals=False
         )
 
-    @run_with_all_backends
     def test_delete_phone_numbers_for_owners(self):
         with self.create_case_contact('9990001') as case1, \
                 self.create_case_contact('9990002') as case2, \

--- a/corehq/apps/sms/tests/test_util.py
+++ b/corehq/apps/sms/tests/test_util.py
@@ -13,7 +13,6 @@ from corehq.apps.sms.util import (
     is_superuser_or_contractor,
 )
 from corehq.apps.users.models import CommCareUser, CouchUser
-from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.form_processor.utils import is_commcarecase
 from corehq.util.test_utils import create_test_case, flag_enabled
 
@@ -32,7 +31,6 @@ class UtilTestCase(TestCase):
         cleaned = clean_phone_number(phone_number)
         self.assertEqual(cleaned, "+3242323421241")
 
-    @run_with_all_backends
     def test_get_contact_for_case(self):
         with create_test_case(self.domain, 'contact', 'test-case') as case:
             contact = get_contact(self.domain, case.case_id)
@@ -54,7 +52,6 @@ class UtilTestCase(TestCase):
         with self.assertRaises(ContactNotFoundException):
             get_contact(self.domain, 'this-id-should-not-be-found')
 
-    @run_with_all_backends
     def test_is_contact_active_for_case(self):
         with create_test_case(self.domain, 'contact', 'test-case') as case:
             self.assertTrue(is_contact_active(self.domain, 'CommCareCase', case.case_id))

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -28,7 +28,6 @@ from corehq.apps.userreports.reports.specs import (
 from corehq.apps.userreports.sql.columns import expand_column
 from corehq.apps.userreports.util import get_indicator_adapter
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.sql_db.connections import UCR_ENGINE_ID, connection_manager
 
 
@@ -84,7 +83,6 @@ class TestFieldColumn(SimpleTestCase):
             }, is_static=False)
 
 
-@run_with_sql_backend
 class ChoiceListColumnDbTest(TestCase):
 
     def test_column_uniqueness_when_truncated(self):
@@ -125,7 +123,6 @@ class ChoiceListColumnDbTest(TestCase):
         self.assertEqual(1, q.count())
 
 
-@run_with_sql_backend
 class ArrayTypeColumnDbTest(TestCase):
 
     def test_array_type_column(self):
@@ -165,7 +162,6 @@ class ArrayTypeColumnDbTest(TestCase):
         self.assertEqual(qs.first().referral_health_problem, ['bleeding', 'convulsions'])
 
 
-@run_with_sql_backend
 class TestExpandedColumn(TestCase):
     domain = 'foo'
     case_type = 'person'

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -26,7 +26,6 @@ from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors, CaseAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.util.test_utils import (
     create_and_save_a_case,
     create_and_save_a_form,
@@ -932,7 +931,6 @@ class RelatedDocExpressionTest(SimpleTestCase):
         self.assertEqual('foo', self.expression(my_doc, context))
 
 
-@run_with_sql_backend
 class RelatedDocExpressionDbTest(TestCase):
     domain = 'related-doc-db-test-domain'
 
@@ -1126,7 +1124,6 @@ class TestEvaluatorTypes(SimpleTestCase):
         self.assertEqual(type(ExpressionFactory.from_spec(spec)({})), int)
 
 
-@run_with_sql_backend
 class TestFormsExpressionSpec(TestCase):
 
     @classmethod
@@ -1185,7 +1182,6 @@ class TestFormsExpressionSpec(TestCase):
         self.assertEqual(forms, [])
 
 
-@run_with_sql_backend
 class TestGetSubcasesExpression(TestCase):
 
     def setUp(self):
@@ -1243,7 +1239,6 @@ class TestGetSubcasesExpression(TestCase):
         self.assertEqual(extension.case_id, subcases[0]['_id'])
 
 
-@run_with_sql_backend
 class TestGetCaseSharingGroupsExpression(TestCase):
 
     def setUp(self):
@@ -1305,7 +1300,6 @@ class TestGetCaseSharingGroupsExpression(TestCase):
         self.assertEqual(len(case_sharing_groups), 0)
 
 
-@run_with_sql_backend
 class TestGetReportingGroupsExpression(TestCase):
 
     def setUp(self):

--- a/corehq/apps/userreports/tests/test_extension_expressions.py
+++ b/corehq/apps/userreports/tests/test_extension_expressions.py
@@ -7,10 +7,8 @@ from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.specs import EvaluationContext
-from corehq.form_processor.tests.utils import run_with_sql_backend
 
 
-@run_with_sql_backend
 class IndexedCaseExpressionTest(TestCase):
     def setUp(self):
         super(IndexedCaseExpressionTest, self).setUp()

--- a/corehq/apps/userreports/tests/test_indicators.py
+++ b/corehq/apps/userreports/tests/test_indicators.py
@@ -23,7 +23,6 @@ from corehq.form_processor.parsers.ledgers.helpers import (
     StockReportHelper,
     StockTransactionHelper,
 )
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.form_processor.utils import get_simple_wrapped_form
 from corehq.form_processor.utils.xform import TestFormMetadata
 
@@ -598,7 +597,6 @@ class DueListDateIndicatorTest(SimpleTestCase):
         )
 
 
-@run_with_sql_backend
 class TestGetValuesByProduct(TestCase):
     domain_name = 'test-domain'
     case_id = 'case1'

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -173,7 +173,7 @@ class ConfigurableReportTableManagerDbTest(TestCase):
         self.assertEqual(2, len(table_manager.table_adapters_by_domain[ds_1_domain]))
         self.assertEqual(
             {data_source_1._id, data_source_2._id},
-            set([table_adapter.config._id for table_adapter in table_manager.table_adapters_by_domain[ds_1_domain]])
+            {t.config._id for t in table_manager.table_adapters_by_domain[ds_1_domain]}
         )
 
     @patch("corehq.apps.cachehq.mixins.invalidate_document")
@@ -268,7 +268,7 @@ class ChunkedUCRProcessorTest(TestCase):
     def test_full_fallback(self, process_change_patch, process_changes_patch):
 
         process_changes_patch.side_effect = Exception
-        cases = self._create_and_process_changes()
+        self._create_and_process_changes()
 
         process_changes_patch.assert_called_once()
         # since chunked processing failed, normal processing should get called
@@ -283,7 +283,7 @@ class ChunkedUCRProcessorTest(TestCase):
             for i in range(10)
         ]
         iter_docs_patch.return_value = docs[0:6]
-        cases = self._create_and_process_changes(docs)
+        self._create_and_process_changes(docs)
 
         # since chunked processing failed, normal processing should get called
         process_change_patch.assert_has_calls([mock.call(mock.ANY)] * 4)

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -2,7 +2,7 @@ import decimal
 import uuid
 from datetime import datetime, timedelta
 
-from django.test import SimpleTestCase, TestCase, override_settings
+from django.test import SimpleTestCase, TestCase
 
 import mock
 from mock import patch
@@ -203,8 +203,6 @@ class ConfigurableReportTableManagerDbTest(TestCase):
         return DataSourceConfiguration.wrap(data_source_json)
 
 
-
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class ChunkedUCRProcessorTest(TestCase):
     @classmethod
     def setUpClass(cls):
@@ -372,7 +370,6 @@ class ChunkedUCRProcessorTest(TestCase):
         bootstrap_if_needed.assert_called_once_with()
 
 
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class IndicatorPillowTest(TestCase):
 
     @classmethod
@@ -472,7 +469,6 @@ class IndicatorPillowTest(TestCase):
     def test_process_doc_from_sql(self, datetime_mock):
         self._test_process_doc_from_sql(datetime_mock)
 
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def _test_process_doc_from_sql(self, datetime_mock):
         datetime_mock.utcnow.return_value = self.fake_time_now
         sample_doc, expected_indicators = get_sample_doc_and_indicators(self.fake_time_now)
@@ -498,7 +494,6 @@ class IndicatorPillowTest(TestCase):
     def test_process_deleted_doc_from_sql(self, datetime_mock):
         self._test_process_deleted_doc_from_sql(datetime_mock)
 
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def _test_process_deleted_doc_from_sql(self, datetime_mock):
         datetime_mock.utcnow.return_value = self.fake_time_now
         sample_doc, expected_indicators = get_sample_doc_and_indicators(self.fake_time_now)
@@ -521,7 +516,6 @@ class IndicatorPillowTest(TestCase):
         CaseAccessorSQL.hard_delete_cases(case.domain, [case.case_id])
 
     @mock.patch('corehq.apps.userreports.specs.datetime')
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_process_filter_no_longer_pass(self, datetime_mock):
         datetime_mock.utcnow.return_value = self.fake_time_now
         sample_doc, expected_indicators = get_sample_doc_and_indicators(self.fake_time_now)
@@ -536,7 +530,6 @@ class IndicatorPillowTest(TestCase):
         self.assertEqual(0, self.adapter.get_query_object().count())
 
     @mock.patch('corehq.apps.userreports.specs.datetime')
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_check_if_doc_exist(self, datetime_mock):
         datetime_mock.utcnow.return_value = self.fake_time_now
         sample_doc, expected_indicators = get_sample_doc_and_indicators(self.fake_time_now)
@@ -548,7 +541,6 @@ class IndicatorPillowTest(TestCase):
         self.assertIs(self.adapter.doc_exists(sample_doc), True)
 
 
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class ProcessRelatedDocTypePillowTest(TestCase):
     domain = 'bug-domain'
 
@@ -626,7 +618,6 @@ class ProcessRelatedDocTypePillowTest(TestCase):
             self.assertEqual(errors.count(), 0)
 
 
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class ReuseEvaluationContextTest(TestCase):
     domain = 'bug-domain'
 
@@ -704,7 +695,6 @@ class ReuseEvaluationContextTest(TestCase):
             self.assertEqual(int(rows[0].parent_property), 0)
 
 
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class AsyncIndicatorTest(TestCase):
     domain = 'bug-domain'
 

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -11,7 +11,6 @@ from corehq.apps.userreports.reports.view import ConfigurableReportView
 from corehq.apps.userreports.tasks import rebuild_indicators
 from corehq.apps.userreports.tests.test_view import ConfigurableReportTestMixin
 from corehq.apps.userreports.util import get_indicator_adapter
-from corehq.form_processor.tests.utils import run_with_sql_backend
 
 
 class ConfigurableReportAggregationTestMixin(ConfigurableReportTestMixin):
@@ -37,7 +36,6 @@ class ConfigurableReportAggregationTestMixin(ConfigurableReportTestMixin):
         return view
 
 
-@run_with_sql_backend
 class TestReportAggregationSQL(ConfigurableReportAggregationTestMixin, TestCase):
     """
     Integration tests for configurable report aggregation
@@ -607,7 +605,6 @@ class TestReportAggregationSQL(ConfigurableReportAggregationTestMixin, TestCase)
         )
 
 
-@run_with_sql_backend
 @freeze_time("2020-12-30")
 class TestReportMultipleAggregationsSQL(ConfigurableReportAggregationTestMixin, TestCase):
     @classmethod

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -25,7 +25,6 @@ from corehq.form_processor.interfaces.dbaccessors import (
     FormAccessors,
 )
 from corehq.form_processor.models import UserArchivedRebuild
-from corehq.form_processor.tests.utils import run_with_all_backends
 
 
 class RetireUserTestCase(TestCase):
@@ -83,7 +82,6 @@ class RetireUserTestCase(TestCase):
         with self.assertRaisesMessage(ValueError, "Missing unretired_by"):
             self.commcare_user.unretire(self.domain, unretired_by=None)
 
-    @run_with_all_backends
     def test_unretire_user(self):
         case_ids = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
 
@@ -130,7 +128,6 @@ class RetireUserTestCase(TestCase):
         form = FormAccessors(self.domain).get_form(xform.form_id)
         self.assertFalse(form.is_deleted)
 
-    @run_with_all_backends
     def test_undelete_system_forms(self):
         case_ids = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
 
@@ -174,7 +171,6 @@ class RetireUserTestCase(TestCase):
         form_2 = FormAccessors(self.domain).get_form(xform_2.form_id)
         self.assertFalse(form_2.is_deleted)
 
-    @run_with_all_backends
     def test_deleted_indices_removed(self):
         factory = CaseFactory(
             self.domain,
@@ -210,7 +206,6 @@ class RetireUserTestCase(TestCase):
         self.assertTrue(child.indices[0].is_deleted)
         self.assertEqual(2, len(child.xform_ids))
 
-    @run_with_all_backends
     @mock.patch("casexml.apps.case.cleanup.rebuild_case_from_forms")
     def test_rebuild_cases_with_new_owner(self, rebuild_case):
         """
@@ -233,7 +228,6 @@ class RetireUserTestCase(TestCase):
         detail = UserArchivedRebuild(user_id=self.other_user.user_id)
         rebuild_case.assert_called_once_with(self.domain, case_id, detail)
 
-    @run_with_all_backends
     @mock.patch("casexml.apps.case.cleanup.rebuild_case_from_forms")
     def test_dont_rebuild(self, rebuild_case):
         """ Don't rebuild cases that are owned by other users """
@@ -252,7 +246,6 @@ class RetireUserTestCase(TestCase):
 
         self.assertEqual(rebuild_case.call_count, 0)
 
-    @run_with_all_backends
     @mock.patch("casexml.apps.case.cleanup.rebuild_case_from_forms")
     def test_multiple_case_blocks_all_rebuilt(self, rebuild_case):
         """ Rebuild all cases in forms with multiple case blocks """
@@ -276,7 +269,6 @@ class RetireUserTestCase(TestCase):
         self.assertEqual(rebuild_case.call_count, len(case_ids))
         self.assertItemsEqual(rebuild_case.call_args_list, expected_call_args)
 
-    @run_with_all_backends
     @mock.patch("casexml.apps.case.cleanup.rebuild_case_from_forms")
     def test_multiple_case_blocks_some_deleted(self, rebuild_case):
         """ Don't rebuild deleted cases """
@@ -306,7 +298,6 @@ class RetireUserTestCase(TestCase):
         self.assertEqual(rebuild_case.call_count, len(case_ids) - 1)
         self.assertItemsEqual(rebuild_case.call_args_list, expected_call_args)
 
-    @run_with_all_backends
     def test_all_case_forms_deleted(self):
         from corehq.apps.callcenter.sync_usercase import sync_usercase
         sync_usercase(self.commcare_user)
@@ -336,7 +327,6 @@ class RetireUserTestCase(TestCase):
 
         self.assertTrue(CaseAccessors(self.domain).get_case(usercase_id).is_deleted)
 
-    @run_with_all_backends
     def test_forms_touching_live_case_not_deleted(self):
         case_id = uuid.uuid4().hex
         caseblock = CaseBlock.deprecated_init(

--- a/corehq/apps/users/tests/test_user_model.py
+++ b/corehq/apps/users/tests/test_user_model.py
@@ -12,10 +12,7 @@ from corehq.apps.custom_data_fields.models import (
 from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser, DeviceAppMeta, WebUser
-from corehq.form_processor.tests.utils import (
-    FormProcessorTestUtils,
-    run_with_sql_backend,
-)
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.form_processor.utils import (
     TestFormMetadata,
     get_simple_wrapped_form,
@@ -25,7 +22,6 @@ from corehq.util.test_utils import softer_assert
 from corehq.apps.users.models import MAX_LOGIN_ATTEMPTS
 
 
-@run_with_sql_backend
 class UserModelTest(TestCase):
 
     def setUp(self):

--- a/corehq/apps/zapier/tests/test_zapier_forwarding.py
+++ b/corehq/apps/zapier/tests/test_zapier_forwarding.py
@@ -9,7 +9,6 @@ from casexml.apps.case.util import post_case_blocks
 from corehq.apps.zapier.consts import EventTypes
 from corehq.apps.zapier.models import ZapierSubscription
 from corehq.apps.zapier.tests.test_utils import bootrap_domain_for_zapier
-from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.motech.repeaters.dbaccessors import (
     delete_all_repeat_records,
     delete_all_repeaters,
@@ -39,27 +38,21 @@ class TestZapierCaseForwarding(TestCase):
         delete_all_repeat_records()
         ZapierSubscription.objects.all().delete()
 
-    @run_with_all_backends
     def test_create_case_forwarding(self):
         self._run_test(EventTypes.NEW_CASE, 1, 1)
 
-    @run_with_all_backends
     def test_update_case_forwarding(self):
         self._run_test(EventTypes.UPDATE_CASE, 0, 1)
 
-    @run_with_all_backends
     def test_change_case_forwarding(self):
         self._run_test(EventTypes.CHANGED_CASE, 1, 2)
 
-    @run_with_all_backends
     def test_case_forwarding_wrong_type(self):
         self._run_test(EventTypes.NEW_CASE, 0, 0, 'plant')
 
-    @run_with_all_backends
     def test_update_case_forwarding_wrong_type(self):
         self._run_test(EventTypes.UPDATE_CASE, 0, 0, 'plant')
 
-    @run_with_all_backends
     def test_change_case_forwarding_wrong_type(self):
         self._run_test(EventTypes.CHANGED_CASE, 0, 0, 'plant')
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_case_history.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_case_history.py
@@ -4,10 +4,8 @@ from casexml.apps.case.mock import CaseFactory, CaseStructure
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 from casexml.apps.case.util import get_case_history
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend
 
 
-@run_with_sql_backend
 class TestCaseHistory(TestCase):
     def setUp(self):
         self.domain = "isildur"

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_get_case_property_changes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_get_case_property_changes.py
@@ -12,10 +12,8 @@ from casexml.apps.case.util import (
 )
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import RebuildWithReason
-from corehq.form_processor.tests.utils import run_with_sql_backend
 
 
-@run_with_sql_backend
 class TestCasePropertyChanged(TestCase):
     def setUp(self):
         self.domain = "isildur"

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multi_case_submits.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multi_case_submits.py
@@ -3,10 +3,8 @@ import os
 from casexml.apps.case.tests.util import delete_all_xforms, delete_all_cases
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend
 
 
-@run_with_sql_backend
 class MultiCaseTest(TestCase):
 
     def setUp(self):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_out_of_order_processing.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_out_of_order_processing.py
@@ -3,11 +3,9 @@ from django.test import TestCase
 from casexml.apps.case.tests.util import delete_all_cases
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.util.test_utils import softer_assert
 
 
-@run_with_sql_backend
 class OutOfOrderCaseTest(TestCase):
 
     def setUp(self):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_signals.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_signals.py
@@ -5,10 +5,8 @@ from casexml.apps.case.signals import cases_received
 from casexml.apps.case.xform import process_cases_with_casedb
 from corehq.form_processor.backends.sql.dbaccessors import FormAccessorSQL
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import run_with_sql_backend
 
 
-@run_with_sql_backend
 class TestCasesReceivedSignal(TestCase):
 
     def test_casedb_already_has_cases(self):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
@@ -27,7 +27,6 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.util import normalize_username
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.util.test_utils import TestFileMixin
 
 
@@ -35,7 +34,6 @@ def get_registration_xml(restore_user):
     return xml.tostring(xml.get_registration_element(restore_user)).decode('utf-8')
 
 
-@run_with_sql_backend
 class SimpleOtaRestoreTest(TestCase):
 
     def setUp(self):
@@ -79,7 +77,6 @@ class SimpleOtaRestoreTest(TestCase):
         assertRegistrationData("phone_number", "555555")
 
 
-@run_with_sql_backend
 class BaseOtaRestoreTest(TestCase, TestFileMixin):
     file_path = ('data',)
     root = os.path.dirname(__file__)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 
 import casexml.apps.phone.utils as mod
 from casexml.apps.case.mock import CaseStructure
@@ -34,7 +34,6 @@ class TestUtils(SimpleTestCase):
 
 
 @flag_enabled('NON_COMMTRACK_LEDGERS')
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class MockDeviceLedgersTest(BaseSyncTest, TestXmlMixin):
     def setUp(self):
         super(MockDeviceLedgersTest, self).setUp()

--- a/corehq/ex-submodules/couchforms/tests/test_analytics.py
+++ b/corehq/ex-submodules/couchforms/tests/test_analytics.py
@@ -23,7 +23,7 @@ from testapps.test_pillowtop.utils import process_pillow_changes
 from corehq.apps.es.tests.utils import es_test
 from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_sql_backend
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
@@ -37,7 +37,6 @@ from corehq.util.test_utils import (
 
 @es_test
 @disable_quickcache
-@run_with_sql_backend
 class ExportsFormsAnalyticsTest(TestCase, DocTestMixin):
     maxDiff = None
 
@@ -132,7 +131,6 @@ TEST_ES_META = {
 
 
 @disable_quickcache
-@run_with_sql_backend
 class CouchformsESAnalyticsTest(TestCase):
     domain = 'hqadmin-es-accessor'
 

--- a/corehq/ex-submodules/couchforms/tests/test_archive.py
+++ b/corehq/ex-submodules/couchforms/tests/test_archive.py
@@ -2,7 +2,6 @@ import os
 import mock
 from datetime import datetime, timedelta
 from django.test import TestCase
-from django.test.utils import override_settings
 
 from corehq.form_processor.tasks import reprocess_archive_stubs
 from corehq.apps.change_feed import topics
@@ -428,7 +427,6 @@ class TestFormArchiving(TestCase, TestFileMixin):
         self.assertEqual(1, archive_counter)
         self.assertEqual(1, restore_counter)
 
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def testPublishChanges(self):
         xml_data = self.get_xml('basic')
         result = submit_form_locally(

--- a/corehq/form_processor/tests/test_ledger_dbaccessor.py
+++ b/corehq/form_processor/tests/test_ledger_dbaccessor.py
@@ -1,7 +1,6 @@
 import uuid
 
 from django.test import TestCase
-from django.test.utils import override_settings
 
 from casexml.apps.case.mock import CaseFactory
 from corehq.apps.commtrack.helpers import make_product
@@ -18,8 +17,7 @@ class LedgerDBAccessorTest(TestCase):
     def setUpClass(cls):
         super(LedgerDBAccessorTest, cls).setUpClass()
         cls.domain = uuid.uuid4().hex
-        with override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True):
-            FormProcessorTestUtils.delete_all_cases_forms_ledgers(cls.domain)
+        FormProcessorTestUtils.delete_all_cases_forms_ledgers(cls.domain)
         cls.product_a = make_product(cls.domain, 'A Product', 'prodcode_a')
         cls.product_b = make_product(cls.domain, 'B Product', 'prodcode_b')
         cls.product_c = make_product(cls.domain, 'C Product', 'prodcode_c')
@@ -30,8 +28,7 @@ class LedgerDBAccessorTest(TestCase):
         cls.product_b.delete()
         cls.product_c.delete()
 
-        with override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True):
-            FormProcessorTestUtils.delete_all_cases_forms_ledgers(cls.domain)
+        FormProcessorTestUtils.delete_all_cases_forms_ledgers(cls.domain)
         super(LedgerDBAccessorTest, cls).tearDownClass()
 
     def setUp(self):
@@ -168,8 +165,7 @@ class LedgerAccessorErrorTests(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        with override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True):
-            FormProcessorTestUtils.delete_all_cases_forms_ledgers(cls.domain)
+        FormProcessorTestUtils.delete_all_cases_forms_ledgers(cls.domain)
         cls.product.delete()
         super(LedgerAccessorErrorTests, cls).tearDownClass()
 

--- a/corehq/form_processor/tests/test_ledgers.py
+++ b/corehq/form_processor/tests/test_ledgers.py
@@ -11,7 +11,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import LedgerTransaction
 from corehq.form_processor.parsers.ledgers.helpers import UniqueLedgerReference
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_sql_backend, sharded
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
 
 from corehq.util.test_utils import softer_assert
 
@@ -20,7 +20,6 @@ TransactionValues = namedtuple('TransactionValues', ['type', 'product_id', 'delt
 
 
 @sharded
-@run_with_sql_backend
 class LedgerTests(TestCase):
 
     @classmethod

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -158,10 +158,15 @@ def run_with_all_backends(obj):
     return obj
 
 
-def _sharded(cls):
-    """
-    Marks a test to be run with the partitioned database settings in
-    addition to the non-partitioned database settings.
+def sharded(cls):
+    """Tag tests to run with the sharded SQL backend
+
+    This adds a "sharded" attribute to decorated tests indicating that
+    the tests should be run with a sharded database setup. Note that the
+    presence of that attribute does not prevent tests from  also running
+    in the default not-sharded database setup.
+
+    Was previously named @use_sql_backend
     """
     return patch_shard_db_transactions(attr(sharded=True)(cls))
 
@@ -183,20 +188,7 @@ def only_run_with_partitioned_database(cls):
     skip_unless = skipUnless(
         settings.USE_PARTITIONED_DATABASE, 'Only applicable if sharding is setup'
     )
-    return skip_unless(_sharded(cls))
-
-
-def sharded(cls):
-    """Tag tests to run with the sharded SQL backend
-
-    This adds a "sharded" attribute to decorated tests indicating that
-    the tests should be run with a sharded database setup. Note that the
-    presence of that attribute does not prevent tests from  also running
-    in the default not-sharded database setup.
-
-    Was previously named @use_sql_backend
-    """
-    return _sharded(cls)
+    return skip_unless(sharded(cls))
 
 
 def patch_testcase_databases():

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -6,7 +6,6 @@ from uuid import uuid4
 from couchdbkit import ResourceNotFound
 from django.conf import settings
 from django.test import TestCase, TransactionTestCase
-from django.test.utils import override_settings
 from django.utils.decorators import classproperty
 from nose.plugins.attrib import attr
 from nose.tools import nottest
@@ -155,7 +154,10 @@ class FormProcessorTestUtils(object):
                     pass
 
 
-run_with_sql_backend = override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
+def run_with_sql_backend(obj):
+    return obj
+
+
 run_with_all_backends = run_with_sql_backend
 
 

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -154,11 +154,8 @@ class FormProcessorTestUtils(object):
                     pass
 
 
-def run_with_sql_backend(obj):
+def run_with_all_backends(obj):
     return obj
-
-
-run_with_all_backends = run_with_sql_backend
 
 
 def _sharded(cls):
@@ -199,7 +196,7 @@ def sharded(cls):
 
     Was previously named @use_sql_backend
     """
-    return _sharded(run_with_sql_backend(cls))
+    return _sharded(cls)
 
 
 def patch_testcase_databases():

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -154,10 +154,6 @@ class FormProcessorTestUtils(object):
                     pass
 
 
-def run_with_all_backends(obj):
-    return obj
-
-
 def sharded(cls):
     """Tag tests to run with the sharded SQL backend
 

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -22,7 +22,6 @@ from corehq.apps.locations.tests.util import make_loc, setup_location_types
 from corehq.apps.sms.models import PhoneNumber
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.form_processor.utils import is_commcarecase
 from corehq.apps.users.util import normalize_username
 from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
@@ -43,7 +42,6 @@ from corehq.util.test_utils import create_test_case, set_parent_case
 from testapps.test_pillowtop.utils import process_pillow_changes
 
 
-@run_with_sql_backend
 class SchedulingRecipientTest(TestCase):
     domain = 'scheduling-recipient-test'
 

--- a/corehq/messaging/scheduling/tests/test_schedules.py
+++ b/corehq/messaging/scheduling/tests/test_schedules.py
@@ -1,7 +1,7 @@
 from casexml.apps.case.tests.util import create_case
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.tests.utils import sharded, run_with_sql_backend
+from corehq.form_processor.tests.utils import sharded
 from corehq.apps.hqcase.utils import update_case
 from corehq.messaging.scheduling.scheduling_partitioned.dbaccessors import (
     save_alert_schedule_instance,
@@ -35,7 +35,6 @@ from django.test import TestCase
 from mock import patch
 
 
-@run_with_sql_backend
 class BaseScheduleTest(TestCase):
 
     @classmethod
@@ -208,7 +207,6 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
             self.assertEqual(send_patch.call_count, 0)
 
 
-@run_with_sql_backend
 class StopDateCasePropertyTest(TestCase):
 
     @classmethod

--- a/corehq/messaging/scheduling/tests/test_templating.py
+++ b/corehq/messaging/scheduling/tests/test_templating.py
@@ -3,13 +3,11 @@ from corehq.apps.groups.models import Group
 from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.messaging.templating import MessagingTemplateRenderer, CaseMessagingTemplateParam
 from corehq.util.test_utils import create_test_case, set_parent_case
 from django.test import TestCase
 
 
-@run_with_sql_backend
 class TemplatingTestCase(TestCase):
 
     @classmethod

--- a/corehq/motech/dhis2/tests/test_views.py
+++ b/corehq/motech/dhis2/tests/test_views.py
@@ -3,7 +3,6 @@ from django.urls import reverse
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.motech.dhis2.models import SQLDataSetMap, SQLDataValueMap
 from corehq.motech.models import ConnectionSettings
 from corehq.util.test_utils import flag_enabled
@@ -15,7 +14,6 @@ USERNAME = 'test@testy.com'
 PASSWORD = 'password'
 
 
-@run_with_sql_backend
 class BaseViewTest(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/corehq/motech/fhir/tests/test_repeater_helpers.py
+++ b/corehq/motech/fhir/tests/test_repeater_helpers.py
@@ -12,7 +12,6 @@ from corehq.apps.accounting.utils import clear_plan_version_cache
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.form_processor.models import CommCareCaseSQL, CommCareCaseIndexSQL
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.motech.const import (
     COMMCARE_DATA_TYPE_DECIMAL,
     COMMCARE_DATA_TYPE_TEXT,
@@ -31,7 +30,6 @@ from ..repeater_helpers import get_info_resource_list, send_resources
 DOMAIN = ''.join([random.choice(string.ascii_lowercase) for __ in range(20)])
 
 
-@run_with_sql_backend
 class TestGetInfoResourcesListOneCase(TestCase, DomainSubscriptionMixin):
 
     @classmethod
@@ -93,7 +91,6 @@ class TestGetInfoResourcesListOneCase(TestCase, DomainSubscriptionMixin):
         })
 
 
-@run_with_sql_backend
 class TestGetInfoResourcesListSubCases(TestCase, DomainSubscriptionMixin):
 
     @classmethod
@@ -219,7 +216,6 @@ class TestGetInfoResourcesListSubCases(TestCase, DomainSubscriptionMixin):
         self.assertIn({'given': ['Unabomber']}, resource['name'])
 
 
-@run_with_sql_backend
 class TestGetInfoResourcesListResources(TestCase, DomainSubscriptionMixin):
     """
     Demonstrates building multiple resources using subcases.
@@ -411,7 +407,6 @@ class TestGetInfoResourcesListResources(TestCase, DomainSubscriptionMixin):
         }])
 
 
-@run_with_sql_backend
 class TestWhenToBundle(TestCase):
 
     def setUp(self):

--- a/corehq/motech/repeaters/tests/test_payload_generators.py
+++ b/corehq/motech/repeaters/tests/test_payload_generators.py
@@ -14,7 +14,6 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.backends.sql.dbaccessors import FormAccessorSQL
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
-from corehq.form_processor.tests.utils import run_with_sql_backend
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.form_processor.utils.xform import FormSubmissionBuilder
 from corehq.motech.repeater_helpers import (
@@ -33,7 +32,6 @@ from corehq.motech.value_source import (
 SQL_DOMAIN = 'test-sql-domain'
 
 
-@run_with_sql_backend
 class TestSqlDataTypes(TestCase):
     """
     Test that data types returned by FormDictPayloadGenerator match

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -3,7 +3,7 @@ import uuid
 from collections import namedtuple
 from datetime import datetime, timedelta
 
-from django.test import SimpleTestCase, TestCase, override_settings
+from django.test import SimpleTestCase, TestCase
 
 import attr
 from mock import Mock, patch
@@ -31,10 +31,7 @@ from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
     FormAccessors,
 )
-from corehq.form_processor.tests.utils import (
-    FormProcessorTestUtils,
-    run_with_sql_backend,
-)
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.motech.models import ConnectionSettings
 from corehq.motech.repeaters.const import (
     MAX_RETRY_WAIT,
@@ -86,7 +83,6 @@ XFORM_XML_TEMPLATE = """<?xml version='1.0' ?>
 """
 
 
-@run_with_sql_backend
 class BaseRepeaterTest(TestCase, DomainSubscriptionMixin):
     domain = 'base-domain'
 
@@ -789,7 +785,6 @@ class TestRepeaterFormat(BaseRepeaterTest):
         ).generator, self.new_generator)
 
 
-@run_with_sql_backend
 class UserRepeaterTest(TestCase, DomainSubscriptionMixin):
 
     @classmethod
@@ -866,7 +861,6 @@ class UserRepeaterTest(TestCase, DomainSubscriptionMixin):
         )
 
 
-@run_with_sql_backend
 class LocationRepeaterTest(TestCase, DomainSubscriptionMixin):
 
     @classmethod

--- a/corehq/util/tests/test_doc_processor.py
+++ b/corehq/util/tests/test_doc_processor.py
@@ -3,7 +3,6 @@ import uuid
 from couchdbkit import ResourceConflict, ResourceNotFound
 from django.test import TestCase
 from django.test.testcases import SimpleTestCase
-from django.test.utils import override_settings
 from fakecouch import FakeCouchDb
 
 from casexml.apps.case.mock import CaseFactory
@@ -167,15 +166,13 @@ class BaseResumableSqlModelIteratorTest(object):
     @classmethod
     def base_setUpClass(cls):
         cls.domain = uuid.uuid4().hex
-        with override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True):
-            FormProcessorTestUtils.delete_all_cases_forms_ledgers()
-            cls.all_doc_ids = cls.create_docs(cls.domain, 9)
-            cls.first_doc_id = cls.all_doc_ids[0]
+        FormProcessorTestUtils.delete_all_cases_forms_ledgers()
+        cls.all_doc_ids = cls.create_docs(cls.domain, 9)
+        cls.first_doc_id = cls.all_doc_ids[0]
 
     @classmethod
     def base_tearDownClass(cls):
-        with override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True):
-            FormProcessorTestUtils.delete_all_cases_forms_ledgers()
+        FormProcessorTestUtils.delete_all_cases_forms_ledgers()
 
     def base_setUp(self):
         self.iteration_key = uuid.uuid4().hex
@@ -230,7 +227,6 @@ class BaseResumableSqlModelIteratorTest(object):
         self.assertEqual(chunks, [3, 2, 0])  # max chunk: 3
 
 
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class XFormResumableSqlModelIteratorTest(BaseResumableSqlModelIteratorTest, TestCase):
     @property
     def reindex_accessor(self):
@@ -264,7 +260,6 @@ class XFormResumableSqlModelIteratorTest(BaseResumableSqlModelIteratorTest, Test
         super(XFormResumableSqlModelIteratorTest, self).tearDown()
 
 
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class CaseResumableSqlModelIteratorTest(BaseResumableSqlModelIteratorTest, TestCase):
     @property
     def reindex_accessor(self):
@@ -294,7 +289,6 @@ class CaseResumableSqlModelIteratorTest(BaseResumableSqlModelIteratorTest, TestC
         super(CaseResumableSqlModelIteratorTest, self).tearDown()
 
 
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class LedgerResumableSqlModelIteratorTest(BaseResumableSqlModelIteratorTest, TestCase):
     @property
     def reindex_accessor(self):

--- a/custom/abt/tests/test_custom_recipients.py
+++ b/custom/abt/tests/test_custom_recipients.py
@@ -81,7 +81,12 @@ class CustomRecipientTest(TestCase):
             self.assertIsNone(instance(case_id='does-not-exist').recipient)
 
     def test_recipient_location_case_owner_parent_location(self):
-        with create_test_case(self.domain, 'test-case', 'test-name', owner_id=self.child_location.location_id) as case:
+        with create_test_case(
+            self.domain,
+            'test-case',
+            'test-name',
+            owner_id=self.child_location.location_id
+        ) as case:
             self.assertEqual(case.owner_id, self.child_location.location_id)
 
             def instance(case_id=''):

--- a/custom/abt/tests/test_custom_recipients.py
+++ b/custom/abt/tests/test_custom_recipients.py
@@ -2,7 +2,6 @@ from django.test import TestCase
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.messaging.scheduling.scheduling_partitioned.models import CaseTimedScheduleInstance
 from corehq.util.test_utils import create_test_case
 
@@ -53,7 +52,6 @@ class CustomRecipientTest(TestCase):
         self.parent_location_type.delete()
         self.domain_obj.delete()
 
-    @run_with_all_backends
     def test_recipient_mobile_worker_case_owner_location_parent(self):
         with create_test_case(self.domain, 'test-case', 'test-name', owner_id=self.user.get_id) as case:
             self.assertEqual(case.owner_id, self.user.get_id)
@@ -82,7 +80,6 @@ class CustomRecipientTest(TestCase):
             # Remove case
             self.assertIsNone(instance(case_id='does-not-exist').recipient)
 
-    @run_with_all_backends
     def test_recipient_location_case_owner_parent_location(self):
         with create_test_case(self.domain, 'test-case', 'test-name', owner_id=self.child_location.location_id) as case:
             self.assertEqual(case.owner_id, self.child_location.location_id)

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -14,10 +14,9 @@ from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import normalize_username
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_sql_backend
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 
 
-@run_with_sql_backend
 class CaseCommandsTest(TestCase):
     domain = 'cases-domain'
 

--- a/custom/ucla/tests.py
+++ b/custom/ucla/tests.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 import uuid
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.fixtures.models import (
@@ -21,7 +21,6 @@ Reminder = namedtuple('Reminder', ['domain', 'schedule_iteration_num', 'current_
 Handler = namedtuple('Handler', ['events'])
 
 
-@override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class TestUCLACustomHandler(TestCase):
     domain_name = uuid.uuid4().hex
     case_type = 'ucla-reminder'

--- a/testapps/test_pillowtop/tests/base.py
+++ b/testapps/test_pillowtop/tests/base.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 from corehq.apps.callcenter.tests.test_utils import CallCenterDomainMockTest
 from corehq.apps.userreports.models import StaticDataSourceConfiguration
-from corehq.apps.userreports.pillow import ConfigurableReportTableManager
 
 
 class BasePillowTestCase(CallCenterDomainMockTest):

--- a/testapps/test_pillowtop/tests/base.py
+++ b/testapps/test_pillowtop/tests/base.py
@@ -13,7 +13,6 @@ class BasePillowTestCase(CallCenterDomainMockTest):
         # Time savings: ~25s per
         #   DataSourceProvider.get_data_sources() et al and/or
         #   ConfigurableReportTableManager.bootstrap()
-        # and @run_with_all_backends is a multiplier
         cls.patches = [
             patch.object(StaticDataSourceConfiguration, "_all", lambda: []),
             patch("corehq.apps.userreports.pillow.rebuild_sql_tables"),

--- a/testapps/test_pillowtop/tests/test_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_pillow.py
@@ -10,10 +10,7 @@ from corehq.apps.es import CaseES, CaseSearchES
 from corehq.apps.es.tests.utils import es_test
 from corehq.elastic import get_es_new
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import (
-    FormProcessorTestUtils,
-    run_with_sql_backend,
-)
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
@@ -23,7 +20,6 @@ from testapps.test_pillowtop.utils import process_pillow_changes
 
 
 @es_test
-@run_with_sql_backend
 class CasePillowTest(TestCase):
     domain = 'case-pillowtest-domain'
 

--- a/testapps/test_pillowtop/tests/test_case_search_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_search_pillow.py
@@ -15,7 +15,7 @@ from corehq.apps.change_feed.topics import get_multi_topic_offset
 from corehq.apps.es import CaseSearchES
 from corehq.apps.es.tests.utils import es_test
 from corehq.elastic import get_es_new
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_sql_backend
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.pillows.case import get_case_pillow
 from corehq.pillows.case_search import (
     CaseSearchReindexerFactory,
@@ -32,7 +32,6 @@ from pillowtop.es_utils import initialize_index_and_mapping
 
 
 @es_test
-@run_with_sql_backend
 class CaseSearchPillowTest(TestCase):
 
     domain = 'meereen'

--- a/testapps/test_pillowtop/tests/test_form_pillow.py
+++ b/testapps/test_pillowtop/tests/test_form_pillow.py
@@ -1,6 +1,6 @@
 import uuid
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from pillowtop.es_utils import initialize_index_and_mapping
 
@@ -47,7 +47,6 @@ class FormPillowTest(TestCase):
         ensure_index_deleted(USER_INDEX)
         super().tearDownClass()
 
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_form_pillow_sql(self):
         consumer = get_test_kafka_consumer(topics.FORM, topics.FORM_SQL)
         kafka_seq = self._get_kafka_seq()
@@ -64,7 +63,6 @@ class FormPillowTest(TestCase):
         self.pillow.process_changes(since=kafka_seq, forever=False)
         self.assertTrue(Application.get(self.app._id).has_submissions)
 
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_form_pillow_non_existant_build_id(self):
         consumer = get_test_kafka_consumer(topics.FORM, topics.FORM_SQL)
         kafka_seq = self._get_kafka_seq()
@@ -81,7 +79,6 @@ class FormPillowTest(TestCase):
         self.pillow.process_changes(since=kafka_seq, forever=False)
         self.assertFalse(Application.get(self.app._id).has_submissions)
 
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_form_pillow_mismatch_domains(self):
         consumer = get_test_kafka_consumer(topics.FORM, topics.FORM_SQL)
         kafka_seq = self._get_kafka_seq()
@@ -100,7 +97,6 @@ class FormPillowTest(TestCase):
         self.pillow.process_changes(since=kafka_seq, forever=False)
         self.assertFalse(Application.get(self.app._id).has_submissions)
 
-    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_two_forms_with_same_app(self):
         """Ensures two forms submitted to the same app does not error"""
         kafka_seq = self._get_kafka_seq()

--- a/testapps/test_pillowtop/tests/test_reindexer.py
+++ b/testapps/test_pillowtop/tests/test_reindexer.py
@@ -16,8 +16,7 @@ from corehq.apps.hqcase.management.commands.ptop_reindexer_v2 import reindex_and
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.elastic import get_es_new
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, \
-    run_with_sql_backend
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.pillows.case_search import domains_needing_search_index
 from corehq.pillows.mappings.case_mapping import CASE_INDEX, CASE_INDEX_INFO
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX
@@ -35,7 +34,6 @@ DOMAIN = 'reindex-test-domain'
 
 
 @es_test
-@run_with_sql_backend
 class PillowtopReindexerTest(TestCase):
     domain = DOMAIN
 
@@ -130,7 +128,6 @@ class PillowtopReindexerTest(TestCase):
         self.assertEqual(0, results.total)
 
 
-@run_with_sql_backend
 class CheckpointCreationTest(CallCenterDomainMockTest):
     # this class is only here so you can run these explicitly
     pass
@@ -217,7 +214,6 @@ def test_no_checkpoint_creation(self, reindex_id, pillow_name):
         )
 
 
-@run_with_sql_backend
 class UserReindexerTest(TestCase):
 
     def setUp(self):
@@ -259,7 +255,6 @@ class UserReindexerTest(TestCase):
             self.assertEqual('WebUser', user_doc['doc_type'])
 
 
-@run_with_sql_backend
 class GroupReindexerTest(TestCase):
 
     def setUp(self):

--- a/testapps/test_pillowtop/tests/test_report_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_report_case_pillow.py
@@ -8,7 +8,7 @@ from corehq.apps.es import CaseES
 from corehq.apps.es.tests.utils import es_test
 from corehq.apps.hqcase.management.commands.ptop_reindexer_v2 import reindex_and_clean
 from corehq.elastic import get_es_new
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_sql_backend
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.pillows.mappings.reportcase_mapping import REPORT_CASE_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
 from corehq.util.es.elasticsearch import ConnectionError
@@ -20,7 +20,6 @@ from .base import BasePillowTestCase
 DOMAIN = 'report-case-pillowtest-domain'
 
 
-@run_with_sql_backend
 @override_settings(ES_CASE_FULL_INDEX_DOMAINS=[DOMAIN])
 @es_test
 class ReportCasePillowTest(BasePillowTestCase):
@@ -67,7 +66,6 @@ class ReportCasePillowTest(BasePillowTestCase):
         return case_id, case_name
 
 
-@run_with_sql_backend
 @override_settings(ES_CASE_FULL_INDEX_DOMAINS=[DOMAIN])
 class ReportCaseReindexerTest(TestCase):
 

--- a/testapps/test_pillowtop/tests/test_report_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_report_xform_pillow.py
@@ -5,7 +5,7 @@ from corehq.apps.es import FormES
 from corehq.apps.es.tests.utils import es_test
 from corehq.elastic import get_es_new
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_sql_backend
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_INDEX_INFO
 from corehq.pillows.reportxform import ReportFormReindexerFactory
@@ -17,7 +17,6 @@ from testapps.test_pillowtop.utils import process_pillow_changes
 DOMAIN = 'report-xform-pillowtest-domain'
 
 
-@run_with_sql_backend
 @override_settings(ES_XFORM_FULL_INDEX_DOMAINS=[DOMAIN])
 @es_test
 class ReportXformPillowTest(TestCase):
@@ -64,7 +63,6 @@ class ReportXformPillowTest(TestCase):
         return form, metadata
 
 
-@run_with_sql_backend
 @override_settings(ES_XFORM_FULL_INDEX_DOMAINS=[DOMAIN])
 class ReportXformReindexerTest(TestCase):
 

--- a/testapps/test_pillowtop/tests/test_user_pillow.py
+++ b/testapps/test_pillowtop/tests/test_user_pillow.py
@@ -11,7 +11,7 @@ from corehq.apps.users.models import CommCareUser
 from corehq.elastic import get_es_new
 from corehq.form_processor.change_publishers import change_meta_from_sql_form
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
 from corehq.pillows.user import get_user_pillow_old
@@ -91,7 +91,6 @@ class UserPillowTest(UserPillowTestBase):
 
 class UnknownUserPillowTest(UserPillowTestBase):
 
-    @run_with_all_backends
     def test_unknown_user_pillow(self):
         FormProcessorTestUtils.delete_all_xforms()
         user_id = 'test-unknown-user'

--- a/testapps/test_pillowtop/tests/test_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_xform_pillow.py
@@ -16,10 +16,7 @@ from corehq.apps.users.tasks import process_reporting_metadata_staging
 from corehq.elastic import get_es_new
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import (
-    FormProcessorTestUtils,
-    run_with_sql_backend,
-)
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
 from corehq.pillows.xform import transform_xform_for_elasticsearch
@@ -28,7 +25,6 @@ from corehq.util.test_utils import get_form_ready_to_save
 from testapps.test_pillowtop.utils import process_pillow_changes
 
 
-@run_with_sql_backend
 class XFormPillowTest(TestCase):
     domain = 'xform-pillowtest-domain'
     username = 'xform-pillowtest-user'


### PR DESCRIPTION
`run_with_sql_backend`, `run_with_all_backends` and `TESTS_SHOULD_USE_SQL_BACKEND` are no longer necessary since [the SQL backend is now the default](https://github.com/dimagi/commcare-hq/pull/30390).

:tropical_fish: Review by commit.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Nothing other than tests was modified.

### QA Plan

No QA.

### Safety story

Nothing other than tests was modified.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 