### PR TITLE
Dropdown UI for custom filters & actions

### DIFF
--- a/corehq/apps/data_interfaces/forms.py
+++ b/corehq/apps/data_interfaces/forms.py
@@ -403,6 +403,8 @@ class CaseRuleCriteriaForm(forms.Form):
             )
         )
 
+        self.custom_filters = settings.AVAILABLE_CUSTOM_RULE_CRITERIA.keys()
+
     @property
     @memoized
     def requires_system_admin_to_edit(self):
@@ -655,6 +657,8 @@ class CaseRuleActionsForm(forms.Form):
                 css_id="rule-actions",
             ),
         )
+
+        self.custom_actions = settings.AVAILABLE_CUSTOM_RULE_ACTIONS.keys()
 
     @property
     def constants(self):

--- a/corehq/apps/data_interfaces/forms.py
+++ b/corehq/apps/data_interfaces/forms.py
@@ -464,8 +464,6 @@ class CaseRuleCriteriaForm(forms.Form):
                 self._json_fail_hard()
 
             name = obj['name'].strip()
-            if not name or name not in settings.AVAILABLE_CUSTOM_RULE_CRITERIA:
-                raise ValidationError(_("Invalid custom filter id reference"))
 
             result.append({
                 'name': name
@@ -750,8 +748,6 @@ class CaseRuleActionsForm(forms.Form):
                 self._json_fail_hard()
 
             name = obj['name'].strip()
-            if not name or name not in settings.AVAILABLE_CUSTOM_RULE_ACTIONS:
-                raise ValidationError(_("Invalid custom action ID reference"))
 
             result.append({
                 'name': name

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_actions.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_actions.html
@@ -91,7 +91,11 @@
     <div data-bind="template: {name: 'remove-action'}"></div>
     <label class="control-label col-xs-2">{% trans "Custom action ID" %}</label>
     <div class="controls col-xs-4">
-      <input type="text" class="textinput form-control" data-bind="value: name" required placeholder="{% trans 'custom action id' %}" />
+      <select class="select form-control" data-bind="value: name">
+        {% for custom_action in form.custom_actions %}
+          <option value="{{ custom_action }}">{{ custom_action }}</option>
+        {% endfor %}
+      </select>
     </div>
     <label class="col-xs-1 control-label">
       <span class="label label-primary">{% trans "Requires System Admin" %}</span>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_criteria.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_criteria.html
@@ -188,7 +188,11 @@
     <div data-bind="template: {name: 'remove-filter'}"></div>
     <label class="control-label col-xs-2">{% trans "Custom filter ID" %}</label>
     <div class="controls col-xs-4">
-      <input type="text" data-bind="value: name" required class="textinput form-control" placeholder="{% trans 'custom filter id' %}" />
+      <select class="select form-control" data-bind="value: name">
+        {% for custom_filter in form.custom_filters %}
+          <option value="{{ custom_filter }}">{{ custom_filter }}</option>
+        {% endfor %}
+      </select>
     </div>
     <label class="col-xs-1 control-label">
       <span class="label label-primary">Requires System Admin</span>


### PR DESCRIPTION
## Product Description
Currently, USH projects using custom actions or filters must manually type in the IDs for the filters or actions. This addition will allow them to select the IDs from a dropdown list to avoid possible errors when typing in the IDs manually.

## Technical Summary
In response to [this Jira ticket](https://dimagi-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=143&modal=detail&selectedIssue=USH-1195). I made it a simple dropdown using the same HTML style from the case type dropdown also in the Automatically Update Cases page.

Dropdown options are selected from the AVAILABLE_CUSTOM_RULE_CRITERIA and AVAILABLE_CUSTOM_RULE_ACTIONS dictionaries in settings.py.

## Dropdown UI

Selecting from the dropdown:

<img width="600" alt="Criteria" src="https://user-images.githubusercontent.com/6729291/135678036-d5aae101-2742-4d7a-9cad-8bd2680b9ef6.png">

Item selected in dropdown:

<img width="600" alt="Screen Shot 2021-10-01 at 3 45 53 PM" src="https://user-images.githubusercontent.com/6729291/135678075-dac27532-8779-4f8a-a588-c115ffbbe9f6.png">

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests.

### Safety story
I looked at the form value saved after submission to see that it updated properly, i.e. 
`value="[{&quot;name&quot;:&quot;TEST_RULE&quot;}]"`
and
`print(criteria.definition)` outputs `TEST_RULE`

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
