### PR TITLE
Prevent error if there is no 'edit_data' permission

### DIFF
--- a/corehq/apps/users/migrations/0037_add_edit_messaging_permission.py
+++ b/corehq/apps/users/migrations/0037_add_edit_messaging_permission.py
@@ -9,7 +9,7 @@ from corehq.util.django_migrations import skip_on_fresh_install
 @skip_on_fresh_install
 def migrate_edit_migrations_permissions(apps, schema_editor):
     permission, created = SQLPermission.objects.get_or_create(value='edit_messaging')
-    edit_data_permission = SQLPermission.objects.get(value='edit_data')
+    edit_data_permission = SQLPermission.objects.get_or_create(value='edit_data')
     role_ids_with_edit_data = set(UserRole.objects.filter(rolepermission__permission_fk_id=edit_data_permission.id)
                                   .values_list("id", flat=True))
     for chunk in chunked(role_ids_with_edit_data, 50):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This is a followup for https://github.com/dimagi/commcare-hq/pull/30431

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
There would be an error if someone tried to run this migration and they did not already have `edit_data`. This switches from `get` to `get_or_create` for that case

## Safety Assurance

- [X] Risk label is set correctly
- [X] All migrations are backwards compatible and won't block deploy
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
none

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This allows for the instance that `edit_data` doesn't already exist for when this migration is run, but otherwise works the same

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations 
