### PR TITLE
Added sorting to user role dropdowns

### DIFF
--- a/corehq/apps/users/views/utils.py
+++ b/corehq/apps/users/views/utils.py
@@ -32,10 +32,10 @@ def get_editable_role_choices(domain, couch_user, allow_admin_role):
         ]
     elif allow_admin_role:
         roles = [StaticRole.domain_admin(domain)] + roles
-    return [
+    return sorted([
         (role.get_qualified_id(), role.name or _('(No Name)'))
         for role in roles
-    ]
+    ], key=lambda c: c[1].lower())
 
 
 class BulkUploadResponseWrapper(object):


### PR DESCRIPTION
## Product Description
It's tough to find a role on the edit user pages:
![Screen Shot 2021-10-27 at 12 47 07 PM](https://user-images.githubusercontent.com/1486591/139111358-7cdac784-2d7e-45d0-8450-fbcc7dfdad53.png)

## Safety Assurance

### Safety story
Small, tested locally on both edit web and edit mobile user pages.

### Automated test coverage

Probably not

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
