### PR TITLE
Added instances for query prompts in entries

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -212,6 +212,9 @@ class EntriesHelper(object):
 
             EntriesHelper.add_custom_assertions(e, form)
 
+            if module_offers_registry_search(module):
+                EntriesHelper.add_registry_search_instances(e, form)
+
             if (
                 self.app.commtrack_enabled and
                 session_var('supply_point_id') in getattr(form, 'source', "")
@@ -308,6 +311,12 @@ class EntriesHelper(object):
                 'case_autoload.{0}.case_missing'.format(mode),
             )
         ]
+
+    @staticmethod
+    def add_registry_search_instances(entry, form):
+        for prop in form.get_module().search_config.properties:
+            if prop.itemset.instance_id:
+                entry.instances.append(Instance(id=prop.itemset.instance_id, src=prop.itemset.instance_uri))
 
     @staticmethod
     def add_custom_assertions(entry, form):

--- a/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
@@ -6,7 +6,6 @@
                 <locale id="forms.m0f0"/>
             </text>
         </command>
-        <instance id="commcaresession" src="jr://instance/session"/>
         <session>
           <query url="http://localhost:8000/a/test_domain/phone/search/123/" storage-instance="results" template="case" default_search="false">
             <data key="case_type" ref="'case'"/>
@@ -18,12 +17,17 @@
                 </text>
               </display>
             </prompt>
-            <prompt key="dob">
+            <prompt key="favorite_color">
               <display>
                 <text>
-                  <locale id="search_property.m0.dob"/>
+                  <locale id="search_property.m0.favorite_color"/>
                 </text>
               </display>
+              <itemset nodeset="instance('colors')/colors_list/colors">
+                <label ref="name"/>
+                <value ref="value"/>
+                <sort ref="name"/>
+              </itemset>
             </prompt>
           </query>
           <datum detail-confirm="m0_case_long" detail-select="m0_case_short" id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open']" value="./@case_id"/>
@@ -33,6 +37,8 @@
             <data key="commcare_registry" ref="'myregistry'"/>
           </query>
         </session>
+        <instance id="colors" src="jr://fixture/item-list:colors"/>
+        <instance id="commcaresession" src="jr://instance/session"/>
         <stack>
           <create if="(today() - dob) &lt; 7">
             <command value="'m0'"/>

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -5,6 +5,7 @@ from corehq.apps.app_manager.models import (
     Application,
     CaseSearch,
     CaseSearchProperty,
+    Itemset,
     Module,
     AdditionalRegistryQuery, DetailColumn, FormLink, DetailTab,
 )
@@ -44,7 +45,10 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         self.module.search_config = CaseSearch(
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
-                CaseSearchProperty(name='dob', label={'en': 'Date of birth'})
+                CaseSearchProperty(name='favorite_color', label={'en': 'Favorite Color'}, itemset=Itemset(
+                    instance_id='colors', instance_uri='jr://fixture/item-list:colors',
+                    nodeset="instance('colors')/colors_list/colors", label='name', sort='name', value='value'),
+                )
             ],
             data_registry="myregistry"
         )
@@ -73,12 +77,17 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                   </text>
                 </display>
               </prompt>
-              <prompt key="dob">
+              <prompt key="favorite_color">
                 <display>
                   <text>
-                    <locale id="search_property.m0.dob"/>
+                    <locale id="search_property.m0.favorite_color"/>
                   </text>
                 </display>
+                <itemset nodeset="instance('colors')/colors_list/colors">
+                  <label ref="name"/>
+                  <value ref="value"/>
+                  <sort ref="name"/>
+                </itemset>
               </prompt>
             </query>
             <datum id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open']"


### PR DESCRIPTION
## Technical Summary
Followup for https://github.com/dimagi/commcare-hq/pull/30501 - make sure the entry includes any instances used by the query's prompts (lookup table questions).

## Feature Flag
Data registry

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
In PR

### QA Plan
No QA

### Safety story
Tests in PR

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
