### PR TITLE
added management commands to pull exports

### DIFF
--- a/hqscripts/management/commands/pull_exports.py
+++ b/hqscripts/management/commands/pull_exports.py
@@ -1,0 +1,121 @@
+import re
+import os
+from datetime import datetime
+from django.core.management.base import BaseCommand
+
+from corehq.apps.export.export import get_export_file
+from corehq.apps.export.utils import get_export
+
+from corehq.util.view_utils import get_form_or_404
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.export.filters import ModifiedOnRangeFilter, ReceivedOnRangeFilter
+
+
+class Command(BaseCommand):
+    help = 'Pull data linked to a request'
+
+    def add_arguments(self, parser):
+        parser.add_argument('requestsCSV')
+        parser.add_argument('--path_prefix', default=os.getcwd())
+
+    def handle(self, *args, **options):
+        requests = parse_requests(options['requestsCSV'])
+        process_requests(requests, options['path_prefix'])
+
+
+def process_requests(requests, path_prefix):
+    current_time = datetime.now()
+    for request in requests:
+        try:
+            process_request(request, path_prefix, current_time)
+        except Exception as e:
+            print(f'Error occurred with request {request["url"]}')
+            print(e)
+
+
+def process_request(request, path_prefix, current_time):
+    if not path_prefix:
+        path_prefix = os.getcwd()
+
+    pattern = re.compile(
+        r'https?://(?:.*)/a/([^/]+)/data/export/custom/new/(form|case)/download/([^/]+)/?')
+
+    match = pattern.match(request['url'])
+    if match:
+        domain = match.group(1)
+        export_type = match.group(2)
+        export_id = match.group(3)
+        end_date = datetime.strptime(request['date'], '%m/%d/%Y') if export_type == 'case' else current_time
+        path = process_export(domain, export_type, export_id, end_date, path_prefix)
+        print(f'Saved export at: {path}')
+        return
+
+    read_form_regex = re.compile(
+        r'https?://(?:.*)/a/([^/]+)/reports/form_data/([^/]+)/?'
+    )
+
+    match = read_form_regex.match(request['url'])
+    if match:
+        domain = match.group(1)
+        form_id = match.group(2)
+        path = process_form_data(domain, form_id, path_prefix)
+        print(f'Saved form at: {path}')
+        return
+
+    print('no matches')
+
+
+def process_export(domain, export_type, export_id, end_date, path_prefix):
+    print(f'processing {export_type} {export_id}')
+    start_date = get_domain_start_date(domain)
+    if export_type == 'case':
+        filters = [ModifiedOnRangeFilter(gte=start_date, lte=end_date)]
+    else:
+        filters = [ReceivedOnRangeFilter(gte=start_date, lte=end_date)]
+    export_instance = get_export(export_type, domain, export_id)
+    filename = sanitize_filename(f'{export_instance.name} - {export_id}.xlsx')
+    path = os.path.join(path_prefix, filename)
+    get_export_file([export_instance], filters, path)
+
+    return path
+
+
+def process_form_data(domain, form_id, path_prefix):
+    print(f'processing form {form_id}')
+    instance = get_form_or_404(domain, form_id)
+    if not instance:
+        raise Exception(f'No form found for {form_id}')
+
+    filename = sanitize_filename(f'{instance.name} - {instance.form_id}.xml')
+    path = os.path.join(path_prefix, filename)
+
+    with open(path, 'wb') as f:
+        f.write(instance.get_xml())
+
+    return path
+
+
+def sanitize_filename(filename):
+    return filename.replace(os.sep, '-')
+
+
+def get_domain_start_date(domain):
+    return Domain.get_by_name(domain).date_created
+
+
+def parse_requests(filename):
+    requests = []
+    with open(filename, 'r') as f:
+        f.readline()  # Discard, this is the header
+        line = f.readline().strip()
+        while line:
+            request_url, date_requested = line.split(',')
+            requests.append({
+                'url': request_url,
+                'date': date_requested
+            })
+
+            line = f.readline()
+
+    return requests

--- a/hqscripts/management/commands/upload_to_s3.py
+++ b/hqscripts/management/commands/upload_to_s3.py
@@ -1,0 +1,56 @@
+from django.core.management.base import BaseCommand
+
+import boto3
+from botocore.exceptions import ClientError
+
+PROFILE_LENGTH = 4  # An entry for the profile name, then each of the 3 necessary keys
+
+
+class Command(BaseCommand):
+    help = 'Uploads a specified file to S3'
+
+    def add_arguments(self, parser):
+        parser.add_argument('filename')
+        parser.add_argument('bucket_name')
+        parser.add_argument('target_name')
+
+    def handle(self, *args, **options):
+        profile = self.get_profile()
+
+        if not self.is_valid_profile(profile):
+            self.stderr.write('Error with profile configuration')
+            exit(1)
+
+        self.upload_to_s3(options['filename'], options['bucket_name'], options['target_name'], profile)
+
+    def get_profile(self):
+        profile = {}
+
+        self.stdout.write('Paste S3 Profile: ')
+        for i in range(4):
+            try:
+                line = input('')
+            except EOFError:
+                break
+            if i > 0:
+                key, value, = [token.strip() for token in line.split('=', 1)]
+                profile[key] = value
+
+        return profile
+
+    def is_valid_profile(self, profile):
+        keys = ['aws_access_key_id', 'aws_secret_access_key', 'aws_session_token']
+        return not any(key for key in keys if key not in profile)
+
+    def upload_to_s3(self, filename, bucket_name, target_name, profile):
+        session = boto3.Session(**profile)
+        s3 = session.client('s3')
+
+        with open(filename, 'rb') as f:
+            try:
+                s3.upload_fileobj(f, bucket_name, target_name, ExtraArgs={})
+            except ClientError as e:
+                self.stderr.write('Error occurred: ', e)
+                exit(1)
+
+        self.stdout(f'{filename} uploaded successfully to S3 bucket {bucket_name} as {target_name}')


### PR DESCRIPTION
## Product Description
This is a follow-up from https://dimagi-dev.atlassian.net/browse/SAAS-12626. Essentially, there are times when we are unable to fetch data through the web interface, and rather than re-invent the wheel to do so, I thought it beneficial to create scripts to standardize the process.

This adds 2 management commands:
- pull_exports (Pulls down data depending on the URL. Currently supports form/case exports and form data)
- upload_to_s3 (Writes a file to a given bucket on S3)

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests

### Safety story

This was run to grab recent data as part of a P2.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
