### PR TITLE
ignore property values that are not strings

### DIFF
--- a/corehq/pillows/mappings/case_search_mapping.json
+++ b/corehq/pillows/mappings/case_search_mapping.json
@@ -35,7 +35,8 @@
                             "index": "not_analyzed",
                             "type": "string",
                             "null_value": "",
-                            "ignore_above": 8191
+                            "ignore_above": 8191,
+                            "ignore_malformed": true
                         },
                         "numeric": {
                             "type": "double",


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
It is possible for forms to have certain errors that cause HQ to save case property updates in non-string formats (specifically a dictionary in this case). This changes the case search index to not index (but still include in the saved doc) case properties whose values are not strings. This is the same thing we do with overly long case properties, and for the date and numeric versions of string values. Currently these docs just hard fail on attempting to save in the case search index

Tagged everyone who has case search ES context or form processor context, although since the properties are still available in the doc, just not searchable, I don't think this really commits us to any specific action with how we handle the form processing part of this issue. 

More details in https://dimagi-dev.atlassian.net/browse/SAAS-12687 with the example cases, the forms that created them, and how that happened, as well as some context from a brief conversation I had with Clayton.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Case Search and Case List Explorer

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
I will test this on staging, but we use the same option in other parts of the mapping file, and this is broadly equivalent to https://github.com/dimagi/commcare-hq/pull/30009 for a different set of issues.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

To rollback this change, the PR must be reverted and then `cchq <env> django-manage update_es_mapping case_search` must be run on all environments on which it was deployed.