### PR TITLE
Key/value widget updates for valid values editing

### DIFF
--- a/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
+++ b/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
@@ -109,7 +109,7 @@ hqDefine('custom_data_fields/js/custom_data_fields', [
 
         self.fields = uiElementKeyValueList.new(
             String(Math.random()).slice(2),
-            gettext("Profile")
+            gettext("Edit Profile")
         );
         self.fields.on("change", function () {
             $(":submit").prop("disabled", false);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -59,9 +59,11 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.deprecated = ko.observable(deprecated || false);
         self.removeFHIRResourcePropertyPath = ko.observable(removeFHIRResourcePropertyPath || false);
         self.allowedValues = uiElementKeyValueList.new(
-            String(Math.random()).slice(2),
-            gettext("Valid Values"),
-            {"key": gettext("valid value"), "value": gettext("description")}
+            String(Math.random()).slice(2), /* guid */
+            interpolate('Edit valid values for "%s"', [name]), /* modalTitle */
+            gettext("When importing case data, CommCare will warn if rows don't match valid values"), /* subTitle */
+            {"key": gettext("valid value"), "value": gettext("description")}, /* placeholders */
+            10 /* maxDisplay */
         );
         self.allowedValues.val(allowedValues);
         self.$allowedValues = self.allowedValues.ui;

--- a/corehq/apps/groups/static/groups/js/group_members.js
+++ b/corehq/apps/groups/static/groups/js/group_members.js
@@ -15,7 +15,7 @@ hqDefine("groups/js/group_members", [
 ) {
     $(function () {
         // custom data
-        var customDataEditor = uiMapList.new(initialPageData.get("group_id"), gettext("Group Information"));
+        var customDataEditor = uiMapList.new(initialPageData.get("group_id"), gettext("Edit Group Information"));
         customDataEditor.val(initialPageData.get("group_metadata"));
         customDataEditor.on("change", function () {
             $("#group-data").val(JSON.stringify(this.val()));

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-list.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-list.js
@@ -12,7 +12,7 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-list', [
     'use strict';
     var module = {};
 
-    var KeyValList = function (guid, modal_title, placeholders) {
+    var KeyValList = function (guid, modalTitle, subTitle, placeholders, maxDisplay) {
         var that = this;
         hqMain.eventize(this);
         this.placeholders = placeholders;
@@ -21,7 +21,9 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-list', [
         this.translated_value = {};
         this.edit = true;
         this.modal_id = 'enumModal-' + guid;
-        this.modal_title = modal_title;
+        this.modal_title = modalTitle
+        this.sub_title = subTitle ? '<p>' + subTitle + '</p>' : ''
+        this.max_display = maxDisplay
 
         this.$edit_view = $('<div class="well well-sm" />');
         this.$noedit_view = $('<div />');
@@ -35,7 +37,7 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-list', [
         var $modalContent = $('<div class="modal-content" />');
 
         $modalContent.prepend('<div class="modal-header"><a class="close" data-dismiss="modal">×</a><h4 class="modal-title">'
-            + django.gettext('Edit ') + this.modal_title + '</h4></div>');
+            + this.modal_title + '</h4>' + this.sub_title + '</div>');
         var $modal_form = $('<form class="form-horizontal hq-enum-editor" action="" />'),
             $modal_body = $('<div class="modal-body" style="max-height:372px; overflow-y: scroll;" />');
         $modal_body.append($('<fieldset />'));
@@ -95,9 +97,15 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-list', [
                 if (!_.isEmpty(this.value)) {
                     this.$edit_view.text('');
                 }
+                let i = 0;
                 for (var key in this.value) {
                     $modal_fields.append(uiInputMap.new(true, this.placeholders).val(key, this.value[key], this.translated_value[key]).ui);
-                    this.$edit_view.append(uiInputMap.new(true, this.placeholders).val(key, this.value[key], this.translated_value[key]).setEdit(false).$noedit_view);
+                    if (this.max_display === undefined || i < this.max_display) {
+                        this.$edit_view.append(uiInputMap.new(true, this.placeholders).val(key, this.value[key], this.translated_value[key]).setEdit(false).$noedit_view);
+                    } else if (i === this.max_display) {
+                        this.$edit_view.append('<div><strong>&hellip;</strong></div>');
+                    }
+                    i++;
                 }
             }
 
@@ -118,8 +126,8 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-list', [
         },
     };
 
-    module.new = function (guid, modalTitle, placeholders) {
-        return new KeyValList(guid, modalTitle, placeholders);
+    module.new = function (guid, modalTitle, subTitle, placeholders, maxDisplay) {
+        return new KeyValList(guid, modalTitle, subTitle, placeholders, maxDisplay);
     };
 
     return module;

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-list.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-list.js
@@ -21,9 +21,9 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-list', [
         this.translated_value = {};
         this.edit = true;
         this.modal_id = 'enumModal-' + guid;
-        this.modal_title = modalTitle
-        this.sub_title = subTitle ? '<p>' + subTitle + '</p>' : ''
-        this.max_display = maxDisplay
+        this.modal_title = modalTitle;
+        this.sub_title = subTitle ? '<p>' + subTitle + '</p>' : '';
+        this.max_display = maxDisplay;
 
         this.$edit_view = $('<div class="well well-sm" />');
         this.$noedit_view = $('<div />');


### PR DESCRIPTION
(removed safety info because this is a PR into a dev branch)

More specific/descriptive modal title (have caller of the shared code specify full title)
Allow caller to specify "subtitle" to show below the modal title
Allow caller to specify a maximum number of items to display for the display view

## Product Description
More descriptive title and subtitle on modal for edting valid values in data dictionary, maximum summary display of 10 valid values with inclusion of ellipsis if there are actually more than 10 in the property's list. 

