### PR TITLE
Remove "markdown" and make requirements

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -71,7 +71,6 @@ kombu==4.2.2.post1
 billiard!=3.5.0.5  # Should be resolved in celery 4.3: https://github.com/celery/billiard/issues/260
 laboratory==0.2.0
 lxml~=4.6.3
-markdown==2.2.1
 mock==2.0.0
 openpyxl~=3.0
 phonenumberslite~=8.12

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -318,8 +318,6 @@ mako==1.1.3
     # via alembic
 mando==0.6.4
     # via radon
-markdown==2.2.1
-    # via -r base-requirements.in
 markupsafe==1.1.1
     # via
     #   jinja2

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -262,8 +262,6 @@ lxml==4.6.3
     #   eulxml
 mako==1.1.3
     # via alembic
-markdown==2.2.1
-    # via -r base-requirements.in
 markdown-it-py==1.1.0
     # via
     #   mdit-py-plugins

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -267,8 +267,6 @@ lxml==4.6.3
     #   xmlsec
 mako==1.1.3
     # via alembic
-markdown==2.2.1
-    # via -r base-requirements.in
 markupsafe==1.1.1
     # via
     #   jinja2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -249,8 +249,6 @@ lxml==4.6.3
     #   xmlsec
 mako==1.1.3
     # via alembic
-markdown==2.2.1
-    # via -r base-requirements.in
 markupsafe==1.1.1
     # via
     #   jinja2

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -271,8 +271,6 @@ mako==1.1.3
     # via alembic
 mando==0.6.4
     # via radon
-markdown==2.2.1
-    # via -r base-requirements.in
 markupsafe==1.1.1
     # via
     #   jinja2


### PR DESCRIPTION
Unused for a while, probably since before [pycco was removed](https://github.com/dimagi/commcare-hq/pull/30360). We also use a second markdown library, [`markdown-it-py`](https://github.com/dimagi/commcare-hq/blob/7becb79ddfa7fff369404890ae1682cb79c8a060/requirements/docs-requirements.txt#L265), which was  introduced in  https://github.com/dimagi/commcare-hq/pull/30044 to build the docs.

The version pin existed since the requirement was [introduced](https://github.com/dimagi/commcare-hq/commit/f1ce067bc916bfb6d461697defb7b04d62232e10), back when we pinned all requirements and did not have a library upgrade plan (or pip-tools).

This library must be either removed or upgraded before we can upgrade to Python 3.9

## Safety Assurance

### Safety story
Removing unused dependency

### Automated test coverage

None.

### QA Plan

None.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change