### PR TITLE
do not crash if field is missing from doc

### DIFF
--- a/corehq/apps/es/utils.py
+++ b/corehq/apps/es/utils.py
@@ -15,7 +15,7 @@ def values_list(hits, *fields, **kwargs):
         raise TypeError('must be called with at least one field')
     if flat:
         field, = fields
-        return [hit[field] for hit in hits]
+        return [hit.get(field) for hit in hits]
     else:
         return [tuple(hit.get(field) for field in fields) for hit in hits]
 

--- a/corehq/apps/es/utils.py
+++ b/corehq/apps/es/utils.py
@@ -17,7 +17,7 @@ def values_list(hits, *fields, **kwargs):
         field, = fields
         return [hit[field] for hit in hits]
     else:
-        return [tuple(hit[field] for field in fields) for hit in hits]
+        return [tuple(hit.get(field) for field in fields) for hit in hits]
 
 
 def flatten_field_dict(results, fields_property='fields'):


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This came up in the `stale_data_in_es` command but I imagine can come up anywhere this is used. When a field is missing, returning `None` seems more correct than crashing hard, especially since we don't have a lot of guarantees about what field a document will have.

Relevant sentry error https://sentry.io/organizations/dimagi/issues/2685740044/?environment=production&project=136860&query=is%3Aunresolved+reconcile&statsPeriod=14d

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
No meaningful behavior change, other than handling an existing edge case

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
The method is tested in the es tests, so if any break of existing usage will be caught.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
