### PR TITLE
Fix ptop_preindex now that couch forms are gone

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_preindex.py
+++ b/corehq/apps/hqcase/management/commands/ptop_preindex.py
@@ -39,7 +39,7 @@ def get_reindex_commands(hq_index_name):
     pillow_command_map = {
         DOMAIN_HQ_INDEX_NAME: ['domain'],
         CASE_HQ_INDEX_NAME: ['case', 'sql-case'],
-        XFORM_HQ_INDEX_NAME: ['form', 'sql-form'],
+        XFORM_HQ_INDEX_NAME: ['sql-form'],
         # groupstousers indexing must happen after all users are indexed
         USER_HQ_INDEX_NAME: [
             'user',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
`ptop_preindex` failed locally because CouchFormReindexerFactory was removed in https://github.com/dimagi/commcare-hq/commit/78ddcb3179c7e0c9617bde4ca2bc8d84c1701bbb
```
  File "/home/ethan/commcare-hq/corehq/apps/hqcase/management/commands/ptop_preindex.py", line 65, in do_reindex
    factory = FACTORIES_BY_SLUG[reindex_command]
KeyError: 'form'
```


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
