### PR TITLE
Added linked app support to data registry logs

### DIFF
--- a/corehq/apps/registry/models.py
+++ b/corehq/apps/registry/models.py
@@ -359,7 +359,7 @@ class RegistryAuditHelper:
         if related_object.doc_type == "ReportConfiguration":
             related_object_id = related_object.get_id
             related_object_type = RegistryAuditLog.RELATED_OBJECT_UCR
-        elif related_object.doc_type == "Application":
+        elif related_object.doc_type in ["Application", "LinkedApplication"]:
             related_object_id = related_object.get_id
             related_object_type = RegistryAuditLog.RELATED_OBJECT_APPLICATION
         else:


### PR DESCRIPTION
## Product Description
Fixes a 500 when making a case search from a linked app.

## Feature Flag
Data Registries

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

Not requesting QA.

### Safety story
Minor change to feature that isn't yet in use.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
