### PR TITLE
Hack pickle.HIGHEST_PROTOCOL for Celery on Python 3.6

### DIFF
--- a/deployment/gunicorn/commcarehq_wsgi.py
+++ b/deployment/gunicorn/commcarehq_wsgi.py
@@ -1,3 +1,4 @@
+# flake8: noqa: E402
 import os
 from manage import _set_source_root_parent, _set_source_root
 
@@ -10,7 +11,9 @@ _set_source_root(os.path.join('custom', '_legacy'))
 # patch gevent
 from gevent.monkey import patch_all
 from psycogreen.gevent import patch_psycopg
+from manage import patch_pickle
 
+patch_pickle()  # should happen before gevent patch, which imports pickle
 patch_all(subprocess=True)
 patch_psycopg()
 

--- a/manage.py
+++ b/manage.py
@@ -8,6 +8,8 @@ from psycogreen.gevent import patch_psycopg
 
 
 def main():
+    patch_pickle()  # should happen before gevent patch, which imports pickle
+
     # important to apply gevent monkey patches before running any other code
     # applying this later can lead to inconsistencies and threading issues
     # but compressor doesn't like it

--- a/manage.py
+++ b/manage.py
@@ -131,6 +131,12 @@ def patch_pickle():
         import pickle5
         sys.modules["pickle"] = pickle5
 
+        # HACK set HIGHEST_PROTOCOL to one understood by Python 3.6.
+        # Celery uses HIGHEST_PROTOCOL to make pickles and Kombu, a
+        # dependency of Celery, uses the built-in pickle module
+        # (imported before we have a chance to patch it).
+        pickle5.HIGHEST_PROTOCOL = pickle5.DEFAULT_PROTOCOL
+
 
 def patch_jsonfield():
     """Patch the ``to_python`` method of JSONField


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12790

It would be nice if Python's `pickle` package made it bit harder to do the wrong thing. My recommendation would be to not expose `HIGHEST_PROTOCOL` as a public constant. Instead the only and recommended way to use a protocol higher than `DEFAULT_PROTOCOL` should be to reference it by number like `pickle.dumps(obj, protocol=5)`. Currently it is too easy to use `HIGHEST_PROTOCOL` or `-1`, making it difficult to upgrade to a new version of Python while maintaining backward compatibility.

## Safety Assurance

### Safety story

Our old version of Celery is a minefield, and we don't have very good test coverage.

### Automated test coverage

TODO

### QA Plan

Do we have good QA procedures for Celery queues?

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change