### PR TITLE
change how "additional registry queries" works

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2130,12 +2130,6 @@ class CaseSearchAgainLabel(BaseCaseSearchLabel):
     label = DictProperty(default={'en': 'Search Again'})
 
 
-class AdditionalRegistryQuery(DocumentSchema):
-    instance_name = StringProperty()
-    case_type_xpath = StringProperty()
-    case_id_xpath = StringProperty()
-
-
 class CaseSearch(DocumentSchema):
     """
     Properties and search command label
@@ -2155,7 +2149,7 @@ class CaseSearch(DocumentSchema):
     blacklisted_owner_ids_expression = StringProperty()
     additional_case_types = ListProperty(str)
     data_registry = StringProperty()
-    additional_registry_queries = SchemaListProperty(AdditionalRegistryQuery)
+    additional_registry_cases = StringListProperty()  # list of xpath expressions
 
     @property
     def case_session_var(self):

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -169,25 +169,18 @@ hqDefine("app_manager/js/details/case_claim", function () {
         return self;
     };
 
-    var additionalQueryModel = function (options, saveButton) {
-        options = _.defaults(options, {
-            instance_name: '',
-            case_type_xpath: '',
-            case_id_xpath: '',
-        });
+    var additionalRegistryCaseModel = function (xpath, saveButton) {
         var self = {};
         self.uniqueId = generateSemiRandomId();
-        self.instanceName = ko.observable(options.instance_name);
-        self.caseTypeXpath = ko.observable(options.case_type_xpath);
-        self.caseIdXpath = ko.observable(options.case_id_xpath);
-        subscribeToSave(self, ['instanceName', 'caseTypeXpath', 'caseIdXpath'], saveButton);
+        self.caseIdXpath = ko.observable(xpath || '');
+        subscribeToSave(self, ['caseIdXpath'], saveButton);
         return self;
     };
 
     var searchConfigKeys = [
         'autoLaunch', 'blacklistedOwnerIdsExpression', 'defaultSearch', 'searchAgainLabel',
         'searchButtonDisplayCondition', 'searchLabel', 'searchFilter', 'searchDefaultRelevant',
-        'searchAdditionalRelevant', 'dataRegistry', 'additionalRegistryQueries',
+        'searchAdditionalRelevant', 'dataRegistry', 'additionalRegistryCases',
     ];
     var searchConfigModel = function (options, lang, searchFilterObservable, saveButton) {
         hqImport("hqwebapp/js/assert_properties").assertRequired(options, searchConfigKeys);
@@ -195,9 +188,9 @@ hqDefine("app_manager/js/details/case_claim", function () {
         options.searchLabel = options.searchLabel[lang] || "";
         options.searchAgainLabel = options.searchAgainLabel[lang] || "";
         var mapping = {
-            'additionalRegistryQueries': {
+            'additionalRegistryCases': {
                 create: function(options) {
-                    return additionalQueryModel(options.data, saveButton);
+                    return additionalRegistryCaseModel(options.data, saveButton);
                 },
             },
         };
@@ -251,11 +244,11 @@ hqDefine("app_manager/js/details/case_claim", function () {
         });
 
         self.addRegistryQuery = function () {
-            self.additionalRegistryQueries.push(additionalQueryModel({}, saveButton));
+            self.additionalRegistryCases.push(additionalRegistryCaseModel('', saveButton));
         };
 
-        self.removeRegistryQuery = function (query) {
-            self.additionalRegistryQueries.remove(query);
+        self.removeRegistryQuery = function (model) {
+            self.additionalRegistryCases.remove(model);
         };
 
         self.serialize = function () {
@@ -286,13 +279,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                     $("#case_search-search_again_label_media_media_audio input[type=hidden][name='case_search-search_again_label_media_use_default_audio_for_all']").val() || null,
                 search_filter: self.searchFilter(),
                 blacklisted_owner_ids_expression: self.blacklistedOwnerIdsExpression(),
-                additional_registry_queries: self.additionalRegistryQueries().map((query) => {
-                    return {
-                        instance_name: query.instanceName(),
-                        case_type_xpath: query.caseTypeXpath(),
-                        case_id_xpath: query.caseIdXpath(),
-                    };
-                }),
+                additional_registry_cases: self.additionalRegistryCases().map((query) => query.caseIdXpath()),
             };
         };
 

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -48,7 +48,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
                     searchFilter: options.search_filter,
                     blacklistedOwnerIdsExpression: options.blacklisted_owner_ids_expression,
                     dataRegistry: options.data_registry,
-                    additionalRegistryQueries: options.additional_registry_queries,
+                    additionalRegistryCases: options.additional_registry_cases,
                 });
 
                 var $list_home = $("#" + detail.type + "-detail-screen-config-tab");

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -549,7 +549,7 @@ class EntriesHelper(object):
         """
         from corehq.apps.app_manager.suite_xml.post_process.remote_requests import REGISTRY_INSTANCE
 
-        case_types = set(module.search_config.additional_case_types) | {module.case_type}
+        case_types = set(module.search_config.additional_case_types) | {datum.case_type}
         case_ids_expressions = {session_var(datum.datum.id)} | set(module.search_config.additional_registry_cases)
         data = [
             QueryData(key=CASE_SEARCH_REGISTRY_ID_KEY, ref=f"'{module.search_config.data_registry}'")

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -549,13 +549,19 @@ class EntriesHelper(object):
         """
         from corehq.apps.app_manager.suite_xml.post_process.remote_requests import REGISTRY_INSTANCE
 
+        case_types = set(module.search_config.additional_case_types) | {module.case_type}
+        case_ids_expressions = {session_var(datum.datum.id)} | set(module.search_config.additional_registry_cases)
         data = [
-            QueryData(key='case_type', ref=f"'{datum.case_type}'"),
-            QueryData(key='case_id', ref=session_var(datum.datum.id)),
             QueryData(key=CASE_SEARCH_REGISTRY_ID_KEY, ref=f"'{module.search_config.data_registry}'")
         ]
-        for case_id_xpath in module.search_config.additional_registry_cases:
-            data.append(QueryData(key='case_id', ref=case_id_xpath))
+        data.extend([
+            QueryData(key='case_type', ref=f"'{case_type}'")
+            for case_type in sorted(case_types)
+        ])
+        data.extend([
+            QueryData(key='case_id', ref=case_id_xpath)
+            for case_id_xpath in sorted(case_ids_expressions)
+        ])
 
         return FormDatumMeta(
             datum=RemoteRequestQuery(

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -432,7 +432,7 @@ class EntriesHelper(object):
                 if module_offers_registry_search(module):
                     result.append(self.get_data_registry_search_datums(module))
                     result.append(datum)
-                    result.extend(self.get_data_registry_case_datums(datum, module))
+                    result.append(self.get_data_registry_case_datums(datum, module))
                 else:
                     result.append(datum)
             else:
@@ -549,37 +549,26 @@ class EntriesHelper(object):
         """
         from corehq.apps.app_manager.suite_xml.post_process.remote_requests import REGISTRY_INSTANCE
 
-        def _registry_query(instance_name, case_type_xpath, case_id_xpath):
-            return FormDatumMeta(
-                datum=RemoteRequestQuery(
-                    url=absolute_reverse('registry_case', args=[self.app.domain, self.app.get_id]),
-                    storage_instance=instance_name,
-                    template='case',
-                    data=[
-                        QueryData(key='case_type', ref=case_type_xpath),
-                        QueryData(key='case_id', ref=case_id_xpath),
-                        QueryData(key=CASE_SEARCH_REGISTRY_ID_KEY, ref=f"'{module.search_config.data_registry}'")
-                    ],
-                    default_search='true',
-                ),
-                case_type=None,
-                requires_selection=False,
-                action=None
-            )
+        data = [
+            QueryData(key='case_type', ref=f"'{datum.case_type}'"),
+            QueryData(key='case_id', ref=session_var(datum.datum.id)),
+            QueryData(key=CASE_SEARCH_REGISTRY_ID_KEY, ref=f"'{module.search_config.data_registry}'")
+        ]
+        for case_id_xpath in module.search_config.additional_registry_cases:
+            data.append(QueryData(key='case_id', ref=case_id_xpath))
 
-        datums = [_registry_query(
-            instance_name=REGISTRY_INSTANCE,
-            case_type_xpath=f"'{datum.case_type}'",
-            case_id_xpath=session_var(datum.datum.id)
-        )]
-
-        for query in module.search_config.additional_registry_queries:
-            datums.append(_registry_query(
-                instance_name=query.instance_name,
-                case_type_xpath=query.case_type_xpath,
-                case_id_xpath=query.case_id_xpath
-            ))
-        return datums
+        return FormDatumMeta(
+            datum=RemoteRequestQuery(
+                url=absolute_reverse('registry_case', args=[self.app.domain, self.app.get_id]),
+                storage_instance=REGISTRY_INSTANCE,
+                template='case',
+                data=data,
+                default_search='true',
+            ),
+            case_type=None,
+            requires_selection=False,
+            action=None
+        )
 
     @staticmethod
     def get_auto_select_datums_and_assertions(action, auto_select, form):

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -275,7 +275,10 @@
                     <tbody data-bind="foreach: additionalRegistryCases, sortableList: additionalRegistryCases">
                       <tr>
                         <td>
-                          <textarea data-bind="value: caseIdXpath"
+                          <textarea data-bind="
+                              value: caseIdXpath,
+                              xpathValidator: {text: caseIdXpath, allowCaseHashtags: false, errorHtml: $('#searchFilterXpathErrorHtml').html()}
+                              "
                                     class="form-control vertical-resize"
                                     spellcheck="false"
                           ></textarea>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -255,26 +255,30 @@
           </div>
           <div class="form-group">
               <label for="data-registry" class="{% css_label_class %} control-label">
-                  {% trans "Additional Data Registry Queries" %}
+                  {% trans "Load Additional Data Registry Cases" %}
                   <span class="hq-help-template" data-title="{% trans "Data Registry" %}"
-                        data-content="{% trans_html_attr "Load additional data into forms in this module by performing extra queries against the data registry." %}">
+                        data-content="{% blocktrans %}
+                        Load additional cases from the Data Registry into the 'registry' instance for forms in this module.
+                        The case type of the case must be configured in the registry and in the module via the module's
+                        case type or the module's 'Additional Case List and Case Search Types' configuration.
+                        {% endblocktrans %}">
+                  </span>
               </label>
               <div class="{% css_field_class %}">
                   <table class="table table-condensed">
                     <thead data-bind="visible: additionalRegistryCases().length > 0">
                     <tr>
-                      <th class="col-sm-1"></th>
                       <th class="col-sm-12">{% trans "Case ID XPath" %}</th>
                       <th class="col-sm-1"></th>
                     </tr>
                     </thead>
                     <tbody data-bind="foreach: additionalRegistryCases, sortableList: additionalRegistryCases">
                       <tr>
-                        <td class="text-center">
-                          <i class="grip sortable-handle hq-icon-full fa fa-arrows-v"></i>
-                        </td>
                         <td>
-                          <input class="form-control" type="text" data-bind="value: caseIdXpath"/>
+                          <textarea data-bind="value: caseIdXpath"
+                                    class="form-control vertical-resize"
+                                    spellcheck="false"
+                          ></textarea>
                         </td>
                         <td>
                           <i style="cursor: pointer;" class="fa fa-remove"

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -261,25 +261,17 @@
               </label>
               <div class="{% css_field_class %}">
                   <table class="table table-condensed">
-                    <thead data-bind="visible: additionalRegistryQueries().length > 0">
+                    <thead data-bind="visible: additionalRegistryCases().length > 0">
                     <tr>
                       <th class="col-sm-1"></th>
-                      <th class="col-sm-4">{% trans "Instance Name" %}</th>
-                      <th class="col-sm-4">{% trans "Case Type" %}</th>
-                      <th class="col-sm-4">{% trans "Case ID" %}</th>
+                      <th class="col-sm-12">{% trans "Case ID XPath" %}</th>
                       <th class="col-sm-1"></th>
                     </tr>
                     </thead>
-                    <tbody data-bind="foreach: additionalRegistryQueries, sortableList: additionalRegistryQueries">
+                    <tbody data-bind="foreach: additionalRegistryCases, sortableList: additionalRegistryCases">
                       <tr>
                         <td class="text-center">
                           <i class="grip sortable-handle hq-icon-full fa fa-arrows-v"></i>
-                        </td>
-                        <td>
-                          <input class="form-control" type="text" data-bind="value: instanceName"/>
-                        </td>
-                        <td>
-                          <input class="form-control" type="text" data-bind="value: caseTypeXpath"/>
                         </td>
                         <td>
                           <input class="form-control" type="text" data-bind="value: caseIdXpath"/>
@@ -292,7 +284,7 @@
                     </tbody>
                   </table>
                   <button type="button" class="btn btn-default" data-bind="click: addRegistryQuery">
-                    <i class="fa fa-plus"></i> {% trans "Add Data Registry Query" %}
+                    <i class="fa fa-plus"></i> {% trans "Add Case ID to Data Registry Query" %}
                   </button>
               </div>
           </div>

--- a/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
@@ -32,9 +32,9 @@
           </query>
           <datum detail-confirm="m0_case_long" detail-select="m0_case_short" id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open']" value="./@case_id"/>
           <query default_search="true" storage-instance="registry" template="case" url="http://localhost:8000/a/test_domain/phone/registry_case/123/">
+            <data key="commcare_registry" ref="'myregistry'"/>
             <data key="case_type" ref="'case'"/>
             <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
-            <data key="commcare_registry" ref="'myregistry'"/>
           </query>
         </session>
         <instance id="colors" src="jr://fixture/item-list:colors"/>

--- a/corehq/apps/app_manager/tests/test_form_preparation_v2.py
+++ b/corehq/apps/app_manager/tests/test_form_preparation_v2.py
@@ -20,9 +20,6 @@ from corehq.apps.app_manager.models import (
     OpenSubCaseAction,
     PreloadAction,
     UpdateCaseAction,
-    CaseSearch,
-    CaseSearchProperty,
-    AdditionalRegistryQuery,
 )
 from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.app_manager.xform import XForm
@@ -107,23 +104,6 @@ class FormPreparationV2Test(SimpleTestCase, TestXmlMixin):
         self.app.langs = ['fra']  # lang that's not in the form
         with self.assertRaises(XFormException):
             self.form.render_xform()
-
-    def test_instance_check(self):
-        self.module.search_config = CaseSearch(
-            properties=[
-                CaseSearchProperty(name='name', label={'en': 'Name'}),
-            ],
-            data_registry="myregistry",
-            additional_registry_queries=[
-                AdditionalRegistryQuery(
-                    instance_name="other_case", case_type_xpath="'patient'", case_id_xpath="'123'"
-                )
-            ]
-        )
-        xml = self.get_xml('open_case')
-        form = XForm(xml)
-        form.add_missing_instances(self.form, self.app)
-        self.assertEqual(set(form._get_instance_ids()), {"commcaresession", "other_case"})
 
     def test_add_remote_instances(self):
         xml = self.get_xml('missing_instances')

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -96,9 +96,9 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
             <query url="http://localhost:8000/a/test_domain/phone/registry_case/123/"
                 storage-instance="registry" template="case" default_search="true">
+              <data key="commcare_registry" ref="'myregistry'"/>
               <data key="case_type" ref="'case'"/>
               <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
-              <data key="commcare_registry" ref="'myregistry'"/>
             </query>
           </session>
         </partial>"""
@@ -122,6 +122,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
     def test_search_data_registry_additional_registry_query(self, *args):
         base_xpath = "instance('registry')/results/case[@case_id=instance('commcaresession')/session/data/case_id]"
+        self.module.search_config.additional_case_types = ["other_case"]
         self.module.search_config.additional_registry_cases = [
             f"{base_xpath}/potential_duplicate_case_id"
         ]
@@ -131,9 +132,10 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         <partial>
           <query url="http://localhost:8000/a/test_domain/phone/registry_case/123/" storage-instance="registry"
                 template="case" default_search="true">
-            <data key="case_type" ref="'case'"/>
-            <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
             <data key="commcare_registry" ref="'myregistry'"/>
+            <data key="case_type" ref="'case'"/>
+            <data key="case_type" ref="'other_case'"/>
+            <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
             <data key="case_id" ref="{base_xpath}/potential_duplicate_case_id"/>
           </query>
         </partial>"""

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -7,7 +7,9 @@ from corehq.apps.app_manager.models import (
     CaseSearchProperty,
     Itemset,
     Module,
-    AdditionalRegistryQuery, DetailColumn, FormLink, DetailTab,
+    DetailColumn,
+    FormLink,
+    DetailTab,
 )
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
@@ -120,25 +122,22 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
     def test_search_data_registry_additional_registry_query(self, *args):
         base_xpath = "instance('registry')/results/case[@case_id=instance('commcaresession')/session/data/case_id]"
-        self.module.search_config.additional_registry_queries = [
-            AdditionalRegistryQuery(
-                instance_name="duplicate",
-                case_type_xpath=f"{base_xpath}/potential_duplicate_case_type",
-                case_id_xpath=f"{base_xpath}/potential_duplicate_case_id"
-            )
+        self.module.search_config.additional_registry_cases = [
+            f"{base_xpath}/potential_duplicate_case_id"
         ]
         suite = self.app.create_suite()
 
         expected_entry_query = f"""
         <partial>
-          <query url="http://localhost:8000/a/test_domain/phone/registry_case/123/" storage-instance="duplicate"
+          <query url="http://localhost:8000/a/test_domain/phone/registry_case/123/" storage-instance="registry"
                 template="case" default_search="true">
-            <data key="case_type" ref="{base_xpath}/potential_duplicate_case_type"/>
-            <data key="case_id" ref="{base_xpath}/potential_duplicate_case_id"/>
+            <data key="case_type" ref="'case'"/>
+            <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
             <data key="commcare_registry" ref="'myregistry'"/>
+            <data key="case_id" ref="{base_xpath}/potential_duplicate_case_id"/>
           </query>
         </partial>"""
-        self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]/session/query[3]")
+        self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]/session/query[2]")
 
         self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='commcaresession']")
         self.assertXmlDoesNotHaveXpath(suite, "./entry[1]/instance[@id='registry']")

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -70,7 +70,7 @@ from corehq.apps.app_manager.models import (
     SortElement,
     UpdateCaseAction,
     get_all_mobile_filter_configs,
-    get_auto_filter_configurations, AdditionalRegistryQuery,
+    get_auto_filter_configurations,
 )
 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import (
     get_uuids_by_instance_id,
@@ -235,7 +235,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
             'search_again_label':
                 module.search_config.search_again_label.label if hasattr(module, 'search_config') else "",
             'data_registry': module.search_config.data_registry,
-            'additional_registry_queries': module.search_config.additional_registry_queries,
+            'additional_registry_cases': module.search_config.additional_registry_cases,
         },
     }
     if toggles.CASE_DETAIL_PRINT.enabled(app.domain):
@@ -1214,18 +1214,17 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
                     except ValueError as e:
                         return HttpResponseBadRequest(str(e))
 
-            additional_registry_queries = []
-            for query in search_properties.get('additional_registry_queries', []):
-                if not all(list(query.values())):
-                    return HttpResponseBadRequest("All fields for Additional Data Registry Queries are required")
+            additional_registry_cases = []
+            for case_id_xpath in search_properties.get('additional_registry_cases', []):
+                if not case_id_xpath:
+                    continue
 
                 try:
-                    _check_xpath(query["case_type_xpath"], "the Case Type of Additional Data Registry Query")
-                    _check_xpath(query["case_id_xpath"], "the Case ID of Additional Data Registry Query")
+                    _check_xpath(case_id_xpath, "the Case ID of Additional Data Registry Query")
                 except ValueError as e:
                     return HttpResponseBadRequest(str(e))
 
-                additional_registry_queries.append(AdditionalRegistryQuery.wrap(query))
+                additional_registry_cases.append(case_id_xpath)
 
             module.search_config = CaseSearch(
                 search_label=search_label,
@@ -1244,7 +1243,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
                     for p in search_properties.get('default_properties')
                 ],
                 data_registry=search_properties.get('data_registry', ""),
-                additional_registry_queries=additional_registry_queries,
+                additional_registry_cases=additional_registry_cases,
             )
 
     resp = {}

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -835,16 +835,6 @@ class XForm(WrappedNode):
         instances, unknown_instance_ids = get_all_instances_referenced_in_xpaths(
             app, [self.render().decode('utf-8')])
 
-        module = form.get_module()
-        if _module_offers_registry_search(module) and module.search_config.additional_registry_queries:
-            remote_instances = [
-                Instance(id=query.instance_name, src='jr://instance/remote')
-                for query in module.search_config.additional_registry_queries
-            ]
-            for instance in remote_instances:
-                instances.add(instance)
-                unknown_instance_ids.discard(instance.id)
-
         for instance_id in unknown_instance_ids:
             if instance_id not in instance_declarations:
                 missing_unknown_instances.add(instance_id)

--- a/corehq/apps/registry/helper.py
+++ b/corehq/apps/registry/helper.py
@@ -44,7 +44,7 @@ class DataRegistryHelper:
     def log_data_access(self, user, domain, related_object, filters=None):
         self.registry.logger.data_accessed(user, domain, related_object, filters)
 
-    def get_case(self, case_id, case_type, couch_user, accessing_object):
+    def get_case(self, case_id, couch_user, accessing_object):
         """
         :param accessing_object: object that is calling 'get_case'.
             See ``corehq.apps.registry.models.RegistryAuditHelper.data_accessed``
@@ -53,12 +53,9 @@ class DataRegistryHelper:
         from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 
         case = CaseAccessorSQL.get_case(case_id)
-        if case.type != case_type:
-            raise CaseNotFound("Case type mismatch")
-
         self.check_data_access(couch_user, [case.type], case.domain)
         self.log_data_access(couch_user.get_django_user(), case.domain, accessing_object, filters={
-            "case_type": case_type,
+            "case_type": case.type,
             "case_id": case_id
         })
         return case

--- a/corehq/apps/registry/tests/test_helper.py
+++ b/corehq/apps/registry/tests/test_helper.py
@@ -32,7 +32,7 @@ class TestDataRegistryHelper(SimpleTestCase):
     def test_get_case(self):
         mock_case = _mock_case("a", "domain1")
         with patch.object(CaseAccessorSQL, 'get_case', return_value=mock_case):
-            case = self.helper.get_case("case1", "a", _mock_user(), "app")
+            case = self.helper.get_case("case1", _mock_user(), "app")
         self.assertEqual(case, mock_case)
         self.log_data_access.assert_called_with("user", "domain1", "app", filters={
             "case_type": "a",
@@ -43,34 +43,27 @@ class TestDataRegistryHelper(SimpleTestCase):
         mock_case = _mock_case("other-type", "domain1")
         with patch.object(CaseAccessorSQL, 'get_case', return_value=mock_case), \
              self.assertRaisesMessage(RegistryAccessException, "'other-type' not available in registry"):
-            self.helper.get_case("case1", "other-type", _mock_user(), "app")
+            self.helper.get_case("case1", _mock_user(), "app")
         self.log_data_access.not_called()
 
     def test_get_case_not_found(self):
         with self.assertRaises(CaseNotFound), \
              patch.object(CaseAccessorSQL, 'get_case', side_effect=CaseNotFound):
-            self.helper.get_case("case1", "a", _mock_user(), "app")
-        self.log_data_access.not_called()
-
-    def test_get_case_type_mismatch(self):
-        mock_case = _mock_case("other-type", "domain1")
-        with self.assertRaisesMessage(CaseNotFound, "Case type mismatch"), \
-             patch.object(CaseAccessorSQL, 'get_case', return_value=mock_case):
-            self.helper.get_case("case1", "a", _mock_user(), "app")
+            self.helper.get_case("case1", _mock_user(), "app")
         self.log_data_access.not_called()
 
     def test_get_case_domain_not_in_registry(self):
         mock_case = _mock_case("a", "other-domain")
         with self.assertRaisesMessage(RegistryAccessException, "Data not available in registry"), \
              patch.object(CaseAccessorSQL, 'get_case', return_value=mock_case):
-            self.helper.get_case("case1", "a", _mock_user(), "app")
+            self.helper.get_case("case1", _mock_user(), "app")
         self.log_data_access.not_called()
 
     def test_get_case_access_to_current_domain_allowed_even_if_user_has_no_permission(self):
         mock_case = _mock_case("a", "domain1")
         mock_user = _mock_user(has_permission=False)
         with patch.object(CaseAccessorSQL, 'get_case', return_value=mock_case):
-            self.helper.get_case("case1", "a", mock_user, "app")
+            self.helper.get_case("case1", mock_user, "app")
         self.log_data_access.assert_called_with("user", "domain1", "app", filters={
             "case_type": "a",
             "case_id": "case1"
@@ -81,13 +74,13 @@ class TestDataRegistryHelper(SimpleTestCase):
         mock_user = _mock_user(has_permission=False)
         with self.assertRaisesMessage(RegistryAccessException, "User not permitted to access registry data"),\
              patch.object(CaseAccessorSQL, 'get_case', return_value=mock_case):
-            self.helper.get_case("case1", "a", mock_user, "app")
+            self.helper.get_case("case1", mock_user, "app")
 
     def test_get_case_access_to_other_domain_allowed_if_user_has_permission(self):
         mock_case = _mock_case("a", "domain2")
         mock_user = _mock_user(has_permission=True)
         with patch.object(CaseAccessorSQL, 'get_case', return_value=mock_case):
-            self.helper.get_case("case1", "a", mock_user, "app")
+            self.helper.get_case("case1", mock_user, "app")
         self.log_data_access.assert_called_with("user", "domain2", "app", filters={
             "case_type": "a",
             "case_id": "case1"

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -772,7 +772,7 @@ class CaseAccessorSQL(AbstractCaseAccessor):
         try:
             return CommCareCaseSQL.objects.partitioned_get(case_id)
         except CommCareCaseSQL.DoesNotExist:
-            raise CaseNotFound
+            raise CaseNotFound(case_id)
 
     @staticmethod
     def get_cases(case_ids, ordered=False, prefetched_indices=None):

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -538,7 +538,7 @@ class CaseUpdateConfig:
         if index_case.domain != target_case.domain:
             raise DataRegistryCaseUpdateError(f"Index case not found: {self.index_create_case_id}")
 
-        if index_case.case_type != self.index_create_case_type:
+        if index_case.type != self.index_create_case_type:
             raise DataRegistryCaseUpdateError("Index case type does not match")
 
         return {

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -555,13 +555,13 @@ class DataRegistryCaseUpdatePayloadGenerator(BasePayloadGenerator):
 
     def _get_case(self, registry_helper, repeat_record, config, couch_user):
         try:
-            case = registry_helper.get_case(config.case_id, config.case_type, couch_user, repeat_record.repeater)
+            case = registry_helper.get_case(config.case_id, couch_user, repeat_record.repeater)
         except RegistryAccessException:
             raise DataRegistryCaseUpdateError("User does not have permission to access the registry")
         except CaseNotFound:
             raise DataRegistryCaseUpdateError(f"Target case not found: {config.case_id}")
 
-        if case.domain != config.domain:
+        if case.domain != config.domain or case.type != config.case_type:
             raise DataRegistryCaseUpdateError(f"Target case not found: {config.case_id}")
 
         return case

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -73,7 +73,7 @@ def test_generator_update_create_index_to_parent():
 
     def _get_case(case_id):
         assert case_id == "case2"
-        return Mock(domain=TARGET_DOMAIN, case_type="parent_type")
+        return Mock(domain=TARGET_DOMAIN, type="parent_type")
 
     with patch.object(CaseAccessorSQL, 'get_case', new=_get_case):
         _test_payload_generator(intent_case=builder.get_case(), expected_indices={
@@ -85,7 +85,7 @@ def test_generator_update_create_index_to_host():
 
     def _get_case(case_id):
         assert case_id == "case2"
-        return Mock(domain=TARGET_DOMAIN, case_type="parent_type")
+        return Mock(domain=TARGET_DOMAIN, type="parent_type")
 
     with patch.object(CaseAccessorSQL, 'get_case', new=_get_case):
         _test_payload_generator(intent_case=builder.get_case(), expected_indices={
@@ -105,7 +105,7 @@ def test_generator_update_create_index_domain_mismatch():
 
     def _get_case(case_id):
         assert case_id == "case2"
-        return Mock(domain="not target", case_type="parent_type")
+        return Mock(domain="not target", type="parent_type")
 
     with assert_raises(DataRegistryCaseUpdateError, msg="Index case not found: case2"):
         with patch.object(CaseAccessorSQL, 'get_case', new=_get_case):
@@ -117,7 +117,7 @@ def test_generator_update_create_index_case_type_mismatch():
 
     def _get_case(case_id):
         assert case_id == "case2"
-        return Mock(domain=TARGET_DOMAIN, case_type="not parent")
+        return Mock(domain=TARGET_DOMAIN, type="not parent")
 
     with assert_raises(DataRegistryCaseUpdateError, msg="Index case type does not match"):
         with patch.object(CaseAccessorSQL, 'get_case', new=_get_case):
@@ -152,7 +152,7 @@ def test_generator_update_create_and_remove_index():
 
     def _get_case(case_id):
         assert case_id == "case2"
-        return Mock(domain=TARGET_DOMAIN, case_type="host_type")
+        return Mock(domain=TARGET_DOMAIN, type="host_type")
 
     with patch.object(CaseAccessorSQL, 'get_case', new=_get_case):
         _test_payload_generator(intent_case=builder.get_case(), expected_indices={
@@ -169,7 +169,7 @@ def test_generator_update_create_and_remove_same_index():
 
     def _get_case(case_id):
         assert case_id == "case2"
-        return Mock(domain=TARGET_DOMAIN, case_type="new_parent_type")
+        return Mock(domain=TARGET_DOMAIN, type="new_parent_type")
 
     with patch.object(CaseAccessorSQL, 'get_case', new=_get_case):
         _test_payload_generator(intent_case=builder.get_case(), expected_indices={
@@ -195,7 +195,7 @@ def test_generator_update_multiple_cases():
     main_case_builder.set_subcases([subcase1, subcase2])
 
     def _get_case(case_id):
-        return Mock(domain=TARGET_DOMAIN, case_type="parent", case_id=case_id)
+        return Mock(domain=TARGET_DOMAIN, type="parent", case_id=case_id)
 
     with patch.object(CaseAccessorSQL, 'get_case', new=_get_case):
         _test_payload_generator(intent_case=main_case_builder.get_case(), expected_updates={
@@ -231,11 +231,11 @@ def _test_payload_generator(intent_case, target_case_exists=True,
     generator.submission_username = Mock(return_value='user1')
 
     # target_case is the case in the target domain which is being updated
-    def _get_case(self, case_id, case_type, *args, **kwargs):
+    def _get_case(self, case_id, *args, **kwargs):
         if not target_case_exists:
             raise CaseNotFound
 
-        return Mock(domain=TARGET_DOMAIN, case_type=case_type, case_id=case_id, case_json={
+        return Mock(domain=TARGET_DOMAIN, type="patient", case_id=case_id, case_json={
             "existing_prop": uuid.uuid4().hex,
             "existing_blank_prop": ""
         }, live_indices=[


### PR DESCRIPTION
## Product Description
Instead of making separate queries and loading the data into a new 'instance' this PR makes it so that the additional cases are loaded into the 'registry' instance along with the selected registry case.

This simplifies the workflow slightly but also allows the feature to be used in other places to provide consistent access to cases. Specifically in the dedupe workflow where one case is loaded from the 'casedb' and the other is loaded from the 'registry'. With this change the 'casedb' case can be added to the 'registry' instance to provide consistent access to the cases regardless of whether they are local or remote.

## Technical Summary
* UI and model updates to just store the case ID xpath
* add case_ids to the main 'registry' query
* add additional case types to the 'registry' query
* update the registry_case view to support multiple case IDs

Jira: https://dimagi-dev.atlassian.net/browse/USH-1395
(also fixes: https://dimagi-dev.atlassian.net/browse/USH-1382)

## Feature Flag
Data Registry

## Safety Assurance

### Safety story
Changes to a FF feature that are well covered by tests

### Automated test coverage
Tests updated

### QA Plan
QA being done by AE team

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
