### PR TITLE
Management command to call task synchronously

### DIFF
--- a/custom/onse/management/commands/update_onse_facility_cases.py
+++ b/custom/onse/management/commands/update_onse_facility_cases.py
@@ -1,6 +1,9 @@
+import sys
+
 from django.core.management import BaseCommand
 
 from custom.onse.tasks import (
+    check_server_status,
     execute_update_facility_cases_from_dhis2_data_elements,
     get_dhis2_server,
 )
@@ -21,6 +24,12 @@ class Command(BaseCommand):
         period = options.get('period')
         print_notifications = True
         dhis2_server = get_dhis2_server(print_notifications)
+
+        server_status = check_server_status(dhis2_server)
+        if server_status['error']:
+            print(str(server_status['error']), file=sys.stderr)
+            sys.exit(1)
+
         execute_update_facility_cases_from_dhis2_data_elements(
             dhis2_server,
             period,

--- a/custom/onse/management/commands/update_onse_facility_cases.py
+++ b/custom/onse/management/commands/update_onse_facility_cases.py
@@ -1,6 +1,9 @@
 from django.core.management import BaseCommand
 
-from custom.onse.tasks import update_facility_cases_from_dhis2_data_elements
+from custom.onse.tasks import (
+    execute_update_facility_cases_from_dhis2_data_elements,
+    get_dhis2_server,
+)
 
 
 class Command(BaseCommand):
@@ -15,7 +18,11 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        update_facility_cases_from_dhis2_data_elements.apply(kwargs={
-            'period': options.get('period'),
-            'print_notifications': True,
-        })
+        period = options.get('period')
+        print_notifications = True
+        dhis2_server = get_dhis2_server(print_notifications)
+        execute_update_facility_cases_from_dhis2_data_elements(
+            dhis2_server,
+            period,
+            print_notifications,
+        )

--- a/custom/onse/tasks.py
+++ b/custom/onse/tasks.py
@@ -71,21 +71,8 @@ class CassiusMarcellus:  # TODO: Come up with a better name. Please!
                       hour=22, minute=30),
     queue='background_queue',
 )
-def update_facility_cases_from_dhis2_data_elements(
-    period: Optional[str] = None,
-    print_notifications: bool = False,
-):
-    """
-    Update facility_supervision cases with indicators collected in DHIS2
-    over the last quarter.
-
-    :param period: The period of data to import. e.g. "2020Q1". Defaults
-        to last quarter.
-    :param print_notifications: If True, notifications are printed,
-        otherwise they are emailed.
-
-    """
-    _update_facility_cases_from_dhis2_data_elements.delay(period, print_notifications)
+def update_facility_cases_from_dhis2_data_elements():
+    _update_facility_cases_from_dhis2_data_elements.delay()
 
 
 @task(bind=True, max_retries=MAX_RETRY_ATTEMPTS)
@@ -96,7 +83,7 @@ def _update_facility_cases_from_dhis2_data_elements(self, period, print_notifica
     server_status = _check_server_status(dhis2_server)
 
     if server_status['ready']:
-        _execute_update_facility_cases_from_dhis2_data_elements(dhis2_server, period, print_notifications)
+        execute_update_facility_cases_from_dhis2_data_elements(dhis2_server, period, print_notifications)
     else:
         exception = server_status['error']
         retry_days = 2 ** self.request.retries
@@ -127,11 +114,23 @@ def _check_server_status(dhis2_server: ConnectionSettings):
     return server_status
 
 
-def _execute_update_facility_cases_from_dhis2_data_elements(
+def execute_update_facility_cases_from_dhis2_data_elements(
     dhis2_server: ConnectionSettings,
     period: Optional[str] = None,
     print_notifications: bool = False,
 ):
+    """
+    Update facility_supervision cases with indicators collected in DHIS2
+    over the last quarter.
+
+    :param dhis2_server: The ConnectionSettings instance to connect to
+        the remote API.
+    :param period: The period of data to import. e.g. "2020Q1". Defaults
+        to last quarter.
+    :param print_notifications: If True, notifications are printed,
+        otherwise they are emailed.
+
+    """
     try:
         clays = get_clays()
         with ThreadPoolExecutor(max_workers=MAX_THREAD_WORKERS) as executor:

--- a/custom/onse/tasks.py
+++ b/custom/onse/tasks.py
@@ -102,7 +102,7 @@ def check_server_status(dhis2_server: ConnectionSettings):
     }
     requests = dhis2_server.get_requests()
     try:
-        requests.send_request_unlogged("HEAD", dhis2_server.url, raise_for_status=True)
+        requests.send_request("HEAD", dhis2_server.url, raise_for_status=True)
     except HTTPError as e:
         if e.response.status_code != 405:  # ignore method not allowed
             server_status['ready'] = False

--- a/custom/onse/tasks.py
+++ b/custom/onse/tasks.py
@@ -80,7 +80,7 @@ def _update_facility_cases_from_dhis2_data_elements(self, period, print_notifica
     if not domain_exists(DOMAIN):
         return
     dhis2_server = get_dhis2_server(print_notifications)
-    server_status = _check_server_status(dhis2_server)
+    server_status = check_server_status(dhis2_server)
 
     if server_status['ready']:
         execute_update_facility_cases_from_dhis2_data_elements(dhis2_server, period, print_notifications)
@@ -95,7 +95,7 @@ def _update_facility_cases_from_dhis2_data_elements(self, period, print_notifica
         self.retry(countdown=(retry_days * TASK_RETRY_FACTOR))
 
 
-def _check_server_status(dhis2_server: ConnectionSettings):
+def check_server_status(dhis2_server: ConnectionSettings):
     server_status = {
         'ready': True,
         'error': None

--- a/custom/onse/tests.py
+++ b/custom/onse/tests.py
@@ -35,7 +35,7 @@ class TestUpdateFromDhis2Task(TestCase):
 
     @patch('custom.onse.tasks.domain_exists', return_value=True)
     @patch('custom.onse.tasks.get_dhis2_server', return_value=ConnectionSettings())
-    @patch('custom.onse.tasks._check_server_status', return_value={'ready': False, 'error': RequestException})
+    @patch('custom.onse.tasks.check_server_status', return_value={'ready': False, 'error': RequestException})
     def test_retry(self, *args):
         task = _update_facility_cases_from_dhis2_data_elements.delay(None, True)
         assert task.result.__class__ == MaxRetriesExceededError


### PR DESCRIPTION
## Technical Summary

When importing from DHIS2 for ONSE fails, we sometimes need to use a management command to retry manually after the partner has fixed upstream problems. The command needs to execute the import synchronously so that the user has immediate feedback on its success or failure.

This change also logs server checks, because log everything.

<p align="center"> :fish: :blowfish: :tropical_fish: </p>

## Safety Assurance

### Safety story

This is a management command for custom code. It only affects a single project, and is only used quarterly, at most.

The code that the command calls is unchanged.

### Automated test coverage

The (unchanged) code that the command calls is covered by tests.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
