### PR TITLE
[Hubspot] No longer block users based on email domain, only on domains whose Billing Accounts have blocked hubspot

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -160,13 +160,6 @@ class BillingAccountBasicForm(forms.Form):
         help_text="Users in any projects connected to this account will not "
                   "have data sent to Hubspot",
     )
-    block_email_domains_from_hubspot = forms.CharField(
-        label="Block Email Domains From Hubspot Data",
-        required=False,
-        help_text="(ex: dimagi.com, commcarehq.org) Anyone with a username or "
-                  "email matching an email-domain here, regardless of "
-                  "project membership, will not have data synced with Hubspot.",
-    )
 
     def __init__(self, account, *args, **kwargs):
         self.account = account
@@ -188,7 +181,6 @@ class BillingAccountBasicForm(forms.Form):
                 'last_payment_method': account.last_payment_method,
                 'pre_or_post_pay': account.pre_or_post_pay,
                 'block_hubspot_data_for_all_users': account.block_hubspot_data_for_all_users,
-                'block_email_domains_from_hubspot': ', '.join(account.block_email_domains_from_hubspot),
             }
         else:
             kwargs['initial'] = {
@@ -270,10 +262,6 @@ class BillingAccountBasicForm(forms.Form):
                     hqcrispy.MultiInlineField(
                         'block_hubspot_data_for_all_users',
                     ),
-                ),
-                crispy.Field(
-                    'block_email_domains_from_hubspot',
-                    css_class='input-xxlarge',
                 ),
             ])
         self.helper.layout = crispy.Layout(
@@ -380,12 +368,6 @@ class BillingAccountBasicForm(forms.Form):
             )
         return transfer_subs
 
-    def clean_block_email_domains_from_hubspot(self):
-        email_domains = self.cleaned_data['block_email_domains_from_hubspot']
-        if email_domains:
-            return [e.strip() for e in email_domains.split(r',')]
-        return []  # Do not return a list with an empty string
-
     @transaction.atomic
     def create_account(self):
         name = self.cleaned_data['name']
@@ -421,7 +403,6 @@ class BillingAccountBasicForm(forms.Form):
         account.enterprise_restricted_signup_domains = self.cleaned_data['enterprise_restricted_signup_domains']
         account.invoicing_plan = self.cleaned_data['invoicing_plan']
         account.block_hubspot_data_for_all_users = self.cleaned_data['block_hubspot_data_for_all_users']
-        account.block_email_domains_from_hubspot = self.cleaned_data['block_email_domains_from_hubspot']
         transfer_id = self.cleaned_data['active_accounts']
         if transfer_id:
             transfer_account = BillingAccount.objects.get(id=transfer_id)

--- a/corehq/apps/analytics/management/commands/list_blocked_from_hubspot.py
+++ b/corehq/apps/analytics/management/commands/list_blocked_from_hubspot.py
@@ -2,7 +2,6 @@ from django.core.management import BaseCommand
 
 from corehq.apps.analytics.utils import (
     get_blocked_hubspot_domains,
-    get_blocked_hubspot_email_domains,
     get_blocked_hubspot_accounts,
 )
 
@@ -12,14 +11,10 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         blocked_domains = get_blocked_hubspot_domains()
-        blocked_email_domains = get_blocked_hubspot_email_domains()
         blocked_hubspot_accounts = get_blocked_hubspot_accounts()
 
         self.stdout.write('\n\nDomains Blocked From Hubspot\n')
         self.stdout.write('\n'.join(blocked_domains))
-
-        self.stdout.write('\n\nEmail-Domains Blocked From Hubspot\n')
-        self.stdout.write('\n'.join(blocked_email_domains))
 
         self.stdout.write('\n\nAccounts Blocked From Hubspot\n')
         self.stdout.write('\n'.join(blocked_hubspot_accounts))

--- a/corehq/apps/analytics/management/commands/manually_cleanup_blocked_hubspot_contacts.py
+++ b/corehq/apps/analytics/management/commands/manually_cleanup_blocked_hubspot_contacts.py
@@ -1,7 +1,6 @@
 from django.core.management import BaseCommand
 
 from corehq.apps.analytics.utils import (
-    remove_blocked_email_domains_from_hubspot,
     remove_blocked_domain_contacts_from_hubspot,
 )
 
@@ -10,5 +9,4 @@ class Command(BaseCommand):
     help = "Manually cleans up blocked Hubspot contacts"
 
     def handle(self, **options):
-        remove_blocked_email_domains_from_hubspot(self.stdout)
         remove_blocked_domain_contacts_from_hubspot(self.stdout)

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -39,7 +39,6 @@ from corehq.apps.analytics.utils import (
     get_blocked_hubspot_email_domains,
     hubspot_enabled_for_user,
     hubspot_enabled_for_email,
-    remove_blocked_email_domains_from_hubspot,
     remove_blocked_domain_contacts_from_hubspot,
     MAX_API_RETRIES,
 )
@@ -871,5 +870,4 @@ def cleanup_blocked_hubspot_contacts():
     if not HUBSPOT_ENABLED:
         return
 
-    remove_blocked_email_domains_from_hubspot()
     remove_blocked_domain_contacts_from_hubspot()

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -36,7 +36,6 @@ from corehq.apps.analytics.utils import (
     get_instance_string,
     get_meta,
     get_blocked_hubspot_domains,
-    get_blocked_hubspot_email_domains,
     hubspot_enabled_for_user,
     hubspot_enabled_for_email,
     remove_blocked_domain_contacts_from_hubspot,
@@ -505,7 +504,6 @@ def track_periodic_data():
     hubspot_number_of_users_blocked = 0
 
     blocked_domains = get_blocked_hubspot_domains()
-    blocked_email_domains = get_blocked_hubspot_email_domains()
 
     for chunk in range(num_chunks):
         users_to_domains = (user_query
@@ -542,28 +540,6 @@ def track_periodic_data():
         for user in users_to_domains:
             email = user.get('email') or user.get('username')
             if not _email_is_valid(email):
-                continue
-
-            email_domain = email.split('@')[-1]
-            if email_domain in blocked_email_domains:
-                metrics_gauge(
-                    'commcare.hubspot_data.rejected.periodic_task.email_domain',
-                    1,
-                    tags={
-                        'email_domain': email_domain,
-                    }
-                )
-                continue
-
-            username_email_domain = user.get('username').split('@')[-1]
-            if username_email_domain in blocked_email_domains:
-                metrics_gauge(
-                    'commcare.hubspot_data.rejected.periodic_task.username',
-                    1,
-                    tags={
-                        'username': username_email_domain,
-                    }
-                )
                 continue
 
             date_created = user.get('date_joined')

--- a/corehq/apps/analytics/tests/test_hubspot.py
+++ b/corehq/apps/analytics/tests/test_hubspot.py
@@ -111,6 +111,14 @@ class TestBlockedHubspotData(TestCase):
         cls.blocked_user.save()
         cls.blocked_couch_user = CouchUser.get_by_username(cls.blocked_user.username)
 
+        cls.second_blocked_user = WebUser.create(
+            cls.second_blocked_domain.name, 'aaa-test@gmail.com', '*****', None, None
+        )
+        cls.second_blocked_user.save()
+        cls.second_blocked_couch_user = CouchUser.get_by_username(
+            cls.second_blocked_user.username
+        )
+
         cls.blocked_commcare_user = CommCareUser.create(
             cls.blocked_domain.name, 'testuser', '****', None, None
         )
@@ -134,10 +142,12 @@ class TestBlockedHubspotData(TestCase):
 
     def test_hubspot_enabled_for_user(self):
         self.assertFalse(hubspot_enabled_for_user(self.blocked_user))
+        self.assertFalse(hubspot_enabled_for_user(self.second_blocked_user))
         self.assertTrue(hubspot_enabled_for_user(self.allowed_user))
 
     def test_hubspot_enabled_for_email(self):
         self.assertFalse(hubspot_enabled_for_email(self.blocked_user.username))
+        self.assertFalse(hubspot_enabled_for_email(self.second_blocked_user.username))
         self.assertTrue(hubspot_enabled_for_email(self.allowed_user.username))
 
     def test_couch_user_is_blocked(self):
@@ -150,6 +160,7 @@ class TestBlockedHubspotData(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.blocked_user.delete(cls.blocked_domain.name, deleted_by=None)
+        cls.second_blocked_user.delete(cls.second_blocked_domain.name, deleted_by=None)
         cls.allowed_user.delete(cls.allowed_domain.name, deleted_by=None)
         cls.blocked_domain.delete()
         cls.second_blocked_domain.delete()

--- a/corehq/apps/analytics/tests/test_hubspot.py
+++ b/corehq/apps/analytics/tests/test_hubspot.py
@@ -13,7 +13,6 @@ from corehq.apps.analytics.utils import (
     get_blocked_hubspot_email_domains,
     get_blocked_hubspot_accounts,
     is_domain_blocked_from_hubspot,
-    is_email_blocked_from_hubspot,
     hubspot_enabled_for_user,
     hubspot_enabled_for_email,
 )
@@ -112,16 +111,10 @@ class TestBlockedHubspotData(TestCase):
         )
         cls.allowed_user.save()
 
-        cls.blocked_by_email_user = WebUser.create(
-            cls.allowed_domain.name, 'jjj@blocked.com', '*****', None, None
-        )
-        cls.blocked_by_email_user.save()
-
         cls.blocked_user = WebUser.create(
             cls.blocked_domain.name, 'fff@example.com', '*****', None, None
         )
         cls.blocked_user.save()
-
         cls.blocked_couch_user = CouchUser.get_by_username(cls.blocked_user.username)
 
         cls.blocked_commcare_user = CommCareUser.create(
@@ -159,17 +152,11 @@ class TestBlockedHubspotData(TestCase):
         self.assertTrue(is_domain_blocked_from_hubspot(self.second_blocked_domain.name))
         self.assertFalse(is_domain_blocked_from_hubspot(self.allowed_domain.name))
 
-    def test_is_email_blocked_from_hubspot(self):
-        self.assertTrue(is_email_blocked_from_hubspot(self.blocked_by_email_user.username))
-        self.assertFalse(is_email_blocked_from_hubspot(self.allowed_user.username))
-
     def test_hubspot_enabled_for_user(self):
-        self.assertFalse(hubspot_enabled_for_user(self.blocked_by_email_user))
         self.assertFalse(hubspot_enabled_for_user(self.blocked_user))
         self.assertTrue(hubspot_enabled_for_user(self.allowed_user))
 
     def test_hubspot_enabled_for_email(self):
-        self.assertFalse(hubspot_enabled_for_email(self.blocked_by_email_user.username))
         self.assertFalse(hubspot_enabled_for_email(self.blocked_user.username))
         self.assertTrue(hubspot_enabled_for_email(self.allowed_user.username))
 
@@ -183,7 +170,6 @@ class TestBlockedHubspotData(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.blocked_user.delete(cls.blocked_domain.name, deleted_by=None)
-        cls.blocked_by_email_user.delete(cls.allowed_domain.name, deleted_by=None)
         cls.allowed_user.delete(cls.allowed_domain.name, deleted_by=None)
         cls.blocked_domain.delete()
         cls.second_blocked_domain.delete()

--- a/corehq/apps/analytics/tests/test_hubspot.py
+++ b/corehq/apps/analytics/tests/test_hubspot.py
@@ -71,7 +71,7 @@ class TestBlockedHubspotData(TestCase):
 
         plan = DefaultProductPlan.get_default_plan_version(edition=SoftwarePlanEdition.ADVANCED)
 
-        cls.blocked_account = generator.billing_account('test@diamgi.com', 'test@test.com')
+        cls.blocked_account = generator.billing_account('test@dimagi.com', 'test@test.com')
         cls.blocked_account.block_hubspot_data_for_all_users = True
         cls.blocked_account.save()
 
@@ -93,7 +93,7 @@ class TestBlockedHubspotData(TestCase):
 
         # this domain is not linked to an account that is blocking hubspot
         cls.allowed_domain = create_domain('allow-domain-hubspot')
-        allowed_account = generator.billing_account('test@diamgi.com', 'test@test.com')
+        allowed_account = generator.billing_account('test@dimagi.com', 'test@test.com')
         allowed_sub = Subscription.new_domain_subscription(
             allowed_account, cls.allowed_domain.name, plan
         )

--- a/corehq/apps/analytics/tests/test_hubspot.py
+++ b/corehq/apps/analytics/tests/test_hubspot.py
@@ -10,7 +10,6 @@ from corehq.apps.accounting.models import (
 from corehq.apps.accounting.tests import generator
 from corehq.apps.analytics.utils import (
     get_blocked_hubspot_domains,
-    get_blocked_hubspot_email_domains,
     get_blocked_hubspot_accounts,
     is_domain_blocked_from_hubspot,
     hubspot_enabled_for_user,
@@ -74,11 +73,6 @@ class TestBlockedHubspotData(TestCase):
 
         cls.blocked_account = generator.billing_account('test@diamgi.com', 'test@test.com')
         cls.blocked_account.block_hubspot_data_for_all_users = True
-        cls.blocked_account.block_email_domains_from_hubspot = [
-            'blocked.com',
-            'foo.org',
-            'gmail.com',
-        ]
         cls.blocked_account.save()
 
         # this is one domain linked to the billing account that blocks hubspot
@@ -126,20 +120,6 @@ class TestBlockedHubspotData(TestCase):
         self.assertListEqual(
             get_blocked_hubspot_domains(),
             [self.blocked_domain.name, self.second_blocked_domain.name]
-        )
-
-    def test_get_blocked_email_domains(self):
-        """
-        Ensure that gmail.com is never included in the list of blocked hubspot
-        email domains, and that if multiple values were specified, that they
-        are included.
-        """
-        self.assertListEqual(
-            sorted(get_blocked_hubspot_email_domains()),
-            sorted([
-                'blocked.com',
-                'foo.org',
-            ])
         )
 
     def test_get_blocked_hubspot_accounts(self):

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -78,25 +78,6 @@ def get_blocked_hubspot_domains():
     ).values_list('subscriber__domain', flat=True))
 
 
-def get_blocked_hubspot_email_domains():
-    """
-    Get the list of email domains (everything after the @ in an email address)
-    that have been blocked from Hubspot by BillingAccounts (excluding gmail.com)
-    :return: list
-    """
-    email_domains = {_email for email_list in BillingAccount.objects.filter(
-        is_active=True,
-    ).exclude(
-        block_email_domains_from_hubspot=[],
-    ).values_list(
-        'block_email_domains_from_hubspot',
-        flat=True,
-    ) for _email in email_list}
-    # we want to ensure that gmail.com is never a part of this list
-    email_domains.difference_update(['gmail.com'])
-    return list(email_domains)
-
-
 def get_blocked_hubspot_accounts():
     return [
         f'{account[1]} - ID # {account[0]}'

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -28,14 +28,6 @@ def analytics_enabled_for_email(email_address):
     return user.analytics_enabled if user else True
 
 
-def is_email_blocked_from_hubspot(email_address):
-    email_domain = email_address.split('@')[-1]
-    return BillingAccount.objects.filter(
-        is_active=True,
-        block_email_domains_from_hubspot__contains=[email_domain],
-    ).exists()
-
-
 def is_domain_blocked_from_hubspot(domain):
     return Subscription.visible_objects.filter(
         is_active=True,
@@ -52,8 +44,6 @@ def hubspot_enabled_for_user(user):
     :param user: CouchUser or WebUser
     :return: Boolean (True if hubspot is enabled/allowed)
     """
-    if is_email_blocked_from_hubspot(user.username):
-        return False
     if isinstance(user, WebUser):
         web_user = user
     else:

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -238,29 +238,6 @@ def _get_contact_ids_for_email_domain(email_domain, retry_num=0):
     return []
 
 
-def remove_blocked_email_domains_from_hubspot(stdout=None):
-    """
-    Removes contacts from Hubspot that emails matching our list of
-    blocked email domains.
-    :param stdout: the stdout of a management command (if applicable)
-    """
-    blocked_email_domains = get_blocked_hubspot_email_domains()
-    for email_domain in blocked_email_domains:
-        ids_to_delete = _get_contact_ids_for_email_domain(email_domain)
-        if stdout:
-            stdout.write(f"\n\nChecking EMAIL DOMAIN {email_domain}")
-            stdout.write(f"Found {len(ids_to_delete)} id(s) to delete.")
-        num_deleted = sum(_delete_hubspot_contact(vid) for vid in ids_to_delete)
-        metrics_gauge(
-            'commcare.hubspot_data.deleted_user.blocked_email_domain',
-            num_deleted,
-            tags={
-                'email_domain': email_domain,
-                'ids_deleted': ids_to_delete,
-            }
-        )
-
-
 def remove_blocked_domain_contacts_from_hubspot(stdout=None):
     """
     Removes contacts from Hubspot that are members of blocked domains.


### PR DESCRIPTION
## Product Description
Due to lots of confusion and risk for miscommunication, we have decided to remove the option for blocking users from Hubspot based on email domain. Instead, users will only be blocked if they are a member of any domain whose BillingAccount has blocked hubspot data for all users.

## Technical Summary
See https://dimagi-dev.atlassian.net/browse/SS-136 and associated summary doc for what prompted this change.

There will be a follow-up PR to remove the `block_email_domains_from_hubspot` property from `BillingAccounts`. For now, this just removes the functionality from HQ.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Yes.

### QA Plan
Tests are sufficient

### Safety story
Tests and metrics do a great job of ensuring that these changes will not cause issues.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
