### PR TITLE
remove name tag from main lock metrics

### DIFF
--- a/corehq/util/metrics/lockmeter.py
+++ b/corehq/util/metrics/lockmeter.py
@@ -20,16 +20,15 @@ class MeteredLock(object):
         self.name = name
         self.key = lock.name
         self.lock_timer = metrics_histogram_timer(
-            "commcare.lock.locked_time", self.timing_buckets, self.tags
+            "commcare.lock.locked_time", self.timing_buckets
         )
         self.track_unreleased = track_unreleased
         self.end_time = None
         self.lock_trace = None
 
     def acquire(self, *args, **kw):
-        tags = self.tags
         buckets = self.timing_buckets
-        with metrics_histogram_timer("commcare.lock.acquire_time", buckets, tags), \
+        with metrics_histogram_timer("commcare.lock.acquire_time", buckets), \
                 tracer.trace("commcare.lock.acquire", resource=self.key) as span:
             acquired = self.lock.acquire(*args, **kw)
             span.set_tags({

--- a/corehq/util/metrics/metrics.py
+++ b/corehq/util/metrics/metrics.py
@@ -112,7 +112,7 @@ class DebugMetrics:
     def __getattr__(self, item):
         if item in ('counter', 'gauge', 'histogram'):
             def _check(name, value, *args, **kwargs):
-                tags = kwargs.get('tags', {})
+                tags = kwargs.get('tags') or {}
                 _enforce_prefix(name, 'commcare')
                 _validate_tag_names(tags)
                 metrics_logger.debug("[%s] %s %s %s", item, name, tags, value)

--- a/corehq/util/metrics/tests/test_lockmeter.py
+++ b/corehq/util/metrics/tests/test_lockmeter.py
@@ -20,14 +20,14 @@ class TestMeteredLock(TestCase):
         with capture_metrics() as metrics:
             lock.acquire()
             self.assertTrue(fake.locked)
-        self.assertEqual(1, len(metrics.list("commcare.lock.acquire_time", lock_name='test')), metrics)
+        self.assertEqual(1, len(metrics.list("commcare.lock.acquire_time")), metrics)
 
     def test_not_acquired(self):
         fake = FakeLock()
         lock = MeteredLock(fake, "test")
         with capture_metrics() as metrics:
             self.assertFalse(lock.acquire(blocking=False))
-        self.assertEqual(1, len(metrics.list("commcare.lock.acquire_time", lock_name='test')), metrics)
+        self.assertEqual(1, len(metrics.list("commcare.lock.acquire_time")), metrics)
 
     def test_release(self):
         fake = FakeLock()
@@ -36,7 +36,7 @@ class TestMeteredLock(TestCase):
         with capture_metrics() as metrics:
             lock.release()
             self.assertFalse(fake.locked)
-        self.assertEqual(1, len(metrics.list("commcare.lock.locked_time", lock_name='test')), metrics)
+        self.assertEqual(1, len(metrics.list("commcare.lock.locked_time")), metrics)
 
     def test_release_not_locked(self):
         fake = FakeLock()
@@ -53,8 +53,8 @@ class TestMeteredLock(TestCase):
             with lock:
                 self.assertTrue(fake.locked)
             self.assertFalse(fake.locked)
-        self.assertEqual(1, len(metrics.list("commcare.lock.acquire_time", lock_name='test')), metrics)
-        self.assertEqual(1, len(metrics.list("commcare.lock.locked_time", lock_name='test')), metrics)
+        self.assertEqual(1, len(metrics.list("commcare.lock.acquire_time")), metrics)
+        self.assertEqual(1, len(metrics.list("commcare.lock.locked_time")), metrics)
 
     def test_release_failed(self):
         lock = MeteredLock(FakeLock(), "test")


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12683

Combined these represent about 5% of our custom metrics, due to the 14k+ lock names. However these two metrics are not currently aggregated by name anywhere in datadog, except one graph that does not work because there are too many metrics to graph. This should cut our number of custom metrics, while preserving the extra detail for the metrics that are more closely aligned with lock issues (`release_failed`, `not_released`, `released_after_timeout`, `degraded`)


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Metrics only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
