### PR TITLE
Remove `serializer='pickle'` from locations app

### DIFF
--- a/corehq/apps/locations/tasks.py
+++ b/corehq/apps/locations/tasks.py
@@ -35,7 +35,7 @@ def sync_administrative_status(location_type):
         location.save()
 
 
-@task(serializer='pickle')
+@task
 def download_locations_async(domain, download_id, include_consumption,
                              headers_only, owner_id, root_location_id=None):
     DownloadBase.set_progress(download_locations_async, 0, 100)
@@ -93,7 +93,7 @@ def import_locations_async(domain, file_ref_id, user_id):
     }
 
 
-@task(serializer='pickle')
+@task
 def update_users_at_locations(domain, location_ids, supply_point_ids, ancestor_ids):
     """
     Update location fixtures for users given locations


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[JIRA Ticket
](https://dimagi-dev.atlassian.net/browse/SAAS-11385)
This PR is part of a series of PRs aimed at removing our use of pickling in celery tasks due to a lack of support that is blocking our ability to upgrade celery.

This PR just removes the serializer='pickle' argument from tasks that had them, since the data being passed to celery were all already JSON serializable.

These tasks were:

update_users_at_locations(domain, location_ids, supply_point_ids, ancestor_ids)
download_locations_async(domain, download_id, include_consumption, headers_only, owner_id, root_location_id=None)

where `domain`, (__)_id(s) are strings (or list of strings) and `include_consumption`, `headers_only` are bools.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested on staging.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
