### PR TITLE
Remove `'serializer='pickle'`  from hqcase

### DIFF
--- a/corehq/apps/hqcase/tasks.py
+++ b/corehq/apps/hqcase/tasks.py
@@ -22,7 +22,7 @@ from corehq.form_processor.interfaces.dbaccessors import (
 )
 
 
-@task(serializer='pickle')
+@task
 def explode_case_task(domain, user_id, factor):
     return explode_cases(domain, user_id, factor, explode_case_task)
 
@@ -137,7 +137,7 @@ def topological_sort_cases(cases):
     return sorted_ids
 
 
-@task(serializer='pickle')
+@task
 def delete_exploded_case_task(domain, explosion_id):
     return delete_exploded_cases(domain, explosion_id, delete_exploded_case_task)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[JIRA Ticket
](https://dimagi-dev.atlassian.net/browse/SAAS-11385)
This PR is part of a series of PRs aimed at removing our use of pickling in celery tasks due to a lack of support that is blocking our ability to upgrade celery.

This PR just removes the serializer='pickle' argument from tasks that had them, since the data being passed to celery were all already JSON serializable.

These tasks were:

explode_case_task(domain, user_id, factor)
delete_exploded_case_task(domain, explosion_id)

where `domain`, `(__)_id` are strings and `factor` is an int. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
