### PR TITLE
Fix flaky import in test_utils

### DIFF
--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -18,7 +18,6 @@ from django.db import connections
 from django.db.backends import utils
 from django.test import TransactionTestCase
 from django.test.utils import CaptureQueriesContext
-from flaky import flaky
 
 import mock
 
@@ -839,8 +838,11 @@ def flaky_slow(test=None, max_runs=5, min_passes=1, rerun_filter=lambda *a: True
 
     Use for tests that depend on eventual database consistency.
     """
+    from flaky import flaky
+
     def rerun(*args):
         sleep(0.5)
         return rerun_filter(*args)
+
     deco = flaky(max_runs=max_runs, min_passes=min_passes, rerun_filter=rerun)
     return deco if test is None else deco(test)


### PR DESCRIPTION
Fix import of test dependency in code that is imported in production environments. This broke the deploy.

## Safety Assurance

### Safety story

Moving the import into a place where it will only be run by tests.

### Automated test coverage

No tests. I will think about whether it's possible to add a test that would catch this type of issue, but at the moment that sounds tricky.
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

No QA.
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change