### PR TITLE
add event_date check while querying couch_id

### DIFF
--- a/corehq/apps/auditcare/couch_to_sql.py
+++ b/corehq/apps/auditcare/couch_to_sql.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 import re
 
@@ -133,7 +134,9 @@ def get_events_from_couch(start_key, end_key, batch_size, start_doc_id=None):
         navigation_objects,
         access_objects,
         nav_couch_ids,
-        access_couch_ids
+        access_couch_ids,
+        start_key,
+        end_key
     )
 
     res_obj.update({
@@ -175,11 +178,15 @@ def _get_couch_docs(start_key, end_key, batch_size, start_doc_id=None):
     return list(result)
 
 
-def get_unsaved_events(nav_objs, access_objs, nav_couch_ids, access_couch_ids):
+def get_unsaved_events(nav_objs, access_objs, nav_couch_ids, access_couch_ids, start_key, end_key):
     existing_access_events = set(AccessAudit.objects.filter(
+        event_date__lt=_get_datetime_from_key(start_key),
+        event_date__gt=_get_datetime_from_key(end_key),
         couch_id__in=access_couch_ids
     ).values_list('couch_id', flat=True))
     existing_nav_events = set(NavigationEventAudit.objects.filter(
+        event_date__lt=_get_datetime_from_key(start_key),
+        event_date__gt=_get_datetime_from_key(end_key),
         couch_id__in=nav_couch_ids
     ).values_list('couch_id', flat=True))
 
@@ -201,3 +208,7 @@ def get_unsaved_events(nav_objs, access_objs, nav_couch_ids, access_couch_ids):
 
 def _pick(doc, keys):
     return {key: doc.get(key) for key in keys if doc.get(key)}
+
+
+def _get_datetime_from_key(key):
+    return datetime(*key[:6])


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
We have been trying to speed up the auditcare migrations, while profiling we found out that the query that we do to find existing ids in SQL is taking almost 95% of the time. It happens out to be the query was scanning all partitions from starting to end. So adding the `event_date` filter made it much more efficient.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12241
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tests are running fine which ensures that the change does not break anything.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
