### PR TITLE
remove kafka wait for zookeeper

### DIFF
--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -124,7 +124,7 @@ services:
           KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
           KAFKA_BROKER_ID: 1
           KAFKA_ADVERTISED_PORT: 9092
-          CUSTOM_INIT_SCRIPT: "curl https://raw.githubusercontent.com/vishnubob/wait-for-it/c096cface5fbd9f2d6b037391dfecae6fde1362e/wait-for-it.sh > wait.sh && chmod +x ./wait.sh && ./wait.sh -t 30 zookeeper:2181 || exit 1"
+#          CUSTOM_INIT_SCRIPT: "curl https://raw.githubusercontent.com/vishnubob/wait-for-it/c096cface5fbd9f2d6b037391dfecae6fde1362e/wait-for-it.sh > wait.sh && chmod +x ./wait.sh && ./wait.sh -t 30 zookeeper:2181 || exit 1"
           KAFKA_ADVERTISED_HOST_NAME: "kafka"
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
At some point downloading the 'wait-for-it.sh' script started failing. See this build output: https://app.travis-ci.com/github/dimagi/commcare-hq/builds/238633405

Removing this wait seems to work (at least more reliably than with the wait).

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Only impacts travis tests and dev environment setup

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
