### PR TITLE
pass user through to filters in report data API

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -603,7 +603,7 @@ class ConfigurableReportDataResource(HqBaseResource, DomainSpecificResourceMixin
         else:
             return ""
 
-    def _get_report_data(self, report_config, domain, start, limit, get_params):
+    def _get_report_data(self, report_config, domain, start, limit, get_params, couch_user):
         report = ConfigurableReportDataSource.from_spec(report_config, include_prefilters=True)
 
         string_type_params = [
@@ -613,7 +613,8 @@ class ConfigurableReportDataResource(HqBaseResource, DomainSpecificResourceMixin
         ]
         filter_values = get_filter_values(
             report_config.ui_filters,
-            query_dict_to_dict(get_params, domain, string_type_params)
+            query_dict_to_dict(get_params, domain, string_type_params),
+            couch_user,
         )
         report.set_filter_values(filter_values)
 
@@ -640,7 +641,7 @@ class ConfigurableReportDataResource(HqBaseResource, DomainSpecificResourceMixin
 
         report_config = self._get_report_configuration(pk, domain)
         page, columns, total_records = self._get_report_data(
-            report_config, domain, start, limit, bundle.request.GET)
+            report_config, domain, start, limit, bundle.request.GET, bundle.request.couch_user)
 
         return ConfigurableReportData(
             data=page,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Attempting to fix a crashing bug on certain report data APIs (those that have a location filter).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://forum.dimagi.com/t/report-download-api-not-working-for-static-reports/8469/9

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

N/A

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
I tested the API itself locally as a safeguard against regressions, and I confirmed the user is properly passed through. I did *not* take the time to reproduce the exact bug, so I don't know for sure that this is the correct fix. Though reasoning through the code it seems logical that it is right.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

The API has existing tests. I did not add any for this edge case.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression

I would prefer to have reproduced the bug prior to the fix, but I didn't have time. I'm not as confident as I've ever been about a change, but given that this is a very rarely used API and a fix that is relatively straightforward to reason with, I feel it is unlikely to have a serious negative outcome.