### PR TITLE
Fix broken CommCareCaseIndexSQL.__eq__

### DIFF
--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -839,9 +839,16 @@ class CaseAccessorSQL(AbstractCaseAccessor):
 
     @staticmethod
     def get_reverse_indices(domain, case_id):
-        return list(CommCareCaseIndexSQL.objects.plproxy_raw(
+        indices = list(CommCareCaseIndexSQL.objects.plproxy_raw(
             'SELECT * FROM get_case_indices_reverse(%s, %s)', [domain, case_id]
         ))
+
+        def _set_referenced_id(index):
+            # see corehq/couchapps/case_indices/views/related/map.js
+            index.referenced_id = index.case_id
+            return index
+
+        return [_set_referenced_id(index) for index in indices]
 
     @staticmethod
     def get_all_reverse_indices_info(domain, case_ids):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -839,16 +839,9 @@ class CaseAccessorSQL(AbstractCaseAccessor):
 
     @staticmethod
     def get_reverse_indices(domain, case_id):
-        indices = list(CommCareCaseIndexSQL.objects.plproxy_raw(
+        return list(CommCareCaseIndexSQL.objects.plproxy_raw(
             'SELECT * FROM get_case_indices_reverse(%s, %s)', [domain, case_id]
         ))
-
-        def _set_referenced_id(index):
-            # see corehq/couchapps/case_indices/views/related/map.js
-            index.referenced_id = index.case_id
-            return index
-
-        return [_set_referenced_id(index) for index in indices]
 
     @staticmethod
     def get_all_reverse_indices_info(domain, case_ids):

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -1212,11 +1212,11 @@ class CommCareCaseIndexSQL(PartitionedModel, models.Model, SaveStateMixin):
 
     def __eq__(self, other):
         return isinstance(other, CommCareCaseIndexSQL) and (
-            self.case_id == other.case_id and
-            self.identifier == other.identifier,
-            self.referenced_id == other.referenced_id,
-            self.referenced_type == other.referenced_type,
-            self.relationship_id == other.relationship_id,
+            self.case_id == other.case_id
+            and self.identifier == other.identifier
+            and self.referenced_id == other.referenced_id
+            and self.referenced_type == other.referenced_type
+            and self.relationship_id == other.relationship_id
         )
 
     def __hash__(self):

--- a/corehq/form_processor/tests/test_case_dbaccessor.py
+++ b/corehq/form_processor/tests/test_case_dbaccessor.py
@@ -126,6 +126,7 @@ class CaseAccessorTestsSQL(TestCase):
     def test_get_reverse_indices(self):
         referenced_case_id = uuid.uuid4().hex
         case, index = _create_case_with_index(referenced_case_id)
+        index.referenced_id = index.case_id  # see CaseAccessorSQL.get_reverse_indices
         _create_case_with_index(referenced_case_id, case_is_deleted=True)
         indices = CaseAccessorSQL.get_reverse_indices(DOMAIN, referenced_case_id)
         self.assertEqual([index], indices)

--- a/corehq/form_processor/tests/test_case_dbaccessor.py
+++ b/corehq/form_processor/tests/test_case_dbaccessor.py
@@ -128,8 +128,7 @@ class CaseAccessorTestsSQL(TestCase):
         case, index = _create_case_with_index(referenced_case_id)
         _create_case_with_index(referenced_case_id, case_is_deleted=True)
         indices = CaseAccessorSQL.get_reverse_indices(DOMAIN, referenced_case_id)
-        self.assertEqual(1, len(indices))
-        self.assertEqual(index, indices[0])
+        self.assertEqual([index], indices)
 
     def test_get_reverse_indexed_cases(self):
         referenced_case_ids = [uuid.uuid4().hex, uuid.uuid4().hex]


### PR DESCRIPTION
I think `CommCareCaseIndexSQL.__eq__` is only used by tests, but I am less certain about the change to `CaseAccessorSQL.get_reverse_indices`. [This comment](https://github.com/dimagi/commcare-hq/commit/e6bb6b2e0971714a016e4ab6b0c6a161500e35a3#r16199848) makes it sound like resetting `index.referenced_id` is unnecessary since we only support SQL cases now. Am I interpreting that correctly?

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Tests updated.

### QA Plan

No QA.

### Safety story

Need review and signoff from @snopoke before this feels safe. I will also have more confidence if all tests pass.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
