### PR TITLE
more validation for registry case update repeater

### DIFF
--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -605,6 +605,10 @@ class DataRegistryCaseUpdatePayloadGenerator(BasePayloadGenerator):
                 CaseUpdateConfig.from_payload(extension_case)
                 for extension_case in extensions
             ])
+
+        domains = {config.domain for config in configs}
+        if len(domains) > 1:
+            raise DataRegistryCaseUpdateError("Multiple updates must all be in the same domain")
         return configs
 
     def _get_target_cases(self, repeat_record, configs, couch_user):

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -483,12 +483,15 @@ class CaseUpdateConfig:
                 raise DataRegistryCaseUpdateError("Target case not found")
             if not self.owner_id:
                 raise DataRegistryCaseUpdateError("'owner_id' required when creating cases")
-
             kwargs = {
                 "create": True,
                 "case_type": self.case_type,
                 "date_opened": self.intent_case.opened_on
             }
+        elif self.create_case:
+            # should never get here but added as a precaution
+            raise DataRegistryCaseUpdateError("Unable to create target case as it already exists")
+
         return CaseBlock(
             case_id=self.case_id,
             owner_id=self.owner_id,
@@ -629,6 +632,9 @@ class DataRegistryCaseUpdatePayloadGenerator(BasePayloadGenerator):
             if config.create_case:
                 return
             raise DataRegistryCaseUpdateError(f"Target case not found: {config.case_id}")
+
+        if config.create_case:
+            raise DataRegistryCaseUpdateError("Unable to create target case as it already exists")
 
         if case.domain != config.domain or case.type != config.case_type:
             raise DataRegistryCaseUpdateError(f"Target case not found: {config.case_id}")

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -206,6 +206,20 @@ def test_generator_update_multiple_cases():
         })
 
 
+def test_generator_update_multiple_cases_multiple_domains():
+    main_case_builder = IntentCaseBuilder().case_properties(new_prop="new_prop_val")
+    subcase = (
+        IntentCaseBuilder()
+        .target_case(domain="other_domain", case_id="sub1")
+        .case_properties(sub1_prop="sub1_val")
+        .get_case()
+    )
+    main_case_builder.set_subcases([subcase])
+
+    with assert_raises(DataRegistryCaseUpdateError, msg="Multiple updates must all be in the same domain"):
+        _test_payload_generator(intent_case=main_case_builder.get_case())
+
+
 def test_generator_required_fields():
     intent_case = CommCareCaseSQL(
         domain=SOURCE_DOMAIN,

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -60,6 +60,13 @@ def test_generator_create_case():
     )
 
 
+def test_generator_create_case_target_exists():
+    builder = IntentCaseBuilder().case_properties(new_prop="new_prop_val").create_case("123")
+
+    with assert_raises(DataRegistryCaseUpdateError, msg="Unable to create target case as it already exists"):
+        _test_payload_generator(intent_case=builder.get_case(), target_case_exists=True)
+
+
 def test_generator_create_close():
     builder = IntentCaseBuilder().case_properties(new_prop="new_prop_val").close_case()
     _test_payload_generator(


### PR DESCRIPTION
## Product Description
* ensure all cases target the same domain
* fail if create a new case and there is already a case with the same ID

## Feature Flag
DATA_REGISTRY

## Safety Assurance

### Safety story
Changes covered by tests and limited to a feature flagged repeater

### Automated test coverage
Added

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
