### PR TITLE
[Security] ensure getobject is at least v 1.0.0 due to security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "resolutions": {
         "debug": "^2.6.9",
         "dot-prop": "^5.1.1",
+        "getobject": "^1.0.0",
         "growl": "^1.10.0",
         "grunt": "^1.2.0",
         "js-yaml": "^3.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2099,10 +2099,10 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-getobject@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/getobject/-/getobject-0.1.0.tgz#047a449789fa160d018f5486ed91320b6ec7885c"
-  integrity sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=
+getobject@^1.0.0, getobject@~0.1.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/getobject/-/getobject-1.0.2.tgz#25ec87a50370f6dcc3c6ba7ef43c4c16215c4c89"
+  integrity sha512-2zblDBaFcb3rB4rF77XVnuINOE2h2k/OnqXAiy0IrTxUfV1iFp3la33oAQVY9pCpWU268WFYVt2t71hlMuLsOg==
 
 getpass@^0.1.1:
   version "0.1.7"


### PR DESCRIPTION
## Technical Summary
`getobject` is a sub-sub dependency of `grunt`, meaning that if tests pass, then we can consider this upgrade safe to merge. Does not affect production-run code.

Here is the [security alert for getobject](https://github.com/dimagi/commcare-hq/security/dependabot/yarn.lock/getobject/open)


## Safety Assurance

### Safety story
Safe to merge when tests pass as this only affects tests.

### Automated test coverage
yes

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
