### PR TITLE
only call ajax callback if request was successful

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_utils.js
@@ -77,20 +77,22 @@ hqDefine('app_manager/js/app_manager_utils', [
 
     var handleAjaxAppChange = function (callback) {
         $(document).ajaxComplete(function (e, xhr, options) {
-            var match = options.url.match(/\/apps\/(.*)/);
-            if (match) {
-                var suffix = match[1];  // first captured group
-                if (/^edit_form_attr/.test(suffix) ||
-                    /^edit_module_attr/.test(suffix) ||
-                    /^edit_module_detail_screens/.test(suffix) ||
-                    /^edit_app_attr/.test(suffix) ||
-                    /^edit_form_actions/.test(suffix) ||
-                    /^edit_commcare_settings/.test(suffix) ||
-                    /^rearrange/.test(suffix) ||
-                    /^patch_xform/.test(suffix)) {
-                    callback();
+            xhr.done(() => {
+                var match = options.url.match(/\/apps\/(.*)/);
+                if (match) {
+                    var suffix = match[1];  // first captured group
+                    if (/^edit_form_attr/.test(suffix) ||
+                        /^edit_module_attr/.test(suffix) ||
+                        /^edit_module_detail_screens/.test(suffix) ||
+                        /^edit_app_attr/.test(suffix) ||
+                        /^edit_form_actions/.test(suffix) ||
+                        /^edit_commcare_settings/.test(suffix) ||
+                        /^rearrange/.test(suffix) ||
+                        /^patch_xform/.test(suffix)) {
+                        callback();
+                    }
                 }
-            }
+            });
         });
     };
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-3609

## Product Description
Prevent showing "Updates available to Publish" notification if the request to save changes fails.

## Technical Summary
Only call ajax callback if the request was successful.

This is currently used in two places:
1. Showing the "Updates available to Publish" label after save
2. Highlighting the app preview refresh button after save

## Safety Assurance

### Safety story
* the change moves the code inside an ajax success handler which is a well documented approach
* changes are minor and to non-critical pieces of code

### Automated test coverage
None

### QA Plan
Tested locally

### Migrations
No migrations

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
