### PR TITLE
Update last pull on report/keyword updates

### DIFF
--- a/corehq/apps/linked_domain/keywords.py
+++ b/corehq/apps/linked_domain/keywords.py
@@ -54,18 +54,18 @@ def update_keyword(domain_link, keyword_id, user_id):
             _("Linked keyword could not be found")
         )
     try:
-        master_keyword = Keyword.objects.get(id=linked_keyword.upstream_id)
+        upstream_keyword = Keyword.objects.get(id=linked_keyword.upstream_id)
     except Keyword.DoesNotExist:
         raise DomainLinkError(
             _("Upstream keyword could not be found. Maybe it has been deleted?")
         )
 
     for prop in ['keyword', 'description', 'delimiter', 'override_open_sessions', 'initiator_doc_type_filter']:
-        setattr(linked_keyword, prop, getattr(master_keyword, prop))
+        setattr(linked_keyword, prop, getattr(upstream_keyword, prop))
 
     linked_keyword.save()
 
-    _update_actions(domain_link, linked_keyword, master_keyword.keywordaction_set.all())
+    _update_actions(domain_link, linked_keyword, upstream_keyword.keywordaction_set.all())
 
     domain_link.update_last_pull(
         MODEL_KEYWORD,

--- a/corehq/apps/linked_domain/keywords.py
+++ b/corehq/apps/linked_domain/keywords.py
@@ -3,7 +3,9 @@ import uuid
 from django.utils.translation import ugettext as _
 
 from corehq.apps.linked_domain.applications import get_downstream_app_id
+from corehq.apps.linked_domain.const import MODEL_KEYWORD
 from corehq.apps.linked_domain.exceptions import DomainLinkError, MultipleDownstreamAppsError
+from corehq.apps.linked_domain.models import KeywordLinkDetail
 from corehq.apps.sms.models import Keyword
 
 
@@ -41,7 +43,7 @@ def create_linked_keyword(domain_link, keyword_id):
     return keyword.id
 
 
-def update_keyword(domain_link, keyword_id):
+def update_keyword(domain_link, keyword_id, user_id):
     try:
         linked_keyword = Keyword.objects.get(id=keyword_id)
     except Keyword.DoesNotExist:
@@ -61,6 +63,12 @@ def update_keyword(domain_link, keyword_id):
     linked_keyword.save()
 
     _update_actions(domain_link, linked_keyword, master_keyword.keywordaction_set.all())
+
+    domain_link.update_last_pull(
+        MODEL_KEYWORD,
+        user_id,
+        model_detail=KeywordLinkDetail(keyword_id=str(linked_keyword.id)).to_json(),
+    )
 
 
 def _update_actions(domain_link, linked_keyword, keyword_actions):

--- a/corehq/apps/linked_domain/keywords.py
+++ b/corehq/apps/linked_domain/keywords.py
@@ -4,7 +4,10 @@ from django.utils.translation import ugettext as _
 
 from corehq.apps.linked_domain.applications import get_downstream_app_id
 from corehq.apps.linked_domain.const import MODEL_KEYWORD
-from corehq.apps.linked_domain.exceptions import DomainLinkError, MultipleDownstreamAppsError
+from corehq.apps.linked_domain.exceptions import (
+    DomainLinkError,
+    MultipleDownstreamAppsError,
+)
 from corehq.apps.linked_domain.models import KeywordLinkDetail
 from corehq.apps.sms.models import Keyword
 

--- a/corehq/apps/linked_domain/tasks.py
+++ b/corehq/apps/linked_domain/tasks.py
@@ -150,13 +150,13 @@ The following linked project spaces received content:
         except Exception as e:  # intentionally broad
             return self._error_tuple(error_prefix + str(e))
 
-    def _release_report(self, domain_link, model):
+    def _release_report(self, domain_link, model, user_id):
         report_id = model['detail']['report_id']
         found = False
         for linked_report in get_report_configs_for_domain(domain_link.linked_domain):
             if linked_report.report_meta.master_id == report_id:
                 found = True
-                update_linked_ucr(domain_link, linked_report.get_id)
+                update_linked_ucr(domain_link, linked_report.get_id, user_id)
 
         if not found:
             report = ReportConfiguration.get(report_id)
@@ -223,7 +223,7 @@ def release_domain(upstream_domain, downstream_domain, username, models, build_a
             if model['type'] == MODEL_APP:
                 errors = manager._release_app(domain_link, model, manager.user, build_apps)
             elif model['type'] == MODEL_REPORT:
-                errors = manager._release_report(domain_link, model)
+                errors = manager._release_report(domain_link, model, manager.user._id)
             elif model['type'] in FEATURE_FLAG_DATA_MODEL_TOGGLES:
                 errors = manager._release_flag_dependent_model(domain_link, model, manager.user,
                                                                FEATURE_FLAG_DATA_MODEL_TOGGLES[model['type']])

--- a/corehq/apps/linked_domain/tasks.py
+++ b/corehq/apps/linked_domain/tasks.py
@@ -46,7 +46,7 @@ def push_models(upstream_domain, models, downstream_domains, build_apps, usernam
     ReleaseManager(upstream_domain, username).release(models, downstream_domains, build_apps)
 
 
-class ReleaseManager():
+class ReleaseManager:
     def __init__(self, upstream_domain, username):
         self.upstream_domain = upstream_domain
         self.user = CouchUser.get_by_username(username)
@@ -57,7 +57,7 @@ class ReleaseManager():
         self.successes_by_domain = {'html': defaultdict(list), 'text': defaultdict(list)}
 
     def results(self):
-        return (self.successes_by_domain, self.errors_by_domain)
+        return self.successes_by_domain, self.errors_by_domain
 
     def add_error(self, domain, html, text=None):
         text = text or html

--- a/corehq/apps/linked_domain/tasks.py
+++ b/corehq/apps/linked_domain/tasks.py
@@ -42,13 +42,13 @@ def pull_missing_multimedia_for_app_and_notify_task(domain, app_id, email=None):
 
 
 @task(queue='linked_domain_queue')
-def push_models(master_domain, models, linked_domains, build_apps, username):
-    ReleaseManager(master_domain, username).release(models, linked_domains, build_apps)
+def push_models(upstream_domain, models, downstream_domains, build_apps, username):
+    ReleaseManager(upstream_domain, username).release(models, downstream_domains, build_apps)
 
 
 class ReleaseManager():
-    def __init__(self, master_domain, username):
-        self.master_domain = master_domain
+    def __init__(self, upstream_domain, username):
+        self.upstream_domain = upstream_domain
         self.user = CouchUser.get_by_username(username)
         self._reset()
 
@@ -92,14 +92,14 @@ class ReleaseManager():
     def _get_successes(self, domain, html=True):
         return self.successes_by_domain['html' if html else 'text'][domain]
 
-    def release(self, models, linked_domains, build_apps=False):
+    def release(self, models, downstream_domains, build_apps=False):
         self._reset()
         header = [
-            release_domain.si(self.master_domain, linked_domain, self.user.username, models, build_apps)
-            for linked_domain in linked_domains
+            release_domain.si(self.upstream_domain, downstream_domain, self.user.username, models, build_apps)
+            for downstream_domain in downstream_domains
         ]
-        callback = send_linked_domain_release_email.s(self.master_domain, self.user.username,
-                                                      models, linked_domains)
+        callback = send_linked_domain_release_email.s(self.upstream_domain, self.user.username,
+                                                      models, downstream_domains)
         chord(header)(callback)
 
     def get_email_message(self, models, linked_domains, html=True):
@@ -208,13 +208,13 @@ The following linked project spaces received content:
 
 
 @task(queue='linked_domain_queue')
-def release_domain(master_domain, linked_domain, username, models, build_apps=False):
-    manager = ReleaseManager(master_domain, username)
+def release_domain(upstream_domain, downstream_domain, username, models, build_apps=False):
+    manager = ReleaseManager(upstream_domain, username)
 
-    domain_link = get_upstream_domain_link(linked_domain)
-    if not domain_link or domain_link.master_domain != master_domain:
-        manager.add_error(linked_domain, _("Project space {} is no longer linked to {}. No content "
-                                           "was released to it.").format(master_domain, linked_domain))
+    domain_link = get_upstream_domain_link(downstream_domain)
+    if not domain_link or domain_link.master_domain != upstream_domain:
+        manager.add_error(downstream_domain, _("Project space {} is no longer linked to {}. No content "
+                                           "was released to it.").format(upstream_domain, downstream_domain))
         return manager.results()
 
     for model in models:
@@ -247,11 +247,11 @@ def release_domain(master_domain, linked_domain, username, models, build_apps=Fa
 
 
 @task(queue='linked_domain_queue')
-def send_linked_domain_release_email(results, master_domain, username, models, linked_domains):
-    manager = ReleaseManager(master_domain, username)
+def send_linked_domain_release_email(results, upstream_domain, username, models, downstream_domains):
+    manager = ReleaseManager(upstream_domain, username)
 
     # chord sends a list of results only if there were multiple tasks
-    if len(linked_domains) == 1:
+    if len(downstream_domains) == 1:
         results = [results]
 
     for result in results:
@@ -267,7 +267,7 @@ def send_linked_domain_release_email(results, master_domain, username, models, l
     send_html_email_async(
         subject,
         email,
-        manager.get_email_message(models, linked_domains, html=True),
-        text_content=manager.get_email_message(models, linked_domains, html=False),
+        manager.get_email_message(models, downstream_domains, html=True),
+        text_content=manager.get_email_message(models, downstream_domains, html=False),
         email_from=settings.DEFAULT_FROM_EMAIL
     )

--- a/corehq/apps/linked_domain/tasks.py
+++ b/corehq/apps/linked_domain/tasks.py
@@ -177,7 +177,7 @@ The following linked project spaces received content:
 
         return self._release_model(domain_link, model, user)
 
-    def _release_keyword(self, domain_link, model):
+    def _release_keyword(self, domain_link, model, user_id):
         upstream_id = model['detail']['keyword_id']
         try:
             linked_keyword_id = (Keyword.objects.values_list('id', flat=True)
@@ -196,7 +196,7 @@ The following linked project spaces received content:
                 _('Could not find linked keyword. Please check the keyword has been linked.'),
             )
 
-        update_keyword(domain_link, linked_keyword_id)
+        update_keyword(domain_link, linked_keyword_id, user_id)
 
     def _release_model(self, domain_link, model, user):
         update_model_type(domain_link, model['type'], model_detail=model['detail'])
@@ -228,7 +228,7 @@ def release_domain(upstream_domain, downstream_domain, username, models, build_a
                 errors = manager._release_flag_dependent_model(domain_link, model, manager.user,
                                                                FEATURE_FLAG_DATA_MODEL_TOGGLES[model['type']])
             elif model['type'] == MODEL_KEYWORD:
-                errors = manager._release_keyword(domain_link, model)
+                errors = manager._release_keyword(domain_link, model, manager.user._id)
             else:
                 errors = manager._release_model(domain_link, model, manager.user)
         except Exception as e:   # intentionally broad

--- a/corehq/apps/linked_domain/tests/test_linked_keywords.py
+++ b/corehq/apps/linked_domain/tests/test_linked_keywords.py
@@ -52,7 +52,7 @@ class TestLinkedKeywords(BaseLinkedAppsTest):
         keyword_action.message_content = "bar"
         keyword_action.save()
 
-        update_keyword(self.domain_link, new_keyword_id)
+        update_keyword(self.domain_link, new_keyword_id, 'test-user-id')
 
         linked_keyword = Keyword.objects.get(id=new_keyword_id)
         self.assertEqual(linked_keyword.keyword, "foo")

--- a/corehq/apps/linked_domain/tests/test_linked_keywords.py
+++ b/corehq/apps/linked_domain/tests/test_linked_keywords.py
@@ -1,5 +1,6 @@
 from corehq.apps.linked_domain.keywords import create_linked_keyword, update_keyword
 from corehq.apps.app_manager.models import Module
+from corehq.apps.linked_domain.models import DomainLinkHistory, KeywordLinkDetail
 from corehq.apps.linked_domain.tests.test_linked_apps import BaseLinkedAppsTest
 from corehq.apps.reminders.models import METHOD_SMS
 from corehq.apps.sms.models import Keyword, KeywordAction
@@ -45,7 +46,9 @@ class TestLinkedKeywords(BaseLinkedAppsTest):
 
     def test_update_keyword_link(self):
         new_keyword_id = create_linked_keyword(self.domain_link, self.keyword.id)
-
+        pre_count = DomainLinkHistory.objects.filter(
+            link=self.domain_link, model_detail=KeywordLinkDetail(keyword_id=str(new_keyword_id)).to_json()
+        ).count()
         self.keyword.keyword = "foo"
         self.keyword.save()
         keyword_action = self.keyword.keywordaction_set.first()
@@ -57,3 +60,8 @@ class TestLinkedKeywords(BaseLinkedAppsTest):
         linked_keyword = Keyword.objects.get(id=new_keyword_id)
         self.assertEqual(linked_keyword.keyword, "foo")
         self.assertEqual(linked_keyword.keywordaction_set.first().message_content, "bar")
+        # make sure a domain link history event was added
+        post_count = DomainLinkHistory.objects.filter(
+            link=self.domain_link, model_detail=KeywordLinkDetail(keyword_id=str(new_keyword_id)).to_json()
+        ).count()
+        self.assertEqual(post_count - pre_count, 1)

--- a/corehq/apps/linked_domain/tests/test_linked_userreports.py
+++ b/corehq/apps/linked_domain/tests/test_linked_userreports.py
@@ -75,7 +75,7 @@ class TestLinkedUCR(BaseLinkedAppsTest):
         self.report.title = "New title"
         self.report.save()
 
-        update_linked_ucr(self.domain_link, linked_report_info.report.get_id)
+        update_linked_ucr(self.domain_link, linked_report_info.report.get_id, 'test-user-id')
 
         report = ReportConfiguration.get(linked_report_info.report.get_id)
         self.assertEqual("New title", report.title)
@@ -85,12 +85,12 @@ class TestLinkedUCR(BaseLinkedAppsTest):
     def test_delete_master_deletes_linked(self):
         linked_report_info = create_linked_ucr(self.domain_link, self.report.get_id)
         soft_delete(self.report)
-        update_linked_ucr(self.domain_link, linked_report_info.report.get_id)
+        update_linked_ucr(self.domain_link, linked_report_info.report.get_id, 'test-user-id')
         report = ReportConfiguration.get(linked_report_info.report.get_id)
         self.assertTrue(is_deleted(report))
 
         self.report.config.deactivate()
-        update_linked_ucr(self.domain_link, linked_report_info.report.get_id)
+        update_linked_ucr(self.domain_link, linked_report_info.report.get_id, 'test-user-id')
         report = ReportConfiguration.get(linked_report_info.report.get_id)
         self.assertTrue(report.config.is_deactivated)
 
@@ -147,6 +147,6 @@ class TestLinkedUCR(BaseLinkedAppsTest):
         self.report.title = "Another new title"
         self.report.save()
 
-        update_linked_ucr(self.domain_link, linked_report_info.report.get_id)
+        update_linked_ucr(self.domain_link, linked_report_info.report.get_id, 'test-user-id')
         report = ReportConfiguration.get(linked_report_info.report.get_id)
         self.assertEqual("Another new title", report.title)

--- a/corehq/apps/linked_domain/tests/test_linked_userreports.py
+++ b/corehq/apps/linked_domain/tests/test_linked_userreports.py
@@ -8,6 +8,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.domain.tests.test_utils import delete_all_domains
 from corehq.apps.linked_domain.applications import link_app
 from corehq.apps.linked_domain.decorators import REMOTE_REQUESTER_HEADER
+from corehq.apps.linked_domain.models import DomainLinkHistory, ReportLinkDetail
 from corehq.apps.linked_domain.tests.test_linked_apps import BaseLinkedAppsTest
 from corehq.apps.linked_domain.ucr import create_linked_ucr, update_linked_ucr
 from corehq.apps.userreports.dbaccessors import delete_all_report_configs
@@ -74,6 +75,10 @@ class TestLinkedUCR(BaseLinkedAppsTest):
         linked_report_info = create_linked_ucr(self.domain_link, self.report.get_id)
         self.report.title = "New title"
         self.report.save()
+        pre_count = DomainLinkHistory.objects.filter(
+            link=self.domain_link,
+            model_detail=ReportLinkDetail(report_id=str(linked_report_info.report.get_id)).to_json()
+        ).count()
 
         update_linked_ucr(self.domain_link, linked_report_info.report.get_id, 'test-user-id')
 
@@ -81,6 +86,11 @@ class TestLinkedUCR(BaseLinkedAppsTest):
         self.assertEqual("New title", report.title)
         self.assertEqual(self.report.get_id, report.report_meta.master_id)
         self.assertNotEqual(self.report.config_id, report.config_id)
+        post_count = DomainLinkHistory.objects.filter(
+            link=self.domain_link,
+            model_detail=ReportLinkDetail(report_id=str(linked_report_info.report.get_id)).to_json()
+        ).count()
+        self.assertEqual(post_count - pre_count, 1)
 
     def test_delete_master_deletes_linked(self):
         linked_report_info = create_linked_ucr(self.domain_link, self.report.get_id)

--- a/corehq/apps/linked_domain/ucr.py
+++ b/corehq/apps/linked_domain/ucr.py
@@ -3,11 +3,18 @@ from collections import namedtuple
 
 from django.utils.translation import ugettext as _
 
-from corehq.apps.linked_domain.applications import get_downstream_app_id, get_upstream_app_ids
+from corehq.apps.linked_domain.applications import (
+    get_downstream_app_id,
+    get_upstream_app_ids,
+)
 from corehq.apps.linked_domain.const import MODEL_REPORT
-from corehq.apps.linked_domain.exceptions import DomainLinkError, MultipleDownstreamAppsError
+from corehq.apps.linked_domain.exceptions import (
+    DomainLinkError,
+    MultipleDownstreamAppsError,
+)
 from corehq.apps.linked_domain.models import ReportLinkDetail
-from corehq.apps.linked_domain.remote_accessors import get_ucr_config as remote_get_ucr_config
+from corehq.apps.linked_domain.remote_accessors import \
+    get_ucr_config as remote_get_ucr_config
 from corehq.apps.userreports.dbaccessors import (
     get_datasources_for_domain,
     get_report_configs_for_domain,

--- a/corehq/apps/linked_domain/ucr.py
+++ b/corehq/apps/linked_domain/ucr.py
@@ -4,7 +4,9 @@ from collections import namedtuple
 from django.utils.translation import ugettext as _
 
 from corehq.apps.linked_domain.applications import get_downstream_app_id, get_upstream_app_ids
+from corehq.apps.linked_domain.const import MODEL_REPORT
 from corehq.apps.linked_domain.exceptions import DomainLinkError, MultipleDownstreamAppsError
+from corehq.apps.linked_domain.models import ReportLinkDetail
 from corehq.apps.linked_domain.remote_accessors import get_ucr_config as remote_get_ucr_config
 from corehq.apps.userreports.dbaccessors import (
     get_datasources_for_domain,
@@ -107,7 +109,7 @@ def _get_or_create_report_link(domain_link, report, datasource):
     return new_report
 
 
-def update_linked_ucr(domain_link, report_id):
+def update_linked_ucr(domain_link, report_id, user_id):
     linked_report = ReportConfiguration.get(report_id)
     linked_datasource = linked_report.config
 
@@ -121,6 +123,12 @@ def update_linked_ucr(domain_link, report_id):
 
     _update_linked_datasource(master_datasource, linked_datasource)
     _update_linked_report(master_report, linked_report)
+
+    domain_link.update_last_pull(
+        MODEL_REPORT,
+        user_id,
+        model_detail=ReportLinkDetail(report_id=linked_report.get_id).to_json(),
+    )
 
 
 def _update_linked_datasource(master_datasource, linked_datasource):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Noticed this issue after testing [this PR](https://github.com/dimagi/commcare-hq/pull/30404) that removed the need to link reports/keywords. 

Currently, keywords and reports do not create a new domain link history event when updated after the initial link. This was very apparent once making the previously mentioned change, because `update_last_pull` was never called and caused the "Last Updated" time to be blank on the downstream domain's linked project page.

Every time either of these data models are updated, there should be an associated DomainLinkHistory event. This ensures that is the case. 

Also, the branch name is a bit of a misnomer. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAIN`
## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Updated test to check for a DomainLinkHistory event.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
