### PR TITLE
Add domain tag to celery time_to_run metric

### DIFF
--- a/corehq/celery_monitoring/signals.py
+++ b/corehq/celery_monitoring/signals.py
@@ -1,4 +1,5 @@
 import datetime
+import inspect
 
 from django.core.cache import cache
 
@@ -127,3 +128,14 @@ class TimeToStartTimer(CeleryTimer):
 class TimeToRunTimer(CeleryTimer):
     def __init__(self, task_id):
         super(TimeToRunTimer, self).__init__(task_id, timing_type='time_started')
+
+
+def get_domain_from_task(task, args, kwargs):
+    undecorated_task_function = inspect.unwrap(task)
+    call_args = inspect.getcallargs(undecorated_task_function, *args, **kwargs)
+    if 'domain' in call_args:
+        return call_args['domain']
+    elif 'domain_name' in call_args:
+        return call_args['domain_name']
+    else:
+        return None

--- a/corehq/celery_monitoring/signals.py
+++ b/corehq/celery_monitoring/signals.py
@@ -1,5 +1,6 @@
 import datetime
 import inspect
+import logging
 
 from django.core.cache import cache
 
@@ -52,7 +53,12 @@ def celery_record_time_to_run(task_id=None, task=None, state=None, args=None, kw
         metrics_histogram,
     )
 
-    domain = get_domain_from_task(task, args, kwargs)
+    try:
+        domain = get_domain_from_task(task, args, kwargs)
+    except Exception:
+        domain = None
+        logging.exception("Error while attempting to get the domain for a celery task")
+        metrics_counter('commcare.celery.task.time_to_run_domain_unavailable')
 
     get_task_time_to_start.clear(task_id)
 

--- a/corehq/celery_monitoring/signals.py
+++ b/corehq/celery_monitoring/signals.py
@@ -58,7 +58,9 @@ def celery_record_time_to_run(task_id=None, task=None, state=None, args=None, kw
     except Exception:
         domain = None
         logging.exception("Error while attempting to get the domain for a celery task")
-        metrics_counter('commcare.celery.task.time_to_run_domain_unavailable')
+        metrics_counter('commcare.celery.task.time_to_run_domain_unavailable', tags={
+            'celery_task_name': task.name,
+        })
 
     get_task_time_to_start.clear(task_id)
 

--- a/corehq/celery_monitoring/signals.py
+++ b/corehq/celery_monitoring/signals.py
@@ -45,12 +45,14 @@ def celery_record_time_to_start(task_id=None, task=None, **kwargs):
 
 
 @task_postrun.connect
-def celery_record_time_to_run(task_id=None, task=None, state=None, **kwargs):
+def celery_record_time_to_run(task_id=None, task=None, state=None, args=None, kwargs=None, **kw):
     from corehq.util.metrics import (
         DAY_SCALE_TIME_BUCKETS,
         metrics_counter,
         metrics_histogram,
     )
+
+    domain = get_domain_from_task(task, args, kwargs)
 
     get_task_time_to_start.clear(task_id)
 
@@ -58,6 +60,7 @@ def celery_record_time_to_run(task_id=None, task=None, state=None, **kwargs):
         'celery_task_name': task.name,
         'celery_queue': task.queue,
         'state': state,
+        'domain': domain or 'N/A',
     }
     timer = TimeToRunTimer(task_id)
     try:

--- a/corehq/celery_monitoring/signals.py
+++ b/corehq/celery_monitoring/signals.py
@@ -1,11 +1,13 @@
 import datetime
 
-from celery.signals import before_task_publish, task_prerun, task_postrun
 from django.core.cache import cache
+
+from celery.signals import before_task_publish, task_postrun, task_prerun
+
+from dimagi.utils.parsing import string_to_utc_datetime
 
 from corehq.util.metrics import push_metrics
 from corehq.util.quickcache import quickcache
-from dimagi.utils.parsing import string_to_utc_datetime
 
 
 @before_task_publish.connect
@@ -43,7 +45,11 @@ def celery_record_time_to_start(task_id=None, task=None, **kwargs):
 
 @task_postrun.connect
 def celery_record_time_to_run(task_id=None, task=None, state=None, **kwargs):
-    from corehq.util.metrics import metrics_counter, metrics_histogram, DAY_SCALE_TIME_BUCKETS
+    from corehq.util.metrics import (
+        DAY_SCALE_TIME_BUCKETS,
+        metrics_counter,
+        metrics_histogram,
+    )
 
     get_task_time_to_start.clear(task_id)
 


### PR DESCRIPTION
## Product Description
No user facing effects

## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12655

This was prompted by our current inability to disaggregate celery metrics by domain. This PR adds a `domain` tag to the celery `time_to_run` metric.

Note: the first two commits are a very simple prefactor that account for most lines of code changed in this PR. Best reviewed commit-by-commit.

## Feature Flag
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

There is a unit test for the new function. The celery hooks themselves aren't tested, only the helper functions they call.

### QA Plan

No QA-team QA planned.

### Safety story
I'm going to deploy this on staging and make sure that it works as expected. The unit tests in this module, including the one I added, provide some safety.

I may add extra defensiveness around the new call with a blanket except and report the error, to prevent this metrics change from causing a user-facing error ever.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
