### PR TITLE
refresh case if newer in es

### DIFF
--- a/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
@@ -181,7 +181,8 @@ class CaseHelper:
         es_modified_on_by_ids = CaseHelper._get_es_modified_dates(case_ids)
         case_search_es_modified_on_by_ids = CaseHelper._get_case_search_es_modified_dates(case_search_ids)
         for case_id, case_type, modified_on, domain in chunk:
-            stale, data_row = CaseHelper._check_stale(case_id, case_type, modified_on, domain, es_modified_on_by_ids, case_search_es_modified_on_by_ids)
+            stale, data_row = CaseHelper._check_stale(case_id, case_type, modified_on, domain,
+                                                      es_modified_on_by_ids, case_search_es_modified_on_by_ids)
             if stale:
                 yield data_row
 
@@ -196,8 +197,8 @@ class CaseHelper:
                 return CaseHelper._check_stale(case_id, case_type, refreshed.server_modified_on,
                                     refreshed.domain, es_modified_on_by_ids, case_search_es_modified_on_by_ids)
             else:
-                return True, DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type, domain=domain,
-                                     es_date=es_modified_on, primary_date=modified_on)
+                return True, DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type,
+                                     domain=domain, es_date=es_modified_on, primary_date=modified_on)
         elif domain in domains_needing_search_index():
             es_modified_on, es_domain = case_search_es_modified_on_by_ids.get(case_id, (None, None))
             if (es_modified_on, es_domain) != (modified_on, domain):
@@ -205,10 +206,11 @@ class CaseHelper:
                 if es_modified_on is not None and es_modified_on > modified_on:
                     refreshed = CaseAccessors(domain).get_case(case_id)
                     return CaseHelper._check_stale(case_id, case_type, refreshed.server_modified_on,
-                                        refreshed.domain, es_modified_on_by_ids, case_search_es_modified_on_by_ids)
+                                                   refreshed.domain, es_modified_on_by_ids,
+                                                   case_search_es_modified_on_by_ids)
                 else:
-                    return True, DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type, domain=domain,
-                                        es_date=es_modified_on, primary_date=modified_on)
+                    return True, DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type,
+                                         domain=domain, es_date=es_modified_on, primary_date=modified_on)
         return False, None
 
     @staticmethod

--- a/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
@@ -193,7 +193,7 @@ class CaseHelper:
             # if the doc is newer in ES than sql, refetch from sql to get newest
             if es_modified_on is not None and es_modified_on > modified_on:
                 refreshed = CaseAccessors(domain).get_case(case_id)
-                return _check_stale(case_id, case_type, refreshed.server_modified_on,
+                return CaseHelper._check_stale(case_id, case_type, refreshed.server_modified_on,
                                     refreshed.domain, es_modified_on_by_ids, case_search_es_modified_on_by_ids)
             else:
                 return True, DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type, domain=domain,
@@ -204,7 +204,7 @@ class CaseHelper:
                 # if the doc is newer in ES than sql, refetch from sql to get newest
                 if es_modified_on is not None and es_modified_on > modified_on:
                     refreshed = CaseAccessors(domain).get_case(case_id)
-                    return _check_stale(case_id, case_type, refreshed.server_modified_on,
+                    return CaseHelper._check_stale(case_id, case_type, refreshed.server_modified_on,
                                         refreshed.domain, es_modified_on_by_ids, case_search_es_modified_on_by_ids)
                 else:
                     return True, DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type, domain=domain,

--- a/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
@@ -17,6 +17,7 @@ from corehq.form_processor.backends.sql.dbaccessors import (
     CaseReindexAccessor,
     FormReindexAccessor,
 )
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.pillows.case_search import domains_needing_search_index
 from corehq.util.dates import iso_string_to_datetime
 from corehq.util.doc_processor.progress import (
@@ -180,15 +181,35 @@ class CaseHelper:
         es_modified_on_by_ids = CaseHelper._get_es_modified_dates(case_ids)
         case_search_es_modified_on_by_ids = CaseHelper._get_case_search_es_modified_dates(case_search_ids)
         for case_id, case_type, modified_on, domain in chunk:
-            es_modified_on, es_domain = es_modified_on_by_ids.get(case_id, (None, None))
+            stale, data_row = CaseHelper._check_stale(case_id, case_type, modified_on, domain, es_modified_on_by_ids, case_search_es_modified_on_by_ids)
+            if stale:
+                yield data_row
+
+    @staticmethod
+    def _check_stale(case_id, case_type, modified_on, domain,
+                     es_modified_on_by_ids, case_search_es_modified_on_by_ids):
+        es_modified_on, es_domain = es_modified_on_by_ids.get(case_id, (None, None))
+        if (es_modified_on, es_domain) != (modified_on, domain):
+            # if the doc is newer in ES than sql, refetch from sql to get newest
+            if es_modified_on is not None and es_modified_on > modified_on:
+                refreshed = CaseAccessors(domain).get_case(case_id)
+                return _check_stale(case_id, case_type, refreshed.server_modified_on,
+                                    refreshed.domain, es_modified_on_by_ids, case_search_es_modified_on_by_ids)
+            else:
+                return True, DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type, domain=domain,
+                                     es_date=es_modified_on, primary_date=modified_on)
+        elif domain in domains_needing_search_index():
+            es_modified_on, es_domain = case_search_es_modified_on_by_ids.get(case_id, (None, None))
             if (es_modified_on, es_domain) != (modified_on, domain):
-                yield DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type, domain=domain,
-                              es_date=es_modified_on, primary_date=modified_on)
-            elif domain in domains_needing_search_index():
-                es_modified_on, es_domain = case_search_es_modified_on_by_ids.get(case_id, (None, None))
-                if (es_modified_on, es_domain) != (modified_on, domain):
-                    yield DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type, domain=domain,
-                                  es_date=es_modified_on, primary_date=modified_on)
+                # if the doc is newer in ES than sql, refetch from sql to get newest
+                if es_modified_on is not None and es_modified_on > modified_on:
+                    refreshed = CaseAccessors(domain).get_case(case_id)
+                    return _check_stale(case_id, case_type, refreshed.server_modified_on,
+                                        refreshed.domain, es_modified_on_by_ids, case_search_es_modified_on_by_ids)
+                else:
+                    return True, DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type, domain=domain,
+                                        es_date=es_modified_on, primary_date=modified_on)
+        return False, None
 
     @staticmethod
     @retry_on_es_timeout


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The nightly reconciliation task runs for long enough that some docs are updated between the time we fetch the cases in sql, and eventually check in ES, leading to false positives where the ES date was in the future compared to the sql one.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
The management command has tests.

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This runs in an isolated celery task.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
