### PR TITLE
Remove mock dependency 

### DIFF
--- a/corehq/apps/accounting/tests/generator.py
+++ b/corehq/apps/accounting/tests/generator.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 from django.apps import apps
 from django.conf import settings
 
-import mock
+from unittest import mock
 from nose.tools import nottest
 
 from dimagi.utils.data import generator as data_gen

--- a/corehq/apps/accounting/tests/test_autopay.py
+++ b/corehq/apps/accounting/tests/test_autopay.py
@@ -1,6 +1,6 @@
 from django.core import mail
 
-import mock
+from unittest import mock
 from django_prbac.models import Role
 from stripe import Charge
 from stripe.stripe_object import StripeObject

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from django.test import TestCase
 
 from dateutil import relativedelta
-from mock import Mock
+from unittest.mock import Mock
 
 from dimagi.utils.dates import add_months_to_date
 

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from django.core import mail
 from django.db import models
 
-import mock
+from unittest import mock
 
 from dimagi.utils.dates import add_months_to_date
 

--- a/corehq/apps/accounting/tests/test_stripe_payment.py
+++ b/corehq/apps/accounting/tests/test_stripe_payment.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.test.client import RequestFactory
 
 import stripe
-from mock import patch
+from unittest.mock import patch
 from stripe.stripe_object import StripeObject
 
 from corehq.apps.accounting.models import (

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -3,7 +3,7 @@ from datetime import date, time
 
 from django.test import SimpleTestCase, TransactionTestCase
 
-from mock import Mock, call, patch
+from unittest.mock import Mock, call, patch
 
 from corehq.apps.accounting.exceptions import SubscriptionAdjustmentError
 from corehq.apps.accounting.models import (

--- a/corehq/apps/analytics/tests/test_hubspot.py
+++ b/corehq/apps/analytics/tests/test_hubspot.py
@@ -1,6 +1,6 @@
 from django.test import RequestFactory, TestCase, override_settings
 
-import mock
+from unittest import mock
 
 from corehq.apps.accounting.models import (
     DefaultProductPlan,

--- a/corehq/apps/api/odata/tests/test_auth.py
+++ b/corehq/apps/api/odata/tests/test_auth.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 
-import mock
+from unittest import mock
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.export.models import CaseExportInstance, TableConfiguration

--- a/corehq/apps/api/tests/app_resources.py
+++ b/corehq/apps/api/tests/app_resources.py
@@ -1,6 +1,6 @@
 import json
 
-from unittest.mock.mock import patch
+from unittest.mock import patch
 from testil import Regex
 
 from corehq.apps.api.resources import v0_4

--- a/corehq/apps/api/tests/app_resources.py
+++ b/corehq/apps/api/tests/app_resources.py
@@ -1,6 +1,6 @@
 import json
 
-from mock.mock import patch
+from unittest.mock.mock import patch
 from testil import Regex
 
 from corehq.apps.api.resources import v0_4

--- a/corehq/apps/api/tests/core_api.py
+++ b/corehq/apps/api/tests/core_api.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 from django.test import SimpleTestCase, TestCase
 from django.test.client import RequestFactory
-from mock import patch
+from unittest.mock import patch
 
 from django.urls import reverse
 from django.utils.http import urlencode

--- a/corehq/apps/app_manager/app_schemas/tests/test_app_diffs.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_app_diffs.py
@@ -1,6 +1,6 @@
 from django.test.testcases import SimpleTestCase, TestCase
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from corehq.apps.app_manager.app_schemas.form_metadata import (
     ADDED,

--- a/corehq/apps/app_manager/app_schemas/tests/test_case_meta.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_case_meta.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.test.testcases import SimpleTestCase
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from nose.tools import nottest
 
 from corehq.apps.app_manager.const import USERCASE_TYPE

--- a/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
@@ -2,7 +2,7 @@ import doctest
 
 from django.test import SimpleTestCase
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import corehq.apps.app_manager.app_schemas.case_properties
 from corehq.apps.app_manager.app_schemas.case_properties import (

--- a/corehq/apps/app_manager/app_schemas/tests/test_schema.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_schema.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from django.test import SimpleTestCase
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from corehq.apps.app_manager import util as util
 from corehq.apps.app_manager.app_schemas.casedb_schema import get_casedb_schema, get_registry_schema

--- a/corehq/apps/app_manager/tests/mocks/mobile_ucr.py
+++ b/corehq/apps/app_manager/tests/mocks/mobile_ucr.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from couchdbkit import ResourceNotFound
 
 

--- a/corehq/apps/app_manager/tests/test_apps.py
+++ b/corehq/apps/app_manager/tests/test_apps.py
@@ -5,7 +5,7 @@ import uuid
 from django.test import SimpleTestCase, TestCase
 
 from memoized import memoized
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.dbaccessors import get_app, get_build_ids
 from corehq.apps.app_manager.models import (

--- a/corehq/apps/app_manager/tests/test_build_errors.py
+++ b/corehq/apps/app_manager/tests/test_build_errors.py
@@ -3,7 +3,7 @@ import os
 
 from django.test import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.models import Application, CaseList, Module
 from corehq.apps.app_manager.tests.app_factory import AppFactory

--- a/corehq/apps/app_manager/tests/test_case_list_form.py
+++ b/corehq/apps/app_manager/tests/test_case_list_form.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.const import (
     AUTO_SELECT_USERCASE,

--- a/corehq/apps/app_manager/tests/test_ccz.py
+++ b/corehq/apps/app_manager/tests/test_ccz.py
@@ -5,7 +5,7 @@ import zipfile
 
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.xform_builder import XFormBuilder

--- a/corehq/apps/app_manager/tests/test_child_module.py
+++ b/corehq/apps/app_manager/tests/test_child_module.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.const import WORKFLOW_PREVIOUS
 from corehq.apps.app_manager.models import (

--- a/corehq/apps/app_manager/tests/test_extension_case.py
+++ b/corehq/apps/app_manager/tests/test_extension_case.py
@@ -1,7 +1,7 @@
 from django.test import SimpleTestCase
 
 from couchdbkit import BadValueError
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.exceptions import CaseError
 from corehq.apps.app_manager.models import (

--- a/corehq/apps/app_manager/tests/test_filters.py
+++ b/corehq/apps/app_manager/tests/test_filters.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 
 from django.test import SimpleTestCase, TestCase
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from corehq.apps.app_manager.models import (
     AncestorLocationTypeFilter,

--- a/corehq/apps/app_manager/tests/test_form_preparation_v2.py
+++ b/corehq/apps/app_manager/tests/test_form_preparation_v2.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.exceptions import (
     XFormException,

--- a/corehq/apps/app_manager/tests/test_form_versioning.py
+++ b/corehq/apps/app_manager/tests/test_form_versioning.py
@@ -1,6 +1,6 @@
 from django.test.testcases import SimpleTestCase, TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.models import (
     Application,

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -6,7 +6,7 @@ from django.test import SimpleTestCase, TestCase
 from django.test.utils import override_settings
 
 from lxml import etree
-from mock import patch
+from unittest.mock import patch
 
 import commcare_translations
 from corehq.apps.app_manager import id_strings

--- a/corehq/apps/app_manager/tests/test_modules.py
+++ b/corehq/apps/app_manager/tests/test_modules.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.const import AUTO_SELECT_USERCASE
 from corehq.apps.app_manager.models import (

--- a/corehq/apps/app_manager/tests/test_notifications.py
+++ b/corehq/apps/app_manager/tests/test_notifications.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from corehq.apps.app_manager.views.notifications import notify_event
 

--- a/corehq/apps/app_manager/tests/test_practice_user_config.py
+++ b/corehq/apps/app_manager/tests/test_practice_user_config.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 from couchdbkit import ResourceNotFound
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.exceptions import PracticeUserException
 from corehq.apps.app_manager.models import Application, BuildProfile

--- a/corehq/apps/app_manager/tests/test_release_notes_form.py
+++ b/corehq/apps/app_manager/tests/test_release_notes_form.py
@@ -3,7 +3,7 @@ import uuid
 from django.test import SimpleTestCase, TestCase
 
 from couchdbkit import ResourceNotFound
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.models import Module
 from corehq.apps.app_manager.tests.app_factory import AppFactory

--- a/corehq/apps/app_manager/tests/test_repeater.py
+++ b/corehq/apps/app_manager/tests/test_repeater.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from django.test import TestCase
 from django.test.client import Client
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.accounting.models import SoftwarePlanEdition
 from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin

--- a/corehq/apps/app_manager/tests/test_report_config.py
+++ b/corehq/apps/app_manager/tests/test_report_config.py
@@ -4,7 +4,7 @@ from xml.etree import cElementTree as ElementTree
 
 from django.test import SimpleTestCase, TestCase
 
-import mock
+from unittest import mock
 
 from casexml.apps.phone.tests.utils import (
     call_fixture_generator,

--- a/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
+++ b/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
@@ -4,7 +4,7 @@ from django.test import SimpleTestCase
 
 from lxml import etree
 from lxml.builder import E
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from casexml.apps.phone.models import UCRSyncLog
 

--- a/corehq/apps/app_manager/tests/test_schedule.py
+++ b/corehq/apps/app_manager/tests/test_schedule.py
@@ -2,7 +2,7 @@ import copy
 
 from django.test import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.exceptions import ScheduleError
 from corehq.apps.app_manager.models import (

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -4,7 +4,7 @@ import re
 from django.test import SimpleTestCase
 
 import commcare_translations
-import mock
+from unittest import mock
 from lxml.etree import tostring
 
 from corehq.apps.app_manager.exceptions import (

--- a/corehq/apps/app_manager/tests/test_suite_form_filter_errors.py
+++ b/corehq/apps/app_manager/tests/test_suite_form_filter_errors.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.exceptions import CaseXPathValidationError
 from corehq.apps.app_manager.tests.app_factory import AppFactory

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from django.test import SimpleTestCase
 

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -1,5 +1,5 @@
 from django.test import SimpleTestCase
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.models import (
     AdvancedModule,

--- a/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
+++ b/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from django.test import SimpleTestCase
 

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -7,7 +7,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 
-from mock import patch
+from unittest.mock import patch
 
 from pillowtop.es_utils import initialize_index_and_mapping
 

--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 
-import mock
+from unittest import mock
 from lxml import etree
 from nose.tools import nottest
 

--- a/corehq/apps/cachehq/tests.py
+++ b/corehq/apps/cachehq/tests.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from django.conf import settings
 from django.test import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from dimagi.ext.jsonobject import JsonObject, StringProperty
 

--- a/corehq/apps/callcenter/tests/test_datasources.py
+++ b/corehq/apps/callcenter/tests/test_datasources.py
@@ -1,6 +1,6 @@
 from django.test.testcases import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.callcenter.data_source import (
     call_center_data_source_configuration_provider,

--- a/corehq/apps/callcenter/tests/test_indicators.py
+++ b/corehq/apps/callcenter/tests/test_indicators.py
@@ -4,7 +4,7 @@ from django.core import cache
 from django.db import DEFAULT_DB_ALIAS
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.callcenter.const import (
     DATE_RANGES,

--- a/corehq/apps/callcenter/tests/test_utils.py
+++ b/corehq/apps/callcenter/tests/test_utils.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 from django.test import SimpleTestCase, TestCase
 
-import mock
+from unittest import mock
 
 from casexml.apps.case.mock import CaseFactory, CaseStructure
 from casexml.apps.case.tests.util import delete_all_cases

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -6,7 +6,7 @@ from django.utils.dateparse import parse_datetime
 
 from celery import states
 from celery.exceptions import Ignore
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseFactory, CaseStructure
 from casexml.apps.case.tests.util import delete_all_cases

--- a/corehq/apps/case_importer/tests/test_suggested_fields.py
+++ b/corehq/apps/case_importer/tests/test_suggested_fields.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 
-import mock
+from unittest import mock
 
 from corehq.apps.case_importer.suggested_fields import (
     FieldSpec,

--- a/corehq/apps/case_importer/tracking/tests/test_dbaccessors.py
+++ b/corehq/apps/case_importer/tracking/tests/test_dbaccessors.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from django.forms import model_to_dict
 from django.test import TestCase
 
-import mock
+from unittest import mock
 
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 

--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.test import TestCase
 
-import mock
+from unittest import mock
 
 from casexml.apps.case.mock import CaseBlock, IndexAttrs
 

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -1,6 +1,6 @@
 import uuid
 
-import mock
+from unittest import mock
 from django.test import TestCase
 
 from casexml.apps.case.mock import CaseBlock, IndexAttrs

--- a/corehq/apps/case_search/tests/test_models.py
+++ b/corehq/apps/case_search/tests/test_models.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from mock import call, patch
+from unittest.mock import call, patch
 
 from corehq.apps.case_search.models import (
     disable_case_search,

--- a/corehq/apps/change_feed/tests/test_pillow.py
+++ b/corehq/apps/change_feed/tests/test_pillow.py
@@ -6,7 +6,7 @@ from django.test import SimpleTestCase, TestCase
 from fakecouch import FakeCouchDb
 from kafka import KafkaConsumer
 from kafka.common import KafkaUnavailableError
-from mock import patch
+from unittest.mock import patch
 
 from pillowtop.dao.exceptions import DocumentMismatchError
 from pillowtop.feed.interface import Change, ChangeMeta

--- a/corehq/apps/change_feed/tests/test_producer_reconciliation.py
+++ b/corehq/apps/change_feed/tests/test_producer_reconciliation.py
@@ -3,7 +3,7 @@ import uuid
 from django.test import SimpleTestCase
 
 from kafka.future import Future
-from mock import Mock
+from unittest.mock import Mock
 from nose.tools import assert_equal, assert_true
 
 from pillowtop.feed.interface import ChangeMeta

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -3,7 +3,7 @@ import json
 from django.test import TestCase
 from django.urls import reverse
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.cloudcare.views import ReadableQuestions
 from corehq.apps.domain.shortcuts import create_domain

--- a/corehq/apps/cloudcare/tests/test_esaccessors.py
+++ b/corehq/apps/cloudcare/tests/test_esaccessors.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.test import SimpleTestCase
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from pillowtop.es_utils import initialize_index_and_mapping
 

--- a/corehq/apps/data_analytics/tests/test_gir.py
+++ b/corehq/apps/data_analytics/tests/test_gir.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.data_analytics.gir_generator import GIRTableGenerator
 from corehq.apps.domain.models import Domain

--- a/corehq/apps/data_dictionary/tests/test_util.py
+++ b/corehq/apps/data_dictionary/tests/test_util.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
 from corehq.apps.data_dictionary.util import generate_data_dictionary

--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from django.test import TestCase, override_settings
 
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseFactory
 from casexml.apps.case.signals import case_post_save

--- a/corehq/apps/data_interfaces/tests/test_case_deduplication.py
+++ b/corehq/apps/data_interfaces/tests/test_case_deduplication.py
@@ -4,7 +4,7 @@ from itertools import chain
 from django.test import TestCase, override_settings
 
 from faker import Faker
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseFactory
 from pillowtop.es_utils import initialize_index_and_mapping

--- a/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
+++ b/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, time
 from django.db.models import Q
 from django.test import TestCase
 
-from mock import call, patch
+from unittest.mock import call, patch
 
 from casexml.apps.case.tests.util import create_case
 from corehq.apps.app_manager.models import (

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -3,7 +3,7 @@ from functools import wraps
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponseForbidden, HttpResponse
 from django.test import SimpleTestCase, TestCase, RequestFactory
-from mock import mock
+from unittest.mock import mock
 
 from corehq.apps.api.cors import ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_ALLOW, ACCESS_CONTROL_ALLOW_HEADERS
 from corehq.apps.api.decorators import allow_cors

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -3,7 +3,7 @@ from functools import wraps
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponseForbidden, HttpResponse
 from django.test import SimpleTestCase, TestCase, RequestFactory
-from unittest.mock import mock
+from unittest.mock import patch
 
 from corehq.apps.api.cors import ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_ALLOW, ACCESS_CONTROL_ALLOW_HEADERS
 from corehq.apps.api.decorators import allow_cors
@@ -206,9 +206,9 @@ class ApiAuthTest(SimpleTestCase, AuthTestMixin):
         decorated_view = api_auth(sample_view)
         request = _get_request()
         request.META['HTTP_AUTHORIZATION'] = auth_header
-        with mock.patch(decorator_to_mock, mock_successful_auth):
+        with patch(decorator_to_mock, mock_successful_auth):
             self.assertEqual(SUCCESS, decorated_view(request, self.domain_name))
-        with mock.patch(decorator_to_mock, mock_failed_auth):
+        with patch(decorator_to_mock, mock_failed_auth):
             self.assertForbidden(decorated_view(request, self.domain_name))
 
     def test_api_auth_oauth(self):
@@ -229,12 +229,12 @@ class ApiAuthTest(SimpleTestCase, AuthTestMixin):
         decorated_view = api_auth(sample_view)
         request = _get_request()
         request.META['HTTP_X_MAC_DIGEST'] = 'fomplayerAuth'
-        with mock.patch(decorator_to_mock, mock_successful_auth):
+        with patch(decorator_to_mock, mock_successful_auth):
             # even if formplayer returns successful auth, the api_auth decorator rejects it because
             # it calls _get_multi_auth_decorator with allow_formplayer=False, short-circuiting
             # any additional auth checkng.
             self.assertForbidden(decorated_view(request, self.domain_name))
-        with mock.patch(decorator_to_mock, mock_failed_auth):
+        with patch(decorator_to_mock, mock_failed_auth):
             self.assertForbidden(decorated_view(request, self.domain_name))
 
 

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -9,7 +9,7 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from dateutil.relativedelta import relativedelta
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseFactory
 from casexml.apps.phone.models import SyncLogSQL

--- a/corehq/apps/domain/tests/test_domain_transfer.py
+++ b/corehq/apps/domain/tests/test_domain_transfer.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq import toggles
 from corehq.apps.domain.exceptions import InactiveTransferDomainException

--- a/corehq/apps/domain/tests/test_two_factor_check.py
+++ b/corehq/apps/domain/tests/test_two_factor_check.py
@@ -2,7 +2,7 @@ import json
 
 from django.test import RequestFactory, TestCase
 
-from unittest.mock import Mock, mock
+from unittest.mock import Mock, patch
 
 from corehq.apps.domain.decorators import (
     OTP_AUTH_FAIL_RESPONSE,
@@ -75,7 +75,7 @@ class TestTwoFactorCheck(TestCase):
         view_func = 'dummy_view_func'
         two_factor_check_fn = two_factor_check(view_func, api_key)
         function_getting_checked_with_auth = two_factor_check_fn(mock_fn_to_call)
-        with mock.patch('corehq.apps.domain.decorators._ensure_request_couch_user',
+        with patch('corehq.apps.domain.decorators._ensure_request_couch_user',
                         return_value=request.couch_user):
             response = function_getting_checked_with_auth(request, self.domain.name)
             self.assertEqual(response.status_code, 401)
@@ -92,7 +92,7 @@ class TestTwoFactorCheck(TestCase):
         view_func = 'dummy_view_func'
         two_factor_check_fn = two_factor_check(view_func, api_key)
         function_getting_checked_with_auth = two_factor_check_fn(mock_fn_to_call)
-        with mock.patch('corehq.apps.domain.decorators._ensure_request_couch_user',
+        with patch('corehq.apps.domain.decorators._ensure_request_couch_user',
                         return_value=request.couch_user):
             response = function_getting_checked_with_auth(request, self.domain.name)
             self.assertEqual(response, 'Function was called!')

--- a/corehq/apps/domain/tests/test_two_factor_check.py
+++ b/corehq/apps/domain/tests/test_two_factor_check.py
@@ -2,7 +2,7 @@ import json
 
 from django.test import RequestFactory, TestCase
 
-from mock import Mock, mock
+from unittest.mock import Mock, mock
 
 from corehq.apps.domain.decorators import (
     OTP_AUTH_FAIL_RESPONSE,

--- a/corehq/apps/domain/tests/test_views.py
+++ b/corehq/apps/domain/tests/test_views.py
@@ -5,7 +5,7 @@ from django.test.client import Client
 from django.urls import reverse
 
 from bs4 import BeautifulSoup
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.accounting.models import SoftwarePlanEdition
 from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin

--- a/corehq/apps/dropbox/tests/test_dropbox_upload_helper.py
+++ b/corehq/apps/dropbox/tests/test_dropbox_upload_helper.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser

--- a/corehq/apps/dump_reload/tests/test_couch_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_couch_dump_load.py
@@ -8,7 +8,7 @@ from io import StringIO
 from django.test import SimpleTestCase, TestCase
 
 from couchdbkit.exceptions import ResourceNotFound
-from mock import patch
+from unittest.mock import patch
 from nose.tools import nottest
 
 from dimagi.utils.chunked import chunked

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -5,7 +5,7 @@ from collections import Counter
 from datetime import datetime
 from io import StringIO
 
-import mock
+from unittest import mock
 from django.contrib.admin.utils import NestedObjects
 from django.db import transaction, IntegrityError
 from django.db.models.signals import post_delete, post_save

--- a/corehq/apps/enterprise/tests/test_permissions.py
+++ b/corehq/apps/enterprise/tests/test_permissions.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from django.test.testcases import TestCase
 from django.urls import reverse

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -5,7 +5,7 @@ from datetime import date
 from django.test import TestCase
 from django.test.testcases import SimpleTestCase
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from casexml.apps.case.models import CommCareCase
 from pillowtop.es_utils import initialize_index_and_mapping

--- a/corehq/apps/es/tests/test_esquery.py
+++ b/corehq/apps/es/tests/test_esquery.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from django.test import SimpleTestCase
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.es import filters, forms, users
 from corehq.apps.es.es_query import HQESQuery

--- a/corehq/apps/export/tests/test_daily_saved_exports.py
+++ b/corehq/apps/export/tests/test_daily_saved_exports.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from corehq.apps.export.models import CaseExportInstance, FormExportInstance
 from corehq.apps.export.tasks import saved_exports

--- a/corehq/apps/export/tests/test_export_column.py
+++ b/corehq/apps/export/tests/test_export_column.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 from django.test import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.export.const import (
     EMPTY_VALUE,

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -2,7 +2,7 @@ import os
 
 from django.test import SimpleTestCase, TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.models import (
     AdvancedModule,

--- a/corehq/apps/export/tests/test_export_form_subcases.py
+++ b/corehq/apps/export/tests/test_export_form_subcases.py
@@ -3,7 +3,7 @@ import os
 
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from couchexport.models import Format
 

--- a/corehq/apps/export/tests/test_export_forms.py
+++ b/corehq/apps/export/tests/test_export_forms.py
@@ -3,7 +3,7 @@ import datetime
 from django.test import SimpleTestCase, TestCase
 
 import pytz
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.export.filters import (

--- a/corehq/apps/export/tests/test_export_instance.py
+++ b/corehq/apps/export/tests/test_export_instance.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 from django.test import SimpleTestCase, TestCase
 
-import mock
+from unittest import mock
 
 from couchexport.models import Format
 

--- a/corehq/apps/export/tests/test_export_item.py
+++ b/corehq/apps/export/tests/test_export_item.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 from django.test import SimpleTestCase
 
-import mock
+from unittest import mock
 
 from corehq.apps.export.models import (
     ExportColumn,

--- a/corehq/apps/export/tests/test_export_views.py
+++ b/corehq/apps/export/tests/test_export_views.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from botocore.response import StreamingBody
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.export.dbaccessors import (

--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -6,7 +6,7 @@ from django.test import SimpleTestCase
 
 from corehq.util.es.elasticsearch import ConnectionError
 from corehq.apps.es.tests.utils import es_test
-from mock import patch
+from unittest.mock import patch
 from openpyxl import load_workbook
 
 from couchexport.export import get_writer

--- a/corehq/apps/export/tests/test_sms_export.py
+++ b/corehq/apps/export/tests/test_sms_export.py
@@ -4,7 +4,7 @@ import uuid
 
 from django.test.testcases import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from couchexport.models import Format
 

--- a/corehq/apps/hqadmin/tests/test_stale_data_in_es.py
+++ b/corehq/apps/hqadmin/tests/test_stale_data_in_es.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 
-import mock
+from unittest import mock
 from corehq.apps.domain.models import Domain
 from corehq.apps.es.tests.utils import es_test
 from corehq.apps.hqadmin.management.commands.stale_data_in_es import DataRow

--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -4,7 +4,7 @@ from django.http import HttpResponse
 from django.test import SimpleTestCase
 
 from lxml import etree
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.hqadmin.views.users import AdminRestoreView, DisableUserView

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -3,7 +3,7 @@ import uuid
 from django.test import TestCase
 from django.urls import reverse
 
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseBlock
 

--- a/corehq/apps/hqcase/tests/test_dbaccessors.py
+++ b/corehq/apps/hqcase/tests/test_dbaccessors.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from pillowtop.es_utils import initialize_index_and_mapping
 

--- a/corehq/apps/hqmedia/tests/test_manage_paths.py
+++ b/corehq/apps/hqmedia/tests/test_manage_paths.py
@@ -4,7 +4,7 @@ import re
 
 from django.test import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.tests.app_factory import AppFactory

--- a/corehq/apps/hqwebapp/tests/test_bug_report_email.py
+++ b/corehq/apps/hqwebapp/tests/test_bug_report_email.py
@@ -1,6 +1,6 @@
 import textwrap
 
-import mock
+from unittest import mock
 from django.test import SimpleTestCase
 
 from corehq.apps.domain.models import Domain

--- a/corehq/apps/hqwebapp/tests/test_proptable_tags.py
+++ b/corehq/apps/hqwebapp/tests/test_proptable_tags.py
@@ -2,7 +2,7 @@ from datetime import date, datetime
 
 import pytz
 from django.test import SimpleTestCase, override_settings
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.hqwebapp.doc_info import DocInfo
 from corehq.apps.hqwebapp.templatetags.proptable_tags import DisplayConfig

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -5,7 +5,7 @@ from django.test.testcases import TestCase
 
 from couchdbkit.exceptions import ResourceNotFound
 from lxml import etree
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.exceptions import AppEditingError, AppLinkError
 from corehq.apps.app_manager.models import (

--- a/corehq/apps/linked_domain/tests/test_linked_case_claim.py
+++ b/corehq/apps/linked_domain/tests/test_linked_case_claim.py
@@ -1,6 +1,6 @@
 import json
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.case_search.models import (
     CaseSearchConfig,

--- a/corehq/apps/linked_domain/tests/test_linked_userreports.py
+++ b/corehq/apps/linked_domain/tests/test_linked_userreports.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from dimagi.utils.couch.undo import is_deleted, soft_delete
 

--- a/corehq/apps/linked_domain/tests/test_release_manager.py
+++ b/corehq/apps/linked_domain/tests/test_release_manager.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.models import Application, LinkedApplication
 from corehq.apps.app_manager.tests.util import patch_validate_xform

--- a/corehq/apps/linked_domain/tests/test_update_roles.py
+++ b/corehq/apps/linked_domain/tests/test_update_roles.py
@@ -1,7 +1,7 @@
 import uuid
 
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.linked_domain.models import DomainLink

--- a/corehq/apps/locations/tests/test_bulk_management.py
+++ b/corehq/apps/locations/tests/test_bulk_management.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from django.test import SimpleTestCase, TestCase
 from django.utils.functional import cached_property
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from corehq.apps.custom_data_fields.models import (
     CustomDataFieldsDefinition,

--- a/corehq/apps/locations/tests/test_dbaccessors.py
+++ b/corehq/apps/locations/tests/test_dbaccessors.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from django.test import TestCase
 
 from corehq.apps.commtrack.tests.util import bootstrap_location_types

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -6,7 +6,7 @@ from xml.etree import cElementTree as ElementTree
 
 from django.test import TestCase
 
-import mock
+from unittest import mock
 
 from casexml.apps.phone.models import SimplifiedSyncLog
 from casexml.apps.phone.restore import RestoreParams

--- a/corehq/apps/locations/tests/test_location_groups.py
+++ b/corehq/apps/locations/tests/test_location_groups.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.phone.tests.utils import call_fixture_generator
 

--- a/corehq/apps/locations/tests/test_location_safety.py
+++ b/corehq/apps/locations/tests/test_location_safety.py
@@ -1,6 +1,6 @@
 from django.views.generic.base import View
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from corehq.apps.reports.dispatcher import ReportDispatcher
 from corehq.apps.reports.generic import GenericReportView

--- a/corehq/apps/locations/tests/test_permissions.py
+++ b/corehq/apps/locations/tests/test_permissions.py
@@ -7,7 +7,7 @@ from io import BytesIO
 from django.http import HttpResponse
 from django.urls import reverse
 
-import mock
+from unittest import mock
 
 from casexml.apps.case.tests.util import delete_all_xforms
 

--- a/corehq/apps/locations/tests/test_views.py
+++ b/corehq/apps/locations/tests/test_views.py
@@ -4,7 +4,7 @@ from django.contrib.messages import get_messages
 from django.test import Client, TestCase
 from django.urls import reverse
 
-import mock
+from unittest import mock
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.exceptions import LocationConsistencyError

--- a/corehq/apps/ota/tests/test_app_aware_restore.py
+++ b/corehq/apps/ota/tests/test_app_aware_restore.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 from datetime import datetime, timedelta
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.phone.models import SimplifiedSyncLog
 from casexml.apps.phone.tests.utils import (

--- a/corehq/apps/ota/tests/test_digest_restore.py
+++ b/corehq/apps/ota/tests/test_digest_restore.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse
 from django.test import Client, TestCase
 from django.urls import reverse
 
-import mock
+from unittest import mock
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.domain.tests.test_utils import delete_all_domains

--- a/corehq/apps/receiverwrapper/tests/test_submissions.py
+++ b/corehq/apps/receiverwrapper/tests/test_submissions.py
@@ -7,7 +7,7 @@ from django.test.client import Client
 from django.test.utils import override_settings
 from django.urls import reverse
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.receiverwrapper.util import submit_form_locally

--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -9,7 +9,7 @@ from django.test.client import Client
 from django.urls import reverse
 
 from botocore.exceptions import ConnectionClosedError
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.exceptions import IllegalCaseId
 from couchforms.models import UnfinishedSubmissionStub

--- a/corehq/apps/reports/tests/test_daterange.py
+++ b/corehq/apps/reports/tests/test_daterange.py
@@ -2,7 +2,7 @@ import datetime
 
 from django.test import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.reports.daterange import (
     get_all_daterange_choices,

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -5,7 +5,7 @@ from django.test import SimpleTestCase, TestCase
 
 import pytz
 from corehq.util.es.elasticsearch import ConnectionError
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.commtrack.tests.util import bootstrap_domain

--- a/corehq/apps/reports/tests/test_export_response.py
+++ b/corehq/apps/reports/tests/test_export_response.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.reports.standard.monitoring import WorkerActivityReport

--- a/corehq/apps/reports/tests/test_filters.py
+++ b/corehq/apps/reports/tests/test_filters.py
@@ -5,7 +5,7 @@ from corehq.util.elastic import ensure_index_deleted
 from django.test import SimpleTestCase, TestCase
 from django.test.client import RequestFactory
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import clear_domain_names

--- a/corehq/apps/reports/tests/test_form_export.py
+++ b/corehq/apps/reports/tests/test_form_export.py
@@ -2,7 +2,7 @@ import datetime
 
 from django.test import SimpleTestCase
 
-import mock
+from unittest import mock
 
 from corehq.apps.export.models import (
     ExportColumn,

--- a/corehq/apps/reports/tests/test_project_health.py
+++ b/corehq/apps/reports/tests/test_project_health.py
@@ -2,7 +2,7 @@ import datetime
 
 from django.test import RequestFactory, TestCase
 
-import mock
+from unittest import mock
 
 from dimagi.utils.dates import add_months
 

--- a/corehq/apps/reports/tests/test_readable_formdata.py
+++ b/corehq/apps/reports/tests/test_readable_formdata.py
@@ -7,7 +7,7 @@ from django.test import SimpleTestCase
 from django.test.testcases import TestCase
 
 import yaml
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.app_schemas.app_case_metadata import (
     FormQuestionResponse,

--- a/corehq/apps/sms/tests/inbound_handlers.py
+++ b/corehq/apps/sms/tests/inbound_handlers.py
@@ -1,7 +1,7 @@
 import contextlib
 from datetime import time
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.hqcase.utils import update_case
 from corehq.apps.reminders.models import RECIPIENT_OWNER, RECIPIENT_USER_GROUP

--- a/corehq/apps/sms/tests/test_backends.py
+++ b/corehq/apps/sms/tests/test_backends.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from django.test.client import Client
 from django.test.utils import override_settings
 
-from mock import patch
+from unittest.mock import patch
 from six.moves.urllib.parse import urlencode
 
 from corehq.apps.accounting.models import SoftwarePlanEdition

--- a/corehq/apps/sms/tests/test_chat.py
+++ b/corehq/apps/sms/tests/test_chat.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from dimagi.utils.parsing import json_format_datetime
 

--- a/corehq/apps/sms/tests/test_form_session_handler.py
+++ b/corehq/apps/sms/tests/test_form_session_handler.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import uuid
 
 from django.test import TestCase
-from mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.sms.handlers.form_session import form_session_handler

--- a/corehq/apps/sms/tests/test_phone_numbers.py
+++ b/corehq/apps/sms/tests/test_phone_numbers.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqcase.utils import update_case

--- a/corehq/apps/sms/tests/test_queueing.py
+++ b/corehq/apps/sms/tests/test_queueing.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from django.conf import settings
 from django.test.utils import override_settings
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from testil import eq
 
 from corehq.apps.sms.tests.data_generator import get_test_sms_fields

--- a/corehq/apps/sms/tests/test_registration.py
+++ b/corehq/apps/sms/tests/test_registration.py
@@ -4,7 +4,7 @@ import json
 from django.test import Client, TestCase
 
 from django_prbac.models import Role
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from corehq.apps.accounting.models import (
     BillingAccount,

--- a/corehq/apps/sms/tests/test_registration.py
+++ b/corehq/apps/sms/tests/test_registration.py
@@ -1,18 +1,5 @@
 import base64
-import json
 
-from django.test import Client, TestCase
-
-from django_prbac.models import Role
-from unittest.mock import Mock, patch
-
-from corehq.apps.accounting.models import (
-    BillingAccount,
-    DefaultProductPlan,
-    SoftwarePlanEdition,
-    Subscription,
-    SubscriptionAdjustment,
-)
 from corehq.apps.domain.calculations import num_mobile_users
 from corehq.apps.domain.models import Domain
 from corehq.apps.sms.api import incoming

--- a/corehq/apps/smsbillables/tests/test_gateway_charges.py
+++ b/corehq/apps/smsbillables/tests/test_gateway_charges.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.sms.api import create_billable_for_sms
 from corehq.apps.smsbillables.models import SmsBillable, SmsGatewayFee

--- a/corehq/apps/smsbillables/tests/test_gateway_fees.py
+++ b/corehq/apps/smsbillables/tests/test_gateway_fees.py
@@ -3,7 +3,7 @@ from random import choice, randint
 from django.apps import apps
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq import toggles
 from corehq.apps.accounting.tests.generator import init_default_currency

--- a/corehq/apps/smsbillables/tests/test_usage_fees.py
+++ b/corehq/apps/smsbillables/tests/test_usage_fees.py
@@ -2,7 +2,7 @@ from random import randint
 
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.accounting.tests.generator import init_default_currency
 from corehq.apps.sms.models import SQLMobileBackend

--- a/corehq/apps/smsforms/tests/test_app.py
+++ b/corehq/apps/smsforms/tests/test_app.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.xform_builder import XFormBuilder

--- a/corehq/apps/smsforms/tests/test_session_synchronization.py
+++ b/corehq/apps/smsforms/tests/test_session_synchronization.py
@@ -1,7 +1,7 @@
 import pickle
 from uuid import uuid4
 
-import mock
+from unittest import mock
 
 from corehq.apps.smsforms.models import XFormsSessionSynchronization, RunningSessionInfo, SMSChannel, \
     SQLXFormsSession

--- a/corehq/apps/smsforms/tests/test_sql_session.py
+++ b/corehq/apps/smsforms/tests/test_sql_session.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from django.test import TestCase
 
 from couchdbkit import MultipleResultsFound
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from corehq.apps.sms.handlers.form_session import (
     get_single_open_session_or_close_multiple,

--- a/corehq/apps/sso/tests/test_forms.py
+++ b/corehq/apps/sso/tests/test_forms.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from mock import patch
+from unittest.mock import patch
 
 from django import forms
 from django.test import TestCase

--- a/corehq/apps/toggle_ui/tests.py
+++ b/corehq/apps/toggle_ui/tests.py
@@ -1,6 +1,6 @@
 import uuid
 from decimal import Decimal
-from mock import patch
+from unittest.mock import patch
 
 from django.test import TestCase, SimpleTestCase
 

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -5,7 +5,7 @@ from io import BytesIO
 
 from django.test import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from couchexport.export import export_raw
 from couchexport.models import Format

--- a/corehq/apps/translations/tests/test_transifex_blacklisting.py
+++ b/corehq/apps/translations/tests/test_transifex_blacklisting.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import TestXmlMixin

--- a/corehq/apps/translations/tests/test_updating_app_from_trans_dict.py
+++ b/corehq/apps/translations/tests/test_updating_app_from_trans_dict.py
@@ -2,7 +2,7 @@ from io import BytesIO
 
 from django.test import SimpleTestCase
 
-import mock
+from unittest import mock
 
 from couchexport.export import export_raw
 

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from django.contrib.admin.models import LogEntry
 from django.test import SimpleTestCase, TestCase
 
-from mock import mock, patch
+from unittest.mock import mock, patch
 
 from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
 from corehq.apps.commtrack.tests.util import make_loc

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from django.contrib.admin.models import LogEntry
 from django.test import SimpleTestCase, TestCase
 
-from unittest.mock import mock, patch
+from unittest.mock import patch
 
 from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
 from corehq.apps.commtrack.tests.util import make_loc
@@ -802,7 +802,7 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         self.assertEqual(False, user.is_active)
         self.assertEqual(False, user.is_account_confirmed)
 
-    @mock.patch('corehq.apps.user_importer.importer.send_account_confirmation_if_necessary')
+    @patch('corehq.apps.user_importer.importer.send_account_confirmation_if_necessary')
     def test_upload_with_unconfirmed_account_send_email(self, mock_account_confirm_email):
         import_users_and_groups(
             self.domain.name,
@@ -833,7 +833,7 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         self.assertEqual(mock_account_confirm_email.call_count, 1)
         self.assertEqual('with_email', mock_account_confirm_email.call_args[0][0].raw_username)
 
-    @mock.patch('corehq.apps.user_importer.importer.Invitation.send_activation_email')
+    @patch('corehq.apps.user_importer.importer.Invitation.send_activation_email')
     def test_upload_invite_web_user(self, mock_send_activation_email):
         import_users_and_groups(
             self.domain.name,
@@ -857,7 +857,7 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         self.assertEqual(user_history.user_id, self.user.get_id)
         self.assertEqual(user_history.action, UserModelAction.CREATE.value)
 
-    @mock.patch('corehq.apps.user_importer.importer.Invitation')
+    @patch('corehq.apps.user_importer.importer.Invitation')
     def test_upload_add_web_user(self, mock_invitation_class):
         self.loc1 = make_loc('loc1', type='state', domain=self.domain_name)
 
@@ -952,7 +952,7 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         self.assertEqual(user_history.user_id, commcare_user.get_id)
         self.assertEqual(user_history.action, UserModelAction.CREATE.value)
 
-    @mock.patch('corehq.apps.user_importer.importer.Invitation.send_activation_email')
+    @patch('corehq.apps.user_importer.importer.Invitation.send_activation_email')
     def test_update_pending_user_role(self, mock_send_activation_email):
         import_users_and_groups(
             self.domain.name,
@@ -1630,7 +1630,7 @@ class TestWebUserBulkUpload(TestCase, DomainSubscriptionMixin):
         web_user = WebUser.get_by_username(self.uploading_user.username)
         self.assertTrue(web_user.is_member_of(self.domain.name))
 
-    @mock.patch('corehq.apps.user_importer.importer.Invitation.send_activation_email')
+    @patch('corehq.apps.user_importer.importer.Invitation.send_activation_email')
     def test_upload_invite(self, mock_send_activation_email):
         self.setup_users()
         import_users_and_groups(

--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -1,5 +1,5 @@
 from faker import Faker
-from mock import patch
+from unittest.mock import patch
 from testil import assert_raises
 
 from corehq.apps.user_importer.exceptions import UserUploadError

--- a/corehq/apps/userreports/tests/test_app_manager_integration.py
+++ b/corehq/apps/userreports/tests/test_app_manager_integration.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.sharedmodels import CommCareCaseIndex

--- a/corehq/apps/userreports/tests/test_async_indicators.py
+++ b/corehq/apps/userreports/tests/test_async_indicators.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.test import SimpleTestCase, TestCase
 
-import mock
+from unittest import mock
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.userreports.app_manager.helpers import clean_table_name

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -4,7 +4,7 @@ from functools import partial
 from django.test import SimpleTestCase, TestCase
 from django.utils.translation import ugettext
 
-import mock
+from unittest import mock
 
 from pillowtop.es_utils import initialize_index_and_mapping
 

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -4,7 +4,7 @@ import time
 from django.test import SimpleTestCase, TestCase
 
 from jsonobject.exceptions import BadValueError
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.models import DataSourceConfiguration

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from django.test import SimpleTestCase, TestCase
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from simpleeval import InvalidExpression
 from testil import Config
 

--- a/corehq/apps/userreports/tests/test_get_report_configs.py
+++ b/corehq/apps/userreports/tests/test_get_report_configs.py
@@ -4,7 +4,7 @@ import uuid
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from corehq.apps.userreports.exceptions import ReportConfigurationNotFoundError
 from corehq.apps.userreports.models import (

--- a/corehq/apps/userreports/tests/test_indicators.py
+++ b/corehq/apps/userreports/tests/test_indicators.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from django.test import SimpleTestCase, TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.tests.util import delete_all_ledgers, delete_all_xforms
 from casexml.apps.stock.const import REPORT_TYPE_BALANCE

--- a/corehq/apps/userreports/tests/test_multi_db.py
+++ b/corehq/apps/userreports/tests/test_multi_db.py
@@ -4,7 +4,7 @@ from contextlib import ExitStack
 from django.db import DEFAULT_DB_ALIAS
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.userreports.models import (
     DataSourceConfiguration,

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from django.test import SimpleTestCase, TestCase
 
 from unittest import mock
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.signals import case_post_save

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 from django.test import SimpleTestCase, TestCase
 
-import mock
+from unittest import mock
 from mock import patch
 
 from casexml.apps.case.mock import CaseBlock

--- a/corehq/apps/userreports/tests/test_rebuild_migrate.py
+++ b/corehq/apps/userreports/tests/test_rebuild_migrate.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-import mock
+from unittest import mock
 from sqlalchemy.engine import reflection
 
 from corehq.apps.userreports.models import (

--- a/corehq/apps/userreports/tests/test_registry_pillow.py
+++ b/corehq/apps/userreports/tests/test_registry_pillow.py
@@ -1,7 +1,7 @@
 import uuid
 
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 from corehq.apps.domain.shortcuts import create_user

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.app_manager.models import Application, Module
 from corehq.apps.app_manager.tests.app_factory import AppFactory

--- a/corehq/apps/userreports/tests/test_static_data_sources.py
+++ b/corehq/apps/userreports/tests/test_static_data_sources.py
@@ -5,7 +5,7 @@ from collections import Counter
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from corehq.apps.userreports.models import (
     DataSourceConfiguration,

--- a/corehq/apps/userreports/tests/test_static_reports.py
+++ b/corehq/apps/userreports/tests/test_static_reports.py
@@ -4,7 +4,7 @@ from collections import Counter, defaultdict
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from corehq.apps.userreports.models import (
     StaticDataSourceConfiguration,

--- a/corehq/apps/userreports/tests/test_transforms.py
+++ b/corehq/apps/userreports/tests/test_transforms.py
@@ -2,7 +2,7 @@ from datetime import date, datetime, timedelta
 
 from django.test import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.transforms.factory import TransformFactory

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -3,7 +3,7 @@ import uuid
 from django.http import HttpRequest
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.signals import case_post_save

--- a/corehq/apps/userreports/tests/utils.py
+++ b/corehq/apps/userreports/tests/utils.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 import six
 import sqlalchemy
 from django.db import DEFAULT_DB_ALIAS
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.models import CommCareCase
 from dimagi.utils.parsing import json_format_datetime

--- a/corehq/apps/users/tests/fixture_status.py
+++ b/corehq/apps/users/tests/fixture_status.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from django.test import TestCase
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import clear_domain_names

--- a/corehq/apps/users/tests/permissions.py
+++ b/corehq/apps/users/tests/permissions.py
@@ -1,7 +1,7 @@
 from couchdbkit.ext.django.schema import ListProperty
 from django.test import SimpleTestCase
 
-import mock
+from unittest import mock
 from testil import eq, assert_raises
 
 from corehq.apps.export.views.utils import user_can_view_deid_exports

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -3,7 +3,7 @@ from xml.etree import cElementTree as ElementTree
 
 from django.test import TestCase, override_settings
 
-import mock
+from unittest import mock
 
 from casexml.apps.case.mock import (
     CaseBlock,

--- a/corehq/apps/users/tests/test_download.py
+++ b/corehq/apps/users/tests/test_download.py
@@ -1,7 +1,7 @@
 import re
 
 from datetime import datetime
-from mock import patch
+from unittest.mock import patch
 
 from django.test import TestCase
 

--- a/corehq/apps/users/tests/test_signals.py
+++ b/corehq/apps/users/tests/test_signals.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.test import SimpleTestCase
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 # Also, you need to patch the path to the function in the file where the signal

--- a/corehq/blobs/tests/test_blob_import.py
+++ b/corehq/blobs/tests/test_blob_import.py
@@ -6,7 +6,7 @@ from timeit import Timer
 
 from django.test import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.blobs.management.commands.run_blob_import import (
     NUM_WORKERS,

--- a/corehq/blobs/tests/test_blob_timeout.py
+++ b/corehq/blobs/tests/test_blob_timeout.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from mock import patch
+from unittest.mock import patch
 from datetime import datetime, timedelta
 from django.test import TestCase
 

--- a/corehq/blobs/tests/test_fsdb.py
+++ b/corehq/blobs/tests/test_fsdb.py
@@ -7,7 +7,7 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 
 import corehq.blobs.fsdb as mod
 from corehq.blobs import CODES

--- a/corehq/blobs/tests/test_init.py
+++ b/corehq/blobs/tests/test_init.py
@@ -2,7 +2,7 @@ import re
 from os.path import join
 
 from django.test import override_settings
-from mock import patch
+from unittest.mock import patch
 from testil import assert_raises, tempdir
 
 import corehq.blobs as mod

--- a/corehq/blobs/tests/test_mixin.py
+++ b/corehq/blobs/tests/test_mixin.py
@@ -17,7 +17,7 @@ from corehq.blobs.tests.util import (TemporaryFilesystemBlobDB,
 from corehq.util.io import ClosingContextProxy
 from corehq.util.test_utils import generate_cases, trap_extra_setup
 from dimagi.ext.couchdbkit import Document
-from mock import patch
+from unittest.mock import patch
 
 
 class BaseTestCase(TestCase):

--- a/corehq/blobs/tests/test_models.py
+++ b/corehq/blobs/tests/test_models.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from io import BytesIO
 
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from corehq.blobs.models import BlobMeta, DeletedBlobMeta
 from corehq.blobs.tests.util import get_meta, new_meta, TemporaryFilesystemBlobDB

--- a/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
@@ -1,5 +1,4 @@
-from unittest.mock import MagicMock
-from datetime import date, datetime
+from datetime import datetime
 from casexml.apps.case.xml.generator import date_to_xml_string
 
 DUMMY_ID = "foo"

--- a/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
@@ -1,4 +1,4 @@
-from mock import MagicMock
+from unittest.mock import MagicMock
 from datetime import date, datetime
 from casexml.apps.case.xml.generator import date_to_xml_string
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from io import BytesIO
 from django.test import TestCase, SimpleTestCase, override_settings
 from casexml.apps.phone.restore_caching import AsyncRestoreTaskIdCache, RestorePayloadPathCache

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.test import TestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.const import CASE_ACTION_UPDATE
 from casexml.apps.case.models import CommCareCase, CommCareCaseAction

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -3,7 +3,7 @@ import uuid
 from datetime import datetime
 from xml.etree import cElementTree as ElementTree
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.util import post_case_blocks
 from casexml.apps.phone.exceptions import RestoreException

--- a/corehq/ex-submodules/couchexport/tests/test_writers.py
+++ b/corehq/ex-submodules/couchexport/tests/test_writers.py
@@ -5,7 +5,7 @@ import os
 
 from django.test import SimpleTestCase
 from lxml import html, etree
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from couchexport.export import export_from_tables
 from couchexport.models import Format

--- a/corehq/ex-submodules/couchforms/tests/test_analytics.py
+++ b/corehq/ex-submodules/couchforms/tests/test_analytics.py
@@ -2,7 +2,7 @@ import datetime
 import uuid
 
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 from requests import ConnectionError
 
 from couchforms.analytics import (

--- a/corehq/ex-submodules/couchforms/tests/test_archive.py
+++ b/corehq/ex-submodules/couchforms/tests/test_archive.py
@@ -1,5 +1,5 @@
 import os
-import mock
+from unittest import mock
 from datetime import datetime, timedelta
 from django.test import TestCase
 

--- a/corehq/ex-submodules/couchforms/tests/test_edits.py
+++ b/corehq/ex-submodules/couchforms/tests/test_edits.py
@@ -4,7 +4,7 @@ import uuid
 
 from django.core.files.uploadedfile import UploadedFile
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 from requests.exceptions import HTTPError
 from casexml.apps.case.mock import CaseBlock
 from corehq.apps.hqcase.utils import submit_case_blocks

--- a/corehq/ex-submodules/dimagi/test_utils/base.py
+++ b/corehq/ex-submodules/dimagi/test_utils/base.py
@@ -5,7 +5,7 @@ if not settings.configured:
     settings.configure(DEBUG=True)
 
 
-from mock import MagicMock, NonCallableMock, patch
+from unittest.mock import MagicMock, NonCallableMock, patch
 from unittest import TestCase
 
 from memoized import memoized

--- a/corehq/ex-submodules/dimagi/utils/tests/test_retry.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/test_retry.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from mock import patch
+from unittest.mock import patch
 from testil import assert_raises, eq
 
 from corehq.util.test_utils import timelimit

--- a/corehq/ex-submodules/pillow_retry/tests/test_all_pillows.py
+++ b/corehq/ex-submodules/pillow_retry/tests/test_all_pillows.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.conf import settings
 from django.test import TestCase
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from pillow_retry.models import PillowError
 from pillowtop import get_all_pillow_configs

--- a/corehq/ex-submodules/pillow_retry/tests/test_retry.py
+++ b/corehq/ex-submodules/pillow_retry/tests/test_retry.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.test import TestCase
 from fakecouch import FakeCouchDb
 from kafka import KafkaConsumer
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import change_meta_from_kafka_message, KafkaChangeFeed

--- a/corehq/ex-submodules/pillowtop/tests/test_bulk.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_bulk.py
@@ -1,7 +1,7 @@
 import uuid
 
 from django.test import SimpleTestCase, TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from casexml.apps.case.signals import case_post_save
 from corehq.apps.change_feed.data_sources import SOURCE_COUCH

--- a/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
@@ -1,5 +1,5 @@
 import functools
-import mock
+from unittest import mock
 import uuid
 
 

--- a/corehq/ex-submodules/soil/tests/test_progress_manager.py
+++ b/corehq/ex-submodules/soil/tests/test_progress_manager.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from django.test import SimpleTestCase
 from freezegun import freeze_time
 

--- a/corehq/form_processor/tests/test_basics.py
+++ b/corehq/form_processor/tests/test_basics.py
@@ -4,7 +4,7 @@ from io import BytesIO
 
 from django.core.files.uploadedfile import UploadedFile
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests.util import deprecated_check_user_has_case

--- a/corehq/form_processor/tests/test_reprocess_errors.py
+++ b/corehq/form_processor/tests/test_reprocess_errors.py
@@ -3,7 +3,7 @@ import uuid
 
 from django.db.utils import IntegrityError, InternalError
 from django.test import TestCase, TransactionTestCase
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseBlock, CaseFactory, CaseStructure
 from casexml.apps.case.signals import case_post_save

--- a/corehq/form_processor/tests/test_sql_update_strategy.py
+++ b/corehq/form_processor/tests/test_sql_update_strategy.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from freezegun import freeze_time
-from mock import patch
+from unittest.mock import patch
 from testil import eq
 from corehq.util.soft_assert.core import SoftAssert
 

--- a/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
+++ b/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
@@ -3,7 +3,7 @@ from django.db.models import Q
 from django.test import TestCase
 from datetime import time
 from io import BytesIO
-from mock import patch
+from unittest.mock import patch
 import re
 import tempfile
 

--- a/corehq/messaging/scheduling/tests/test_content.py
+++ b/corehq/messaging/scheduling/tests/test_content.py
@@ -14,7 +14,7 @@ from corehq.messaging.scheduling.scheduling_partitioned.models import (
     CaseTimedScheduleInstance,
 )
 from django.test import TestCase, override_settings
-from mock import Mock
+from unittest.mock import Mock
 
 
 AVAILABLE_CUSTOM_SCHEDULING_CONTENT = {

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -4,7 +4,7 @@ from datetime import time
 
 from django.test import TestCase, override_settings
 
-from mock import patch
+from unittest.mock import patch
 
 from casexml.apps.case.tests.util import create_case
 from corehq.apps.casegroups.models import CommCareCaseGroup

--- a/corehq/messaging/scheduling/tests/test_schedules.py
+++ b/corehq/messaging/scheduling/tests/test_schedules.py
@@ -32,7 +32,7 @@ from corehq.messaging.scheduling.tasks import (
 )
 from datetime import datetime, date, time
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 
 
 class BaseScheduleTest(TestCase):

--- a/corehq/messaging/smsbackends/airtel_tcl/tests/test_airtel_tcl.py
+++ b/corehq/messaging/smsbackends/airtel_tcl/tests/test_airtel_tcl.py
@@ -3,7 +3,7 @@ from corehq.messaging.smsbackends.airtel_tcl.exceptions import AirtelTCLError, I
 from corehq.messaging.smsbackends.airtel_tcl.models import AirtelTCLBackend
 from datetime import datetime
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 
 
 class AirtelTCLBackendTest(TestCase):

--- a/corehq/messaging/smsbackends/start_enterprise/tests/test_response.py
+++ b/corehq/messaging/smsbackends/start_enterprise/tests/test_response.py
@@ -7,7 +7,7 @@ from corehq.messaging.smsbackends.start_enterprise.models import (
 )
 from corehq.apps.sms.models import SMS
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 
 SUCCESSFUL_RESPONSE = "919999999999-200904066072538"
 RECOGNIZED_ERROR_MESSAGE = "Account Blocked"

--- a/corehq/messaging/smsbackends/unicel/tests/test_send.py
+++ b/corehq/messaging/smsbackends/unicel/tests/test_send.py
@@ -1,6 +1,6 @@
 from six.moves.urllib.parse import parse_qs, urlparse
 
-from mock import patch
+from unittest.mock import patch
 
 from django.test import SimpleTestCase
 

--- a/corehq/messaging/smsbackends/vertex/tests/test_response.py
+++ b/corehq/messaging/smsbackends/vertex/tests/test_response.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-import mock
+from unittest import mock
 
 from corehq.apps.sms.models import QueuedSMS
 from corehq.messaging.smsbackends.vertex.exceptions import VertexBackendException

--- a/corehq/motech/dhis2/tests/test_models.py
+++ b/corehq/motech/dhis2/tests/test_models.py
@@ -33,7 +33,7 @@ from ..models import (
     parse_dataset_for_request,
     get_end_of_period,
 )
-from mock import patch
+from unittest.mock import patch
 
 
 def test_should_send_on_date():

--- a/corehq/motech/dhis2/tests/test_repeaters.py
+++ b/corehq/motech/dhis2/tests/test_repeaters.py
@@ -8,7 +8,7 @@ from unittest import skip
 
 from django.test import SimpleTestCase, TestCase
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from nose.tools import assert_equal, assert_true
 
 from corehq.motech.dhis2.const import DHIS2_MAX_VERSION

--- a/corehq/motech/openmrs/tests/test_atom_feed.py
+++ b/corehq/motech/openmrs/tests/test_atom_feed.py
@@ -9,7 +9,7 @@ from django.test import SimpleTestCase, TestCase
 import attr
 from dateutil.tz import tzoffset, tzutc
 from lxml import etree
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 import corehq.motech.openmrs.atom_feed
 from corehq.motech.openmrs.atom_feed import (

--- a/corehq/motech/openmrs/tests/test_importer.py
+++ b/corehq/motech/openmrs/tests/test_importer.py
@@ -2,7 +2,7 @@ import datetime
 
 from django.test import SimpleTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 from corehq.motech.const import (
     IMPORT_FREQUENCY_DAILY,

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -7,7 +7,7 @@ import uuid
 
 from django.test import SimpleTestCase, TestCase
 
-import mock
+from unittest import mock
 from requests import RequestException
 from testil import eq
 

--- a/corehq/motech/openmrs/tests/test_tasks.py
+++ b/corehq/motech/openmrs/tests/test_tasks.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.test import SimpleTestCase
 
 import pytz
-from mock import patch
+from unittest.mock import patch
 from nose.tools import assert_raises_regexp
 from requests.exceptions import ConnectTimeout, ReadTimeout
 

--- a/corehq/motech/openmrs/tests/test_workflow.py
+++ b/corehq/motech/openmrs/tests/test_workflow.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 
 from corehq.motech.openmrs.workflow import (
     WorkflowError,

--- a/corehq/motech/repeaters/management/commands/update_cancelled_records.py
+++ b/corehq/motech/repeaters/management/commands/update_cancelled_records.py
@@ -5,7 +5,7 @@ import time
 
 from django.core.management.base import BaseCommand
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from corehq.motech.repeaters.const import RECORD_CANCELLED_STATE
 from corehq.motech.repeaters.dbaccessors import iter_repeat_records_by_domain

--- a/corehq/motech/repeaters/management/commands/update_cancelled_records.py
+++ b/corehq/motech/repeaters/management/commands/update_cancelled_records.py
@@ -5,8 +5,6 @@ import time
 
 from django.core.management.base import BaseCommand
 
-from unittest.mock import MagicMock
-
 from corehq.motech.repeaters.const import RECORD_CANCELLED_STATE
 from corehq.motech.repeaters.dbaccessors import iter_repeat_records_by_domain
 from corehq.motech.repeaters.models import Repeater, RepeatRecordAttempt

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from django.test import SimpleTestCase, TestCase
 
 import attr
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from requests import RequestException
 
 from casexml.apps.case.mock import CaseBlock, CaseFactory

--- a/corehq/motech/tests/test_models.py
+++ b/corehq/motech/tests/test_models.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from django.test import SimpleTestCase, TestCase
 
 import requests
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import pp_json
 from corehq.motech.const import ALGO_AES, PASSWORD_PLACEHOLDER

--- a/corehq/motech/tests/test_repeater_helpers.py
+++ b/corehq/motech/tests/test_repeater_helpers.py
@@ -1,5 +1,5 @@
 from django.test.testcases import TestCase
-from mock import patch
+from unittest.mock import patch
 from corehq.form_processor.models import CommCareCaseSQL
 from datetime import datetime
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors

--- a/corehq/motech/tests/test_requests.py
+++ b/corehq/motech/tests/test_requests.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.test import SimpleTestCase, TestCase
 
 import requests
-from mock import patch
+from unittest.mock import patch
 
 from corehq.motech.auth import AuthManager, BasicAuthManager, DigestAuthManager
 from corehq.motech.const import OAUTH2_PWD, REQUEST_TIMEOUT

--- a/corehq/project_limits/tests/test_rate_limiter.py
+++ b/corehq/project_limits/tests/test_rate_limiter.py
@@ -1,4 +1,4 @@
-from mock import mock, Mock
+from unittest.mock import mock, Mock
 
 from testil import eq
 

--- a/corehq/project_limits/tests/test_rate_limiter.py
+++ b/corehq/project_limits/tests/test_rate_limiter.py
@@ -1,4 +1,4 @@
-from unittest.mock import mock, Mock
+from unittest.mock import Mock, patch
 
 from testil import eq
 
@@ -6,7 +6,7 @@ from corehq.project_limits.rate_limiter import RateLimiter, RateDefinition, \
     PerUserRateDefinition
 
 
-@mock.patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
 def test_rate_limit_interface():
     """
     Just test that very basic usage doesn't error
@@ -20,7 +20,7 @@ def test_rate_limit_interface():
         my_feature_rate_limiter.report_usage('my_domain')
 
 
-@mock.patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
 def test_get_window_of_first_exceeded_limit():
     per_user_rate_def = RateDefinition(per_second=10)
     min_rate_def = RateDefinition(per_second=100)
@@ -32,7 +32,7 @@ def test_get_window_of_first_exceeded_limit():
     eq(actual_window, expected_window)
 
 
-@mock.patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
 def test_get_window_of_first_exceeded_limit_none():
     per_user_rate_def = RateDefinition(per_second=10)
     min_rate_def = RateDefinition(per_second=100)
@@ -44,7 +44,7 @@ def test_get_window_of_first_exceeded_limit_none():
     eq(actual_window, expected_window)
 
 
-@mock.patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
 def test_get_window_of_first_exceeded_limit_priority():
     per_user_rate_def = RateDefinition(per_second=10, per_week=10)
     min_rate_def = RateDefinition(per_second=100)

--- a/corehq/sql_db/tests/test_connections.py
+++ b/corehq/sql_db/tests/test_connections.py
@@ -4,7 +4,7 @@ from django.db import DEFAULT_DB_ALIAS
 from django.test import override_settings
 from django.test.testcases import SimpleTestCase
 
-import mock
+from unittest import mock
 from decorator import contextmanager
 from testil import eq
 

--- a/corehq/sql_db/tests/test_routers.py
+++ b/corehq/sql_db/tests/test_routers.py
@@ -4,7 +4,7 @@ from django.db import DEFAULT_DB_ALIAS
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
-from mock import patch
+from unittest.mock import patch
 from nose.tools import assert_equal, assert_false, assert_true
 
 from corehq.sql_db.config import PlProxyConfig, _get_standby_plproxy_config

--- a/corehq/tabs/tests.py
+++ b/corehq/tabs/tests.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from django.test import SimpleTestCase
 

--- a/corehq/tests/nose.py
+++ b/corehq/tests/nose.py
@@ -25,7 +25,7 @@ from django.test.utils import get_unique_databases_and_mirrors
 from couchdbkit import ResourceNotFound
 from couchdbkit.ext.django import loading
 from django_nose.plugin import DatabaseContext
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from nose.plugins import Plugin
 from nose.tools import nottest
 from requests.exceptions import HTTPError

--- a/corehq/tests/test_middleware.py
+++ b/corehq/tests/test_middleware.py
@@ -1,6 +1,6 @@
 import time
 
-import mock
+from unittest import mock
 from django.http import HttpResponse
 from django.test import override_settings, SimpleTestCase, TestCase
 from django.urls import path, include

--- a/corehq/util/context_managers.py
+++ b/corehq/util/context_managers.py
@@ -40,8 +40,8 @@ def notify_someone(email, success_message, error_message='Sorry, your HQ task fa
 @contextmanager
 def catch_signal(signal):
     """Catch django signal and return the mocked call."""
-    import mock
-    handler = mock.Mock()
+    from unittest.mock import Mock
+    handler = Mock()
     signal.connect(handler)
     yield handler
     signal.disconnect(handler)

--- a/corehq/util/es/testing.py
+++ b/corehq/util/es/testing.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from mock import patch
+from unittest.mock import patch
 
 from django.conf import settings
 

--- a/corehq/util/metrics/tests/test_lockmeter.py
+++ b/corehq/util/metrics/tests/test_lockmeter.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 import attr
-from mock import ANY, call, patch
+from unittest.mock import ANY, call, patch
 
 from corehq.util.metrics.tests.utils import capture_metrics
 from ..lockmeter import MeteredLock

--- a/corehq/util/metrics/tests/test_lockmeter.py
+++ b/corehq/util/metrics/tests/test_lockmeter.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 import attr
-from unittest.mock import ANY, call, patch
+from unittest.mock import call, patch
 
 from corehq.util.metrics.tests.utils import capture_metrics
 from ..lockmeter import MeteredLock

--- a/corehq/util/metrics/tests/utils.py
+++ b/corehq/util/metrics/tests/utils.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from contextlib import contextmanager
 
-import mock
+from unittest import mock
 
 from corehq.util.metrics import DebugMetrics, DelegatedMetrics
 

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -26,7 +26,7 @@ from django.db.backends import utils
 from django.test import TransactionTestCase
 from django.test.utils import CaptureQueriesContext
 
-import mock
+from unittest import mock
 
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.decorators import ContextDecorator

--- a/corehq/util/tests/test_couch.py
+++ b/corehq/util/tests/test_couch.py
@@ -5,7 +5,7 @@ from django.test import TestCase, SimpleTestCase
 from corehq.apps.groups.dbaccessors import refresh_group_views
 from corehq.apps.groups.models import Group
 from jsonobject.exceptions import WrappingAttributeError
-from mock import Mock
+from unittest.mock import Mock
 from corehq.util.exceptions import DocumentClassNotFound
 
 from ..couch import (get_document_or_404, IterDB, iter_update, IterUpdateError,

--- a/corehq/util/tests/test_view_utils.py
+++ b/corehq/util/tests/test_view_utils.py
@@ -1,5 +1,5 @@
 from django.test import SimpleTestCase
-from mock import patch
+from unittest.mock import patch
 from corehq.util.view_utils import json_error
 
 

--- a/corehq/util/timezones/tests/test_utils.py
+++ b/corehq/util/timezones/tests/test_utils.py
@@ -1,5 +1,5 @@
 import pytz
-from mock import patch
+from unittest.mock import patch
 
 from django.test import SimpleTestCase, override_settings
 

--- a/custom/champ/tests/__init__.py
+++ b/custom/champ/tests/__init__.py
@@ -2,7 +2,7 @@ import os
 
 from django.test.utils import override_settings
 
-import mock
+from unittest import mock
 import postgres_copy
 import sqlalchemy
 

--- a/custom/champ/tests/test_pva_chart.py
+++ b/custom/champ/tests/test_pva_chart.py
@@ -1,5 +1,5 @@
 import json
-import mock
+from unittest import mock
 
 from corehq.util.test_utils import softer_assert
 from custom.champ.tests.utils import ChampTestCase

--- a/custom/champ/tests/test_pva_table.py
+++ b/custom/champ/tests/test_pva_table.py
@@ -3,7 +3,7 @@ from custom.champ.tests.utils import ChampTestCase
 from custom.champ.views import PrevisionVsAchievementsTableView
 
 import json
-import mock
+from unittest import mock
 
 from django.urls import reverse
 

--- a/custom/champ/tests/test_service_uptake.py
+++ b/custom/champ/tests/test_service_uptake.py
@@ -2,7 +2,7 @@ from custom.champ.tests.utils import ChampTestCase
 from custom.champ.views import ServiceUptakeView
 
 import json
-import mock
+from unittest import mock
 
 from django.urls import reverse
 

--- a/custom/cowin/tests.py
+++ b/custom/cowin/tests.py
@@ -5,7 +5,7 @@ import uuid
 from django.test import SimpleTestCase
 
 import requests
-from mock import PropertyMock, patch
+from unittest.mock import PropertyMock, patch
 
 from corehq.form_processor.models import CommCareCaseSQL
 from corehq.motech.models import ConnectionSettings

--- a/custom/inddex/tests/test_master_report.py
+++ b/custom/inddex/tests/test_master_report.py
@@ -7,7 +7,7 @@ from django.test import SimpleTestCase, TestCase
 from django.utils.functional import cached_property
 
 from memoized import memoized
-from mock import patch
+from unittest.mock import patch
 
 from dimagi.utils.dates import DateSpan
 

--- a/custom/onse/tests.py
+++ b/custom/onse/tests.py
@@ -1,5 +1,5 @@
 import doctest
-from mock import patch
+from unittest.mock import patch
 
 from django.test import TestCase
 from datetime import date

--- a/custom/up_nrhm/tests/__init__.py
+++ b/custom/up_nrhm/tests/__init__.py
@@ -2,7 +2,7 @@ import os
 
 from django.test.utils import override_settings
 
-import mock
+from unittest import mock
 import postgres_copy
 import sqlalchemy
 

--- a/custom/up_nrhm/tests/reports/test_asha_reports.py
+++ b/custom/up_nrhm/tests/reports/test_asha_reports.py
@@ -1,5 +1,5 @@
 from unittest import mock
-from mock.mock import MagicMock
+from unittest.mock.mock import MagicMock
 
 from corehq.util.test_utils import softer_assert
 from custom.up_nrhm.reports.asha_facilitators_report import (

--- a/custom/up_nrhm/tests/reports/test_asha_reports.py
+++ b/custom/up_nrhm/tests/reports/test_asha_reports.py
@@ -1,5 +1,4 @@
-from unittest import mock
-from unittest.mock.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from corehq.util.test_utils import softer_assert
 from custom.up_nrhm.reports.asha_facilitators_report import (
@@ -35,7 +34,7 @@ RUN_QUERY_VALUE = {
 
 class TestASHAFunctionalityChecklistReport(UpNrhmTestCase):
 
-    @mock.patch('corehq.apps.es.es_query.run_query', return_value=RUN_QUERY_VALUE)
+    @patch('corehq.apps.es.es_query.run_query', return_value=RUN_QUERY_VALUE)
     def test_asha_functionality_checklist_report(self, mock_run_query):
         mock = MagicMock()
         mock.couch_user = self.user
@@ -76,7 +75,7 @@ class TestASHAFunctionalityChecklistReport(UpNrhmTestCase):
             ]
         )
 
-    @mock.patch('corehq.apps.es.es_query.run_query', return_value=RUN_QUERY_VALUE)
+    @patch('corehq.apps.es.es_query.run_query', return_value=RUN_QUERY_VALUE)
     def test_asha_facilitators_report(self, mock_run_query):
         mock = MagicMock()
         mock.couch_user = self.user
@@ -145,7 +144,7 @@ class TestASHAFunctionalityChecklistReport(UpNrhmTestCase):
             for record in expected[0][i]:
                 self.assertIn(record, rows[0][i])
 
-    @mock.patch('corehq.apps.es.es_query.run_query', return_value=RUN_QUERY_VALUE)
+    @patch('corehq.apps.es.es_query.run_query', return_value=RUN_QUERY_VALUE)
     def test_block_level_month_report(self, mock_run_query):
         mock = MagicMock()
         mock.couch_user = self.user
@@ -223,7 +222,7 @@ class TestASHAFunctionalityChecklistReport(UpNrhmTestCase):
             for record in expected[0][i]:
                 self.assertIn(record, rows[0][i])
 
-    @mock.patch('corehq.apps.es.es_query.run_query', return_value=RUN_QUERY_VALUE)
+    @patch('corehq.apps.es.es_query.run_query', return_value=RUN_QUERY_VALUE)
     def test_block_level_af_report(self, mock_run_query):
         mock = MagicMock()
         mock.couch_user = self.user
@@ -362,7 +361,7 @@ class TestASHAFunctionalityChecklistReport(UpNrhmTestCase):
             for record in expected[0][i]:
                 self.assertIn(record, rows[0][i])
 
-    @mock.patch('corehq.apps.es.es_query.run_query', return_value=RUN_QUERY_VALUE)
+    @patch('corehq.apps.es.es_query.run_query', return_value=RUN_QUERY_VALUE)
     def test_district_functionality_report(self, mock_run_query):
         mock = MagicMock()
         mock.couch_user = self.user

--- a/custom/up_nrhm/tests/reports/test_asha_reports.py
+++ b/custom/up_nrhm/tests/reports/test_asha_reports.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from mock.mock import MagicMock
 
 from corehq.util.test_utils import softer_assert

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -71,7 +71,6 @@ kombu==4.2.2.post1
 billiard!=3.5.0.5  # Should be resolved in celery 4.3: https://github.com/celery/billiard/issues/260
 laboratory==0.2.0
 lxml~=4.6.3
-mock==2.0.0
 openpyxl~=3.0
 phonenumberslite~=8.12
 pickle5  # For Pythons pre 3.8.3. Can be removed when no environment will ever revert to < 3.8

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -322,8 +322,6 @@ markupsafe==1.1.1
     #   mako
 mccabe==0.6.1
     # via flake8
-mock==2.0.0
-    # via -r base-requirements.in
 nose==1.3.7
     # via
     #   -r test-requirements.in
@@ -344,8 +342,6 @@ packaging==20.4
     # via sphinx
 parso==0.7.1
     # via jedi
-pbr==5.5.0
-    # via mock
 pep517==0.10.0
     # via pip-tools
 pexpect==4.8.0
@@ -533,7 +529,6 @@ six==1.15.0
     #   jsonpath-ng
     #   jsonschema
     #   mando
-    #   mock
     #   packaging
     #   protobuf
     #   pyopenssl

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -270,8 +270,6 @@ markupsafe==1.1.1
     #   mako
 mdit-py-plugins==0.2.8
     # via myst-parser
-mock==2.0.0
-    # via -r base-requirements.in
 myst-parser==0.15.2
     # via -r docs-requirements.in
 oauthlib==3.1.0
@@ -284,8 +282,6 @@ openpyxl==3.0.6
     #   commcaretranslationchecker
 packaging==20.9
     # via sphinx
-pbr==5.5.0
-    # via mock
 phonenumberslite==8.12.10
     # via -r base-requirements.in
 pickle5==0.0.11
@@ -432,7 +428,6 @@ six==1.15.0
     #   jsonobject-couchdbkit
     #   jsonpath-ng
     #   jsonschema
-    #   mock
     #   protobuf
     #   python-dateutil
     #   pyzxcvbn

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -269,8 +269,6 @@ markupsafe==1.1.1
     # via
     #   jinja2
     #   mako
-mock==2.0.0
-    # via -r base-requirements.in
 ndg-httpsclient==0.5.1
     # via -r prod-requirements.in
 oauthlib==3.1.0
@@ -283,8 +281,6 @@ openpyxl==3.0.6
     #   commcaretranslationchecker
 parso==0.7.1
     # via jedi
-pbr==5.5.0
-    # via mock
 pexpect==4.8.0
     # via ipython
 phonenumberslite==8.12.10
@@ -449,7 +445,6 @@ six==1.15.0
     #   jsonobject-couchdbkit
     #   jsonpath-ng
     #   jsonschema
-    #   mock
     #   protobuf
     #   pyopenssl
     #   python-dateutil

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -251,8 +251,6 @@ markupsafe==1.1.1
     # via
     #   jinja2
     #   mako
-mock==2.0.0
-    # via -r base-requirements.in
 oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
@@ -261,8 +259,6 @@ openpyxl==3.0.6
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker
-pbr==5.5.0
-    # via mock
 phonenumberslite==8.12.10
     # via -r base-requirements.in
 pickle5==0.0.11
@@ -406,7 +402,6 @@ six==1.15.0
     #   jsonobject-couchdbkit
     #   jsonpath-ng
     #   jsonschema
-    #   mock
     #   protobuf
     #   pyopenssl
     #   python-dateutil

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -273,8 +273,6 @@ markupsafe==1.1.1
     # via
     #   jinja2
     #   mako
-mock==2.0.0
-    # via -r base-requirements.in
 nose==1.3.7
     # via
     #   -r test-requirements.in
@@ -290,8 +288,6 @@ openpyxl==3.0.6
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker
-pbr==5.5.0
-    # via mock
 pep517==0.10.0
     # via pip-tools
 phonenumberslite==8.12.10
@@ -448,7 +444,6 @@ six==1.15.0
     #   jsonpath-ng
     #   jsonschema
     #   mando
-    #   mock
     #   protobuf
     #   pyopenssl
     #   python-dateutil

--- a/testapps/test_gunicorn/tests.py
+++ b/testapps/test_gunicorn/tests.py
@@ -1,6 +1,6 @@
 import os
 
-import mock
+from unittest import mock
 from deployment.gunicorn.gunicorn_conf import _child_exit, _on_starting
 from testil import eq
 

--- a/testapps/test_pillowtop/tests/test_app_pillow.py
+++ b/testapps/test_pillowtop/tests/test_app_pillow.py
@@ -1,5 +1,5 @@
 import uuid
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from django.test import TestCase
 from corehq.util.es.elasticsearch import ConnectionError

--- a/testapps/test_pillowtop/tests/test_case_search_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_search_pillow.py
@@ -1,7 +1,7 @@
 import uuid
 
 from django.test import TestCase
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from corehq.apps.case_search.const import SPECIAL_CASE_PROPERTIES_MAP
 from corehq.apps.case_search.exceptions import CaseSearchNotEnabledException

--- a/testapps/test_pillowtop/tests/test_changes.py
+++ b/testapps/test_pillowtop/tests/test_changes.py
@@ -1,5 +1,5 @@
 import uuid
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from django.test import TestCase
 

--- a/testapps/test_pillowtop/tests/test_chunk_pillow.py
+++ b/testapps/test_pillowtop/tests/test_chunk_pillow.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.test import TestCase
 from kafka.common import KafkaUnavailableError
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, KafkaCheckpointEventHandler

--- a/testapps/test_pillowtop/tests/test_domain_pillow.py
+++ b/testapps/test_pillowtop/tests/test_domain_pillow.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from django.test import TestCase
 from corehq.apps.change_feed import topics

--- a/testapps/test_pillowtop/tests/test_pillows_xforms.py
+++ b/testapps/test_pillowtop/tests/test_pillows_xforms.py
@@ -1,5 +1,5 @@
 import copy
-import mock
+from unittest import mock
 from django.test import SimpleTestCase
 from django.conf import settings
 from corehq.apps.api.es import report_term_filter

--- a/testapps/test_pillowtop/tests/test_reindexer.py
+++ b/testapps/test_pillowtop/tests/test_reindexer.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.test import TestCase
 from corehq.util.es.elasticsearch import ConnectionError
-import mock
+from unittest import mock
 
 from corehq.apps.callcenter.tests.test_utils import CallCenterDomainMockTest
 from corehq.apps.case_search.models import CaseSearchConfig

--- a/testapps/test_pillowtop/tests/test_sms_pillow.py
+++ b/testapps/test_pillowtop/tests/test_sms_pillow.py
@@ -13,7 +13,7 @@ from corehq.util.elastic import ensure_index_deleted, reset_es_index
 from datetime import datetime
 from dimagi.utils.parsing import json_format_datetime
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 
 
 @patch('corehq.apps.sms.change_publishers.do_publish')

--- a/testapps/test_pillowtop/tests/test_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_xform_pillow.py
@@ -5,7 +5,7 @@ from django.test import override_settings
 from django.test.testcases import SimpleTestCase, TestCase
 
 from couchdbkit import ResourceConflict
-from mock import patch
+from unittest.mock import patch
 
 from dimagi.utils.parsing import string_to_utc_datetime
 from pillow_retry.models import PillowError


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
**Reviewing by commit should make it slightly easier**

As of Python 3.3, mock is a standard part of python under the `unittest` package. We have a mixture of code that references the built-in `unittest` version of mock, and code that references the 3rd party version of `mock`. This was mostly find and replace, with a few spots that used the syntax `from unittest.mock import mock` which I don't believe is correct, so I modified those slightly. I didn't run anything locally since there are so many files it seemed most efficient to just run via github actions. 

The django-digest submodule imports mock as well, so I plan to create a PR to address that. I'm not sure if that submodule relies on HQ importing the `mock` library, but if so, we can make sure that PR is merged before merging this. 

UPDATE: as noted below, it looks like django-digest depends on HQ's requirements. PR to remove mock dependency from django-digest [here](https://github.com/dimagi/django-digest/pull/44).

I want to run `isort` on the modified files, but that results in lots of modifications that may cause conflicts/be unnecessary. And part of me thinks a better method would be to go app by app, and creating individual PRs for apps to minimize conflicts. This would also only be worth doing if the team is set on using isort and wants to maintain that import organization moving forward.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
As mentioned below, we can be confident this is safe if all tests pass.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
This change _only_ impacts automated tests, so as long as tests still pass, it is safe.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
