### PR TITLE
Remove link if superuser

### DIFF
--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -102,7 +102,7 @@ from corehq.apps.userreports.models import (
     ReportConfiguration,
 )
 from corehq.apps.users.decorators import require_permission
-from corehq.apps.users.models import Permissions
+from corehq.apps.users.models import Permissions, WebUser
 from corehq.privileges import RELEASE_MANAGEMENT
 from corehq.util.timezones.utils import get_timezone_for_request
 
@@ -520,9 +520,17 @@ class DomainLinkHistoryReport(GenericTabularReport):
             '{} -> {}'.format(link.master_domain, link.linked_domain),
             server_to_user_time(record.date, self.timezone),
             self._make_model_cell(record),
-            pretty_doc_info(get_doc_info_by_id(self.domain, record.user_id))
+            self._make_user_cell(record)
         ]
         return row
+
+    def _make_user_cell(self, record):
+        doc_info = get_doc_info_by_id(self.domain, record.user_id)
+        user = WebUser.get_by_user_id(record.user_id)
+        if self.domain not in user.get_domains() and 'link' in doc_info:
+            doc_info['link'] = None
+
+        return pretty_doc_info(doc_info)
 
     @memoized
     def linked_app_names(self, domain):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-163)

QA discovered [this bug](https://dimagi-dev.atlassian.net/browse/QA-3202) in the linked project space history report. which boiled down to attempting to access the user page for a superuser that isn't actually a member of the domain resulting in a 404. Now, if the user is not a member of the domain, there is no hyperlink (see Sandip's user [here](https://staging.commcarehq.org/a/3157-3156-down/settings/project/project_link_report/?domain_link_model=app)).

The change I made is specific to how this manifests in this report, but I do wonder if there are other areas that hyperlink to a superuser that is not a member of the domain. I did a quick search to see if it was obvious to figure this out, but think this requires a bit of a deeper dive if we want to tackle this at a more general level (for instance, making [this code](https://github.com/dimagi/commcare-hq/blob/679c6324af53e45f157b42fb43a8255be0b26476/corehq/apps/hqwebapp/doc_info.py#L124-L130) aware of superuser vs non-superuser).
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested on staging ✅ 
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Final self-reflection
- [x] My safety story above is convincing and gives me confidence that this PR will not introduce a regression
