### PR TITLE
Rc/data preview accessibility

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -66,6 +66,9 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
         self.evalXPath = new EvaluateXPath(options);
         self.isMinimized = ko.observable(true);
 
+        self.expandAriaLabel = gettext('Expand Data Preview');
+        self.collapseAriaLabel = gettext('Collapse Data Preview');
+
         // Whether or not the debugger is in the middle of updating from an ajax request
         self.updating = ko.observable(false);
 
@@ -82,6 +85,8 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
             }
             hqImport('analytix/js/kissmetrix').track.event('[app-preview] User toggled CloudCare debugger');
         };
+
+
         self.collapseNavbar = function () {
             $('.navbar-collapse').collapse('hide');
         };

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -10,17 +10,19 @@
         }
         ">
     <!-- Tab title -->
-    <div class="debugger-tab-title" role="button"  tabindex="0"
+    <button class="btn-block debugger-tab-title" tabindex="0"
       data-bind="click: toggleState,
-        attr: {'aria-label': isMinimized() ? 'Expand Data Preview' : 'Collapse Data Preview'}">
+        attr: {'aria-label': isMinimized() ? expandAriaLabel : collapseAriaLabel}">
       <span class="sr-only">{% trans "Expand Data Preview Section." %}</span>
       <i class="fa fa-close pull-right"></i>
-      <i class="fa fa-table"></i>
-      <span class="debugger-title">{% trans "Data Preview" %}</span>
-    </div>
+      <div class="pull-left">
+        <i class="fa fa-table"></i>
+        <span class="debugger-title">{% trans "Data Preview" %}</span>
+      </div>
+    </button>
 
     <!-- Debugger content -->
-    <div data-bind="visible: !isMinimized(), attr: {'aria-hidden': isMinimized()}" class="debugger-container">
+    <div data-bind="visible: !isMinimized()" class="debugger-container">
       <!-- navigation tabs -->
 
       <nav class="navbar navbar-default debugger-navbar">

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -20,7 +20,7 @@
     </div>
 
     <!-- Debugger content -->
-    <div data-bind="attr: {'aria-hidden': isMinimized()}" class="debugger-container">
+    <div data-bind="visible: !isMinimized(), attr: {'aria-hidden': isMinimized()}" class="debugger-container">
       <!-- navigation tabs -->
 
       <nav class="navbar navbar-default debugger-navbar">

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -10,7 +10,7 @@
         }
         ">
     <!-- Tab title -->
-    <div class="debugger-tab-title" data-bind="click: toggleState">
+    <div role="button" class="debugger-tab-title" data-bind="click: toggleState">
       <i class="fa fa-close pull-right"></i>
       <i class="fa fa-table"></i>
       <span class="debugger-title">{% trans "Data Preview" %}</span>

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -10,7 +10,7 @@
         }
         ">
     <!-- Tab title -->
-    <div role="button" class="debugger-tab-title" data-bind="click: toggleState">
+    <div class="debugger-tab-title" role="button"  tabindex="0" data-bind="click: toggleState">
       <i class="fa fa-close pull-right"></i>
       <i class="fa fa-table"></i>
       <span class="debugger-title">{% trans "Data Preview" %}</span>

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -17,7 +17,7 @@
     </div>
 
     <!-- Debugger content -->
-    <div class="debugger-container">
+    <div data-bind="attr: {'aria-hidden': isMinimized() ? true : false}" class="debugger-container">
       <!-- navigation tabs -->
 
       <nav class="navbar navbar-default debugger-navbar">

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -10,14 +10,17 @@
         }
         ">
     <!-- Tab title -->
-    <div class="debugger-tab-title" role="button"  tabindex="0" data-bind="click: toggleState">
+    <div class="debugger-tab-title" role="button"  tabindex="0"
+      data-bind="click: toggleState,
+        attr: {'aria-label': isMinimized() ? 'Expand Data Preview' : 'Collapse Data Preview'}">
+      <span class="sr-only">{% trans "Expand Data Preview Section." %}</span>
       <i class="fa fa-close pull-right"></i>
       <i class="fa fa-table"></i>
       <span class="debugger-title">{% trans "Data Preview" %}</span>
     </div>
 
     <!-- Debugger content -->
-    <div data-bind="attr: {'aria-hidden': isMinimized() ? true : false}" class="debugger-container">
+    <div data-bind="attr: {'aria-hidden': isMinimized()}" class="debugger-container">
       <!-- navigation tabs -->
 
       <nav class="navbar navbar-default debugger-navbar">

--- a/corehq/apps/hqwebapp/static/cloudcare/less/debugger/debugger.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/debugger/debugger.less
@@ -53,6 +53,9 @@
   color: white;
   background-color: @cc-brand-low;
   border-bottom: #ddd solid 4px;
+  border-top: 0;
+  border-left: 0;
+  border-right: 0;
   padding: 6px;
   cursor: pointer;
   .debugger-title {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

- Makes `Data Preview` only visible to screen readers when expanded.
- Labels `Data Preview` 'button' (clickable div) with action: 'Expand' or 'Collapse' 
- Adds tab index to clickable div to maintain current UX while fixing focus issue
- Adds button role to div to make functionality clear to screen readers
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[USH-579](https://dimagi-dev.atlassian.net/browse/USH-579)
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
[QA-3596](https://dimagi-dev.atlassian.net/browse/QA-3596)
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally. Screen reader-only changes.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
