### PR TITLE
Removed users/base_template.html

### DIFF
--- a/corehq/apps/users/static/users/js/invite_web_user.js
+++ b/corehq/apps/users/static/users/js/invite_web_user.js
@@ -4,6 +4,7 @@ hqDefine('users/js/invite_web_user',[
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',
     'hqwebapp/js/validators.ko',
+    'locations/js/widgets',
 ], function (
     $,
     ko,

--- a/corehq/apps/users/templates/users/base_template.html
+++ b/corehq/apps/users/templates/users/base_template.html
@@ -1,7 +1,3 @@
 {% extends 'hqwebapp/base_section.html' %}
 {% load i18n %}
 {% load hq_shared_tags %}
-
-{% block js %}{{ block.super }}
-  <script src="{% static "locations/js/widgets.js" %}"></script>
-{% endblock %}

--- a/corehq/apps/users/templates/users/base_template.html
+++ b/corehq/apps/users/templates/users/base_template.html
@@ -1,3 +1,0 @@
-{% extends 'hqwebapp/base_section.html' %}
-{% load i18n %}
-{% load hq_shared_tags %}

--- a/corehq/apps/users/templates/users/confirm_turn_off_demo_mode.html
+++ b/corehq/apps/users/templates/users/confirm_turn_off_demo_mode.html
@@ -1,4 +1,4 @@
-{% extends 'users/base_template.html' %}
+{% extends 'hqwebapp/base_section.html' %}
 {% load hq_shared_tags %}
 {% load i18n %}
 

--- a/corehq/apps/users/templates/users/deleted_account.html
+++ b/corehq/apps/users/templates/users/deleted_account.html
@@ -1,4 +1,4 @@
-{% extends "users/base_template.html" %}
+{% extends 'hqwebapp/base_section.html' %}
 {% load i18n %}
 
 {% block page_content %}

--- a/corehq/apps/users/templates/users/edit_commcare_user.html
+++ b/corehq/apps/users/templates/users/edit_commcare_user.html
@@ -1,5 +1,4 @@
-{% extends 'users/base_template.html' %}
-{# This is for editing information for a CommCareUser #}
+{% extends 'hqwebapp/base_section.html' %}
 
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}

--- a/corehq/apps/users/templates/users/edit_web_user.html
+++ b/corehq/apps/users/templates/users/edit_web_user.html
@@ -1,4 +1,4 @@
-{% extends 'users/base_template.html' %}
+{% extends 'hqwebapp/base_section.html' %}
 
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}

--- a/corehq/apps/users/templates/users/edit_web_user.html
+++ b/corehq/apps/users/templates/users/edit_web_user.html
@@ -4,6 +4,8 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
+{% requirejs_main "locations/js/widgets" %}
+
 {% block page_content %}
   {% if has_untrusted_identity_provider %}
     <div class="alert alert-setting">

--- a/corehq/apps/users/templates/users/extra_users_confirm_billing.html
+++ b/corehq/apps/users/templates/users/extra_users_confirm_billing.html
@@ -1,4 +1,4 @@
-{% extends "users/base_template.html" %}
+{% extends 'hqwebapp/base_section.html' %}
 {% load i18n %}
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}

--- a/corehq/apps/users/templates/users/filter_and_download.html
+++ b/corehq/apps/users/templates/users/filter_and_download.html
@@ -1,4 +1,4 @@
-{% extends 'users/base_template.html' %}
+{% extends 'hqwebapp/base_section.html' %}
 {% load hq_shared_tags %}
 {% load i18n %}
 {% load crispy_forms_tags %}

--- a/corehq/apps/users/templates/users/invite_web_user.html
+++ b/corehq/apps/users/templates/users/invite_web_user.html
@@ -1,4 +1,4 @@
-{% extends "users/base_template.html" %}
+{% extends 'hqwebapp/base_section.html' %}
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 {% load i18n %}

--- a/docs/class_views.rst
+++ b/docs/class_views.rst
@@ -140,13 +140,6 @@ in addition to:
             {# a great place to put modals #}
         {% endblock %}
 
-.. note:: Organizing Section Templates
-
-    Currently, the practice is to extend `hqwebapp/base_section.html` in a base template for
-    your section (e.g. `users/base_template.html`) and your section page will then extend
-    its section's base template.
-
-
 Adding to Urlpatterns
 ---------------------
 


### PR DESCRIPTION
## Technical Summary
Noticed while reviewing https://github.com/dimagi/commcare-hq/pull/30503/

Requirejs pages shouldn't have script tags, either in themselves or in any of their ancestor templates.

Most of the child templates either 
1. don't need the locations widgets or 
1. _do_ need the locations widgets, but they already have a requirejs_main module that includes the locations widgets as a dependency.

The exceptions are
1. The edit web user page. This one wasn't using any other javascript, so I just made the locations widget its requirejs_main.
1. The invite web user page. I think this was able to work because it only depends on globals. Or possibly it wasn't working and that went unreported because the location widget is only visible on this page for commtrack domains.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None

### QA Plan

No QA

### Safety story
I tested locally that the locations widget still works on the edit web users page. The other changes are rote.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
