### PR TITLE
get_or_create() returns a tuple

### DIFF
--- a/corehq/apps/users/migrations/0037_add_edit_messaging_permission.py
+++ b/corehq/apps/users/migrations/0037_add_edit_messaging_permission.py
@@ -9,7 +9,7 @@ from corehq.util.django_migrations import skip_on_fresh_install
 @skip_on_fresh_install
 def migrate_edit_migrations_permissions(apps, schema_editor):
     permission, created = SQLPermission.objects.get_or_create(value='edit_messaging')
-    edit_data_permission = SQLPermission.objects.get_or_create(value='edit_data')
+    edit_data_permission, created = SQLPermission.objects.get_or_create(value='edit_data')
     role_ids_with_edit_data = set(UserRole.objects.filter(rolepermission__permission_fk_id=edit_data_permission.id)
                                   .values_list("id", flat=True))
     for chunk in chunked(role_ids_with_edit_data, 50):


### PR DESCRIPTION
## Technical Summary
Fixes migration users/0037_add_edit_messaging_permission

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story

Only affects migrations

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
