### PR TITLE
Python 3.9 Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.9
 MAINTAINER Dimagi <devops@dimagi.com>
 
 ENV PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
This branch is used to build the [`commcarehq_py39` docker image hosted on hub.docker.com](https://hub.docker.com/r/dimagi/commcarehq_py39)

Other PRs working on the Python 3.9 porting effort should change `docker/Dockerfile` so their tests will use that image:
```diff
- FROM dimagi/commcarehq_base:latest
+ FROM dimagi/commcarehq_py39:latest
```

Any changes made on a Python 3.9 porting branch should be backward-compatible with Python 3.6. Once tests are passing on Python 3.9, changes can be cherry-picked to another branch that does not update the base image in `docker/Dockerfile` and PR'd separately (where tests will run against Python 3.6) and merged into master.

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Tests for this change are run in https://github.com/dimagi/commcare-hq/pull/30612

### QA Plan

https://dimagi-dev.atlassian.net/browse/QA-3683

### Rollback instructions

If this PR is rolled back it will affect docker images built on Docker Hub, which are used to run tests.
