### PR TITLE
Update CaseAccessors.get_case() to check domain

### DIFF
--- a/corehq/apps/api/resources/v0_3.py
+++ b/corehq/apps/api/resources/v0_3.py
@@ -58,12 +58,8 @@ class CommCareCaseResource(HqBaseResource, DomainSpecificResourceMixin):
 
     def obj_get(self, bundle, **kwargs):
         case_id = kwargs['pk']
-        domain = kwargs['domain']
         try:
-            case = CaseAccessors(domain).get_case(case_id)
-            if case.domain != domain:
-                raise CaseNotFound
-            return case
+            return CaseAccessors(kwargs['domain']).get_case(case_id)
         except CaseNotFound:
             raise object_does_not_exist("CommCareCase", case_id)
 

--- a/corehq/apps/sms/tests/test_phone_numbers.py
+++ b/corehq/apps/sms/tests/test_phone_numbers.py
@@ -373,7 +373,7 @@ class SQLPhoneNumberTestCase(TestCase):
 
     def test_case_owner(self):
         with create_test_case(self.domain, 'participant', 'test') as case:
-            number = PhoneNumber(owner_doc_type='CommCareCase', owner_id=case.case_id)
+            number = PhoneNumber(domain=self.domain, owner_doc_type='CommCareCase', owner_id=case.case_id)
             owner = number.owner
             self.assertTrue(is_commcarecase(owner))
             self.assertEqual(owner.case_id, case.case_id)

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -326,7 +326,7 @@ class TestCaseHierarchy(TestCase):
         ).as_text()
         submit_case_blocks(case_block, 'test-transactions', form_id=form_id)
         with self.assertRaises(CaseNotFound):
-            CaseAccessors().get_case(case_id2)
+            CaseAccessors('domain_name').get_case(case_id2)
 
         # form with same ID submitted but now has a new case transaction
         new_case_block = CaseBlock.deprecated_init(
@@ -335,7 +335,7 @@ class TestCaseHierarchy(TestCase):
             case_type='t1',
         ).as_text()
         submit_case_blocks([case_block, new_case_block], 'test-transactions', form_id=form_id)
-        case2 = CaseAccessors().get_case(case_id2)
+        case2 = CaseAccessors('test-transactions').get_case(case_id2)
         self.assertEqual([form_id], case2.xform_ids)
         self.assertEqual('t1', case2.type)
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_factory.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_factory.py
@@ -105,7 +105,7 @@ class CaseFactoryTest(TestCase):
     def test_simple_create(self):
         factory = CaseFactory()
         case = factory.create_case()
-        self.assertIsNotNone(CaseAccessors().get_case(case.case_id))
+        self.assertIsNotNone(CaseAccessors(case.domain).get_case(case.case_id))
 
     def test_create_overrides(self):
         factory = CaseFactory()

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_from_xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_from_xform.py
@@ -32,7 +32,7 @@ class CaseFromXFormTest(TestCase):
 
         xform2, case = bootstrap_case_from_xml(self, "update.xml", original_case.case_id)
         # fetch the case from the DB to ensure it is property wrapped
-        case = CaseAccessors().get_case(case.case_id)
+        case = CaseAccessors(case.domain).get_case(case.case_id)
         self.assertEqual(False, case.closed)
 
         self._check_transactions(case, [xform1, xform2])

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multi_case_submits.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multi_case_submits.py
@@ -40,6 +40,6 @@ class MultiCaseTest(TestCase):
 
     def _check_ids(self, form, cases):
         for case in cases:
-            ids = CaseAccessors().get_case_xform_ids(case.case_id)
+            ids = CaseAccessors(case.domain).get_case_xform_ids(case.case_id)
             self.assertEqual(1, len(ids))
             self.assertEqual(form.form_id, ids[0])

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -198,7 +198,7 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
     def testOTARestoreSingle(self):
         _, case = self._doCreateCaseWithMultimedia()
         restore_attachments = ['fruity_file']
-        self._validateOTARestore(case.case_id, restore_attachments)
+        self._validateOTARestore(case.domain, case.case_id, restore_attachments)
 
     @flag_enabled('MM_CASE_PROPERTIES')
     def testOTARestoreMultiple(self):
@@ -207,10 +207,10 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
         removes = ['fruity_file']
         _, case = self._doSubmitUpdateWithMultimedia(new_attachments=restore_attachments, removes=removes)
 
-        self._validateOTARestore(case.case_id, restore_attachments)
+        self._validateOTARestore(case.domain, case.case_id, restore_attachments)
 
-    def _validateOTARestore(self, case_id, restore_attachments):
-        case_xml = CaseAccessors().get_case(case_id).to_xml(V2)
+    def _validateOTARestore(self, domain, case_id, restore_attachments):
+        case_xml = CaseAccessors(domain).get_case(case_id).to_xml(V2)
         root_node = lxml.etree.fromstring(case_xml)
         attaches = root_node.find('{http://commcarehq.org/case/transaction/v2}attachment')
         self.assertEqual(len(restore_attachments), len(attaches))

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_out_of_order_processing.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_out_of_order_processing.py
@@ -20,7 +20,7 @@ class OutOfOrderCaseTest(TestCase):
                 xml_data = f.read()
             submit_form_locally(xml_data, 'test-domain')
 
-        case = CaseAccessors().get_case('30bc51f6-3247-4966-b4ae-994f572e85fe')
+        case = CaseAccessors('test-domain').get_case('30bc51f6-3247-4966-b4ae-994f572e85fe')
         self.assertEqual('from the update form', case.case_json['pupdate'])
         self.assertEqual('from the create form', case.case_json['pcreate'])
         # NOTE the SQL form processor works differently than the Couch one did:

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -221,7 +221,7 @@ class CaseRebuildTest(TestCase):
             [update_block.as_xml()], form_extras={'received_on': earlier}
         )
 
-        case_accessors = CaseAccessors(REBUILD_TEST_DOMAIN)
+        case_accessors = CaseAccessors('test-domain')
         case = case_accessors.get_case(case_id)
         self.assertEqual(earlier, case.modified_on)
 
@@ -262,7 +262,7 @@ class CaseRebuildTest(TestCase):
             CaseBlock.deprecated_init(child_case_id, index={'mom': ('mother', parent_case_id)}).as_xml()
         ])
 
-        case_accessors = CaseAccessors(REBUILD_TEST_DOMAIN)
+        case_accessors = CaseAccessors('test-domain')
         case = case_accessors.get_case(child_case_id)
         self.assertEqual(1, len(case.indices))
 

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -398,7 +398,7 @@ class CaseAccessors(object):
             raise CaseNotFound
         case = self.db_accessor.get_case(case_id)
         if case.domain != self.domain:
-            raise CaseNotFound
+            raise CaseNotFound(case_id)
         return case
 
     def get_cases(self, case_ids, ordered=False, prefetched_indices=None):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -384,7 +384,7 @@ class CaseAccessors(object):
     Facade for Case DB access that proxies method calls to SQL or Couch version
     """
 
-    def __init__(self, domain=None):
+    def __init__(self, domain):
         self.domain = domain
 
     @property
@@ -396,7 +396,10 @@ class CaseAccessors(object):
     def get_case(self, case_id):
         if not case_id:
             raise CaseNotFound
-        return self.db_accessor.get_case(case_id)
+        case = self.db_accessor.get_case(case_id)
+        if case.domain != self.domain:
+            raise CaseNotFound
+        return case
 
     def get_cases(self, case_ids, ordered=False, prefetched_indices=None):
         return self.db_accessor.get_cases(

--- a/corehq/form_processor/tests/test_dbcache.py
+++ b/corehq/form_processor/tests/test_dbcache.py
@@ -58,7 +58,7 @@ class CaseDbCacheTest(TestCase):
             self.assertFalse(cache.in_cache(id))
 
         for id in case_ids:
-            cache.set(id, CaseAccessors().get_case(id))
+            cache.set(id, CaseAccessors('dbcache-test').get_case(id))
 
         for i, id in enumerate(case_ids):
             self.assertTrue(cache.in_cache(id))

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -976,7 +976,7 @@ class TestRepeaterPause(BaseRepeaterTest):
         with patch.object(RepeatRecord, 'fire') as mock_fire:
             with patch.object(RepeatRecord, 'postpone_by') as mock_postpone_fire:
                 # calls _process_repeat_record():
-                self.repeat_record = self.repeater.register(CaseAccessors(self.domain_obj).get_case(CASE_ID))
+                self.repeat_record = self.repeater.register(CaseAccessors(self.domain).get_case(CASE_ID))
                 self.assertEqual(mock_fire.call_count, 1)
                 self.assertEqual(mock_postpone_fire.call_count, 0)
 
@@ -1027,7 +1027,7 @@ class TestRepeaterDeleted(BaseRepeaterTest):
         self.repeater.retire()
 
         with patch.object(RepeatRecord, 'fire') as mock_fire:
-            self.repeat_record = self.repeater.register(CaseAccessors(self.domain_obj).get_case(CASE_ID))
+            self.repeat_record = self.repeater.register(CaseAccessors(self.domain).get_case(CASE_ID))
             _process_repeat_record(self.repeat_record)
             self.assertEqual(mock_fire.call_count, 0)
             self.assertEqual(self.repeat_record.doc_type, "RepeatRecord-Deleted")
@@ -1037,7 +1037,7 @@ class TestRepeaterDeleted(BaseRepeaterTest):
         self.repeater.retire()
 
         with patch.object(RepeatRecord, 'fire') as mock_fire:
-            self.repeat_record = self.repeater.register(CaseAccessors(self.domain_obj).get_case(CASE_ID))
+            self.repeat_record = self.repeater.register(CaseAccessors(self.domain).get_case(CASE_ID))
             _process_repeat_record(self.repeat_record)
             self.assertEqual(mock_fire.call_count, 0)
             self.assertEqual(self.repeat_record.doc_type, "RepeatRecord-Deleted")


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[JIRA ticket
](https://dimagi-dev.atlassian.net/browse/SAAS-11927)

Now checks to make sure case domain matches what the caller passed in. Undoes [this PR](https://github.com/dimagi/commcare-hq/pull/29302) which was a temporary solution to the bug.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

[Jira Ticket
](https://dimagi-dev.atlassian.net/browse/QA-3598)
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Locally tested (tests updated to reflect changes). 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
