### PR TITLE
Stop race condition creating extra StaticDevices

### DIFF
--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -28,6 +28,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _, ngettext, ugettext_lazy, ugettext_noop
 
 from corehq.apps.users.analytics import get_role_user_count
+from dimagi.utils.couch import CriticalSection
 from soil.exceptions import TaskFailedError
 from soil.util import expose_cached_download, get_download_context
 from django.views.decorators.csrf import csrf_exempt
@@ -296,12 +297,15 @@ class BaseEditUserView(BaseUserSettingsView):
     @property
     def backup_token(self):
         if Domain.get_by_name(self.request.domain).two_factor_auth:
-            device = self.editable_user.get_django_user().staticdevice_set.get_or_create(name='backup')[0]
-            token = device.token_set.first()
-            if token:
-                return device.token_set.first().token
-            else:
-                return device.token_set.create(token=StaticToken.random_token()).token
+            with CriticalSection([f"backup-token-{self.editable_user._id}"]):
+                device = (self.editable_user.get_django_user()
+                          .staticdevice_set
+                          .get_or_create(name='backup')[0])
+                token = device.token_set.first()
+                if token:
+                    return device.token_set.first().token
+                else:
+                    return device.token_set.create(token=StaticToken.random_token()).token
         return None
 
     @property


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Prevent data consistency issue that caused the mobile worker page to 500 in rare circumstances

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SUPPORT-10799
https://sentry.io/organizations/dimagi/issues/2651164237/?environment=production&project=136860&query=is%3Aunresolved+domain%3Any-onondaga-cdcms&statsPeriod=14d

`StaticDevices` is a third party model and it doesn't have a uniqueness constraint on user_id and name, although we expect it to.  This ensures that only one thread at a time will attempt to create it for a given
user.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
