### PR TITLE
Fix missing BulkIndexError import

### DIFF
--- a/corehq/util/es/elasticsearch.py
+++ b/corehq/util/es/elasticsearch.py
@@ -42,7 +42,7 @@ elif settings.ELASTICSEARCH_MAJOR_VERSION == 5:
         IndicesClient,
         SnapshotClient,
     )
-    from elasticsearch5.helpers import bulk, scan
+    from elasticsearch5.helpers import BulkIndexError, bulk, scan
 else:
     raise ValueError("ELASTICSEARCH_MAJOR_VERSION must currently be 2 or 5, given {}".format(
         settings.ELASTICSEARCH_MAJOR_VERSION))


### PR DESCRIPTION
## Technical Summary

Fixes missed import for dimagi/commcare-hq#?

## Safety Assurance

### Safety story

Fixes `ImportError` when using Elasticsearch 5.x.  No-op on production code.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
