### PR TITLE
Fixed smart linking of linked app

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -595,7 +595,7 @@ def session_endpoint(request, domain, app_id, endpoint_id):
         from corehq.apps.linked_domain.applications import get_downstream_app_id_map
         id_map = get_downstream_app_id_map(domain)
         if app_id in id_map:
-            if len(id_map[app_id] == 1):
+            if len(id_map[app_id]) == 1:
                 build = _fetch_build(domain, request.couch_user.username, id_map[app_id][0])
         if not build:
             return _fail(_("Could not find application."))

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -595,7 +595,8 @@ def session_endpoint(request, domain, app_id, endpoint_id):
         from corehq.apps.linked_domain.applications import get_downstream_app_id_map
         id_map = get_downstream_app_id_map(domain)
         if app_id in id_map:
-            build = _fetch_build(domain, request.couch_user.username, id_map[app_id])
+            if len(id_map[app_id] == 1):
+                build = _fetch_build(domain, request.couch_user.username, id_map[app_id][0])
         if not build:
             return _fail(_("Could not find application."))
     build = wrap_app(build)


### PR DESCRIPTION
## Technical Summary
Followup for https://github.com/dimagi/commcare-hq/pull/30441

I missed that the `get_downstream_app_id_map` returns a dict where values are lists of ids, not single ids.

The case where you have multiple downstream apps is pretty unlikely, so I didn't make a distinct error for it.

## Feature Flag
Data registry

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

None for this line

### QA Plan

No QA

### Safety story
Minor change to code that isn't being used by any real clients yet.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
