### PR TITLE
coerce case properties to string in case search pillow

### DIFF
--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -78,7 +78,7 @@ class TestCaseSearchEndpoint(TestCase):
         ])
 
     def test_dynamic_property(self):
-        res = get_case_search_results(self.domain, {'family': 'Ramos'})
+        res = get_case_search_results(self.domain, {'case_type': 'person', 'family': 'Ramos'})
         self.assertItemsEqual(["Jane"], [case.name for case in res])
 
     def test_app_aware_related_cases(self):

--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -77,7 +77,7 @@ class TestCaseSearchEndpoint(TestCase):
             case.name for case in res
         ])
 
-    def dynamic_property(self):
+    def test_dynamic_property(self):
         res = get_case_search_results(self.domain, {'family': 'Ramos'})
         self.assertItemsEqual(["Jane"], [case.name for case in res])
 

--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -77,6 +77,10 @@ class TestCaseSearchEndpoint(TestCase):
             case.name for case in res
         ])
 
+    def dynamic_property(self):
+        res = get_case_search_results(self.domain, {'family': 'Ramos'})
+        self.assertItemsEqual(["Jane"], [case.name for case in res])
+
     def test_app_aware_related_cases(self):
         with mock.patch('corehq.apps.case_search.utils.get_app_cached', new=lambda _, __: self.factory.app):
             res = get_case_search_results(self.domain, {'case_type': 'person'}, 'fake_app_id')

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -88,7 +88,7 @@ def _get_case_properties(doc_dict):
     ]
     dynamic_case_properties = dict(doc_dict['case_json'])
 
-    dynamic_mapping = [{'key': key, VALUE: value} for key, value in dynamic_case_properties.items()]
+    dynamic_mapping = [{'key': key, VALUE: str(value)} for key, value in dynamic_case_properties.items()]
 
     return base_case_properties + dynamic_mapping
 

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -36,6 +36,7 @@ from corehq.util.doc_processor.sql import SqlDocumentProvider
 from corehq.util.es.interface import ElasticsearchInterface
 from corehq.util.log import get_traceback_string
 from corehq.util.quickcache import quickcache
+from corehq.util.soft_assert import soft_assert
 from dimagi.utils.parsing import json_format_datetime
 from pillowtop.checkpoints.manager import (
     get_checkpoint_for_elasticsearch_pillow,
@@ -52,6 +53,8 @@ from pillowtop.reindexer.reindexer import (
     ReindexerFactory,
     ResumableBulkElasticPillowReindexer,
 )
+
+_assert_string_property = soft_assert(to='{}@{}.com'.format('cellowitz', 'dimagi'), notify_admins=True)
 
 
 @quickcache([], timeout=24 * 60 * 60, memoize_timeout=60)
@@ -79,8 +82,18 @@ def transform_case_for_elasticsearch(doc_dict):
     return doc
 
 
+def _format_property(key, value, case_id):
+    if not isinstance(value, str):
+        value = str(value)
+        _assert_string_property(False, f'Case {case_id} has property {key} saved in unexpected format')
+    return {
+        "key": key,
+        VALUE: value
+    }
+
 def _get_case_properties(doc_dict):
     domain = doc_dict.get('domain')
+    case_id = doc_dict.get('_id')
     assert domain
     base_case_properties = [
         {'key': base_case_property.key, 'value': base_case_property.value_getter(doc_dict)}
@@ -88,7 +101,7 @@ def _get_case_properties(doc_dict):
     ]
     dynamic_case_properties = dict(doc_dict['case_json'])
 
-    dynamic_mapping = [{'key': key, VALUE: str(value)} for key, value in dynamic_case_properties.items()]
+    dynamic_mapping = [_format_property(key, value, case_id) for key, value in dynamic_case_properties.items()]
 
     return base_case_properties + dynamic_mapping
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This is an alternate attempt at https://github.com/dimagi/commcare-hq/pull/30488

Case properties should already always be strings, but in some weird cases (due to improperly submitted data), they are not. That means this should do nothing almost all the time, but in the few cases where we are holding data in alternate formats, will coerce it to a string so that elasticsearch doesn't choke. I did not include specific error handling because if this fails, the doc would have been rejected by ES anyway, and this way the doc will be recorded in the pillow errors table. That being said, it's extremely unlikely to fail as nearly every python object has some string representation to fall back to.

There is more context in https://dimagi-dev.atlassian.net/browse/SAAS-12687

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Case search endpoint tests cover these changes because they use the modified function to transform the docs then ensure then query against them in ES.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Covered by existing automated tests and change no behavior in pillow

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
