### PR TITLE
[Security] Upgrade babel to >= 2.9.1

### DIFF
--- a/corehq/apps/settings/tests/test_validators.py
+++ b/corehq/apps/settings/tests/test_validators.py
@@ -1,0 +1,28 @@
+from django.core.exceptions import ValidationError
+from django.test import SimpleTestCase
+
+from corehq.apps.settings.validators import validate_international_phonenumber
+
+
+class GetTempFileTests(SimpleTestCase):
+
+    def test_valid_us_number(self):
+        validate_international_phonenumber('+16175555555')
+
+    def test_invalid_international_number(self):
+        with self.assertRaises(ValidationError):
+            validate_international_phonenumber('6175555555')
+
+    def test_valid_south_africa_number(self):
+        validate_international_phonenumber('+27623555555')
+
+    def test_invalid_south_africa_number(self):
+        with self.assertRaises(ValidationError):
+            validate_international_phonenumber('+27555555555')
+
+    def test_valid_india_number(self):
+        validate_international_phonenumber('+911125555555')
+
+    def test_invalid_india_number(self):
+        with self.assertRaises(ValidationError):
+            validate_international_phonenumber('+915555555555')

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -29,7 +29,7 @@ django-logentry-admin==1.0.6
 django-oauth-toolkit==1.5.0
 django-otp~=0.9.3
 django-partial-index~=0.6.0
-django-phonenumber-field==2.3.1  # remove after upgrade >=3.0.1 is deemed safe
+django-phonenumber-field==5.2.0
 django-prbac>=0.0.8
 django-redis-sessions==0.6.1
 django-redis==4.12.1

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -37,7 +37,7 @@ django-simple-captcha==0.5.13
 django-statici18n==1.9.0
 django-tastypie==0.14.3
 django-transfer==0.4
-django-two-factor-auth~=1.12
+django-two-factor-auth~=1.13
 django-user-agents==0.4.0
 django-websocket-redis==0.6.0
 django~=2.2.21

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -1,6 +1,7 @@
 alembic==1.4.3
 architect==0.5.6
 attrs<22
+babel>=2.9.1  # added to address a security vulnerability. sub dependency of django-phonenumber-field
 boto3~=1.17
 # celery 4.1.1 forked to work around https://github.com/celery/celery/issues/4737	celery==4.4.7
 # upgrade when https://github.com/celery/celery/issues/4980 is fixed

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -1,7 +1,6 @@
 alembic==1.4.3
 architect==0.5.6
 attrs<22
-babel>=2.9.1  # added to address a security vulnerability. sub dependency of django-phonenumber-field
 boto3~=1.17
 # celery 4.1.1 forked to work around https://github.com/celery/celery/issues/4737	celery==4.4.7
 # upgrade when https://github.com/celery/celery/issues/4980 is fixed

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -10,8 +10,6 @@ alembic==1.4.3
     # via -r base-requirements.in
 amqp==2.6.1
     # via kombu
-appnope==0.1.2
-    # via ipython
 architect==0.5.6
     # via -r base-requirements.in
 attrs==18.2.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -17,9 +17,7 @@ attrs==18.2.0
     #   -r base-requirements.in
     #   jsonschema
 babel==2.9.1
-    # via
-    #   -r base-requirements.in
-    #   sphinx
+    # via sphinx
 backcall==0.2.0
     # via ipython
 beautifulsoup4==4.10.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -10,15 +10,17 @@ alembic==1.4.3
     # via -r base-requirements.in
 amqp==2.6.1
     # via kombu
+appnope==0.1.2
+    # via ipython
 architect==0.5.6
     # via -r base-requirements.in
 attrs==18.2.0
     # via
     #   -r base-requirements.in
     #   jsonschema
-babel==2.8.0
+babel==2.9.1
     # via
-    #   django-phonenumber-field
+    #   -r base-requirements.in
     #   sphinx
 backcall==0.2.0
     # via ipython
@@ -157,7 +159,7 @@ django-otp==0.9.4
     #   django-two-factor-auth
 django-partial-index==0.6.0
     # via -r base-requirements.in
-django-phonenumber-field==2.3.1
+django-phonenumber-field==5.2.0
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
@@ -177,7 +179,7 @@ django-tastypie==0.14.3
     # via -r base-requirements.in
 django-transfer==0.4
     # via -r base-requirements.in
-django-two-factor-auth==1.12.1
+django-two-factor-auth==1.13.1
     # via -r base-requirements.in
 django-user-agents==0.4.0
     # via -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -18,9 +18,7 @@ attrs==21.2.0
     #   jsonschema
     #   markdown-it-py
 babel==2.9.1
-    # via
-    #   -r base-requirements.in
-    #   sphinx
+    # via sphinx
 billiard==3.5.0.4
     # via
     #   -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -17,9 +17,9 @@ attrs==21.2.0
     #   -r base-requirements.in
     #   jsonschema
     #   markdown-it-py
-babel==2.8.0
+babel==2.9.1
     # via
-    #   django-phonenumber-field
+    #   -r base-requirements.in
     #   sphinx
 billiard==3.5.0.4
     # via
@@ -136,7 +136,7 @@ django-otp==0.9.4
     #   django-two-factor-auth
 django-partial-index==0.6.0
     # via -r base-requirements.in
-django-phonenumber-field==2.3.1
+django-phonenumber-field==5.2.0
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
@@ -156,7 +156,7 @@ django-tastypie==0.14.3
     # via -r base-requirements.in
 django-transfer==0.4
     # via -r base-requirements.in
-django-two-factor-auth==1.12.1
+django-two-factor-auth==1.13.1
     # via -r base-requirements.in
 django-user-agents==0.4.0
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -15,9 +15,7 @@ attrs==18.2.0
     #   -r base-requirements.in
     #   jsonschema
 babel==2.9.1
-    # via
-    #   -r base-requirements.in
-    #   flower
+    # via flower
 backcall==0.2.0
     # via ipython
 billiard==3.5.0.4

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -8,15 +8,17 @@ alembic==1.4.3
     # via -r base-requirements.in
 amqp==2.6.1
     # via kombu
+appnope==0.1.2
+    # via ipython
 architect==0.5.6
     # via -r base-requirements.in
 attrs==18.2.0
     # via
     #   -r base-requirements.in
     #   jsonschema
-babel==2.8.0
+babel==2.9.1
     # via
-    #   django-phonenumber-field
+    #   -r base-requirements.in
     #   flower
 backcall==0.2.0
     # via ipython
@@ -139,7 +141,7 @@ django-otp==0.9.4
     #   django-two-factor-auth
 django-partial-index==0.6.0
     # via -r base-requirements.in
-django-phonenumber-field==2.3.1
+django-phonenumber-field==5.2.0
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
@@ -159,7 +161,7 @@ django-tastypie==0.14.3
     # via -r base-requirements.in
 django-transfer==0.4
     # via -r base-requirements.in
-django-two-factor-auth==1.12.1
+django-two-factor-auth==1.13.1
     # via -r base-requirements.in
 django-user-agents==0.4.0
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -8,8 +8,6 @@ alembic==1.4.3
     # via -r base-requirements.in
 amqp==2.6.1
     # via kombu
-appnope==0.1.2
-    # via ipython
 architect==0.5.6
     # via -r base-requirements.in
 attrs==18.2.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,8 +14,6 @@ attrs==18.2.0
     # via
     #   -r base-requirements.in
     #   jsonschema
-babel==2.9.1
-    # via -r base-requirements.in
 billiard==3.5.0.4
     # via
     #   -r base-requirements.in
@@ -330,7 +328,6 @@ python3-saml==1.12.0
 pytz==2020.1
     # via
     #   -r base-requirements.in
-    #   babel
     #   celery
     #   django
     #   twilio

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,8 +14,8 @@ attrs==18.2.0
     # via
     #   -r base-requirements.in
     #   jsonschema
-babel==2.8.0
-    # via django-phonenumber-field
+babel==2.9.1
+    # via -r base-requirements.in
 billiard==3.5.0.4
     # via
     #   -r base-requirements.in
@@ -130,7 +130,7 @@ django-otp==0.9.4
     #   django-two-factor-auth
 django-partial-index==0.6.0
     # via -r base-requirements.in
-django-phonenumber-field==2.3.1
+django-phonenumber-field==5.2.0
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
@@ -150,7 +150,7 @@ django-tastypie==0.14.3
     # via -r base-requirements.in
 django-transfer==0.4
     # via -r base-requirements.in
-django-two-factor-auth==1.12.1
+django-two-factor-auth==1.13.1
     # via -r base-requirements.in
 django-user-agents==0.4.0
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -14,8 +14,8 @@ attrs==18.2.0
     # via
     #   -r base-requirements.in
     #   jsonschema
-babel==2.8.0
-    # via django-phonenumber-field
+babel==2.9.1
+    # via -r base-requirements.in
 beautifulsoup4==4.10.0
     # via -r test-requirements.in
 billiard==3.5.0.4
@@ -140,7 +140,7 @@ django-otp==0.9.4
     #   django-two-factor-auth
 django-partial-index==0.6.0
     # via -r base-requirements.in
-django-phonenumber-field==2.3.1
+django-phonenumber-field==5.2.0
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
@@ -160,7 +160,7 @@ django-tastypie==0.14.3
     # via -r base-requirements.in
 django-transfer==0.4
     # via -r base-requirements.in
-django-two-factor-auth==1.12.1
+django-two-factor-auth==1.13.1
     # via -r base-requirements.in
 django-user-agents==0.4.0
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -14,8 +14,6 @@ attrs==18.2.0
     # via
     #   -r base-requirements.in
     #   jsonschema
-babel==2.9.1
-    # via -r base-requirements.in
 beautifulsoup4==4.10.0
     # via -r test-requirements.in
 billiard==3.5.0.4
@@ -366,7 +364,6 @@ python3-saml==1.12.0
 pytz==2020.1
     # via
     #   -r base-requirements.in
-    #   babel
     #   celery
     #   django
     #   twilio


### PR DESCRIPTION
## Technical Summary
In order to address a security vulnerability, we need to ensure that `babel`, a sub-dependency of `django-phonenumber-field` is at a version `>=2.9.1`.

When doing this upgrade, I first approached it by ensuring the parent dependency `django-phonenumber-field` was at the latest version.

It seems that we only use `django-phonenumber-field` for its validator `from phonenumber_field.phonenumber import to_python`. So I added some tests for that usecase.

https://dimagi-dev.atlassian.net/browse/SAAS-12771

## Safety Assurance

### Safety story
A big concern  about this PR is needing to upgrade `django-twofactor-auth`. QA is most definitely needed

### Automated test coverage
Added some tests for the validator mentioned above

### QA Plan
QA should ensure that
1) phone numbers can be added in user settings and mobile workers and that they are properly validated by the form field
2) two-factor authentication behaves as expected (this will be on staging)


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
