### PR TITLE
allow 'resave case' for user cases

### DIFF
--- a/corehq/apps/reports/templates/reports/reportdata/case_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_data.html
@@ -217,13 +217,15 @@
               {% trans 'Clean Case Data' %}
             </button>
           {% endif %}
-          {% if show_case_rebuild and not is_usercase %}
+          {% if show_case_rebuild %}
             <form action="{% url 'resave_case' domain case_id %}" method="post" class="pull-left">{% csrf_token %}
               <button type="submit" class="btn btn-default disable-on-submit" >
                 <i class="fa fa-save"></i>
                 {% trans 'Resave Case' %}
               </button>
             </form>
+          {% endif %}
+          {% if show_case_rebuild and not is_usercase %}
             <form action="{% url 'rebuild_case' domain case_id %}" method="post" class="pull-left">{% csrf_token %}
               <button type="submit" class="btn btn-default disable-on-submit" >
                 <i class="fa fa-cubes"></i>


### PR DESCRIPTION
## Product Description
Show 'Resave Case' option for user cases.

## Technical Summary
There's not reason not to show this for user cases. I'm guessing this was just an oversight.

## Feature Flag
SUPPORT

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
NA

### QA Plan
None


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
