### PR TITLE
remove couch form and case kafka topics

### DIFF
--- a/corehq/apps/change_feed/partitioners.py
+++ b/corehq/apps/change_feed/partitioners.py
@@ -9,9 +9,7 @@ from pillowtop import get_pillow_by_name, get_all_pillow_configs
 
 
 TOPIC_TO_PILLOW_NAME_MAP = {
-    topics.CASE: 'case-pillow',
     topics.CASE_SQL: 'case-pillow',
-    topics.FORM: 'xform-pillow',
     topics.FORM_SQL: 'xform-pillow',
 }
 

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -52,7 +52,7 @@ class KafkaProcessor(PillowProcessor):
 
 
 def get_default_couch_db_change_feed_pillow(pillow_id, **kwargs):
-    return get_change_feed_pillow_for_db(pillow_id, CommCareCase.get_db(), topics.CASE)
+    return get_change_feed_pillow_for_db(pillow_id, CommCareCase.get_db())
 
 
 def get_user_groups_db_kafka_pillow(pillow_id, **kwargs):

--- a/corehq/apps/change_feed/tests/test_pillow.py
+++ b/corehq/apps/change_feed/tests/test_pillow.py
@@ -34,7 +34,7 @@ class ChangeFeedPillowTest(SimpleTestCase):
         # Specifically KafkaChangeFeedTest.test_multiple_topics_with_partial_checkpoint
         self._fake_couch.dbname = 'test_commcarehq'
         self.consumer = KafkaConsumer(
-            topics.CASE,
+            topics.CASE_SQL,
             bootstrap_servers=settings.KAFKA_BROKERS,
             consumer_timeout_ms=100,
             enable_auto_commit=False,

--- a/corehq/apps/change_feed/tests/test_producer_reconciliation.py
+++ b/corehq/apps/change_feed/tests/test_producer_reconciliation.py
@@ -41,7 +41,7 @@ class TestKafkaAuditLogging(SimpleTestCase):
 
         with capture_log_output(KAFKA_AUDIT_LOGGER) as logs:
             with self.assertRaises(Exception):
-                kafka_producer.send_change(topics.CASE, meta)
+                kafka_producer.send_change(topics.CASE_SQL, meta)
 
         self._check_logs(logs, meta.document_id, [CHANGE_PRE_SEND, CHANGE_ERROR])
 
@@ -55,7 +55,7 @@ class TestKafkaAuditLogging(SimpleTestCase):
         )
 
         with capture_log_output(KAFKA_AUDIT_LOGGER) as logs:
-            kafka_producer.send_change(topics.CASE, meta)
+            kafka_producer.send_change(topics.CASE_SQL, meta)
             future.failure(Exception())
 
         self._check_logs(logs, meta.document_id, [CHANGE_PRE_SEND, CHANGE_ERROR])
@@ -65,7 +65,7 @@ class TestKafkaAuditLogging(SimpleTestCase):
         with capture_log_output(KAFKA_AUDIT_LOGGER) as logs:
             meta = ChangeMeta(document_id=uuid.uuid4().hex, data_source_type='dummy-type',
                               data_source_name='dummy-name')
-            kafka_producer.send_change(topics.CASE, meta)
+            kafka_producer.send_change(topics.CASE_SQL, meta)
             if not auto_flush:
                 kafka_producer.flush()
         self._check_logs(logs, meta.document_id, [CHANGE_PRE_SEND, CHANGE_SENT])

--- a/corehq/apps/change_feed/tests/test_topics.py
+++ b/corehq/apps/change_feed/tests/test_topics.py
@@ -10,11 +10,7 @@ class TopicTests(SimpleTestCase):
 
 
 @generate_cases([
-    ('CommCareCase', data_sources.SOURCE_COUCH, topics.CASE),
-    ('CommCareCase', None, topics.CASE),
     ('CommCareCase', data_sources.SOURCE_SQL, topics.CASE_SQL),
-    ('XFormInstance', data_sources.SOURCE_COUCH, topics.FORM),
-    ('XFormInstance', None, topics.FORM),
     ('XFormInstance', data_sources.SOURCE_SQL, topics.FORM_SQL),
 ], TopicTests)
 def test_get_topic_for_doc_type(self, doc_type, data_source, expected_topic):

--- a/corehq/apps/change_feed/topics.py
+++ b/corehq/apps/change_feed/topics.py
@@ -5,8 +5,6 @@ from corehq.apps.change_feed.connection import get_simple_kafka_client
 from corehq.apps.change_feed.exceptions import UnavailableKafkaOffset
 from corehq.form_processor.models import XFormInstanceSQL
 
-CASE = 'case'
-FORM = 'form'
 DOMAIN = 'domain'
 META = 'meta'
 APP = 'app'
@@ -21,15 +19,13 @@ LOCATION = 'location'
 SYNCLOG_SQL = 'synclog-sql'
 
 
-CASE_TOPICS = (CASE, CASE_SQL)
-FORM_TOPICS = (FORM, FORM_SQL)
+CASE_TOPICS = (CASE_SQL, )
+FORM_TOPICS = (FORM_SQL, )
 USER_TOPICS = (COMMCARE_USER, WEB_USER)
 ALL = (
-    CASE,
     CASE_SQL,
     COMMCARE_USER,
     DOMAIN,
-    FORM,
     FORM_SQL,
     GROUP,
     LEDGER,
@@ -47,15 +43,9 @@ def get_topic_for_doc_type(doc_type, data_source_type=None, default_topic=None):
     from corehq.apps.locations.document_store import LOCATION_DOC_TYPE
 
     if doc_type in document_types.CASE_DOC_TYPES:
-        return {
-            'sql': CASE_SQL,
-            'couch': CASE
-        }.get(data_source_type, CASE)
+        return CASE_SQL
     elif doc_type in XFormInstanceSQL.ALL_DOC_TYPES:
-        return {
-            'sql': FORM_SQL,
-            'couch': FORM
-        }.get(data_source_type, FORM)
+        return FORM_SQL
     elif doc_type in document_types.DOMAIN_DOC_TYPES:
         return DOMAIN
     elif doc_type in document_types.MOBILE_USER_DOC_TYPES:

--- a/corehq/apps/userreports/const.py
+++ b/corehq/apps/userreports/const.py
@@ -30,9 +30,7 @@ UCR_CELERY_QUEUE = 'ucr_queue'
 UCR_INDICATOR_CELERY_QUEUE = 'ucr_indicator_queue'
 
 KAFKA_TOPICS = (
-    topics.CASE,
     topics.CASE_SQL,
-    topics.FORM,
     topics.FORM_SQL,
     topics.LOCATION,
     topics.COMMCARE_USER,

--- a/corehq/ex-submodules/fluff/management/commands/ptop_reindexer_fluff.py
+++ b/corehq/ex-submodules/fluff/management/commands/ptop_reindexer_fluff.py
@@ -60,9 +60,7 @@ class Command(BaseCommand):
                     bad_domains, available_domains
                 ))
 
-        if pillow.kafka_topic in (topics.CASE, topics.FORM):
-            couch_db = couch_config.get_db(None)
-        elif pillow.kafka_topic == topics.COMMCARE_USER:
+        if pillow.kafka_topic == topics.COMMCARE_USER:
             couch_db = couch_config.get_db(settings.USERS_GROUPS_DB)
         else:
             raise CommandError('Reindexer not configured for topic: {}'.format(pillow.kafka_topic))

--- a/corehq/ex-submodules/pillow_retry/tests/test_retry.py
+++ b/corehq/ex-submodules/pillow_retry/tests/test_retry.py
@@ -46,7 +46,7 @@ class CouchPillowRetryProcessingTest(TestCase, TestMixin):
         self._fake_couch = FakeCouchDb()
         self._fake_couch.dbname = 'test_commcarehq'
         self.consumer = KafkaConsumer(
-            topics.CASE,
+            topics.CASE_SQL,
             client_id='test-consumer',
             bootstrap_servers=settings.KAFKA_BROKERS,
             consumer_timeout_ms=100,
@@ -114,7 +114,7 @@ class KakfaPillowRetryProcessingTest(TestCase, TestMixin):
             name='test-kafka-case-feed',
             checkpoint=None,
             change_feed=KafkaChangeFeed(
-                topics=[topics.CASE, topics.CASE_SQL], client_id='test-kafka-case-feed'
+                topics=[topics.CASE_SQL], client_id='test-kafka-case-feed'
             ),
             processor=self.processor
         )

--- a/corehq/form_processor/tests/test_kafka.py
+++ b/corehq/form_processor/tests/test_kafka.py
@@ -30,13 +30,13 @@ class KafkaPublishingTest(TestCase):
         cls.form_pillow = ConstructedPillow(
             name='test-kafka-form-feed',
             checkpoint=None,
-            change_feed=KafkaChangeFeed(topics=[topics.FORM, topics.FORM_SQL], client_id='test-kafka-form-feed'),
+            change_feed=KafkaChangeFeed(topics=[topics.FORM_SQL], client_id='test-kafka-form-feed'),
             processor=cls.processor
         )
         cls.case_pillow = ConstructedPillow(
             name='test-kafka-case-feed',
             checkpoint=None,
-            change_feed=KafkaChangeFeed(topics=[topics.CASE, topics.CASE_SQL], client_id='test-kafka-case-feed'),
+            change_feed=KafkaChangeFeed(topics=[topics.CASE_SQL], client_id='test-kafka-case-feed'),
             processor=cls.processor
         )
         cls.process_form_changes = process_pillow_changes('DefaultChangeFeedPillow')

--- a/testapps/test_pillowtop/tests/test_case_search_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_search_pillow.py
@@ -11,7 +11,7 @@ from corehq.apps.change_feed.consumer.feed import (
     change_meta_from_kafka_message,
 )
 from corehq.apps.change_feed.tests.utils import get_test_kafka_consumer
-from corehq.apps.change_feed.topics import get_multi_topic_offset
+from corehq.apps.change_feed.topics import get_topic_offset
 from corehq.apps.es import CaseSearchES
 from corehq.apps.es.tests.utils import es_test
 from corehq.elastic import get_es_new
@@ -115,9 +115,7 @@ class CaseSearchPillowTest(TestCase):
         self._assert_case_in_es(self.domain, case)
 
     def _get_kafka_seq(self):
-        # KafkaChangeFeed listens for multiple topics (case, case-sql) in the case search pillow,
-        # so we need to provide a dict of seqs to kafka
-        return get_multi_topic_offset([topics.CASE, topics.CASE_SQL])
+        return get_topic_offset(topics.CASE_SQL)
 
     def _make_case(self, domain=None, case_properties=None):
         # make a case

--- a/testapps/test_pillowtop/tests/test_chunk_pillow.py
+++ b/testapps/test_pillowtop/tests/test_chunk_pillow.py
@@ -20,12 +20,12 @@ class ChunkedPorcessingTest(TestCase):
         for i in range(count):
             meta = ChangeMeta(document_id=uuid.uuid4().hex,
                 data_source_type='dummy-type', data_source_name='dummy-name')
-            producer.send_change(topics.CASE, meta)
+            producer.send_change(topics.CASE_SQL, meta)
 
     @trap_extra_setup(KafkaUnavailableError)
     def test_basic(self):
         # setup
-        feed = KafkaChangeFeed(topics=[topics.CASE], client_id='test-kafka-feed')
+        feed = KafkaChangeFeed(topics=[topics.CASE_SQL], client_id='test-kafka-feed')
         pillow_name = 'test-chunked-processing'
         checkpoint = PillowCheckpoint(pillow_name, feed.sequence_format)
         processor = ChunkedCountProcessor()

--- a/testapps/test_pillowtop/tests/test_form_pillow.py
+++ b/testapps/test_pillowtop/tests/test_form_pillow.py
@@ -11,7 +11,7 @@ from corehq.apps.change_feed.consumer.feed import (
     change_meta_from_kafka_message,
 )
 from corehq.apps.change_feed.tests.utils import get_test_kafka_consumer
-from corehq.apps.change_feed.topics import get_multi_topic_offset
+from corehq.apps.change_feed.topics import get_topic_offset
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.elastic import get_es_new
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
@@ -48,7 +48,7 @@ class FormPillowTest(TestCase):
         super().tearDownClass()
 
     def test_form_pillow_sql(self):
-        consumer = get_test_kafka_consumer(topics.FORM, topics.FORM_SQL)
+        consumer = get_test_kafka_consumer(topics.FORM_SQL)
         kafka_seq = self._get_kafka_seq()
 
         form = self._make_form()
@@ -64,7 +64,7 @@ class FormPillowTest(TestCase):
         self.assertTrue(Application.get(self.app._id).has_submissions)
 
     def test_form_pillow_non_existant_build_id(self):
-        consumer = get_test_kafka_consumer(topics.FORM, topics.FORM_SQL)
+        consumer = get_test_kafka_consumer(topics.FORM_SQL)
         kafka_seq = self._get_kafka_seq()
 
         form = self._make_form(build_id='not-here')
@@ -80,7 +80,7 @@ class FormPillowTest(TestCase):
         self.assertFalse(Application.get(self.app._id).has_submissions)
 
     def test_form_pillow_mismatch_domains(self):
-        consumer = get_test_kafka_consumer(topics.FORM, topics.FORM_SQL)
+        consumer = get_test_kafka_consumer(topics.FORM_SQL)
         kafka_seq = self._get_kafka_seq()
         self.app.domain = 'not-this-domain'
         self.app.save()
@@ -129,6 +129,4 @@ class FormPillowTest(TestCase):
         return result.xform
 
     def _get_kafka_seq(self):
-        # KafkaChangeFeed listens for multiple topics (form, form-sql) in the form pillow,
-        # so we need to provide a dict of seqs to kafka
-        return get_multi_topic_offset([topics.FORM, topics.FORM_SQL])
+        return get_topic_offset(topics.FORM_SQL)

--- a/testapps/test_pillowtop/tests/test_user_pillow.py
+++ b/testapps/test_pillowtop/tests/test_user_pillow.py
@@ -2,7 +2,7 @@ from corehq.apps.change_feed import data_sources
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.document_types import change_meta_from_doc
 from corehq.apps.change_feed.producer import producer
-from corehq.apps.change_feed.topics import get_topic_offset, get_multi_topic_offset
+from corehq.apps.change_feed.topics import get_topic_offset
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es import UserES
 from corehq.apps.es.tests.utils import es_test
@@ -120,7 +120,7 @@ class UnknownUserPillowTest(UserPillowTestBase):
         self.assertEqual('UnknownUser', user_doc['doc_type'])
 
     def _get_kafka_seq(self):
-        return get_multi_topic_offset([topics.FORM_SQL, topics.FORM])
+        return get_topic_offset(topics.FORM_SQL)
 
 
 def _user_to_change_meta(user):


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Now that we have no couch forms and cases, let's get rid of their kafka topics. This is primarily motivated because we are starting to get the missing kafka change error on prod deploy since we havent had new forms or cases in months, but it also seems like good cleanup to do anyway.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
There are no forms and cases going into these topics so they should be safe to remove. I checked both topics in prod last week and there were zero forms across all partitions and no cases, although there were a few messages in there due it's status as the default topic for the default db change feed pillow. This PR updates that code so the case topic is no longer default.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Pillows are well tested and all the generic kafka tests have been upgraded to use the new topics

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
