### PR TITLE
[Security] ensure that datatables.net as a subdependency also resolves to 1.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "d3": "3.5.17",
         "datamaps": "0.5.9",
         "datatables.net": "1.11.3",
-        "datatables.net-dt": "1.10.23",
+        "datatables.net-dt": "1.11.3",
         "datatables-bootstrap3": "Jowin/Datatables-Bootstrap3",
         "datatables-buttons": "DataTables/Buttons#^1.5.6",
         "datatables-colreorder": "DataTables/ColReorder#^1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1207,22 +1207,15 @@ datatables-scroller@DataTables/Scroller#^1.5.1:
   version "0.0.0"
   resolved "https://codeload.github.com/DataTables/Scroller/tar.gz/7dc5c7a56c7797677b224cff4be0a3a18604cc75"
 
-datatables.net-dt@1.10.23:
-  version "1.10.23"
-  resolved "https://registry.yarnpkg.com/datatables.net-dt/-/datatables.net-dt-1.10.23.tgz#49f93e7eb439c2e1e89d28757cc4300597898cd3"
-  integrity sha512-Iky6RAKXKv/cZ4mfQRyHHGOdD1GyV9YuvGQrPCl5qqh+ENqaWphOiWVW/vqDsgDaVjvLwLfeRNMbmnf3w9sRRg==
+datatables.net-dt@1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/datatables.net-dt/-/datatables.net-dt-1.11.3.tgz#242556a490585b457b7d2b9f5fd8fb10761d621b"
+  integrity sha512-EX/thRwXpQRj8hZSb+ZMDNQ4uW1zLZa9BoAhhw1b5HIDH1nJ9WRTkERsoxE+3WISeX8bDiaEydf8TTQBSqxXVw==
   dependencies:
-    datatables.net "1.10.23"
+    datatables.net ">=1.10.25"
     jquery ">=1.7"
 
-datatables.net@1.10.23:
-  version "1.10.23"
-  resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.10.23.tgz#59f7d7b12845183b1b379530d1385077e113ec01"
-  integrity sha512-we3tlNkzpxvgkKKlTxTMXPCt35untVXNg8zUYWpQyC1U5vJc+lT0+Zdc1ztK8d3lh5CfdnuFde2p8n3XwaGl3Q==
-  dependencies:
-    jquery ">=1.7"
-
-datatables.net@1.11.3:
+datatables.net@1.11.3, datatables.net@>=1.10.25:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.11.3.tgz#80e691036efcd62467558ee64c07dd566cb761b4"
   integrity sha512-VMj5qEaTebpNurySkM6jy6sGpl+s6onPK8xJhYr296R/vUBnz1+id16NVqNf9z5aR076OGcpGHCuiTuy4E05oQ==


### PR DESCRIPTION
## Technical Summary
We had recently upgraded datatables.net to resolve a security vulnerability. However, the stylesheet library for datatables (`datatables.net-dt`) was missed during this process. As a result, a version of `datatables.net` lower than 1.11.3 is still being installed as a sub-dependency. This PR ensures that `datatables.net-dt` is upgraded to the same version as `datatables.net`. Since this is a stylesheet update, I think it would be on the safe side to do another round of QA on datatables.

https://dimagi-dev.atlassian.net/browse/SAAS-12741

## Safety Assurance

### Safety story
The upgrade of `datatables.net` was recently QA'd successfully, however since this is now upgrading the stylesheet, I think it would be safest to do another round of QA.

### Automated test coverage
No

### QA Plan
Ensure that pages with datatables load without JS errors or visual issues.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
