### PR TITLE
Fixed 500 on new domains accessing enterprise permissions page

### DIFF
--- a/corehq/apps/enterprise/models.py
+++ b/corehq/apps/enterprise/models.py
@@ -33,7 +33,7 @@ class EnterprisePermissions(models.Model):
         try:
             return cls.objects.get(account=account)
         except cls.DoesNotExist:
-            return cls()
+            return cls(account=account)
 
     @classmethod
     @quickcache(['source_domain'], timeout=7 * 24 * 60 * 60)

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -341,6 +341,8 @@ class EnterpriseBillingStatementsView(DomainAccountingSettings, CRUDPaginatedVie
 @require_enterprise_admin
 def enterprise_permissions(request, domain):
     config = EnterprisePermissions.get_by_domain(domain)
+    if not config.id:
+        config.save()
     all_domains = set(config.account.get_domains())
     ignored_domains = all_domains - set(config.domains) - {config.source_domain}
 


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-1306

The enterprise permissions page was erroring for domains that didn't yet have an `EnterprisePermissions` object created.

This does not affect any production users of this feature, who are all USH clients who had their permissions manually created last year.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests for the code being changed.

### QA Plan

Not requesting QA.

### Safety story
This is a limited change not affecting real clients. Tested locally that the 500 is fixed and that the enterprise permissions page still loads fine for a non-new domain that already had an `EnterprisePermissions` object.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
