### PR TITLE
Updated smart link generation to include endpoint args

### DIFF
--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -61,28 +61,22 @@ class SuiteGenerator(object):
         self.suite = Suite(version=self.app.version, descriptor=self.descriptor)
         self.build_profile_id = build_profile_id
 
-    def _add_sections(self, contributors):
-        elements = {}
-        for contributor in contributors:
-            section = contributor.section_name
-            section_elements = contributor.get_section_elements()
-            elements[section] = section_elements
-            getattr(self.suite, section).extend(section_elements)
-        return elements
+    def add_section(self, contributor_cls):
+        contributor = contributor_cls(self.suite, self.app, self.modules, self.build_profile_id)
+        section = contributor.section_name
+        section_elements = contributor.get_section_elements()
+        getattr(self.suite, section).extend(section_elements)
+        return section_elements
 
     def generate_suite(self):
         # Note: the order in which things happen in this function matters
 
-        basic_elements = self._add_sections([
-            FormResourceContributor(self.suite, self.app, self.modules, self.build_profile_id),
-            LocaleResourceContributor(self.suite, self.app, self.modules, self.build_profile_id),
-            DetailContributor(self.suite, self.app, self.modules, self.build_profile_id),
-        ])
+        self.add_section(FormResourceContributor)
+        self.add_section(LocaleResourceContributor)
+        detail_section_elements = self.add_section(DetailContributor)
 
         if self.app.supports_practice_users and self.app.get_practice_user(self.build_profile_id):
-            self._add_sections([
-                PracticeUserRestoreContributor(self.suite, self.app, self.modules, self.build_profile_id)
-            ])
+            self.add_section(PracticeUserRestoreContributor)
 
         # by module
         entries = EntriesContributor(self.suite, self.app, self.modules, self.build_profile_id)
@@ -104,12 +98,9 @@ class SuiteGenerator(object):
         if training_menu:
             self.suite.menus.append(training_menu)
 
-        self._add_sections([
-            FixtureContributor(self.suite, self.app, self.modules),
-            SchedulerFixtureContributor(self.suite, self.app, self.modules),
-        ])
+        self.add_section(FixtureContributor)
+        self.add_section(SchedulerFixtureContributor)
 
-        detail_section_elements = basic_elements[DetailContributor.section_name]
         RemoteRequestsHelper(self.suite, self.app, self.modules).update_suite(detail_section_elements)
 
         if self.app.supports_session_endpoints:

--- a/corehq/apps/app_manager/suite_xml/post_process/endpoints.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/endpoints.py
@@ -41,7 +41,7 @@ class EndpointsHelper(PostProcessor):
 
         stack = Stack()
         children = self.get_frame_children(module, form)
-        argument_ids = self._get_argument_ids(children)
+        argument_ids = self.get_argument_ids(children)
 
         # Add a claim request for each endpoint argument.
         # This assumes that all arguments are case ids.
@@ -64,7 +64,7 @@ class EndpointsHelper(PostProcessor):
         }
         return SessionEndpoint(**kwargs)
 
-    def _get_argument_ids(self, frame_children):
+    def get_argument_ids(self, frame_children):
         return [
             child.id for child in frame_children
             if isinstance(child, WorkflowDatumMeta) and child.requires_selection

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -291,7 +291,7 @@ class RemoteRequestFactory(object):
         if argument_ids:
             params = f", '?{argument_ids[-1]}=', ${argument_ids[-1]}"
             for argument_id in argument_ids[:-1]:
-                params = f", '&{argument_id}=', ${argument_id}"
+                params += f", '&{argument_id}=', ${argument_id}"
         return f"concat('{prefix}', $domain, '{suffix}'{params})"
 
     def get_smart_link_variables(self):

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -71,7 +71,8 @@ class QuerySessionXPath(InstanceXpath):
 
 
 class RemoteRequestFactory(object):
-    def __init__(self, module, detail_section_elements):
+    def __init__(self, suite, module, detail_section_elements):
+        self.suite = suite
         self.app = module.get_app()
         self.domain = self.app.domain
         self.module = module
@@ -296,8 +297,8 @@ class RemoteRequestFactory(object):
 
 
 class SessionEndpointRemoteRequestFactory(RemoteRequestFactory):
-    def __init__(self, module, detail_section_elements, endpoint_id, case_session_var):
-        super().__init__(module, detail_section_elements)
+    def __init__(self, suite, module, detail_section_elements, endpoint_id, case_session_var):
+        super().__init__(suite, module, detail_section_elements)
         self.endpoint_id = endpoint_id
         self.case_session_var = case_session_var
 
@@ -351,7 +352,7 @@ class RemoteRequestsHelper(PostProcessor):
         for module in self.modules:
             if module_offers_search(module) or module_uses_smart_links(module):
                 self.suite.remote_requests.append(RemoteRequestFactory(
-                    module, detail_section_elements).build_remote_request()
+                    self.suite, module, detail_section_elements).build_remote_request()
                 )
             if module.session_endpoint_id:
                 self.suite.remote_requests.extend(
@@ -370,6 +371,6 @@ class RemoteRequestsHelper(PostProcessor):
         for child in children:
             if isinstance(child, WorkflowDatumMeta) and child.requires_selection:
                 elements.append(SessionEndpointRemoteRequestFactory(
-                    module, detail_section_elements, endpoint_id, child.id).build_remote_request(),
+                    self.suite, module, detail_section_elements, endpoint_id, child.id).build_remote_request(),
                 )
         return elements

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -541,7 +541,7 @@ class EntriesHelper(object):
         details screen. The case details is then populated with data from the results of the query.
         """
         from corehq.apps.app_manager.suite_xml.post_process.remote_requests import RemoteRequestFactory
-        factory = RemoteRequestFactory(module, [])
+        factory = RemoteRequestFactory(None, module, [])
         query = factory.build_remote_request_queries()[0]
         return FormDatumMeta(datum=query, case_type=None, requires_selection=False, action=None)
 


### PR DESCRIPTION
PR into https://github.com/dimagi/commcare-hq/pull/30657, removed safety info

https://docs.google.com/document/d/11uf45JcGJqqzn1TpeKeQi0mvIchM-D1UOrS7Vw99ln4/edit?disco=AAAAQK6qumM

This adds endpoint args to the smart link URL on the HQ side instead of the formplayer side. 

Previously, [this code](https://github.com/dimagi/formplayer/blob/51bc4ad199e258389515b51d33572ec7d9b15a50/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java#L503-L506) would add session data as URL params, so the URL could be defined like this:
```<text>
  <xpath function="concat('http://localhost:8000/a/', $domain, '/app/v1/32d29ff8e7ca4a0cab792b1dbbae00fd/endpoint_songs/')">
    <variable name="domain">
      <xpath function="instance('results')/results/case[@case_id=instance('commcaresession')/session/data/search_case_id]/commcare_project"/>
    </variable>
  </xpath>
</text>
```

Now, the URL definition also includes the endpoint arg(s):
```<text>
  <xpath function="concat('http://localhost:8000/a/', $domain, '/app/v1/32d29ff8e7ca4a0cab792b1dbbae00fd/endpoint_songs/', '?case_id=', $case_id)">
    <variable name="domain">
      <xpath function="instance('results')/results/case[@case_id=instance('commcaresession')/session/data/search_case_id]/commcare_project"/>
    </variable>
    <variable name="case_id">
      <xpath function="instance('commcaresession')/session/data/search_case_id"/>
    </variable>
  </xpath>
</text>
```