### PR TITLE
Case Search: Remove unused search option

### DIFF
--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -12,7 +12,6 @@ from corehq.util.quickcache import quickcache
 
 CLAIM_CASE_TYPE = 'commcare-case-claim'
 FUZZY_PROPERTIES = "fuzzy_properties"
-SEARCH_QUERY_CUSTOM_VALUE = 'commcare_custom_value'
 CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY = 'commcare_blacklisted_owner_ids'
 CASE_SEARCH_XPATH_QUERY_KEY = '_xpath_query'
 CASE_SEARCH_REGISTRY_ID_KEY = 'commcare_registry'

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -23,7 +23,6 @@ from corehq.apps.case_search.models import (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
     CASE_SEARCH_REGISTRY_ID_KEY,
     CASE_SEARCH_XPATH_QUERY_KEY,
-    SEARCH_QUERY_CUSTOM_VALUE,
     UNSEARCHABLE_KEYS,
     CaseSearchConfig,
 )
@@ -178,7 +177,7 @@ class CaseSearchCriteria:
                 return search_es.filter(case_search.blacklist_owner_id(value.split(' ')))
         elif key == COMMCARE_PROJECT:
             return search_es.filter(filters.domain(value))
-        elif key not in UNSEARCHABLE_KEYS and not key.startswith(SEARCH_QUERY_CUSTOM_VALUE):
+        elif key not in UNSEARCHABLE_KEYS:
             return search_es.add_query(self._get_case_property_query(key, value), queries.MUST)
         return search_es
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://github.com/dimagi/commcare-hq/pull/30553#discussion_r725191858
This option is obsolete, should have been removed in https://github.com/dimagi/commcare-hq/pull/28278

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
