### PR TITLE
Fix bug when pulling reports and keywords

### DIFF
--- a/corehq/apps/linked_domain/keywords.py
+++ b/corehq/apps/linked_domain/keywords.py
@@ -3,12 +3,10 @@ import uuid
 from django.utils.translation import ugettext as _
 
 from corehq.apps.linked_domain.applications import get_downstream_app_id
-from corehq.apps.linked_domain.const import MODEL_KEYWORD
 from corehq.apps.linked_domain.exceptions import (
     DomainLinkError,
     MultipleDownstreamAppsError,
 )
-from corehq.apps.linked_domain.models import KeywordLinkDetail
 from corehq.apps.sms.models import Keyword
 
 
@@ -46,7 +44,7 @@ def create_linked_keyword(domain_link, keyword_id):
     return keyword.id
 
 
-def update_keyword(domain_link, keyword_id, user_id):
+def update_keyword(domain_link, keyword_id):
     try:
         linked_keyword = Keyword.objects.get(id=keyword_id)
     except Keyword.DoesNotExist:
@@ -66,12 +64,6 @@ def update_keyword(domain_link, keyword_id, user_id):
     linked_keyword.save()
 
     _update_actions(domain_link, linked_keyword, upstream_keyword.keywordaction_set.all())
-
-    domain_link.update_last_pull(
-        MODEL_KEYWORD,
-        user_id,
-        model_detail=KeywordLinkDetail(keyword_id=str(linked_keyword.id)).to_json(),
-    )
 
 
 def _update_actions(domain_link, linked_keyword, keyword_actions):

--- a/corehq/apps/linked_domain/ucr.py
+++ b/corehq/apps/linked_domain/ucr.py
@@ -7,12 +7,10 @@ from corehq.apps.linked_domain.applications import (
     get_downstream_app_id,
     get_upstream_app_ids,
 )
-from corehq.apps.linked_domain.const import MODEL_REPORT
 from corehq.apps.linked_domain.exceptions import (
     DomainLinkError,
     MultipleDownstreamAppsError,
 )
-from corehq.apps.linked_domain.models import ReportLinkDetail
 from corehq.apps.linked_domain.remote_accessors import \
     get_ucr_config as remote_get_ucr_config
 from corehq.apps.userreports.dbaccessors import (
@@ -116,7 +114,7 @@ def _get_or_create_report_link(domain_link, report, datasource):
     return new_report
 
 
-def update_linked_ucr(domain_link, report_id, user_id):
+def update_linked_ucr(domain_link, report_id):
     linked_report = ReportConfiguration.get(report_id)
     linked_datasource = linked_report.config
 
@@ -130,12 +128,6 @@ def update_linked_ucr(domain_link, report_id, user_id):
 
     _update_linked_datasource(master_datasource, linked_datasource)
     _update_linked_report(master_report, linked_report)
-
-    domain_link.update_last_pull(
-        MODEL_REPORT,
-        user_id,
-        model_detail=ReportLinkDetail(report_id=linked_report.get_id).to_json(),
-    )
 
 
 def _update_linked_datasource(master_datasource, linked_datasource):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I introduced a bug [here](https://github.com/dimagi/commcare-hq/pull/30455) by not accounting for the pull workflow. The `user_id` parameter was unexpected [here](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/linked_domain/updates.py#L123) so pulling reports or keywords is broke.

I moved the `update_last_pull` call one level up to avoid needing to pass user_id to the specific update methods. The push workflow isn't the cleanest from a code perspective in comparison to the pull workflow, so I have intentions of giving this area more attention in the future. For now, this will have to do.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
