### PR TITLE
Remove THROTTLE_SYSTEM_FORMS toggle

### DIFF
--- a/corehq/apps/receiverwrapper/tests/test_submissions.py
+++ b/corehq/apps/receiverwrapper/tests/test_submissions.py
@@ -318,20 +318,12 @@ class SubmitFormLocallyRateLimitTest(TestCase, TestFileMixin):
     file_path = ('data',)
     domain = 'test-domain'
 
-    @flag_enabled('THROTTLE_SYSTEM_FORMS')
     def test_rate_limiting(self, allow_usage):
         form_xml = self.get_xml('simple_form')
         submit_form_locally(form_xml, domain=self.domain)
         allow_usage.assert_called()
 
-    @flag_enabled('THROTTLE_SYSTEM_FORMS')
     def test_no_rate_limiting(self, allow_usage):
         form_xml = self.get_xml('simple_form')
         submit_form_locally(form_xml, domain=self.domain, max_wait=None)
-        allow_usage.assert_not_called()
-
-    @flag_disabled('THROTTLE_SYSTEM_FORMS')
-    def test_no_rate_limiting_with_flag_disabled(self, allow_usage):
-        form_xml = self.get_xml('simple_form')
-        submit_form_locally(form_xml, domain=self.domain)
         allow_usage.assert_not_called()

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -9,7 +9,6 @@ from couchdbkit import ResourceNotFound
 
 import couchforms
 from corehq.apps.receiverwrapper.rate_limiter import rate_limit_submission
-from corehq.toggles import THROTTLE_SYSTEM_FORMS, NAMESPACE_DOMAIN
 from couchforms.models import DefaultAuthContext
 
 from corehq.apps.app_manager.dbaccessors import get_app
@@ -41,7 +40,7 @@ def submit_form_locally(instance, domain, max_wait=..., **kwargs):
     """
 
     if max_wait is ...:
-        max_wait = 0.1 if THROTTLE_SYSTEM_FORMS.enabled(domain, namespace=NAMESPACE_DOMAIN) else None
+        max_wait = 0.1
     if max_wait is not None:
         rate_limit_submission(domain, delay_rather_than_reject=True, max_wait=max_wait)
     # intentionally leave these unauth'd for now

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -2158,12 +2158,3 @@ DO_NOT_REPUBLISH_DOCS = StaticToggle(
     TAG_INTERNAL,
     namespaces=[NAMESPACE_DOMAIN],
 )
-
-THROTTLE_SYSTEM_FORMS = FeatureRelease(
-    'throttle_system_forms',
-    ('Throttles system forms (from auto update rules, etc.) with soft delays (no hard rejections) '
-     'to make them a better part of the overall submission rate limiting system.'),
-    TAG_INTERNAL,
-    namespaces=[NAMESPACE_DOMAIN],
-    owner='Danny Roberts',
-)


### PR DESCRIPTION
## Product Description
None

## Technical Summary
Cleanup for https://github.com/dimagi/commcare-hq/pull/30453

## Feature Flag
THROTTLE_SYSTEM_FORMS (removed in this PR)

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

There's the basic tests I added in the original PR.

### QA Plan

Not planning on it.

### Safety story
This is a fairly straightforward removal of a flag that's already on for all domains on india & production.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
