### PR TITLE
Reorganize PULL_REQUEST_TEMPLATE.md to flow better

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -50,4 +50,4 @@ Otherwise replace it with detailed instructions or reasons a rollback is impossi
 - [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
 
 ## Final self-reflection
-- [ ] My safety story above is convincing and give me confidence that this PR will not introduce a regression
+- [ ] My safety story above is convincing and gives me confidence that this PR will not introduce a regression

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
 
 ### Safety story
 <!--
-Describe any other pieces to the safety story including
+Describe how you became confident in this change, such as
 local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
 -->
 
@@ -31,7 +31,7 @@ local testing, why the change is inherently safe, and/or plans to limit the blas
 
 
 ### Migrations
-
+<!-- Delete this section if the PR does not contain any migrations -->
 - [ ] The migrations in this code can be safely applied first independently of the code
 
 <!-- Please link to any past code changes that are coordinated with this migration -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,15 +12,11 @@
 
 ## Safety Assurance
 
-- [ ] Risk label is set correctly
-- [ ] All migrations are backwards compatible and won't block deploy
-- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
-- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
-- [ ] I have confidence that this PR will not introduce a regression for the reasons below
-
-## Migrations
-
-- [ ] The migrations in this code can be safely applied first independently of the code
+### Safety story
+<!--
+Describe any other pieces to the safety story including
+local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
+-->
 
 ### Automated test coverage
 
@@ -33,11 +29,12 @@
 - Link to QA Ticket
 -->
 
-### Safety story
-<!--
-Describe any other pieces to the safety story including
-local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--->
+
+### Migrations
+
+- [ ] The migrations in this code can be safely applied first independently of the code
+
+<!-- Please link to any past code changes that are coordinated with this migration -->
 
 ### Rollback instructions
 
@@ -46,4 +43,11 @@ If this PR follows standards of revertability, check the box below.
 Otherwise replace it with detailed instructions or reasons a rollback is impossible.
 -->
 
-- [ ] This PR can be reverted after deploy with no further considerations 
+- [ ] This PR can be reverted after deploy with no further considerations
+
+### Labels & Review
+- [ ] Risk label is set correctly
+- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
+
+## Final self-reflection
+- [ ] My safety story above is convincing and give me confidence that this PR will not introduce a regression


### PR DESCRIPTION
## Product Description
None

## Technical Summary
I've gotten feedback that the current pull request template is tedious. Having used the current version for a while myself, I have found that the ordering of the sections and checklists didn't quite match the flow of what I'm thinking about when, and I tried to reorganize it to fit the actual PR / Review process a bit better.

## Feature Flag
None

## Safety Assurance

### Safety story
Doesn't touch executed code, only the PR template. No questions are removed, they are just organized in a way that I hope makes people more likely to reflect on them.

### Automated test coverage

N/A

### QA Plan

N/A

### Migrations
None

- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression