### PR TITLE
auditcare export additions and improvements

### DIFF
--- a/corehq/apps/auditcare/management/commands/export_domain_logins.py
+++ b/corehq/apps/auditcare/management/commands/export_domain_logins.py
@@ -1,0 +1,77 @@
+import argparse
+import csv
+import gzip
+from contextlib import contextmanager
+from textwrap import dedent
+
+from django.core.management.base import BaseCommand, CommandError
+
+from corehq.apps.auditcare.utils.export import get_domain_first_access_times
+from corehq.apps.domain.models import Domain
+from corehq.util.argparse_types import date_type
+
+
+class Command(BaseCommand):
+
+    help = dedent("""\
+        Generate request report of domain "login" events.
+
+        NOTES
+            - Queries SQL `NavigationEventAudit` events for "domain login times".
+            - See `export.get_domain_first_access_times()` for more details.
+            - Does _not_ query couch!
+    """)
+
+    def create_parser(self, prog_name, subcommand, **kwargs):
+        parser = super().create_parser(prog_name, subcommand, **kwargs)
+        # adding `formatter_class` to kwargs causes BaseCommand to specify it twice
+        parser.formatter_class = argparse.RawDescriptionHelpFormatter
+        return parser
+
+    def add_arguments(self, parser):
+        parser.add_argument("-o", "--outfile", metavar="FILE",
+            help="write output to %(metavar)s rather than STDOUT")
+        parser.add_argument("-z", "--gzip", action="store_true", default=False,
+            help="gzip-compress the output (only valid with --outfile option)")
+        parser.add_argument("-s", "--start", metavar="YYYY-MM-DD", type=date_type,
+            help="query login events starting %(metavar)s")
+        parser.add_argument("-e", "--end", metavar="YYYY-MM-DD", type=date_type,
+            help="query login events ending %(metavar)s")
+        parser.add_argument("domains", metavar="DOMAIN", nargs="+",
+            help="query login events for %(metavar)s(s)")
+
+    def handle(self, **options):
+        outfile = options["outfile"]
+        if outfile is None:
+            outfile = self.stdout
+
+            @contextmanager
+            def opener(file, mode):
+                yield file
+
+            if options["gzip"]:
+                raise CommandError("--gzip option requires specifying --outfile")
+        else:
+            if options["gzip"]:
+                opener = gzip.open
+            else:
+                opener = open
+
+        domains = self.validate_domains(options["domains"])
+        with opener(outfile, "wt") as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow(["Date", "Domain", "Username"])
+            for event in get_domain_first_access_times(domains, options["start"],
+                                                       options["end"]):
+                writer.writerow([
+                    event["access_time"],
+                    event["domain"],
+                    event["user"],
+                ])
+
+    @staticmethod
+    def validate_domains(domains):
+        for domain in domains:
+            if not Domain.get_by_name(domain):
+                raise CommandError(f"Invalid domain name: {domain}")
+        return domains

--- a/corehq/apps/auditcare/management/commands/generate_request_report.py
+++ b/corehq/apps/auditcare/management/commands/generate_request_report.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
             - Specifying the --domain option excludes all non-domain navigation events
               (admin activities, account/profile management, etc).
             - Specifying the --domain option without the --user option will result in a
-              report limited to "users associated with that domain" and superusers.
+              report limited to "users associated with that domain" (not including enterprise users) and superusers.
     """)
 
     def create_parser(self, prog_name, subcommand, **kwargs):

--- a/corehq/apps/auditcare/management/commands/generate_request_report.py
+++ b/corehq/apps/auditcare/management/commands/generate_request_report.py
@@ -1,18 +1,41 @@
+import argparse
 import csv
+import gzip
+from textwrap import dedent
 
 from django.core.management.base import BaseCommand, CommandError
 
 from corehq.apps.domain.models import Domain
 from corehq.util.argparse_types import date_type
 
-from ...utils.export import get_users_to_export, write_log_events
+from ...utils.export import get_users_to_for_domain, write_log_events
 
 
 class Command(BaseCommand):
-    help = """Generate request report"""
+
+    help = dedent("""\
+        Generate request report of NavigationEventAudit events
+
+        NOTES
+            - AccessAudit events are not included in this report.
+            - All filtering options are AND'd together (important to consider when
+              combining both --user and --domain options).
+            - Specifying the --domain option excludes all non-domain navigation events
+              (admin activities, account/profile management, etc).
+            - Specifying the --domain option without the --user option will result in a
+              report limited to "users associated with that domain" and superusers.
+    """)
+
+    def create_parser(self, prog_name, subcommand, **kwargs):
+        parser = super().create_parser(prog_name, subcommand, **kwargs)
+        # cannot add `formatter_class` to kwargs because BaseCommand will specify it twice
+        parser.formatter_class = argparse.RawDescriptionHelpFormatter
+        return parser
 
     def add_arguments(self, parser):
         parser.add_argument('filename', help="Output file path")
+        parser.add_argument('-z', '--gzip', action="store_true", default=False,
+            help="gzip-compress the output")
         parser.add_argument('-d', '--domain', dest='domain', help="Limit logs to only this domain")
         parser.add_argument('-u', '--user', dest='user', help="Limit logs to only this user")
         parser.add_argument(
@@ -39,28 +62,39 @@ class Command(BaseCommand):
 
     def handle(self, filename, **options):
         domain = options["domain"]
-        user = options["user"]
+        username = options["user"]
         display_superuser = options["display_superuser"]
 
         dimagi_username = ""
         if not display_superuser:
             dimagi_username = "Dimagi Support"
 
-        if not domain and not user:
-            raise CommandError("Please provide one of 'domain' or 'user'")
+        if not domain and not username:
+            raise CommandError("Please provide one of 'domain' or 'username'")
 
         if domain:
             domain_object = Domain.get_by_name(domain)
             if not domain_object:
                 raise CommandError("Domain not found")
 
-        users, removed_users, super_users = get_users_to_export(user, domain)
+        if username:
+            users = [username]
+        else:
+            users, removed_users, super_users = get_users_to_for_domain(domain)
 
-        with open(filename, 'w') as csvfile:
+        if options["gzip"]:
+            opener = gzip.open
+        else:
+            opener = open
+
+        with opener(filename, "wt") as csvfile:
             writer = csv.writer(csvfile)
             writer.writerow(['Date', 'User', 'Domain', 'IP Address', 'Request Path'])
             for user in users:
                 write_log_events(writer, user, domain, start_date=options['start'], end_date=options['end'])
+            if not username:
+                # no `removed_users` or `super_users` when `username` is provided
+                return
 
             for user in removed_users:
                 write_log_events(

--- a/corehq/apps/auditcare/management/commands/generate_request_report.py
+++ b/corehq/apps/auditcare/management/commands/generate_request_report.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand, CommandError
 from corehq.apps.domain.models import Domain
 from corehq.util.argparse_types import date_type
 
-from ...utils.export import get_users_to_for_domain, write_log_events
+from ...utils.export import get_users_for_domain, write_log_events
 
 
 class Command(BaseCommand):
@@ -81,7 +81,7 @@ class Command(BaseCommand):
         if username:
             users = [username]
         else:
-            users, removed_users, super_users = get_users_to_for_domain(domain)
+            users, removed_users, super_users = get_users_for_domain(domain)
 
         if options["gzip"]:
             opener = gzip.open

--- a/corehq/apps/auditcare/management/commands/generate_request_report.py
+++ b/corehq/apps/auditcare/management/commands/generate_request_report.py
@@ -23,7 +23,8 @@ class Command(BaseCommand):
             - Specifying the --domain option excludes all non-domain navigation events
               (admin activities, account/profile management, etc).
             - Specifying the --domain option without the --user option will result in a
-              report limited to "users associated with that domain" (not including enterprise users) and superusers.
+              report limited to "users associated with that domain" (not including
+              enterprise users) and superusers.
     """)
 
     def create_parser(self, prog_name, subcommand, **kwargs):

--- a/corehq/apps/auditcare/tests/test_export.py
+++ b/corehq/apps/auditcare/tests/test_export.py
@@ -261,12 +261,12 @@ class TestNavigationEventsQueries(AuditcareTest):
                 session_key=uuid.uuid4().hex,
                 event_date=datetime.utcnow(),
             )
-            for domain, minutes in [(None, -1),
-                                    (domain, 0),
-                                    (domain, 1)]:
+            for event_domain, minutes in [(None, -1),
+                                          (domain, 0),
+                                          (domain, 1)]:
                 fields = login_event.copy()
                 # save one event with domain/date changed by loop params:
-                fields["domain"] = domain
+                fields["domain"] = event_domain
                 fields['event_date'] += timedelta(minutes=minutes)
                 NavigationEventAudit(**fields).save()
                 # update the fields and save another:

--- a/corehq/apps/auditcare/tests/test_export.py
+++ b/corehq/apps/auditcare/tests/test_export.py
@@ -251,6 +251,16 @@ class TestNavigationEventsQueries(AuditcareTest):
         self.assertEqual(get_sql_start_date(), datetime(2021, 2, 1, 3))
 
 
+class TestNavigationEventsQueriesWithoutData(AuditcareTest):
+
+    def test_get_all_log_events_returns_empty(self):
+        start = end = datetime.utcnow()
+        self.assertEqual(list(get_all_log_events(start, end)), [])
+
+    def test_get_sql_start_date_returns_datetime(self):
+        self.assertIsInstance(get_sql_start_date(), datetime)
+
+
 @contextmanager
 def patch_window_size(size):
     with patch.object(AuditWindowQuery.__init__, "__defaults__", (size,)):

--- a/corehq/apps/auditcare/tests/test_export.py
+++ b/corehq/apps/auditcare/tests/test_export.py
@@ -282,9 +282,11 @@ class TestNavigationEventsQueries(AuditcareTest):
         login_events = []
         for x in range(2):
             login_event = create_session_events(domain)
-            # rename `access_time` to `event_date`
+            # rename `event_date` to `access_time` (name of aggregation field)
             login_event["access_time"] = login_event.pop("event_date")
             login_events.append(login_event)
+            # remove the session key (not returned by the query)
+            del login_event["session_key"]
         self.assertEqual(list(get_domain_first_access_times([domain])), login_events)
 
 

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -75,7 +75,7 @@ def get_domain_first_access_times(domains, start_date=None, end_date=None):
     NOTE: This function does _not_ query couch.
 
     NOTE: This function may return multiple "access events" from the same
-          session (if multiple of `domains` were accessed in the same session).
+          session (if multiple `domains` were accessed in the same session).
 
     Resulting SQL query:
 
@@ -89,7 +89,7 @@ def get_domain_first_access_times(domains, start_date=None, end_date=None):
     WHERE (
         domain IN ( {domains} )
         AND event_date > {start_date}
-        AND event_date < {end_date}
+        AND event_date <= {end_date}
         AND "user" IS NOT NULL
         AND session_key IS NOT NULL
     )

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -45,7 +45,7 @@ def write_log_event(writer, event, override_user=None):
     writer.writerow([event.event_date, event.user, event.domain, event.ip_address, event.request_path])
 
 
-def get_users_to_for_domain(domain):
+def get_users_for_domain(domain):
     users = {u.username for u in WebUser.by_domain(domain)}
     super_users = {u['username'] for u in User.objects.filter(is_superuser=True).values('username')}
     users_who_accepted_invitations = set(Invitation.objects.filter(

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -45,17 +45,15 @@ def write_log_event(writer, event, override_user=None):
     writer.writerow([event.event_date, event.user, event.domain, event.ip_address, event.request_path])
 
 
-def get_users_to_export(username, domain):
-    if username:
-        users = [username]
-        removed_users = []
-        super_users = []
-    else:
-        users = {u.username for u in WebUser.by_domain(domain)}
-        super_users = {u['username'] for u in User.objects.filter(is_superuser=True).values('username')}
-        users_who_accepted_invitations = set(Invitation.objects.filter(is_accepted=True, domain=domain).values_list('email', flat=True))
-        removed_users = users_who_accepted_invitations - users
-        super_users = super_users - users
+def get_users_to_for_domain(domain):
+    users = {u.username for u in WebUser.by_domain(domain)}
+    super_users = {u['username'] for u in User.objects.filter(is_superuser=True).values('username')}
+    users_who_accepted_invitations = set(Invitation.objects.filter(
+        is_accepted=True,
+        domain=domain).values_list('email', flat=True)
+    )
+    removed_users = users_who_accepted_invitations - users
+    super_users = super_users - users
     return users, removed_users, super_users
 
 

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -201,7 +201,7 @@ def get_sql_start_date():
         return fixed_sql_start
     manager = NavigationEventAudit.objects
     row = manager.order_by("event_date").values("event_date")[:1].first()
-    return row["event_date"] if row else None
+    return row["event_date"] if row else datetime.utcnow()
 
 
 class CouchAuditEvent:

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -81,10 +81,9 @@ def get_domain_first_access_times(domains, start_date=None, end_date=None):
 
     ```sql
     SELECT
-        MIN(event_date) AS access_time,
         "user",
         domain,
-        session_key
+        MIN(event_date) AS access_time
     FROM auditcare_navigationeventaudit
     WHERE (
         domain IN ( {domains} )
@@ -103,8 +102,9 @@ def get_domain_first_access_times(domains, start_date=None, end_date=None):
     where["user__isnull"] = False
     where["session_key__isnull"] = False
     return (NavigationEventAudit.objects
-            .values("user", "domain", "session_key")
+            .values("user", "domain", "session_key")  # GROUP BY fields
             .annotate(access_time=Min("event_date"))
+            .values("user", "domain", "access_time")  # SELECT fields
             .filter(**where)
             .order_by("access_time")
             .iterator())


### PR DESCRIPTION
## Technical Summary

- Adds more help text with clarifying notes in existing `generate_request_report` management command to help developers identify when the command may or may not be useful.
- Fixes confusing crash bug in `get_sql_start_date()`
- Adds new `export_domain_logins` management command and requisite `get_domain_first_access_times()` export function for fetching "domain login" events.

Jira [SAAS-12719](https://dimagi-dev.atlassian.net/browse/SAAS-12719)

## Safety Assurance

### Safety story

Read-only management commands for developers. Invisible and safe.

### Automated test coverage

Adds new tests and fixes auditcare export utility which would crash with obscure `TypeError` exception when `auditcare_navigationeventaudit` table is empty.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
