### PR TITLE
Change "blocked" label for invited web users and add tooltip

### DIFF
--- a/corehq/apps/users/static/users/js/web_users.js
+++ b/corehq/apps/users/static/users/js/web_users.js
@@ -201,5 +201,11 @@ hqDefine("users/js/web_users",[
             );
             e.preventDefault();
         });
+
+        $('#undeliverable-label').tooltip({
+            placement: 'right',
+            html: true,
+            title: gettext("We have sent the invitation email to this user but the user's email server rejected it. This usually means either the email address is incorrect or your organization is blocking emails from our address (commcarehq-noreply-production@dimagi.com)."),
+        });
     });
 });

--- a/corehq/apps/users/static/users/js/web_users.js
+++ b/corehq/apps/users/static/users/js/web_users.js
@@ -202,10 +202,12 @@ hqDefine("users/js/web_users",[
             e.preventDefault();
         });
 
-        $('#undeliverable-label').tooltip({
+        $('.undeliverable-label').tooltip({
             placement: 'right',
             html: true,
-            title: gettext("We have sent the invitation email to this user but the user's email server rejected it. This usually means either the email address is incorrect or your organization is blocking emails from our address (commcarehq-noreply-production@dimagi.com)."),
+            title: gettext(`We have sent the invitation email to this user but the user's email server
+            rejected it. This usually means either the email address is incorrect or your organization
+            is blocking emails from our address (${initialPageData.get('fromAddress')}).`),
         });
     });
 });

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -270,7 +270,7 @@
             <tr data-bind="visible: visible">
               <td>
                 <!-- ko text: email --><!-- /ko -->
-                <span class="label label-danger" data-bind="visible: email_marked_as_bounced">{% trans "Blocked" %}</span>
+                <span class="label label-danger" id="undeliverable-label" data-bind="visible: email_marked_as_bounced">{% trans "Undeliverable" %}</span>
               </td>
               <td data-bind="text: role_label"></td>
               <td>

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -7,6 +7,7 @@
 
 {% block page_content %}
   {% initial_page_data "invitations" invitations %}
+  {% initial_page_data "fromAddress" from_address %}
   {% registerurl "delete_invitation" domain %}
   {% registerurl "delete_request" domain %}
   {% registerurl "paginate_web_users" domain %}
@@ -270,7 +271,7 @@
             <tr data-bind="visible: visible">
               <td>
                 <!-- ko text: email --><!-- /ko -->
-                <span class="label label-danger" id="undeliverable-label" data-bind="visible: email_marked_as_bounced">{% trans "Undeliverable" %}</span>
+                <span class="label label-danger undeliverable-label" data-bind="visible: email_marked_as_bounced">{% trans "Undeliverable" %}</span>
               </td>
               <td data-bind="text: role_label"></td>
               <td>

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1,6 +1,7 @@
 import json
 from collections import defaultdict
 from datetime import datetime
+from django.conf import settings
 
 import langcodes
 import six.moves.urllib.error
@@ -544,6 +545,7 @@ class ListWebUsersView(BaseRoleAccessView):
     page_title = ugettext_lazy("Web Users")
     urlname = 'web_users'
 
+
     @property
     @memoized
     def role_labels(self):
@@ -580,6 +582,7 @@ class ListWebUsersView(BaseRoleAccessView):
             'admins': WebUser.get_admins_by_domain(self.domain),
             'domain_object': self.domain_object,
             'bulk_download_url': bulk_download_url,
+            'from_address': settings.DEFAULT_FROM_EMAIL
         }
 
 


### PR DESCRIPTION
## Product Description
Invited web users whose invitation does not reach them are marked as "Blocked". This label was confusing to users, so we have decided to change the label to "Undeliverable", with tooltip helper-text to explain why the invitation is marked so.

Note the helper text in the images below.

## Technical Summary
[USH-186](https://dimagi-dev.atlassian.net/browse/USH-186). 

I simply changed the email_marked_as_bounced variable to turn on and off the label for testing. Actually sending the email in my local env is a functionality I do not have set up.

Before:
<img width="248" alt="blocked" src="https://user-images.githubusercontent.com/6729291/136979509-0f272212-06ce-4a2e-ab31-affce670f8a4.png">

After:

![image](https://user-images.githubusercontent.com/6729291/136979567-506980ac-d805-4e29-8a54-0dcc3f05ce98.png)

After, with mouse hover to show tooltip helper-text:

![image](https://user-images.githubusercontent.com/6729291/136979604-bbf1b330-bfce-4796-87e3-1ec413e61cfd.png)

### Safety story
I tested locally, this could possibly use some extra testing on staging or production to make sure it all looks nice, but no changes were made to the email_marked_as_bounced variable, so it the functionality should be OK.

### Automated test coverage

No tests.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
