### PR TITLE
Tabular structure for more than one check box question

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -397,7 +397,9 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         self.isMulti = true;
         self.hideLabel = options.hideLabel;
 
-        self.colStyleIfHideLabel = self.hideLabel ? self.getColStyle(self.choices().length) : null;
+        self.colStyleIfHideLabel = ko.computed(function () {
+            return self.hideLabel ? self.getColStyle(self.choices().length) : null;
+        });
 
         self.onClear = function () {
             self.rawAnswer([]);
@@ -497,7 +499,9 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
 
         self.hideLabel = options.hideLabel;
 
-        self.colStyle = self.getColStyle(self.choices().length);
+        self.colStyle = ko.computed(function () {
+            return self.getColStyle(self.choices().length);
+        });
 
         self.onClear = function () {
             self.rawAnswer(Const.NO_ANSWER);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -390,6 +390,20 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         self.isMulti = true;
         self.hideLabel = ko.observable(options.hideLabel);
 
+        // A custom binding to add a column layout class only if hideLabel = true
+        ko.bindingHandlers.addColStyle = {
+            update: function(element, valueAccessor) {
+                var value = valueAccessor();
+                var shouldAddColStyle = ko.unwrap(value);
+
+                if (shouldAddColStyle) {
+                    // Account for number of choices plus column for clear button
+                    var colWidth = parseInt(12 / (self.choices().length + 1)) || 1;
+                    $(element).addClass('col-xs-' + colWidth)
+                }
+            }
+        }
+
         self.onClear = function () {
             self.rawAnswer([]);
         };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -388,6 +388,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         self.templateType = 'select';
         self.choices = question.choices;
         self.isMulti = true;
+        self.hideLabel = ko.observable(options.hideLabel);
 
         self.onClear = function () {
             self.rawAnswer([]);
@@ -1059,8 +1060,23 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
                 break;
             case Const.MULTI_SELECT:
                 isMinimal = style === Const.MINIMAL;
+                if (style) {
+                    isLabel = style === Const.LABEL;
+                    hideLabel = style === Const.LIST_NOLABEL;
+                }
+
                 if (isMinimal) {
                     entry = new MultiDropdownEntry(question, {});
+                } else if (isLabel) {
+                    // ChoiceLabelEntry is usually only for radio-type inputs, but utilizing here because
+                    //  it will just be label text.
+                    entry = new ChoiceLabelEntry(question, {
+                        hideLabel: false,
+                    });
+                } else if (hideLabel) {
+                    entry = new MultiSelectEntry(question, {
+                        hideLabel: true,
+                    });
                 } else {
                     entry = new MultiSelectEntry(question, {});
                 }

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -419,7 +419,7 @@
   <legend aria-hidden="true" class="sr-only">{% trans "Answer Choices" %}</legend>
     <div class="sel clear">
       <div data-bind="foreach: choices, as: 'choice'">
-        <div data-bind="css: { checkbox: $parent.isMulti, radio: !$parent.isMulti }, addColStyle: $parent.hideLabel">
+        <div data-bind="css: { checkbox: $parent.isMulti, radio: !$parent.isMulti }, class: $parent.colStyleIfHideLabel">
           <label>
               <input data-bind="
                           checked: $parent.rawAnswer,

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -421,18 +421,21 @@
       <div data-bind="foreach: choices, as: 'choice'">
         <div data-bind="css: { checkbox: $parent.isMulti, radio: !$parent.isMulti }">
           <label>
-            <input data-bind="
-                        checked: $parent.rawAnswer,
-                        checkedValue: $index() + 1,
-                        attr: {
-                            id: 'group-' + $parent.entryId + '-choice-' + $index(),
-                            type: $parent.isMulti ? 'checkbox' : 'radio',
-                            name: $parent.entryId,
-                            class: 'group-' + $parent.entryId,
-                        },
-                    "/>
-            <span data-bind="renderMarkdown: $data"></span>
+              <input data-bind="
+                          checked: $parent.rawAnswer,
+                          checkedValue: $index() + 1,
+                          attr: {
+                              id: 'group-' + $parent.entryId + '-choice-' + $index(),
+                              type: $parent.isMulti ? 'checkbox' : 'radio',
+                              name: $parent.entryId,
+                              class: 'group-' + $parent.entryId,
+                          },
+                      "/>
+            <!-- ko ifnot: $parent.hideLabel -->
+              <span data-bind="renderMarkdown: $data"></span>
+            <!-- /ko -->
           </label>
+          </div>
         </div>
       </div>
       <button class="btn btn-default btn-xs pull-right" data-bind="click: onClear, fadeVisible: !isMulti && rawAnswer()">

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -419,7 +419,7 @@
   <legend aria-hidden="true" class="sr-only">{% trans "Answer Choices" %}</legend>
     <div class="sel clear">
       <div data-bind="foreach: choices, as: 'choice'">
-        <div data-bind="css: { checkbox: $parent.isMulti, radio: !$parent.isMulti }">
+        <div data-bind="css: { checkbox: $parent.isMulti, radio: !$parent.isMulti }, addColStyle: $parent.hideLabel">
           <label>
               <input data-bind="
                           checked: $parent.rawAnswer,


### PR DESCRIPTION
## Product Description

Currently, app builders have the ability to create a “tabular structure” for multiple-choice questions. This uses the app manager features: Question List Group and Appearance Attributes (instructions on how to create a tabular stucture [here](https://confluence.dimagi.com/display/commcarepublic/Advanced+CommCare+Formatting#AdvancedCommCareFormatting-CombinedMultipleChoiceusingaQuestionListGroup)). Using this structure an app builder can specify more than one multiple choice answer for a single question. Here's an example:  

<img src="https://user-images.githubusercontent.com/6729291/140939380-00261632-8cd6-4d31-9048-58da4155b52c.png" width=500>

However, this is currently only possible with a multiple-choice option where a single answer is selected (a "radio" input). It is not currently possible with checkboxes. The closest you can get is this kind of display:

<img src="https://user-images.githubusercontent.com/6729291/140939558-4b07953f-e7d1-475a-aef7-5259a5d54d49.png" width=400>

With the addition of this PR, app builders can create a tabular structure for checkbox questions, by using the same Question List Group and Appearance Attribute settings as they do for non-checkbox multiple-choice questions.

<img src="https://user-images.githubusercontent.com/6729291/140939727-9258aaeb-fd03-4dc8-8b18-859781d88950.png" width=600>

## Technical Summary

[USH-694](https://dimagi-dev.atlassian.net/browse/USH-694?atlOrigin=eyJpIjoiNDlkNjEyNGI4ZjNkNGM1YjgwYzY1ZWRhZDA3YmQ5M2IiLCJwIjoiaiJ9).
 
There were two different ways to tackle this in the code. 1) In entries.js, I could have created another Entry JavaScript class just for displaying singular checkbox items that don't have a label, as we did with the ChoiceLabelEntry object for radio select elements. A sidenote: editing ChoiceLabelEntry itself for this would have been impossible because the class extends EntrySingleAnswer and for a checkbox answer we need an EntryArrayAnswer.
 
But instead of creating a new JavaScript class and possibly a new custom element in the template, I opted to simply extend MultiSelectEntry and change the display of the select element template (id="select-entry-ko-template") to display differently if hideLabel was set to true (i.e. had the appearance attribute for the question set to “list-nolabel”). 

This is where it gets a bit weird: I used a custom Knockout binding to add the “col-xs-” class only if hideLabel is true. I tried using the traditional, simple attr binding to set the class, but when hideLabel is false and the class attribute is null it still overwrites Bootstrap classes, causing *all* select menus to lose some of their special formattings.

I’m curious if anyone has input on whether I should have just created a new JavaScript class and added a new kind of custom element in the template. This felt the simplest addition but may have been a bit out of the style with which the rest of the code was written.

## Feature Flag

None that I'm aware of.

## Safety Assurance

### Safety story

I tested by using a form that has a regular multiple choice select question, a checkbox select question, and then the tabular structure for both regular multiple choice and checkbox questions. The output was as expected for all these types of questions.

### Automated test coverage

No automated tests added (yet). Ran grunt tests for cloudcare/form_entry just in case.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Submitting QA ticket after review and test on staging. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
