### PR TITLE
Move submodules to pull from https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,24 +1,24 @@
 [submodule "corehq/apps/hqmedia/static/hqmedia/MediaUploader"]
 	path = corehq/apps/hqmedia/static/hqmedia/MediaUploader
-	url = git://github.com/dimagi/MediaUploader.git
+	url = https://github.com/dimagi/MediaUploader.git
 [submodule "submodules/commcare-translations"]
 	path = submodules/commcare-translations
-	url = git://github.com/dimagi/commcare-translations.git
+	url = https://github.com/dimagi/commcare-translations.git
 [submodule "submodules/couchdbkit-aggregate"]
 	path = submodules/couchdbkit-aggregate
-	url = git://github.com/dimagi/couchdbkit-aggregate.git
+	url = https://github.com/dimagi/couchdbkit-aggregate.git
 [submodule "submodules/django-digest-src"]
 	path = submodules/django-digest-src
-	url = git://github.com/dimagi/django-digest.git
+	url = https://github.com/dimagi/django-digest.git
 [submodule "submodules/django-no-exceptions"]
 	path = submodules/django-no-exceptions
-	url = git://github.com/dimagi/django-no-exceptions.git
+	url = https://github.com/dimagi/django-no-exceptions.git
 [submodule "submodules/langcodes"]
 	path = submodules/langcodes
-	url = git://github.com/dimagi/langcodes.git
+	url = https://github.com/dimagi/langcodes.git
 [submodule "submodules/python-digest"]
 	path = submodules/python-digest
-	url = git://github.com/dimagi/python-digest.git
+	url = https://github.com/dimagi/python-digest.git
 [submodule "submodules/xml2json"]
 	path = submodules/xml2json
-	url = git://github.com/dimagi/xml2json.git
+	url = https://github.com/dimagi/xml2json.git


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When pulling submodules, we were running into this error:
``` 
Cloning into '/home/runner/work/commcare-hq/commcare-hq/corehq/apps/hqmedia/static/hqmedia/MediaUploader'...
  Error: fatal: remote error: 
    The unauthenticated git protocol on port 9418 is no longer supported.
```
This changes the protocol from `git:` to `https:`

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
