### PR TITLE
Update uses to ElementTree.Element.getchildren() for Python 3.9

### DIFF
--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -837,13 +837,13 @@ class Detail(OrderedXmlObject, IdNode):
         # can't check len(self.variables) directly since NodeList uses an
         # xpath to find its children which doesn't work here since
         # each node has a custom name
-        return self._variables is not None and len(self.variables.node.getchildren()) > 0
+        return self._variables is not None and len(self.variables.node) > 0
 
     def get_variables(self):
         """
         :returns: List of DetailVariable objects
         """
-        return [self.variables.mapper.to_python(node) for node in self.variables.node.getchildren()]
+        return [self.variables.mapper.to_python(node) for node in self.variables.node]
 
     def get_all_xpaths(self):
         result = set()

--- a/corehq/apps/fixtures/tests/test_fixture_data.py
+++ b/corehq/apps/fixtures/tests/test_fixture_data.py
@@ -406,8 +406,7 @@ class TestFixtureOrdering(TestCase):
 
     def test_fixture_order(self):
         (fixture,) = call_fixture_generator(self.user.to_ota_restore_user())
-        rows = fixture.getchildren()[0].getchildren()
-        actual_names = [row.getchildren()[0].text for row in rows]
+        actual_names = [row[0].text for row in fixture[0]]
         self.assertEqual(
             ["Targaryen", "Stark", "Lannister", "Tyrell", "Tully", "Martell", "Baratheon"],
             actual_names

--- a/corehq/apps/translations/app_translations/upload_form.py
+++ b/corehq/apps/translations/app_translations/upload_form.py
@@ -254,7 +254,7 @@ class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
             node.xml.getparent().remove(node.xml)
         escaped_trans = self.escape_output_value(new_translation)
         value_node.xml.text = escaped_trans.text
-        for n in escaped_trans.getchildren():
+        for n in escaped_trans:
             value_node.xml.append(n)
 
     def _looks_like_markdown(self, str):


### PR DESCRIPTION
`getchildren()` was deprecated in 3.2 and removed in 3.9
https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren

## Safety Assurance

### Safety story

This change is switching from a long-deprecated method to the more conventional way of referencing child nodes of an XML element.

### Automated test coverage

All changes in this PR are covered by tests.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change