### PR TITLE
Use AppConfig to load signals

### DIFF
--- a/corehq/motech/repeaters/apps.py
+++ b/corehq/motech/repeaters/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class RepeaterAppConfig(AppConfig):
+    name = 'corehq.motech.repeaters'
+
+    def ready(self):
+        from . import signals  # noqa: disable=unused-import,F401

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1434,8 +1434,3 @@ def domain_can_forward(domain):
         domain_has_privilege(domain, ZAPIER_INTEGRATION)
         or domain_has_privilege(domain, DATA_FORWARDING)
     )
-
-
-# import signals
-# Do not remove this import, its required for the signals code to run even though not explicitly used in this file
-from corehq.motech.repeaters import signals  # noqa: disable=unused-import,F401


### PR DESCRIPTION
## Technical Summary

(Small. Scratches an itch.)

`corehq.motech.repeaters` should be loading `signals` using `AppConfig`, [as Django suggests](https://docs.djangoproject.com/en/2.2/ref/applications/#django.apps.AppConfig.ready) and as we do for [other modules](https://github.com/dimagi/commcare-hq/blob/579b52f1037d30c8e9184214f7278bb1d6a8b9d2/corehq/apps/zapier/apps.py#L10) in the codebase, rather than by importing it in the `models` module.

## Safety Assurance

### Safety story

* Covered by existing tests.
* Tested locally.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My life has the meaning that I give to it.
- [x] The purpose of the universe may be to cause itself, but why does it need a purpose?
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
