### PR TITLE
Added daylight savings command for reports

### DIFF
--- a/corehq/apps/saved_reports/management/commands/daylight_savings.py
+++ b/corehq/apps/saved_reports/management/commands/daylight_savings.py
@@ -41,12 +41,10 @@ def adjust_report(report, forward=False):
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
-        parser.add_argument('path')
+        parser.add_argument('domains', nargs='+')
         parser.add_argument('-F', '--forward', action='store_true')
 
-    def handle(self, path, forward=False, *args, **kwargs):
-        domains = get_domains(path)
-
+    def handle(self, domains, forward=False, *args, **kwargs):
         for domain in domains:
             print(f'processing domain: {domain}')
             reports = get_reports_by_domain(domain)

--- a/corehq/apps/saved_reports/management/commands/daylight_savings.py
+++ b/corehq/apps/saved_reports/management/commands/daylight_savings.py
@@ -21,6 +21,13 @@ class Command(BaseCommand):
                 print(f'Updated hour on report {report._id} from {previous_hour} to {report.hour}')
 
 
+def get_reports_by_domain(domain):
+    key = [domain]
+    reports = ReportNotification.view('reportconfig/user_notifications',
+        reduce=False, include_docs=True, startkey=key, endkey=key + [{}])
+    return reports
+
+
 DAYS_IN_WEEK = 7
 
 
@@ -40,10 +47,3 @@ def adjust_report(report, forward=False):
         report.day = trigger_time.day
 
     return report
-
-
-def get_reports_by_domain(domain):
-    key = [domain]
-    reports = ReportNotification.view('reportconfig/user_notifications',
-        reduce=False, include_docs=True, startkey=key, endkey=key + [{}])
-    return reports

--- a/corehq/apps/saved_reports/management/commands/daylight_savings.py
+++ b/corehq/apps/saved_reports/management/commands/daylight_savings.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timedelta
+from django.core.management import BaseCommand
+
+from corehq.apps.saved_reports.models import ReportNotification
+
+
+def get_domains(path):
+    with open(path, 'r') as f:
+        domains = f.readlines()
+
+    return [domain.strip() for domain in domains]
+
+
+def get_reports_by_domain(domain):
+    key = [domain]
+    reports = ReportNotification.view('reportconfig/user_notifications',
+        reduce=False, include_docs=True, startkey=key, endkey=key + [{}])
+    return reports
+
+
+DAYS_IN_WEEK = 7
+
+
+def adjust_report(report, forward=False):
+    day = report.day + 1 if report.interval == 'weekly' else report.day  # account for 0-indexed days
+    trigger_time = datetime.now().replace(hour=report.hour, minute=report.minute, day=day)
+
+    if forward:
+        trigger_time += timedelta(hours=1)
+    else:
+        trigger_time -= timedelta(hours=1)
+
+    report.hour = trigger_time.hour
+    if report.interval == 'weekly':
+        report.day = (trigger_time.day - 1) % DAYS_IN_WEEK
+    elif report.interval == 'monthly':
+        report.day = trigger_time.day
+
+    return report
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('path')
+        parser.add_argument('-F', '--forward', action='store_true')
+
+    def handle(self, path, forward=False, *args, **kwargs):
+        domains = get_domains(path)
+
+        for domain in domains:
+            print(f'processing domain: {domain}')
+            reports = get_reports_by_domain(domain)
+
+            for report in reports:
+                previous_hour = report.hour
+                report = adjust_report(report, forward)
+                report.save()
+                print(f'Updated hour on report {report._id} from {previous_hour} to {report.hour}')

--- a/corehq/apps/saved_reports/tests/test_daylight_savings.py
+++ b/corehq/apps/saved_reports/tests/test_daylight_savings.py
@@ -1,0 +1,46 @@
+from django.test import SimpleTestCase
+from corehq.apps.saved_reports.management.commands.daylight_savings import adjust_report
+
+from ..models import ReportNotification
+
+
+class AdjustReportTests(SimpleTestCase):
+    def test_moves_report_hour_back(self):
+        report = ReportNotification(hour=1, minute=5, day=4, interval='daily')
+        adjust_report(report, forward=False)
+        self.assertEqual(report.hour, 0)
+
+    def test_moves_report_hour_forward(self):
+        report = ReportNotification(hour=1, minute=5, day=4, interval='daily')
+        adjust_report(report, forward=True)
+        self.assertEqual(report.hour, 2)
+
+    def test_wraps_hour_backwards(self):
+        report = ReportNotification(hour=0, minute=5, day=4, interval='daily')
+        adjust_report(report, forward=False)
+        self.assertEqual(report.hour, 23)
+
+    def test_wraps_hour_forwards(self):
+        report = ReportNotification(hour=23, minute=5, day=4, interval='daily')
+        adjust_report(report, forward=True)
+        self.assertEqual(report.hour, 0)
+
+    def test_wrapping_daily_does_not_increment_day(self):
+        report = ReportNotification(hour=23, minute=5, day=4, interval='daily')
+        adjust_report(report, forward=True)
+        self.assertEqual(report.day, 4)
+
+    def test_increments_day_on_weekly_wrap(self):
+        report = ReportNotification(hour=23, minute=5, day=4, interval='weekly')
+        adjust_report(report, forward=True)
+        self.assertEqual(report.day, 5)
+
+    def test_wraps_day_on_weekly(self):
+        report = ReportNotification(hour=23, minute=5, day=6, interval='weekly')
+        adjust_report(report, forward=True)
+        self.assertEqual(report.day, 0)
+
+    def test_handles_weekly_mondays(self):
+        report = ReportNotification(hour=23, minute=5, day=0, interval='weekly')
+        adjust_report(report, forward=True)
+        # Ensure does not throw


### PR DESCRIPTION
## Product Description
This is just a management command intended as a quick fix to update all USH scheduled reports for daylight savings time, until we can formally introduce support for daylight savings time.
The command should be executed as `./manage.py daylight_savings <domains>`, where path `domains`  should be a space-separated list of domain names. If this is a long list, I suggest creating a file with each domain on a separate line, and then calling ``./manage.py daylight_savings `cat <domain_file>` ``

## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12628

## Safety Assurance

### Safety story
Local testing was performed, and the changes themselves are reversible: by default, this decrements the hour by 1, but if the '-F' flag is supplied, the hour is incremented. In addition, a log is generated (which you can save via `tee`), so this could be automatically reverted if necessary. Finally, any error would halt execution, so the script can't run wild.

### Automated test coverage

Temporary test suite is available in _test_daylight_savings_. I think this and the management command should go away when proper support is implemented.  No test proves that the monthly day rolls over correctly, because I don't think our system currently supports all days, as is. Reports can be specified to run on the 31st of each month, and it's unclear what would happen for days with fewer days than that.

### QA Plan

No QA required.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
