### PR TITLE
Remove SupplyPointCase and things that used it

### DIFF
--- a/corehq/apps/commtrack/const.py
+++ b/corehq/apps/commtrack/const.py
@@ -16,11 +16,6 @@ MOBILE_WORKER_UUID_NS = uuid.UUID(
     ).hex
 )
 
-
-def is_supply_point_form(form):
-    return form.xmlns == COMMTRACK_SUPPLY_POINT_XMLNS
-
-
 SUPPLY_POINT_CASE_TYPE = 'supply-point'
 REQUISITION_CASE_TYPE = 'commtrack-requisition'  # legacy case type
 FULFILLMENT_CASE_TYPE = 'commtrack-fulfillment'
@@ -28,16 +23,6 @@ RECEIVED_CASE_TYPE = 'commtrack-received'
 ORDER_CASE_TYPE = 'commtrack-order'
 
 DAYS_IN_MONTH = 30.0
-
-
-def is_commtrack_case(case):
-    return case.type in [
-        SUPPLY_POINT_CASE_TYPE,
-        REQUISITION_CASE_TYPE,
-        FULFILLMENT_CASE_TYPE,
-        ORDER_CASE_TYPE,
-    ]
-
 ALL_PRODUCTS_TRANSACTION_TAG = '_all_products'
 
 # supply point products --> supply points and sp product --> requisitions
@@ -48,6 +33,7 @@ PARENT_CASE_REF = 'parent'
 
 def enum(**enums):
     return type('Enum', (), enums)
+
 
 StockActions = enum(
     STOCKONHAND='stockonhand',
@@ -62,5 +48,6 @@ def get_commtrack_user_id(domain):
     # abstracted out in case we one day want to back this
     # by a real user, but for now it's like demo_user
     return COMMTRACK_USERNAME
+
 
 USER_LOCATION_OWNER_MAP_TYPE = 'user-owner-mapping-case'

--- a/corehq/apps/commtrack/helpers.py
+++ b/corehq/apps/commtrack/helpers.py
@@ -1,7 +1,5 @@
 import uuid
 
-import six
-
 from casexml.apps.case.mock import CaseBlock
 
 from corehq.apps.commtrack import const

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -258,25 +258,6 @@ class StockRestoreConfig(models.Model):
         }
 
 
-class SupplyPointCase(CommCareCase):
-    """
-    A wrapper around CommCareCases to get more built in functionality
-    specific to supply points.
-    """
-    location_id = StringProperty()
-
-    class Meta(object):
-        # This is necessary otherwise couchdbkit will confuse this app with casexml
-        app_label = "commtrack"
-
-    @property
-    @memoized
-    def sql_location(self):
-        return SQLLocation.objects.get(location_id=self.location_id)
-
-    location = sql_location
-
-
 UNDERSTOCK_THRESHOLD = 0.5  # months
 OVERSTOCK_THRESHOLD = 2.  # months
 DEFAULT_CONSUMPTION = 10.  # per month

--- a/corehq/apps/commtrack/util.py
+++ b/corehq/apps/commtrack/util.py
@@ -9,8 +9,6 @@ from django.utils.translation import ugettext as _
 
 from text_unidecode import unidecode
 
-from casexml.apps.case.models import CommCareCase
-
 from corehq import feature_previews, toggles
 from corehq.apps.commtrack import const
 from corehq.apps.commtrack.models import (
@@ -20,7 +18,6 @@ from corehq.apps.commtrack.models import (
     ConsumptionConfig,
     StockLevelsConfig,
     StockRestoreConfig,
-    SupplyPointCase,
 )
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.products.models import SQLProduct
@@ -185,12 +182,6 @@ def get_commtrack_location_id(user, domain):
         return user.get_domain_membership(domain.name).location_id
     else:
         return None
-
-
-def get_case_wrapper(data):
-    return {
-        const.SUPPLY_POINT_CASE_TYPE: SupplyPointCase,
-    }.get(data.get('type'), CommCareCase)
 
 
 def unicode_slug(text):

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -79,24 +79,6 @@ def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
     return result.xform, result.cases
 
 
-def get_case_wrapper(data):
-    from corehq.apps.commtrack.util import get_case_wrapper as commtrack_wrapper
-
-    def pact_wrapper(data):
-        if data['domain'] == 'pact' and data['type'] == 'cc_path_client':
-            from pact.models import PactPatientCase
-            return PactPatientCase
-
-    wrapper_funcs = [pact_wrapper, commtrack_wrapper]
-
-    wrapper = None
-    for wf in wrapper_funcs:
-        wrapper = wf(data)
-        if wrapper is not None:
-            break
-    return wrapper
-
-
 def get_case_by_identifier(domain, identifier):
 
     case_accessors = CaseAccessors(domain)

--- a/corehq/apps/locations/tests/util.py
+++ b/corehq/apps/locations/tests/util.py
@@ -2,9 +2,6 @@ from collections import namedtuple
 
 from django.test import TestCase
 
-from dimagi.utils.couch.database import iter_bulk_delete
-
-from corehq.apps.commtrack.models import SupplyPointCase
 from corehq.apps.commtrack.tests.util import bootstrap_domain
 from corehq.apps.users.models import Permissions, UserRole
 from corehq.util.test_utils import unit_testing_only
@@ -28,11 +25,6 @@ def make_loc(code, name=None, domain=TEST_DOMAIN, type=TEST_LOCATION_TYPE,
 
 @unit_testing_only
 def delete_all_locations():
-    ids = [
-        doc['id'] for doc in
-        SupplyPointCase.get_db().view('supply_point_by_loc/view', reduce=False).all()
-    ]
-    iter_bulk_delete(SupplyPointCase.get_db(), ids)
     SQLLocation.objects.all().delete()
     LocationType.objects.all().delete()
 

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -1,16 +1,11 @@
-import logging
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-from couchdbkit.exceptions import ResourceNotFound
 from dateutil import parser
 from memoized import memoized
 
-from casexml.apps.stock.const import COMMTRACK_REPORT_XMLNS, SECTION_TYPE_STOCK
-from casexml.apps.stock.models import StockReport
+from casexml.apps.stock.const import SECTION_TYPE_STOCK
 from casexml.apps.stock.utils import months_of_stock_remaining, stock_category
-from couchforms.models import XFormInstance
-from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.couch.loosechange import map_reduce
 
 from corehq.apps.locations.models import SQLLocation
@@ -27,7 +22,6 @@ from corehq.apps.reports.commtrack.util import (
     get_product_ids_for_program,
     get_relevant_supply_point_ids,
 )
-from corehq.apps.reports.standard.monitoring import MultiFormDrilldownMixin
 
 
 def format_decimal(d):

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -13,7 +13,6 @@ from couchforms.models import XFormInstance
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.couch.loosechange import map_reduce
 
-from corehq.apps.commtrack.models import SupplyPointCase
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.products.models import Product
 from corehq.apps.reports.analytics.dbaccessors import (

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -10,26 +10,21 @@ from datetime import datetime
 import logging
 
 from django.core.cache import cache
-from django.conf import settings
-from django.utils.translation import ugettext as _
 from couchdbkit.exceptions import ResourceNotFound
 
 from casexml.apps.case.dbaccessors import get_reverse_indices
 from corehq.apps.sms.mixin import MessagingCaseContactMixin
 from corehq.blobs.mixin import DeferredBlobMixin, CODES
 from corehq.form_processor.abstract_models import AbstractCommCareCase, DEFAULT_PARENT_IDENTIFIER
-from dimagi.ext.couchdbkit import *
+from dimagi.ext.couchdbkit import *  # noqa: F403
 from casexml.apps.case.signals import case_post_save
 from casexml.apps.case import const
-from dimagi.utils.modules import to_function
-from dimagi.utils import web
 from memoized import memoized
 from dimagi.utils.indicators import ComputedDocumentMixin
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 from couchforms.models import XFormInstance
 from corehq.form_processor.exceptions import CaseNotFound
 from casexml.apps.case.sharedmodels import IndexHoldingMixIn, CommCareCaseIndex, CommCareCaseAttachment
-from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.couch import (
     CouchDocLockableMixIn,
     LooselyEqualDocumentSchema,
@@ -326,19 +321,6 @@ class CommCareCase(DeferredBlobMixin, SafeSaveDocument, IndexHoldingMixIn,
             return super(CommCareCase, cls).get(id, **kwargs)
         except ResourceNotFound:
             raise CaseNotFound(id)
-
-    @classmethod
-    def get_wrap_class(cls, data):
-        try:
-            settings.CASE_WRAPPER
-        except AttributeError:
-            cls._case_wrapper = None
-        else:
-            CASE_WRAPPER = to_function(settings.CASE_WRAPPER, failhard=True)
-        
-        if CASE_WRAPPER:
-            return CASE_WRAPPER(data) or cls
-        return cls
 
     def get_server_modified_date(self):
         # gets (or adds) the server modified timestamp

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -692,29 +692,9 @@ class XFormPhoneMetadata(jsonobject.JsonObject):
             return LooseVersion(version_text)
 
 
-class SupplyPointCaseMixin(object):
-    CASE_TYPE = 'supply-point'
-
-    @property
-    @memoized
-    def location(self):
-        from corehq.apps.locations.models import SQLLocation
-        if self.location_id is None:
-            return None
-        try:
-            return self.sql_location
-        except SQLLocation.DoesNotExist:
-            return None
-
-    @property
-    def sql_location(self):
-        from corehq.apps.locations.models import SQLLocation
-        return SQLLocation.objects.get(location_id=self.location_id)
-
-
 class CommCareCaseSQL(PartitionedModel, models.Model, RedisLockableMixIn,
                       AttachmentMixin, AbstractCommCareCase, TrackRelatedChanges,
-                      SupplyPointCaseMixin, MessagingCaseContactMixin):
+                      MessagingCaseContactMixin):
     partition_attr = 'case_id'
 
     case_id = models.CharField(max_length=255, unique=True, db_index=True)
@@ -768,6 +748,27 @@ class CommCareCaseSQL(PartitionedModel, models.Model, RedisLockableMixIn,
     @memoized
     def xform_ids(self):
         return [t.form_id for t in self.transactions if not t.revoked and t.is_form_transaction]
+
+    @property
+    @memoized
+    def location(self):
+        """Get supply point location or `None` if it does not exist."""
+        from corehq.apps.locations.models import SQLLocation
+        if self.location_id is None:
+            return None
+        try:
+            return self.sql_location
+        except SQLLocation.DoesNotExist:
+            return None
+
+    @property
+    def sql_location(self):
+        """Get supply point location
+
+        Raises `SQLLocation.DoesNotExist` if not found.
+        """
+        from corehq.apps.locations.models import SQLLocation
+        return SQLLocation.objects.get(location_id=self.location_id)
 
     @property
     def user_id(self):

--- a/corehq/form_processor/tests/test_case_dbaccessor.py
+++ b/corehq/form_processor/tests/test_case_dbaccessor.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from django.db import router
 from django.test import TestCase
 
+from corehq.apps.commtrack.const import SUPPLY_POINT_CASE_TYPE
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.backends.sql.processor import FormProcessorSQL
 from corehq.form_processor.exceptions import (
@@ -22,7 +23,6 @@ from corehq.form_processor.models import (
     CaseTransaction,
     CommCareCaseIndexSQL,
     CommCareCaseSQL,
-    SupplyPointCaseMixin,
     XFormInstanceSQL,
 )
 from corehq.form_processor.tests.test_basics import _submit_case_block
@@ -285,7 +285,7 @@ class CaseAccessorTestsSQL(TestCase):
         )
 
     def test_get_case_by_location(self):
-        case = _create_case(case_type=SupplyPointCaseMixin.CASE_TYPE)
+        case = _create_case(case_type=SUPPLY_POINT_CASE_TYPE)
         location_id = uuid.uuid4().hex
         case.location_id = location_id
         CaseAccessorSQL.save_case(case)

--- a/settings.py
+++ b/settings.py
@@ -1697,8 +1697,6 @@ ALLOWED_CUSTOM_CONTENT_HANDLERS = {
 # These are custom templates which can wrap default the sms/chat.html template
 CUSTOM_CHAT_TEMPLATES = {}
 
-CASE_WRAPPER = 'corehq.apps.hqcase.utils.get_case_wrapper'
-
 PILLOWTOPS = {
     'core': [
         {


### PR DESCRIPTION
Everything removed in this PR is unused.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No new tests since nothing new was added.

### QA Plan

No QA.

### Safety story

This is only removing unused code.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
