### PR TITLE
Upgrade gevent and greenlet

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -50,9 +50,9 @@ email_validator==1.1.3
 ethiopian-date-converter==0.1.5
 eulxml==1.1.3
 Faker==5.0.2
-gevent==1.4.0
+gevent>1.4.0
 ghdiff==0.4
-greenlet==0.4.17
+greenlet>=0.4.17
 gunicorn
 hiredis==2.0.0
 httpagentparser~=1.7

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -222,7 +222,7 @@ freezegun==1.1.0
     # via -r test-requirements.in
 future==0.18.2
     # via radon
-gevent==1.4.0
+gevent==21.8.0
     # via
     #   -r base-requirements.in
     #   django-websocket-redis
@@ -237,7 +237,7 @@ gitpython==3.1.14
     # via transifex-client
 gnureadline==8.0.0
     # via -r dev-requirements.in
-greenlet==0.4.17
+greenlet==1.1.2
     # via
     #   -r base-requirements.in
     #   django-websocket-redis
@@ -659,6 +659,10 @@ zipp==3.2.0
     # via
     #   importlib-metadata
     #   pep517
+zope.event==4.5.0
+    # via gevent
+zope.interface==5.4.0
+    # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.2.4
@@ -666,6 +670,7 @@ pip==21.2.4
 setuptools==50.3.0
     # via
     #   django-websocket-redis
+    #   gevent
     #   gunicorn
     #   ipython
     #   jsonschema
@@ -673,3 +678,5 @@ setuptools==50.3.0
     #   protobuf
     #   python-termstyle
     #   sphinx
+    #   zope.event
+    #   zope.interface

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -190,13 +190,13 @@ eulxml==1.1.3
     # via -r base-requirements.in
 faker==5.0.2
     # via -r base-requirements.in
-gevent==1.4.0
+gevent==21.8.0
     # via
     #   -r base-requirements.in
     #   django-websocket-redis
 ghdiff==0.4
     # via -r base-requirements.in
-greenlet==0.4.17
+greenlet==1.1.2
     # via
     #   -r base-requirements.in
     #   django-websocket-redis
@@ -526,12 +526,19 @@ xlwt==1.3.0
     # via -r base-requirements.in
 zipp==3.4.0
     # via importlib-metadata
+zope.event==4.5.0
+    # via gevent
+zope.interface==5.4.0
+    # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==53.0.0
     # via
     #   django-websocket-redis
+    #   gevent
     #   gunicorn
     #   jsonschema
     #   protobuf
     #   sphinx
+    #   zope.event
+    #   zope.interface

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -189,13 +189,13 @@ faker==5.0.2
     # via -r base-requirements.in
 flower==0.9.2
     # via -r prod-requirements.in
-gevent==1.4.0
+gevent==21.8.0
     # via
     #   -r base-requirements.in
     #   django-websocket-redis
 ghdiff==0.4
     # via -r base-requirements.in
-greenlet==0.4.17
+greenlet==1.1.2
     # via
     #   -r base-requirements.in
     #   django-websocket-redis
@@ -530,6 +530,10 @@ xmlsec==1.3.11
     # via python3-saml
 zipp==3.4.0
     # via importlib-metadata
+zope.event==4.5.0
+    # via gevent
+zope.interface==5.4.0
+    # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.2.4
@@ -537,7 +541,10 @@ pip==21.2.4
 setuptools==50.3.0
     # via
     #   django-websocket-redis
+    #   gevent
     #   gunicorn
     #   ipython
     #   jsonschema
     #   protobuf
+    #   zope.event
+    #   zope.interface

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -178,13 +178,13 @@ eulxml==1.1.3
     # via -r base-requirements.in
 faker==5.0.2
     # via -r base-requirements.in
-gevent==1.4.0
+gevent==21.8.0
     # via
     #   -r base-requirements.in
     #   django-websocket-redis
 ghdiff==0.4
     # via -r base-requirements.in
-greenlet==0.4.17
+greenlet==1.1.2
     # via
     #   -r base-requirements.in
     #   django-websocket-redis
@@ -479,11 +479,18 @@ xmlsec==1.3.11
     # via python3-saml
 zipp==3.4.0
     # via importlib-metadata
+zope.event==4.5.0
+    # via gevent
+zope.interface==5.4.0
+    # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==50.3.0
     # via
     #   django-websocket-redis
+    #   gevent
     #   gunicorn
     #   jsonschema
     #   protobuf
+    #   zope.event
+    #   zope.interface

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -196,13 +196,13 @@ freezegun==1.1.0
     # via -r test-requirements.in
 future==0.18.2
     # via radon
-gevent==1.4.0
+gevent==21.8.0
     # via
     #   -r base-requirements.in
     #   django-websocket-redis
 ghdiff==0.4
     # via -r base-requirements.in
-greenlet==0.4.17
+greenlet==1.1.2
     # via
     #   -r base-requirements.in
     #   django-websocket-redis
@@ -536,6 +536,10 @@ zipp==3.4.0
     # via
     #   importlib-metadata
     #   pep517
+zope.event==4.5.0
+    # via gevent
+zope.interface==5.4.0
+    # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.2.4
@@ -543,7 +547,10 @@ pip==21.2.4
 setuptools==50.3.0
     # via
     #   django-websocket-redis
+    #   gevent
     #   gunicorn
     #   jsonschema
     #   pip-tools
     #   protobuf
+    #   zope.event
+    #   zope.interface


### PR DESCRIPTION
I think the only thing holding these back was `gipc`, which [has been removed](https://github.com/dimagi/commcare-hq/pull/30354).

A newer version of gevent is required before we can upgrade to Python 3.9 because v1.4.0, which is no longer supported, cannot be installed there.

## Safety Assurance

### Safety story

This seems like a big upgrade, but on the other hand might just work? Should probably deploy to staging and do some QA.

### Automated test coverage

Dependency upgrade. No new tests added.

### QA Plan

https://dimagi-dev.atlassian.net/browse/QA-3632

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change