### PR TITLE
only create pghashlib extension where necessary

### DIFF
--- a/corehq/sql_accessors/migrations/0056_add_hashlib_functions.py
+++ b/corehq/sql_accessors/migrations/0056_add_hashlib_functions.py
@@ -22,5 +22,5 @@ class Migration(migrations.Migration):
             'CREATE EXTENSION IF NOT EXISTS hashlib',
             'DROP EXTENSION hashlib'
         )
-        if settings.UNIT_TESTING else noop_migration()
+        if settings.UNIT_TESTING and settings.USE_PARTITIONED_DATABASE else noop_migration()
     ]


### PR DESCRIPTION
## Technical Summary

pghashlib is only required when running a sharded DB. Having this in the normal DB means you are required to have pghashlib installed in your PG instance. For dev's not running docker (our docker images don't work on new amd64 chips) having to install pghashlib is an unnecessary step.

## Safety Assurance

### Safety story
This change will only impact tests.

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
