### PR TITLE
keep reconciliation data for six years

### DIFF
--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -270,12 +270,12 @@ def _reconcile_es_data(data_type, metric, blob_parent_id, start=None, end=None, 
         with open(file_path, 'rb') as f:
             blob_db = get_blob_db()
             key = f'{blob_parent_id}_{today.isoformat()}'
-            thirty_days = 60 * 24 * 30
+            six_years = 60 * 24 * 365 * 6
             blob_db.put(
                 f,
                 type_code=CODES.tempfile,
                 domain='<unknown>',
                 parent_id=blob_parent_id,
                 key=key,
-                timeout=thirty_days
+                timeout=six_years
             )


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
As discussed this morning, this extends how long we keep the records of stale es docs in S3.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Internal tool only and no change in behavior

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
