### PR TITLE
session schema support for loading unrelated cases

### DIFF
--- a/corehq/apps/app_manager/app_schemas/casedb_schema.py
+++ b/corehq/apps/app_manager/app_schemas/casedb_schema.py
@@ -1,9 +1,11 @@
-from corehq import toggles
+from django.utils.text import slugify
+
 from corehq.apps.app_manager.app_schemas.case_properties import (
     ParentCasePropertyBuilder,
     get_usercase_properties,
 )
 from corehq.apps.app_manager.const import USERCASE_TYPE
+from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans
 from corehq.apps.app_manager.util import is_usercase_in_use
 from corehq.apps.data_dictionary.util import get_case_property_description_dict
 
@@ -18,6 +20,14 @@ def get_casedb_schema(form):
     subsets = []
     if form.requires_case() and not form.get_module().search_config.data_registry:
         subsets.extend(_get_case_schema_subsets(app, form.get_module().case_type))
+
+    parent_select = form.get_module().parent_select
+    if parent_select.active and parent_select.relationship is None:
+        # for child modules that use parent select where the parent is not a 'related' case
+        # See toggles.NON_PARENT_MENU_SELECTION
+        parent_module = app.get_module_by_unique_id(parent_select.module_id)
+        source = clean_trans(parent_module.name, app.langs)
+        subsets.extend(_get_case_schema_subsets(app, parent_module.case_type, source=source))
 
     if is_usercase_in_use(app.domain):
         subsets.append({
@@ -43,11 +53,12 @@ def get_registry_schema(form):
     This lists all case types and their properties for the given app.
     """
     app = form.get_app()
-    data_registry = form.get_module().search_config.data_registry
+    module = form.get_module()
+    data_registry = module.search_config.data_registry
 
     subsets = []
     if form.requires_case() and data_registry:
-        subsets.extend(_get_case_schema_subsets(app, form.get_module().case_type, hashtag='#registry_case/'))
+        subsets.extend(_get_case_schema_subsets(app, module.case_type, hashtag='#registry_case/'))
 
     return {
         "id": "registry",
@@ -59,7 +70,7 @@ def get_registry_schema(form):
     }
 
 
-def _get_case_schema_subsets(app, base_case_type, hashtag='#case/'):
+def _get_case_schema_subsets(app, base_case_type, hashtag='#case/', source=None):
     builder = ParentCasePropertyBuilder.for_app(app, ['case_name'], include_parent_properties=False)
     related = builder.get_parent_type_map(None)
     map = builder.get_properties_by_case_type()
@@ -82,15 +93,24 @@ def _get_case_schema_subsets(app, base_case_type, hashtag='#case/'):
     # Remove any duplicate types or empty generations
     generations = [set(g) for g in generations if len(g)]
 
+    name_source = f" - {source}" if source else ""
+    id_source = f":{slugify(source)}" if source else ""
+    hashtag = f"{hashtag}{id_source}"
+
+    def _name(i, ctypes):
+        if i > 0:
+            return "{} ({}){}".format(generation_names[i], " or ".join(ctypes), name_source)
+        return f"{base_case_type}{name_source}"
+
     return [{
-        "id": generation_names[i],
-        "name": "{} ({})".format(generation_names[i], " or ".join(ctypes)) if i > 0 else base_case_type,
+        "id": f"{generation_names[i]}{id_source}",
+        "name": _name(i, ctypes),
         "structure": {
             p: {"description": descriptions_dict.get(t, {}).get(p, '')}
             for t in ctypes for p in map[t]},
         "related": {"parent": {
             "hashtag": hashtag + generation_names[i + 1],
-            "subset": generation_names[i + 1],
+            "subset": f"{generation_names[i + 1]}{id_source}",
             "key": "@case_id",
         }} if i < len(generations) - 1 else None,
     } for i, ctypes in enumerate(generations)]

--- a/corehq/apps/app_manager/app_schemas/session_schema.py
+++ b/corehq/apps/app_manager/app_schemas/session_schema.py
@@ -1,5 +1,8 @@
+from django.utils.text import slugify
+
 from corehq import toggles
 from corehq.apps.app_manager.const import USERCASE_TYPE
+from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans
 from corehq.apps.app_manager.util import is_usercase_in_use
 
 
@@ -8,29 +11,52 @@ def get_session_schema(form):
     """
     from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
     app = form.get_app()
-    module = form.get_module()
-    data_registry = module.search_config.data_registry
     structure = {}
     datums = EntriesHelper(app).get_datums_meta_for_form_generic(form)
     datums = [
         d for d in datums
         if d.requires_selection and d.case_type and not d.is_new_case_id
     ]
-    if len(datums):
-        session_var = datums[-1].datum.id
-        structure["data"] = {
-            "merge": True,
-            "structure": {
-                session_var: {
-                    "reference": {
-                        "hashtag": '#registry_case' if data_registry else "#case",
-                        "source": "registry" if data_registry else "casedb",
-                        "subset": "case",
-                        "key": "@case_id",
-                    },
-                },
+
+    def _get_structure(datum, data_registry, source=None):
+        id_source = f":{slugify(source)}" if source else ""
+        return {
+            "reference": {
+                "hashtag": f'#registry_case{id_source}' if data_registry else f"#case{id_source}",
+                "source": "registry" if data_registry else "casedb",
+                "subset": f"case{id_source}",
+                "key": "@case_id",
             },
         }
+
+    unrelated_parents = set()
+    for datum in datums:
+        if datum.module_id:
+            module = app.get_module_by_unique_id(datum.module_id)
+            parent_select_active = hasattr(module, 'parent_select') and module.parent_select.active
+            if parent_select_active and module.parent_select.relationship is None:
+                # for child modules that use parent select where the parent is not a 'related' case
+                # See toggles.NON_PARENT_MENU_SELECTION
+                unrelated_parents.add(module.parent_select.module_id)
+
+    data_structure = {}
+    for i, datum in enumerate(reversed(datums)):
+        module = app.get_module_by_unique_id(datum.module_id)
+        data_registry = module.search_config.data_registry
+        if i == 0:
+            # always add the datum for this module
+            data_structure[datum.datum.id] = _get_structure(datum, data_registry)
+        else:
+            if datum.module_id and datum.module_id in unrelated_parents:
+                source = clean_trans(module.name, app.langs)  # ensure that this structure reference is unique
+                data_structure[datum.datum.id] = _get_structure(datum, data_registry, source)
+
+    if data_structure:
+        structure["data"] = {
+            "merge": True,
+            "structure": data_structure,
+        }
+
     if is_usercase_in_use(app.domain):
         structure["context"] = {
             "merge": True,

--- a/corehq/apps/app_manager/app_schemas/tests/test_schema.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_schema.py
@@ -206,7 +206,7 @@ class SchemaTest(SimpleTestCase):
                     }
                 },
                 "id": "case",
-                "name": "guppy"
+                "name": "guppy",
             },
             {
                 "structure": {
@@ -219,7 +219,135 @@ class SchemaTest(SimpleTestCase):
                 },
                 "related": None,
                 "id": "parent",
-                "name": "parent (gold-fish)"
+                "name": "parent (gold-fish)",
+            }
+        ]
+
+        self.assertEqual(casedb_schema['subsets'], expected_casedb_schema_subsets)
+        self.assertEqual(session_schema['structure'], expected_session_schema_structure)
+
+    def test_get_session_schema_for_child_module_not_parent_case_type(self):
+        # m0 - opens 'goldfish' case.
+        # m1 - has m0 as root-module, has parent-select, updates 'guppy' case
+        self.module_0, m0f0 = self.factory.new_basic_module('parent', 'goldfish')
+        self.factory.form_requires_case(m0f0)
+
+        self.module_1, m1f0 = self.factory.new_basic_module('child', 'guppy', parent_module=self.module_0)
+        self.factory.form_requires_case(m1f0)
+        self.module_1.parent_select.active = True
+        self.module_1.parent_select.relationship = None
+        self.module_1.parent_select.module_id = self.module_0.unique_id
+
+        casedb_schema = get_casedb_schema(m1f0)
+        session_schema = get_session_schema(m1f0)
+
+        expected_session_schema_structure = {
+            "data": {
+                "merge": True,
+                "structure": {
+                    "case_id_guppy": {
+                        "reference": {
+                            "hashtag": "#case",
+                            "subset": "case",
+                            "source": "casedb",
+                            "key": "@case_id"
+                        }
+                    },
+                    "case_id": {
+                        "reference": {
+                            "hashtag": "#case:parent-module",
+                            "subset": "case:parent-module",
+                            "source": "casedb",
+                            "key": "@case_id"
+                        }
+                    }
+                }
+            }
+        }
+
+        expected_casedb_schema_subsets = [
+            {
+                "structure": {
+                    "case_name": {
+                        "description": "",
+                    }
+                },
+                "related": None,
+                "id": "case",
+                "name": "guppy",
+            },
+            {
+                "structure": {
+                    "case_name": {
+                        "description": "",
+                    }
+                },
+                "related": None,
+                "id": "case:parent-module",
+                "name": "goldfish - parent module",
+            }
+        ]
+
+        self.assertEqual(casedb_schema['subsets'], expected_casedb_schema_subsets)
+        self.assertEqual(session_schema['structure'], expected_session_schema_structure)
+
+    def test_get_session_schema_for_child_module_same_case_type(self):
+        self.module_0, m0f0 = self.factory.new_basic_module('parent', 'goldfish')
+        self.factory.form_requires_case(m0f0)
+
+        self.module_1, m1f0 = self.factory.new_basic_module('child', 'goldfish', parent_module=self.module_0)
+        self.factory.form_requires_case(m1f0)
+        self.module_1.parent_select.active = True
+        self.module_1.parent_select.relationship = None
+        self.module_1.parent_select.module_id = self.module_0.unique_id
+
+        casedb_schema = get_casedb_schema(m1f0)
+        session_schema = get_session_schema(m1f0)
+
+        expected_session_schema_structure = {
+            "data": {
+                "merge": True,
+                "structure": {
+                    "case_id_goldfish": {
+                        "reference": {
+                            "hashtag": "#case",
+                            "subset": "case",
+                            "source": "casedb",
+                            "key": "@case_id"
+                        }
+                    },
+                    "case_id": {
+                        "reference": {
+                            "hashtag": "#case:parent-module",
+                            "subset": "case:parent-module",
+                            "source": "casedb",
+                            "key": "@case_id"
+                        }
+                    }
+                }
+            }
+        }
+
+        expected_casedb_schema_subsets = [
+            {
+                "structure": {
+                    "case_name": {
+                        "description": "",
+                    }
+                },
+                "related": None,
+                "id": "case",
+                "name": "goldfish",
+            },
+            {
+                "structure": {
+                    "case_name": {
+                        "description": "",
+                    }
+                },
+                "related": None,
+                "id": "case:parent-module",
+                "name": "goldfish - parent module",
             }
         ]
 
@@ -363,6 +491,73 @@ class SchemaTest(SimpleTestCase):
             },
             'related': None,
         })
+
+    def test_get_session_schema_for_child_module_with_registry(self):
+        """Child module loads a case with the same case type as the parent module.
+        Child module is using data registry search"""
+        self.module_0, m0f0 = self.factory.new_basic_module('parent', 'patient')
+        self.factory.form_requires_case(m0f0)
+
+        self.module_1, m1f0 = self.factory.new_basic_module('child', 'patient', parent_module=self.module_0)
+        self.factory.form_requires_case(m1f0)
+        self.module_1.search_config.data_registry = "reg1"
+        self.module_1.parent_select.active = True
+        self.module_1.parent_select.relationship = None
+        self.module_1.parent_select.module_id = self.module_0.unique_id
+
+        session_schema = get_session_schema(m1f0)
+        casedb_schema = get_casedb_schema(m1f0)
+        registry_schema = get_registry_schema(m1f0)
+
+        expected_session_schema_structure = {
+            "data": {
+                "merge": True,
+                "structure": {
+                    "case_id_patient": {
+                        "reference": {
+                            "hashtag": "#registry_case",
+                            "source": "registry",
+                            "subset": "case",
+                            "key": "@case_id",
+                        }
+                    },
+                    "case_id": {
+                        "reference": {
+                            "hashtag": "#case:parent-module",
+                            "subset": "case:parent-module",
+                            "source": "casedb",
+                            "key": "@case_id"
+                        }
+                    }
+                }
+            }
+        }
+
+        expected_casedb_schema_subsets = [{
+            "structure": {
+                "case_name": {
+                    "description": "",
+                }
+            },
+            "related": None,
+            "id": "case:parent-module",
+            "name": "patient - parent module",
+        }]
+        expected_registry_schema_subsets = [{
+            "structure": {
+                "case_name": {
+                    "description": "",
+                }
+            },
+            "related": None,
+            "id": "case",
+            "name": "patient",
+
+        }]
+
+        self.assertEqual(session_schema['structure'], expected_session_schema_structure)
+        self.assertEqual(casedb_schema['subsets'], expected_casedb_schema_subsets)
+        self.assertEqual(registry_schema['subsets'], expected_registry_schema_subsets)
 
     # -- helpers --
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-1324

## Product Description
Allows using drag and drop in form builder to reference case properties from cases that are loaded from parent modules
which are not related to the current module's case type.

Example of loading two cases of the same type:
![image](https://user-images.githubusercontent.com/249606/136029018-61c8594f-d709-49ab-b344-94598e861b8a.png)

The second case in the tree includes the source module name to disambiguate it.

The hashtag is also different:
![Screenshot from 2021-10-05 15-09-45](https://user-images.githubusercontent.com/249606/136029402-119e27fc-8de8-4dde-8ce7-7617373a3015.png)

Prior to this change the only way to reference these would be write the xpath manually.

## Technical Summary
This adds new elements to the app schema which tells Vellum how to reference these cases. 

Cases from parent modules use the module name to disambiguate them. I considered using the module ID since module names may not be unique but Vellum that would also mean that hashtags would include the module ID which isn't useful. I think it's unlikely that a parent and child module will share the same name.

First commit is a prefactor.

## Feature Flag
NON_PARENT_MENU_SELECTION

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added

### QA Plan
I did test this locally but I'm going to put it on staging as well.

### Safety story
Existing functionality is unchanged. This only projects using the feature flag and then only easy references in form builder. The existing references should not change but new references will become available.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
