### PR TITLE
set date_opened and date_modified for cases updated by DR

### DIFF
--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -485,15 +485,17 @@ class CaseUpdateConfig:
                 raise DataRegistryCaseUpdateError("'owner_id' required when creating cases")
 
             kwargs = {
+                "create": True,
                 "case_type": self.case_type,
+                "date_opened": self.intent_case.opened_on
             }
         return CaseBlock(
-            create=target_case is None,
             case_id=self.case_id,
             owner_id=self.owner_id,
             update=self.get_case_updates(),
             index=self.get_case_indices(target_case),
             close=bool(self.close_case),
+            date_modified=self.intent_case.modified_on,
             **kwargs
         ).as_text()
 

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
@@ -111,11 +111,11 @@ class DataRegistryCaseUpdateRepeaterTest(TestCase, TestXmlMixin, DomainSubscript
                 relationship=CASE_INDEX_EXTENSION,
             )]
         )
-        factory.create_or_update_case(extension, user_id=self.mobile_user.get_id)
+        cases = factory.create_or_update_case(extension, user_id=self.mobile_user.get_id)
         repeat_records = self.repeat_records(self.domain).all()
         self.assertEqual(len(repeat_records), 1)
         payload = repeat_records[0].get_payload()
-        form = DataRegistryUpdateForm(payload)
+        form = DataRegistryUpdateForm(payload, cases[0])
         form.assert_case_updates({
             self.target_case_id_1: {"new_prop": "new_val_case1"},
             self.target_case_id_2: {"new_prop": "new_val_case2"}


### PR DESCRIPTION
## Technical Summary
Preserve dates from the intent case when creating / updating the target case.

## Feature Flag
DATA_REGISTRY

## Safety Assurance

### Safety story
Covered by tests and changes limited to restricted feature.

### Automated test coverage
Updated

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
