### PR TITLE
[Hubspot] management command to check that blocked hubspot users are in fact blocked

### DIFF
--- a/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
+++ b/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
             help='Skip to this domain name and check domains from there.',
         )
         parser.add_argument(
-            '-s',
+            '-d',
             '--domain',
             action='store',
             dest='domain',

--- a/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
+++ b/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
@@ -15,50 +15,89 @@ class Command(BaseCommand):
     help = "Manually cleans up blocked Hubspot contacts"
     api_key = None
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-s',
+            '--skip',
+            action='store',
+            dest='skip',
+            help='Skip to this domain name and check domains from there.',
+        )
+        parser.add_argument(
+            '-s',
+            '--domain',
+            action='store',
+            dest='domain',
+            help='Only check this domain.',
+        )
+
     def handle(self, **options):
         self.api_key = settings.ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)
 
         if not self.api_key:
             self.stdout.write("No HubSpot API key found.")
+            return
 
         blocked_domains = get_blocked_hubspot_domains()
-        for domain in blocked_domains:
-            users_not_blocked = {}
-            user_query = UserES().domain(domain).source(['email', 'username'])
 
-            total_users = user_query.count()
-            chunk_size = 30  # Hubspot recommends fewer than 100 emails per request
-            num_chunks = int(math.ceil(float(total_users) / float(chunk_size)))
+        check_domain = options.get('domain')
+        skip_to_domain = options.get('skip')
 
-            for chunk in range(num_chunks):
-                blocked_users = (user_query
-                                 .size(chunk_size)
-                                 .start(chunk * chunk_size)
-                                 .run()
-                                 .hits)
-                blocked_emails = []
-                for user in blocked_users:
-                    username = user.get('username')
-                    user_email = user.get('email')
-                    blocked_emails.append(username)
-                    if user_email and user_email != username:
-                        blocked_emails.append(user_email)
-                    users_not_blocked.update(self.get_blocked_status_for_emails(
-                        list(set(blocked_emails))
-                    ))
-            if users_not_blocked:
-                self.stdout.write(self.style.ERROR(
-                    f"\n\nFound {len(users_not_blocked)} users in "
-                    f"HubSpot who are members of the project {domain} "
-                    f"that is blocking HubSpot data:"
+        if check_domain:
+            if check_domain not in blocked_domains:
+                self.stdout.write(
+                    f"{check_domain} is not a blocked HubSpot domain."
+                )
+                return
+            self.print_domain_summary(check_domain)
+        else:
+            skip = skip_to_domain is not None
+
+            for domain in blocked_domains:
+                if domain == skip_to_domain:
+                    skip = False
+                if skip:
+                    continue
+                self.print_domain_summary(domain)
+
+    def print_domain_summary(self, domain):
+        users_not_blocked = {}
+        user_query = UserES().domain(domain).source(['email', 'username'])
+
+        total_users = user_query.count()
+        chunk_size = 30  # Hubspot recommends fewer than 100 emails per request
+        num_chunks = int(math.ceil(float(total_users) / float(chunk_size)))
+
+        for chunk in range(num_chunks):
+            blocked_users = (user_query
+                             .size(chunk_size)
+                             .start(chunk * chunk_size)
+                             .run()
+                             .hits)
+            blocked_emails = []
+            for user in blocked_users:
+                username = user.get('username')
+                user_email = user.get('email')
+                blocked_emails.append(username)
+                if user_email and user_email != username:
+                    blocked_emails.append(user_email)
+                users_not_blocked.update(self.get_blocked_status_for_emails(
+                    list(set(blocked_emails))
                 ))
-                self.stdout.write("\nEmail\tFirst Conversion")
-                for user, status in users_not_blocked:
-                    self.stdout.write(f"{user}\t{status}")
-            else:
-                self.stdout.write(self.style.SUCCESS(
-                    f"All users in project {domain} are absent on HubSpot."
-                ))
+        if users_not_blocked:
+            self.stdout.write(self.style.ERROR(
+                f"\n\nFound {len(users_not_blocked)} users in "
+                f"HubSpot who are members of the project {domain} "
+                f"that is blocking HubSpot data:"
+            ))
+            self.stdout.write("\nEmail\tFirst Conversion")
+            for user, status in users_not_blocked:
+                self.stdout.write(f"{user}\t{status}")
+            self.stdout.write('\n\n')
+        else:
+            self.stdout.write(self.style.SUCCESS(
+                f"All users in project {domain} are absent on HubSpot."
+            ))
 
     def get_blocked_status_for_emails(self, list_of_emails, retry_num=0):
         try:

--- a/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
+++ b/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
@@ -91,7 +91,7 @@ class Command(BaseCommand):
                 f"that is blocking HubSpot data:"
             ))
             self.stdout.write("\nEmail\tFirst Conversion")
-            for user, status in users_not_blocked:
+            for user, status in users_not_blocked.items():
                 self.stdout.write(f"{user}\t{status}")
             self.stdout.write('\n\n')
         else:

--- a/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
+++ b/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
@@ -1,0 +1,89 @@
+import math
+import requests
+
+from django.conf import settings
+from django.core.management import BaseCommand
+
+from corehq.apps.analytics.utils import (
+    get_blocked_hubspot_domains,
+    MAX_API_RETRIES,
+)
+from corehq.apps.es import UserES
+
+
+class Command(BaseCommand):
+    help = "Manually cleans up blocked Hubspot contacts"
+    api_key = None
+
+    def handle(self, **options):
+        if not settings.HUBSPOT_ENABLED:
+            self.stdout.write("HubSpot is not enabled for this environment.")
+
+        self.api_key = settings.ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)
+
+        if not self.api_key:
+            self.stdout.write("No HubSpot API key found.")
+
+        blocked_domains = get_blocked_hubspot_domains()
+        for domain in blocked_domains:
+            users_not_blocked = []
+            user_query = UserES().domain(domain).source(['email', 'username'])
+
+            total_users = user_query.count()
+            chunk_size = 30  # Hubspot recommends fewer than 100 emails per request
+            num_chunks = int(math.ceil(float(total_users) / float(chunk_size)))
+
+            for chunk in range(num_chunks):
+                blocked_users = (user_query
+                                 .size(chunk_size)
+                                 .start(chunk * chunk_size)
+                                 .run()
+                                 .hits)
+                blocked_emails = []
+                for user in blocked_users:
+                    username = user.get('username')
+                    user_email = user.get('email')
+                    blocked_emails.append(username)
+                    if user_email and user_email != username:
+                        blocked_emails.append(user_email)
+                    users_not_blocked.extend(self.get_blocked_status_for_emails(
+                        blocked_emails
+                    ))
+            if users_not_blocked:
+                self.stdout.write(f"\n\nFound {len(users_not_blocked)} users in "
+                            f"HubSpot who are members of the project {domain} "
+                            f"that is blocking HubSpot data:")
+                self.stdout.write("\nEmail\tFirst Conversion")
+                for summary in users_not_blocked:
+                    self.stdout.write(f"{summary[0]}\t{summary[1]}")
+
+    def get_blocked_status_for_emails(self, list_of_emails, retry_num=0):
+        try:
+            req = requests.get(
+                "https://api.hubapi.com/contacts/v1/contact/emails/batch/",
+                params={
+                    'hapikey': self.api_key,
+                    'email': list_of_emails,
+                },
+            )
+            if req.status_code == 404:
+                return []
+            req.raise_for_status()
+        except (ConnectionError, requests.exceptions.HTTPError) as e:
+            if retry_num <= MAX_API_RETRIES:
+                return self.get_blocked_status_for_emails(list_of_emails, retry_num + 1)
+            else:
+                self.stdout.write(f"Failed to get data from hubspot for "
+                                  f"{list_of_emails.join(',')}.")
+        else:
+            status_summary = []
+            for contact_id, data in req.json().items():
+                first_conversion_status = data.get(
+                    'properties', {}
+                ).get('first_conversion_clustered_', {}).get('value')
+                email = data.get(
+                    'properties', {}
+                ).get('email', {}).get('value')
+                status_summary.append((email, first_conversion_status))
+            return status_summary
+        return []

--- a/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
+++ b/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
@@ -47,9 +47,11 @@ class Command(BaseCommand):
                         blocked_emails
                     ))
             if users_not_blocked:
-                self.stdout.write(f"\n\nFound {len(users_not_blocked)} users in "
-                            f"HubSpot who are members of the project {domain} "
-                            f"that is blocking HubSpot data:")
+                self.stdout.write(self.style.ERROR(
+                    f"\n\nFound {len(users_not_blocked)} users in "
+                    f"HubSpot who are members of the project {domain} "
+                    f"that is blocking HubSpot data:"
+                ))
                 self.stdout.write("\nEmail\tFirst Conversion")
                 for summary in users_not_blocked:
                     self.stdout.write(f"{summary[0]}\t{summary[1]}")
@@ -70,8 +72,10 @@ class Command(BaseCommand):
             if retry_num <= MAX_API_RETRIES:
                 return self.get_blocked_status_for_emails(list_of_emails, retry_num + 1)
             else:
-                self.stdout.write(f"Failed to get data from hubspot for "
-                                  f"{list_of_emails.join(',')}.")
+                self.stdout.write(self.style.ERROR(
+                    f"Failed to get data from hubspot for "
+                    f"{list_of_emails.join(',')}."
+                ))
         else:
             status_summary = []
             for contact_id, data in req.json().items():

--- a/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
+++ b/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
@@ -16,9 +16,6 @@ class Command(BaseCommand):
     api_key = None
 
     def handle(self, **options):
-        if not settings.HUBSPOT_ENABLED:
-            self.stdout.write("HubSpot is not enabled for this environment.")
-
         self.api_key = settings.ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)
 
         if not self.api_key:

--- a/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
+++ b/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
@@ -55,6 +55,10 @@ class Command(BaseCommand):
                 self.stdout.write("\nEmail\tFirst Conversion")
                 for summary in users_not_blocked:
                     self.stdout.write(f"{summary[0]}\t{summary[1]}")
+            else:
+                self.stdout.write(self.style.SUCCESS(
+                    f"All users in project {domain} are absent on HubSpot."
+                ))
 
     def get_blocked_status_for_emails(self, list_of_emails, retry_num=0):
         try:


### PR DESCRIPTION
## Product Description
This PR introduces a new management command to summarize the status of users blocked from hubspot. When run it iterates through all the domains blocking hubspot data and ensures that users in those domains are in fact absent from hubspot. If a user is found in a domain that is present on hubspot, that user's email is displayed along with their first conversion status to ensure that their presence on hubspot is at least valid.

## Technical Summary
To run you can use the following command:
```
cchq production --control django-manage blocked_hubspot_users_summary
```

To skip to a specific domain in the list and continue from there (perhaps due to a dropped connection), the following command can be used:
```
cchq production --control django-manage blocked_hubspot_users_summary --skip <domain>
```

To only run checks against a specific domain, the following command can be used:
```
cchq production --control django-manage blocked_hubspot_users_summary --domain <domain>
```

### Safety story
Simple management command. Affects no functionality on production.

### Automated test coverage
Not needed

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
