### PR TITLE
small data registry tweaks

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -282,7 +282,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                     return {
                         instance_name: query.instanceName(),
                         case_type_xpath: query.caseTypeXpath(),
-                        case_id_xpath: query.caseTypeXpath(),
+                        case_id_xpath: query.caseIdXpath(),
                     };
                 }),
             };

--- a/corehq/apps/ota/tests/test_registry_case_details.py
+++ b/corehq/apps/ota/tests/test_registry_case_details.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 
 from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseIndex
 from corehq.apps.app_manager.tests.app_factory import AppFactory
+from corehq.apps.case_search.const import COMMCARE_PROJECT
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.registry.helper import DataRegistryHelper
@@ -77,8 +78,16 @@ class RegistryCaseDetailsTests(TestCase):
         response_content = self._make_request({
             "commcare_registry": self.registry.slug, "case_id": self.parent_case_id, "case_type": "parent",
         }, 200)
-        case_ids = self._get_cases_in_response(response_content)
-        self.assertEqual(case_ids, {case.case_id for case in self.cases})
+        actual_cases = self._get_cases_in_response(response_content)
+        expected_cases = {case.case_id: case for case in self.cases}
+        self.assertEqual(set(actual_cases), set(expected_cases))
+
+        actual_domains = {
+            case.case_id: case.get_property(COMMCARE_PROJECT) for case in actual_cases.values()
+        }
+        expected_domains = {case.case_id: case.domain for case in self.cases}
+        self.assertEqual(actual_domains, expected_domains)
+
         self.assertEqual(1, RegistryAuditLog.objects.filter(
             registry=self.registry,
             action=RegistryAuditLog.ACTION_DATA_ACCESSED,
@@ -105,7 +114,22 @@ class RegistryCaseDetailsTests(TestCase):
 
     def _get_cases_in_response(self, response_content):
         xml = ElementTree.fromstring(response_content)
-        return {node.get("case_id") for node in xml.findall("case")}
+        return {node.get('case_id'): _FixtureCase(node) for node in xml.findall("case")}
+
+
+class _FixtureCase:
+    """
+    Shim class for working with XML case blocks in a case DB fixture.
+    """
+    def __init__(self, xml_element):
+        self.xml_element = xml_element
+
+    @property
+    def case_id(self):
+        return self.xml_element.get('case_id')
+
+    def get_property(self, name):
+        return self.xml_element.findtext(name)
 
 
 @generate_cases([

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -68,6 +68,7 @@ from .utils import (
     handle_401_response,
     is_permitted_to_restore,
 )
+from ..case_search.const import COMMCARE_PROJECT
 
 PROFILE_PROBABILITY = float(os.getenv('COMMCARE_PROFILE_RESTORE_PROBABILITY', 0))
 PROFILE_LIMIT = os.getenv('COMMCARE_PROFILE_RESTORE_LIMIT')
@@ -440,4 +441,6 @@ def registry_case(request, domain, app_id):
         return HttpResponseNotFound(f"Case '{case_id}' not found")
 
     cases = helper.get_case_hierarchy(request.couch_user, case)
+    for case in cases:
+        case.case_json[COMMCARE_PROJECT] = case.domain
     return HttpResponse(CaseDBFixture(cases).fixture, content_type="text/xml; charset=utf-8")

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -761,7 +761,7 @@ class DataRegistryCaseUpdateRepeater(CreateCaseRepeater):
         return toggles.DATA_REGISTRY_CASE_UPDATE_REPEATER.enabled(domain)
 
     def get_url(self, repeat_record):
-        new_domain = self.payload_doc(repeat_record).get_case_property('target_case_domain')
+        new_domain = self.payload_doc(repeat_record).get_case_property('target_domain')
         return self.connection_settings.url.format(domain=new_domain)
 
     def send_request(self, repeat_record, payload):

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
@@ -123,6 +123,9 @@ class DataRegistryCaseUpdateRepeaterTest(TestCase, TestXmlMixin, DomainSubscript
             self.target_case_id_2: {"new_prop": "new_val_case2"}
         })
 
+        url = self.repeater.get_url(repeat_records[0])
+        self.assertEqual(url, f"case-repeater-url/{self.target_domain}/")
+
     @classmethod
     def repeat_records(cls, domain_name):
         # Enqueued repeat records have next_check set 48 hours in the future.


### PR DESCRIPTION
## Technical Summary
* Make 'commcare_project' property available on cases fetched from the registry via the 'registry case' view.
* Fix bug in data registry repeater
* Fix bug in registry app config for additional queries

## Feature Flag
DATA_REGISTRY

## Safety Assurance

### Safety story
Minor changes to feature flagged features that are still in pre-release.

### Automated test coverage
Tests for this code has been updated.

### QA Plan
None


### Migrations
no migrations

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
