### PR TITLE
add notifications JS to app preview

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -266,8 +266,10 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         };
         var sess = WebFormSession(data);
         sess.renderFormXml(data, $('#webforms'));
-        var notifications = hqImport('notifications/js/notifications_service_main');
-        notifications.initNotifications();
+        if (user.environment === hqImport("cloudcare/js/formplayer/constants").WEB_APPS_ENVIRONMENT) {
+            var notifications = hqImport('notifications/js/notifications_service_main');
+            notifications.initNotifications();
+        }
         $('.menu-scrollable-container').addClass('hide');
     });
 


### PR DESCRIPTION
## Technical Summary
Don't load the notifications service when in app preview to avoid this error:

`The module 'notifications/js/notifications_service_main' has not yet been defined.`

This also manifests and an error notification when submitting a form with end of form navigation:
![image](https://user-images.githubusercontent.com/249606/137924097-baa628ab-9312-4ba9-8034-b9fb03f5c75b.png)

The code where the error is happening is: https://github.com/dimagi/commcare-hq/blob/19a02d3e1a394abff7cddd009ed0ae36bc5cefa1/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js#L269

## Safety Assurance

### Safety story
Notifications are already loaded by app builder so don't need to be loaded by web apps when in app preview.

### Automated test coverage
None

### QA Plan
None


### Migrations
No migrations

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
