### PR TITLE
Upgrade defusedxml to 0.7.1 for Python 3.9

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -12,7 +12,7 @@ csiphash==0.0.5
 datadog==0.39.0
 ddtrace==0.44.0
 decorator==4.0.11  # required by django-digest
-defusedxml==0.5.0
+defusedxml>0.5.0
 diff-match-patch==20200713
 dimagi-memoized==1.1.3
 django-angular~=2.2.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -87,7 +87,7 @@ decorator==4.0.11
     #   ipython
     #   jsonpath-ng
     #   traitlets
-defusedxml==0.5.0
+defusedxml==0.7.1
     # via -r base-requirements.in
 deprecated==1.2.10
     # via pygithub

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -68,7 +68,7 @@ decorator==4.0.11
     #   -r base-requirements.in
     #   datadog
     #   jsonpath-ng
-defusedxml==0.5.0
+defusedxml==0.7.1
     # via -r base-requirements.in
 deprecated==1.2.10
     # via pygithub

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -74,7 +74,7 @@ decorator==4.0.11
     #   ipython
     #   jsonpath-ng
     #   traitlets
-defusedxml==0.5.0
+defusedxml==0.7.1
     # via -r base-requirements.in
 deprecated==1.2.10
     # via pygithub

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -65,7 +65,7 @@ decorator==4.0.11
     #   -r base-requirements.in
     #   datadog
     #   jsonpath-ng
-defusedxml==0.5.0
+defusedxml==0.7.1
     # via -r base-requirements.in
 deprecated==1.2.10
     # via pygithub

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -73,7 +73,7 @@ decorator==4.0.11
     #   -r base-requirements.in
     #   datadog
     #   jsonpath-ng
-defusedxml==0.5.0
+defusedxml==0.7.1
     # via -r base-requirements.in
 deprecated==1.2.10
     # via pygithub


### PR DESCRIPTION
Fixes tests that were failing on Python 3.9.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Reviewed change log. No major changes noted.

### Automated test coverage

Tests caught the incompatibility, so at least some of our usages of the library are covered by tests.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change