### PR TITLE
Conditional Alert Warning for Parent Case Recipient Type

### DIFF
--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -62,6 +62,7 @@ from corehq.messaging.scheduling.models import (
     SMSCallbackContent,
 )
 from corehq.messaging.scheduling.scheduling_partitioned.models import ScheduleInstance, CaseScheduleInstanceMixin
+from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED
 from couchdbkit import ResourceNotFound
 from langcodes import get_name as get_language_name
 
@@ -1774,8 +1775,9 @@ class ScheduleForm(Form):
                             not Parent / Extension or Host / Extension relationships.
                         """
                     )),
-                data_bind=("visible: recipientTypeSelected('%s')"
-                    % CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE)
+                data_bind="visible: (recipientTypeSelected('{parentCase}') && {extensionFlagEnabled})".format(
+                    parentCase=CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE,
+                    extensionFlagEnabled="true" if EXTENSION_CASES_SYNC_ENABLED.enabled(self.domain) else "false")
             ),
             crispy.Div(
                 crispy.Field(

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -1768,7 +1768,7 @@ class ScheduleForm(Form):
                             %s
                         </p>
                     """
-                    % ugettext_lazy(
+                    % _(
                         """
                             The "Case's Parent Case" Recipient setting only works for Parent / Child relationships,
                             not Parent / Host or Host / Extension relationships.

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -1771,7 +1771,7 @@ class ScheduleForm(Form):
                     % _(
                         """
                             The "Case's Parent Case" Recipient setting only works for Parent / Child relationships,
-                            not Parent / Host or Host / Extension relationships.
+                            not Parent / Extension or Host / Extension relationships.
                         """
                     )),
                 data_bind=("visible: recipientTypeSelected('%s')"

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -1761,6 +1761,23 @@ class ScheduleForm(Form):
                 style="width: 100%;"
             ),
             crispy.Div(
+                crispy.HTML(
+                    """
+                        <p id="parent-case-type-warning" class="help-block alert alert-info">
+                        <i class="fa fa-info-circle"></i>
+                            %s
+                        </p>
+                    """
+                    % ugettext_lazy(
+                        """
+                            The "Case's Parent Case" Recipient setting only works for Parent / Child relationships,
+                            not Parent / Host or Host / Extension relationships.
+                        """
+                    )),
+                data_bind=("visible: recipientTypeSelected('%s')"
+                    % CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE)
+            ),
+            crispy.Div(
                 crispy.Field(
                     'user_recipients',
                     data_bind='value: user_recipients.value',


### PR DESCRIPTION
## Product Description

Problem: In situations where applications have Parent / Extension or Host / Extension relationships, it is not clear that the Parent Case recipient option for conditional alerts does not include these extending relationships (currently an error message is displayed when trying to alert parent/extension or host/extension cases). 

Implemented solution: when the "Case's Parent Case" option is selected from the list, a warning message is shown:

<img width="600" alt="Screen Shot 2021-10-05 at 11 10 19 AM" src="https://user-images.githubusercontent.com/6729291/136050767-21e41e40-3c53-43ec-a995-c3ee22026a6b.png">

## Technical Summary
In response to [USH-1153](https://dimagi-dev.atlassian.net/browse/USH-1153). 

The warning is only shown when the "Case's Parent Case" option is selected.

Note: solving this error completely and allowing Parent / Extension and Host / Extension relationship conditional alerts is a separate task ([USH-1155](https://dimagi-dev.atlassian.net/browse/USH-1155)).

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests are needed.

### Safety story

Display only and does not affect any key operations. I tested to make sure a new conditional alert could still be created

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
