### PR TITLE
Removed js references to global django

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -1,4 +1,3 @@
-/* globals hqDefine django hqImport */
 hqDefine('app_manager/js/app_manager', function () {
     'use strict';
     var initialPageData = hqImport("hqwebapp/js/initial_page_data");
@@ -141,7 +140,7 @@ hqDefine('app_manager/js/app_manager', function () {
      */
     var _initAddItemPopovers = function () {
         $('.js-add-new-item').popover({
-            title: django.gettext("Add"),
+            title: gettext("Add"),
             container: 'body',
             sanitize: false,
             content: function () {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
@@ -1,4 +1,4 @@
-/* globals hqDefine, hqImport, define, require, WS4Redis, django */
+/* globals define, require, WS4Redis */
 hqDefine("app_manager/js/forms/form_designer", function () {
     var initialPageData = hqImport("hqwebapp/js/initial_page_data").get,
         appcues = hqImport('analytix/js/appcues'),
@@ -170,7 +170,7 @@ hqDefine("app_manager/js/forms/form_designer", function () {
                 hqImport('analytix/js/kissmetrix').track.event('Entered the Form Builder');
 
                 hqImport('app_manager/js/app_manager').setPrependedPageTitle("\u270E ", true);
-                hqImport('app_manager/js/app_manager').setAppendedPageTitle(django.gettext("Edit Form"));
+                hqImport('app_manager/js/app_manager').setAppendedPageTitle(gettext("Edit Form"));
 
                 if (initialPageData('form_uses_cases')) {
                     // todo make this a more broadly used util, perhaps? actually add buttons to formplayer?

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -9,7 +9,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
             moduleType = moduleBrief.module_type,
             options = initial_page_data('js_options') || {};
 
-        hqImport('app_manager/js/app_manager').setAppendedPageTitle(django.gettext("Menu Settings"));
+        hqImport('app_manager/js/app_manager').setAppendedPageTitle(gettext("Menu Settings"));
         // Set up details
         if (moduleBrief.case_type) {
             var details = initial_page_data('details');

--- a/corehq/apps/app_manager/static/app_manager/js/releases/app_view_release_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/app_view_release_manager.js
@@ -1,7 +1,7 @@
 hqDefine("app_manager/js/releases/app_view_release_manager", function () {
     var initial_page_data = hqImport("hqwebapp/js/initial_page_data").get;
 
-    hqImport('app_manager/js/app_manager').setPrependedPageTitle(django.gettext("Releases"));
+    hqImport('app_manager/js/app_manager').setPrependedPageTitle(gettext("Releases"));
 
     // Main releases content
     var releasesMainModel = hqImport('app_manager/js/releases/releases').releasesMainModel;

--- a/corehq/apps/export/static/export/js/download_data_files.js
+++ b/corehq/apps/export/static/export/js/download_data_files.js
@@ -1,4 +1,3 @@
-/* globals hqDefine, django, $ */
 hqDefine("export/js/download_data_files",[
     'jquery',
     'hqwebapp/js/alert_user',
@@ -23,7 +22,7 @@ hqDefine("export/js/download_data_files",[
         var textareaElem = $('#url_'.concat($(this).data("id")));
 
         var showCopyDialog = function () {
-            window.prompt(django.gettext("Copy to clipboard: Ctrl-C, Enter (Mac: Cmd-C, Enter)"), url);
+            window.prompt(gettext("Copy to clipboard: Ctrl-C, Enter (Mac: Cmd-C, Enter)"), url);
         };
         try {
             // Most browsers since Sept 2015
@@ -32,7 +31,7 @@ hqDefine("export/js/download_data_files",[
             var copied = document.execCommand("copy");
             textareaElem.hide();
             if (copied) {
-                alertUser(django.gettext("Data file URL copied to clipboard."), "success", true);
+                alertUser(gettext("Data file URL copied to clipboard."), "success", true);
             } else {
                 showCopyDialog();
             }
@@ -58,7 +57,7 @@ hqDefine("export/js/download_data_files",[
             type: "DELETE",
             success: function () {
                 rowElem.remove();
-                alertUser(django.gettext("Data file deleted."), "success", true);
+                alertUser(gettext("Data file deleted."), "success", true);
             },
         });
     };

--- a/corehq/apps/groups/static/groups/js/group_members.js
+++ b/corehq/apps/groups/static/groups/js/group_members.js
@@ -69,11 +69,11 @@ hqDefine("groups/js/group_members", [
                 var alertClass, message;
                 if (isSuccess) {
                     alertClass = 'alert-success';
-                    message = django.gettext('Successfully saved ') + name.toLowerCase() + '.';
+                    message = gettext('Successfully saved ') + name.toLowerCase() + '.';
                     unsavedChanges[name] = false;
                 } else {
                     alertClass = 'alert-danger';
-                    message = django.gettext('Failed to save ') + name.toLowerCase() + '.';
+                    message = gettext('Failed to save ') + name.toLowerCase() + '.';
                 }
                 $(id).find(':button').enableButton();
                 $('#save-alert').removeClass('alert-danger alert-success alert-info').addClass(alertClass);

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
@@ -295,19 +295,19 @@ hqDefine('hqwebapp/js/main', [
     };
 
     var SaveButton = makeSaveButton({
-        SAVE: django.gettext("Save"),
-        SAVING: django.gettext("Saving..."),
-        SAVED: django.gettext("Saved"),
-        RETRY: django.gettext("Try Again"),
-        ERROR_SAVING: django.gettext("There was an error saving"),
+        SAVE: gettext("Save"),
+        SAVING: gettext("Saving..."),
+        SAVED: gettext("Saved"),
+        RETRY: gettext("Try Again"),
+        ERROR_SAVING: gettext("There was an error saving"),
     }, 'btn btn-primary');
 
     var DeleteButton = makeSaveButton({
-        SAVE: django.gettext("Delete"),
-        SAVING: django.gettext("Deleting..."),
-        SAVED: django.gettext("Deleted"),
-        RETRY: django.gettext("Try Again"),
-        ERROR_SAVING: django.gettext("There was an error deleting"),
+        SAVE: gettext("Delete"),
+        SAVING: gettext("Deleting..."),
+        SAVED: gettext("Deleted"),
+        RETRY: gettext("Try Again"),
+        ERROR_SAVING: gettext("There was an error deleting"),
     }, 'btn btn-danger', 'savebtn-bar-danger');
 
     ko.bindingHandlers.saveButton = {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-input-map.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-input-map.js
@@ -26,8 +26,8 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-input-map', [
         });
 
         this.$edit_view = $('<div class="form-inline" style="margin-left:5px;" />');
-        var key_input = $('<input type="text" class="form-control enum-key" style="width:220px;" placeholder="' + django.gettext('key') + '" />'),
-            val_input = $('<input type="text" class="form-control enum-value" style="width:220px;" placeholder="' + django.gettext('value') + '" />');
+        var key_input = $('<input type="text" class="form-control enum-key" style="width:220px;" placeholder="' + gettext('key') + '" />'),
+            val_input = $('<input type="text" class="form-control enum-value" style="width:220px;" placeholder="' + gettext('value') + '" />');
         key_input.change(function () {
             that.fire('change');
         });
@@ -39,7 +39,7 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-input-map', [
         this.$edit_view.append(val_input);
         if (this.show_delete) {
             var $deleteButton = $('<a href="#" data-enum-action="remove" class="btn btn-danger" />');
-            $deleteButton.append('<i class="fa fa-remove"></i> ' + django.gettext('Delete'));
+            $deleteButton.append('<i class="fa fa-remove"></i> ' + gettext('Delete'));
             $deleteButton.click(function () {
                 that.fire('remove');
                 return false;

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-list.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-list.js
@@ -26,7 +26,7 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-list', [
         this.$noedit_view = $('<div />');
         this.$formatted_view = $('<input type="hidden" />');
         this.$modal_trigger = $('<a class="btn btn-default enum-edit" href="#' + this.modal_id + '" ' +
-            'data-toggle="modal" />').html('<i class="fa fa-pencil"></i> ' + django.gettext('Edit'));
+            'data-toggle="modal" />').html('<i class="fa fa-pencil"></i> ' + gettext('Edit'));
 
         // Create new modal controller for this element
         var $enumModal = $('<div id="' + this.modal_id + '" class="modal fade hq-enum-modal" />');
@@ -34,16 +34,16 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-list', [
         var $modalContent = $('<div class="modal-content" />');
 
         $modalContent.prepend('<div class="modal-header"><a class="close" data-dismiss="modal">×</a><h4 class="modal-title">'
-            + django.gettext('Edit Mapping for ') + this.modal_title + '</h4></div>');
+            + gettext('Edit Mapping for ') + this.modal_title + '</h4></div>');
         var $modal_form = $('<form class="form-horizontal hq-enum-editor" action="" />'),
             $modal_body = $('<div class="modal-body" style="max-height:372px; overflow-y: scroll;" />');
         $modal_body.append($('<fieldset />'));
         $modal_body.append('<a href="#" class="btn btn-primary" data-enum-action="add"><i class="fa fa-plus"></i> ' +
-            django.gettext('Add Key &rarr; Value Mapping') + '</a>');
+            gettext('Add Key &rarr; Value Mapping') + '</a>');
 
         $modal_form.append($modal_body);
         $modal_form.append('<div class="modal-footer"><button class="btn btn-primary" data-dismiss="modal">' +
-            django.gettext('Done') + '</button></div>');
+            gettext('Done') + '</button></div>');
         $modalContent.append($modal_form);
         $modalDialog.append($modalContent);
         $enumModal.append($modalDialog);
@@ -84,7 +84,7 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-list', [
                 var $modal_fields = $('#' + this.modal_id + ' form fieldset');
                 $modal_fields.text('');
                 this.$noedit_view.text('');
-                this.$edit_view.html(django.gettext('Click <strong>Edit</strong> below to add mappings'));
+                this.$edit_view.html(gettext('Click <strong>Edit</strong> below to add mappings'));
 
                 this.value = original_pairs;
                 if (translated_pairs !== undefined) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-mapping.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-mapping.js
@@ -168,26 +168,26 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-mapping', function () {
         self.labels = ko.computed(function () {
             if (self.values_are_icons()) {
                 return {
-                    placeholder: django.gettext('Calculation'),
-                    duplicated: django.gettext('Calculation is duplicated'),
-                    addButton: django.gettext('Add Image'),
-                    badXML: django.gettext('Calculation contains an invalid character.'),
+                    placeholder: gettext('Calculation'),
+                    duplicated: gettext('Calculation is duplicated'),
+                    addButton: gettext('Add Image'),
+                    badXML: gettext('Calculation contains an invalid character.'),
                 };
             }
             else if (self.keys_are_conditions()) {
                 return {
-                    placeholder: django.gettext('Calculation'),
-                    duplicated: django.gettext('Calculation is duplicated'),
-                    addButton: django.gettext('Add Key, Value Mapping'),
-                    badXML: django.gettext('Calculation contains an invalid character.'),
+                    placeholder: gettext('Calculation'),
+                    duplicated: gettext('Calculation is duplicated'),
+                    addButton: gettext('Add Key, Value Mapping'),
+                    badXML: gettext('Calculation contains an invalid character.'),
                 };
             }
             else {
                 return {
-                    placeholder: django.gettext('Key'),
-                    duplicated: django.gettext('Key is duplicated'),
-                    addButton: django.gettext('Add Key, Value Mapping'),
-                    badXML: django.gettext('Key contains an invalid character.'),
+                    placeholder: gettext('Key'),
+                    duplicated: gettext('Key is duplicated'),
+                    addButton: gettext('Add Key, Value Mapping'),
+                    badXML: gettext('Key contains an invalid character.'),
                 };
             }
         });

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -88,7 +88,7 @@ hqDefine('registration/js/new_user.ko', [
         self.fullName = ko.observable(defaults.full_name)
             .extend({
                 required: {
-                    message: django.gettext("Please enter your name."),
+                    message: gettext("Please enter your name."),
                     params: true,
                 },
             });
@@ -97,7 +97,7 @@ hqDefine('registration/js/new_user.ko', [
         self.email = ko.observable()
             .extend({
                 required: {
-                    message: django.gettext("Please specify an email."),
+                    message: gettext("Please specify an email."),
                     params: true,
                 },
             })
@@ -148,7 +148,7 @@ hqDefine('registration/js/new_user.ko', [
             self.email(defaults.email);
         }
         self.isEmailValidating = ko.observable(false);
-        self.validatingEmailMsg = ko.observable(django.gettext("Checking email..."));
+        self.validatingEmailMsg = ko.observable(gettext("Checking email..."));
         self.emailDelayed.isValidating.subscribe(function (isValidating) {
             self.isEmailValidating(isValidating && self.email.isValid());
             module.resetEmailFeedback(isValidating);
@@ -158,7 +158,7 @@ hqDefine('registration/js/new_user.ko', [
         self.password = ko.observable(defaults.password)
             .extend({
                 required: {
-                    message: django.gettext("Please specify a password."),
+                    message: gettext("Please specify a password."),
                     params: true,
                 },
             });
@@ -178,7 +178,7 @@ hqDefine('registration/js/new_user.ko', [
         self.projectName = ko.observable(defaults.project_name)
             .extend({
                 required: {
-                    message: django.gettext("Please specify a project name."),
+                    message: gettext("Please specify a project name."),
                     params: true,
                 },
             });
@@ -195,7 +195,7 @@ hqDefine('registration/js/new_user.ko', [
         self.personaOther = ko.observable()
             .extend({
                 required: {
-                    message: django.gettext("Please specify."),
+                    message: gettext("Please specify."),
                     params: true,
                 },
             });

--- a/corehq/apps/reports/static/reports/js/project_health_dashboard.js
+++ b/corehq/apps/reports/static/reports/js/project_health_dashboard.js
@@ -1,4 +1,4 @@
-/* globals d3, django, moment, nv */
+/* globals d3, moment, nv */
 hqDefine("reports/js/project_health_dashboard", function () {
     // "Performing / Active User Trends" Chart
     function setupCharts(data) {
@@ -137,9 +137,9 @@ hqDefine("reports/js/project_health_dashboard", function () {
             "searching": false,
             "lengthChange": false,
             "oLanguage": {
-                'sEmptyTable': django.gettext('No data available in table'),
-                'sInfo': django.gettext('Showing _START_ to _END_ of _TOTAL_ entries'),
-                'sInfoEmpty': django.gettext('Showing _START_ to _END_ of _TOTAL_ entries'),
+                'sEmptyTable': gettext('No data available in table'),
+                'sInfo': gettext('Showing _START_ to _END_ of _TOTAL_ entries'),
+                'sInfoEmpty': gettext('Showing _START_ to _END_ of _TOTAL_ entries'),
             },
         });
     }

--- a/corehq/apps/userreports/static/userreports/js/builder_view_models.js
+++ b/corehq/apps/userreports/static/userreports/js/builder_view_models.js
@@ -1,4 +1,3 @@
-/* global django */
 hqDefine('userreports/js/builder_view_models', function () {
     'use strict';
 
@@ -373,9 +372,9 @@ hqDefine('userreports/js/builder_view_models', function () {
             initialCols: userFilters,
             buttonText: 'Add User Filter',
             analyticsAction: 'Add User Filter',
-            propertyHelpText: django.gettext('Choose the property you would like to add as a filter to this report.'),
-            displayHelpText: django.gettext('Web users viewing the report will see this display text instead of the property name. Name your filter something easy for users to understand.'),
-            formatHelpText: django.gettext('What type of property is this filter?<br/><br/><strong>Date</strong>: Select this if the property is a date.<br/><strong>Choice</strong>: Select this if the property is text or multiple choice.'),
+            propertyHelpText: gettext('Choose the property you would like to add as a filter to this report.'),
+            displayHelpText: gettext('Web users viewing the report will see this display text instead of the property name. Name your filter something easy for users to understand.'),
+            formatHelpText: gettext('What type of property is this filter?<br/><br/><strong>Date</strong>: Select this if the property is a date.<br/><strong>Choice</strong>: Select this if the property is text or multiple choice.'),
             reportType: reportType,
             propertyOptions: self.dataSourceIndicators,
             selectablePropertyOptions: self.selectableDataSourceIndicators,
@@ -388,9 +387,9 @@ hqDefine('userreports/js/builder_view_models', function () {
             initialCols: defaultFilters,
             buttonText: 'Add Default Filter',
             analyticsAction: 'Add Default Filter',
-            propertyHelpText: django.gettext('Choose the property you would like to add as a filter to this report.'),
-            formatHelpText: django.gettext('What type of property is this filter?<br/><br/><strong>Date</strong>: Select this to filter the property by a date range.<br/><strong>Value</strong>: Select this to filter the property by a single value.'),
-            filterValueHelpText: django.gettext('What value or date range must the property be equal to?'),
+            propertyHelpText: gettext('Choose the property you would like to add as a filter to this report.'),
+            formatHelpText: gettext('What type of property is this filter?<br/><br/><strong>Date</strong>: Select this to filter the property by a date range.<br/><strong>Value</strong>: Select this to filter the property by a single value.'),
+            filterValueHelpText: gettext('What value or date range must the property be equal to?'),
             reportType: reportType,
             propertyOptions: self.dataSourceIndicators,
             selectablePropertyOptions: self.selectableDataSourceIndicators,
@@ -401,7 +400,7 @@ hqDefine('userreports/js/builder_view_models', function () {
             initialCols: columns,
             buttonText: 'Add Column',
             analyticsAction: 'Add Column',
-            calcHelpText: django.gettext("Column format selection will determine how each row's value is calculated."),
+            calcHelpText: gettext("Column format selection will determine how each row's value is calculated."),
             requireColumns: reportType !== "chart",
             requireColumnsText: "At least one column is required",
             noColumnsValidationCallback: function () {
@@ -430,7 +429,7 @@ hqDefine('userreports/js/builder_view_models', function () {
 
             if (!isValid) {
                 self.validationErrorText(
-                    django.gettext("Please check above for any errors in your configuration.")
+                    gettext("Please check above for any errors in your configuration.")
                 );
                 _.defer(function (el) {
                     $(el).find('.disable-on-submit').enableButton();

--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -1,4 +1,3 @@
-/* global _, $, django, window */
 hqDefine('userreports/js/report_config', function () {
     return {
         reportBuilder: function () {
@@ -302,9 +301,9 @@ hqDefine('userreports/js/report_config', function () {
                     reorderItemCallback: function () {
                         _ga_track_config_change('Reorder User Filter');
                     },
-                    propertyHelpText: django.gettext('Choose the property you would like to add as a filter to this report.'),
-                    displayHelpText: django.gettext('Web users viewing the report will see this display text instead of the property name. Name your filter something easy for users to understand.'),
-                    formatHelpText: django.gettext('What type of property is this filter?<br/><br/><strong>Date</strong>: Select this if the property is a date.<br/><strong>Choice</strong>: Select this if the property is text or multiple choice.'),
+                    propertyHelpText: gettext('Choose the property you would like to add as a filter to this report.'),
+                    displayHelpText: gettext('Web users viewing the report will see this display text instead of the property name. Name your filter something easy for users to understand.'),
+                    formatHelpText: gettext('What type of property is this filter?<br/><br/><strong>Date</strong>: Select this if the property is a date.<br/><strong>Choice</strong>: Select this if the property is text or multiple choice.'),
                     reportType: self.reportType(),
                     propertyOptions: config['dataSourceProperties'],
                     selectablePropertyOptions: self.selectablePropertyOptions,
@@ -330,9 +329,9 @@ hqDefine('userreports/js/report_config', function () {
                     reorderItemCallback: function () {
                         _ga_track_config_change('Reorder Default Filter');
                     },
-                    propertyHelpText: django.gettext('Choose the property you would like to add as a filter to this report.'),
-                    formatHelpText: django.gettext('What type of property is this filter?<br/><br/><strong>Date</strong>: Select this to filter the property by a date range.<br/><strong>Value</strong>: Select this to filter the property by a single value.'),
-                    filterValueHelpText: django.gettext('What value or date range must the property be equal to?'),
+                    propertyHelpText: gettext('Choose the property you would like to add as a filter to this report.'),
+                    formatHelpText: gettext('What type of property is this filter?<br/><br/><strong>Date</strong>: Select this to filter the property by a date range.<br/><strong>Value</strong>: Select this to filter the property by a single value.'),
+                    filterValueHelpText: gettext('What value or date range must the property be equal to?'),
                     reportType: self.reportType(),
                     propertyOptions: config['dataSourceProperties'],
                     selectablePropertyOptions: self.selectablePropertyOptions,

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -859,9 +859,9 @@ class MultipleSelectionForm(forms.Form):
                 var multiselect_utils = hqImport('hqwebapp/js/multiselect_utils');
                 multiselect_utils.createFullMultiselectWidget(
                     'id_of_multiselect_field',
-                    django.gettext("Available Things"),
-                    django.gettext("Things Selected"),
-                    django.gettext("Search Things...")
+                    gettext("Available Things"),
+                    gettext("Things Selected"),
+                    gettext("Search Things...")
                 );
             });
         });

--- a/docs/js-guide/integration-patterns.md
+++ b/docs/js-guide/integration-patterns.md
@@ -85,7 +85,7 @@ An alternative approach to passing server data to partials is to encode is as `d
 
 ## I18n
 Just like Django lets you use `ugettext('...')` in python
-and `{% trans '...' %}`, you can also use `django.gettext('...')`
+and `{% trans '...' %}`, you can also use `gettext('...')`
 in any JavaScript.
 
 For any page extending our main template, there's nothing further


### PR DESCRIPTION
## Technical Summary
Let's always refer to `gettext` the same way and never again see lint errors like [this](https://github.com/dimagi/commcare-hq/pull/30660#discussion_r738561831). (The plain version doesn't throw a warning because it's [registered with ESLint](https://github.com/dimagi/commcare-hq/blob/b1964058c2ba85589b8a580e6507482797b46de2/.eslintrc.js#L24-L25).)

## Safety Assurance

### Safety story
Mechanical change.

### Automated test coverage

Little if any.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
