### PR TITLE
customise available search workflows for data registry search

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -205,6 +205,14 @@ hqDefine("app_manager/js/details/case_claim", function () {
 
         self.workflow = ko.computed({
             read: function () {
+                if (self.dataRegistry()) {
+                    if (self.autoLaunch()) {
+                        if (self.defaultSearch()) {
+                            return "es_only";
+                        }
+                    }
+                    return "auto_launch";
+                }
                 if (self.autoLaunch()) {
                     if (self.defaultSearch()) {
                         return "es_only";

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -95,10 +95,16 @@
           <div class="form-group">
             {% if show_search_workflow %}
               <div class="form-group">
-                <label class="control-label {% css_label_class %}" for="search-workflow">
+                <label class="control-label {% css_label_class %}" for="search-workflow" data-bind="hidden: dataRegistry">
                   {% trans "Web Apps Search Workflow" %}
                   <span class="hq-help-template" data-title="{% trans "Web Apps Search Workflow" %}"
                         data-content="{% trans_html_attr "<strong>Normal Case List</strong> is the &quot;classic&quot; case search workflow.  <br><br><strong>Search First</strong> skips the Normal Case List view and lands the user on the Search screen. This is typically used for a &quot;Search Cases&quot; module.  <br><br><strong>See More</strong> is the same functionality as Normal Case List, except clicking the search button runs the default searches and returns the results. The user doesn't get to change the search criteria. This enables a workflow where the user sees what's in the local casedb then clicks &quot;See More&quot; to view all cases that fit the criteria.  <br><br><strong>Skip to Default Case Search Results</strong> always displays the results from the default case search. The user never sees the results of the casedb." %}">
+                  </span>
+                </label>
+                <label class="control-label {% css_label_class %}" for="search-workflow" data-bind="visible: dataRegistry">
+                  {% trans "Web Apps Search Workflow" %}
+                  <span class="hq-help-template" data-title="{% trans "Web Apps Search Workflow (Data Registry)" %}"
+                        data-content="{% trans_html_attr "<strong>Search First</strong> skips the Normal Case List view and lands the user on the Search screen. This is the default for Data Registry search.  <br><br><strong>Skip to Default Case Search Results</strong> always displays the results from the default case search." %}">
                   </span>
                 </label>
                 <div class="{% css_field_class %}">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -103,9 +103,9 @@
                 </label>
                 <div class="{% css_field_class %}">
                   <select class="form-control" data-bind="value: workflow" id="search-workflow">
-                    <option value="classic">{% trans "Normal Case List" %}</option>
+                    <option value="classic" data-bind="hidden: dataRegistry">{% trans "Normal Case List" %}</option>
                     <option value="auto_launch">{% trans "Search First" %}</option>
-                    <option value="see_more">{% trans "See More" %}</option>
+                    <option value="see_more" data-bind="hidden: dataRegistry">{% trans "See More" %}</option>
                     <option value="es_only">{% trans "Skip to Default Case Search Results" %}</option>
                   </select>
                 </div>


### PR DESCRIPTION
## Product Description
This removes the 'Normal Search' and 'See more' workflows when data registry search is active. These workflows aren't possible with DR search.

## Technical Summary
Restrict options to "Search First" (default) and "Default Search"

## Feature Flag
DATA_REGISTRY

## Safety Assurance

### Safety story
Changes only apply when a data registry is selected. Changes are limited to the search configuration page in apps.

### Automated test coverage
None

### QA Plan
Tested locally


### Migrations
No migrations

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
