### PR TITLE
small fixes to `ptop_preindex` command

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_preindex.py
+++ b/corehq/apps/hqcase/management/commands/ptop_preindex.py
@@ -91,12 +91,12 @@ class Command(BaseCommand):
         runs = []
         all_es_indices = list(get_all_expected_es_indices())
         es = get_es_new()
-        indices_needing_reindex = [info for info in all_es_indices if not es.indices.exists(info.index)]
 
-        if not indices_needing_reindex:
-            if options['reset']:
-                indices_needing_reindex = all_es_indices
-            else:
+        if options['reset']:
+            indices_needing_reindex = all_es_indices
+        else:
+            indices_needing_reindex = [info for info in all_es_indices if not es.indices.exists(info.index)]
+            if not indices_needing_reindex:
                 print('Nothing needs to be reindexed')
                 return
 

--- a/corehq/apps/hqcase/management/commands/ptop_preindex.py
+++ b/corehq/apps/hqcase/management/commands/ptop_preindex.py
@@ -89,13 +89,16 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         runs = []
-        all_es_indices = get_all_expected_es_indices()
+        all_es_indices = list(get_all_expected_es_indices())
         es = get_es_new()
         indices_needing_reindex = [info for info in all_es_indices if not es.indices.exists(info.index)]
 
         if not indices_needing_reindex:
-            print('Nothing needs to be reindexed')
-            return
+            if options['reset']:
+                indices_needing_reindex = all_es_indices
+            else:
+                print('Nothing needs to be reindexed')
+                return
 
         print("Reindexing:\n\t", end=' ')
         print('\n\t'.join(map(str, indices_needing_reindex)))


### PR DESCRIPTION
## Technical Summary
Fix the reindex `--reset` workflow by reindexing all indexes and passing the correct args.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
This should only impact dev workflows.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
