### PR TITLE
Airflow is no longer used

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -844,15 +844,6 @@ files from Vellum directly, do the following.
     ```
 
 
-## Airflow
-
-It is usually not required to have a local airflow environment running.
-
-However, if you do need to get setup on Airflow (which is used to back some
-reporting infrastructure) you can follow the instructions in the
-[pipes repository](https://github.com/dimagi/pipes/).
-
-
 ## Running Tests
 
 To run the standard tests for CommCare HQ, run


### PR DESCRIPTION
## Technical Summary

Tiny change to update DEV_SETUP.md. Airflow is no longer used, and the "pipes" repo no longer exists.

## Safety Assurance

### Safety story

Documentation-only change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
