### PR TITLE
add link to help docs for NON_PARENT_MENU_SELECTION plugin

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1212,9 +1212,8 @@ NON_PARENT_MENU_SELECTION = StaticToggle(
     'Allow selecting of module of any case-type in select-parent workflow',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
-    description="""
-    Allow selecting of module of any case-type in select-parent workflow
-    """,
+    description="Allow selecting of module of any case-type in select-parent workflow",
+    help_link="https://confluence.dimagi.com/display/USH/Selecting+any+case+in+%27select+parent+first%27+workflow"
 )
 
 FORMPLAYER_USE_LIVEQUERY = StaticToggle(


### PR DESCRIPTION
Plugin docs update

## Feature Flag
NON_PARENT_MENU_SELECTION

## Safety Assurance

### Safety story
Adding link to plugin docs

### Automated test coverage
NA

### QA Plan
NA

### Migrations
No migrations

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
