### PR TITLE
checkpoint timeout

### DIFF
--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -18,6 +18,7 @@ from corehq.apps.change_feed.exceptions import UnknownDocumentStore
 from corehq.apps.change_feed.topics import validate_offsets
 
 MIN_TIMEOUT = 500
+MAX_TIMEOUT = 1000 * 60 * 60 * 24 # 1 day in ms
 
 
 class KafkaChangeFeed(ChangeFeed):
@@ -62,7 +63,7 @@ class KafkaChangeFeed(ChangeFeed):
         """
         ``since`` must be a dictionary of topic partition offsets, or None
         """
-        timeout = float('inf') if forever else MIN_TIMEOUT
+        timeout = MAX_TIMEOUT if forever else MIN_TIMEOUT
         start_from_latest = since is None
         reset = 'largest' if start_from_latest else 'smallest'
         self._init_consumer(timeout, auto_offset_reset=reset)
@@ -94,8 +95,8 @@ class KafkaChangeFeed(ChangeFeed):
                 self._processed_topic_offsets[(message.topic, message.partition)] = message.offset
                 yield change_from_kafka_message(message)
         except StopIteration:
-            assert not forever, 'Kafka pillow should not timeout when waiting forever!'
             # no need to do anything since this is just telling us we've reached the end of the feed
+            pass
 
     def get_current_checkpoint_offsets(self):
         # the way kafka works, the checkpoint should increment by 1 because

--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -18,7 +18,7 @@ from corehq.apps.change_feed.exceptions import UnknownDocumentStore
 from corehq.apps.change_feed.topics import validate_offsets
 
 MIN_TIMEOUT = 500
-MAX_TIMEOUT = 1000 * 60 * 60 * 24 # 1 day in ms
+MAX_TIMEOUT = 1000 * 60 * 60 * 24  # 1 day in ms
 
 
 class KafkaChangeFeed(ChangeFeed):

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -611,19 +611,20 @@ class ProcessRelatedDocTypePillowTest(TestCase):
 
         http://manage.dimagi.com/default.asp?245341
         '''
-
-        pillow = pillow or self.pillow
-        for i in range(3):
-            since = pillow.get_change_feed().get_latest_offsets()
-            form, cases = self._post_case_blocks(i)
-            with self.assertNumQueries(num_queries):
-                pillow.process_changes(since=since, forever=False)
-            rows = self.adapter.get_query_object()
-            self.assertEqual(rows.count(), 1)
-            row = rows[0]
-            self.assertEqual(int(row.parent_property), i)
-            errors = PillowError.objects.filter(doc_id='child-id', pillow=pillow.pillow_id)
-            self.assertEqual(errors.count(), 0)
+        with mock.patch('corehq.pillows.case.KafkaCheckpointEventHandler.should_update_checkpoint') as fake_checkpoint:
+            fake_checkpoint.return_value = False
+            pillow = pillow or self.pillow
+            for i in range(3):
+                since = pillow.get_change_feed().get_latest_offsets()
+                form, cases = self._post_case_blocks(i)
+                with self.assertNumQueries(num_queries):
+                    pillow.process_changes(since=since, forever=False)
+                rows = self.adapter.get_query_object()
+                self.assertEqual(rows.count(), 1)
+                row = rows[0]
+                self.assertEqual(int(row.parent_property), i)
+                errors = PillowError.objects.filter(doc_id='child-id', pillow=pillow.pillow_id)
+                self.assertEqual(errors.count(), 0)
 
 
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
@@ -675,8 +676,10 @@ class ReuseEvaluationContextTest(TestCase):
         )
 
     def _test_pillow(self, pillow, since, num_queries=12):
-        with self.assertNumQueries(num_queries):
-            pillow.process_changes(since=since, forever=False)
+        with mock.patch('corehq.pillows.case.KafkaCheckpointEventHandler.should_update_checkpoint') as fake_checkpoint:
+            fake_checkpoint.return_value = False
+            with self.assertNumQueries(num_queries):
+                pillow.process_changes(since=since, forever=False)
 
     def test_reuse_cache(self):
         self._test_reuse_cache()

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -612,9 +612,9 @@ class ProcessRelatedDocTypePillowTest(TestCase):
         http://manage.dimagi.com/default.asp?245341
         '''
         with mock.patch(
-                'corehq.pillows.case.KafkaCheckpointEventHandler.should_update_checkpoint'
-        ) as fake_checkpoint:
-            fake_checkpoint.return_value = False
+                'corehq.pillows.case.KafkaCheckpointEventHandler.should_update_checkpoint',
+                return_value=False
+        ):
             pillow = pillow or self.pillow
             for i in range(3):
                 since = pillow.get_change_feed().get_latest_offsets()
@@ -679,9 +679,9 @@ class ReuseEvaluationContextTest(TestCase):
 
     def _test_pillow(self, pillow, since, num_queries=12):
         with mock.patch(
-                'corehq.pillows.case.KafkaCheckpointEventHandler.should_update_checkpoint'
-        ) as fake_checkpoint:
-            fake_checkpoint.return_value = False
+                'corehq.pillows.case.KafkaCheckpointEventHandler.should_update_checkpoint',
+                return_value=False
+        ):
             with self.assertNumQueries(num_queries):
                 pillow.process_changes(since=since, forever=False)
 

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -611,7 +611,9 @@ class ProcessRelatedDocTypePillowTest(TestCase):
 
         http://manage.dimagi.com/default.asp?245341
         '''
-        with mock.patch('corehq.pillows.case.KafkaCheckpointEventHandler.should_update_checkpoint') as fake_checkpoint:
+        with mock.patch(
+                'corehq.pillows.case.KafkaCheckpointEventHandler.should_update_checkpoint'
+        ) as fake_checkpoint:
             fake_checkpoint.return_value = False
             pillow = pillow or self.pillow
             for i in range(3):
@@ -676,7 +678,9 @@ class ReuseEvaluationContextTest(TestCase):
         )
 
     def _test_pillow(self, pillow, since, num_queries=12):
-        with mock.patch('corehq.pillows.case.KafkaCheckpointEventHandler.should_update_checkpoint') as fake_checkpoint:
+        with mock.patch(
+                'corehq.pillows.case.KafkaCheckpointEventHandler.should_update_checkpoint'
+        ) as fake_checkpoint:
             fake_checkpoint.return_value = False
             with self.assertNumQueries(num_queries):
                 pillow.process_changes(since=since, forever=False)

--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -123,16 +123,19 @@ class PillowCheckpointEventHandler(ChangeEventHandler):
         self.max_checkpoint_delay = getattr(settings, 'PTOP_CHECKPOINT_DELAY_OVERRIDE', MAX_CHECKPOINT_DELAY)
         self.checkpoint = checkpoint
         self.checkpoint_frequency = checkpoint_frequency
-        self.last_update = datetime.utcnow()
-        self.last_log = datetime.utcnow()
+        self.last_update = None
+        self.last_log = None
         self.checkpoint_callback = checkpoint_callback
 
     def should_update_checkpoint(self, context):
         frequency_hit = context.changes_seen >= self.checkpoint_frequency
         time_hit = False
         if self.max_checkpoint_delay:
-            seconds_since_last_update = (datetime.utcnow() - self.last_update).total_seconds()
-            time_hit = seconds_since_last_update >= self.max_checkpoint_delay
+            if self.last_update is None:
+                seconds_since_last_update = (datetime.utcnow() - self.last_update).total_seconds()
+                time_hit = seconds_since_last_update >= self.max_checkpoint_delay
+            else:
+                time_hit = True
         return frequency_hit or time_hit
 
     def get_new_seq(self, change):
@@ -146,7 +149,7 @@ class PillowCheckpointEventHandler(ChangeEventHandler):
             if self.checkpoint_callback:
                 self.checkpoint_callback.checkpoint_updated()
             return True
-        elif (datetime.utcnow() - self.last_log).total_seconds() > 10:
+        elif self.last_log is None or (datetime.utcnow() - self.last_log).total_seconds() > 10:
             self.last_log = datetime.utcnow()
             pillow_logging.info("Heartbeat: %s", self.get_new_seq(change))
 

--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -131,7 +131,7 @@ class PillowCheckpointEventHandler(ChangeEventHandler):
         frequency_hit = context.changes_seen >= self.checkpoint_frequency
         time_hit = False
         if self.max_checkpoint_delay:
-            if self.last_update is None:
+            if self.last_update is not None:
                 seconds_since_last_update = (datetime.utcnow() - self.last_update).total_seconds()
                 time_hit = seconds_since_last_update >= self.max_checkpoint_delay
             else:

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -184,6 +184,10 @@ class PillowBase(metaclass=ABCMeta):
                 else:
                     self._update_checkpoint(None, None)
             process_offset_chunk(changes_chunk, context)
+            if forever:
+                if change:
+                    self._update_checkpoint(change, context)
+                self.process_changes(since=self.get_last_checkpoint_sequence(), forever=forever)
         except PillowtopCheckpointReset:
             process_offset_chunk(changes_chunk, context)
             self.process_changes(since=self.get_last_checkpoint_sequence(), forever=forever)

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -184,12 +184,12 @@ class PillowBase(metaclass=ABCMeta):
                 else:
                     self._update_checkpoint(None, None)
             process_offset_chunk(changes_chunk, context)
-            if forever:
-                if change:
-                    self._update_checkpoint(change, context)
-                self.process_changes(since=self.get_last_checkpoint_sequence(), forever=forever)
         except PillowtopCheckpointReset:
             process_offset_chunk(changes_chunk, context)
+            self.process_changes(since=self.get_last_checkpoint_sequence(), forever=forever)
+        if forever:
+            if change:
+                self._update_checkpoint(change, context)
             self.process_changes(since=self.get_last_checkpoint_sequence(), forever=forever)
 
     def _batch_process_with_error_handling(self, changes_chunk):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12509
This is part two of my attempts to alleviate the kafka checkpoint warning, but also hopefully just a good change to make. It changes pillows to no longer wait on kafka changes forever, but to give up after 24 hours, checkpoint their progress, and try again. This should fix both the warning on deploy, and the related issue that if changes come into bulk pillows very infrequently, some changes can be missed, as the pillow waits for new changes long enough that the old ones are cleaned up by kafka. Additionally, it effectively sets a cap of 24 hours for bulk pillows to stop waiting to fill a batch, making behavior of low volume batch pillows slightly more predictable.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Ran pillows locally

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
