### PR TITLE
fix registry app bugs

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -38,16 +38,18 @@ from corehq.util.timer import time_method
 from corehq.util.view_utils import absolute_reverse
 
 
-class FormDatumMeta(namedtuple('FormDatumMeta', 'datum case_type requires_selection action from_parent')):
-    def __new__(cls, datum, case_type, requires_selection, action, from_parent=False):
+class FormDatumMeta(namedtuple('FormDatumMeta', 'datum case_type requires_selection action from_parent module_id')):
+    def __new__(cls, datum, case_type, requires_selection, action, from_parent=False, module_id=None):
         """
         :param datum: The actual SessionDatum object
         :param case_type: The case type this datum represents
         :param requires_selection: True if this datum requires the user to make a selection
         :param action: The action that produced this datum
         :param from_parent: True if this datum is a placeholder necessary to match the parent module's session.
+        :param module_id: The ID of the module where this datum comes from.
         """
-        return super(FormDatumMeta, cls).__new__(cls, datum, case_type, requires_selection, action, from_parent)
+        return super(FormDatumMeta, cls).__new__(
+            cls, datum, case_type, requires_selection, action, from_parent, module_id)
 
     @property
     def is_new_case_id(self):
@@ -388,12 +390,26 @@ class EntriesHelper(object):
                         return True
             return False
 
-        datums = self.get_case_datums_basic_module(module, form)
-        for datum in datums:
+        case_datums = self.get_case_datums_basic_module(module, form)
+        all_datums = self.add_remote_query_datums(case_datums)
+        for datum in all_datums:
             e.datums.append(datum.datum)
 
         if form and self.app.case_sharing and case_sharing_requires_assertion(form):
             EntriesHelper.add_case_sharing_assertion(e)
+
+    def add_remote_query_datums(self, datums):
+        """Add in any `query` datums that are necessary.
+        This only applies to datums that are loaded from a data registry.
+        """
+        result = []
+        for datum in datums:
+            result.append(datum)
+            if datum.module_id and datum.case_type:
+                module = self.app.get_module_by_unique_id(datum.module_id)
+                if module_offers_search(module) and module.search_config.data_registry:
+                    result.extend(self.get_data_registry_query_datums(datum, module))
+        return result
 
     def get_datum_meta_module(self, module, use_filter=False):
         datums = []
@@ -473,11 +489,10 @@ class EntriesHelper(object):
                 ),
                 case_type=datum['case_type'],
                 requires_selection=True,
-                action='update_case'
+                action='update_case',
+                module_id=detail_module.get_or_create_unique_id()
             ))
 
-            if module_offers_search(detail_module) and detail_module.search_config.data_registry:
-                datums.extend(self.get_data_registry_query_datums(datum, detail_module))
         return datums
 
     def get_data_registry_query_datums(self, datum, module):
@@ -507,8 +522,8 @@ class EntriesHelper(object):
 
         datums = [_registry_query(
             instance_name=REGISTRY_INSTANCE,
-            case_type_xpath=f"'{datum['case_type']}'",
-            case_id_xpath=session_var(datum['session_var'])
+            case_type_xpath=f"'{datum.case_type}'",
+            case_id_xpath=session_var(datum.datum.id)
         )]
 
         for query in module.search_config.additional_registry_queries:

--- a/corehq/apps/app_manager/tests/data/suite_registry/detail_tabs.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/detail_tabs.xml
@@ -1,0 +1,31 @@
+<partial>
+  <detail id="m0_case_long">
+    <title>
+      <text>
+        <locale id="cchq.case"/>
+      </text>
+    </title>
+    <detail>
+      <title>
+        <text>
+          <locale id="m0.case_long.tab.1.title"/>
+        </text>
+      </title>
+      <field>
+        <header>
+          <text>
+            <locale id="m0.case_long.case_whatever_2.header"/>
+          </text>
+        </header>
+        <template>
+          <text>
+            <xpath function="whatever"/>
+          </text>
+        </template>
+      </field>
+    </detail>
+    <variables>
+      <case_id function="./@case_id"/>
+    </variables>
+  </detail>
+</partial>

--- a/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
@@ -1,0 +1,25 @@
+<partial>
+    <entry>
+        <form>xmlns1.0</form>
+        <command id="m0-f0">
+            <text>
+                <locale id="forms.m0f0"/>
+            </text>
+        </command>
+        <instance id="casedb" src="jr://instance/casedb"/>
+        <instance id="commcaresession" src="jr://instance/session"/>
+        <session>
+          <datum detail-confirm="m0_case_long" detail-select="m0_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='case'][@status='open']" value="./@case_id"/>
+          <query default_search="true" storage-instance="registry" template="case" url="http://localhost:8000/a/test_domain/phone/registry_case/123/">
+            <data key="case_type" ref="'case'"/>
+            <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
+            <data key="commcare_registry" ref="'myregistry'"/>
+          </query>
+        </session>
+        <stack>
+          <create if="(today() - dob) &lt; 7">
+            <command value="'m0'"/>
+          </create>
+        </stack>
+    </entry>
+</partial>

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -6,7 +6,7 @@ from corehq.apps.app_manager.models import (
     CaseSearch,
     CaseSearchProperty,
     Module,
-    AdditionalRegistryQuery, DetailColumn, FormLink,
+    AdditionalRegistryQuery, DetailColumn, FormLink, DetailTab,
 )
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
@@ -31,6 +31,15 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         self.form = self.app.new_form(0, "Untitled Form", None, attachment=get_simple_form("xmlns1.0"))
         self.form.requires = 'case'
         self.module.case_type = 'case'
+
+        self.module.case_details.long.columns.append(
+            DetailColumn.wrap(dict(
+                header={"en": "name"},
+                model="case",
+                format="plain",
+                field="whatever",
+            ))
+        )
 
         self.module.search_config = CaseSearch(
             properties=[
@@ -112,3 +121,13 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             self.app.create_suite(),
             "./entry[1]"
         )
+
+    def test_case_detail_tabs_with_registry_module(self, *args):
+        self.app.get_module(0).case_details.long.tabs = [
+            DetailTab(starting_index=1)
+        ]
+
+        self.assertXmlPartialEqual(
+            self.get_xml("detail_tabs"),
+            self.app.create_suite(),
+            './detail[@id="m0_case_long"]')

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -1,16 +1,17 @@
 from django.test import SimpleTestCase
 
+from corehq.apps.app_manager.const import WORKFLOW_FORM
 from corehq.apps.app_manager.models import (
     Application,
     CaseSearch,
     CaseSearchProperty,
     Module,
-    AdditionalRegistryQuery,
+    AdditionalRegistryQuery, DetailColumn, FormLink,
 )
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
     TestXmlMixin,
-    patch_get_xform_resource_overrides,
+    patch_get_xform_resource_overrides, get_simple_form,
 )
 from corehq.apps.builds.models import BuildSpec
 from corehq.util.test_utils import flag_enabled
@@ -20,14 +21,14 @@ DOMAIN = 'test_domain'
 
 @patch_get_xform_resource_overrides()
 class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
-    file_path = ('data', 'suite')
+    file_path = ('data', 'suite_registry')
 
     def setUp(self):
         self.app = Application.new_app(DOMAIN, "Untitled Application")
         self.app._id = '123'
         self.app.build_spec = BuildSpec(version='2.35.0', build_number=1)
         self.module = self.app.add_module(Module.new_module("Untitled Module", None))
-        self.form = self.app.new_form(0, "Untitled Form", None)
+        self.form = self.app.new_form(0, "Untitled Form", None, attachment=get_simple_form("xmlns1.0"))
         self.form.requires = 'case'
         self.module.case_type = 'case'
 
@@ -36,16 +37,17 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
                 CaseSearchProperty(name='dob', label={'en': 'Date of birth'})
             ],
+            data_registry="myregistry"
         )
 
         # wrap to have assign_references called
         self.app = Application.wrap(self.app.to_json())
         # reset to newly wrapped module
         self.module = self.app.modules[0]
+        self.form = self.module.forms[0]
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
     def test_search_data_registry(self, *args):
-        self.module.search_config.data_registry = "myregistry"
         suite = self.app.create_suite()
 
         expected_entry_query = """
@@ -75,7 +77,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
     def test_search_data_registry_additional_registry_query(self, *args):
-        self.module.search_config.data_registry = "myregistry"
         base_xpath = "instance('registry')/results/case[@case_id=instance('commcaresession')/session/data/case_id]"
         self.module.search_config.additional_registry_queries = [
             AdditionalRegistryQuery(
@@ -100,3 +101,14 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         # assert that session and registry instances are added to the entry
         self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='commcaresession']")
         self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='registry']")
+
+    def test_form_linking_with_registry_module(self, *args):
+        self.form.post_form_workflow = WORKFLOW_FORM
+        self.form.form_links = [
+            FormLink(xpath="(today() - dob) &lt; 7", module_unique_id=self.module.unique_id)
+        ]
+        self.assertXmlPartialEqual(
+            self.get_xml('form_link_followup_module_registry'),
+            self.app.create_suite(),
+            "./entry[1]"
+        )

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -1,0 +1,102 @@
+from django.test import SimpleTestCase
+
+from corehq.apps.app_manager.models import (
+    Application,
+    CaseSearch,
+    CaseSearchProperty,
+    Module,
+    AdditionalRegistryQuery,
+)
+from corehq.apps.app_manager.tests.util import (
+    SuiteMixin,
+    TestXmlMixin,
+    patch_get_xform_resource_overrides,
+)
+from corehq.apps.builds.models import BuildSpec
+from corehq.util.test_utils import flag_enabled
+
+DOMAIN = 'test_domain'
+
+
+@patch_get_xform_resource_overrides()
+class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
+    file_path = ('data', 'suite')
+
+    def setUp(self):
+        self.app = Application.new_app(DOMAIN, "Untitled Application")
+        self.app._id = '123'
+        self.app.build_spec = BuildSpec(version='2.35.0', build_number=1)
+        self.module = self.app.add_module(Module.new_module("Untitled Module", None))
+        self.form = self.app.new_form(0, "Untitled Form", None)
+        self.form.requires = 'case'
+        self.module.case_type = 'case'
+
+        self.module.search_config = CaseSearch(
+            properties=[
+                CaseSearchProperty(name='name', label={'en': 'Name'}),
+                CaseSearchProperty(name='dob', label={'en': 'Date of birth'})
+            ],
+        )
+
+        # wrap to have assign_references called
+        self.app = Application.wrap(self.app.to_json())
+        # reset to newly wrapped module
+        self.module = self.app.modules[0]
+
+    @flag_enabled('USH_CASE_CLAIM_UPDATES')
+    def test_search_data_registry(self, *args):
+        self.module.search_config.data_registry = "myregistry"
+        suite = self.app.create_suite()
+
+        expected_entry_query = """
+        <partial>
+          <query url="http://localhost:8000/a/test_domain/phone/registry_case/123/"
+                storage-instance="registry" template="case" default_search="true">
+            <data key="case_type" ref="'case'"/>
+            <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
+            <data key="commcare_registry" ref="'myregistry'"/>
+          </query>
+        </partial>"""
+        self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]/session/query")
+
+        # assert that session instance is added to the entry
+        self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='commcaresession']")
+
+        # assert post is disabled
+        self.assertXmlHasXpath(suite, "./remote-request[1]/post[@relevant='false()']")
+
+        expected_data = """
+        <partial>
+          <data key="commcare_registry" ref="'myregistry'"/>
+        </partial>
+        """
+        self.assertXmlPartialEqual(
+            expected_data, suite, "./remote-request[1]/session/query/data[@key='commcare_registry']")
+
+    @flag_enabled('USH_CASE_CLAIM_UPDATES')
+    def test_search_data_registry_additional_registry_query(self, *args):
+        self.module.search_config.data_registry = "myregistry"
+        base_xpath = "instance('registry')/results/case[@case_id=instance('commcaresession')/session/data/case_id]"
+        self.module.search_config.additional_registry_queries = [
+            AdditionalRegistryQuery(
+                instance_name="duplicate",
+                case_type_xpath=f"{base_xpath}/potential_duplicate_case_type",
+                case_id_xpath=f"{base_xpath}/potential_duplicate_case_id"
+            )
+        ]
+        suite = self.app.create_suite()
+
+        expected_entry_query = f"""
+        <partial>
+          <query url="http://localhost:8000/a/test_domain/phone/registry_case/123/" storage-instance="duplicate"
+                template="case" default_search="true">
+            <data key="case_type" ref="{base_xpath}/potential_duplicate_case_type"/>
+            <data key="case_id" ref="{base_xpath}/potential_duplicate_case_id"/>
+            <data key="commcare_registry" ref="'myregistry'"/>
+          </query>
+        </partial>"""
+        self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]/session/query[2]")
+
+        # assert that session and registry instances are added to the entry
+        self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='commcaresession']")
+        self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='registry']")


### PR DESCRIPTION
## Product Description
Fix some bugs that appear when using data registry search in combination with other app features.

## Technical Summary
This change ensures that the remote query is only added to the form entry and not included in the datums returned by `get_datums_meta_for_form_generic` or `get_datum_meta_module`.

See discussion on https://github.com/dimagi/commcare-hq/pull/30412

## Feature Flag
DATA_REGISTRY

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Updated

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
