### PR TITLE
It's XPath, not Xpath

### DIFF
--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -136,7 +136,7 @@ class FormattedDetailColumn(object):
         )
 
         if self.column.useXpathExpression:
-            xpath = sx.CalculatedPropertyXpath(function=self.xpath)
+            xpath = sx.CalculatedPropertyXPath(function=self.xpath)
             if re.search(r'\$lang', self.xpath):
                 xpath.variables.node.append(
                     sx.CalculatedPropertyXPathVariable(
@@ -176,7 +176,7 @@ class FormattedDetailColumn(object):
             )
 
             if self.column.useXpathExpression:
-                xpath = sx.CalculatedPropertyXpath(function=self.xpath)
+                xpath = sx.CalculatedPropertyXPath(function=self.xpath)
                 if re.search(r'\$lang', self.xpath):
                     xpath.variables.node.append(
                         sx.CalculatedPropertyXPathVariable(
@@ -206,7 +206,7 @@ class FormattedDetailColumn(object):
                     type=sort_type,
                 )
                 if not sort_calculation and self.column.useXpathExpression:
-                    xpath = sx.CalculatedPropertyXpath(function=self.xpath)
+                    xpath = sx.CalculatedPropertyXPath(function=self.xpath)
                     if re.search(r'\$lang', self.xpath):
                         xpath.variables.node.append(
                             sx.CalculatedPropertyXPathVariable(

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -139,18 +139,18 @@ class FormattedDetailColumn(object):
             xpath = sx.CalculatedPropertyXpath(function=self.xpath)
             if re.search(r'\$lang', self.xpath):
                 xpath.variables.node.append(
-                    sx.CalculatedPropertyXpathVariable(
+                    sx.CalculatedPropertyXPathVariable(
                         name='lang',
                         locale_id=self.id_strings.current_language()
                     ).node
                 )
-            xpath_variable = sx.XpathVariable(name='calculated_property', xpath=xpath)
+            xpath_variable = sx.XPathVariable(name='calculated_property', xpath=xpath)
             template.text.xpath.variables.node.append(xpath_variable.node)
 
         if self.variables:
             for key, value in sorted(self.variables.items()):
                 template.text.xpath.variables.node.append(
-                    sx.XpathVariable(name=key, locale_id=value).node
+                    sx.XPathVariable(name=key, locale_id=value).node
                 )
 
         return template
@@ -179,12 +179,12 @@ class FormattedDetailColumn(object):
                 xpath = sx.CalculatedPropertyXpath(function=self.xpath)
                 if re.search(r'\$lang', self.xpath):
                     xpath.variables.node.append(
-                        sx.CalculatedPropertyXpathVariable(
+                        sx.CalculatedPropertyXPathVariable(
                             name='lang',
                             locale_id=self.id_strings.current_language()
                         ).node
                     )
-                xpath_variable = sx.XpathVariable(name='calculated_property', xpath=xpath)
+                xpath_variable = sx.XPathVariable(name='calculated_property', xpath=xpath)
                 sort.text.xpath.variables.node.append(xpath_variable.node)
 
         if self.sort_element:
@@ -209,11 +209,11 @@ class FormattedDetailColumn(object):
                     xpath = sx.CalculatedPropertyXpath(function=self.xpath)
                     if re.search(r'\$lang', self.xpath):
                         xpath.variables.node.append(
-                            sx.CalculatedPropertyXpathVariable(
+                            sx.CalculatedPropertyXPathVariable(
                                 name='lang', locale_id=self.id_strings.current_language()
                             ).node
                         )
-                    xpath_variable = sx.XpathVariable(name='calculated_property', xpath=xpath)
+                    xpath_variable = sx.XPathVariable(name='calculated_property', xpath=xpath)
                     sort.text.xpath.variables.node.append(xpath_variable.node)
 
             if self.sort_element.type == 'distance':
@@ -409,7 +409,7 @@ class ConditionalEnum(Enum):
             variables = self.variables
             for key in variables:
                 node.text.xpath.node.append(
-                    sx.XpathVariable(name=key, locale_id=variables[key]).node
+                    sx.XPathVariable(name=key, locale_id=variables[key]).node
                 )
         return node
 

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -365,7 +365,7 @@ class Phone(FormattedDetailColumn):
 @register_format_type('enum')
 class Enum(FormattedDetailColumn):
     def _make_xpath(self, type):
-        return sx.XpathEnum.build(
+        return sx.XPathEnum.build(
             enum=self.column.enum,
             template=self._xpath_template(type),
             get_template_context=self._xpath_template_context(type),

--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -116,7 +116,7 @@ class SuiteValidationError(SuiteError):
     pass
 
 
-class LocationXpathValidationError(AppManagerException):
+class LocationXPathValidationError(AppManagerException):
     pass
 
 

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -26,7 +26,7 @@ from corehq.apps.app_manager.exceptions import (
     AppEditingError,
     CaseXPathValidationError,
     FormNotFoundException,
-    LocationXpathValidationError,
+    LocationXPathValidationError,
     ModuleIdMissingException,
     ModuleNotFoundException,
     ParentModuleReferenceError,
@@ -389,13 +389,13 @@ class ModuleBaseValidator(object):
                 try:
                     if not should_sync_hierarchical_fixture(domain_obj, self.module.get_app()):
                         # discontinued feature on moving to flat fixture format
-                        raise LocationXpathValidationError(
+                        raise LocationXPathValidationError(
                             _('That format is no longer supported. To reference the location hierarchy you need to'
                               ' use the "Custom Calculations in Case List" feature preview. For more information '
                               'see: https://confluence.dimagi.com/pages/viewpage.action?pageId=38276915'))
                     hierarchy = hierarchy or parent_child(domain)
                     LocationXpath('').validate(column.field_property, hierarchy)
-                except LocationXpathValidationError as e:
+                except LocationXPathValidationError as e:
                     yield {
                         'type': 'invalid location xpath',
                         'details': str(e),

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -20,7 +20,7 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
     Sort,
     Template,
     Text,
-    Xpath,
+    XPath,
     XPathVariable,
 )
 from corehq.apps.reports_core.filters import (
@@ -261,7 +261,7 @@ def _get_summary_details(config, domain, module, new_mobile_ucr_restore=False):
             last_sync_string = "format-date(date(instance('reports')/reports/@last_sync), '%Y-%m-%d %H:%M')"
 
         return Text(
-            xpath=Xpath(
+            xpath=XPath(
                 function=last_sync_string
             )
         )
@@ -269,7 +269,7 @@ def _get_summary_details(config, domain, module, new_mobile_ucr_restore=False):
     def _get_description_text(report_config):
         if report_config.use_xpath_description:
             return Text(
-                xpath=Xpath(function=config.xpath_description)
+                xpath=XPath(function=config.xpath_description)
             )
         else:
             return Text(
@@ -340,11 +340,11 @@ def _get_data_detail(config, domain, new_mobile_ucr_restore):
     """
     def get_xpath(column_id):
         if new_mobile_ucr_restore:
-            return Xpath(
+            return XPath(
                 function="{}".format(column_id),
             )
         else:
-            return Xpath(
+            return XPath(
                 function="column[@id='{}']".format(column_id),
             )
     def _column_to_field(column):
@@ -395,7 +395,7 @@ def _get_data_detail(config, domain, new_mobile_ucr_restore):
                         word_eval,
                         xpath_function
                     )
-                return Xpath(
+                return XPath(
                     function=xpath_function.format(
                         column_id=col.column_id
                     ),

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -21,7 +21,7 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
     Template,
     Text,
     Xpath,
-    XpathVariable,
+    XPathVariable,
 )
 from corehq.apps.reports_core.filters import (
     ChoiceListFilter,
@@ -399,7 +399,7 @@ def _get_data_detail(config, domain, new_mobile_ucr_restore):
                     function=xpath_function.format(
                         column_id=col.column_id
                     ),
-                    variables=[XpathVariable(name='lang', locale_id='lang.current')],
+                    variables=[XPathVariable(name='lang', locale_id='lang.current')],
                 )
             else:
                 return get_xpath(col.column_id)

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -36,9 +36,9 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
     Style,
     Template,
     Text,
-    Xpath,
     XPathVariable,
 )
+from corehq.apps.app_manager.suite_xml.xml_models import XPath as XPathEl
 from corehq.apps.app_manager.util import (
     create_temp_sort_column,
     get_sort_and_sort_only_columns,
@@ -446,7 +446,7 @@ class DetailContributor(SectionContributor):
                     grid_y=0,
                 ),
                 header=Header(text=Text()),
-                template=Template(text=Text(xpath=Xpath(
+                template=Template(text=Text(xpath=XPathEl(
                     function="concat($message, ' ', format-date(date(instance('commcare-reports:index')/report_index/reports/@last_update), '%e/%n/%Y'))",
                     variables=[XPathVariable(name='message', locale_id=id_strings.reports_last_updated_on())],
                 ))),
@@ -459,7 +459,7 @@ class DetailContributor(SectionContributor):
             id=id_strings.fixture_detail(module),
             title=Text(),
         )
-        xpath = Xpath(function=module.fixture_select.display_column)
+        xpath = XPathEl(function=module.fixture_select.display_column)
         if module.fixture_select.localize:
             template_text = Text(locale=Locale(child_id=Id(xpath=xpath)))
         else:

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -37,7 +37,7 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
     Template,
     Text,
     Xpath,
-    XpathVariable,
+    XPathVariable,
 )
 from corehq.apps.app_manager.util import (
     create_temp_sort_column,
@@ -448,7 +448,7 @@ class DetailContributor(SectionContributor):
                 header=Header(text=Text()),
                 template=Template(text=Text(xpath=Xpath(
                     function="concat($message, ' ', format-date(date(instance('commcare-reports:index')/report_index/reports/@last_update), '%e/%n/%Y'))",
-                    variables=[XpathVariable(name='message', locale_id=id_strings.reports_last_updated_on())],
+                    variables=[XPathVariable(name='message', locale_id=id_strings.reports_last_updated_on())],
                 ))),
             )]
         )
@@ -698,7 +698,7 @@ class CaseTileHelper(object):
         variables = []
         for i, mapping in enumerate(column.enum):
             variables.append(
-                XpathVariable(
+                XPathVariable(
                     name=mapping.key_as_variable,
                     locale_id=id_strings.detail_column_enum_variable(
                         self.module, self.detail_type, column, mapping.key_as_variable

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -541,10 +541,10 @@ class Entry(OrderedXmlObject, XmlObject):
         for instance_id in instance_ids:
             if instance_id not in covered_ids:
                 raise UnknownInstanceError(
-                    "Instance reference not recognized: {} in xpath \"{}\""
+                    "Instance reference not recognized: {} in XPath \"{}\""
                     # to get xpath context to show in this error message
                     # make instance_id a unicode subclass with an xpath property
-                    .format(instance_id, getattr(instance_id, 'xpath', "(Xpath Unknown)")))
+                    .format(instance_id, getattr(instance_id, 'xpath', "(XPath Unknown)")))
 
         sorted_instances = sorted(self.instances,
                                   key=lambda instance: instance.id)

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -43,7 +43,7 @@ class IdNode(XmlObject):
     id = StringField('@id')
 
 
-class CalculatedPropertyXpathVariable(XmlObject):
+class CalculatedPropertyXPathVariable(XmlObject):
     ROOT_NAME = 'variable'
     name = StringField('@name')
     locale_id = StringField('locale/@id')
@@ -52,10 +52,10 @@ class CalculatedPropertyXpathVariable(XmlObject):
 class CalculatedPropertyXpath(XmlObject):
     ROOT_NAME = 'xpath'
     function = XPathField('@function')
-    variables = NodeListField('variable', CalculatedPropertyXpathVariable)
+    variables = NodeListField('variable', CalculatedPropertyXPathVariable)
 
 
-class XpathVariable(XmlObject):
+class XPathVariable(XmlObject):
     ROOT_NAME = 'variable'
     name = StringField('@name')
 
@@ -70,7 +70,7 @@ class XpathVariable(XmlObject):
 class Xpath(XmlObject):
     ROOT_NAME = 'xpath'
     function = XPathField('@function')
-    variables = NodeListField('variable', XpathVariable)
+    variables = NodeListField('variable', XPathVariable)
 
 
 class LocaleArgument(XmlObject):
@@ -91,7 +91,7 @@ class XPathEnum(Xpath):
         for item in enum:
             v_key = item.key_as_variable
             v_val = get_value(v_key)
-            variables.append(XpathVariable(name=v_key, locale_id=v_val))
+            variables.append(XPathVariable(name=v_key, locale_id=v_val))
 
         parts = []
         for i, item in enumerate(enum):

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -67,7 +67,7 @@ class XPathVariable(XmlObject):
         return self.locale_id or self.xpath
 
 
-class Xpath(XmlObject):
+class XPath(XmlObject):
     ROOT_NAME = 'xpath'
     function = XPathField('@function')
     variables = NodeListField('variable', XPathVariable)
@@ -81,10 +81,10 @@ class LocaleArgument(XmlObject):
 
 class Id(XmlObject):
     ROOT_NAME = 'id'
-    xpath = NodeField('xpath', Xpath)
+    xpath = NodeField('xpath', XPath)
 
 
-class XPathEnum(Xpath):
+class XPathEnum(XPath):
     @classmethod
     def build(cls, enum, template, get_template_context, get_value):
         variables = []
@@ -129,7 +129,7 @@ class Text(XmlObject):
 
     ROOT_NAME = 'text'
 
-    xpath = NodeField('xpath', Xpath)
+    xpath = NodeField('xpath', XPath)
     xpath_function = XPathField('xpath/@function')
 
     locale = NodeField('locale', Locale)
@@ -279,7 +279,7 @@ class MediaText(XmlObject):
     ROOT_NAME = 'text'
     form_name = StringField('@form', choices=['image', 'audio'])  # Nothing XForm-y about this 'form'
     locale = NodeField('locale', LocaleId)
-    xpath = NodeField('xpath', Xpath)
+    xpath = NodeField('xpath', XPath)
     xpath_function = XPathField('xpath/@function')
 
 

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -49,7 +49,7 @@ class CalculatedPropertyXPathVariable(XmlObject):
     locale_id = StringField('locale/@id')
 
 
-class CalculatedPropertyXpath(XmlObject):
+class CalculatedPropertyXPath(XmlObject):
     ROOT_NAME = 'xpath'
     function = XPathField('@function')
     variables = NodeListField('variable', CalculatedPropertyXPathVariable)
@@ -60,7 +60,7 @@ class XPathVariable(XmlObject):
     name = StringField('@name')
 
     locale_id = StringField('locale/@id')
-    xpath = NodeField('xpath', CalculatedPropertyXpath)
+    xpath = NodeField('xpath', CalculatedPropertyXPath)
 
     @property
     def value(self):

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -84,7 +84,7 @@ class Id(XmlObject):
     xpath = NodeField('xpath', Xpath)
 
 
-class XpathEnum(Xpath):
+class XPathEnum(Xpath):
     @classmethod
     def build(cls, enum, template, get_template_context, get_value):
         variables = []

--- a/corehq/apps/app_manager/templates/app_manager/partials/custom_icon.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/custom_icon.html
@@ -21,7 +21,7 @@
       </label>
       <label>
                 <span>
-                    {% trans "Xpath Function" %}
+                    {% trans "XPath Function" %}
                 </span>
         <input class="form-control" name="custom_icon_xpath" id="custom_icon_xpath"
                value="{% if custom_icon.xpath %}{{ custom_icon.xpath }}{% endif %}">

--- a/corehq/apps/app_manager/tests/data/suite/app_graphing.json
+++ b/corehq/apps/app_manager/tests/data/suite/app_graphing.json
@@ -283,7 +283,7 @@
                            "enum": [
                            ],
                            "header": {
-                               "en": "Xy Xpath Function"
+                               "en": "XY XPath Function"
                            },
                            "time_ago_interval": 365.25,
                            "calc_xpath": ".",

--- a/corehq/apps/app_manager/tests/test_location_xpath.py
+++ b/corehq/apps/app_manager/tests/test_location_xpath.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 
-from corehq.apps.app_manager.exceptions import LocationXpathValidationError
+from corehq.apps.app_manager.exceptions import LocationXPathValidationError
 from corehq.apps.app_manager.xpath import LocationXpath
 
 
@@ -35,12 +35,12 @@ class LocationXpathTest(SimpleTestCase):
         ]
         for input in test_cases:
             self.assertRaises(
-                LocationXpathValidationError,
+                LocationXPathValidationError,
                 LocationXpath('commtrack:locations').validate,
                 input, self.hierarchy,
             )
             self.assertRaises(
-                LocationXpathValidationError,
+                LocationXPathValidationError,
                 LocationXpath('commtrack:locations').location,
                 input, self.hierarchy,
             )
@@ -53,12 +53,12 @@ class LocationXpathTest(SimpleTestCase):
         ]
         for input in test_cases:
             self.assertRaises(
-                LocationXpathValidationError,
+                LocationXPathValidationError,
                 LocationXpath('commtrack:locations').validate,
                 input, self.hierarchy,
             )
             self.assertRaises(
-                LocationXpathValidationError,
+                LocationXPathValidationError,
                 LocationXpath('commtrack:locations').location,
                 input, self.hierarchy,
             )

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -15,7 +15,7 @@ from corehq.apps.app_manager.const import (
 )
 from corehq.apps.app_manager.exceptions import (
     CaseXPathValidationError,
-    LocationXpathValidationError,
+    LocationXPathValidationError,
     ScheduleError,
 )
 
@@ -287,7 +287,7 @@ class LocationXpath(XPath):
         types = self._ordered_types(hierarchy)
         for type in [my_type, ref_type]:
             if type not in types:
-                raise LocationXpathValidationError(
+                raise LocationXPathValidationError(
                     _('Type {type} must be in list of domain types: {list}').format(
                         type=type,
                         list=', '.join(types)
@@ -295,7 +295,7 @@ class LocationXpath(XPath):
                 )
 
         if types.index(ref_type) > types.index(my_type):
-            raise LocationXpathValidationError(
+            raise LocationXPathValidationError(
                 _('Reference type {ref} cannot be a child of primary type {main}.'.format(
                     ref=ref_type,
                     main=my_type,
@@ -308,7 +308,7 @@ class LocationXpath(XPath):
             ref_type, property = ref.split('/')
             return my_type, ref_type, property
         except ValueError:
-            raise LocationXpathValidationError(_(
+            raise LocationXPathValidationError(_(
                 'Property not correctly formatted. '
                 'Must be formatted like: loacation:mytype:referencetype/property. '
                 'For example: location:outlet:state/name'

--- a/corehq/apps/app_manager/xpath_validator/__init__.py
+++ b/corehq/apps/app_manager/xpath_validator/__init__.py
@@ -1,4 +1,4 @@
-from .exceptions import XpathValidationError
+from .exceptions import XPathValidationError
 from .wrapper import validate_xpath
 
-__all__ = ['validate_xpath', 'XpathValidationError']
+__all__ = ['validate_xpath', 'XPathValidationError']

--- a/corehq/apps/app_manager/xpath_validator/exceptions.py
+++ b/corehq/apps/app_manager/xpath_validator/exceptions.py
@@ -1,6 +1,6 @@
 
 
-class XpathValidationError(Exception):
+class XPathValidationError(Exception):
     """
     When an error occurs in the process of xpath validation
     (NOT when an xpath is invalid)

--- a/corehq/apps/app_manager/xpath_validator/tests.py
+++ b/corehq/apps/app_manager/xpath_validator/tests.py
@@ -6,7 +6,7 @@ from corehq.apps.app_manager.xpath_validator.wrapper import (
 )
 
 
-class XpathValidatorTest(SimpleTestCase):
+class XPathValidatorTest(SimpleTestCase):
 
     def test_simple_valid(self):
         self.assertEqual(

--- a/corehq/apps/app_manager/xpath_validator/wrapper.py
+++ b/corehq/apps/app_manager/xpath_validator/wrapper.py
@@ -6,7 +6,7 @@ from corehq.apps.app_manager.xpath_validator.config import (
     get_xpath_validator_path,
 )
 from corehq.apps.app_manager.xpath_validator.exceptions import (
-    XpathValidationError,
+    XPathValidationError,
 )
 
 XpathValidationResponse = namedtuple('XpathValidationResponse', ['is_valid', 'message'])
@@ -27,6 +27,6 @@ def validate_xpath(xpath, allow_case_hashtags=False):
     elif exit_code == 1:
         return XpathValidationResponse(is_valid=False, message=stdout)
     else:
-        raise XpathValidationError(
+        raise XPathValidationError(
             "{path} failed with exit code {exit_code}:\n{stderr}"
             .format(path=path, exit_code=exit_code, stderr=stderr))

--- a/corehq/apps/reports/standard/cases/case_list_explorer.py
+++ b/corehq/apps/reports/standard/cases/case_list_explorer.py
@@ -22,7 +22,7 @@ from corehq.apps.reports.standard.cases.basic import CaseListReport
 from corehq.apps.reports.standard.cases.data_sources import SafeCaseDisplay
 from corehq.apps.reports.standard.cases.filters import (
     CaseListExplorerColumns,
-    XpathCaseSearchFilter,
+    XPathCaseSearchFilter,
 )
 from corehq.elastic import iter_es_docs_from_query
 from corehq.util.metrics import metrics_histogram_timer
@@ -40,7 +40,7 @@ class CaseListExplorer(CaseListReport):
     _is_exporting = False
 
     fields = [
-        XpathCaseSearchFilter,
+        XPathCaseSearchFilter,
         CaseListExplorerColumns,
         CaseListFilter,
         CaseTypeFilter,
@@ -65,7 +65,7 @@ class CaseListExplorer(CaseListReport):
     def _build_query(self, sort=True):
         query = super(CaseListExplorer, self)._build_query()
         query = self._populate_sort(query, sort)
-        xpath = XpathCaseSearchFilter.get_value(self.request, self.domain)
+        xpath = XPathCaseSearchFilter.get_value(self.request, self.domain)
         if xpath:
             try:
                 query = query.xpath_query(self.domain, xpath)

--- a/corehq/apps/reports/standard/cases/filters.py
+++ b/corehq/apps/reports/standard/cases/filters.py
@@ -28,14 +28,14 @@ class CaseSearchFilter(BaseSimpleFilter):
     ))
 
 
-class XpathCaseSearchFilter(BaseSimpleFilter):
+class XPathCaseSearchFilter(BaseSimpleFilter):
     slug = 'search_xpath'
     label = ugettext_lazy("Search")
     template = "reports/filters/xpath_textarea.html"
 
     @property
     def filter_context(self):
-        context = super(XpathCaseSearchFilter, self).filter_context
+        context = super(XPathCaseSearchFilter, self).filter_context
         context.update({
             'placeholder': "e.g. name = 'foo' and dob <= '2017-02-12'",
             'text': self.get_value(self.request, self.domain) or '',


### PR DESCRIPTION
## Technical Summary
I got tripped up the other day working in `details.py`, which uses an `Xpath` class and an `XPath` class which is...not ideal.

This doesn't fully expunge "Xpath", just reduces its usage. "Xpath" is also used in couch class attribute names, so it's unlikely we'll fully eradicate it while still on couch.

## Safety Assurance

### Safety story
This is a mechanical change where human review plus tests should sufficient.

### Automated test coverage

Most of this has test coverage.

### QA Plan

No QA.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
