### PR TITLE
Check for release management privilege in addition to linked projects toggle

### DIFF
--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -89,8 +89,8 @@ class CopyApplicationForm(forms.Form):
     def clean(self):
         domain = self.cleaned_data.get('domain')
         if self.cleaned_data.get('linked'):
-            if not toggles.LINKED_DOMAINS.enabled(domain):
-                raise forms.ValidationError("The target project space does not have linked apps enabled.")
+            if not domain_has_privilege(domain, RELEASE_MANAGEMENT) and not toggles.LINKED_DOMAINS.enabled(domain):
+                raise forms.ValidationError("The target project space does not have this feature enabled.")
             link = DomainLink.objects.filter(linked_domain=domain)
             if link and link[0].master_domain != self.from_domain:
                 raise forms.ValidationError(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
QA caught this issue where linking apps was unsuccessful on project spaces with _only_ the release_management privilege enabled. This slipped through the cracks initially because we were focused on the transition from linked projects ff to the privilege, so both permissions were enabled when testing the release_management privilege.

I looked for other spots that don't also check for the privilege but it seems all other spots have been properly setup to check, minus multi_master_linked_projects checks which I am ignoring for now. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Small change to also check for the release management privilege. This is a simple if conditional change.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No test coverage.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
