### PR TITLE
Check domain_obj is not None

### DIFF
--- a/corehq/motech/dhis2/tasks.py
+++ b/corehq/motech/dhis2/tasks.py
@@ -25,7 +25,9 @@ from corehq.apps.domain.models import Domain
 )
 def send_datasets_for_all_domains():
     for domain in find_domains_with_toggle_enabled(toggles.DHIS2_INTEGRATION):
-        send_datasets.delay(domain) if _data_forwarding_privilege(domain) else None
+        domain_obj = Domain.get_by_name(domain)
+        if domain_obj and domain_obj.has_privilege(DATA_FORWARDING):
+            send_datasets.delay(domain)
 
 
 @task(serializer='pickle', queue='background_queue')
@@ -35,10 +37,6 @@ def send_datasets(domain_name, send_now=False, send_date=None):
     for dataset_map in SQLDataSetMap.objects.filter(domain=domain_name).all():
         if send_now or should_send_on_date(dataset_map, send_date):
             send_dataset(dataset_map, send_date)
-
-
-def _data_forwarding_privilege(domain_name):
-    return Domain.get_by_name(domain_name).has_privilege(DATA_FORWARDING)
 
 
 def send_dataset(

--- a/corehq/motech/dhis2/tests/test_tasks.py
+++ b/corehq/motech/dhis2/tests/test_tasks.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+
+from corehq import toggles
+from corehq.motech.dhis2.tasks import send_datasets_for_all_domains
+
+
+class TestSendDatasetsForAllDomains(TestCase):
+
+    domain_name = 'does-not-exist'
+
+    def setUp(self):
+        toggles.DHIS2_INTEGRATION.set(
+            self.domain_name,
+            enabled=True,
+            namespace=toggles.NAMESPACE_DOMAIN
+        )
+
+    def tearDown(self):
+        toggles.DHIS2_INTEGRATION.set(
+            self.domain_name,
+            enabled=False,
+            namespace=toggles.NAMESPACE_DOMAIN
+        )
+
+    def test_check_domain_exists(self):
+        """
+        send_datasets_for_all_domains() should not raise an AttributeError
+        if a domain does not exist
+        """
+        send_datasets_for_all_domains()


### PR DESCRIPTION
## Technical Summary

Context: [SC-1758](https://dimagi-dev.atlassian.net/browse/SC-1758)

On Staging there is a domain that has the DHIS2_INTEGRATION toggle enabled, but has been deleted. Instead of just unsetting the toggle for that domain name, I also made this change to check whether a Domain object exists before trying to check its privileges.

## Feature Flag
DHIS2 Integration

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Includes test.

### QA Plan

QA picked up this bug on Staging in [QA-3491](https://dimagi-dev.atlassian.net/browse/QA-3491)

### Safety story

Investigated this bug, and tested this change in a shell on Staging.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
