### PR TITLE
ensure there has been at least one change

### DIFF
--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -188,7 +188,7 @@ class PillowBase(metaclass=ABCMeta):
             process_offset_chunk(changes_chunk, context)
             self.process_changes(since=self.get_last_checkpoint_sequence(), forever=forever)
         if forever:
-            if context.changes_seen > 0 and change:
+            if context.changes_seen and change:
                 self._update_checkpoint(change, context)
             self.process_changes(since=self.get_last_checkpoint_sequence(), forever=forever)
 

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -188,7 +188,7 @@ class PillowBase(metaclass=ABCMeta):
             process_offset_chunk(changes_chunk, context)
             self.process_changes(since=self.get_last_checkpoint_sequence(), forever=forever)
         if forever:
-            if change:
+            if context.changes_seen > 0 and change:
                 self._update_checkpoint(change, context)
             self.process_changes(since=self.get_last_checkpoint_sequence(), forever=forever)
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This fixes https://sentry.io/organizations/dimagi/issues/2709806055/?environment=staging&project=136860&query=is%3Aunresolved

If the `for` loop is empty, `change` is undefined. `changes_seen` is incremented each time the loop repeats and is set to zero at the top of the function, so serves as a good proxy for whether we have processed a change.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This fixes an existing bug and is `context` is guaranteed to be defined. It also serves as a nice proxy for whether we need a checkpoint since it is reset at each checkpoint and as such is an accurate count of changes processed since the last one.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
