### PR TITLE
disable case updates for 'registry cases'

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
@@ -140,10 +140,21 @@
 
     {% if form.source %}
       <!--ko if: actionType() === 'update' -->
+      {% if module_offers_registry_search %}
+      <div class="panel panel-appmanager">
+        <div class="panel-body">
+          <p>{% blocktrans trimmed %}Updating cases directly is not supported when using data registry search. Refer
+            to the <a href="https://confluence.dimagi.com/display/USH/Data+Registry#DataRegistry-Updatingcases" target="_blank">documentation</a>
+            for information on how to update cases from a data registry.
+          {% endblocktrans %}</p>
+        </div>
+      </div>
+      {% else %}
       <div data-bind="template: {
                         name: 'case-config:case-transaction',
                         data: case_transaction
                       }"></div>
+      {% endif %}
       <!--/ko-->
       <!--ko if: actionType() === 'open' -->
       <div data-bind="template: {
@@ -152,7 +163,12 @@
                       }"></div>
       <!--/ko-->
       {% if add_ons.subcases %}
+        {% if module_offers_registry_search %}
+        {# only allow subcases when also opening a case since we can't attach subcases to a case in another domain #}
+        <!--ko if: actionType() === 'open'-->
+        {% else %}
         <!--ko if: actionType() !== 'none'-->
+        {% endif %}
         <hr />
         <p class="lead">
           {% blocktrans %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
@@ -115,7 +115,11 @@
           </p>
 
           {% trans "Registration: This form opens a new case" as registers_case %}
-          {% trans "Followup: This form loads a case and may then update or close it" as updates_case %}
+          {% if module_offers_registry_search %}
+            {% trans "Followup: This form loads a case from a data registry" as updates_case %}
+          {% else %}
+            {% trans "Followup: This form loads a case and may then update or close it" as updates_case %}
+          {% endif %}
           <select class="form-control"
                   id="case-action-select"
                   data-bind="optstr: [

--- a/corehq/apps/app_manager/tests/test_extension_case.py
+++ b/corehq/apps/app_manager/tests/test_extension_case.py
@@ -189,7 +189,7 @@ class CaseBlockIndexRelationshipTest(SimpleTestCase, TestXmlMixin):
             has_case_sharing=self.form.get_app().case_sharing,
             case_id=case_id
         )
-        self.subcase_block.add_update_block(self.subcase.case_properties)
+        self.subcase_block.add_case_updates(self.subcase.case_properties)
 
     def test_xform_case_block_index_supports_relationship(self):
         """

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -81,7 +81,7 @@ from corehq.apps.app_manager.util import (
     advanced_actions_use_usercase,
     enable_usercase,
     is_usercase_in_use,
-    save_xform,
+    save_xform, module_offers_registry_search,
 )
 from corehq.apps.app_manager.views.media_utils import handle_media_edits
 from corehq.apps.app_manager.views.notifications import notify_form_changed
@@ -778,6 +778,7 @@ def get_form_view_context_and_template(request, domain, form, langs, current_lan
         ],
         'form_icon': None,
         'session_endpoints_enabled': toggles.SESSION_ENDPOINTS.enabled(domain),
+        'module_offers_registry_search': module_offers_registry_search(module),
     }
 
     if toggles.CUSTOM_ICON_BADGES.enabled(domain):

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1563,11 +1563,12 @@ class XForm(WrappedNode):
     def _create_casexml_2(self, form):
         actions = form.active_actions()
 
-        if form.requires == 'none' and 'open_case' not in actions and 'update_case' in actions:
+        form_opens_case = 'open_case' in actions
+        if form.requires == 'none' and not form_opens_case and 'update_case' in actions:
             raise CaseError("To update a case you must either open a case or require a case to begin with")
 
         delegation_case_block = None
-        if not actions or (form.requires == 'none' and 'open_case' not in actions):
+        if not actions or (form.requires == 'none' and not form_opens_case):
             case_block = None
         else:
             case_block = XFormCaseBlock(self)
@@ -1600,7 +1601,7 @@ class XForm(WrappedNode):
                     delegation_case_block = make_delegation_stub_case_block()
 
             case_id_xpath = get_add_case_preloads_case_id_xpath(module, form)
-            if 'open_case' in actions:
+            if form_opens_case:
                 open_case_action = actions['open_case']
                 case_block.add_create_block(
                     relevance=self.action_relevance(open_case_action.condition),

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -468,7 +468,7 @@ class XFormCaseBlock(object):
         self.elem.append(update_block)
         return update_block
 
-    def add_update_block(self, updates, make_relative=False):
+    def add_case_updates(self, updates, make_relative=False):
         update_block = self.update_block
         if not updates:
             return
@@ -1396,7 +1396,7 @@ class XForm(WrappedNode):
             self._add_usercase_bind(usercase_path)
             usercase_block = _make_elem('{x}commcare_usercase')
             case_block = XFormCaseBlock(self, usercase_path)
-            case_block.add_update_block(actions['usercase_update'].update)
+            case_block.add_case_updates(actions['usercase_update'].update)
             usercase_block.append(case_block.elem)
             self.data_node.append(usercase_block)
 
@@ -1682,7 +1682,7 @@ class XForm(WrappedNode):
                     case_id=case_id
                 )
 
-                subcase_block.add_update_block(subcase.case_properties)
+                subcase_block.add_case_updates(subcase.case_properties)
 
                 if subcase.close_condition.is_active():
                     subcase_block.add_close_block(self.action_relevance(subcase.close_condition))
@@ -1947,7 +1947,7 @@ class XForm(WrappedNode):
             )
 
             if action.case_properties:
-                open_case_block.add_update_block(action.case_properties)
+                open_case_block.add_case_updates(action.case_properties)
 
             for case_index in action.case_indices:
                 parent_meta = form.actions.actions_meta_by_tag.get(case_index.tag)
@@ -2007,7 +2007,7 @@ class XForm(WrappedNode):
             # 90% use-case
             basic_updates = updates_by_case.pop('')
             if basic_updates:
-                case_block.add_update_block(basic_updates)
+                case_block.add_case_updates(basic_updates)
         if updates_by_case:
             self.add_casedb()
 
@@ -2038,7 +2038,7 @@ class XForm(WrappedNode):
                     node_path,
                     parent_path,
                     case_id_xpath=case_id_xpath)
-                parent_case_block.add_update_block(updates)
+                parent_case_block.add_case_updates(updates)
                 node.append(parent_case_block.elem)
 
     def get_scheduler_case_updates(self):


### PR DESCRIPTION
## Product Description
When using registry case search the case can not be updated directly via normal case management since they may belong to a different project space. 

This PR updates the case management UI and xform generation code to disable the case update sections. Cases can still be opened as normal.

Any updates to the cases loaded from the registry must be done indirectly using save-to-case. See https://confluence.dimagi.com/display/USH/Data+Registry#DataRegistry-Updatingcases

## Technical Summary
When action is 'followup' and the module is configured with 'registry case search':
* Disable case update UI
* Disable adding case blocks into the form to update the case 

Best reviewed by commit.

## Feature Flag
DATA_REGISTRY

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Code is well covered by tests. New specific to this workflow are added.

### QA Plan
Will be QA'd on staging

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
