### PR TITLE
Use html.escape instead of cgi.escape

### DIFF
--- a/corehq/apps/reports/standard/message_event_display.py
+++ b/corehq/apps/reports/standard/message_event_display.py
@@ -1,4 +1,4 @@
-import cgi
+import html
 from collections import namedtuple
 
 from django.urls import reverse
@@ -74,7 +74,7 @@ def get_status_display(event, sms=None):
     # Sometimes the additional information from touchforms has < or >
     # characters, so we need to escape them for display
     if error_message:
-        return '%s - %s' % (_(status), cgi.escape(error_message))
+        return '%s - %s' % (_(status), html.escape(error_message))
     else:
         return _(status)
 

--- a/corehq/apps/reports/tests/test_message_event_display.py
+++ b/corehq/apps/reports/tests/test_message_event_display.py
@@ -1,0 +1,14 @@
+from testil import eq
+
+from corehq.apps.sms.models import MessagingEvent
+from ..standard.message_event_display import get_status_display
+
+
+def test_get_status_display_escapes_error_message():
+    class fake_event:
+        status = MessagingEvent.STATUS_ERROR
+        error_code = None
+        additional_error_text = "<&>"
+
+    result = get_status_display(fake_event)
+    eq(result, "Error - View details for more information. &lt;&amp;&gt;")


### PR DESCRIPTION
cgi.escape has been deprecated since Python 3.2 and was removed in Python 3.8
https://docs.python.org/3.7/library/cgi.html#cgi.escape

Found while looking through Sentry for errors caused by the upgrade to Python 3.9
https://sentry.io/organizations/dimagi/issues/2769196152/?environment=staging&project=136860&query=is%3Aunresolved

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Minor bugfix. Very low risk.

### Automated test coverage

~None.~ Yes.

### QA Plan

None.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
