### PR TITLE
create disabled web apps redirect page

### DIFF
--- a/corehq/apps/cloudcare/decorators.py
+++ b/corehq/apps/cloudcare/decorators.py
@@ -24,15 +24,13 @@ def require_cloudcare_access_ex():
 
                 apps_in_domain = get_apps_in_domain(domain)
                 if (len(apps_in_domain) == 1):
-                    app_or_domain_name = "application " + apps_in_domain[0].name
+                    app_or_domain_name = apps_in_domain[0].name
                 else:
-                    app_or_domain_name = "domain " + domain
-
-                is_superuser = hasattr(request, "couch_user") and request.couch_user.is_superuser
+                    app_or_domain_name = domain
 
                 context = {
                     "app_or_domain_name": app_or_domain_name,
-                    "show_ff_detail_message": is_superuser or toggles.SUPPORT.enabled_for_request(request)
+                    "is_superuser": hasattr(request, "couch_user") and request.couch_user.is_superuser
                 }
                 return render(request, "cloudcare/web_apps_disabled.html", context)
             if hasattr(request, "couch_user"):

--- a/corehq/apps/cloudcare/decorators.py
+++ b/corehq/apps/cloudcare/decorators.py
@@ -1,11 +1,15 @@
 from functools import wraps
 
 from django.http import HttpResponse
+from django.shortcuts import render
 
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq import toggles
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
+from corehq.apps.app_manager.dbaccessors import (
+    get_apps_in_domain
+)
 
 
 def require_cloudcare_access_ex():
@@ -17,11 +21,20 @@ def require_cloudcare_access_ex():
         @wraps(view_func)
         def _inner(request, domain, *args, **kwargs):
             if toggles.DISABLE_WEB_APPS.enabled_for_request(request):
-                message = 'Service Temporarily Unavailable'
+
+                apps_in_domain = get_apps_in_domain(domain)
+                if (len(apps_in_domain) == 1):
+                    app_or_domain_name = "application " + apps_in_domain[0].name
+                else:
+                    app_or_domain_name = "domain " + domain
+
                 is_superuser = hasattr(request, "couch_user") and request.couch_user.is_superuser
-                if is_superuser or toggles.SUPPORT.enabled_for_request(request):
-                    message += " (due to 'disable_web_apps' feature flag)"
-                return HttpResponse(message, content_type='text/plain', status=503)
+
+                context = {
+                    "app_or_domain_name": app_or_domain_name,
+                    "show_ff_detail_message": is_superuser or toggles.SUPPORT.enabled_for_request(request)
+                }
+                return render(request, "cloudcare/web_apps_disabled.html", context)
             if hasattr(request, "couch_user"):
                 if request.couch_user.is_web_user():
                     return require_permission(Permissions.access_web_apps)(view_func)(request, domain, *args, **kwargs)

--- a/corehq/apps/cloudcare/templates/cloudcare/web_apps_disabled.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/web_apps_disabled.html
@@ -1,12 +1,13 @@
 {% extends "hqwebapp/base_page.html" %}
 {% load i18n %}
+{% load hq_shared_tags %}
 
 {% block title %}{% trans "Functionality Disabled" %}{% endblock %}
 
 {% block page_name %}{% trans "This functionality is disabled." %}{% endblock %}
 {% block page_content %}
-<div>{% blocktrans %}Web apps for your {{app_or_domain_name}} are currently down for maintainence.{% endblocktrans %}</div>
-{% if show_ff_detail_message %}
+<div>{% blocktrans %}Web apps for {{app_or_domain_name}} are currently down for maintainence.{% endblocktrans %}</div>
+{% if is_superuser or request|toggle_enabled:"SUPPORT" %}
 <br/>
 <span>{% blocktrans %}The 'disable_web_apps' feature flag is turned on.{% endblocktrans %}</span>
 {% endif %}

--- a/corehq/apps/cloudcare/templates/cloudcare/web_apps_disabled.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/web_apps_disabled.html
@@ -1,0 +1,13 @@
+{% extends "hqwebapp/base_page.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Functionality Disabled" %}{% endblock %}
+
+{% block page_name %}{% trans "This functionality is disabled." %}{% endblock %}
+{% block page_content %}
+<div>{% blocktrans %}Web apps for your {{app_or_domain_name}} are currently down for maintainence.{% endblocktrans %}</div>
+{% if show_ff_detail_message %}
+<br/>
+<span>{% blocktrans %}The 'disable_web_apps' feature flag is turned on.{% endblocktrans %}</span>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Product Description
When the  'disable_web_apps' feature flag is enabled, users trying to access their web app after clicking on the "Web Apps" tab are currently shown a simple "Service Temporarily Unavailable" message:

<img src="https://user-images.githubusercontent.com/6729291/137195527-06069f1a-7ed2-4e2d-bf4d-6eb774deb9f8.png" width="400">

To clarify that this is often due to maintenance and is intentionally blocked by an administrator, this will change the UI to explain and look cleaner:

<img src="https://user-images.githubusercontent.com/6729291/137195733-2cc3fa52-63c5-450c-b585-a2eb846bf452.png" width="500">

If the domain only has a since application the app name will be shown instead. If the user is not a certain type of administrator, the feature flag detail will be omitted:

<img src="https://user-images.githubusercontent.com/6729291/137196226-b0ecff73-b8ff-494b-8a79-c382222d73ac.png" width="500">

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[USH-852](https://dimagi-dev.atlassian.net/browse/USH-852)

I added a new template, extending base_page.html.

I noticed that the same poor error message is returned in SessionDetailsView when trying to send a post request, but since this is only used via an internal API I thought this was OK to ignore. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

DISABLE_WEB_APPS

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

This is only a UI change and only modifies a single HTTPResponse (that is already an error message) and should not affect any other part of HQ. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Unneeded, but all 12 tests for apps.corehq.cloudcare passed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
