### PR TITLE
Use consistent date formatting for report filters

### DIFF
--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -99,8 +99,8 @@ class DateFilterValue(FilterValue):
             enddate = self._offset_enddate(enddate)
 
         if self.filter.get('compare_as_string'):
-            startdate = str(startdate) if startdate is not None else None
-            enddate = str(enddate) if enddate is not None else None
+            startdate = startdate.isoformat() if startdate is not None else None
+            enddate = enddate.isoformat() if enddate is not None else None
 
         sql_values = {}
         if startdate is not None:


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12673.
Users are seeing reports which should be included in the reporting time spans specified not be included in the output. This is caused due to different formats used for inserting vs comparing times. On insert, we use what appears to be default JSON formatting, turning dates into ISO-formatted strings. For filtering, we use python's string conversion on dates. This change uses ISO formatting for both, so that the dates are compared as intended.

## Safety Assurance

### Safety story
I tested this change locally, verifying that a custom user report showed the appropriate cases after this fix. I ran through the code, hoping to feel comfortable that we use the same date formatting everywhere (so that this change won't break other reports). As this filter is specifically in user reports, I think that's a safe assumption.

### Automated test coverage

A new test suite was added in _corehq/apps/userreports/tests/test_filters_. As is mentioned in the comment there, this test is unfortunately inadequate to verify what really needs verifying, which is that the insertion and filter code both use the same time formatting. Ideally, this should be done by modifying the code in the future.

### QA Plan

No QA required.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
