### PR TITLE
Add pickle5 support for Python 3.6

### DIFF
--- a/corehq/tests/test_pickle.py
+++ b/corehq/tests/test_pickle.py
@@ -1,5 +1,7 @@
 import pickle
 
+from django.conf import settings
+from django_redis.serializers.pickle import PickleSerializer
 from testil import eq
 
 
@@ -23,3 +25,16 @@ def test_dump_and_load_all_protocols():
 
     for protocol in range(1, pickle.HIGHEST_PROTOCOL + 1):
         yield test, protocol
+
+
+def test_django_redis_protocol():
+    # Override default pickle protocol to allow smoother Python upgrades.
+    # Heroics like this will not be necessary once we have upgraded to a
+    # version of django_redis that uses pickle.DEFAULT_PROTOCOL. See:
+    # https://github.com/jazzband/django-redis/issues/547
+    # https://github.com/jazzband/django-redis/pull/555
+    #
+    # This test may be removed after upgrading django_redis.
+    # In the mean time, test for effective protocol override in settings.py
+    pkl = PickleSerializer(settings.CACHES['default'].get("OPTIONS", {}))
+    eq(pkl.dumps(False)[1], pickle.DEFAULT_PROTOCOL)

--- a/corehq/tests/test_pickle.py
+++ b/corehq/tests/test_pickle.py
@@ -1,0 +1,25 @@
+import pickle
+
+from testil import eq
+
+
+def test_highest_protocol():
+    assert pickle.HIGHEST_PROTOCOL <= 5, """
+        The highest pickle procol supported by Python at time of writing
+        this test is 5. Support for newer protocols must be added or the
+        default version used by libraries such as django_redis must be
+        limited to 5 or less so pickles written by a newer Python can be
+        read by an older Python after a downgrade.
+    """
+
+
+def test_pickle_5():
+    eq(pickle.loads(b'\x80\x05\x89.'), False)
+
+
+def test_dump_and_load_all_protocols():
+    def test(protocol):
+        eq(pickle.loads(pickle.dumps(False, protocol=protocol)), False)
+
+    for protocol in range(1, pickle.HIGHEST_PROTOCOL + 1):
+        yield test, protocol

--- a/manage.py
+++ b/manage.py
@@ -113,11 +113,23 @@ def run_patches():
     import mimetypes
     mimetypes.init()
 
+    patch_pickle()
     patch_jsonfield()
 
     import django
     _setup_once.setup = django.setup
     django.setup = _setup_once
+
+
+def patch_pickle():
+    """Patch pickle to support protocol 5
+
+    Remove after upgrading to Python 3.8+
+    """
+    import pickle
+    if pickle.HIGHEST_PROTOCOL < 5:
+        import pickle5
+        sys.modules["pickle"] = pickle5
 
 
 def patch_jsonfield():

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -74,6 +74,7 @@ lxml~=4.6.3
 mock==2.0.0
 openpyxl~=3.0
 phonenumberslite~=8.12
+pickle5  # For Pythons pre 3.8.3. Can be removed when no environment will ever revert to < 3.8
 Pillow>=8.3.2
 polib==1.1.0
 prometheus-client==0.7.1

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -354,6 +354,8 @@ pexpect==4.8.0
     # via ipython
 phonenumberslite==8.12.10
     # via -r base-requirements.in
+pickle5==0.0.11
+    # via -r base-requirements.in
 pickleshare==0.7.5
     # via ipython
 pillow==8.3.2

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -290,6 +290,8 @@ pbr==5.5.0
     # via mock
 phonenumberslite==8.12.10
     # via -r base-requirements.in
+pickle5==0.0.11
+    # via -r base-requirements.in
 pillow==8.3.2
     # via
     #   -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -291,6 +291,8 @@ pexpect==4.8.0
     # via ipython
 phonenumberslite==8.12.10
     # via -r base-requirements.in
+pickle5==0.0.11
+    # via -r base-requirements.in
 pickleshare==0.7.5
     # via ipython
 pillow==8.3.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -267,6 +267,8 @@ pbr==5.5.0
     # via mock
 phonenumberslite==8.12.10
     # via -r base-requirements.in
+pickle5==0.0.11
+    # via -r base-requirements.in
 pillow==8.3.2
     # via
     #   -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -298,6 +298,8 @@ pep517==0.10.0
     # via pip-tools
 phonenumberslite==8.12.10
     # via -r base-requirements.in
+pickle5==0.0.11
+    # via -r base-requirements.in
 pillow==8.3.2
     # via
     #   -r base-requirements.in

--- a/settings.py
+++ b/settings.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# flake8: noqa: F405
 
 import inspect
 from collections import defaultdict
@@ -2023,6 +2024,15 @@ if 'locmem' not in CACHES:
     CACHES['locmem'] = {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}
 if 'dummy' not in CACHES:
     CACHES['dummy'] = {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}
+
+# Make django_redis use pickle.DEFAULT_PROTOCOL by default.
+# Remove after upgrading django_redis to a version that does that.
+# See also corehq.tests.test_pickle.test_django_redis_protocol
+from pickle import DEFAULT_PROTOCOL as _protocol
+for _value in CACHES.values():
+    if _value.get("BACKEND", "").startswith("django_redis"):
+        _value.setdefault("OPTIONS", {}).setdefault("PICKLE_VERSION", _protocol)
+del _value, _protocol
 
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
Add pickle protocol 5 for older Pythons

The highest protocol on Python 3.6 is 4. The pickle5 library backports protocol 5, which was added in Python 3.8.

The tests added here are intended to fail when a new protocol becomes available (for example, when upgrading Python). This is so libraries like `django_redis`, which uses the highest available protocol by default, are able to read pickles written after upgrading and then reverting due to some unforeseen issue forcing a downgrade.

:blowfish: Review by commit

## Safety Assurance

### Automated test coverage

Tests added to detect when a new version of Python increases the highest pickle protocol version beyond one we currently support.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
