### PR TITLE
Fix tests for Python 3.9

### DIFF
--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -14,10 +14,10 @@ def _format_to_regex(pattern):
     everything else gets `re.escape`d
 
     >>> import re
-    >>> format_ = '%shello %%sam %s, you are %d years old.'
+    >>> format_ = '%shello %%sam %s you are %d years old.'
     >>> regex = _format_to_regex(format_)
     >>> print(regex)
-    .*hello\ %sam\ .*\,\ you\ are\ [0-9]+\ years\ old\.
+    .*hello\ %sam\ .*\ you\ are\ [0-9]+\ years\ old\.
     >>> bool(re.match(regex, format_ % ("Oh ", "i am", 6)))
     True
     >>> bool(re.match(regex, format_))

--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -1,11 +1,8 @@
-import difflib
 import os
 import uuid
 
-import lxml
 import mock
 from lxml import etree
-from lxml.doctestcompare import LHTMLOutputChecker, LXMLOutputChecker
 from nose.tools import nottest
 
 import commcare_translations
@@ -15,6 +12,11 @@ from corehq.apps.builds.models import (
     BuildSpec,
     CommCareBuild,
     CommCareBuildConfig,
+)
+from corehq.tests.util.xml import (
+    assert_html_equal,
+    assert_xml_equal,
+    parse_normalize,
 )
 from corehq.util.test_utils import TestFileMixin, unit_testing_only
 
@@ -33,10 +35,7 @@ class TestXmlMixin(TestFileMixin):
         self.assertXmlEqual(expected, actual, normalize=False)
 
     def assertXmlEqual(self, expected, actual, normalize=True):
-        if normalize:
-            expected = parse_normalize(expected)
-            actual = parse_normalize(actual)
-        _check_shared(expected, actual, LXMLOutputChecker(), "xml")
+        assert_xml_equal(expected, actual, normalize)
 
     def assertXmlHasXpath(self, element, xpath):
         message = "Could not find xpath expression '{}' in below XML\n".format(xpath)
@@ -49,13 +48,10 @@ class TestXmlMixin(TestFileMixin):
     def _assertXpathHelper(self, element, xpath, message, should_not_exist):
         element = parse_normalize(element, to_string=False)
         if bool(element.xpath(xpath)) == should_not_exist:
-            raise AssertionError(message + lxml.etree.tostring(element, pretty_print=True, encoding='unicode'))
+            raise AssertionError(message + etree.tostring(element, pretty_print=True, encoding='unicode'))
 
     def assertHtmlEqual(self, expected, actual, normalize=True):
-        if normalize:
-            expected = parse_normalize(expected, is_html=True)
-            actual = parse_normalize(actual, is_html=True)
-        _check_shared(expected, actual, LHTMLOutputChecker(), "html")
+        assert_html_equal(expected, actual, normalize)
 
 
 class SuiteMixin(TestFileMixin):
@@ -91,59 +87,13 @@ class SuiteMixin(TestFileMixin):
         self._assertHasAllStrings(app_xml, app_strings)
 
 
-def normalize_attributes(xml):
-    """Sort XML attributes to make it easier to find differences"""
-    for node in xml.iterfind(".//*"):
-        if node.attrib:
-            attrs = sorted(node.attrib.items())
-            node.attrib.clear()
-            node.attrib.update(attrs)
-    return xml
-
-
-def parse_normalize(xml, to_string=True, is_html=False):
-    parser_class = lxml.etree.XMLParser
-    markup_class = lxml.etree.XML
-    meth = "xml"
-    if is_html:
-        parser_class = lxml.etree.HTMLParser
-        markup_class = lxml.etree.HTML
-        meth = "html"
-    parser = parser_class(remove_blank_text=True)
-    parse = lambda *args: normalize_attributes(markup_class(*args))
-    parsed = parse(xml, parser)
-    return lxml.etree.tostring(parsed, pretty_print=True, method=meth, encoding='utf-8') if to_string else parsed
-
-
-def _check_shared(expected, actual, checker, extension):
-    # snippet from http://stackoverflow.com/questions/321795/comparing-xml-in-a-unit-test-in-python/7060342#7060342
-    if isinstance(expected, bytes):
-        expected = expected.decode('utf-8')
-    if isinstance(actual, bytes):
-        actual = actual.decode('utf-8')
-    if not checker.check_output(expected, actual, 0):
-        original_message = message = "{} mismatch\n\n".format(extension.upper())
-        diff = difflib.unified_diff(
-            expected.splitlines(keepends=True),
-            actual.splitlines(keepends=True),
-            fromfile='want.{}'.format(extension),
-            tofile='got.{}'.format(extension)
-        )
-        for line in diff:
-            message += line
-        if message != original_message:
-            # check that there was actually a diff, because checker.check_output
-            # doesn't work with unicode characters in xml node names
-            raise AssertionError(message)
-
-
 def extract_xml_partial(xml, xpath):
     actual = parse_normalize(xml, to_string=False)
     nodes = actual.findall(xpath)
-    root = lxml.etree.Element('partial')
+    root = etree.Element('partial')
     for node in nodes:
         root.append(node)
-    return lxml.etree.tostring(root, pretty_print=True, encoding='utf-8')
+    return etree.tostring(root, pretty_print=True, encoding='utf-8')
 
 
 def add_build(version, build_number):

--- a/corehq/ex-submodules/casexml/apps/case/tests/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/util.py
@@ -4,8 +4,6 @@ from contextlib import contextmanager
 from datetime import datetime
 from xml.etree import cElementTree as ElementTree
 
-from lxml import etree
-
 from dimagi.utils.dates import utcnow_sans_milliseconds
 
 from casexml.apps.case.mock import CaseFactory
@@ -15,6 +13,7 @@ from casexml.apps.phone.restore_caching import RestorePayloadPathCache
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
+from corehq.tests.util.xml import assert_xml_equal
 from corehq.util.test_utils import unit_testing_only
 
 TEST_DOMAIN_NAME = 'test-domain'
@@ -87,33 +86,9 @@ def _replace_ids_in_xform_xml(xml_data, case_id_override=None):
     return xml_data, uid, case_id
 
 
-def check_xml_line_by_line(test_case, expected, actual):
-    """Does what it's called, hopefully parameters are self-explanatory"""
-    # this is totally wacky, but elementtree strips needless
-    # whitespace that mindom will preserve in the original string
-    parser = etree.XMLParser(remove_blank_text=True)
-    parsed_expected = etree.tostring(etree.XML(expected, parser), pretty_print=True, encoding='utf-8').decode('utf-8')
-    parsed_actual = etree.tostring(etree.XML(actual, parser), pretty_print=True, encoding='utf-8').decode('utf-8')
-
-    if parsed_expected == parsed_actual:
-        return
-
-    try:
-        expected_lines = parsed_expected.split("\n")
-        actual_lines = parsed_actual.split("\n")
-        test_case.assertEqual(
-            len(expected_lines),
-            len(actual_lines),
-            "Parsed xml files are different lengths\n" +
-            "Expected: \n%s\nActual:\n%s" % (parsed_expected, parsed_actual))
-
-        for i in range(len(expected_lines)):
-            test_case.assertEqual(expected_lines[i], actual_lines[i])
-
-    except AssertionError:
-        import logging
-        logging.error("Failure in xml comparison\nExpected:\n%s\nActual:\n%s" % (parsed_expected, parsed_actual))
-        raise
+def check_xml_line_by_line(test_case, expected, actual, **kw):
+    """Assert that the given strings contain equivalent XML"""
+    assert_xml_equal(expected, actual, **kw)
 
 
 def get_case_xmlns(version):
@@ -192,7 +167,10 @@ def _check_payload_has_cases(testcase, payload_string, username, case_blocks, sh
 
     def check_block(case_block):
         case_block.set('xmlns', XMLNS)
-        case_block = _RestoreCaseBlock(ElementTree.fromstring(ElementTree.tostring(case_block, encoding='utf-8')), version=version)
+        case_block = _RestoreCaseBlock(
+            ElementTree.fromstring(ElementTree.tostring(case_block, encoding='utf-8')),
+            version=version,
+        )
         case_id = case_block.get_case_id()
         n = 0
 

--- a/corehq/tests/util/__init__.py
+++ b/corehq/tests/util/__init__.py
@@ -1,0 +1,10 @@
+"""Test utilities
+
+Code in this package may import test-only dependencies. Therefore this
+package should not be imported by non-test code.
+
+The intent of this package is to become a better organized home of most
+things that currently live in `corehq.util.test_utils`. Note that there
+are some things in that module that are imported by non-test code; they
+should not be moved here.
+"""

--- a/corehq/tests/util/xml.py
+++ b/corehq/tests/util/xml.py
@@ -1,0 +1,64 @@
+"""XML test utilities"""
+import difflib
+
+import lxml
+from lxml.doctestcompare import LHTMLOutputChecker, LXMLOutputChecker
+
+
+def assert_xml_equal(expected, actual, normalize=True):
+    if normalize:
+        expected = parse_normalize(expected)
+        actual = parse_normalize(actual)
+    _check_shared(expected, actual, LXMLOutputChecker(), "xml")
+
+
+def assert_html_equal(expected, actual, normalize=True):
+    if normalize:
+        expected = parse_normalize(expected, is_html=True)
+        actual = parse_normalize(actual, is_html=True)
+    _check_shared(expected, actual, LHTMLOutputChecker(), "html")
+
+
+def parse_normalize(xml, to_string=True, is_html=False):
+    parser_class = lxml.etree.XMLParser
+    markup_class = lxml.etree.XML
+    meth = "xml"
+    if is_html:
+        parser_class = lxml.etree.HTMLParser
+        markup_class = lxml.etree.HTML
+        meth = "html"
+    parser = parser_class(remove_blank_text=True)
+    parsed = normalize_attributes(markup_class(xml, parser))
+    return lxml.etree.tostring(parsed, pretty_print=True, method=meth, encoding='utf-8') if to_string else parsed
+
+
+def normalize_attributes(xml):
+    """Sort XML attributes to make it easier to find differences"""
+    for node in xml.iterfind(".//*"):
+        if node.attrib:
+            attrs = sorted(node.attrib.items())
+            node.attrib.clear()
+            node.attrib.update(attrs)
+    return xml
+
+
+def _check_shared(expected, actual, checker, extension):
+    # snippet from http://stackoverflow.com/questions/321795/comparing-xml-in-a-unit-test-in-python/7060342#7060342
+    if isinstance(expected, bytes):
+        expected = expected.decode('utf-8')
+    if isinstance(actual, bytes):
+        actual = actual.decode('utf-8')
+    if not checker.check_output(expected, actual, 0):
+        original_message = message = "{} mismatch\n\n".format(extension.upper())
+        diff = difflib.unified_diff(
+            expected.splitlines(keepends=True),
+            actual.splitlines(keepends=True),
+            fromfile='want.{}'.format(extension),
+            tofile='got.{}'.format(extension)
+        )
+        for line in diff:
+            message += line
+        if message != original_message:
+            # check that there was actually a diff, because checker.check_output
+            # doesn't work with unicode characters in xml node names
+            raise AssertionError(message)

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -1,3 +1,10 @@
+"""DO NOT ADD NEW THINGS TO THIS MODULE
+
+New test utilities should be added to a module in the
+`corehq.tests.util` package. Things in this module may be moved there as
+it makes sense to do so. See the docstring on that package for important
+guidelines.
+"""
 import functools
 import json
 import logging


### PR DESCRIPTION
Tests are running against Python 3.6 here, so this should be safe to merge before the upgrade to 3.9 is complete.

This PR is changing `check_xml_line_by_line` to be functionally equivalent to `assert_xml_equal`, a new stand-alone function based on `TestXmlMixin.assertXmlEqual`. `assert_xml_equal` is slightly less strict, but in a good way. For example, unlike `check_xml_line_by_line`, it does not care about the order of attributes in a tag.

## Safety Assurance

### Safety story

Only tests are changing in this PR.

### Automated test coverage

Fixes tests so they pass on both Python 3.6 and 3.9.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change