### PR TITLE
Bump Kafka timeout from 15s to 30s

### DIFF
--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -124,7 +124,7 @@ services:
           KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
           KAFKA_BROKER_ID: 1
           KAFKA_ADVERTISED_PORT: 9092
-          CUSTOM_INIT_SCRIPT: "curl https://raw.githubusercontent.com/vishnubob/wait-for-it/c096cface5fbd9f2d6b037391dfecae6fde1362e/wait-for-it.sh > wait.sh && chmod +x ./wait.sh && ./wait.sh zookeeper:2181 || exit 1"
+          CUSTOM_INIT_SCRIPT: "curl https://raw.githubusercontent.com/vishnubob/wait-for-it/c096cface5fbd9f2d6b037391dfecae6fde1362e/wait-for-it.sh > wait.sh && chmod +x ./wait.sh && ./wait.sh -t 30 zookeeper:2181 || exit 1"
           KAFKA_ADVERTISED_HOST_NAME: "kafka"
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
## Technical Summary

This PR is intended to address a recent issue with Kafka on Travis, and my own dev environment.

Kafka waits 15 seconds for Zookeeper to start. Zookeeper may take a fraction longer, in which case Kafka terminates. This change increases the wait time to 30 seconds.

For more information, see [the script used to implement the wait time](https://raw.githubusercontent.com/vishnubob/wait-for-it/c096cface5fbd9f2d6b037391dfecae6fde1362e/wait-for-it.sh). The 15 second default is set on the line:

    WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story

This change affects Travis and local dev environments.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
