### PR TITLE
Make rebuildstaging --deploy use cchq --control option

### DIFF
--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -70,8 +70,8 @@ if [[ $deploy = 'y' && $no_push != 'y' ]]
 then
     rebuildstaging $args && {
         which commcare-cloud \
-        && commcare-cloud staging deploy --quiet \
-        || echo 'Could not auto-deploy for you. Run `commcare-cloud staging deploy` to deploy.'
+        && commcare-cloud --control staging deploy --quiet \
+        || echo 'Could not auto-deploy for you. Run `commcare-cloud --control staging deploy` to deploy.'
     }
 else
     rebuildstaging $args


### PR DESCRIPTION
## Product Description
Dev-facing only.

## Technical Summary
This fixes `rebuildstaging --deploy` to use the staging deploy command that we now recommend.

## Feature Flag
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None

### QA Plan

None

### Safety story
This is a small change to a dev tool for staging that can't possibly cause a production issue.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
