### PR TITLE
add remote instances to form

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1166,7 +1166,7 @@ class FormBase(DocumentSchema):
         xform.normalize_itext()
         xform.strip_vellum_ns_attributes()
         xform.set_version(self.get_version())
-        xform.add_missing_instances(app)
+        xform.add_missing_instances(self, app)
 
     @memoized
     def render_xform(self, build_profile_id=None):

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -38,6 +38,7 @@ from .exceptions import (
     XFormValidationError,
     XFormValidationFailed,
 )
+from .suite_xml.xml_models import Instance
 from .xpath import CaseIDXPath, QualifiedScheduleFormXPath, session_var
 
 VALID_VALUE_FORMS = ('image', 'audio', 'video', 'video-inline', 'markdown')
@@ -826,12 +827,23 @@ class XForm(WrappedNode):
                 if key.startswith(vellum_ns):
                     del node.attrib[key]
 
-    def add_missing_instances(self, app):
+    def add_missing_instances(self, form, app):
         from corehq.apps.app_manager.suite_xml.post_process.instances import get_all_instances_referenced_in_xpaths
         instance_declarations = self._get_instance_ids()
         missing_unknown_instances = set()
         instances, unknown_instance_ids = get_all_instances_referenced_in_xpaths(
             app, [self.render().decode('utf-8')])
+
+        module = form.get_module()
+        if _module_offers_registry_search(module) and module.search_config.additional_registry_queries:
+            remote_instances = [
+                Instance(id=query.instance_name, src='jr://instance/remote')
+                for query in module.search_config.additional_registry_queries
+            ]
+            for instance in remote_instances:
+                instances.add(instance)
+                unknown_instance_ids.discard(instance.id)
+
         for instance_id in unknown_instance_ids:
             if instance_id not in instance_declarations:
                 missing_unknown_instances.add(instance_id)


### PR DESCRIPTION
## Product Description
Automatically add required instance declarations into forms using data registry queries.

## Feature Flag
DATA_REGISTRY

## Safety Assurance

### Safety story
This impacts for XML generation for apps but is gated by the FF configuration so should not impact existing forms. Tests also cover form XML generation.

### Automated test coverage
Updated tests for adding instances into forms

### QA Plan
Tested locally and with unit tests.


### Migrations
No migrations

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
