### PR TITLE
Sk/dr copy from case

### DIFF
--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -406,11 +406,19 @@ class CaseUpdateConfig:
         "close_case": "target_case_close",
         "includes": "target_property_includelist",
         "excludes": "target_property_excludelist",
+        # index create
         "index_create_case_id": "target_index_create_case_id",
         "index_create_case_type": "target_index_create_case_type",
         "index_create_relationship": "target_index_create_relationship",
+        # index remove
         "index_remove_case_id": "target_index_remove_case_id",
         "index_remove_relationship": "target_index_remove_relationship",
+        # copy from other case
+        "copy_domain": "target_copy_properties_from_case_domain",
+        "copy_case_id": "target_copy_properties_from_case_id",
+        "copy_case_type": "target_copy_properties_from_case_type",
+        "copy_includelist": "target_copy_properties_includelist",
+        "copy_excludelist": "target_copy_properties_excludelist"
     }
     REQUIRED_FIELDS = [
         "registry_slug",
@@ -434,6 +442,11 @@ class CaseUpdateConfig:
     index_create_relationship = attr.ib()
     index_remove_case_id = attr.ib()
     index_remove_relationship = attr.ib()
+    copy_domain = attr.ib()
+    copy_case_id = attr.ib()
+    copy_case_type = attr.ib()
+    copy_includelist = attr.ib()
+    copy_excludelist = attr.ib()
 
     @classmethod
     def from_payload(cls, payload_doc):

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -519,7 +519,7 @@ class CaseUpdateConfig:
         )
 
     def get_case_updates(self, couch_user, registry_helper, repeat_record):
-        updates = self._get_case_updates_from_source(self.intent_case, self.includes, self.excludes)
+        updates = {}
         if self.copy_case_id:
             copy_from = self._get_registry_case(
                 self.copy_domain, self.copy_case_id, self.copy_case_type, False,
@@ -527,6 +527,8 @@ class CaseUpdateConfig:
             )
             updates.update(self._get_case_updates_from_source(
                 copy_from, self.copy_includelist, self.copy_excludelist))
+        # properties on the intent case override properties from the other case
+        updates.update(self._get_case_updates_from_source(self.intent_case, self.includes, self.excludes))
         return updates
 
     def _get_case_updates_from_source(self, from_case, includes, excludes):

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -592,13 +592,13 @@ class CaseUpdateConfig:
         except CaseNotFound:
             if for_create:
                 return
-            raise DataRegistryCaseUpdateError(f"Target case not found: {case_id}")
+            raise DataRegistryCaseUpdateError(f"Case not found: {case_id}")
 
         if for_create:
-            raise DataRegistryCaseUpdateError("Unable to create target case as it already exists")
+            raise DataRegistryCaseUpdateError(f"Unable to create case as it already exists: {case_id}")
 
         if case.domain != domain or case.type != case_type:
-            raise DataRegistryCaseUpdateError(f"Target case not found: {case_id}")
+            raise DataRegistryCaseUpdateError(f"Case not found: {case_id}")
 
         return case
 

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -619,25 +619,29 @@ class DataRegistryCaseUpdatePayloadGenerator(BasePayloadGenerator):
         registry_slug = main_config.registry_slug
         helper = DataRegistryHelper(main_config.intent_case.domain, registry_slug=registry_slug)
         return list(filter(None, [
-            self._get_case(helper, repeat_record, config, couch_user)
+            self._get_case(
+                config.domain, config.case_id, config.case_type, not config.create_case,
+                helper, repeat_record, couch_user
+            )
             for config in configs
         ]))
 
-    def _get_case(self, registry_helper, repeat_record, config, couch_user):
+    def _get_case(self, domain, case_id, case_type, is_required, registry_helper, repeat_record, couch_user):
         try:
-            case = registry_helper.get_case(config.case_id, couch_user, repeat_record.repeater)
+            case = registry_helper.get_case(case_id, couch_user, repeat_record.repeater)
         except RegistryAccessException:
             raise DataRegistryCaseUpdateError("User does not have permission to access the registry")
         except CaseNotFound:
-            if config.create_case:
+            if not is_required:
                 return
-            raise DataRegistryCaseUpdateError(f"Target case not found: {config.case_id}")
+            raise DataRegistryCaseUpdateError(f"Target case not found: {case_id}")
 
-        if config.create_case:
+
+if config.create_case:
             raise DataRegistryCaseUpdateError("Unable to create target case as it already exists")
 
-        if case.domain != config.domain or case.type != config.case_type:
-            raise DataRegistryCaseUpdateError(f"Target case not found: {config.case_id}")
+        if case.domain != domain or case.type != case_type:
+            raise DataRegistryCaseUpdateError(f"Target case not found: {case_id}")
 
         return case
 

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -254,11 +254,9 @@ def test_generator_copy_from_other_case():
         .copy_props_from("other_domain", "other_case_id", "other_case_type")
 
     registry_cases = _mock_registry()
-    registry_cases["other_case_id"] = Mock(
-        domain="other_domain", case_id="other_case_id", type="other_case_type",
-        case_json={"other_prop": "other_val"}
+    registry_cases["other_case_id"] = _mock_case(
+        "other_case_id", domain="other_domain", case_type="other_case_type", props={"other_prop": "other_val"}
     )
-
     _test_payload_generator(
         intent_case=builder.get_case(),
         registry_mock_cases=registry_cases,
@@ -454,13 +452,20 @@ def _mock_registry():
     }
 
 
-def _mock_case(case_id):
-    return Mock(domain=TARGET_DOMAIN, type="patient", case_id=case_id, case_json={
+def _mock_case(case_id, props=None, domain=TARGET_DOMAIN, case_type="patient"):
+    props = props if props is not None else {
         "existing_prop": uuid.uuid4().hex,
         "existing_blank_prop": ""
-    }, live_indices=[
-        Mock(
-            identifier="parent", referenced_type="parent_type",
-            referenced_id="parent_case_id", relationship_id="child"
-        )
-    ])
+    }
+    mock_case = Mock(
+        domain=domain, type=case_type, case_id=case_id,
+        external_id=None,
+        case_json=props,
+        live_indices=[
+            Mock(
+                identifier="parent", referenced_type="parent_type",
+                referenced_id="parent_case_id", relationship_id="child"
+            )
+        ])
+    mock_case.name = None
+    return mock_case

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -28,7 +28,7 @@ def test_generator_empty_update():
 def test_generator_fail_if_case_domain_mismatch():
     builder = IntentCaseBuilder().include_props([]).target_case(domain="other")
 
-    with assert_raises(DataRegistryCaseUpdateError, msg="Target case not found: 1"):
+    with assert_raises(DataRegistryCaseUpdateError, msg="Case not found: 1"):
         _test_payload_generator(intent_case=builder.get_case())
 
 
@@ -63,7 +63,7 @@ def test_generator_create_case():
 def test_generator_create_case_target_exists():
     builder = IntentCaseBuilder().case_properties(new_prop="new_prop_val").create_case("123")
 
-    with assert_raises(DataRegistryCaseUpdateError, msg="Unable to create target case as it already exists"):
+    with assert_raises(DataRegistryCaseUpdateError, msg="Unable to create case as it already exists: 1"):
         _test_payload_generator(intent_case=builder.get_case())
 
 

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -250,12 +250,15 @@ def test_generator_required_fields():
 
 def test_generator_copy_from_other_case():
     builder = IntentCaseBuilder() \
-        .case_properties(intent_prop="intent_prop_val")\
+        .case_properties(intent_prop="intent_prop_val", overwrite_prop="new_val")\
         .copy_props_from("other_domain", "other_case_id", "other_case_type")
 
     registry_cases = _mock_registry()
     registry_cases["other_case_id"] = _mock_case(
-        "other_case_id", domain="other_domain", case_type="other_case_type", props={"other_prop": "other_val"}
+        "other_case_id", domain="other_domain", case_type="other_case_type", props={
+            "other_prop": "other_val",
+            "overwrite_prop": "old_val"
+        }
     )
     _test_payload_generator(
         intent_case=builder.get_case(),
@@ -264,6 +267,7 @@ def test_generator_copy_from_other_case():
             "1": {
                 "intent_prop": "intent_prop_val",
                 "other_prop": "other_val",
+                "overwrite_prop": "new_val",
             }})
 
 


### PR DESCRIPTION
## Product Description
Re-parent a case to a new domain during dedupe workflow:

#### Example:
*Initial cases:*
* domainA
  * patient
    * lab_result

*Final cases*
* domainB
  * patient (new case)
    * lab_result ('clone' of lab_result in domain A)


- close "patient" case in domain A
- create "patient" new case in domain B
- copy "lab_result" case from domain A to domain B and attach it to "patient" in domain B

## Technical Summary
In the `DataRegistryCaseUpdateRepeater` allow copying properties from another case. This other case can be in another domain but must be accessible to the user via the data registry.

Spec: https://docs.google.com/document/d/1tyep82t6aj6fyv1lAFTY1t-c7EI2yVLYgBCiqnOo8d8/edit#heading=h.cswz8rsmrqzw
Jira: https://dimagi-dev.atlassian.net/browse/USH-1406

## Feature Flag
DATA_REGISTRY

## Safety Assurance

### Safety story
Scope of changes limited to feature flagged repeater.

### Automated test coverage
Test created / updated

### QA Plan
QA by AE team


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
