### PR TITLE
include past window options in fetch command

### DIFF
--- a/corehq/apps/hqadmin/management/commands/fetch_reconciliation_records.py
+++ b/corehq/apps/hqadmin/management/commands/fetch_reconciliation_records.py
@@ -4,18 +4,22 @@ from corehq.blobs import CODES, get_blob_db
 
 class Command(BaseCommand):
 
+    data_type_blob_id_map = {
+        'form': 'reconcile_es_forms',
+        'case': 'reconcile_es_cases',
+        'missed_forms': 'es_forms_past_window',
+        'missed_cases': 'es_cases_past_window',
+    }
+
     def add_arguments(self, parser):
         parser.add_argument('data_type')
         parser.add_argument('date')
 
     def handle(self, data_type, date, **options):
         blob_db = get_blob_db()
-        if data_type == 'form':
-            parent_id = 'reconcile_es_forms'
-        elif data_type == 'case':
-            parent_id = 'reconcile_es_cases'
-        else:
-            raise CommandError('data_type must be either form or case')
+        parent_id = self.data_type_blob_id_map.get(data_type)
+        if parent_id is None:
+            raise CommandError(f'data_type must be in {", ".join(self.data_type_blob_id_map.keys())}')
         key = f'{parent_id}_{date}'
         blob = blob_db.get(
             key=key,


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The `fetch_reconciliation_records` could only download the outputs of the forms and cases we were republishing in the ES reconciliation tasks. It could not be used to get the records that were past the window and only logged. This adds support for those records.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Internal use management command, tested locally

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
