### PR TITLE
Add commcare.restore.case_load.count tracking total cases sync'd

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -37,7 +37,7 @@ from casexml.apps.phone.tasks import ASYNC_RESTORE_SENT
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.sql_db.routers import read_from_plproxy_standbys
 from corehq.toggles import LIVEQUERY_READ_FROM_STANDBYS, NAMESPACE_USER
-from corehq.util.metrics import metrics_histogram
+from corehq.util.metrics import metrics_histogram, metrics_counter
 from corehq.util.metrics.load_counters import case_load_counter
 
 
@@ -95,6 +95,7 @@ def do_livequery(timing_context, restore_state, response, async_task=None):
                     'restore_type': 'incremental' if restore_state.last_sync_log else 'fresh'
                 }
             )
+            metrics_counter('commcare.restore.case_load.count', len(sync_ids), {'domain': accessor.domain})
             compile_response(
                 timing_context,
                 restore_state,


### PR DESCRIPTION
## Technical Summary

https://dimagi-dev.atlassian.net/browse/SAAS-12697

This new metric will count all cases sync'd (i.e. number of restores times mean size of restores) by domain. Our experience suggests that this is a good measure of how expensive a project's data syncing is for our servers.

## Feature Flag
None

## Safety Assurance

### Safety story
This just adds a metric, and the line is covered by tests.

### Automated test coverage

At least one test (`casexml.apps.phone.tests.test_extension_indexes:LiveQueryIndexTreeTest.test_Alternating_Chain`) fails if I add `raise Exception` in place of this code change, so unless the error is implausibly subtle, our tests would catch a problem in this PR.

### QA Plan

I'm going to put this on staging and just make sure the metric looks the way it should, which will also mitigate any remaining chance that an error made it past tests.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
