### PR TITLE
Create get_enabled_users method on StaticToggle

### DIFF
--- a/corehq/apps/users/migrations/0038_add_ucr_permissions.py
+++ b/corehq/apps/users/migrations/0038_add_ucr_permissions.py
@@ -7,7 +7,7 @@ from corehq.util.django_migrations import skip_on_fresh_install
 
 @skip_on_fresh_install
 def add_ucr_permissions(apps, schema_editor):
-    usernames = _get_usernames_for_toggle(USER_CONFIGURABLE_REPORTS)
+    usernames = USER_CONFIGURABLE_REPORTS.get_enabled_users()
     all_user_roles = []
     user_objs = [CouchUser.get_by_username(username) for username in usernames]
 
@@ -24,12 +24,6 @@ def add_ucr_permissions(apps, schema_editor):
         if not permissions.edit_ucrs:
             permissions.edit_ucrs = True
             role.set_permissions(permissions.to_list())
-
-
-def _get_usernames_for_toggle(toggle):
-    toggle_obj = Toggle.get(toggle.slug)
-    return [user for user in toggle_obj.enabled_users
-            if not user.startswith("domain:")]
 
 
 class Migration(migrations.Migration):

--- a/corehq/apps/users/migrations/0038_add_ucr_permissions.py
+++ b/corehq/apps/users/migrations/0038_add_ucr_permissions.py
@@ -1,7 +1,7 @@
 from django.db import migrations
 
 from corehq.apps.users.models import CouchUser
-from corehq.toggles import USER_CONFIGURABLE_REPORTS, Toggle
+from corehq.toggles import USER_CONFIGURABLE_REPORTS
 from corehq.util.django_migrations import skip_on_fresh_install
 
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -245,6 +245,17 @@ class StaticToggle(object):
         domains -= self.always_disabled
         return list(domains)
 
+    def get_enabled_users(self):
+        try:
+            toggle = Toggle.get(self.slug)
+        except ResourceNotFound:
+            return []
+
+        users = {user for user in toggle.enabled_users if not user.startswith("domain:")}
+        users |= self.always_enabled
+        users -= self.always_disabled
+        return list(users)
+
 
 def was_domain_created_after(domain, checkpoint):
     """

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -251,10 +251,7 @@ class StaticToggle(object):
         except ResourceNotFound:
             return []
 
-        users = {user for user in toggle.enabled_users if not user.startswith("domain:")}
-        users |= self.always_enabled
-        users -= self.always_disabled
-        return list(users)
+        return [user for user in toggle.enabled_users if not user.startswith("domain:")]
 
 
 def was_domain_created_after(domain, checkpoint):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Blocking a swiss deploy and would present issues for local hosters who do not use the UCR feature flag.

This just creates a method on `StaticToggle` similar to get_enabled_domains, but for users instead. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
