### PR TITLE
Use https instead of git

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -102,7 +102,7 @@ schema
 sentry-sdk==0.19.5
 sh==1.14.2
 # Package has an unfixed issue https://github.com/danthedeckie/simpleeval/issues/90 Can use that once https://github.com/danthedeckie/simpleeval/pull/91 is merged
-simpleeval @ git+git://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
+simpleeval @ git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
 simplejson~=3.11
 six~=1.11
 socketpool==0.5.3

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -505,7 +505,7 @@ sh==1.14.2
     # via
     #   -r base-requirements.in
     #   git-build-branch
-git+git://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
+git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
     # via -r base-requirements.in
 simplejson==3.17.2
     # via

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -407,7 +407,7 @@ sentry-sdk==0.19.5
     # via -r base-requirements.in
 sh==1.14.2
     # via -r base-requirements.in
-git+git://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
+git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
     # via -r base-requirements.in
 simplejson==3.17.2
     # via

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -423,7 +423,7 @@ setproctitle==1.2.2
     # via -r prod-requirements.in
 sh==1.14.2
     # via -r base-requirements.in
-git+git://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
+git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
     # via -r base-requirements.in
 simplejson==3.17.2
     # via

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -381,7 +381,7 @@ sentry-sdk==0.19.5
     # via -r base-requirements.in
 sh==1.14.2
     # via -r base-requirements.in
-git+git://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
+git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
     # via -r base-requirements.in
 simplejson==3.17.2
     # via

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -422,7 +422,7 @@ sentry-sdk==0.19.5
     # via -r base-requirements.in
 sh==1.14.2
     # via -r base-requirements.in
-git+git://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
+git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
     # via -r base-requirements.in
 simplejson==3.17.2
     # via


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The use of `git:` caused this error:
```
Cloning git://github.com/dimagi/simpleeval.git (to revision d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec) to /private/var/folders/29/7q9sy5dd24q_qpwwm2q6jhlc0000gn/T/pip-req-build-q_b4sepq
  Running command git clone --filter=blob:none -q git://github.com/dimagi/simpleeval.git /private/var/folders/29/7q9sy5dd24q_qpwwm2q6jhlc0000gn/T/pip-req-build-q_b4sepq
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
  ```
  
As github [suggests](https://github.blog/2021-09-01-improving-git-protocol-security-github/#whats-changing), we cannot use `git:` to checkout repos anymore. 
  
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Fixed my issue locally. Test builds were failing due to this issue previously, so if builds pass that is a good sign.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Rolling back this PR will re-introduce the bug which causes all test builds and deploys to fail.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
