### PR TITLE
prevent infinite loop if sql version really is latest

### DIFF
--- a/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
@@ -194,23 +194,24 @@ class CaseHelper:
             # if the doc is newer in ES than sql, refetch from sql to get newest
             if es_modified_on is not None and es_modified_on > modified_on:
                 refreshed = CaseAccessors(domain).get_case(case_id)
-                return CaseHelper._check_stale(case_id, case_type, refreshed.server_modified_on,
-                                    refreshed.domain, es_modified_on_by_ids, case_search_es_modified_on_by_ids)
-            else:
-                return True, DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type,
-                                     domain=domain, es_date=es_modified_on, primary_date=modified_on)
+                if refreshed.server_modified_on != modified_on:
+                    return CaseHelper._check_stale(case_id, case_type, refreshed.server_modified_on,
+                                                   refreshed.domain, es_modified_on_by_ids,
+                                                   case_search_es_modified_on_by_ids)
+            return True, DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type,
+                                 domain=domain, es_date=es_modified_on, primary_date=modified_on)
         elif domain in domains_needing_search_index():
             es_modified_on, es_domain = case_search_es_modified_on_by_ids.get(case_id, (None, None))
             if (es_modified_on, es_domain) != (modified_on, domain):
                 # if the doc is newer in ES than sql, refetch from sql to get newest
                 if es_modified_on is not None and es_modified_on > modified_on:
                     refreshed = CaseAccessors(domain).get_case(case_id)
-                    return CaseHelper._check_stale(case_id, case_type, refreshed.server_modified_on,
-                                                   refreshed.domain, es_modified_on_by_ids,
-                                                   case_search_es_modified_on_by_ids)
-                else:
-                    return True, DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type,
-                                         domain=domain, es_date=es_modified_on, primary_date=modified_on)
+                    if refreshed.server_modified_on != modified_on:
+                        return CaseHelper._check_stale(case_id, case_type, refreshed.server_modified_on,
+                                                       refreshed.domain, es_modified_on_by_ids,
+                                                       case_search_es_modified_on_by_ids)
+                return True, DataRow(doc_id=case_id, doc_type='CommCareCase', doc_subtype=case_type,
+                                     domain=domain, es_date=es_modified_on, primary_date=modified_on)
         return False, None
 
     @staticmethod


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
There was an infinite loop here if the sql modified date really was before the es modified date. It is unclear how this happens, but does exist in some historical documents. The changes makes it so that we stop checking for a newer version in sql if the query does not return a newer doc.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Internal management command that just collects data.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
The command functionality is tested

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
