### PR TITLE
Case importer matching page updates for valid values

### DIFF
--- a/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
+++ b/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
@@ -59,8 +59,8 @@ hqDefine('case_importer/js/excel_fields', [
             row.hasNonDiscoverableField = ko.computed(function () {
                 return row.caseFieldSpec().description && !row.caseFieldSpec().discoverable;
             });
-            row.valuesHint = ko.computed(function () {
-                return row.caseFieldSpec().values_hint || [];
+            row.valuesHints = ko.computed(function () {
+                return row.caseFieldSpec().values_hints || [];
             });
 
             row.reset = function () {

--- a/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
+++ b/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
@@ -59,6 +59,10 @@ hqDefine('case_importer/js/excel_fields', [
             row.hasNonDiscoverableField = ko.computed(function () {
                 return row.caseFieldSpec().description && !row.caseFieldSpec().discoverable;
             });
+            row.valuesHint = ko.computed(function () {
+                return row.caseFieldSpec().values_hint || [];
+            });
+
             row.reset = function () {
                 var field = row.excelField();
                 field = field && sanitizeCaseField(field);

--- a/corehq/apps/case_importer/suggested_fields.py
+++ b/corehq/apps/case_importer/suggested_fields.py
@@ -8,7 +8,7 @@ from corehq.apps.app_manager.app_schemas.case_properties import (
     get_all_case_properties_for_case_type,
 )
 from corehq.apps.case_importer.util import RESERVED_FIELDS
-from corehq.apps.data_dictionary.util import get_values_hint_dict
+from corehq.apps.data_dictionary.util import get_values_hints_dict
 from corehq.toggles import BULK_UPLOAD_DATE_OPENED
 
 
@@ -32,11 +32,11 @@ def _combine_field_specs(field_specs, exclude_fields):
 
 def get_suggested_case_fields(domain, case_type, exclude=None):
     exclude_fields = set(RESERVED_FIELDS) | set(exclude or [])
-    hint_dict = get_values_hint_dict(domain, case_type)
+    hints_dict = get_values_hints_dict(domain, case_type)
 
     special_field_specs = (field_spec for field_spec in get_special_fields(domain))
 
-    dynamic_field_specs = (FieldSpec(field=field, show_in_menu=True, values_hint=hint_dict[field])
+    dynamic_field_specs = (FieldSpec(field=field, show_in_menu=True, values_hints=hints_dict[field])
                            for field in get_all_case_properties_for_case_type(domain, case_type))
 
     return _combine_field_specs(
@@ -50,7 +50,7 @@ class FieldSpec(jsonobject.StrictJsonObject):
     description = jsonobject.StringProperty()
     show_in_menu = jsonobject.BooleanProperty(default=False)
     discoverable = jsonobject.BooleanProperty(default=True)
-    values_hint = jsonobject.ListProperty()
+    values_hints = jsonobject.ListProperty()
 
 
 def get_special_fields(domain=None):

--- a/corehq/apps/case_importer/suggested_fields.py
+++ b/corehq/apps/case_importer/suggested_fields.py
@@ -8,6 +8,7 @@ from corehq.apps.app_manager.app_schemas.case_properties import (
     get_all_case_properties_for_case_type,
 )
 from corehq.apps.case_importer.util import RESERVED_FIELDS
+from corehq.apps.data_dictionary.util import get_values_hint_dict
 from corehq.toggles import BULK_UPLOAD_DATE_OPENED
 
 
@@ -31,10 +32,11 @@ def _combine_field_specs(field_specs, exclude_fields):
 
 def get_suggested_case_fields(domain, case_type, exclude=None):
     exclude_fields = set(RESERVED_FIELDS) | set(exclude or [])
+    hint_dict = get_values_hint_dict(domain, case_type)
 
     special_field_specs = (field_spec for field_spec in get_special_fields(domain))
 
-    dynamic_field_specs = (FieldSpec(field=field, show_in_menu=True)
+    dynamic_field_specs = (FieldSpec(field=field, show_in_menu=True, values_hint=hint_dict[field])
                            for field in get_all_case_properties_for_case_type(domain, case_type))
 
     return _combine_field_specs(
@@ -48,6 +50,7 @@ class FieldSpec(jsonobject.StrictJsonObject):
     description = jsonobject.StringProperty()
     show_in_menu = jsonobject.BooleanProperty(default=False)
     discoverable = jsonobject.BooleanProperty(default=True)
+    values_hint = jsonobject.ListProperty()
 
 
 def get_special_fields(domain=None):

--- a/corehq/apps/case_importer/templates/case_importer/excel_fields.html
+++ b/corehq/apps/case_importer/templates/case_importer/excel_fields.html
@@ -28,7 +28,8 @@
         <th>{% trans "Excel Field" %}</th>
         <th></th>
         <th>{% trans "Case Property" %}<button type="button" class="btn btn-default btn-xs pull-right" id="autofill">{% trans "Set to default" %}</button></th>
-        <th></th>
+        <th class="col-md-1">{% trans "Create new property" %}</th>
+        <th>{% include "data_dictionary/partials/valid_values_th_content.html" %}</th>
         </thead>
         <tbody id="excel-field-rows" class="ko-template">
         {% include "case_importer/partials/excel_field_rows.html" %}

--- a/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
@@ -59,20 +59,27 @@
     <div class="has-warning">
       <p class="help-block">
         {% blocktrans with '<!--ko foreach: caseFieldSuggestions--><!--ko if: $index() !== 0-->, <!--/ko--><strong data-bind="text: $data"></strong><!--/ko-->' as suggestion %}
-          Did you mean {{ suggestion }}?
+          Did you mean "{{ suggestion }}" instead?
         {% endblocktrans %}
       </p>
     </div>
     <!--/ko-->
   </td>
 
-  <td>
+  <td class="col-md-1">
     <div class="checkbox">
       <label>
-        <input type="checkbox" class="new_property" data-bind="checked: isCustom"/>
-        {% trans "Create a new property instead" %}
+        <input type="checkbox" class="new_property" style="margin-left: auto;" data-bind="checked: isCustom"/>
       </label>
     </div>
+  </td>
+
+  <td>
+    <!--ko if: valuesHint().length-->
+      <ul class="list-unstyled">
+        <!--ko foreach: valuesHint--><li data-bind="text: $data"></li><!--/ko-->
+      </ul>
+    <!--/ko-->
   </td>
 
 </tr>

--- a/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
@@ -75,11 +75,9 @@
   </td>
 
   <td>
-    <!--ko if: valuesHint().length-->
-      <ul class="list-unstyled">
-        <!--ko foreach: valuesHint--><li data-bind="text: $data"></li><!--/ko-->
+      <ul class="list-unstyled" data-bind="visible: valuesHints().length, foreach: valuesHints">
+        <li data-bind="text: $data"></li>
       </ul>
-    <!--/ko-->
   </td>
 
 </tr>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -72,14 +72,7 @@
         {% if fhir_integration_enabled %}
           <th>{% trans "FHIR Resource Property Path" %}</th>
         {% endif %}
-        <th>
-          {% trans "Valid Values &amp; Formats" %}
-          <span
-            class="hq-help-template"
-            data-title="{% trans 'Valid values or format' %}"
-            data-content="{% trans 'Only import rows with cells that match the listed values or formats' %}">
-          </span>
-        </th>
+        <th>{% include "data_dictionary/partials/valid_values_th_content.html" %}</th>
         <th></th>
         </thead>
         <tbody data-bind="sortable: casePropertyList">

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/valid_values_th_content.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/valid_values_th_content.html
@@ -1,0 +1,7 @@
+{% load i18n %}
+{% trans "Valid Values &amp; Formats" %}
+<span
+  class="hq-help-template"
+  data-title="{% trans 'Valid values or format' %}"
+  data-content="{% trans 'Only import rows with cells that match the listed values or formats' %}">
+</span>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/valid_values_th_content.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/valid_values_th_content.html
@@ -1,7 +1,8 @@
 {% load i18n %}
+{% load hq_shared_tags %}
 {% trans "Valid Values &amp; Formats" %}
 <span
   class="hq-help-template"
-  data-title="{% trans 'Valid values or format' %}"
-  data-content="{% trans 'Only import rows with cells that match the listed values or formats' %}">
+  data-title="{% trans_html_attr 'Valid values or format' %}"
+  data-content="{% trans_html_attr 'Only import rows with cells that match the listed values or formats' %}">
 </span>

--- a/corehq/apps/data_dictionary/tests/test_util.py
+++ b/corehq/apps/data_dictionary/tests/test_util.py
@@ -1,11 +1,13 @@
 import uuid
 
 from django.test import TestCase
+from django.utils.translation import ugettext
 
 from mock import patch
 
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
-from corehq.apps.data_dictionary.util import generate_data_dictionary
+from corehq.apps.data_dictionary.tests.utils import setup_data_dictionary
+from corehq.apps.data_dictionary.util import generate_data_dictionary, get_values_hints_dict
 
 
 @patch('corehq.apps.data_dictionary.util._get_all_case_properties')
@@ -85,3 +87,40 @@ class GenerateDictionaryTest(TestCase):
 
         self.assertEqual(CaseType.objects.filter(domain=self.domain).count(), 1)
         self.assertEqual(CaseProperty.objects.filter(case_type__domain=self.domain).count(), 1)
+
+
+class MiscUtilTest(TestCase):
+    domain = uuid.uuid4().hex
+
+    def tearDown(self):
+        CaseType.objects.filter(domain=self.domain).delete()
+
+    def test_no_data_dict_info(self):
+        case_type_name = 'bare'
+        setup_data_dictionary(self.domain, case_type_name)
+        self.assertEqual({}, get_values_hints_dict(self.domain, case_type_name))
+
+    def test_date_hint(self):
+        case_type_name = 'case1'
+        date_prop_name = 'intake_date'
+        setup_data_dictionary(self.domain, case_type_name, [(date_prop_name, 'date')])
+        values_hints = get_values_hints_dict(self.domain, case_type_name)
+        self.assertEqual(len(values_hints), 1)
+        self.assertTrue(date_prop_name in values_hints)
+        self.assertEqual(values_hints[date_prop_name], [ugettext('YYYY-MM-DD')])
+
+    def test_select_hints(self):
+        case_type_name = 'case1'
+        select_prop1 = 'status'
+        select_prop2 = 'active'
+        av_dict = {
+            select_prop1: ['foster', 'pending', 'adopted'],
+            select_prop2: ['true', 'false'],
+        }
+        prop_list = [(prop, 'select') for prop in [select_prop1, select_prop2]]
+        setup_data_dictionary(self.domain, case_type_name, prop_list, av_dict)
+        values_hints = get_values_hints_dict(self.domain, case_type_name)
+        self.assertEqual(len(values_hints), 2)
+        for prop_name, _ in prop_list:
+            self.assertTrue(prop_name in values_hints)
+            self.assertEqual(sorted(values_hints[prop_name]), sorted(av_dict[prop_name]))

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -131,7 +131,7 @@ def get_values_hint_dict(domain, case_type_name):
     values_hint_dict = defaultdict(list)
     case_type = CaseType.objects.filter(domain=domain, name=case_type_name).first()
     if case_type:
-        for prop in case_type.properties:
+        for prop in case_type.properties.all():
             if prop.data_type == 'date':
                 values_hint_dict[prop.name] = [ugettext('YYYY-MM-DD')]
             elif prop.data_type == 'select':

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from itertools import groupby
 from operator import attrgetter
 
@@ -124,6 +125,18 @@ def get_case_property_description_dict(domain):
     for case_type in annotated_types:
         descriptions_dict[case_type.name] = {prop.name: prop.description for prop in case_type.properties.all()}
     return descriptions_dict
+
+
+def get_values_hint_dict(domain, case_type_name):
+    values_hint_dict = defaultdict(list)
+    case_type = CaseType.objects.filter(domain=domain, name=case_type_name).first()
+    if case_type:
+        for prop in case_type.properties:
+            if prop.data_type == 'date':
+                values_hint_dict[prop.name] = [ugettext('YYYY-MM-DD')]
+            elif prop.data_type == 'select':
+                values_hint_dict[prop.name] = [av.allowed_value for av in prop.allowed_values.all()]
+    return values_hint_dict
 
 
 def save_case_property(name, case_type, domain=None, data_type=None,

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -127,16 +127,16 @@ def get_case_property_description_dict(domain):
     return descriptions_dict
 
 
-def get_values_hint_dict(domain, case_type_name):
-    values_hint_dict = defaultdict(list)
+def get_values_hints_dict(domain, case_type_name):
+    values_hints_dict = defaultdict(list)
     case_type = CaseType.objects.filter(domain=domain, name=case_type_name).first()
     if case_type:
         for prop in case_type.properties.all():
             if prop.data_type == 'date':
-                values_hint_dict[prop.name] = [ugettext('YYYY-MM-DD')]
+                values_hints_dict[prop.name] = [ugettext('YYYY-MM-DD')]
             elif prop.data_type == 'select':
-                values_hint_dict[prop.name] = [av.allowed_value for av in prop.allowed_values.all()]
-    return values_hint_dict
+                values_hints_dict[prop.name] = [av.allowed_value for av in prop.allowed_values.all()]
+    return values_hints_dict
 
 
 def save_case_property(name, case_type, domain=None, data_type=None,


### PR DESCRIPTION
## Product Description
On "Match Excel Columns to Case Properties" page during case import:

- Add "Valid values & formats" column with tooltip
- Populate that column when possible (chosen property is a date or has valid values in data dictionary)
- Move label text of checkbox for "create new property" to the header
- Move "instead" from this label to the help text of "Did you mean..."

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [ ] Risk label is set correctly
- [ ] All migrations are backwards compatible and won't block deploy
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
