### PR TITLE
[Hubspot] Additional cleanup with metrics and unused methods

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -241,9 +241,8 @@ def _send_form_to_hubspot(form_id, webuser, hubspot_cookie, meta, extra_fields=N
     if ((webuser and not hubspot_enabled_for_user(webuser))
             or (not webuser and not hubspot_enabled_for_email(email))):
         # This user has analytics disabled
-        metrics_gauge(
+        metrics_counter(
             'commcare.hubspot_data.rejected.send_form_to_hubspot',
-            1,
             tags={
                 'username': webuser.username if webuser else email,
             }

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -169,44 +169,6 @@ def _get_contact_ids_for_emails(list_of_emails, retry_num=0):
     return []
 
 
-def _get_contact_ids_for_email_domain(email_domain, retry_num=0):
-    """
-    Searches Hubspot for an email domain and returns the list of matching
-    contact IDs for that email domain.
-    :param email_domain:
-    :param retry_num: the number of the current retry attempt
-    :return: list of matching contact IDs
-    """
-    if retry_num > 0:
-        time.sleep(10)  # wait 10 seconds if this is another retry attempt
-
-    api_key = settings.ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)
-    if api_key:
-        try:
-            req = requests.get(
-                "https://api.hubapi.com/contacts/v1/search/query",
-                params={
-                    'hapikey': api_key,
-                    'q': f'@{email_domain}',
-                },
-            )
-            if req.status_code == 404:
-                return []
-            req.raise_for_status()
-        except (ConnectionError, requests.exceptions.HTTPError) as e:
-            metrics_counter(
-                'commcare.hubspot_data.retry.get_contact_ids_for_email_domain'
-            )
-            if retry_num <= MAX_API_RETRIES:
-                return _get_contact_ids_for_email_domain(email_domain, retry_num + 1)
-            else:
-                logger.error(f"Failed to get Hubspot contact ids for email "
-                             f"domain {email_domain} due to {str(e)}.")
-        else:
-            return [contact.get('vid') for contact in req.json().get('contacts')]
-    return []
-
-
 def remove_blocked_domain_contacts_from_hubspot(stdout=None):
     """
     Removes contacts from Hubspot that are members of blocked domains.

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -5,7 +5,7 @@ import logging
 
 from django.conf import settings
 
-from corehq.util.metrics import metrics_gauge
+from corehq.util.metrics import metrics_gauge, metrics_counter
 from corehq.apps.accounting.models import Subscription, BillingAccount
 from corehq.apps.es.users import UserES
 from corehq.apps.users.models import WebUser, CommCareUser
@@ -156,9 +156,8 @@ def _get_contact_ids_for_emails(list_of_emails, retry_num=0):
                 return []
             req.raise_for_status()
         except (ConnectionError, requests.exceptions.HTTPError) as e:
-            metrics_gauge(
-                'commcare.hubspot_data.retry.get_contact_ids_for_emails',
-                1
+            metrics_counter(
+                'commcare.hubspot_data.retry.get_contact_ids_for_emails'
             )
             if retry_num <= MAX_API_RETRIES:
                 return _get_contact_ids_for_emails(list_of_emails, retry_num + 1)
@@ -195,9 +194,8 @@ def _get_contact_ids_for_email_domain(email_domain, retry_num=0):
                 return []
             req.raise_for_status()
         except (ConnectionError, requests.exceptions.HTTPError) as e:
-            metrics_gauge(
-                'commcare.hubspot_data.retry.get_contact_ids_for_email_domain',
-                1
+            metrics_counter(
+                'commcare.hubspot_data.retry.get_contact_ids_for_email_domain'
             )
             if retry_num <= MAX_API_RETRIES:
                 return _get_contact_ids_for_email_domain(email_domain, retry_num + 1)


### PR DESCRIPTION
## Product Description
Small backend changes to improve metrics in datadog and clean up unused code.

## Technical Summary
- use `metrics_counter` instead of `metrics_gauge` for certain hubspot metrics
- remove unused method for looking up users based on email_domain in the hubspot API

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
None here as only metrics were updated a method was removed that wasn't used anywhere

### QA Plan
Not needed

### Safety story
Small changes that are super isolated. No user-interaction changes

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
