### PR TITLE
Add static reports and remove temporary reports from UCR report api

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -73,7 +73,7 @@ from corehq.apps.userreports.reports.view import (
     get_filter_values,
     query_dict_to_dict,
 )
-from corehq.apps.userreports.util import get_existing_reports
+from corehq.apps.userreports.util import get_configurable_and_static_reports
 from corehq.apps.users.audit.change_messages import UserChangeMessage
 from corehq.apps.users.dbaccessors import (
     get_all_user_id_username_pairs_by_domain,
@@ -848,7 +848,7 @@ class SimpleReportConfigurationResource(CouchResourceMixin, HqBaseResource, Doma
 
     def obj_get_list(self, bundle, **kwargs):
         domain = kwargs['domain']
-        return get_existing_reports(domain)
+        return get_configurable_and_static_reports(domain)
 
     def detail_uri_kwargs(self, bundle_or_obj):
         return {

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -73,6 +73,7 @@ from corehq.apps.userreports.reports.view import (
     get_filter_values,
     query_dict_to_dict,
 )
+from corehq.apps.userreports.util import get_existing_reports
 from corehq.apps.users.audit.change_messages import UserChangeMessage
 from corehq.apps.users.dbaccessors import (
     get_all_user_id_username_pairs_by_domain,
@@ -847,7 +848,7 @@ class SimpleReportConfigurationResource(CouchResourceMixin, HqBaseResource, Doma
 
     def obj_get_list(self, bundle, **kwargs):
         domain = kwargs['domain']
-        return ReportConfiguration.by_domain(domain)
+        return get_existing_reports(domain)
 
     def detail_uri_kwargs(self, bundle_or_obj):
         return {

--- a/corehq/apps/userreports/const.py
+++ b/corehq/apps/userreports/const.py
@@ -5,6 +5,9 @@ from django.utils.translation import ugettext_lazy as _
 
 from corehq.apps.change_feed import topics
 
+
+TEMP_REPORT_PREFIX = '__tmp'  # reports made by the report bulider use this
+
 REPORT_BUILDER_EVENTS_KEY = 'REPORT_BUILDER_EVENTS_KEY'
 
 DATA_SOURCE_NOT_FOUND_ERROR_MESSAGE = _(

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -135,7 +135,7 @@ def allowed_report_builder_reports(request):
     return 0
 
 
-def _get_existing_reports(domain):
+def get_existing_reports(domain):
     from corehq.apps.userreports.models import ReportConfiguration
     from corehq.apps.userreports.views import TEMP_REPORT_PREFIX
     existing_reports = ReportConfiguration.by_domain(domain)
@@ -147,7 +147,7 @@ def _get_existing_reports(domain):
 
 def number_of_report_builder_reports(domain):
     builder_reports = [
-        report for report in _get_existing_reports(domain)
+        report for report in get_existing_reports(domain)
         if report.report_meta.created_by_builder
     ]
     return len(builder_reports)
@@ -155,7 +155,7 @@ def number_of_report_builder_reports(domain):
 
 def number_of_ucr_reports(domain):
     ucr_reports = [
-        report for report in _get_existing_reports(domain)
+        report for report in get_existing_reports(domain)
         if not report.report_meta.created_by_builder
     ]
     return len(ucr_reports)

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -145,7 +145,7 @@ def get_existing_reports(domain):
     existing_reports = ReportConfiguration.by_domain(domain)
     return [
         report for report in existing_reports
-        if not report.title.startswith(TEMP_REPORT_PREFIX)
+        if not (report.title and report.title.startswith(TEMP_REPORT_PREFIX))
     ]
 
 

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -135,6 +135,11 @@ def allowed_report_builder_reports(request):
     return 0
 
 
+def get_configurable_and_static_reports(domain):
+    from corehq.apps.userreports.models import StaticReportConfiguration
+    return get_existing_reports(domain) + StaticReportConfiguration.by_domain(domain)
+
+
 def get_existing_reports(domain):
     from corehq.apps.userreports.models import ReportConfiguration
     existing_reports = ReportConfiguration.by_domain(domain)

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -8,7 +8,7 @@ from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.linked_domain.util import is_linked_report
 from corehq.apps.userreports.adapter import IndicatorAdapterLoadTracker
-from corehq.apps.userreports.const import REPORT_BUILDER_EVENTS_KEY
+from corehq.apps.userreports.const import REPORT_BUILDER_EVENTS_KEY, TEMP_REPORT_PREFIX
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.toggles import ENABLE_UCR_MIRRORS
 from corehq.util import reverse
@@ -137,7 +137,6 @@ def allowed_report_builder_reports(request):
 
 def get_existing_reports(domain):
     from corehq.apps.userreports.models import ReportConfiguration
-    from corehq.apps.userreports.views import TEMP_REPORT_PREFIX
     existing_reports = ReportConfiguration.by_domain(domain)
     return [
         report for report in existing_reports

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -84,6 +84,7 @@ from corehq.apps.userreports.const import (
     NAMED_EXPRESSION_PREFIX,
     NAMED_FILTER_PREFIX,
     REPORT_BUILDER_EVENTS_KEY,
+    TEMP_REPORT_PREFIX,
 )
 from corehq.apps.userreports.dbaccessors import get_datasources_for_domain
 from corehq.apps.userreports.exceptions import (
@@ -151,8 +152,6 @@ from corehq.util import reverse
 from corehq.util.couch import get_document_or_404
 from corehq.util.quickcache import quickcache
 from corehq.util.soft_assert import soft_assert
-
-TEMP_REPORT_PREFIX = '__tmp'
 
 
 def get_datasource_config_or_404(config_id, domain):

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -66,7 +66,7 @@ from corehq.apps.userreports.reports.view import (
     ConfigurableReportView,
     CustomConfigurableReportDispatcher,
 )
-from corehq.apps.userreports.views import TEMP_REPORT_PREFIX
+from corehq.apps.userreports.const import TEMP_REPORT_PREFIX
 from corehq.motech.repeaters.views import (
     DomainForwardingRepeatRecords,
     SQLRepeatRecordReport,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

The [list reports API](https://confluence.dimagi.com/display/commcarepublic/List+Reports) currently includes all database defined reports, including report builder temporary reports that are never meant to be user-facing, and *excluding* statically defined reports.

This change removes the temporary system reports and adds the static reports.

Review by commit.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

https://forum.dimagi.com/t/report-download-api-not-working-for-static-reports/8469/3

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

n/a

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

The API has tests which would catch potential regressions. I did not add new tests for the cases that would be impacted, though I did test both manually on my local environment.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

I don't think this needs any QA.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

It's a very simple code change and I tested all pathways locally.

Impacted APIs should only be improved.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
