### PR TITLE
[Hubspot] Don't delete users who have engaged outside of HQ 

### DIFF
--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -14,6 +14,21 @@ logger = logging.getLogger('analytics')
 
 MAX_API_RETRIES = 5
 
+ALLOWED_CONVERSIONS = [
+    'Blog',
+    'Case study/ Ev. Base',
+    'Contact us',
+    'Event',
+    'Live Chat',
+    'Newletter',
+    'Newsletter',
+    'Offer',
+    'Outbound',
+    'Paid Ads',
+    'Video',
+    None
+]
+
 
 def get_meta(request):
     return {
@@ -131,10 +146,13 @@ def _delete_hubspot_contact(vid, retry_num=0):
     return False
 
 
-def _get_contact_ids_for_emails(list_of_emails, retry_num=0):
+def _get_contact_ids_to_delete(list_of_emails, retry_num=0):
     """
     Gets a list of Contact IDs on Hubspot from a list of emails.
     If an email in the list doesn't exist on Hubspot, it's simply ignored.
+    We also check the list returned from HubSpot to ensure that users
+    who engaged with HubSpot under an allowed first conversion action are
+    not removed from HubSpot.
     :param list_of_emails:
     :param retry_num: the number of the current retry attempt
     :return: list of contact ids
@@ -160,12 +178,25 @@ def _get_contact_ids_for_emails(list_of_emails, retry_num=0):
                 'commcare.hubspot_data.retry.get_contact_ids_for_emails'
             )
             if retry_num <= MAX_API_RETRIES:
-                return _get_contact_ids_for_emails(list_of_emails, retry_num + 1)
+                return _get_contact_ids_to_delete(list_of_emails, retry_num + 1)
             else:
                 logger.error(f"Failed to get Hubspot contact ids for emails "
                              f"{list_of_emails.join(', ')} due to {str(e)}.")
         else:
-            return req.json().keys()
+            ids_to_delete = []
+            for contact_id, data in req.json().items():
+                first_conversion_status = data.get(
+                    'properties', {}
+                ).get('first_conversion_clustered_', {}).get('value')
+
+                # If a user's first conversion IS in the allowed list, it means
+                # they have directly interacted with us and we want to keep them
+                # in the email list. However, we will not send project data
+                # about them to HubSpot as they will still be blocked from
+                # updates in track_periodic_data.
+                if first_conversion_status not in ALLOWED_CONVERSIONS:
+                    ids_to_delete.append(contact_id)
+            return ids_to_delete
     return []
 
 
@@ -197,7 +228,7 @@ def remove_blocked_domain_contacts_from_hubspot(stdout=None):
                 blocked_emails.append(username)
                 if user_email and user_email != username:
                     blocked_emails.append(user_email)
-            ids_to_delete = _get_contact_ids_for_emails(set(blocked_emails))
+            ids_to_delete = _get_contact_ids_to_delete(set(blocked_emails))
             if stdout:
                 stdout.write(f"Found {len(ids_to_delete)} id(s) to delete.")
             num_deleted = sum(_delete_hubspot_contact(vid) for vid in ids_to_delete)


### PR DESCRIPTION
## Product Description
This change ensures that if a user interacts with Dimagi outside of HQ, their email remains in our mailing list. If the user is a member of a project whose `BillingAccount` is blocking HubSpot data, analytics about project-level data will continue to be skipped for the user. However, if the user signed up for a newsletter or engaged with Dimagi outside of CommCare HQ, we will allow their email to remain in our HubSpot email list.

## Technical Summary
This change checks the returned hubspot property `first_conversion_clustered_` against a list of allowed conversions. If a user's first conversion is not in this list, they will be removed from HubSpot if they are a member of a project that is blocking analytics data to hubspot.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
This is an interaction with Hubspot's API, so no tests.

### QA Plan
Not needed. The default of this check is that it continues to follow the current functionality already in HQ.

### Safety story
Tested locally against hubspot's API. The default is that a user is deleted, which is already the functionality on HQ.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
