### PR TITLE
Improve data dictionary usablity

### DIFF
--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -198,10 +198,10 @@
           <td class="fhir-path">
             <input class="form-control" data-bind="value: $data.fhirResourcePropPath, disable: removeFHIRResourcePropertyPath"></input>
             <!-- ko if: fhirResourcePropPath() && !removeFHIRResourcePropertyPath() -->
-            <i data-bind="click: removePath" class="fa fa-close"></i>
+            <button title="{% trans_html_attr 'Remove Path' %}" data-bind="click: removePath" class="fa fa-close"></button>
             <!-- /ko -->
             <!-- ko if: removeFHIRResourcePropertyPath() -->
-            <i data-bind="click: restorePath" class="fa fa-undo"></i>
+            <button title="{% trans_html_attr 'Restore Path' %}" data-bind="click: restorePath" class="fa fa-undo"></button>
             <!-- /ko -->
           </td>
           {% endif %}
@@ -215,10 +215,10 @@
           </td>
           <td>
             <!-- ko if: !deprecated() -->
-            <i data-bind="click: deprecateProperty" class="fa fa-archive"></i>
+            <button title="{% trans_html_attr 'Deprecate Property' %}"  data-bind="click: deprecateProperty" class="fa fa-archive"></button>
             <!-- /ko -->
             <!-- ko if: deprecated() -->
-            <i data-bind="click: restoreProperty" class="fa fa-undo"></i>
+            <button title="{% trans_html_attr 'Restore Property' %}" data-bind="click: restoreProperty" class="fa fa-undo"></button>
             <!-- /ko -->
           </td>
         </tr>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/valid_values_th_content.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/valid_values_th_content.html
@@ -4,5 +4,5 @@
 <span
   class="hq-help-template"
   data-title="{% trans_html_attr 'Valid values or format' %}"
-  data-content="{% trans_html_attr 'Only import rows with cells that match the listed values or formats' %}">
+  data-content="{% trans_html_attr 'When importing data, CommCare will only save rows with cells that match the listed values or format.' %}">
 </span>

--- a/corehq/apps/hqwebapp/static/data_dictionary/less/data_dictionary.less
+++ b/corehq/apps/hqwebapp/static/data_dictionary/less/data_dictionary.less
@@ -9,4 +9,17 @@
     display: inline-block;
     max-width: 85%;
   }
+
+  button.fa {
+    border: none;
+    background-color: inherit;
+  }
+
+  .enum-pairs .well {
+    margin-bottom: 8px;
+  }
+}
+
+ul.nav-hq-sidebar {
+  overflow-wrap: break-word;
 }

--- a/corehq/apps/hqwebapp/static/data_dictionary/less/data_dictionary.less
+++ b/corehq/apps/hqwebapp/static/data_dictionary/less/data_dictionary.less
@@ -19,7 +19,3 @@
     margin-bottom: 8px;
   }
 }
-
-ul.nav-hq-sidebar {
-  overflow-wrap: break-word;
-}

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/navs.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/navs.less
@@ -11,6 +11,7 @@
 .nav-hq-sidebar {
   font-size: 13px;
   line-height: 18px;
+  overflow-wrap: break-word;
 
   &.nav > li {
     a {


### PR DESCRIPTION
Adds title attribute for all buttons that previously had text and now have icons instead.
Titles have been set to be what the button text used to be.
Make these actual buttons, not `<i>` elements. Add styling rules to remove auto-button-appearance.
Tighten space between allowed values and "Edit" button (20px to 8px bottom margin).
Update copy on help text for the Valid Values & Formats column.
Force wrapping of very long case names in the sidebar.

(@orangejenny removed safety info because this isn't a PR into master)