### PR TITLE
Allow case searching by "commcare_project"

### DIFF
--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -181,6 +181,8 @@ class CaseSearchCriteria:
         elif key == CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY:
             if value:
                 return case_search.blacklist_owner_id(value.split(' ')), False
+        elif key == COMMCARE_PROJECT:
+            return filters.domain(value), False
         elif key not in UNSEARCHABLE_KEYS and not key.startswith(SEARCH_QUERY_CUSTOM_VALUE):
             return self._get_case_property_query(key, value), True
         return None, None


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-1319
This is really only relevant to the data registry.  Right now there's no way to further restrict results by domain - you search all domains available to your domain/user.  This change allows you to search `commcare_project`, and it will further restrict the results (it doesn't allow access beyond what the data registry gives you).  We already insert a pseudo case property into registry search results called `commcare_project`, so this is a natural parallel.  Note that it's not specifically limited to data registry searches, but it wouldn't be useful outside that context.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
Enable Data Registries

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally and with automated tests

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 