### PR TITLE
Fixed call to submission_username

### DIFF
--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -389,7 +389,7 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
         return self.repeater.connection_settings.username
 
     def submission_user_id(self):
-        return CouchUser.get_by_username(self.submission_username).user_id
+        return CouchUser.get_by_username(self.submission_username()).user_id
 
 
 class AppStructureGenerator(BasePayloadGenerator):


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/custom/81/SUPPORT-10811

https://dimagi-dev.atlassian.net/browse/USH-1293

Case transfer repeaters are 500ing: https://sentry.io/organizations/dimagi/issues/2652767385/

Followup for https://github.com/dimagi/commcare-hq/pull/30353/

## Feature Flag
USH: Allow refer case repeaters to be setup

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

This specific line isn't tested.

### QA Plan

Not requesting QA.

### Safety story
Tiny change in flag used by a small set of projects, feature is currently broken and this change isn't going to make that worse.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
