### PR TITLE
Added id property to RemoteRequestQuery

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -152,7 +152,11 @@ class DetailContributor(SectionContributor):
             if len(d.details):
                 helper = EntriesHelper(self.app)
                 datums = helper.get_datum_meta_module(module)
-                d.variables.extend([DetailVariable(name=datum.datum.id, function=datum.datum.value) for datum in datums])
+                d.variables.extend([
+                    DetailVariable(name=datum.datum.id, function=datum.datum.value)
+                    for datum in datums
+                    if datum.datum.id
+                ])
                 return d
             else:
                 return None

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -500,6 +500,10 @@ class RemoteRequestQuery(OrderedXmlObject, XmlObject):
     prompts = NodeListField('prompt', QueryPrompt)
     default_search = BooleanField("@default_search")
 
+    @property
+    def id(self):
+        return None
+
 
 class Entry(OrderedXmlObject, XmlObject):
     ROOT_NAME = 'entry'


### PR DESCRIPTION
## Product Description
Fixes build error when working with data registries.

## Technical Summary
When setting up a case search config with a data registry locally, I was getting this:
```
...
  File "/Users/jschweers/Documents/commcare-hq/corehq/apps/app_manager/models.py", line 5048, in create_suite
    return SuiteGenerator(self, build_profile_id).generate_suite()
  File "/Users/jschweers/Documents/commcare-hq/corehq/apps/app_manager/suite_xml/generator.py", line 79, in generate_suite
    DetailContributor(self.suite, self.app, self.modules, self.build_profile_id),
  File "/Users/jschweers/Documents/commcare-hq/corehq/apps/app_manager/suite_xml/generator.py", line 68, in _add_sections
    section_elements = contributor.get_section_elements()
  File "/Users/jschweers/Documents/commcare-hq/corehq/util/timer.py", line 224, in _inner
    return fn(self, *args, **kwargs)
  File "/Users/jschweers/Documents/commcare-hq/corehq/apps/app_manager/suite_xml/sections/details.py", line 98, in get_section_elements
    print_template=print_template_path,
  File "/Users/jschweers/Documents/commcare-hq/corehq/apps/app_manager/suite_xml/sections/details.py", line 157, in build_detail
    for datum in datums
  File "/Users/jschweers/Documents/commcare-hq/corehq/apps/app_manager/suite_xml/sections/details.py", line 157, in <listcomp>
    for datum in datums
AttributeError: 'RemoteRequestQuery' object has no attribute 'id'
```

## Feature Flag
Data registries

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

I haven't dug into why existing tests like `test_search_data_registry` and `test_search_data_registry_additional_registry_query` don't throw this error. @snopoke @esoergel if either of you have ideas offhand I'm interested, if not I can look more closely tomorrow.

### QA Plan

Not requesting QA

### Safety story
Changes are minor and largely isolated to a feature flag that's still in development.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
