### PR TITLE
Adjust the "reset to default" button as requested in figma.

### DIFF
--- a/corehq/apps/case_importer/templates/case_importer/excel_fields.html
+++ b/corehq/apps/case_importer/templates/case_importer/excel_fields.html
@@ -1,8 +1,18 @@
 {% extends "hqwebapp/base_section.html" %}
+{% load compress %}
 {% load hq_shared_tags %}
 {% load i18n %}
 
 {% requirejs_main "case_importer/js/main" %}
+
+{% block stylesheets %}{{ block.super }}
+  {% compress css %}
+  <link type="text/less"
+        rel="stylesheet"
+        media="all"
+        href="{% static 'case_importer/less/case_importer.less' %}" />
+  {% endcompress %}
+{% endblock %}
 
 {% block page_content %}
   {% include 'case_importer/partials/help_message.html' %}
@@ -21,13 +31,18 @@
     <input type="hidden" name="create_new_cases" value="{{create_new_cases}}" />
 
     <fieldset>
-      <legend>{% trans "Match Excel Columns to Case Properties" %}</legend>
+      <legend>
+        {% trans "Match Excel Columns to Case Properties" %}
+        <button type="button" class="btn btn-default pull-right" id="autofill" title="{% trans_html_attr 'Reset file-to-case-property matching to default' %}">
+          {% trans "Reset to default matching" %}
+        </button>
+      </legend>
       <table class="table table-condensed" id="fieldlist">
         <thead>
         <th class="span1"></th>
         <th>{% trans "Excel Field" %}</th>
         <th></th>
-        <th>{% trans "Case Property" %}<button type="button" class="btn btn-default btn-xs pull-right" id="autofill">{% trans "Set to default" %}</button></th>
+        <th>{% trans "Case Property" %}</th>
         <th class="col-md-1">{% trans "Create new property" %}</th>
         <th>{% include "data_dictionary/partials/valid_values_th_content.html" %}</th>
         </thead>

--- a/corehq/apps/hqwebapp/static/case_importer/less/case_importer.less
+++ b/corehq/apps/hqwebapp/static/case_importer/less/case_importer.less
@@ -1,0 +1,4 @@
+fieldset legend {
+  border-bottom: none;
+  font-size: 22px;
+}


### PR DESCRIPTION
## Product Description
During case import, when matching excel columns to case properties:

1. Move the "reset to default" button from in the "Case Property" header to the legend line, pulled right
2. Change the label to "Reset to default matching"
3. Add Title attribute to "Reset to file-to-case-property matching to default"

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [ ] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
