### PR TITLE
daterange bug fix for manually entered dates

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -249,6 +249,10 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     oldValue = $input.val(),
                     parts = _.map(oldValue.split(separator), function (v) { return moment(v); }),
                     newValue = '';
+                // conditions where only one valid date is typed in rather than a range
+                if (parts.length === 1 && function (parts) { return parts.isValid(); }) {
+                    $input.val(oldValue + separator + oldValue).trigger('change');
+                }
                 if (parts.length === 2 && _.every(parts, function (part) { return part.isValid(); })) {
                     newValue = parts[0].format(dateFormat) + separator + parts[1].format(dateFormat);
                 }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -5,7 +5,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
     // 'hqwebapp/js/hq.helpers' is a dependency. It needs to be added
     // explicitly when webapps is migrated to requirejs
     var FormplayerFrontend = hqImport("cloudcare/js/formplayer/app");
-    var separator = " to ";
+    var separator = " to ",
         dateFormat = "YYYY-MM-DD";
     var selectDelimiter = "#,#"; // Formplayer also uses this
     var Const = hqImport("cloudcare/js/form_entry/const"),
@@ -253,8 +253,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 if (_.every(parts, function (part) { return part.isValid(); }))  {
                     if (parts.length === 1) { // condition where only one valid date is typed in rather than a range
                         $input.val(oldValue + separator + oldValue).trigger('change');
-                    }
-                    else if (parts.length === 2) {
+                    } else if (parts.length === 2) {
                         newValue = parts[0].format(dateFormat) + separator + parts[1].format(dateFormat);
                     }
                 }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -249,12 +249,14 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     oldValue = $input.val(),
                     parts = _.map(oldValue.split(separator), function (v) { return moment(v); }),
                     newValue = '';
-                // conditions where only one valid date is typed in rather than a range
-                if (parts.length === 1 && function (parts) { return parts.isValid(); }) {
-                    $input.val(oldValue + separator + oldValue).trigger('change');
-                }
-                if (parts.length === 2 && _.every(parts, function (part) { return part.isValid(); })) {
-                    newValue = parts[0].format(dateFormat) + separator + parts[1].format(dateFormat);
+
+                if (_.every(parts, function (part) { return part.isValid(); }))  {
+                    if (parts.length === 1) { // condition where only one valid date is typed in rather than a range
+                        $input.val(oldValue + separator + oldValue).trigger('change');
+                    }
+                    else if (parts.length === 2) {
+                        newValue = parts[0].format(dateFormat) + separator + parts[1].format(dateFormat);
+                    }
                 }
                 if (oldValue !== newValue) {
                     $input.val(newValue).trigger('change');


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Ticket here: https://dimagi-dev.atlassian.net/browse/USH-1328
The value would clear after copying in or typing in a date with format like ‘2000/8/8’

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The date would clear even with formats like "2000-8-8" as well ,so the issue actually lied in it being a single date instead of a range using the separator. This PR adds a condition if the input is a single valid date is typed in rather than a range. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
locally tested and ensured the dates that previously work still work after this change

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
