### PR TITLE
Remove `serializer='pickle'` from translation app 

### DIFF
--- a/corehq/apps/translations/tasks.py
+++ b/corehq/apps/translations/tasks.py
@@ -20,7 +20,7 @@ from corehq.apps.translations.integrations.transifex.project_migrator import (
 from corehq.apps.translations.integrations.transifex.transifex import Transifex
 
 
-@task(serializer='pickle')
+@task
 def delete_resources_on_transifex(domain, data, email):
     version = data.get('version')
     transifex = Transifex(domain,
@@ -44,7 +44,7 @@ def delete_resources_on_transifex(domain, data, email):
     email.send()
 
 
-@task(serializer='pickle')
+@task
 def push_translation_files_to_transifex(domain, data, email):
     upload_status = None
     if data.get('target_lang'):
@@ -83,7 +83,7 @@ def push_translation_files_to_transifex(domain, data, email):
         email.send()
 
 
-@task(serializer='pickle')
+@task
 def pull_translation_files_from_transifex(domain, data, user_email=None):
     def notify_error(error):
         email = EmailMessage(
@@ -123,7 +123,7 @@ def pull_translation_files_from_transifex(domain, data, user_email=None):
             os.remove(translation_file.name)
 
 
-@task(serializer='pickle')
+@task
 def backup_project_from_transifex(domain, data, email):
     version = data.get('version')
     transifex = Transifex(domain,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11385)

This PR is part of a series of PRs aimed at removing our use of pickling in celery tasks due to a lack of support that is blocking our ability to upgrade celery.

This PR just removes the serializer='pickle' argument from tasks that had them, since the data being passed to celery were all already JSON serializable.

These tasks were:

delete_resources_on_transifex(domain, data, email)
push_translation_files_to_transifex(domain, data, email)
pull_translation_files_from_transifex(domain, data, user_email=None)
backup_project_from_transifex(domain, data, email)

where `domain`, `email` are strings and `data` is a dictionary with basic data types as its values (ints, str/list or str, bools)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
