### PR TITLE
Add support to resume cancelled batches

### DIFF
--- a/corehq/apps/auditcare/couch_to_sql.py
+++ b/corehq/apps/auditcare/couch_to_sql.py
@@ -46,7 +46,7 @@ def copy_events_to_sql(start_time, end_time, batch_size):
     count, other_doc_type_count = util.get_existing_count(key)
     try:
         while not break_query:
-            events_info = get_events_from_couch(next_start_key, end_key, batch_size, last_doc_id)
+            events_info = get_events_from_couch(start_key, next_start_key, end_key, batch_size, last_doc_id)
             next_start_key = events_info['next_start_key']
             NavigationEventAudit.objects.bulk_create(events_info['navigation_events'], ignore_conflicts=True)
             AccessAudit.objects.bulk_create(events_info['audit_events'], ignore_conflicts=True)
@@ -78,7 +78,7 @@ def get_migration_key(start_time, end_time):
     return get_formatted_datetime_string(start_time) + '_' + get_formatted_datetime_string(end_time)
 
 
-def get_events_from_couch(start_key, end_key, batch_size, start_doc_id=None):
+def get_events_from_couch(batch_start_key, start_key, end_key, batch_size, start_doc_id=None):
     navigation_objects = []
     access_objects = []
     records_returned = 0
@@ -135,7 +135,7 @@ def get_events_from_couch(start_key, end_key, batch_size, start_doc_id=None):
         access_objects,
         nav_couch_ids,
         access_couch_ids,
-        start_key,
+        batch_start_key,
         end_key
     )
 

--- a/corehq/apps/auditcare/management/commands/copy_events_to_sql.py
+++ b/corehq/apps/auditcare/management/commands/copy_events_to_sql.py
@@ -26,9 +26,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             '--only_errored',
-            default=False,
-            type=bool,
-            choices=[True, False],
+            action="store_true",
             help="Will try to process batches that have been errored"
         )
         parser.add_argument(

--- a/corehq/apps/auditcare/management/commands/copy_events_to_sql.py
+++ b/corehq/apps/auditcare/management/commands/copy_events_to_sql.py
@@ -37,6 +37,11 @@ class Command(BaseCommand):
             type=int,
             help="Number of documents to query from couch"
         )
+        parser.add_argument(
+            '--cancelled',
+            action="store_true",
+            help="Will start cancelled batches"
+        )
 
     def handle(self, **options):
         workers = options['workers']
@@ -50,6 +55,11 @@ class Command(BaseCommand):
                     batches = util.get_errored_keys(5)
                     if not batches:
                         print("No errored keys present")
+                        return
+                elif options['cancelled']:
+                    batches = util.get_cancelled_keys(5)
+                    if not batches:
+                        print("No cancelled keys present")
                         return
                 else:
                     batches = util.generate_batches(workers, batch_by)

--- a/corehq/apps/auditcare/tests/test_auditcare_migration.py
+++ b/corehq/apps/auditcare/tests/test_auditcare_migration.py
@@ -165,7 +165,7 @@ class TestManagementCommand(TestCase):
     def test_copy_failed_events(self):
         AuditcareMigrationMeta(key=self.errored_keys[0], state=AuditcareMigrationMeta.ERRORED).save()
         AuditcareMigrationMeta(key=self.errored_keys[1], state=AuditcareMigrationMeta.ERRORED).save()
-        call_command("copy_events_to_sql", "--only_errored=True")
+        call_command("copy_events_to_sql", "--only_errored")
 
         count_access_objects = AccessAudit.objects.filter(event_date__lte=datetime(2021, 5, 30)).count()
         count_navigation_objects = NavigationEventAudit.objects.filter(

--- a/corehq/apps/auditcare/utils/migration.py
+++ b/corehq/apps/auditcare/utils/migration.py
@@ -65,6 +65,13 @@ class AuditCareMigrationUtil():
 
         return [get_datetimes_from_key(key) for key in errored_keys]
 
+    def get_cancelled_keys(self, limit=5):
+        cancelled_keys = (AuditcareMigrationMeta.objects
+            .filter(state=AuditcareMigrationMeta.STARTED, finished_at__isnull=True)
+            .values_list('key', flat=True)[:limit]
+        )
+        return [get_datetimes_from_key(key) for key in cancelled_keys]
+
     def log_batch_start(self, key):
         if AuditcareMigrationMeta.objects.filter(key=key):
             return


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
I realised that we have not added support to start canceled batches in Auditcare Migration. So this PR addresses that. Another thing that I noticed while running errored batches on India env is that in https://github.com/dimagi/commcare-hq/pull/30561 we are passing the couch query `start_key` instead of the actual `start_key` that was passed. We are updating `start_key` by adding 1 second while making couch queries. It was causing issues in fetching the couch ids that already exist. So I have updated the behavior too in the last commit.    
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The changes have been tested on staging.
### Automated test coverage
There is fair coverage for the updated code and tests run fine
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
No QA required.
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
