### PR TITLE
re-work suite file for data registry search modules

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2483,7 +2483,9 @@ class ModuleDetailsMixin(object):
             ('ref_short', self.ref_details.short, False),
             ('ref_long', self.ref_details.long, False),
         ]
-        if module_offers_search(self) and not self.case_details.short.custom_xml:
+        custom_detail = self.case_details.short.custom_xml
+        registry_search = self.search_config.data_registry
+        if module_offers_search(self) and not custom_detail and not registry_search:
             details.append(('search_short', self.search_detail("short"), True))
             details.append(('search_long', self.search_detail("long"), True))
         return tuple(details)

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -130,6 +130,7 @@ INSTANCE_KWARGS_BY_ID = {
     'casedb': dict(id='casedb', src='jr://instance/casedb'),
     'commcaresession': dict(id='commcaresession', src='jr://instance/session'),
     'registry': dict(id='registry', src='jr://instance/remote'),
+    'results': dict(id='results', src='jr://instance/remote'),
 }
 
 

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -197,7 +197,7 @@ class DetailContributor(SectionContributor):
                     if form.is_registration_form(module.case_type) or form.unique_id in valid_forms:
                         d.actions.append(self._get_case_list_form_action(module))
 
-                if module_offers_search(module):
+                if module_offers_search(module) and not module.search_config.data_registry:
                     d.actions.append(self._get_case_search_action(module, in_search="search" in id))
 
             try:

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -522,6 +522,10 @@ class EntriesHelper(object):
         return datums
 
     def get_data_registry_search_datums(self, module):
+        """When a data registry is the source of the search results we skip the normal case search
+        workflow and perform the search directly as part of the entry instead of via an action in the
+        details screen. The case details is then populated with data from the results of the query.
+        """
         from corehq.apps.app_manager.suite_xml.sections.remote_requests import RemoteRequestFactory
         factory = RemoteRequestFactory(module, [])
         query = factory.build_remote_request_queries()[0]

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -19,7 +19,7 @@ from corehq.apps.app_manager.suite_xml.utils import (
     get_select_chain_meta,
 )
 from corehq.apps.app_manager.suite_xml.xml_models import *
-from corehq.apps.app_manager.util import actions_use_usercase, module_offers_search
+from corehq.apps.app_manager.util import actions_use_usercase, module_offers_registry_search
 from corehq.apps.app_manager.xform import (
     autoset_owner_id_for_advanced_action,
     autoset_owner_id_for_open_case,
@@ -420,7 +420,7 @@ class EntriesHelper(object):
         for datum in datums:
             if datum.module_id and datum.case_type:
                 module = self.app.get_module_by_unique_id(datum.module_id)
-                if module_offers_search(module) and module.search_config.data_registry:
+                if module_offers_registry_search(module):
                     result.append(self.get_data_registry_search_datums(module))
                     result.append(datum)
                     result.extend(self.get_data_registry_case_datums(datum, module))
@@ -489,7 +489,7 @@ class EntriesHelper(object):
             filter_xpath = EntriesHelper.get_filter_xpath(detail_module) if use_filter else ''
 
             instance_name, root_element = "casedb", "casedb"
-            if module_offers_search(detail_module) and module.search_config.data_registry:
+            if module_offers_registry_search(detail_module):
                 instance_name, root_element = "results", "results"
 
             nodeset = EntriesHelper._get_nodeset_xpath(

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -426,6 +426,8 @@ class EntriesHelper(object):
                     result.extend(self.get_data_registry_case_datums(datum, module))
                 else:
                     result.append(datum)
+            else:
+                result.append(datum)
         return result
 
     def get_datum_meta_module(self, module, use_filter=False):

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -87,6 +87,9 @@ class RemoteRequestFactory(object):
                 ),
             ],
         }
+        relevant = self.get_post_relevant()
+        if relevant:
+            kwargs["relevant"] = relevant
         return RemoteRequestPost(**kwargs)
 
     def get_post_relevant(self):
@@ -116,6 +119,9 @@ class RemoteRequestFactory(object):
         # need these instances to be available
         xpaths.update(self._get_xpaths_for_module())
         instances, unknown_instances = get_all_instances_referenced_in_xpaths(self.app, xpaths)
+
+        # exclude remote instances
+        instances = [instance for instance in instances if 'remote' not in instance.src]
 
         # sorted list to prevent intermittent test failures
         return sorted(set(list(instances) + prompt_select_instances), key=lambda i: i.id)

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -87,13 +87,6 @@ class RemoteRequestFactory(object):
                 ),
             ],
         }
-        if self.module.search_config.data_registry:
-            # Disable claim request for data registry
-            kwargs["relevant"] = "false()"
-        else:
-            relevant = self.get_post_relevant()
-            if relevant:
-                kwargs["relevant"] = relevant
         return RemoteRequestPost(**kwargs)
 
     def get_post_relevant(self):
@@ -315,7 +308,7 @@ class RemoteRequestContributor(SuiteContributorByModule):
     @time_method()
     def get_module_contributions(self, module, detail_section_elements):
         elements = []
-        if module_offers_search(module):
+        if module_offers_search(module) and not module.search_config.data_registry:
             elements.append(RemoteRequestFactory(
                 module, detail_section_elements).build_remote_request()
             )

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -519,6 +519,8 @@ class Entry(OrderedXmlObject, XmlObject):
     def require_instances(self, instances=(), instance_ids=()):
         used = {(instance.id, instance.src) for instance in self.instances}
         for instance in instances:
+            if 'remote' in instance.src:
+                continue
             if (instance.id, instance.src) not in used:
                 self.instances.append(
                     # it's important to make a copy,

--- a/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
@@ -6,10 +6,27 @@
                 <locale id="forms.m0f0"/>
             </text>
         </command>
-        <instance id="casedb" src="jr://instance/casedb"/>
         <instance id="commcaresession" src="jr://instance/session"/>
         <session>
-          <datum detail-confirm="m0_case_long" detail-select="m0_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='case'][@status='open']" value="./@case_id"/>
+          <query url="http://localhost:8000/a/test_domain/phone/search/123/" storage-instance="results" template="case" default_search="false">
+            <data key="case_type" ref="'case'"/>
+            <data key="commcare_registry" ref="'myregistry'"/>
+            <prompt key="name">
+              <display>
+                <text>
+                  <locale id="search_property.m0.name"/>
+                </text>
+              </display>
+            </prompt>
+            <prompt key="dob">
+              <display>
+                <text>
+                  <locale id="search_property.m0.dob"/>
+                </text>
+              </display>
+            </prompt>
+          </query>
+          <datum detail-confirm="m0_case_long" detail-select="m0_case_short" id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open']" value="./@case_id"/>
           <query default_search="true" storage-instance="registry" template="case" url="http://localhost:8000/a/test_domain/phone/registry_case/123/">
             <data key="case_type" ref="'case'"/>
             <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -61,28 +61,43 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
 
         expected_entry_query = """
         <partial>
-          <query url="http://localhost:8000/a/test_domain/phone/registry_case/123/"
+          <session>
+            <query url="http://localhost:8000/a/test_domain/phone/search/123/" storage-instance="results"
+                template="case" default_search="false">
+              <data key="case_type" ref="'case'"/>
+              <data key="commcare_registry" ref="'myregistry'"/>
+              <prompt key="name">
+                <display>
+                  <text>
+                    <locale id="search_property.m0.name"/>
+                  </text>
+                </display>
+              </prompt>
+              <prompt key="dob">
+                <display>
+                  <text>
+                    <locale id="search_property.m0.dob"/>
+                  </text>
+                </display>
+              </prompt>
+            </query>
+            <datum id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open']"
+                value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
+            <query url="http://localhost:8000/a/test_domain/phone/registry_case/123/"
                 storage-instance="registry" template="case" default_search="true">
-            <data key="case_type" ref="'case'"/>
-            <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
-            <data key="commcare_registry" ref="'myregistry'"/>
-          </query>
+              <data key="case_type" ref="'case'"/>
+              <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
+              <data key="commcare_registry" ref="'myregistry'"/>
+            </query>
+          </session>
         </partial>"""
-        self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]/session/query")
+        self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]/session")
 
         # assert that session instance is added to the entry
         self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='commcaresession']")
 
-        # assert post is disabled
-        self.assertXmlHasXpath(suite, "./remote-request[1]/post[@relevant='false()']")
-
-        expected_data = """
-        <partial>
-          <data key="commcare_registry" ref="'myregistry'"/>
-        </partial>
-        """
-        self.assertXmlPartialEqual(
-            expected_data, suite, "./remote-request[1]/session/query/data[@key='commcare_registry']")
+        # assert remote request is not added
+        self.assertXmlDoesNotHaveXpath(suite, "./remote-request")
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
     def test_search_data_registry_additional_registry_query(self, *args):
@@ -107,9 +122,8 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         </partial>"""
         self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]/session/query[2]")
 
-        # assert that session and registry instances are added to the entry
         self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='commcaresession']")
-        self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='registry']")
+        self.assertXmlDoesNotHaveXpath(suite, "./entry[1]/instance[@id='registry']")
 
     def test_form_linking_with_registry_module(self, *args):
         self.form.post_form_workflow = WORKFLOW_FORM

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -120,7 +120,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             <data key="commcare_registry" ref="'myregistry'"/>
           </query>
         </partial>"""
-        self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]/session/query[2]")
+        self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]/session/query[3]")
 
         self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='commcaresession']")
         self.assertXmlDoesNotHaveXpath(suite, "./entry[1]/instance[@id='registry']")

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -98,6 +98,9 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
 
         # assert remote request is not added
         self.assertXmlDoesNotHaveXpath(suite, "./remote-request")
+        self.assertXmlDoesNotHaveXpath(suite, "./detail[@id='m0_case_short']/action")
+        self.assertXmlDoesNotHaveXpath(suite, "./detail[@id='m0_search_short']")
+        self.assertXmlDoesNotHaveXpath(suite, "./detail[@id='m0_search_long']")
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
     def test_search_data_registry_additional_registry_query(self, *args):

--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -49,7 +49,7 @@ class TestXmlMixin(TestFileMixin):
     def _assertXpathHelper(self, element, xpath, message, should_not_exist):
         element = parse_normalize(element, to_string=False)
         if bool(element.xpath(xpath)) == should_not_exist:
-            raise AssertionError(message + lxml.etree.tostring(element, pretty_print=True, encoding='utf-8'))
+            raise AssertionError(message + lxml.etree.tostring(element, pretty_print=True, encoding='unicode'))
 
     def assertHtmlEqual(self, expected, actual, normalize=True):
         if normalize:

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -376,6 +376,10 @@ def prefix_usercase_properties(properties):
     return {'{}{}'.format(USERCASE_PREFIX, prop) for prop in properties}
 
 
+def module_offers_registry_search(module):
+    return module_offers_search(module) and module.search_config.data_registry
+
+
 def module_offers_search(module):
     from corehq.apps.app_manager.models import AdvancedModule, Module, ShadowModule
 

--- a/corehq/apps/registry/fixtures.py
+++ b/corehq/apps/registry/fixtures.py
@@ -3,7 +3,7 @@ from lxml.builder import E
 from casexml.apps.phone.fixtures import FixtureProvider
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
-from corehq.apps.app_manager.util import module_offers_search
+from corehq.apps.app_manager.util import module_offers_registry_search
 from corehq.apps.domain.models import Domain
 from corehq.apps.registry.helper import DataRegistryHelper
 from corehq.apps.registry.models import DataRegistry
@@ -23,7 +23,7 @@ class RegistryFixtureProvider(FixtureProvider):
             module.search_config.data_registry
             for app in apps
             for module in app.get_modules()
-            if module_offers_search(module) and module.search_config.data_registry
+            if module_offers_registry_search(module)
         }
         if not registry_slugs:
             return []


### PR DESCRIPTION
## Technical Summary
This makes fundamental changes to the suite file when case search is configured to search from a data registry.

Normal case search:
1. form entry contains a datum which references the module details
2. module details contains an action which kicks off a stack operation to show case search (remote-request)
3. case search is complete (case selected, claim performed, sync complete) the stack rewinds back to the details but with the needed datum selected
  - since the case was claimed and a sync was performed the case is now in the user's casedb
4. navigation continues to the form

This workflow doesn't work for data registry search because in step 3 we don't perform the claim and sync which means that the case is not going to be in the user's casedb. This makes it impossible for navigation to continue.

Instead of having the search be launched from an action in the details what we will do is have the search performed directly as part of the form entry. This search populates a 'remote' instance which is then used by the form's datum to show the case details. 

More details in the spec and in the tests.

Spec: https://docs.google.com/document/d/1FCSxVBoBG8LnmogMwei1nb6eC74eUhs7HWuJmBg6i3k/edit#heading=h.oij9d37sohxx

## Feature Flag
DATA_REGISTRY

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added

### QA Plan
I'm not planning to put this through QA prior to merging. This is still being tested by USH so it will get QA'd then.

### Safety story
The changes in this PR do current work on formplayer (except for accessing the remote instance in the form). This should not impact any app builds that are not using 'registry case search'. Given the comprehensive test suite I am confident that this won't impact anything outside of the FF.

There are still further changes that need to be made to get this working nicely with other app features like "form linking", "search again".

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
