### PR TITLE
add correct form command when computing app workflow

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -120,7 +120,7 @@ class WorkflowHelper(PostProcessor):
         frame_children.extend(common_datums)
 
         if form:
-            frame_children.append(CommandId(id_strings.form_command(form)))
+            frame_children.append(CommandId(id_strings.form_command(form, module)))
             form_datums = module_datums[f'f{form.id}']
             remaining_datums = form_datums[len(common_datums):]
             frame_children.extend(remaining_datums)

--- a/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-module-in-root.xml
+++ b/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-module-in-root.xml
@@ -239,7 +239,7 @@
     <stack>
       <create>
         <command value="'m6'"/>
-        <command value="'m1-f1'"/>
+        <command value="'m6-f1'"/>
       </create>
     </stack>
   </entry>
@@ -258,7 +258,7 @@
       <create>
         <command value="'m6'"/>
         <command value="'m7'"/>
-        <command value="'m5-f0'"/>
+        <command value="'m7-f0'"/>
         <datum id="case_id_new_patient_0" value="uuid()"/>
       </create>
     </stack>

--- a/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-previous.xml
+++ b/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-previous.xml
@@ -249,7 +249,7 @@
     <stack>
       <create>
         <command value="'m6'"/>
-        <command value="'m1-f1'"/>
+        <command value="'m6-f1'"/>
       </create>
     </stack>
   </entry>
@@ -268,7 +268,7 @@
       <create>
         <command value="'m6'"/>
         <command value="'m7'"/>
-        <command value="'m5-f0'"/>
+        <command value="'m7-f0'"/>
         <datum id="case_id_new_patient_0" value="uuid()"/>
       </create>
     </stack>


### PR DESCRIPTION
## Technical Summary
Functionally this is the same since it only affects shadow modules but
it is more 'correct' to use the form entry from the shadow module
and not the one from the source module.

This also impacts future work which may build off generated suite files.

## Safety Assurance

### Safety story
This change is more semantic than functional.

### Automated test coverage
Updated app workflow tests

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
