### PR TITLE
Celery pickle patch

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -133,12 +133,6 @@ def patch_pickle():
         import pickle5
         sys.modules["pickle"] = pickle5
 
-        # HACK set HIGHEST_PROTOCOL to one understood by Python 3.6.
-        # Celery uses HIGHEST_PROTOCOL to make pickles and Kombu, a
-        # dependency of Celery, uses the built-in pickle module
-        # (imported before we have a chance to patch it).
-        pickle5.HIGHEST_PROTOCOL = pickle5.DEFAULT_PROTOCOL
-
 
 def patch_jsonfield():
     """Patch the ``to_python`` method of JSONField

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -5,7 +5,7 @@ boto3~=1.17
 # celery 4.1.1 forked to work around https://github.com/celery/celery/issues/4737	celery==4.4.7
 # upgrade when https://github.com/celery/celery/issues/4980 is fixed
 # originally changes were made on nickpell/celery, but this was moved to dimagi/celery
-celery @ https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
+celery @ https://github.com/dimagi/celery/raw/v4.1.1.2/releases/celery-4.1.1.2-py2.py3-none-any.whl
 CommcareTranslationChecker==0.9.7
 concurrent-log-handler==0.9.12
 csiphash==0.0.5

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -32,7 +32,7 @@ botocore==1.20.85
     # via
     #   boto3
     #   s3transfer
-https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
+https://github.com/dimagi/celery/raw/v4.1.1.2/releases/celery-4.1.1.2-py2.py3-none-any.whl
     # via
     #   -r base-requirements.in
     #   django-celery-results

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -29,7 +29,7 @@ botocore==1.20.85
     # via
     #   boto3
     #   s3transfer
-https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
+https://github.com/dimagi/celery/raw/v4.1.1.2/releases/celery-4.1.1.2-py2.py3-none-any.whl
     # via
     #   -r base-requirements.in
     #   django-celery-results

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -28,7 +28,7 @@ botocore==1.20.85
     # via
     #   boto3
     #   s3transfer
-https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
+https://github.com/dimagi/celery/raw/v4.1.1.2/releases/celery-4.1.1.2-py2.py3-none-any.whl
     # via
     #   -r base-requirements.in
     #   django-celery-results

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -24,7 +24,7 @@ botocore==1.20.85
     # via
     #   boto3
     #   s3transfer
-https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
+https://github.com/dimagi/celery/raw/v4.1.1.2/releases/celery-4.1.1.2-py2.py3-none-any.whl
     # via
     #   -r base-requirements.in
     #   django-celery-results

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -26,7 +26,7 @@ botocore==1.20.85
     # via
     #   boto3
     #   s3transfer
-https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
+https://github.com/dimagi/celery/raw/v4.1.1.2/releases/celery-4.1.1.2-py2.py3-none-any.whl
     # via
     #   -r base-requirements.in
     #   django-celery-results


### PR DESCRIPTION
Upgrade to a (still forked) version of Celery that patches pickle to support protocol 5. See https://github.com/dimagi/celery/pull/1 for more details.

## Safety Assurance

### Safety story

The only real change is to patch pickle on celery startup rather than doing that hacky thing with setting `HIGHEST_PROTOCOL` to match `DEFAULT_PROTOCOL`.

### Automated test coverage

No.

### QA Plan

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
