### PR TITLE
Remove serializer='pickle' from phonelog

### DIFF
--- a/corehq/ex-submodules/phonelog/tasks.py
+++ b/corehq/ex-submodules/phonelog/tasks.py
@@ -24,11 +24,12 @@ def purge_old_device_report_entries():
     UserEntry.objects.filter(server_date__lt=max_age).delete()
 
 
-@no_result_task(serializer='pickle', queue='sumologic_logs_queue', default_retry_delay=10 * 60, max_retries=3, bind=True)
+@no_result_task(queue='sumologic_logs_queue', default_retry_delay=10 * 60, max_retries=3, bind=True)
 def send_device_log_to_sumologic(self, url, data, headers):
     with Session() as s:
         s.mount(url, HTTPAdapter(max_retries=5))
         try:
-            s.post(url, data=data, headers=headers, timeout=5)
+            s.post(url, data=data.encode('utf-8'),
+                   headers={b"X-Sumo-Category": headers.encode('utf-8')}, timeout=5)
         except RequestException as e:
             self.retry(exc=e)

--- a/corehq/ex-submodules/phonelog/tasks.py
+++ b/corehq/ex-submodules/phonelog/tasks.py
@@ -26,10 +26,11 @@ def purge_old_device_report_entries():
 
 @no_result_task(queue='sumologic_logs_queue', default_retry_delay=10 * 60, max_retries=3, bind=True)
 def send_device_log_to_sumologic(self, url, data, headers):
+    encoded_headers = {key.encode('utf-8'): header.encode('utf-8') for key, header in headers.items()}
     with Session() as s:
         s.mount(url, HTTPAdapter(max_retries=5))
         try:
             s.post(url, data=data.encode('utf-8'),
-                   headers={b"X-Sumo-Category": headers.encode('utf-8')}, timeout=5)
+                   headers=encoded_headers, timeout=5)
         except RequestException as e:
             self.retry(exc=e)

--- a/corehq/ex-submodules/phonelog/utils.py
+++ b/corehq/ex-submodules/phonelog/utils.py
@@ -191,11 +191,11 @@ class SumoLogicLog(object):
         self.xform = xform
 
     def send_data(self, url):
-        send_device_log_to_sumologic.delay(url, self.log_subreport(should_encode=False),
+        send_device_log_to_sumologic.delay(url, self.log_subreport(),
                                            self._get_header('log', False))
-        send_device_log_to_sumologic.delay(url, self.user_error_subreport(should_encode=False),
+        send_device_log_to_sumologic.delay(url, self.user_error_subreport(),
                                            self._get_header('user_error', False))
-        send_device_log_to_sumologic.delay(url, self.force_close_subreport(should_encode=False),
+        send_device_log_to_sumologic.delay(url, self.force_close_subreport(),
                                            self._get_header('force_close', False))
 
     def _get_header(self, fmt, should_encode=True):
@@ -258,14 +258,11 @@ class SumoLogicLog(object):
                 user_id = user_subreport[0].get('user_id')
             return username, user_id
 
-    def log_subreport(self, should_encode=True):
+    def log_subreport(self):
         logs = _get_logs(self.xform.form_data, 'log_subreport', 'log')
-        data = ("\n".join([self._fill_base_template(log) for log in logs if log.get('type') != 'forceclose']))
-        if should_encode:
-            return data.encode('utf-8')
-        return data
+        return "\n".join([self._fill_base_template(log) for log in logs if log.get('type') != 'forceclose'])
 
-    def user_error_subreport(self, should_encode=True):
+    def user_error_subreport(self):
         logs = _get_logs(self.xform.form_data, 'user_error_subreport', 'user_error')
         log_additions_template = " [app_id={app_id}] [user_id={user_id}] [session={session}] [expr={expr}]"
 
@@ -278,11 +275,9 @@ class SumoLogicLog(object):
             ) for log in logs
         ))
 
-        if should_encode:
-            return data.encode('utf-8')
         return data
 
-    def force_close_subreport(self, should_encode=True):
+    def force_close_subreport(self):
         logs = _get_logs(self.xform.form_data, 'force_close_subreport', 'force_close')
         log_additions_template = (
             " [app_id={app_id}] [user_id={user_id}] [session={session}] "
@@ -297,8 +292,6 @@ class SumoLogicLog(object):
             ) for log in logs
         ))
 
-        if should_encode:
-            return data.encode('utf-8')
         return data
 
 def clear_device_log_request(domain, xform):

--- a/corehq/ex-submodules/phonelog/utils.py
+++ b/corehq/ex-submodules/phonelog/utils.py
@@ -191,14 +191,11 @@ class SumoLogicLog(object):
         self.xform = xform
 
     def send_data(self, url):
-        send_device_log_to_sumologic.delay(url, self.log_subreport(),
-                                           self._get_header('log', False))
-        send_device_log_to_sumologic.delay(url, self.user_error_subreport(),
-                                           self._get_header('user_error', False))
-        send_device_log_to_sumologic.delay(url, self.force_close_subreport(),
-                                           self._get_header('force_close', False))
+        send_device_log_to_sumologic.delay(url, self.log_subreport(), self._get_header('log'))
+        send_device_log_to_sumologic.delay(url, self.user_error_subreport(), self._get_header('user_error'))
+        send_device_log_to_sumologic.delay(url, self.force_close_subreport(), self._get_header('force_close'))
 
-    def _get_header(self, fmt, should_encode=True):
+    def _get_header(self, fmt):
         """
         https://docs.google.com/document/d/18sSwv2GRGepOIHthC6lxQAh_aUYgDcTou6w9jL2976o/edit#bookmark=id.ao4j7x5tjvt7
         """
@@ -211,9 +208,6 @@ class SumoLogicLog(object):
             environment = 'prod'
 
         header = "{env}/{domain}/{fmt}".format(env=environment, domain=self.domain, fmt=fmt)
-
-        if should_encode:
-            return {b"X-Sumo-Category": header.encode('utf-8')}
         return {"X-Sumo-Category": header}
 
     def _fill_base_template(self, log):

--- a/corehq/ex-submodules/phonelog/utils.py
+++ b/corehq/ex-submodules/phonelog/utils.py
@@ -191,14 +191,14 @@ class SumoLogicLog(object):
         self.xform = xform
 
     def send_data(self, url):
-        send_device_log_to_sumologic.delay(url, self.log_subreport().decode('utf-8'),
-                                           self._get_header('log', True))
-        send_device_log_to_sumologic.delay(url, self.user_error_subreport().decode('utf-8'),
-                                           self._get_header('user_error', True))
-        send_device_log_to_sumologic.delay(url, self.force_close_subreport().decode('utf-8'),
-                                           self._get_header('force_close', True))
+        send_device_log_to_sumologic.delay(url, self.log_subreport(should_encode=False),
+                                           self._get_header('log', False))
+        send_device_log_to_sumologic.delay(url, self.user_error_subreport(should_encode=False),
+                                           self._get_header('user_error', False))
+        send_device_log_to_sumologic.delay(url, self.force_close_subreport(should_encode=False),
+                                           self._get_header('force_close', False))
 
-    def _get_header(self, fmt, isTask=False):
+    def _get_header(self, fmt, should_encode=True):
         """
         https://docs.google.com/document/d/18sSwv2GRGepOIHthC6lxQAh_aUYgDcTou6w9jL2976o/edit#bookmark=id.ao4j7x5tjvt7
         """
@@ -212,9 +212,9 @@ class SumoLogicLog(object):
 
         header = "{env}/{domain}/{fmt}".format(env=environment, domain=self.domain, fmt=fmt)
 
-        if isTask:
-            return header
-        return {b"X-Sumo-Category": header.encode('utf-8')}
+        if should_encode:
+            return {b"X-Sumo-Category": header.encode('utf-8')}
+        return {"X-Sumo-Category": header}
 
     def _fill_base_template(self, log):
         from corehq.apps.receiverwrapper.util import (
@@ -258,40 +258,48 @@ class SumoLogicLog(object):
                 user_id = user_subreport[0].get('user_id')
             return username, user_id
 
-    def log_subreport(self):
+    def log_subreport(self, should_encode=True):
         logs = _get_logs(self.xform.form_data, 'log_subreport', 'log')
-        return ("\n"
-                .join([self._fill_base_template(log) for log in logs if log.get('type') != 'forceclose'])
-                .encode('utf-8'))
+        data = ("\n".join([self._fill_base_template(log) for log in logs if log.get('type') != 'forceclose']))
+        if should_encode:
+            return data.encode('utf-8')
+        return data
 
-    def user_error_subreport(self):
+    def user_error_subreport(self, should_encode=True):
         logs = _get_logs(self.xform.form_data, 'user_error_subreport', 'user_error')
         log_additions_template = " [app_id={app_id}] [user_id={user_id}] [session={session}] [expr={expr}]"
 
-        return ("\n".join(
+        data = ("\n".join(
             self._fill_base_template(log) + log_additions_template.format(
                 app_id=log.get('app_id'),
                 user_id=log.get('user_id'),
                 session=log.get('session'),
                 expr=log.get('expr'),
             ) for log in logs
-        ).encode('utf-8'))
+        ))
 
-    def force_close_subreport(self):
+        if should_encode:
+            return data.encode('utf-8')
+        return data
+
+    def force_close_subreport(self, should_encode=True):
         logs = _get_logs(self.xform.form_data, 'force_close_subreport', 'force_close')
         log_additions_template = (
             " [app_id={app_id}] [user_id={user_id}] [session={session}] "
             "[device_model={device_model}]"
         )
-        return ("\n".join(
+        data = ("\n".join(
             self._fill_base_template(log) + log_additions_template.format(
                 app_id=log.get('app_id'),
                 user_id=log.get('user_id'),
                 session=log.get('session_readable'),
                 device_model=log.get('device_model'),
             ) for log in logs
-        ).encode('utf-8'))
+        ))
 
+        if should_encode:
+            return data.encode('utf-8')
+        return data
 
 def clear_device_log_request(domain, xform):
     from corehq.apps.ota.models import DeviceLogRequest


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[JIRA Ticket
](https://dimagi-dev.atlassian.net/browse/SAAS-11385)
This PR is part of a series of PRs aimed at removing our use of pickling in celery tasks due to a lack of support that is blocking our ability to upgrade celery.

The task modified was:

`send_device_log_to_sumologic(self, url, data, headers)` where `url` is a string, `data` an encoded string and `headers` a dictionary with a single key/value that are also both encoded strings. `data` is now decoded when passed as an argument and `headers` will return a string in context of the celery call. `data` will be encoded (.encode('utf-8')) and the original `headers` dictionary will be defined within the task. 


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Passed QA testing. Ticket [here](https://dimagi-dev.atlassian.net/browse/QA-3603). 

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested on staging. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
