### PR TITLE
[hackathon] Always use user.get_email() for communications

### DIFF
--- a/corehq/apps/accounting/templates/accounting/email/invoice_autopay_setup.html
+++ b/corehq/apps/accounting/templates/accounting/email/invoice_autopay_setup.html
@@ -16,7 +16,7 @@
 <table cellpadding="2" border="1"  style="border-collapse:collapse;">
   <tr>
     <td>{% trans 'Username' %}</td>
-    <td>{{ email }}</td>
+    <td>{{ username }}</td>
   </tr>
   <tr>
     <td>{% trans 'Project Space' %}</td>

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -1038,7 +1038,7 @@ def pull_upstream_app(request, domain, app_id):
     async_update = request.POST.get('notify') == 'on'
     if async_update:
         update_linked_app_and_notify_task.delay(domain, app_id, upstream_app_id,
-                                                request.couch_user.get_id, request.couch_user.email)
+                                                request.couch_user.get_id, request.couch_user.get_email())
         messages.success(request,
                          _('Your request has been submitted. We will notify you via email once completed.'))
     else:

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1241,11 +1241,8 @@ class HQPasswordResetForm(NoAutocompleteMixin, forms.Form):
             if not couch_user:
                 continue
 
-            if couch_user.is_web_user():
-                user_email = user.username
-            elif user.email:
-                user_email = user.email
-            else:
+            user_email = couch_user.get_email()
+            if not user_email:
                 continue
 
             c = {

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -957,7 +957,7 @@ class TransferDomainRequest(models.Model):
 
         send_html_email_async.delay(
             _('Transfer of ownership for CommCare project space.'),
-            self.to_user.email,
+            self.to_user.get_email(),
             html_content,
             text_content=text_content)
 
@@ -974,7 +974,7 @@ class TransferDomainRequest(models.Model):
 
         send_html_email_async.delay(
             _('Transfer of ownership for CommCare project space.'),
-            self.from_user.email,
+            self.from_user.get_email(),
             html_content,
             text_content=text_content)
 

--- a/corehq/apps/enterprise/management/commands/report_on_enterprise_domain.py
+++ b/corehq/apps/enterprise/management/commands/report_on_enterprise_domain.py
@@ -91,7 +91,7 @@ class Command(BaseCommand):
         if kwargs.get('cc'):
             cc = kwargs.get('cc').split(",")
         send_html_email_async(
-            "Report on enterprise account {}".format(account.name), self.couch_user.username,
+            "Report on enterprise account {}".format(account.name), self.couch_user.get_email(),
             linebreaksbr(message), cc=cc, text_content=message, file_attachments=attachments,
         )
         print('Emailed {}{}{}'.format(self.couch_user.username, " and " if cc else "", ", ".join(cc)))

--- a/corehq/apps/enterprise/tasks.py
+++ b/corehq/apps/enterprise/tasks.py
@@ -41,7 +41,7 @@ def email_enterprise_report(domain, slug, couch_user):
     body = "The enterprise report you requested for the account {} is ready.<br>" \
            "You can download the data at the following link: {}<br><br>" \
            "Please remember that this link will only be active for 24 hours.".format(account.name, link)
-    send_html_email_async(subject, couch_user.username, body)
+    send_html_email_async(subject, couch_user.get_email(), body)
 
 
 @task

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -559,8 +559,7 @@ def _get_fixture_upload_args_from_request(request, domain):
             replace = False
         user_email = None
         if toggles.SUPPORT.enabled(request.couch_user.username):
-            user_email = request.couch_user.email if request.couch_user.email is not None \
-                else request.couch_user.username
+            user_email = request.couch_user.get_email()
     except Exception:
         raise FixtureAPIRequestError(
             "Invalid post request."

--- a/corehq/apps/hqadmin/views/operations.py
+++ b/corehq/apps/hqadmin/views/operations.py
@@ -32,7 +32,7 @@ def mass_email(request):
             html = form.cleaned_data['email_body_html']
             text = form.cleaned_data['email_body_text']
             real_email = form.cleaned_data['real_email']
-            send_mass_emails.delay(request.couch_user.username, real_email, subject, html, text)
+            send_mass_emails.delay(request.couch_user.get_email(), real_email, subject, html, text)
             messages.success(request, 'Task started. You will receive an email summarizing the results.')
         else:
             messages.error(request, 'Something went wrong, see below.')

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -425,7 +425,7 @@ class DisableUserView(FormView):
         )
         send_HTML_email(
             "%sYour account has been %s" % (settings.EMAIL_SUBJECT_PREFIX, verb),
-            self.username,
+            self.user.get_email() if self.user else self.username,
             render_to_string('hqadmin/email/account_disabled_email.html', context={
                 'support_email': settings.SUPPORT_EMAIL,
                 'password_reset': reset_password,
@@ -512,7 +512,7 @@ class DisableTwoFactorView(FormView):
             "Two-Factor auth was reset. Details: \n"
             "    Account reset: {username}\n"
             "    Reset by: {reset_by}\n"
-            "    Request Verificatoin Mode: {verification}\n"
+            "    Request Verification Mode: {verification}\n"
             "    Verified by: {verified_by}\n"
             "    Two-Factor disabled for {days} days.".format(
                 username=username,
@@ -524,7 +524,7 @@ class DisableTwoFactorView(FormView):
         )
         send_HTML_email(
             "%sTwo-Factor authentication reset" % settings.EMAIL_SUBJECT_PREFIX,
-            username,
+            couch_user.get_email(),
             render_to_string('hqadmin/email/two_factor_reset_email.html', context={
                 'until': disable_until.strftime('%Y-%m-%d %H:%M:%S UTC') if disable_for_days else None,
                 'support_email': settings.SUPPORT_EMAIL,

--- a/corehq/apps/registration/tasks.py
+++ b/corehq/apps/registration/tasks.py
@@ -47,8 +47,9 @@ def activation_24hr_reminder_email():
             'registration/email/confirm_account.html', email_context)
         subject = ugettext('Reminder to Activate your CommCare project')
 
+        recipient = user.get_email() if user else request.new_user_username
         send_html_email_async.delay(
-            subject, request.new_user_username, message_html,
+            subject, recipient, message_html,
             text_content=message_plaintext,
             email_from=settings.DEFAULT_FROM_EMAIL
         )

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -173,7 +173,7 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
                 for slug in APPCUES_APP_SLUGS
             ]
             callback = send_domain_registration_email.si(
-                request.user.email,
+                request.user.get_email(),
                 dom_req.domain,
                 dom_req.activation_guid,
                 request.user.get_full_name(),
@@ -181,7 +181,7 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
             )
             chord(header)(callback)
         else:
-            send_domain_registration_email(request.user.email,
+            send_domain_registration_email(request.user.get_email(),
                                            dom_req.domain,
                                            dom_req.activation_guid,
                                            request.user.get_full_name(),

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -173,7 +173,7 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
                 for slug in APPCUES_APP_SLUGS
             ]
             callback = send_domain_registration_email.si(
-                request.user.get_email(),
+                request.user.email,
                 dom_req.domain,
                 dom_req.activation_guid,
                 request.user.get_full_name(),
@@ -181,7 +181,7 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
             )
             chord(header)(callback)
         else:
-            send_domain_registration_email(request.user.get_email(),
+            send_domain_registration_email(request.user.email,
                                            dom_req.domain,
                                            dom_req.activation_guid,
                                            request.user.get_full_name(),

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -541,6 +541,5 @@ def eula_agreement(request):
 @login_required
 @require_POST
 def send_mobile_reminder(request):
-    send_mobile_experience_reminder(request.couch_user.email or request.user.username,
-                                    request.couch_user.full_name)
+    send_mobile_experience_reminder(request.couch_user.get_email(), request.couch_user.full_name)
     return HttpResponse()

--- a/corehq/apps/translations/views.py
+++ b/corehq/apps/translations/views.py
@@ -136,7 +136,9 @@ def upload_bulk_app_translations(request, domain, app_id):
                 msgs = [(messages.error, _("Please select language to validate."))]
             else:
                 try:
-                    msgs = validate_bulk_app_translation_upload(app, workbook, request.user.email, lang, file)
+                    msgs = validate_bulk_app_translation_upload(
+                        app, workbook, request.user.get_email(), lang, file
+                    )
                 except BulkAppTranslationsException as e:
                     msgs = [(messages.error, str(e))]
         else:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
We are inconsistent about which user field we send emails to, and in reality should always use the email field if available, and then fall back to the username field if not available. The `get_email` method handles this check, and is what we should always be using. 

A lot of these are just semantic changes, as the logic was already in place to use the email if available, and fall back on the username otherwise which is what `get_email` does. Even for the ones that are more than just a semantic change, it feels very safe because assuming the user has their account set up accurately (e.g., does not have an out of date email set), they will receive these communications where they expect.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
For the most part, the change is straightforward in that we use `user.get_email()` instead of `user.username` or `user.email`. 
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I don't think QA is necessary, but could have them do a smoke test of sorts to ensure areas like accounting still work as expected as far as email comms go.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
