### PR TITLE
add column to roles list for data registry access

### DIFF
--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -126,11 +126,16 @@ hqDefine('users/js/roles',[
                 };
 
                 self = ko.mapping.fromJS(data);
-                self.reportPermissions.filteredSpecific = ko.computed(function () {
-                    return ko.utils.arrayFilter(self.reportPermissions.specific(), function (report) {
-                        return report.value();
+                let filterSpecific = (permissions) => {
+                    return ko.computed(function () {
+                        return ko.utils.arrayFilter(permissions.specific(), function (item) {
+                            return item.value();
+                        });
                     });
-                });
+                };
+                self.reportPermissions.filteredSpecific = filterSpecific(self.reportPermissions);
+                self.manageRegistryPermission.filteredSpecific = filterSpecific(self.manageRegistryPermission);
+                self.viewRegistryContentsPermission.filteredSpecific = filterSpecific(self.viewRegistryContentsPermission);
                 self.unwrap = function () {
                     return cls.unwrap(self);
                 };

--- a/corehq/apps/users/templates/users/roles_and_permissions.html
+++ b/corehq/apps/users/templates/users/roles_and_permissions.html
@@ -106,6 +106,11 @@
           <th class="text-center">
             {% trans "Subscription Info" %}
           </th>
+          {% if request|toggle_enabled:"DATA_REGISTRY" %}
+          <th class="text-center">
+            {% trans "Data Registries" %}
+          </th>
+          {% endif %}
           <th>{% trans "Actions" %}</th>
         </tr>
         </thead>
@@ -185,6 +190,24 @@
                                               manage: permissions.edit_billing
                                             }"></div>
           </td>
+          {% if request|toggle_enabled:"DATA_REGISTRY" %}
+          <td class="text-center">
+            <div data-bind="visible: manageRegistryPermission.all()">{% trans "Manage All" %}</div>
+            <div data-bind="visible: !manageRegistryPermission.all() && manageRegistryPermission.filteredSpecific().length">
+              <strong>{% trans "Manage Only" %}</strong><br/>
+              <span data-bind="foreach: manageRegistryPermission.filteredSpecific">
+                  <span class="label label-default" data-bind="text: name"></span><br />
+              </span>
+            </div>
+            <div data-bind="visible: viewRegistryContentsPermission.all()">{% trans "View All Data" %}</div>
+            <div data-bind="visible: !viewRegistryContentsPermission.all() && viewRegistryContentsPermission.filteredSpecific().length">
+              <strong>{% trans "View Data From" %}</strong><br/>
+              <span data-bind="foreach: viewRegistryContentsPermission.filteredSpecific">
+                  <span class="label label-default" data-bind="text: name"></span><br />
+              </span>
+            </div>
+          </td>
+          {% endif %}
           <td>
             <button class="btn btn-default" data-bind="visible: $data._id, click: $data._id ? $root.setRoleBeingEdited : null">
                                 <span data-bind="visible: !$root.allowEdit">


### PR DESCRIPTION
## Product Description
Add a column to the roles list view to show data registry access

![image](https://user-images.githubusercontent.com/249606/133989237-3ae46733-18d0-4ece-8623-cc1493f6f279.png)

## Feature Flag
DATA_REGISTRY

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
NA

### QA Plan
None

### Safety story
Tested locally:
* with feature flag
* without feature flag
* tested that changes to JS don't impact other permission (specifically reports)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
