### PR TITLE
registry case update changes

### DIFF
--- a/corehq/apps/registry/helper.py
+++ b/corehq/apps/registry/helper.py
@@ -1,7 +1,7 @@
 from corehq.apps.registry.exceptions import RegistryNotFound, RegistryAccessException
 from corehq.apps.registry.models import DataRegistry
 from corehq.apps.registry.utils import RegistryPermissionCheck
-from corehq.form_processor.exceptions import CaseNotFound
+from corehq.form_processor.exceptions import CaseTypeMismatch
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.util.timer import TimingContext
 
@@ -54,7 +54,7 @@ class DataRegistryHelper:
 
         case = CaseAccessorSQL.get_case(case_id)
         if case.type != case_type:
-            raise CaseNotFound("Case type mismatch")
+            raise CaseTypeMismatch("Case type mismatch")
 
         self.check_data_access(couch_user, [case.type], case.domain)
         self.log_data_access(couch_user.get_django_user(), case.domain, accessing_object, filters={

--- a/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
@@ -166,6 +166,9 @@ class CaseBlock(object):
                 # can this be a hierarchical structure? if yes, how to decode?
                 updates[tag] = node.text
 
+        if case.find(NS + "close") is not None:
+            fields["close"] = True
+
         if case.get("date_modified"):
             fields['date_modified'] = string_to_datetime(case.get("date_modified")).replace(tzinfo=None)
 

--- a/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
@@ -152,6 +152,7 @@ class CaseBlock(object):
         fields = {"update": updates}
         for node in case.find(NS + "create") or []:
             tag = tag_of(node)
+            fields["create"] = True
             if tag in cls._built_ins:
                 fields[tag] = node.text
             # can create node have date_opened child node?

--- a/corehq/form_processor/exceptions.py
+++ b/corehq/form_processor/exceptions.py
@@ -10,6 +10,10 @@ class CaseNotFound(ResourceNotFound, ObjectDoesNotExist):
     pass
 
 
+class CaseTypeMismatch(CaseNotFound):
+    pass
+
+
 class XFormNotFound(ResourceNotFound, ObjectDoesNotExist):
     pass
 

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -403,6 +403,7 @@ class CaseUpdateConfig:
         "case_id": "target_case_id",
         "owner_id": "target_case_owner_id",
         "create_case": "target_case_create",
+        "close_case": "target_case_close",
         "includes": "target_property_includelist",
         "excludes": "target_property_excludelist",
         "index_create_case_id": "target_index_create_case_id",
@@ -425,6 +426,7 @@ class CaseUpdateConfig:
     case_id = attr.ib()
     owner_id = attr.ib()
     create_case = attr.ib()
+    close_case = attr.ib()
     includes = attr.ib()
     excludes = attr.ib()
     index_create_case_id = attr.ib()
@@ -491,6 +493,7 @@ class CaseUpdateConfig:
             owner_id=self.owner_id,
             update=self.get_case_updates(),
             index=self.get_case_indices(target_case),
+            close=bool(self.close_case),
             **kwargs
         ).as_text()
 

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -446,8 +446,6 @@ class CaseUpdateConfig:
 
         if self.includes is not None and self.excludes is not None:
             raise DataRegistryCaseUpdateError("Both exclude and include lists specified. Only one is allowed.")
-        if self.includes is None and self.excludes is None:
-            raise DataRegistryCaseUpdateError("Neither exclude and include lists specified. One is required.")
 
     def get_case_block(self, target_case):
         return CaseBlock(
@@ -459,11 +457,12 @@ class CaseUpdateConfig:
 
     def get_case_updates(self):
         case_json = self.intent_case.case_json
-        update_props = []
         if self.excludes is not None:
             update_props = set(case_json) - set(self.excludes.split())
-        if self.includes is not None:
+        elif self.includes is not None:
             update_props = set(case_json) & set(self.includes.split())
+        else:
+            update_props = set(case_json)
 
         update_props.difference_update(set(self.PROPS.values()))
         return {

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -499,6 +499,10 @@ class CaseUpdateConfig:
 
     def get_case_updates(self):
         case_json = self.intent_case.case_json
+        if self.intent_case.name:
+            case_json["case_name"] = self.intent_case.name
+        if self.intent_case.external_id:
+            case_json["external_id"] = self.intent_case.external_id
         if self.excludes is not None:
             update_props = set(case_json) - set(self.excludes.split())
         elif self.includes is not None:

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -403,7 +403,6 @@ class CaseUpdateConfig:
         "case_id": "target_case_id",
         "includes": "target_property_includelist",
         "excludes": "target_property_excludelist",
-        "override_props": "target_property_override",
         "index_create_case_id": "target_index_create_case_id",
         "index_create_case_type": "target_index_create_case_type",
         "index_create_relationship": "target_index_create_relationship",
@@ -422,7 +421,6 @@ class CaseUpdateConfig:
     case_id = attr.ib()
     includes = attr.ib()
     excludes = attr.ib()
-    override_props = attr.ib()
     index_create_case_id = attr.ib()
     index_create_case_type = attr.ib()
     index_create_relationship = attr.ib()
@@ -455,11 +453,11 @@ class CaseUpdateConfig:
         return CaseBlock(
             create=False,
             case_id=target_case.case_id,
-            update=self.get_case_updates(target_case),
+            update=self.get_case_updates(),
             index=self.get_case_index(target_case)
         ).as_text()
 
-    def get_case_updates(self, target_case):
+    def get_case_updates(self):
         case_json = self.intent_case.case_json
         update_props = []
         if self.excludes is not None:
@@ -468,11 +466,6 @@ class CaseUpdateConfig:
             update_props = set(case_json) & set(self.includes.split())
 
         update_props.difference_update(set(self.PROPS.values()))
-        override = self.override_props is None or self.override_props.lower() in ("1", "true")
-        if not override:
-            target_props = set(target_case.case_json)
-            update_props.difference_update(target_props)
-
         return {
             prop: case_json[prop]
             for prop in update_props

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -18,7 +18,7 @@ from corehq.apps.registry.exceptions import RegistryAccessException
 from corehq.apps.registry.helper import DataRegistryHelper
 from corehq.apps.users.models import CouchUser
 from corehq.const import OPENROSA_VERSION_3
-from corehq.form_processor.exceptions import CaseNotFound
+from corehq.form_processor.exceptions import CaseNotFound, CaseTypeMismatch
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.middleware import OPENROSA_VERSION_HEADER
 from corehq.motech.repeaters.exceptions import ReferralError, DataRegistryCaseUpdateError
@@ -612,6 +612,8 @@ class DataRegistryCaseUpdatePayloadGenerator(BasePayloadGenerator):
             case = registry_helper.get_case(config.case_id, config.case_type, couch_user, repeat_record.repeater)
         except RegistryAccessException:
             raise DataRegistryCaseUpdateError("User does not have permission to access the registry")
+        except CaseTypeMismatch:
+            raise DataRegistryCaseUpdateError(f"Target case not found: {config.case_id}")
         except CaseNotFound:
             if config.create_case:
                 return

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -404,9 +404,9 @@ class CaseUpdateConfig:
         "includes": "target_property_includelist",
         "excludes": "target_property_excludelist",
         "override_props": "target_property_override",
-        "index_case_id": "target_index_case_id",
-        "index_case_type": "target_index_case_type",
-        "index_relationship": "target_index_relationship",
+        "index_create_case_id": "target_index_create_case_id",
+        "index_create_case_type": "target_index_create_case_type",
+        "index_create_relationship": "target_index_create_relationship",
     }
     REQUIRED_FIELDS = [
         "registry_slug",
@@ -423,9 +423,9 @@ class CaseUpdateConfig:
     includes = attr.ib()
     excludes = attr.ib()
     override_props = attr.ib()
-    index_case_id = attr.ib()
-    index_case_type = attr.ib()
-    index_relationship = attr.ib()
+    index_create_case_id = attr.ib()
+    index_create_case_type = attr.ib()
+    index_create_relationship = attr.ib()
 
     @classmethod
     def from_payload(cls, payload_doc):
@@ -479,24 +479,24 @@ class CaseUpdateConfig:
         }
 
     def get_case_index(self, target_case):
-        if not (self.index_case_id and self.index_case_type):
+        if not (self.index_create_case_id and self.index_create_case_type):
             return
 
         try:
-            index_case = CaseAccessors(self.domain).get_case(self.index_case_id)
+            index_case = CaseAccessors(self.domain).get_case(self.index_create_case_id)
         except CaseNotFound:
-            raise DataRegistryCaseUpdateError(f"Index case not found: {self.index_case_id}")
+            raise DataRegistryCaseUpdateError(f"Index case not found: {self.index_create_case_id}")
 
         if index_case.domain != target_case.domain:
-            raise DataRegistryCaseUpdateError(f"Index case not found: {self.index_case_id}")
+            raise DataRegistryCaseUpdateError(f"Index case not found: {self.index_create_case_id}")
 
-        if index_case.case_type != self.index_case_type:
+        if index_case.case_type != self.index_create_case_type:
             raise DataRegistryCaseUpdateError("Index case type does not match")
 
-        relationship = self.index_relationship or "child"
+        relationship = self.index_create_relationship or "child"
         key = "parent" if relationship == "child" else "host"
         return {
-            key: (self.index_case_type, self.index_case_id, relationship)
+            key: (self.index_create_case_type, self.index_create_case_id, relationship)
         }
 
 

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -50,18 +50,6 @@ def test_generator_exclude_list():
         }})
 
 
-def test_generator_dont_override_existing():
-    builder = (
-        IntentCaseBuilder(override_properties=False)
-        .case_properties(new_prop="new_prop_val", existing_prop="try override", existing_blank_prop="not blank")
-        .exclude_props([])
-    )
-    _test_payload_generator(intent_case=builder.get_case(), expected_updates={
-        "1": {
-            "new_prop": "new_prop_val",
-        }})
-
-
 def test_generator_update_create_index_to_parent():
     builder = IntentCaseBuilder().create_index("case2", "parent_type", "child").exclude_props([])
 
@@ -229,10 +217,9 @@ class DataRegistryUpdateForm:
 class IntentCaseBuilder:
     CASE_TYPE = "registry_case_update"
 
-    def __init__(self, registry="registry1", override_properties=True):
+    def __init__(self, registry="registry1"):
         self.props: dict = {
             "target_data_registry": registry,
-            "target_property_override": str(int(override_properties)),
         }
         self.target_case()
         self.subcases = []

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -51,7 +51,7 @@ def test_generator_exclude_list():
 
 
 def test_generator_update_create_index_to_parent():
-    builder = IntentCaseBuilder().create_index("case2", "parent_type", "child").exclude_props([])
+    builder = IntentCaseBuilder().create_index("case2", "parent_type", "child")
 
     def _get_case(case_id):
         assert case_id == "case2"
@@ -63,7 +63,7 @@ def test_generator_update_create_index_to_parent():
 
 
 def test_generator_update_create_index_to_host():
-    builder = IntentCaseBuilder().create_index("case2", "parent_type", "extension").exclude_props([])
+    builder = IntentCaseBuilder().create_index("case2", "parent_type", "extension")
 
     def _get_case(case_id):
         assert case_id == "case2"
@@ -75,7 +75,7 @@ def test_generator_update_create_index_to_host():
 
 
 def test_generator_update_create_index_not_found():
-    builder = IntentCaseBuilder().create_index("case2", "parent_type", "child").exclude_props([])
+    builder = IntentCaseBuilder().create_index("case2", "parent_type", "child")
 
     with assert_raises(DataRegistryCaseUpdateError, msg="Index case not found: case2"):
         with patch.object(CaseAccessorSQL, 'get_case', side_effect=CaseNotFound):
@@ -83,7 +83,7 @@ def test_generator_update_create_index_not_found():
 
 
 def test_generator_update_create_index_domain_mismatch():
-    builder = IntentCaseBuilder().create_index("case2", "parent_type", "child").exclude_props([])
+    builder = IntentCaseBuilder().create_index("case2", "parent_type", "child")
 
     def _get_case(case_id):
         assert case_id == "case2"
@@ -95,7 +95,7 @@ def test_generator_update_create_index_domain_mismatch():
 
 
 def test_generator_update_create_index_case_type_mismatch():
-    builder = IntentCaseBuilder().create_index("case2", "parent_type", "child").exclude_props([])
+    builder = IntentCaseBuilder().create_index("case2", "parent_type", "child")
 
     def _get_case(case_id):
         assert case_id == "case2"
@@ -107,19 +107,17 @@ def test_generator_update_create_index_case_type_mismatch():
 
 
 def test_generator_update_multiple_cases():
-    main_case_builder = IntentCaseBuilder().case_properties(new_prop="new_prop_val").exclude_props([])
+    main_case_builder = IntentCaseBuilder().case_properties(new_prop="new_prop_val")
     subcase1 = (
         IntentCaseBuilder()
         .target_case(case_id="sub1")
         .case_properties(sub1_prop="sub1_val")
-        .exclude_props([])
         .get_case()
     )
     subcase2 = (
         IntentCaseBuilder()
         .target_case(case_id="sub2")
         .case_properties(sub2_prop="sub2_val")
-        .exclude_props([])
         .get_case()
     )
     main_case_builder.set_subcases([subcase1, subcase2])

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -247,9 +247,9 @@ class IntentCaseBuilder:
 
     def create_index(self, case_id, case_type, relationship="child"):
         self.props.update({
-            "target_index_case_id": case_id,
-            "target_index_case_type": case_type,
-            "target_index_relationship": relationship,
+            "target_index_create_case_id": case_id,
+            "target_index_create_case_type": case_type,
+            "target_index_create_relationship": relationship,
         })
         return self
 

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
@@ -94,13 +94,11 @@ class DataRegistryCaseUpdateRepeaterTest(TestCase, TestXmlMixin, DomainSubscript
             IntentCaseBuilder(self.registry_slug)
             .target_case(self.target_domain, self.target_case_id_1)
             .case_properties(new_prop="new_val_case1")
-            .exclude_props([])
         )
         builder2 = (
             IntentCaseBuilder(self.registry_slug)
             .target_case(self.target_domain, self.target_case_id_2)
             .case_properties(new_prop="new_val_case2")
-            .exclude_props([])
         )
         factory = CaseFactory(self.domain)
         host = CaseStructure(


### PR DESCRIPTION
## Technical Summary
* rename case index fields
* always override target case properties
* make 'include' / 'exclude' properties optional (default to include all)
* support removing indices on target case
* support creating cases in the target domain
* support closing cases in the target domain
* allow setting `owner_id`, `case_name`, `external_id`

Best reviewed by commit :blowfish: 

## Feature Flag
DATA_REGISTRY

## Safety Assurance

### Safety story
Impact limited to registry data forwarder. Changes tested.

### Automated test coverage
Tests added to cover changes.

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
