### PR TITLE
Add equals in gt and lt in query

### DIFF
--- a/corehq/apps/auditcare/couch_to_sql.py
+++ b/corehq/apps/auditcare/couch_to_sql.py
@@ -180,13 +180,13 @@ def _get_couch_docs(start_key, end_key, batch_size, start_doc_id=None):
 
 def get_unsaved_events(nav_objs, access_objs, nav_couch_ids, access_couch_ids, start_key, end_key):
     existing_access_events = set(AccessAudit.objects.filter(
-        event_date__lt=_get_datetime_from_key(start_key),
-        event_date__gt=_get_datetime_from_key(end_key),
+        event_date__lte=_get_datetime_from_key(start_key),
+        event_date__gte=_get_datetime_from_key(end_key),
         couch_id__in=access_couch_ids
     ).values_list('couch_id', flat=True))
     existing_nav_events = set(NavigationEventAudit.objects.filter(
-        event_date__lt=_get_datetime_from_key(start_key),
-        event_date__gt=_get_datetime_from_key(end_key),
+        event_date__lte=_get_datetime_from_key(start_key),
+        event_date__gte=_get_datetime_from_key(end_key),
         couch_id__in=nav_couch_ids
     ).values_list('couch_id', flat=True))
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A part of https://github.com/dimagi/commcare-hq/pull/30561 , I realized there may be an edge case where a couch `doc_id` which is of same as start time might get missed. So adding the equals check.

## Safety Assurance
Changes have been tested locally.
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage
All the test related to change are passing.
<!-- Identify the related test coverage and the tests it would catch -->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
