### PR TITLE
create case types in the Data Dictionary via the UI

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -239,6 +239,27 @@ hqDefine("data_dictionary/js/data_dictionary", [
             self.removefhirResourceType(false);
         };
 
+        // CREATE workflow
+        self.name = ko.observable("").extend({
+            rateLimit: { method: "notifyWhenChangesStop", timeout: 400, }
+        });
+
+        self.nameValid = ko.observable(false);
+        self.nameChecked = ko.observable(false);
+        self.name.subscribe((value) => {
+            let existing = _.find(self.caseTypes(), function (prop) {
+                return prop.name === value;
+            });
+            self.nameValid(!existing);
+            self.nameChecked(true);
+        });
+
+        self.formCreateCaseTypeSent = ko.observable(false);
+        self.submitCreate = function () {
+            self.formCreateCaseTypeSent(true);
+            return true;
+        };
+
         return self;
     };
 

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -17,6 +17,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
     var caseType = function (name, fhirResourceType) {
         var self = {};
         self.name = name || gettext("No Name");
+        self.url = "#" + name;
         self.fhirResourceType = ko.observable(fhirResourceType);
         self.properties = ko.observableArray();
 
@@ -139,7 +140,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
             self.saveButton.fire('change');
         };
 
-        self.init = function () {
+        self.init = function (callback) {
             $.getJSON(dataUrl)
                 .done(function (data) {
                     _.each(data.case_types, function (caseTypeData) {
@@ -154,6 +155,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                     self.casePropertyList.subscribe(changeSaveButton);
                     self.fhirResourceType.subscribe(changeSaveButton);
                     self.removefhirResourceType.subscribe(changeSaveButton);
+                    callback();
                 });
         };
 
@@ -269,7 +271,21 @@ hqDefine("data_dictionary/js/data_dictionary", [
             typeChoices = initialPageData.get('typeChoices'),
             fhirResourceTypes = initialPageData.get('fhirResourceTypes'),
             viewModel = dataDictionaryModel(dataUrl, casePropertyUrl, typeChoices, fhirResourceTypes);
-        viewModel.init();
+
+        function doHashNavigation() {
+            let fullHash = window.location.hash.split('?')[0],
+                hash = fullHash.substring(1);
+            let caseType = _.find(viewModel.caseTypes(), function (prop) {
+                return prop.name === hash;
+            });
+            if (caseType) {
+                viewModel.goToCaseType(caseType);
+            }
+        }
+
+        window.onhashchange = doHashNavigation;
+
+        viewModel.init(doHashNavigation);
         $('#hq-content').parent().koApplyBindings(viewModel);
         $('#download-dict').click(function () {
             googleAnalytics.track.event('Data Dictionary', 'downloaded data dictionary');

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -6,11 +6,91 @@
 
 {% block page_navigation %}
   <h2 class="text-hq-nav-header">{% trans "Data Dictionary" %}</h2>
-  <ul class="nav nav-hq-sidebar" data-bind="foreach: caseTypes">
+  <ul class="nav nav-hq-sidebar">
+    <!-- ko foreach: caseTypes -->
     <li data-bind="css: { active: $data.name == $root.activeCaseType() }">
       <a href="#" data-bind="text: $data.name, click: $root.goToCaseType"></a>
     </li>
+    <!-- /ko -->
+    <li>
+      <a href="#" data-bind="openModal: 'create-case-type'">
+        <i class="fa fa-plus"></i>
+        {% trans "Add Case Type" %}
+      </a>
+    </li>
   </ul>
+
+  <script type="text/html" id="create-case-type">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal">
+            <span aria-hidden="true">&times;</span>
+          </button>
+          <h4 class="modal-title">{% trans "Create a new Case Type" %}</h4>
+        </div>
+        <form class="form-horizontal"
+                style="margin: 0; padding: 0"
+                action="{% url "create_case_type" domain %}"
+                method="post"
+                data-bind="submit: submitCreate"
+        >
+            {% csrf_token %}
+            <div class="modal-body">
+              <fieldset>
+                <div class="form-group" data-bind="css: {'has-error': nameChecked() && !nameValid()}">
+                  <label for="name" class="col-xs-12 col-sm-4 col-md-4 col-lg-2 control-label">
+                    {% trans "Name" %}
+                  </label>
+                  <i class="fa" data-bind="
+                     visible: nameChecked(),
+                     css: {
+                         'fa-check': nameValid(),
+                         'text-success': nameValid(),
+                         'fa-remove': !nameValid(),
+                         'text-danger': !nameValid(),
+                     }
+                  "></i>
+                  <div class="col-xs-12 col-sm-8 col-md-8 col-lg-8 controls">
+                    <input type="text" name="name" class="form-control" required data-bind="textInput: name"/>
+                    <span class='help-block' data-bind="visible: nameChecked() && !nameValid()">
+                      {% trans "A case type with this name already exists." %}
+                    </span>
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label for="description" class="col-xs-12 col-sm-4 col-md-4 col-lg-2 control-label">
+                      {% trans "Description" %}
+                  </label>
+                  <div class="col-xs-12 col-sm-8 col-md-8 col-lg-8 controls">
+                    <textarea name="description" class="form-control"></textarea>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+            <div class="modal-footer">
+              <a href="#" data-dismiss="modal" class="btn btn-default" data-bind="
+                css: {disabled: formCreateCaseTypeSent()},
+                attr: {disabled: formCreateCaseTypeSent()}
+              ">{% trans 'Cancel' %}</a>
+              <button type="submit" class="btn btn-primary" data-bind="
+                css: {disabled: formCreateCaseTypeSent() || !nameValid()},
+                attr: {disabled: formCreateCaseTypeSent() || !nameValid()}
+              ">
+                <i class="fa fa-plus" data-bind="
+                   css: {
+                       'fa-plus': !formCreateCaseTypeSent(),
+                       'fa-refresh': formCreateCaseTypeSent,
+                       'fa-spin': formCreateCaseTypeSent
+                   }
+                "></i>
+                {% trans "Create Case Type" %}
+              </button>
+            </div>
+          </form>
+      </div>
+    </div>
+</script>
 {% endblock %}
 
 {% block page_content %}

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -9,7 +9,8 @@
   <ul class="nav nav-hq-sidebar">
     <!-- ko foreach: caseTypes -->
     <li data-bind="css: { active: $data.name == $root.activeCaseType() }">
-      <a href="#" data-bind="text: $data.name, click: $root.goToCaseType"></a>
+      {# navigation handle by URL hash #}
+      <a data-bind="text: $data.name, attr: {href: $data.url}"></a>
     </li>
     <!-- /ko -->
     <li>

--- a/corehq/apps/data_dictionary/urls.py
+++ b/corehq/apps/data_dictionary/urls.py
@@ -8,6 +8,7 @@ from corehq.apps.data_dictionary.views import (
     generate_data_dictionary,
     update_case_property,
     update_case_property_description,
+    create_case_type
 )
 from corehq.apps.hqwebapp.decorators import waf_allow
 
@@ -15,6 +16,7 @@ urlpatterns = [
     url(r"^generate/$", generate_data_dictionary, name='generate_data_dictionary'),
     url(r"^json/$", data_dictionary_json, name='data_dictionary_json'),
     url(r"^json/?(?P<case_type_name>\w+)/?$", data_dictionary_json, name='case_type_dictionary_json'),
+    url(r"^create_case_type/$", create_case_type, name='create_case_type'),
     url(r"^update_case_property/$", update_case_property, name='update_case_property'),
     url(r"^update_case_property_description/$", update_case_property_description, name='update_property_description'),
     url(r"^export/$", ExportDataDictionaryView.as_view(), name=ExportDataDictionaryView.urlname),

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError
 from django.db.models.query import Prefetch
 from django.db.transaction import atomic
 from django.http import HttpResponse, JsonResponse
+from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy as _
@@ -107,6 +108,22 @@ def data_dictionary_json(request, domain, case_type_name=None):
             })
         props.append(p)
     return JsonResponse({'case_types': props})
+
+
+@login_and_domain_required
+@toggles.DATA_DICTIONARY.required_decorator()
+def create_case_type(request, domain):
+    name = request.POST.get("name")
+    description = request.POST.get("description")
+    if not name:
+        messages.error(request, _("Case Type 'name' is required"))
+        return redirect(DataDictionaryView.urlname, domain=domain)
+
+    CaseType.objects.get_or_create(domain=domain, name=name, defaults={
+        "description": description,
+        "fully_generated": True
+    })
+    return redirect(DataDictionaryView.urlname, domain=domain)
 
 
 # atomic decorator is a performance optimization for looped saves

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -6,7 +6,7 @@ from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.db.models.query import Prefetch
 from django.db.transaction import atomic
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse, JsonResponse, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -123,7 +123,8 @@ def create_case_type(request, domain):
         "description": description,
         "fully_generated": True
     })
-    return redirect(DataDictionaryView.urlname, domain=domain)
+    url = reverse(DataDictionaryView.urlname, args=[domain])
+    return HttpResponseRedirect(f"{url}#{name}")
 
 
 # atomic decorator is a performance optimization for looped saves


### PR DESCRIPTION
This has bugged me for ages so I decided to fix it.

## Product Description
Allow creating new case types in the Data Dictionary from the UI.
Changes:
* clean up initial view when no case types are present and add a 'create case type' button
* Add a link in the sidebar navigation to create new case types
* Allow navigation to case types directly using URL hash navigtation e.g. `#my_case_type`
* 
![Peek 2021-10-01 11-03](https://user-images.githubusercontent.com/249606/135594475-7c10cc4d-d685-4f91-8adb-58be22d6e1dc.gif)

## Feature Flag
Data dictionary

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
None

### QA Plan
I've tested this locally:
* no case types
* create new case type
* attempt to create case type with the same name as one that exists
* navigate to case types by clicking links in the nav
* navigate to case types by accessing the URL directly

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
