### PR TITLE
fix zero domains error for superusers

### DIFF
--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -212,7 +212,7 @@ def redirect_to_default(req, domain=None):
     else:
         domains = Domain.active_for_user(req.user)
 
-    if not domains and not req.user.is_superuser:
+    if not domains:
         return redirect('registration_domain')
 
     if len(domains) > 1:


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Fix for small bug introduced in #29824.

After registering a new superuser with zero domains, an index error prevents the user from navigating HQ. This fix will automatically direct a superuser with zero domains to the domain registration page, the same way they were before #29824.

I noticed this error upon starting up HQ on my local machine and creating a superuser for the first time. I had to add /register/domain to the url in order to get around the error page and create a domain to start using HQ. 

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No tests.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Logic is the same as in past versions of HQ.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
