### PR TITLE
remove registry access check in get_granted_domains

### DIFF
--- a/corehq/apps/registry/models.py
+++ b/corehq/apps/registry/models.py
@@ -110,7 +110,6 @@ class DataRegistry(models.Model):
         return RegistrySchema(self.schema)
 
     def get_granted_domains(self, domain):
-        self.check_domain_has_access(domain)
         return set(
             self.grants.filter(to_domains__contains=[domain])
             .values_list('from_domain', flat=True)
@@ -120,17 +119,6 @@ class DataRegistry(models.Model):
         return set(self.invitations.filter(
             status=RegistryInvitation.STATUS_ACCEPTED,
         ).values_list('domain', flat=True))
-
-    def check_domain_has_access(self, domain):
-        if not self.is_active:
-            raise RegistryAccessDenied()
-        invites = self.invitations.filter(domain=domain)
-        if not invites:
-            raise RegistryAccessDenied()
-        invite = invites[0]
-        if invite.status != RegistryInvitation.STATUS_ACCEPTED:
-            raise RegistryAccessDenied()
-        return True
 
     def check_ownership(self, domain):
         if self.domain != domain:

--- a/corehq/apps/registry/tests/test_models.py
+++ b/corehq/apps/registry/tests/test_models.py
@@ -88,28 +88,6 @@ class RegistryModelsTests(TestCase):
         create_registry_for_test(self.user, self.domain, grants=[Grant("B", ["A"])])
         self.assertEqual(0, len(DataRegistry.objects.accessible_to_domain("A", has_grants=True)))
 
-    def test_check_access(self):
-        registry = create_registry_for_test(self.user, self.domain, [Invitation("A")])
-        self.assertTrue(registry.check_domain_has_access("A"))
-        with self.assertRaises(RegistryAccessDenied):
-            registry.check_domain_has_access("B")
-
-    def test_check_access_inactive(self):
-        registry = create_registry_for_test(self.user, self.domain, [Invitation("A")])
-        registry.deactivate(self.user)
-        with self.assertRaises(RegistryAccessDenied):
-            registry.check_domain_has_access("A")
-
-    def test_check_access_invite_not_accepted(self):
-        registry = create_registry_for_test(self.user, self.domain, [Invitation("A", accepted=False)])
-        with self.assertRaises(RegistryAccessDenied):
-            registry.check_domain_has_access("A")
-
-    def test_check_access_invite_rejected(self):
-        registry = create_registry_for_test(self.user, self.domain, [Invitation("A", rejected=True)])
-        with self.assertRaises(RegistryAccessDenied):
-            registry.check_domain_has_access("A")
-
     def test_get_granted_domains(self):
         invitations = [Invitation('A'), Invitation('B'), Invitation('C')]
         grants = [


### PR DESCRIPTION
## Product Description
Don't error when apps make requests to domains that have opted out of registries.

## Technical Summary
Removes the access check from `get_granted_domains`. This is safe because the access checks have already been prior to calling this method. 

It is also not practical to do access checks here since we can't tell if we should allow access to inactive/opted out registries.

## Feature Flag
DATA_REGISTRY

## Safety Assurance

### Safety story
Impact to data registries only

### Automated test coverage
Remove tests that cover the access check

### QA Plan
None

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
