### PR TITLE
During case import with mirrored domains enabled,

### DIFF
--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -226,6 +226,9 @@ def excel_fields(request, domain):
     # see: https://dimagi-dev.atlassian.net/browse/USH-81
     if 'domain' in excel_fields and DOMAIN_PERMISSIONS_MIRROR.enabled(domain):
         excel_fields.remove('domain')
+        mirroring_enabled = True
+    else:
+        mirroring_enabled = False
 
     field_specs = get_suggested_case_fields(
         domain, case_type, exclude=[search_field])
@@ -241,6 +244,7 @@ def excel_fields(request, domain):
         'excel_fields': excel_fields,
         'case_field_specs': case_field_specs,
         'domain': domain,
+        'mirroring_enabled': mirroring_enabled,
     }
     context.update(_case_importer_breadcrumb_context(_('Match Excel Columns to Case Properties'), domain))
     return render(request, "case_importer/excel_fields.html", context)

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/valid_values_th_content.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/valid_values_th_content.html
@@ -7,7 +7,7 @@
   data-content="
     {% trans_html_attr 'When importing data, CommCare will only save rows with cells that match the listed values or format.' %}
     {% if mirroring_enabled %}
-        {% trans_html_attr 'Mirrored project spaces may have different valid values.' %}
+        {% trans_html_attr 'Cases being created or updated in different project spaces may have different valid values.' %}
     {% endif %}
     ">
 </span>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/valid_values_th_content.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/valid_values_th_content.html
@@ -4,5 +4,10 @@
 <span
   class="hq-help-template"
   data-title="{% trans_html_attr 'Valid values or format' %}"
-  data-content="{% trans_html_attr 'When importing data, CommCare will only save rows with cells that match the listed values or format.' %}">
+  data-content="
+    {% trans_html_attr 'When importing data, CommCare will only save rows with cells that match the listed values or format.' %}
+    {% if mirroring_enabled %}
+        {% trans_html_attr 'Mirrored project spaces may have different valid values.' %}
+    {% endif %}
+    ">
 </span>


### PR DESCRIPTION
(PR into a dev branch, removed safety info -@orangejenny)

add a note to the tooltip for the valid values and formats column that indicates valid values may differ for mirrored domain.

Refs QA-3630
