### PR TITLE
[data registry] block saving roles without selecting at least one item from the list

### DIFF
--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -27,11 +27,11 @@ hqDefine('users/js/roles',[
             accessSelectedText: gettext("Access Selected"),
             listHeading: gettext("Select which items the role can access:"),
         });
-        const [none, all, selected] = ["none", "all", "selected"];
+        const [NONE, ALL, SELECTED] = ["none", "all", "selected"];
         const selectOptions = [
-            {text: text.accessNoneText, value: none},
-            {text: text.accessAllText, value: all},
-            {text: text.accessSelectedText, value: selected},
+            {text: text.accessNoneText, value: NONE},
+            {text: text.accessAllText, value: ALL},
+            {text: text.accessSelectedText, value: SELECTED},
         ];
         let self = {
             id: id,
@@ -43,33 +43,33 @@ hqDefine('users/js/roles',[
             specific: permissionModel.specific,
         };
         self.showItems = ko.pureComputed(() =>{
-            return self.selection() === selected;
+            return self.selection() === SELECTED;
         });
 
         // set value of selection based on initial data
         if (self.all()) {
-            self.selection(all);
+            self.selection(ALL);
         } else if (_.find(permissionModel.specific(), item => item.value())) {
-            self.selection(selected)
+            self.selection(SELECTED)
         } else {
-            self.selection(none);
+            self.selection(NONE);
         }
 
         self.selection.subscribe(() => {
             // update permission data based on selection
-            if (self.selection() === all) {
+            if (self.selection() === ALL) {
                 self.all(true);
                 self.specific().forEach(item => item.value(false));
                 return;
             }
             self.all(false);
-            if (self.selection() === none) {
+            if (self.selection() === NONE) {
                 self.specific().forEach(item => item.value(false));
             }
         });
 
         self.hasError = ko.pureComputed(() => {
-            return self.selection() === selected && permissionModel.filteredSpecific().length == 0;
+            return self.selection() === SELECTED && permissionModel.filteredSpecific().length == 0;
         });
         return self;
     };

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -369,7 +369,7 @@ hqDefine('users/js/roles',[
                                 [perm.text]
                             );
                         }
-                    })
+                    });
                 };
 
                 return self;

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -175,20 +175,24 @@
                 </select>
                 </div>
               </div>
-              <div class="form-group" data-bind="visible: showItems">
+              <div class="form-group" data-bind="visible: showItems, css: {'has-error': hasError()}">
                 <div class="col-sm-8 col-sm-offset-4 controls">
                   <div class="panel panel-default">
                     <div class="panel-heading" data-bind="text: listHeading"></div>
-                    <div class="panel-body"
-                         data-bind="foreach: specific, slideVisible: showItems">
-                      <div class="form-check">
-                        <input type="checkbox"
-                               data-bind="checked: value, attr: { 'id': $parent.id + slug() + '-checkbox' },
-                                          disable: !$root.allowEdit" />
-                        <label data-bind="attr: { 'for': $parent.id + slug() + '-checkbox' }">
-                          <span data-bind="text: name"></span>
-                        </label>
+                    <div class="panel-body">
+                      <div data-bind="foreach: specific, slideVisible: showItems">
+                        <div class="form-check">
+                          <input type="checkbox"
+                                 data-bind="checked: value, attr: { 'id': $parent.id + slug() + '-checkbox' },
+                                            disable: !$root.allowEdit" />
+                          <label data-bind="attr: { 'for': $parent.id + slug() + '-checkbox' }">
+                            <span data-bind="text: name"></span>
+                          </label>
+                        </div>
                       </div>
+                      <span class='help-block' data-bind="visible: hasError">
+                        {% trans "Please select at least one item." %}
+                      </span>
                     </div>
                   </div>
                 </div>

--- a/corehq/apps/users/templates/users/roles_and_permissions.html
+++ b/corehq/apps/users/templates/users/roles_and_permissions.html
@@ -199,6 +199,7 @@
                   <span class="label label-default" data-bind="text: name"></span><br />
               </span>
             </div>
+            <br/>
             <div data-bind="visible: viewRegistryContentsPermission.all()">{% trans "View All Data" %}</div>
             <div data-bind="visible: !viewRegistryContentsPermission.all() && viewRegistryContentsPermission.filteredSpecific().length">
               <strong>{% trans "View Data From" %}</strong><br/>


### PR DESCRIPTION
# Product Description
QA feedback: https://dimagi-dev.atlassian.net/browse/QA-3553

Add form validation to data registry permissions in roles. This is purely a UI improvement.

In the current code if you save a permission as 'Access Selected' without selecting any items, when you re-load the role the drop down will show 'No Access'. Both of these states are identical from a backend point of view but it may be confusing to a user.

![image](https://user-images.githubusercontent.com/249606/134173849-9d5fdbed-9f8c-4867-8d83-bddc92c39b36.png)

![image](https://user-images.githubusercontent.com/249606/134174048-0cfd5c15-07db-4fbd-8105-90791e57289d.png)

## Technical Summary
Show an error message if the user does not select at least one item from the list and block the form submission.

## Feature Flag
DATA_REGISTRY

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
None

### QA Plan
Tested locally:
* with and without the FF
* all combinations of the dropdown and selections

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
