### PR TITLE
add zookeeper healthcheck and dependency for kafka

### DIFF
--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -66,6 +66,8 @@ services:
       KAFKA_ADVERTISED_HOST_NAME: ${KAFKA_ADVERTISED_HOST_NAME}
     ports:
       - "9092:9092"
+    depends_on:
+        - zookeeper
 
   zookeeper:
     extends:

--- a/docker/hq-compose-travis.yml
+++ b/docker/hq-compose-travis.yml
@@ -1,0 +1,86 @@
+version: '2.3'
+services:
+  web:
+    extends:
+      file: hq-compose.yml
+      service: web
+    depends_on:
+      citus_worker1: { condition: service_healthy }
+      citus_worker2: { condition: service_healthy }
+      postgres: {}
+      couch: {}
+      redis: {}
+      elasticsearch2: {}
+      elasticsearch5: {}
+      kafka: {}
+      minio: {}
+
+  formplayer:
+    extends:
+      file: hq-compose.yml
+      service: formplayer
+    depends_on:
+      - postgres
+      - redis
+
+  postgres:
+    extends:
+      file: hq-compose.yml
+      service: postgres
+
+  couch:
+    extends:
+      file: hq-compose.yml
+      service: couch
+
+  redis:
+    extends:
+      file: hq-compose.yml
+      service: redis
+
+  elasticsearch2:
+    extends:
+      file: hq-compose.yml
+      service: elasticsearch2
+
+  elasticsearch5:
+    extends:
+      file: hq-compose.yml
+      service: elasticsearch5
+
+  zookeeper:
+    extends:
+      file: hq-compose.yml
+      service: zookeeper
+
+  kafka:
+    extends:
+      file: hq-compose.yml
+      service: kafka
+    depends_on:
+      zookeeper: { condition: service_healthy }
+
+  minio:
+    extends:
+      file: hq-compose.yml
+      service: mino
+
+  citus_master:
+    extends:
+      file: hq-compose.yml
+      service: citus_master
+  citus_manager:
+    extends:
+      file: hq-compose.yml
+      service: citus_manager
+    depends_on: { citus_master: { condition: service_healthy } }
+  citus_worker1:
+    extends:
+      file: hq-compose.yml
+      service: citus_worker1
+    depends_on: { citus_manager: { condition: service_healthy } }
+  citus_worker2:
+    extends:
+      file: hq-compose.yml
+      service: citus_worker2
+    depends_on: { citus_manager: { condition: service_healthy } }

--- a/docker/hq-compose-travis.yml
+++ b/docker/hq-compose-travis.yml
@@ -7,13 +7,13 @@ services:
     depends_on:
       citus_worker1: { condition: service_healthy }
       citus_worker2: { condition: service_healthy }
-      postgres: {}
-      couch: {}
-      redis: {}
-      elasticsearch2: {}
-      elasticsearch5: {}
-      kafka: {}
-      minio: {}
+      postgres: { condition: service_healthy }
+      couch: { condition: service_healthy }
+      redis: { condition: service_healthy }
+      elasticsearch2: { condition: service_healthy }
+      elasticsearch5: { condition: service_healthy }
+      kafka: { condition: service_healthy }
+      minio: { condition: service_healthy }
 
   formplayer:
     extends:

--- a/docker/hq-compose-travis.yml
+++ b/docker/hq-compose-travis.yml
@@ -7,13 +7,13 @@ services:
     depends_on:
       citus_worker1: { condition: service_healthy }
       citus_worker2: { condition: service_healthy }
-      postgres: { condition: service_healthy }
-      couch: { condition: service_healthy }
-      redis: { condition: service_healthy }
-      elasticsearch2: { condition: service_healthy }
-      elasticsearch5: { condition: service_healthy }
-      kafka: { condition: service_healthy }
-      minio: { condition: service_healthy }
+      postgres: { condition: service_started }
+      couch: { condition: service_started }
+      redis: { condition: service_started }
+      elasticsearch2: { condition: service_started }
+      elasticsearch5: { condition: service_started }
+      kafka: { condition: service_started }
+      minio: { condition: service_started }
 
   formplayer:
     extends:

--- a/docker/hq-compose-travis.yml
+++ b/docker/hq-compose-travis.yml
@@ -63,7 +63,7 @@ services:
   minio:
     extends:
       file: hq-compose.yml
-      service: mino
+      service: minio
 
   citus_master:
     extends:

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -115,6 +115,10 @@ services:
       - "2181:2181"
     volumes:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-zookeeper:}/opt/zookeeper-3.4.13/data
+    healthcheck:
+        test: "nc -z zookeeper 2182"
+        interval: 5s
+        timeout: 1m
 
   kafka:
       image: wurstmeister/kafka:2.13-2.6.0

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -31,21 +31,9 @@ services:
       TRAVIS_REPO_SLUG: "${TRAVIS_REPO_SLUG}"
       UCR_CITUS_DB: "${UCR_CITUS_DB:-commcare_ucr_citus}"
     privileged: true  # allows mount inside container
-    links:
-      - postgres
-      - couch
-      - redis
-      - elasticsearch2
-      - elasticsearch5
-      - kafka
-      - zookeeper
-      - minio
     volumes:
       - ..:/mnt/commcare-hq-ro${RO}
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-lib:}/mnt/lib
-    depends_on:
-      citus_worker1: { condition: service_healthy }
-      citus_worker2: { condition: service_healthy }
 
   formplayer:
     image: dimagi/formplayer
@@ -159,7 +147,6 @@ services:
   citus_manager:
     image: 'citusdata/membership-manager:0.2.0'
     volumes: ["${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock"]
-    depends_on: { citus_master: { condition: service_healthy } }
     environment:
       CITUS_HOST: citus_master
       POSTGRES_DB: "${UCR_CITUS_DB:-commcare_ucr_citus}"
@@ -168,7 +155,6 @@ services:
   citus_worker1:
     image: 'citusdata/citus:8.1.1'
     labels: ['com.citusdata.role=Worker']
-    depends_on: { citus_manager: { condition: service_healthy } }
     volumes:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-citus_worker1:}/var/lib/postgresql/data
     environment:
@@ -177,7 +163,6 @@ services:
   citus_worker2:
     image: 'citusdata/citus:8.1.1'
     labels: ['com.citusdata.role=Worker']
-    depends_on: { citus_manager: { condition: service_healthy } }
     volumes:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-citus_worker2:}/var/lib/postgresql/data
     environment:

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -104,7 +104,7 @@ services:
     volumes:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-zookeeper:}/opt/zookeeper-3.4.13/data
     healthcheck:
-        test: "nc -z zookeeper 2182"
+        test: "nc -z zookeeper 2181"
         interval: 5s
         timeout: 1m
 

--- a/scripts/docker
+++ b/scripts/docker
@@ -141,7 +141,7 @@ if [ "$CMD" == "test" -o "$CMD" == "hqtest" ]; then
             CMD=help
         fi
     fi
-    export COMPOSE_FILE=docker/hq-compose.yml
+    export COMPOSE_FILE=docker/hq-compose-travis.yml
     export COMPOSE_PROJECT_NAME=hqtest
     export UCR_CITUS_DB="${UCR_CITUS_DB:-test_commcare_ucr_citus}"
     if [ -n "$TRAVIS_BUILD_DIR" ]; then


### PR DESCRIPTION
Add health check to zookeeper container and make kafka container depend on zookeeper.

This should fix the issues with kafka and zookeeper in Travis. Docker should only start kafka after the zookeeper container is marked as healthy.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Impacts test and dev envs only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
