### PR TITLE
Upgrade xlrd for Python 3.9

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -116,5 +116,5 @@ tropo-webapi-python==0.1.3
 turn-python==0.0.1
 twilio==6.5.1
 werkzeug==1.0.1
-xlrd==1.0.0
+xlrd>1.0.0
 xlwt==1.3.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -645,7 +645,7 @@ wheel==0.37.0
     #   pip-tools
 wrapt==1.12.1
     # via deprecated
-xlrd==1.0.0
+xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -518,7 +518,7 @@ werkzeug==1.0.1
     # via -r base-requirements.in
 wrapt==1.12.1
     # via deprecated
-xlrd==1.0.0
+xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -520,7 +520,7 @@ werkzeug==1.0.1
     # via -r base-requirements.in
 wrapt==1.12.1
     # via deprecated
-xlrd==1.0.0
+xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -469,7 +469,7 @@ werkzeug==1.0.1
     # via -r base-requirements.in
 wrapt==1.12.1
     # via deprecated
-xlrd==1.0.0
+xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -524,7 +524,7 @@ wheel==0.37.0
     # via pip-tools
 wrapt==1.12.1
     # via deprecated
-xlrd==1.0.0
+xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in


### PR DESCRIPTION
v1.0.0 was released in 2016 and does not even officially support Python 3.6.

-  xlrd is for parsing older Excel files (`.xls` only). Support for anything other than `.xls` files was removed in v2.0.0. Thankfully we only use it to open `xls` files (we use `openpyxl` for `xlsx` files)
  https://github.com/dimagi/commcare-hq/blob/9da5dc621daa275d26569c5e1a6a5244b962b029/corehq/util/workbook_reading/adapters/generic.py#L10
- There is one place where we use `xlrd` to parse an `xlsx` file (fixed in https://github.com/dimagi/commcare-hq/pull/30621/commits/7850a10cb73855a99b955de163ca7fad1d23ee46)
  https://github.com/dimagi/commcare-hq/blob/9da5dc621daa275d26569c5e1a6a5244b962b029/corehq/apps/smsbillables/management/commands/bootstrap_mach_gateway.py#L20

## Safety Assurance

### Safety story

Reviewed the [change log](https://xlrd.readthedocs.io/en/latest/changes.html). Breaking changes noted above, and ~will be~ have been addressed.

### Automated test coverage

We have tests that exercise the library. No new tests added.

### QA Plan

Cleared with QA team and added to gevent QA ticket: https://dimagi-dev.atlassian.net/browse/QA-3632?focusedCommentId=174308

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change