### PR TITLE
Throttle system forms by delaying them slightly

### DIFF
--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -35,7 +35,7 @@ ALLOWED_CASE_IDENTIFIER_TYPES = [
 
 def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
                        xmlns=None, attachments=None, form_id=None,
-                       form_extras=None, case_db=None, device_id=None, max_wait=0.1):
+                       form_extras=None, case_db=None, device_id=None, max_wait=Ellipsis):
     """
     Submits casexml in a manner similar to how they would be submitted from a phone.
 

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -35,7 +35,7 @@ ALLOWED_CASE_IDENTIFIER_TYPES = [
 
 def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
                        xmlns=None, attachments=None, form_id=None,
-                       form_extras=None, case_db=None, device_id=None):
+                       form_extras=None, case_db=None, device_id=None, max_wait=0.1):
     """
     Submits casexml in a manner similar to how they would be submitted from a phone.
 
@@ -50,6 +50,8 @@ def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
     make it easier to trace the source. All new code should use this
     argument. A human recognizable value is recommended outside of test
     code. Example: "auto-close-rule-<GUID>"
+    :param max_wait: Maximum time to allow the process to be delayed if
+    the project is over its submission rate limit.
 
     returns the UID of the resulting form.
     """
@@ -74,6 +76,7 @@ def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
         domain=domain,
         attachments=attachments,
         case_db=case_db,
+        max_wait=max_wait,
         **form_extras
     )
     return result.xform, result.cases

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -35,7 +35,7 @@ ALLOWED_CASE_IDENTIFIER_TYPES = [
 
 def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
                        xmlns=None, attachments=None, form_id=None,
-                       form_extras=None, case_db=None, device_id=None, max_wait=Ellipsis):
+                       form_extras=None, case_db=None, device_id=None, max_wait=...):
     """
     Submits casexml in a manner similar to how they would be submitted from a phone.
 
@@ -50,8 +50,9 @@ def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
     make it easier to trace the source. All new code should use this
     argument. A human recognizable value is recommended outside of test
     code. Example: "auto-close-rule-<GUID>"
-    :param max_wait: Maximum time to allow the process to be delayed if
+    :param max_wait: Maximum time (in seconds) to allow the process to be delayed if
     the project is over its submission rate limit.
+    See the docstring for submit_form_locally for meaning of values.
 
     returns the UID of the resulting form.
     """

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -1,3 +1,5 @@
+import time
+
 from django.conf import settings
 
 from corehq.project_limits.rate_limiter import (
@@ -71,7 +73,7 @@ SHOULD_RATE_LIMIT_SUBMISSIONS = settings.RATE_LIMIT_SUBMISSIONS and not settings
 @run_only_when(SHOULD_RATE_LIMIT_SUBMISSIONS)
 @silence_and_report_error("Exception raised in the submission rate limiter",
                           'commcare.xform_submissions.rate_limiter_errors')
-def rate_limit_submission(domain):
+def rate_limit_submission(domain, delay_rather_than_reject=False, max_wait=15):
     if TEST_FORM_SUBMISSION_RATE_LIMIT_RESPONSE.enabled(domain):
         return True
     should_allow_usage = (
@@ -85,10 +87,12 @@ def rate_limit_submission(domain):
         # but still delay and record whether they'd be rate limited under the 'test' metric
         allow_usage = True
         _delay_and_report_rate_limit_submission(
-            domain, max_wait=15, datadog_metric='commcare.xform_submissions.rate_limited.test')
+            domain, max_wait=max_wait, delay_rather_than_reject=delay_rather_than_reject,
+            datadog_metric='commcare.xform_submissions.rate_limited.test')
     else:
         allow_usage = _delay_and_report_rate_limit_submission(
-            domain, max_wait=15, datadog_metric='commcare.xform_submissions.rate_limited')
+            domain, max_wait=max_wait, delay_rather_than_reject=delay_rather_than_reject,
+            datadog_metric='commcare.xform_submissions.rate_limited')
 
     return not allow_usage
 
@@ -102,11 +106,31 @@ def report_submission_usage(domain):
     _report_current_global_submission_thresholds()
 
 
-def _delay_and_report_rate_limit_submission(domain, max_wait, datadog_metric):
+def _delay_and_report_rate_limit_submission(domain, max_wait, delay_rather_than_reject, datadog_metric):
+    """
+    Attempt to acquire permission from the rate limiter waiting up to 15 seconds.
+
+    When delay_rather_than_reject is False
+
+        If it's acquired, report throttle_method:delay and duration:<bucketed duration>;
+        otherwise report throttle_method:reject and duration:delayed_reject or quick_reject,
+        depending on whether the rate limiter bothered to wait or could tell there was no chance.
+
+    When delay_rather_than_reject is True
+
+        If it's acquired, report throttle_method:delay and duration:<bucketed duration> (as before);
+        otherwise report throttle_method:delay and duration:delay_rather_than_reject
+
+    Returns whether the permission was eventually acquired (with no variation on delay_rather_than_reject).
+    """
     with TimingContext() as timer:
         acquired = submission_rate_limiter.wait(domain, timeout=max_wait)
     if acquired:
         duration_tag = bucket_value(timer.duration, [.5, 1, 5, 10, 15], unit='s')
+    elif delay_rather_than_reject:
+        if timer.duration < max_wait:
+            time.sleep(max_wait - timer.duration)
+        duration_tag = 'delay_rather_than_reject'
     elif timer.duration < max_wait:
         duration_tag = 'quick_reject'
     else:
@@ -114,7 +138,7 @@ def _delay_and_report_rate_limit_submission(domain, max_wait, datadog_metric):
     metrics_counter(datadog_metric, tags={
         'domain': domain,
         'duration': duration_tag,
-        'throttle_method': "delay" if acquired else "reject"
+        'throttle_method': "delay" if acquired or delay_rather_than_reject else "reject"
     })
     return acquired
 

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -70,7 +70,7 @@ global_submission_rate_limiter = RateLimiter(
 SHOULD_RATE_LIMIT_SUBMISSIONS = settings.RATE_LIMIT_SUBMISSIONS and not settings.UNIT_TESTING
 
 
-@run_only_when(SHOULD_RATE_LIMIT_SUBMISSIONS)
+@run_only_when(lambda: SHOULD_RATE_LIMIT_SUBMISSIONS)
 @silence_and_report_error("Exception raised in the submission rate limiter",
                           'commcare.xform_submissions.rate_limiter_errors')
 def rate_limit_submission(domain, delay_rather_than_reject=False, max_wait=15):

--- a/corehq/apps/receiverwrapper/tests/test_submissions.py
+++ b/corehq/apps/receiverwrapper/tests/test_submissions.py
@@ -323,3 +323,8 @@ class SubmitFormLocallyRateLimitTest(TestCase, TestFileMixin):
         form_xml = self.get_xml('simple_form')
         submit_form_locally(form_xml, domain=self.domain)
         allow_usage.assert_called()
+
+    def test_no_rate_limiting(self, allow_usage):
+        form_xml = self.get_xml('simple_form')
+        submit_form_locally(form_xml, domain=self.domain, max_wait=None)
+        allow_usage.assert_not_called()

--- a/corehq/apps/receiverwrapper/tests/test_submissions.py
+++ b/corehq/apps/receiverwrapper/tests/test_submissions.py
@@ -310,3 +310,16 @@ class SubmissionSQLTransactionsTest(TestCase, TestFileMixin):
 
         transaction = result.cases[0].get_transaction_by_form_id(result.xform.form_id)
         self.assertTrue(transaction.is_form_transaction)
+
+
+@patch('corehq.apps.receiverwrapper.rate_limiter.SHOULD_RATE_LIMIT_SUBMISSIONS', True)
+@patch('corehq.apps.receiverwrapper.rate_limiter.global_submission_rate_limiter.allow_usage', return_value=True)
+class SubmitFormLocallyRateLimitTest(TestCase, TestFileMixin):
+    root = os.path.dirname(__file__)
+    file_path = ('data',)
+    domain = 'test-domain'
+
+    def test_rate_limiting(self, allow_usage):
+        form_xml = self.get_xml('simple_form')
+        submit_form_locally(form_xml, domain=self.domain)
+        allow_usage.assert_called()

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -9,6 +9,7 @@ from couchdbkit import ResourceNotFound
 
 import couchforms
 from corehq.apps.receiverwrapper.rate_limiter import rate_limit_submission
+from corehq.toggles import THROTTLE_SYSTEM_FORMS, NAMESPACE_DOMAIN
 from couchforms.models import DefaultAuthContext
 
 from corehq.apps.app_manager.dbaccessors import get_app
@@ -28,7 +29,11 @@ def get_submit_url(domain, app_id=None):
         return "/a/{domain}/receiver/".format(domain=domain)
 
 
-def submit_form_locally(instance, domain, max_wait=0.1, **kwargs):
+def submit_form_locally(instance, domain, max_wait=Ellipsis, **kwargs):
+    # Using Ellipsis here to mean "The caller did not pass in a value",
+    # because the value None has a special meaning
+    if max_wait is Ellipsis:
+        max_wait = 0.1 if THROTTLE_SYSTEM_FORMS.enabled(domain, namespace=NAMESPACE_DOMAIN) else None
     if max_wait is not None:
         rate_limit_submission(domain, delay_rather_than_reject=True, max_wait=max_wait)
     # intentionally leave these unauth'd for now

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -29,10 +29,18 @@ def get_submit_url(domain, app_id=None):
         return "/a/{domain}/receiver/".format(domain=domain)
 
 
-def submit_form_locally(instance, domain, max_wait=Ellipsis, **kwargs):
-    # Using Ellipsis here to mean "The caller did not pass in a value",
-    # because the value None has a special meaning
-    if max_wait is Ellipsis:
+def submit_form_locally(instance, domain, max_wait=..., **kwargs):
+    """
+    :param instance: XML instance (as a string) to submit
+    :param domain: The domain to submit the form to
+    :param max_wait: Maximum time (in seconds) to allow the process to be delayed if
+    the project is over its submission rate limit.
+    The value None means "do not throttle".
+    The special value ... (Ellipsis) means "The caller did not pass in a value".
+    (This was chosen because of the special meaning already assumed by None.)
+    """
+
+    if max_wait is ...:
         max_wait = 0.1 if THROTTLE_SYSTEM_FORMS.enabled(domain, namespace=NAMESPACE_DOMAIN) else None
     if max_wait is not None:
         rate_limit_submission(domain, delay_rather_than_reject=True, max_wait=max_wait)

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -28,8 +28,9 @@ def get_submit_url(domain, app_id=None):
         return "/a/{domain}/receiver/".format(domain=domain)
 
 
-def submit_form_locally(instance, domain, **kwargs):
-    rate_limit_submission(domain, delay_rather_than_reject=True, max_wait=.1)
+def submit_form_locally(instance, domain, max_wait=0.1, **kwargs):
+    if max_wait is not None:
+        rate_limit_submission(domain, delay_rather_than_reject=True, max_wait=max_wait)
     # intentionally leave these unauth'd for now
     kwargs['auth_context'] = kwargs.get('auth_context') or DefaultAuthContext()
     result = SubmissionPost(

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -29,7 +29,7 @@ def get_submit_url(domain, app_id=None):
 
 
 def submit_form_locally(instance, domain, **kwargs):
-    rate_limit_submission(domain, delay_rather_than_reject=True, rate_limit_submission=.1)
+    rate_limit_submission(domain, delay_rather_than_reject=True, max_wait=.1)
     # intentionally leave these unauth'd for now
     kwargs['auth_context'] = kwargs.get('auth_context') or DefaultAuthContext()
     result = SubmissionPost(

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -8,6 +8,7 @@ from django.http import Http404
 from couchdbkit import ResourceNotFound
 
 import couchforms
+from corehq.apps.receiverwrapper.rate_limiter import rate_limit_submission
 from couchforms.models import DefaultAuthContext
 
 from corehq.apps.app_manager.dbaccessors import get_app
@@ -28,6 +29,7 @@ def get_submit_url(domain, app_id=None):
 
 
 def submit_form_locally(instance, domain, **kwargs):
+    rate_limit_submission(domain, delay_rather_than_reject=True, rate_limit_submission=.1)
     # intentionally leave these unauth'd for now
     kwargs['auth_context'] = kwargs.get('auth_context') or DefaultAuthContext()
     result = SubmissionPost(

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -2142,3 +2142,12 @@ DO_NOT_REPUBLISH_DOCS = StaticToggle(
     TAG_INTERNAL,
     namespaces=[NAMESPACE_DOMAIN],
 )
+
+THROTTLE_SYSTEM_FORMS = FeatureRelease(
+    'throttle_system_forms',
+    ('Throttles system forms (from auto update rules, etc.) with soft delays (no hard rejections) '
+     'to make them a better part of the overall submission rate limiting system.'),
+    TAG_INTERNAL,
+    namespaces=[NAMESPACE_DOMAIN],
+    owner='Danny Roberts',
+)

--- a/corehq/util/decorators.py
+++ b/corehq/util/decorators.py
@@ -56,7 +56,8 @@ def run_only_when(condition):
     def outer(fn):
         @wraps(fn)
         def inner(*args, **kwargs):
-            if condition:
+            condition_ = condition() if callable(condition) else condition
+            if condition_:
                 return fn(*args, **kwargs)
         return inner
     return outer


### PR DESCRIPTION
## Product Description

https://dimagi-dev.atlassian.net/browse/SAAS-12668

Slow down system-internal submissions (mostly auto case rule updates) when we're above our global target submission rate. This smooths out load on the system, allows a domain's real submissions to share in the bandwidth, and improves stability during the time period (midnight UTC) when these happen in the highest volume.

## Technical Summary
Throttle system forms by delaying them slightly under the same conditions that we would reject a normal submission

## Feature Flag
THROTTLE_SYSTEM_FORMS (Feature Release)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Added a few tests that just go through the happy path and make sure that it hasn't broken.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
I put this on staging to test the case import and other things that use `submit_form_locally`, and test that it works even when it's inducing throttling. Case import and "clean case data" work as normal. "Clean case data" emits one `delay_rather_than_reject` if the flag is enabled, and doesn't emit anything if the flag is not enabled, which is consistent with the flag properly gating the feature. (Case import used to have its own delay which now goes through a custom max_wait in `rate_limit_submission` so that it shows up in metrics, and that is working correctly as well.)

To mitigate risk, the net-new part, throttling all calls to `submit_form_locally` by default, is under a flag. When I roll it out I will also watch the behavior of celery tasks related to auto case close at 7pm CT when they all kick off., as well as metrics related to rate limiting.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
