### PR TITLE
Smart linking: don't allow Select Parent First

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -375,11 +375,17 @@ class ModuleBaseValidator(object):
                 'module': self.get_module_info(),
             })
 
-        if module_uses_smart_links(self.module) and not self.module.session_endpoint_id:
-            errors.append({
-                'type': 'smart links missing endpoint',
-                'module': self.get_module_info(),
-            })
+        if module_uses_smart_links(self.module):
+            if not self.module.session_endpoint_id:
+                errors.append({
+                    'type': 'smart links missing endpoint',
+                    'module': self.get_module_info(),
+                })
+            if self.module.parent_select.active:
+                errors.append({
+                    'type': 'smart links select parent first',
+                    'module': self.get_module_info(),
+                })
 
         return errors
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -155,6 +155,12 @@
                 <a href="{{ module_url }}">{{ module_name }}</a>
                 uses smart links but does not have a session endpoint id.
               {% endblocktrans %}
+            {% case "smart links select parent first" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                uses both smart links and Parent Child Selection. These two
+                features are not compatible.
+              {% endblocktrans %}
             {% case "circular case hierarchy" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}
                 The case hierarchy for <a href="{{ module_url }}">{{ module_name }}</a> contains a circular reference.


### PR DESCRIPTION
PR into https://github.com/dimagi/commcare-hq/pull/30657

Parent/child relationships can't cross domain boundaries, so Select Parent First doesn't make sense for those, and apps using the"other" relationship ([this one](https://confluence.dimagi.com/display/USH/Selecting+any+case+in+%27select+parent+first%27+workflow)) for deduping should be using the load case from registry workflow.