### PR TITLE
add release dynamic toggle for livequery

### DIFF
--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -265,7 +265,8 @@ class FlagsAndPrivilegesView(BaseAdminProjectSettingsView):
     def page_context(self):
         return {
             'toggles': self._get_toggles(),
-            'use_livequery': self.domain_object.use_livequery or toggles.LIVEQUERY_SYNC.enabled(self.domain),
+            'use_livequery': (self.domain_object.use_livequery
+                              or toggles.LIVEQUERY_SYNC.enabled(self.domain, toggles.NAMESPACE_DOMAIN)),
             'privileges': self._get_privileges(),
         }
 

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -265,7 +265,7 @@ class FlagsAndPrivilegesView(BaseAdminProjectSettingsView):
     def page_context(self):
         return {
             'toggles': self._get_toggles(),
-            'use_livequery': self.domain_object.use_livequery,
+            'use_livequery': self.domain_object.use_livequery or toggles.LIVEQUERY_SYNC.enabled(self.domain),
             'privileges': self._get_privileges(),
         }
 

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -57,7 +57,8 @@ class CaseProcessingResult(object):
             return
 
         domain_obj = Domain.get_by_name(self.domain)
-        if domain_obj is not None and (domain_obj.use_livequery or toggles.LIVEQUERY_SYNC.enabled(self.domain)):
+        if domain_obj is not None \
+           and (domain_obj.use_livequery or toggles.LIVEQUERY_SYNC.enabled(self.domain, toggles.NAMESPACE_DOMAIN)):
             return
 
         flags_to_save = self.get_flags_to_save()
@@ -152,7 +153,8 @@ def _get_all_dirtiness_flags_from_cases(domain, case_db, touched_cases):
     # process the temporary dirtiness flags first so that any hints for real dirtiness get overridden
     if domain:
         domain_obj = Domain.get_by_name(domain)
-        if domain_obj and domain_obj.use_livequery or toggles.LIVEQUERY_SYNC.enabled(domain):
+        if domain_obj and (domain_obj.use_livequery
+                           or toggles.LIVEQUERY_SYNC.enabled(domain, toggles.NAMESPACE_DOMAIN)):
             return []
 
     dirtiness_flags = list(_get_dirtiness_flags_for_reassigned_case(list(touched_cases.values())))

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -57,7 +57,7 @@ class CaseProcessingResult(object):
             return
 
         domain_obj = Domain.get_by_name(self.domain)
-        if domain_obj is not None and domain_obj.use_livequery:
+        if domain_obj is not None and (domain_obj.use_livequery or toggles.LIVEQUERY_SYNC.enabled(self.domain)):
             return
 
         flags_to_save = self.get_flags_to_save()
@@ -152,7 +152,7 @@ def _get_all_dirtiness_flags_from_cases(domain, case_db, touched_cases):
     # process the temporary dirtiness flags first so that any hints for real dirtiness get overridden
     if domain:
         domain_obj = Domain.get_by_name(domain)
-        if domain_obj and domain_obj.use_livequery:
+        if domain_obj and domain_obj.use_livequery or toggles.LIVEQUERY_SYNC.enabled(domain):
             return []
 
     dirtiness_flags = list(_get_dirtiness_flags_for_reassigned_case(list(touched_cases.values())))

--- a/corehq/ex-submodules/casexml/apps/phone/cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/cleanliness.py
@@ -10,7 +10,7 @@ from corehq.apps.users.util import WEIRD_USER_IDS
 from django.conf import settings
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.toggles import LIVEQUERY_SYNC
+from corehq.toggles import LIVEQUERY_SYNC, NAMESPACE_DOMAIN
 from corehq.util.soft_assert import soft_assert
 from dimagi.utils.logging import notify_exception
 import six
@@ -50,7 +50,7 @@ def set_cleanliness_flags_for_all_domains(force_full=False):
     Updates cleanliness for all domains
     """
     for domain_obj in Domain.get_all():
-        if domain_obj.use_livequery or LIVEQUERY_SYNC.enabled(domain_obj.name):
+        if domain_obj.use_livequery or LIVEQUERY_SYNC.enabled(domain_obj.name, NAMESPACE_DOMAIN):
             continue
         try:
             set_cleanliness_flags_for_domain(domain_obj.name, force_full=force_full)

--- a/corehq/ex-submodules/casexml/apps/phone/cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/cleanliness.py
@@ -10,6 +10,7 @@ from corehq.apps.users.util import WEIRD_USER_IDS
 from django.conf import settings
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.toggles import LIVEQUERY_SYNC
 from corehq.util.soft_assert import soft_assert
 from dimagi.utils.logging import notify_exception
 import six
@@ -49,7 +50,7 @@ def set_cleanliness_flags_for_all_domains(force_full=False):
     Updates cleanliness for all domains
     """
     for domain_obj in Domain.get_all():
-        if domain_obj.use_livequery:
+        if domain_obj.use_livequery or LIVEQUERY_SYNC.enabled(domain_obj.name):
             continue
         try:
             set_cleanliness_flags_for_domain(domain_obj.name, force_full=force_full)

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -24,7 +24,7 @@ from casexml.apps.phone.exceptions import (
 from casexml.apps.phone.restore_caching import AsyncRestoreTaskIdCache, RestorePayloadPathCache
 from casexml.apps.phone.tasks import get_async_restore_payload, ASYNC_RESTORE_SENT
 from casexml.apps.phone.utils import get_cached_items_with_count
-from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED
+from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED, LIVEQUERY_SYNC
 from corehq.util.metrics import metrics_counter, metrics_histogram
 from corehq.util.timer import TimingContext
 from memoized import memoized
@@ -366,7 +366,7 @@ class RestoreState(object):
         self._last_sync_log = Ellipsis
 
         if case_sync is None:
-            if project.use_livequery:
+            if project.use_livequery or LIVEQUERY_SYNC.enabled(self.domain):
                 case_sync = LIVEQUERY
             else:
                 case_sync = DEFAULT_CASE_SYNC

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -24,7 +24,7 @@ from casexml.apps.phone.exceptions import (
 from casexml.apps.phone.restore_caching import AsyncRestoreTaskIdCache, RestorePayloadPathCache
 from casexml.apps.phone.tasks import get_async_restore_payload, ASYNC_RESTORE_SENT
 from casexml.apps.phone.utils import get_cached_items_with_count
-from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED, LIVEQUERY_SYNC
+from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED, LIVEQUERY_SYNC, NAMESPACE_DOMAIN
 from corehq.util.metrics import metrics_counter, metrics_histogram
 from corehq.util.timer import TimingContext
 from memoized import memoized
@@ -366,7 +366,7 @@ class RestoreState(object):
         self._last_sync_log = Ellipsis
 
         if case_sync is None:
-            if project.use_livequery or LIVEQUERY_SYNC.enabled(self.domain):
+            if project.use_livequery or LIVEQUERY_SYNC.enabled(self.domain, NAMESPACE_DOMAIN):
                 case_sync = LIVEQUERY
             else:
                 case_sync = DEFAULT_CASE_SYNC

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -898,6 +898,13 @@ CASE_API_V0_6 = StaticToggle(
     save_fn=_enable_search_index,
 )
 
+LIVEQUERY_SYNC = DynamicallyPredictablyRandomToggle(
+    'livequery_sync',
+    'Enable livequery sync algorithm',
+    TAG_INTERNAL,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
 HIPAA_COMPLIANCE_CHECKBOX = StaticToggle(
     'hipaa_compliance_checkbox',
     'Show HIPAA compliance checkbox',


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12494

This creates a toggle that will allow us to slowly roll out livequery for all domains in chunks. Apologies @orangejenny for immediately reintroducing a flag you had just gotten rid of.

There is a fuller rationale in the ticket itself, but now that everyone is on SQL this should have clear benefits for most domains, including lower memory usage and faster restore timings.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LIVEQUERY_SYNC`

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

Domains that have been enabled by the flag will need to be migrated to have this saved on the domain doc before revert or else all of their users will 412 and need to full restore.