### PR TITLE
Remove `serializer='pickle'` from app_manager 

### DIFF
--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -15,7 +15,7 @@ from corehq.util.decorators import serial_task
 logger = get_task_logger(__name__)
 
 
-@task(serializer='pickle', queue='background_queue', ignore_result=True)
+@task(queue='background_queue', ignore_result=True)
 def create_usercases(domain_name):
     from corehq.apps.callcenter.sync_usercase import sync_usercase
     for user in CommCareUser.by_domain(domain_name):
@@ -48,7 +48,7 @@ def autogenerate_build_task(app_id, domain, version, comment):
     make_async_build_v2(app_id, domain, version, allow_prune=True, comment=comment)
 
 
-@task(serializer='pickle', queue='background_queue', ignore_result=True)
+@task(queue='background_queue', ignore_result=True)
 def create_build_files_for_all_app_profiles(domain, build_id):
     app = get_app(domain, build_id)
     build_profiles = app.build_profiles
@@ -61,7 +61,7 @@ def create_build_files_for_all_app_profiles(domain, build_id):
         app.save()
 
 
-@task(serializer='pickle', queue='background_queue')
+@task(queue='background_queue')
 def prune_auto_generated_builds(domain, app_id):
     last_build_id = get_latest_build_id(domain, app_id)
     saved_builds = get_auto_generated_built_apps(domain, app_id)
@@ -77,7 +77,7 @@ def prune_auto_generated_builds(domain, app_id):
         app.save(increment_version=False)
 
 
-@task(serializer='pickle', queue='background_queue', ignore_result=True)
+@task(queue='background_queue', ignore_result=True)
 def update_linked_app_and_notify_task(domain, app_id, master_app_id, user_id, email):
     from corehq.apps.app_manager.views.utils import update_linked_app_and_notify
     update_linked_app_and_notify(domain, app_id, master_app_id, user_id, email)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[JIRA Ticket
](https://dimagi-dev.atlassian.net/browse/SAAS-11385)
This PR is part of a series of PRs aimed at removing our use of pickling in celery tasks due to a lack of support that is blocking our ability to upgrade celery.

This PR just removes the `serializer='pickle'` argument from tasks that had them, since the data being passed to celery were all already JSON serializable. 

These tasks were: 

create_usercases(domain_name) 
create_build_files_for_all_app_profiles(domain, build_id) 
prune_auto_generated_builds(domain, app_id) 
update_linked_app_and_notify_task(domain, app_id, master_app_id, user_id, email)

Where domain/domain_name, (__)_id and email are strings. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
