### PR TITLE
support 'search again' workflows for registry search

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2484,8 +2484,7 @@ class ModuleDetailsMixin(object):
             ('ref_long', self.ref_details.long, False),
         ]
         custom_detail = self.case_details.short.custom_xml
-        registry_search = self.search_config.data_registry
-        if module_offers_search(self) and not custom_detail and not registry_search:
+        if module_offers_search(self) and not custom_detail:
             details.append(('search_short', self.search_detail("short"), True))
             details.append(('search_long', self.search_detail("long"), True))
         return tuple(details)

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -197,8 +197,9 @@ class DetailContributor(SectionContributor):
                     if form.is_registration_form(module.case_type) or form.unique_id in valid_forms:
                         d.actions.append(self._get_case_list_form_action(module))
 
-                if module_offers_search(module) and not module.search_config.data_registry:
-                    d.actions.append(self._get_case_search_action(module, in_search="search" in id))
+                if module_offers_search(module):
+                    in_search = module.search_config.data_registry or "search" in id
+                    d.actions.append(self._get_case_search_action(module, in_search=in_search))
 
             try:
                 if not self.app.enable_multi_sort:

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -314,7 +314,7 @@ class RemoteRequestContributor(SuiteContributorByModule):
     @time_method()
     def get_module_contributions(self, module, detail_section_elements):
         elements = []
-        if module_offers_search(module) and not module.search_config.data_registry:
+        if module_offers_search(module):
             elements.append(RemoteRequestFactory(
                 module, detail_section_elements).build_remote_request()
             )

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -105,11 +105,17 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         # assert that session instance is added to the entry
         self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='commcaresession']")
 
-        # assert remote request is not added
-        self.assertXmlDoesNotHaveXpath(suite, "./remote-request")
-        self.assertXmlDoesNotHaveXpath(suite, "./detail[@id='m0_case_short']/action")
-        self.assertXmlDoesNotHaveXpath(suite, "./detail[@id='m0_search_short']")
-        self.assertXmlDoesNotHaveXpath(suite, "./detail[@id='m0_search_long']")
+        # needed for 'search again' workflow
+        self.assertXmlPartialEqual(
+            """<partial>
+                <locale id="case_search.m0.again"/>
+            </partial>""",
+            suite,
+            "./detail[@id='m0_case_short']/action/display/text/locale"
+        )
+        self.assertXmlHasXpath(suite, "./remote-request")
+        self.assertXmlHasXpath(suite, "./detail[@id='m0_search_short']")
+        self.assertXmlHasXpath(suite, "./detail[@id='m0_search_long']")
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
     def test_search_data_registry_additional_registry_query(self, *args):


### PR DESCRIPTION
## Product Description
This adds the a 'search again' button into the case details page along with the additional configuration to support that workflow.

## Technical Summary
This adds back detail action, search details and remote query
when registry search is enabled.

## Feature Flag
DATA_REGISTRY

## Safety Assurance

### Safety story
These app configs are already used for normal case search, this PR is just re-enabling them when registry search is configured. 

### Automated test coverage
The app suite files are well tested and tests for this specific configuration have been updated.

### QA Plan
This will get QA'd along with other data registry app changes but the AE team. No separate QA is necessary and QA will not block deploy.

I have also tested this locally with the formplayer changes in https://github.com/dimagi/formplayer/pull/1006 and found that it works as expected.

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
