### PR TITLE
[Hubspot] Update datadog metrics and move error logging to datadog instead of sentry

### DIFF
--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -132,10 +132,7 @@ def _delete_hubspot_contact(vid, retry_num=0):
             req.raise_for_status()
         except (ConnectionError, requests.exceptions.HTTPError) as e:
             metrics_counter(
-                'commcare.hubspot_data.retry.delete_hubspot_contact',
-                tags={
-                    'vid': vid,
-                }
+                'commcare.hubspot_data.retry.delete_hubspot_contact'
             )
             if retry_num <= MAX_API_RETRIES:
                 return _delete_hubspot_contact(vid, retry_num + 1)
@@ -143,7 +140,6 @@ def _delete_hubspot_contact(vid, retry_num=0):
                 metrics_counter(
                     'commcare.hubspot_data.error.delete_hubspot_contact',
                     tags={
-                        'vid': vid,
                         'error': str(e),
                     }
                 )
@@ -181,10 +177,7 @@ def _get_contact_ids_to_delete(list_of_emails, retry_num=0):
             req.raise_for_status()
         except (ConnectionError, requests.exceptions.HTTPError) as e:
             metrics_counter(
-                'commcare.hubspot_data.retry.get_contact_ids_for_emails',
-                tags={
-                    'emails': list_of_emails.join(', '),
-                }
+                'commcare.hubspot_data.retry.get_contact_ids_for_emails'
             )
             if retry_num <= MAX_API_RETRIES:
                 return _get_contact_ids_to_delete(list_of_emails, retry_num + 1)
@@ -192,7 +185,6 @@ def _get_contact_ids_to_delete(list_of_emails, retry_num=0):
                 metrics_counter(
                     'commcare.hubspot_data.error.get_contact_ids_for_emails',
                     tags={
-                        'emails': list_of_emails.join(', '),
                         'error': str(e),
                     }
                 )

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -140,8 +140,13 @@ def _delete_hubspot_contact(vid, retry_num=0):
             if retry_num <= MAX_API_RETRIES:
                 return _delete_hubspot_contact(vid, retry_num + 1)
             else:
-                logger.error(f"Failed to delete Hubspot contact {vid} due to "
-                             f"{str(e)}.")
+                metrics_counter(
+                    'commcare.hubspot_data.error.delete_hubspot_contact',
+                    tags={
+                        'vid': vid,
+                        'error': str(e),
+                    }
+                )
         else:
             return True
     return False
@@ -184,8 +189,13 @@ def _get_contact_ids_to_delete(list_of_emails, retry_num=0):
             if retry_num <= MAX_API_RETRIES:
                 return _get_contact_ids_to_delete(list_of_emails, retry_num + 1)
             else:
-                logger.error(f"Failed to get Hubspot contact ids for emails "
-                             f"{list_of_emails.join(', ')} due to {str(e)}.")
+                metrics_counter(
+                    'commcare.hubspot_data.error.get_contact_ids_for_emails',
+                    tags={
+                        'emails': list_of_emails.join(', '),
+                        'error': str(e),
+                    }
+                )
         else:
             ids_to_delete = []
             for contact_id, data in req.json().items():


### PR DESCRIPTION
## Technical Summary
In order to remove a lot of [non-actionable sentry errors](https://sentry.io/organizations/dimagi/issues/2754449034/?project=136860), I'm moving logging of errors to datadog so I can observe any trends. Also updates a few `metrics_gauge` usages to `metrics_counter`

## Safety Assurance

### Safety story
Datadog changes. Much welcome sentry changes.

### Automated test coverage
None

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
