### PR TITLE
Remove serialize='pickle' from case_importer

### DIFF
--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -83,7 +83,7 @@ class ImporterTest(TestCase):
         # by using a made up upload_id, we ensure it's not referencing any real file
         case_upload = CaseUploadRecord(upload_id=str(uuid.uuid4()), task_id=str(uuid.uuid4()))
         case_upload.save()
-        res = bulk_import_async.delay(self._config(['anything']), self.domain, case_upload.upload_id)
+        res = bulk_import_async.delay(self._config(['anything']).to_json(), self.domain, case_upload.upload_id)
         self.assertIsInstance(res.result, Ignore)
         update_state.assert_called_with(
             state=states.FAILURE,

--- a/corehq/apps/case_importer/tracking/case_upload_tracker.py
+++ b/corehq/apps/case_importer/tracking/case_upload_tracker.py
@@ -77,7 +77,7 @@ class CaseUpload(object):
         with open(self.get_tempfile(), 'rb') as f:
             case_upload_file_meta = persistent_file_store.write_file(f, original_filename, domain)
 
-        task = bulk_import_async.delay(config, domain, self.upload_id)
+        task = bulk_import_async.delay(config.to_json(), domain, self.upload_id)
         CaseUploadRecord(
             domain=domain,
             comment=comment,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[JIRA Ticket
](https://dimagi-dev.atlassian.net/browse/SAAS-11385)
This PR is part of a series of PRs aimed at removing our use of pickling in celery tasks due to a lack of support that is blocking our ability to upgrade celery.

The tasks modified were:

`store_failed_task_result(upload_id)` where uplodate_id is just a string. 

`bulk_import_async(config, domain, excel_id)` where domain and excel_id are strings. `config` is an `ImporterConfig` object which has the methods `to_json(self)`  which converts the object into a dictionary and returns it in JSON form and `from_json(cls, json_rep)` which reverses the process to get back the object. These methods were used to pass into the celery task a json string instead of the object and recreate the object within the task. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested on staging. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
