### PR TITLE
Explicitly include utils/email.js module when using accounting/js/widgets.js

### DIFF
--- a/corehq/apps/accounting/templates/accounting/invoice_list.html
+++ b/corehq/apps/accounting/templates/accounting/invoice_list.html
@@ -1,8 +1,13 @@
 {% extends "accounting/report_filter_actions.html" %}
+{% load compress %}
 {% load hq_shared_tags %}
 
-{% block js %}{{ block.super }}
-  <script src="{% static 'accounting/js/widgets.js' %}"></script>
+{% block js %}
+  {{ block.super }}
+  {% compress js %}
+    <script src="{% static 'hqwebapp/js/utils/email.js' %}"></script>
+    <script src="{% static 'accounting/js/widgets.js' %}"></script>
+  {% endcompress %}
 {% endblock %}
 
 {% block page_content %}

--- a/corehq/apps/domain/templates/domain/confirm_subscription_renewal.html
+++ b/corehq/apps/domain/templates/domain/confirm_subscription_renewal.html
@@ -3,9 +3,8 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% block js %}
-  <script src="{% static 'accounting/js/widgets.js' %}"></script>
-{% endblock %}
+{% requirejs_main 'accounting/js/widgets' %}
+
 {% block plan_breadcrumbs %}{% endblock %}
 
 {% block form_content %}

--- a/corehq/apps/users/templates/users/base_template.html
+++ b/corehq/apps/users/templates/users/base_template.html
@@ -2,4 +2,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main 'locations/js/widgets' %}
+{% block js %}{{ block.super }}
+  <script src="{% static "locations/js/widgets.js" %}"></script>
+{% endblock %}

--- a/corehq/apps/users/templates/users/base_template.html
+++ b/corehq/apps/users/templates/users/base_template.html
@@ -2,6 +2,4 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% block js %}{{ block.super }}
-  <script src="{% static "locations/js/widgets.js" %}"></script>
-{% endblock %}
+{% requirejs_main 'locations/js/widgets' %}

--- a/corehq/apps/users/templates/users/extra_users_confirm_billing.html
+++ b/corehq/apps/users/templates/users/extra_users_confirm_billing.html
@@ -3,9 +3,7 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% block js %}{{ block.super }}
-  <script src="{% static 'accounting/js/widgets.js' %}"></script>
-{% endblock %}
+{% requirejs_main 'accounting/js/widgets' %}
 
 {% block page_content %}
   <div class="alert alert-info">


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12635

The source of the bug is that the `accounting/js/widgets.js` has a commcare JS dependency on `utils/email.js`. If not using `requirejs_main`, the dependency cannot be resolved and results in the email_utils being undefined in `accounting/js/widgets.js`. I noticed that using `compress js` also resolved this issue but due to a coincidence that other files in the accounting app include `utils/emails.js` as well, so the dependency could be resolved. Using `requirejs_main` or explicitly including `utils/email.js` before `accounting/js/widgets.js` are the correct solutions.

The reported issue was specific to the `settings/project/subscription/renew/confirm/` endpoint, but I observed the same issue on the `settings/users/commcare/confirm_charges/` page as well. The `invoice_list.html` file also declares `accounting/js/widgets.js` as a JS depedency, but does not seem impacted by this particular bug. I updated it anyway to properly support all accounting widgets in case they are used in the future.

In the case of the `confirm_subscription_renewal.html` page and `extra_users_confirm_billing.html` page, I was able to use `requirejs_main` instead of `<script>` tags to import the JS module. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated test coverage.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
