### PR TITLE
Make `payload_id` unique

### DIFF
--- a/corehq/motech/dhis2/tasks.py
+++ b/corehq/motech/dhis2/tasks.py
@@ -81,7 +81,10 @@ def send_dataset(
     .. _DHIS2 API docs: https://docs.dhis2.org/master/en/developer/html/webapi_data_values.html
 
     """
-    payload_id = dataset_map.ucr_id  # Allows us to filter Remote API Logs
+    # payload_id lets us filter API logs, and uniquely identifies the
+    # dataset map, to help AEs and administrators link an API log back
+    # to a dataset map.
+    payload_id = f'dhis2/map/{dataset_map.pk}/'
     response_log_url = reverse(
         'motech_log_list_view',
         args=[dataset_map.domain],


### PR DESCRIPTION
## Technical Summary

Prompted by a Slack conversation, this is a tiny change to allow AEs and administrators to uniquely identify which DHIS2 dataset map resulted in an API log.

**BEFORE:**
![image](https://user-images.githubusercontent.com/708421/138861681-406508f2-fae2-49f5-a408-40b1c503da28.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/708421/138861757-f8271e55-0663-4517-8198-ff18b3591c28.png)

This is a cosmetic change. No functionality is connected to the payload ID displayed in API logs. This change does not affect filtering for payloads that use the previous format.

FYI @avazirna


## Feature Flag
DHIS2 integration


## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Cosmetic change. Not covered by tests.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
