### PR TITLE
Case Searc: Use less awkward logic in assembling filters and queries

### DIFF
--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -155,12 +155,7 @@ class CaseSearchCriteria:
     def search_es(self):
         search_es = self._get_initial_search_es()
         for key, value in self.criteria.items():
-            filter_, is_query = self._get_filter(key, value)
-            if filter_:
-                if is_query:
-                    search_es = search_es.add_query(filter_, queries.MUST)
-                else:
-                    search_es = search_es.filter(filter_)
+            search_es = self._apply_filter(search_es, key, value)
         return search_es
 
     def _get_initial_search_es(self):
@@ -171,21 +166,21 @@ class CaseSearchCriteria:
                 .size(CASE_SEARCH_MAX_RESULTS)
                 .set_sorting_block(['_score', '_doc']))
 
-    def _get_filter(self, key, value):
+    def _apply_filter(self, search_es, key, value):
         if key == CASE_SEARCH_XPATH_QUERY_KEY:
             if value:
-                return build_filter_from_xpath(self.query_domains, value), False
+                return search_es.filter(build_filter_from_xpath(self.query_domains, value))
         elif key == 'owner_id':
             if value:
-                return case_search.owner(value), False
+                return search_es.filter(case_search.owner(value))
         elif key == CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY:
             if value:
-                return case_search.blacklist_owner_id(value.split(' ')), False
+                return search_es.filter(case_search.blacklist_owner_id(value.split(' ')))
         elif key == COMMCARE_PROJECT:
-            return filters.domain(value), False
+            return search_es.filter(filters.domain(value))
         elif key not in UNSEARCHABLE_KEYS and not key.startswith(SEARCH_QUERY_CUSTOM_VALUE):
-            return self._get_case_property_query(key, value), True
-        return None, None
+            return search_es.add_query(self._get_case_property_query(key, value), queries.MUST)
+        return search_es
 
     def _validate_multiple_parameter_values(self, key, val):
         if not isinstance(val, list):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://github.com/dimagi/commcare-hq/pull/30522#pullrequestreview-771102687
Would love to just pass through all of these as filters, which I'm pretty sure would be fine, but I'm cautious about changing it.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] All migrations are backwards compatible and won't block deploy
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
