### PR TITLE
Add management command to migrate usernames and emails

### DIFF
--- a/corehq/apps/users/management/commands/migrate_usernames.py
+++ b/corehq/apps/users/management/commands/migrate_usernames.py
@@ -85,6 +85,7 @@ class Command(BaseCommand):
     def update_feature_flags(self, current_username, new_username):
         enabled_toggles = toggles_enabled_for_user(current_username)
         for toggle in enabled_toggles:
+            logger.info(f'Updating toggle {toggle} from {current_username} to {new_username}')
             set_toggle(toggle, current_username, False, namespace=NAMESPACE_USER)
             set_toggle(toggle, new_username, True, namespace=NAMESPACE_USER)
 

--- a/corehq/apps/users/management/commands/migrate_usernames.py
+++ b/corehq/apps/users/management/commands/migrate_usernames.py
@@ -1,0 +1,105 @@
+import csv
+import logging
+
+from django.core.management import BaseCommand
+
+from toggle.shortcuts import set_toggle
+
+from corehq.apps.ota.models import DeviceLogRequest, MobileRecoveryMeasure
+from corehq.apps.users.models import CouchUser, DomainRequest, Invitation
+from corehq.apps.users.util import raw_username
+from corehq.toggles import NAMESPACE_USER, toggles_enabled_for_user
+
+logger = logging.getLogger(__name__)
+
+CURRENT_USERNAME = 'current_username'
+NEW_USERNAME = 'new_username'
+
+
+class Command(BaseCommand):
+    help = "Update a user's username and email"
+
+    def add_arguments(self, parser):
+        parser.add_argument('file', help='')
+        parser.add_argument('--verbose', action="store_true")
+
+    def handle(self, file, **options):
+        logger.setLevel(logging.INFO if options["verbose"] else logging.WARNING)
+
+        for current_username, new_username in self.iterate_usernames_to_update(file):
+            logger.info(f'Migrating {current_username} to {new_username}')
+
+            # update Django user, and Couch user
+            couch_user = CouchUser.get_by_username(current_username)
+            should_update_email = couch_user.username == couch_user.email
+            logger.info(f'Updated couch username from {couch_user.username} to {new_username}')
+            django_user = couch_user.get_django_user()
+            django_user.username = new_username
+            django_user.save()
+            couch_user.username = new_username
+            if should_update_email:
+                logger.info(f'Updated couch email from {couch_user.email} to {new_username}')
+                couch_user.email = new_username
+            else:
+                logger.info(f'Only migrating username, not email, for user {couch_user.username}.')
+            couch_user.save()
+            # clear cache
+            CouchUser.get_by_username.clear(CouchUser, current_username)
+
+            self.update_dependent_db_models(current_username, new_username, should_update_email)
+
+            self.update_feature_flags(current_username, new_username)
+
+    def update_dependent_db_models(self, current_username, new_username, should_update_email):
+        device_log_requests = DeviceLogRequest.objects.filter(username=raw_username(current_username))
+        if device_log_requests:
+            for log_request in device_log_requests:
+                new_raw_username = raw_username(new_username)
+                logger.info(f'Updating DeviceLogRequest from {log_request.username} to {new_raw_username}')
+                log_request.username = new_raw_username
+                log_request.save()
+
+        domain_requests = DomainRequest.objects.filter(email=current_username)
+        if domain_requests and should_update_email:
+            for domain_request in domain_requests:
+                logger.info(f'Updating DomainRequest from {domain_request.email} to {new_username}')
+                domain_request.email = new_username
+                domain_request.save()
+
+        pending_invitations = Invitation.objects.filter(email=current_username, is_accepted=False)
+        if pending_invitations and should_update_email:
+            for invitation in pending_invitations:
+                logger.info(f'Updating Invitation from {invitation.email} to {new_username}')
+                invitation.email = new_username
+                invitation.save()
+
+        recovery_measures = MobileRecoveryMeasure.objects.filter(username=current_username)
+        if recovery_measures:
+            for recovery_measure in recovery_measures:
+                logger.info(
+                    f'Updating MobileRecoveryMeasure from {recovery_measure.username} to {new_username}'
+                )
+                recovery_measure.username = new_username
+                recovery_measure.save()
+
+    def update_feature_flags(self, current_username, new_username):
+        enabled_toggles = toggles_enabled_for_user(current_username)
+        for toggle in enabled_toggles:
+            set_toggle(toggle, current_username, False, namespace=NAMESPACE_USER)
+            set_toggle(toggle, new_username, True, namespace=NAMESPACE_USER)
+
+    def iterate_usernames_to_update(self, file):
+        with open(file, newline='') as csvfile:
+            spamreader = csv.reader(csvfile, delimiter=' ', quotechar='|')
+            header = next(spamreader)
+            header_values = header[0].split(',')
+            try:
+                current_user_index = header_values.index(CURRENT_USERNAME)
+                new_user_index = header_values.index(NEW_USERNAME)
+            except ValueError:
+                logger.error(f'The provided csv file should contain both a {CURRENT_USERNAME} and {NEW_USERNAME} '
+                             'header column')
+                return
+            for row in spamreader:
+                row_values = row[0].split(',')
+                yield row_values[current_user_index], row_values[new_user_index]


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Invisible for the most part, though for users that this command is run for, their username and potentially email will be updated. Ideally we will communicate well enough with the client that they know when to expect this change.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SS-205

The ticket is specific to migrating MSI users on an old email domain to the new domain in order to take full advantage of SSO. However this management command is intended to be useful for future requests as well. As noted in the ticket, I created [this sheet](https://docs.google.com/spreadsheets/d/13EueE1CQ3lvV9jzJU87HngYDsbfQCSAX9j4R7f8pDL8/edit#gid=0) to keep track of which models should be migrated versus which can stay as is. Those models were determined by searching for `username = models.`, `email = models.`, `username = StringProperty`, and `email = StringProperty`. 

In addition to SQL and Couch models, I included migrating feature flags over to the new username.

Initially, the plan was to force logout the user after making this change, but upon further consideration it doesn't seem necessary as a django session is referenced by a cookie, meaning a session is tied to a browser, not directly to a user. I tested this locally and didn't notice any issues with my looking staying logged in after a username/email migration was run.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
I tested this locally while logged into the user being migrated. 
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
[QA Ticket](https://dimagi-dev.atlassian.net/browse/QA-3616)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [ ] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
