### PR TITLE
Add option to force pull remote multimedia

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/multimedia_ajax.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/multimedia_ajax.html
@@ -41,6 +41,12 @@
               {% trans "Email when finished (recommended for applications with large number of multimedia files or heavy files)" %}
             </label>
           </div>
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" name="force">
+              {% trans "Force pull all multimedia (this can take a long time and will re-write all the multimedia in your app)" %}
+            </label>
+          </div>
           <button type="submit" class="btn btn-primary">
             <i class="fa fa-refresh"></i>
             {% trans "Sync" %}

--- a/corehq/apps/linked_domain/tasks.py
+++ b/corehq/apps/linked_domain/tasks.py
@@ -50,8 +50,8 @@ from corehq.privileges import RELEASE_MANAGEMENT
 
 
 @task(queue='linked_domain_queue')
-def pull_missing_multimedia_for_app_and_notify_task(domain, app_id, email=None):
-    pull_missing_multimedia_for_app_and_notify(domain, app_id, email)
+def pull_missing_multimedia_for_app_and_notify_task(domain, app_id, email=None, force=False):
+    pull_missing_multimedia_for_app_and_notify(domain, app_id, email, force)
 
 
 @task(queue='linked_domain_queue')

--- a/corehq/apps/linked_domain/util.py
+++ b/corehq/apps/linked_domain/util.py
@@ -96,7 +96,6 @@ def _get_missing_multimedia(app, old_multimedia_ids=None):
             continue
         try:
             local_media = CommCareMultimedia.get(media_info['multimedia_id'])
-            local_media.get_display_file()
         except ResourceNotFound:
             filename = path.split('/')[-1]
             missing.append((filename, media_info))

--- a/corehq/apps/linked_domain/util.py
+++ b/corehq/apps/linked_domain/util.py
@@ -56,11 +56,11 @@ def server_to_user_time(server_time, timezone):
     return user_time.strftime("%Y-%m-%d %H:%M")
 
 
-def pull_missing_multimedia_for_app_and_notify(domain, app_id, email):
+def pull_missing_multimedia_for_app_and_notify(domain, app_id, email, force=False):
     app = get_app(domain, app_id)
     subject = _("Update Status for linked app %s missing multimedia pull") % app.name
     try:
-        pull_missing_multimedia_for_app(app)
+        pull_missing_multimedia_for_app(app, force=force)
     except MultimediaMissingError as e:
         message = str(e)
     except Exception:
@@ -76,10 +76,13 @@ def pull_missing_multimedia_for_app_and_notify(domain, app_id, email):
     send_html_email_async.delay(subject, email, message)
 
 
-def pull_missing_multimedia_for_app(app, old_multimedia_ids=None):
-    missing_media = _get_missing_multimedia(app, old_multimedia_ids)
+def pull_missing_multimedia_for_app(app, old_multimedia_ids=None, force=False):
+    if force:
+        media_to_pull = _get_all_media(app)
+    else:
+        media_to_pull = _get_missing_multimedia(app, old_multimedia_ids)
     remote_details = app.domain_link.remote_details
-    fetch_remote_media(app.domain, missing_media, remote_details)
+    fetch_remote_media(app.domain, media_to_pull, remote_details)
     if toggles.CAUTIOUS_MULTIMEDIA.enabled(app.domain):
         still_missing_media = _get_missing_multimedia(app, old_multimedia_ids)
         if still_missing_media:
@@ -87,6 +90,13 @@ def pull_missing_multimedia_for_app(app, old_multimedia_ids=None):
                 'Application has missing multimedia even after an attempt to re-pull them. '
                 'Please try re-pulling the app. If this persists, report an issue.'
             ))
+
+
+def _get_all_media(app):
+    return [
+        (path.split('/')[-1], media_info)
+        for path, media_info in app.multimedia_map.items()
+    ]
 
 
 def _get_missing_multimedia(app, old_multimedia_ids=None):

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -239,14 +239,15 @@ def hmac_callout_settings(request, domain):
 @require_can_edit_apps
 def pull_missing_multimedia(request, domain, app_id):
     async_update = request.POST.get('notify') == 'on'
+    force = request.POST.get('force') == 'on'
     if async_update:
-        pull_missing_multimedia_for_app_and_notify_task.delay(domain, app_id, request.user.email)
+        pull_missing_multimedia_for_app_and_notify_task.delay(domain, app_id, request.user.email, force)
         messages.success(request,
                          ugettext('Your request has been submitted. '
                                   'We will notify you via email once completed.'))
     else:
         app = get_app(domain, app_id)
-        pull_missing_multimedia_for_app(app)
+        pull_missing_multimedia_for_app(app, force=force)
     return HttpResponseRedirect(reverse('app_settings', args=[domain, app_id]))
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Adds a checkbox on remote apps to force-pull all multimedia for an app. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
A perhaps more comprehensive solution to: https://github.com/dimagi/commcare-hq/pull/30708 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Linked domains, remote linked only

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
