### PR TITLE
[Hubspot] update rejected.get_user_hubspot_id to use metrics_counter instead of metrics_gauge

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -214,9 +214,8 @@ def _get_user_hubspot_id(web_user, retry_num=0):
         else:
             return req.json().get("vid", None)
     elif api_key:
-        metrics_gauge(
+        metrics_counter(
             'commcare.hubspot_data.rejected.get_user_hubspot_id',
-            1,
             tags={
                 'username': web_user.username,
             }


### PR DESCRIPTION
=## Technical Summary
Just updating another spot where we send datadog metrics about hubspot. Instead of `metrics_gauge` we should use `metrics_counter` instead.

## Safety Assurance

### Safety story
Super simple datadog-only change.

### Automated test coverage
no

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
