### PR TITLE
add Data Registry UCR processor to `case-pillow`

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -310,8 +310,6 @@ class RegistryDataSourceTableManager(UcrTableManager):
 
     def _do_bootstrap(self, configs=None):
         configs = self.get_filtered_configs(configs)
-        if not configs:
-            return
 
         for config in configs:
             self._add_adapter_for_data_source(config)

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -123,7 +123,7 @@ class UcrTableManager(ABC):
         """
         self.bootstrapped = False
         self.last_bootstrapped = self.last_imported = datetime.utcnow()
-        self.bootstrap_interval = bootstrap_interval
+        self.bootstrap_interval = bootstrap_interval or REBUILD_CHECK_INTERVAL
         self.run_migrations = run_migrations
 
     def needs_bootstrap(self):
@@ -192,7 +192,7 @@ class UcrTableManager(ABC):
 class ConfigurableReportTableManager(UcrTableManager):
 
     def __init__(self, data_source_providers, ucr_division=None,
-                 include_ucrs=None, exclude_ucrs=None, bootstrap_interval=REBUILD_CHECK_INTERVAL,
+                 include_ucrs=None, exclude_ucrs=None, bootstrap_interval=None,
                  run_migrations=True):
         """Initializes the processor for UCRs
 
@@ -291,7 +291,7 @@ class ConfigurableReportTableManager(UcrTableManager):
 
 class RegistryDataSourceTableManager(UcrTableManager):
 
-    def __init__(self, bootstrap_interval=REBUILD_CHECK_INTERVAL, run_migrations=True):
+    def __init__(self, bootstrap_interval=None, run_migrations=True):
         """Initializes the processor for UCRs backed by a data registry
         """
         super().__init__(bootstrap_interval, run_migrations)
@@ -610,6 +610,35 @@ class ConfigurableReportKafkaPillow(ConstructedPillow):
         self.retry_errors = retry_errors
 
 
+def get_ucr_processor(data_source_providers,
+                      ucr_division=None,
+                      include_ucrs=None,
+                      exclude_ucrs=None,
+                      bootstrap_interval=None,
+                      run_migrations=True,
+                      ucr_configs=None):
+    table_manager = ConfigurableReportTableManager(
+        data_source_providers=data_source_providers,
+        ucr_division=ucr_division,
+        include_ucrs=include_ucrs,
+        exclude_ucrs=exclude_ucrs,
+        bootstrap_interval=bootstrap_interval,
+        run_migrations=run_migrations,
+    )
+    if ucr_configs:
+        table_manager.bootstrap(ucr_configs)
+    return ConfigurableReportPillowProcessor(table_manager)
+
+
+def get_data_registry_ucr_processor(run_migrations, ucr_configs):
+    table_manager = RegistryDataSourceTableManager(
+        run_migrations=run_migrations
+    )
+    if ucr_configs:
+        table_manager.bootstrap(ucr_configs)
+    return ConfigurableReportPillowProcessor(table_manager)
+
+
 def get_kafka_ucr_pillow(pillow_id='kafka-ucr-main', ucr_division=None,
                          include_ucrs=None, exclude_ucrs=None, topics=None,
                          num_processes=1, process_num=0, dedicated_migration_process=False,
@@ -721,12 +750,10 @@ def get_kafka_ucr_registry_pillow(
         Processors:
           - :py:class:`corehq.apps.userreports.pillow.ConfigurableReportPillowProcessor`
     """
-    table_manager = RegistryDataSourceTableManager(
-        run_migrations=(process_num == 0)  # only first process runs migrations
+    ucr_processor = get_data_registry_ucr_processor(
+        run_migrations=(process_num == 0),  # only first process runs migrations
+        ucr_configs=ucr_configs
     )
-    ucr_processor = ConfigurableReportPillowProcessor(table_manager)
-    if ucr_configs:
-        table_manager.bootstrap(ucr_configs)
 
     return ConfigurableReportKafkaPillow(
         processor=ucr_processor,

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -626,7 +626,10 @@ def get_ucr_processor(data_source_providers,
         run_migrations=run_migrations,
     )
     if ucr_configs:
-        table_manager.bootstrap(ucr_configs)
+        table_manager.bootstrap([
+            config for config in ucr_configs
+            if config.doc_type == "DataSourceConfiguration"
+        ])
     return ConfigurableReportPillowProcessor(table_manager)
 
 
@@ -635,7 +638,10 @@ def get_data_registry_ucr_processor(run_migrations, ucr_configs):
         run_migrations=run_migrations
     )
     if ucr_configs:
-        table_manager.bootstrap(ucr_configs)
+        table_manager.bootstrap([
+            config for config in ucr_configs
+            if config.doc_type == "RegistryDataSourceConfiguration"
+        ])
     return ConfigurableReportPillowProcessor(table_manager)
 
 

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -8,7 +8,7 @@ from casexml.apps.case.models import CommCareCase
 from corehq.apps.change_feed.topics import CASE_TOPICS
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, KafkaCheckpointEventHandler
 from corehq.apps.userreports.data_source_providers import DynamicDataSourceProvider, StaticDataSourceProvider
-from corehq.apps.userreports.pillow import get_ucr_processor
+from corehq.apps.userreports.pillow import get_ucr_processor, get_data_registry_ucr_processor
 from corehq.elastic import get_es_new
 from corehq.form_processor.backends.sql.dbaccessors import CaseReindexAccessor
 from corehq.messaging.pillow import CaseMessagingSyncProcessor
@@ -113,6 +113,10 @@ def get_case_pillow(
         run_migrations=run_migrations,
         ucr_configs=ucr_configs
     )
+    ucr_dr_processor = get_data_registry_ucr_processor(
+        run_migrations=run_migrations,
+        ucr_configs=ucr_configs
+    )
     case_to_es_processor = BulkElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=CASE_INDEX_INFO,
@@ -135,7 +139,7 @@ def get_case_pillow(
         processors.append(get_case_to_report_es_processor())
     if not skip_ucr:
         # this option is useful in tests to avoid extra UCR setup where unneccessary
-        processors = [ucr_processor] + processors
+        processors = [ucr_processor, ucr_dr_processor] + processors
     return ConstructedPillow(
         name=pillow_id,
         change_feed=change_feed,

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -5,7 +5,7 @@ from corehq.apps.groups.dbaccessors import get_group_id_name_map_by_user
 from corehq.apps.users.models import CommCareUser, CouchUser, WebUser
 from corehq.apps.users.util import WEIRD_USER_IDS
 from corehq.apps.userreports.data_source_providers import DynamicDataSourceProvider, StaticDataSourceProvider
-from corehq.apps.userreports.pillow import ConfigurableReportPillowProcessor, ConfigurableReportTableManager
+from corehq.apps.userreports.pillow import get_ucr_processor
 from corehq.elastic import (
     doc_exists_in_es,
     send_to_elasticsearch, get_es_new, ES_META
@@ -157,14 +157,13 @@ def get_user_pillow(pillow_id='user-pillow', num_processes=1, dedicated_migratio
     assert pillow_id == 'user-pillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, USER_INDEX_INFO, topics.USER_TOPICS)
     user_processor = get_user_es_processor()
-    table_manager = ConfigurableReportTableManager(
+    ucr_processor = get_ucr_processor(
         data_source_providers=[
             DynamicDataSourceProvider('CommCareUser'),
             StaticDataSourceProvider('CommCareUser')
         ],
-        run_migrations=(process_num == 0),  # only first process runs migrations
+        run_migrations=(process_num == 0),  # only first process runs migrations,
     )
-    ucr_processor = ConfigurableReportPillowProcessor(table_manager)
     change_feed = KafkaChangeFeed(
         topics=topics.USER_TOPICS, client_id='users-to-es', num_processes=num_processes, process_num=process_num,
         dedicated_migration_process=dedicated_migration_process

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -14,7 +14,7 @@ from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, KafkaCheckpoi
 from corehq.apps.data_interfaces.pillow import CaseDeduplicationProcessor
 from corehq.apps.receiverwrapper.util import get_app_version_info
 from corehq.apps.userreports.data_source_providers import DynamicDataSourceProvider, StaticDataSourceProvider
-from corehq.apps.userreports.pillow import ConfigurableReportPillowProcessor, ConfigurableReportTableManager
+from corehq.apps.userreports.pillow import get_ucr_processor
 from corehq.elastic import get_es_new
 from corehq.form_processor.backends.sql.dbaccessors import FormReindexAccessor
 from corehq.pillows.base import is_couch_change_for_sql_domain
@@ -193,7 +193,7 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
         dedicated_migration_process=dedicated_migration_process
     )
 
-    table_manager = ConfigurableReportTableManager(
+    ucr_processor = get_ucr_processor(
         data_source_providers=[
             DynamicDataSourceProvider('XFormInstance'),
             StaticDataSourceProvider('XFormInstance')
@@ -202,10 +202,9 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
         include_ucrs=include_ucrs,
         exclude_ucrs=exclude_ucrs,
         run_migrations=(process_num == 0),  # only first process runs migrations
+        ucr_configs=ucr_configs
     )
-    ucr_processor = ConfigurableReportPillowProcessor(table_manager)
-    if ucr_configs:
-        table_manager.bootstrap(ucr_configs)
+
     xform_to_es_processor = BulkElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=XFORM_INDEX_INFO,


### PR DESCRIPTION
## Technical Summary
Add a pillow processor to the 'case-pillow' to process data registry UCRs.

An alternative would be to run a separate pillow.

@calellowitz @dannyroberts I don't know if you have a preference for the approach here (separate pillow or part of the case pillow).

## Safety Assurance

### Safety story
Will be testing on staging.

### Automated test coverage
The processor itself has tests but I have not added tests for the case-pillow with data registry UCRs directly.

### QA Plan
I plan to run this on staging for a while before rolling out to prod.

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
