### PR TITLE
Change label to make it clear it displays only additional case types

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -53,11 +53,11 @@
               {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
               <div class="form-group">
                 <label class="{% css_label_class %} control-label">
-                  {% trans "Case List and Case Search Types" %}
+                  {% trans "Additional Case List and Case Search Types" %}
                   <span class="hq-help-template"
-                        data-title="{% trans "Case List and Case Search Types" %}"
+                        data-title="{% trans "Additional Case List and Case Search Types" %}"
                         data-content="{% blocktrans %}
-                             Cases of these types will be displayed in Case List  and Case Search screens.
+                             Cases of these types will be displayed in Case List and Case Search screens, in addition to the Case Type inputted above.
                              <a target='_blank'
                              href='https://confluence.dimagi.com/display/ccinternal/Case+Search+and+Claim'>(More   Information)</a>
                               {% endblocktrans %}">


### PR DESCRIPTION
## Product Description
This is purely a UI change.

It is not clear that the "Case Types and Case Search Types" Case List setting in the app manager only adds _additional_ case types and does not override the core Case Type chosen for a Case List. This lead to some confusion, so this is a simple UI change to update the label/helper text for this setting to make its function clear.

Before:
![image](https://user-images.githubusercontent.com/6729291/137800008-289e95e8-8c24-46f3-9c9f-14fba1a8d3d8.png)
<img width="410" alt="Screen Shot 2021-10-18 at 4 13 52 PM" src="https://user-images.githubusercontent.com/6729291/137800288-63388fb7-119b-4749-8bec-7e5db83cb922.png">

After:
<img width="403" alt="Screen Shot 2021-10-18 at 4 14 29 PM" src="https://user-images.githubusercontent.com/6729291/137800346-3b93a8e6-698d-4a69-9b84-322fa498d92b.png">

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[USH-1216](https://dimagi-dev.atlassian.net/browse/USH-1216) - see the discussion.

Looking through the code and testing in my local environment, it seemed clear that this dropdown menu only adds additional Case Types when viewing a Case List or in a Case Search. It may be best to double-check me that this is indeed is purely additional and does not override the Case Type (in the above input box) for the Case List.

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This is purely a UI change. The only risk is in incorrectly communicating what the setting does.

### Automated test coverage

No tests needed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
