### PR TITLE
feature release toggle

### DIFF
--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -60,6 +60,13 @@
         {% endif %}
       </p>
       <p>{{ static_toggle.tag.description }}</p>
+      {% if is_feature_release %}
+        <div class="alert alert-warning" role="alert">
+          {% blocktrans trimmed with owner=static_toggle.owner %}
+            Please confirm with {{ owner }} before using it.
+          {% endblocktrans %}
+        </div>
+      {% endif %}
       {% if static_toggle.help_link %}
         <p><a href="{{ static_toggle.help_link }}" target="_blank">{% trans "More information" %}</a></p>
       {% endif %}

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -121,11 +121,20 @@
         {% if is_random_editable %}
           <div class="input-group">
             <label for="randomness-edit">Randomness Level: </label>
+            <span data-bind="makeHqHelp: {
+              description: '{% trans "Randomness ranges from 0-1.<br/>0=disabled for all<br/>1=enable for all" %}'}">
+            </span>
             <input id="randomness-edit" class="input-medium form-control" type="number" step="0.01" min="0" max="1" data-bind="value: randomness">
           </div>
         {% endif %}
         {% if allows_items %}
-          <h4>{% trans "Enabled toggle items" %}</h4>
+          <h4>
+            {% trans "Enabled toggle items" %}
+            {% if is_random %}
+            <span data-bind="makeHqHelp: {
+                description: '{% trans "Items added here will be enabled regardless of the randomness" %}'}"></span>
+            {% endif %}
+          </h4>
           <hr/>
           <div class="row" data-bind="visible: latest_use().name">
             <div class="col-sm-6">

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -20,6 +20,10 @@
       border-radius: 4px !important;
       margin-right: 10px !important;
     }
+
+    .label-release {
+      background-color: #c22eff !important;
+    }
   </style>
 {% endblock %}
 

--- a/corehq/apps/toggle_ui/templates/toggle/flags.html
+++ b/corehq/apps/toggle_ui/templates/toggle/flags.html
@@ -17,6 +17,10 @@
     .dataTables_filter input.search-query {
       width: 30%;
     }
+
+    .label-release {
+      background-color: #c22eff !important;
+    }
   </style>
 {% endblock %}
 

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -36,7 +36,7 @@ from corehq.toggles import (
     all_toggles,
     NAMESPACE_EMAIL_DOMAIN,
     toggles_enabled_for_domain,
-    toggles_enabled_for_user,
+    toggles_enabled_for_user, FeatureRelease,
 )
 from corehq.util.soft_assert import soft_assert
 from couchexport.models import Format
@@ -137,6 +137,10 @@ class ToggleEditView(BasePageView):
     def is_random_editable(self):
         return isinstance(self.static_toggle, DynamicallyPredictablyRandomToggle)
 
+    @property
+    def is_feature_release(self):
+        return isinstance(self.static_toggle, FeatureRelease)
+
     @cached_property
     def static_toggle(self):
         """
@@ -164,6 +168,7 @@ class ToggleEditView(BasePageView):
             'server_environment': settings.SERVER_ENVIRONMENT,
             'is_random': self.is_random_editable,
             'is_random_editable': self.is_random_editable,
+            'is_feature_release': self.is_feature_release,
             'allows_items': all(n in ALL_NAMESPACES for n in namespaces)
         }
         if self.usage_info:

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -58,6 +58,11 @@ TAG_PREVIEW = Tag(
     css_class='default',
     description='',
 )
+TAG_RELEASE = Tag(
+    name='Release',
+    css_class='release',
+    description='This is a feature that is in the process of being released.',
+)
 TAG_SAAS_CONDITIONAL = Tag(
     name='SaaS - Conditional Use',
     css_class='primary',
@@ -103,7 +108,7 @@ TAG_INTERNAL = Tag(
     description="These are tools for our engineering team to use to manage the product",
 )
 # Order roughly corresponds to how much we want you to use it
-ALL_TAG_GROUPS = [TAG_SOLUTIONS, TAG_PRODUCT, TAG_CUSTOM, TAG_INTERNAL, TAG_DEPRECATED]
+ALL_TAG_GROUPS = [TAG_SOLUTIONS, TAG_PRODUCT, TAG_CUSTOM, TAG_INTERNAL, TAG_RELEASE, TAG_DEPRECATED]
 ALL_TAGS = [
                TAG_SOLUTIONS_OPEN,
                TAG_SOLUTIONS_CONDITIONAL,
@@ -387,6 +392,28 @@ class DynamicallyPredictablyRandomToggle(PredictablyRandomToggle):
             return dynamic_randomness
         except ValueError:
             return self.default_randomness
+
+
+class FeatureRelease(DynamicallyPredictablyRandomToggle):
+    def __init__(
+        self,
+        slug,
+        label,
+        tag,
+        owner,
+        default_randomness=0.0,
+        help_link=None,
+        description=None,
+        relevant_environments=None
+    ):
+        super().__init__(
+            slug, label, tag, [NAMESPACE_DOMAIN],
+            default_randomness=default_randomness,
+            help_link=help_link,
+            description=description,
+            relevant_environments=relevant_environments
+        )
+        self.owner = owner
 
 
 # if no namespaces are specified the user namespace is assumed

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -395,6 +395,15 @@ class DynamicallyPredictablyRandomToggle(PredictablyRandomToggle):
 
 
 class FeatureRelease(DynamicallyPredictablyRandomToggle):
+    """This class is designed to allow release of features in a controlled manner.
+    The primary purpose is to decouple code deploys from feature releases.
+
+    Only the 'domain' namespace is applicable for feature release toggles.
+
+    In addition the normal arguments, feature release toggles must also provide
+    an 'owner' to indicate the member of the team responsible for releasing this feature.
+    This will be displayed on the UI when editing the toggle.
+    """
     def __init__(
         self,
         slug,

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -398,8 +398,6 @@ class FeatureRelease(DynamicallyPredictablyRandomToggle):
     """This class is designed to allow release of features in a controlled manner.
     The primary purpose is to decouple code deploys from feature releases.
 
-    Only the 'domain' namespace is applicable for feature release toggles.
-
     In addition the normal arguments, feature release toggles must also provide
     an 'owner' to indicate the member of the team responsible for releasing this feature.
     This will be displayed on the UI when editing the toggle.
@@ -409,6 +407,7 @@ class FeatureRelease(DynamicallyPredictablyRandomToggle):
         slug,
         label,
         tag,
+        namespaces,
         owner,
         default_randomness=0.0,
         help_link=None,
@@ -416,7 +415,7 @@ class FeatureRelease(DynamicallyPredictablyRandomToggle):
         relevant_environments=None
     ):
         super().__init__(
-            slug, label, tag, [NAMESPACE_DOMAIN],
+            slug, label, tag, namespaces,
             default_randomness=default_randomness,
             help_link=help_link,
             description=description,


### PR DESCRIPTION
## Product Description
This PR adds a new type of toggle designed to be used for controlled release of features.

![image](https://user-images.githubusercontent.com/249606/133601091-a682491e-173b-4ae2-a1dd-a55ed43478ff.png)

![image](https://user-images.githubusercontent.com/249606/133601029-8aae96b3-b945-4539-8220-72256e040546.png)

## Technical Summary
New toggle class and updates to the UI.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
NA

### QA Plan
Tested locally

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
