### PR TITLE
update db checks to no longer query the table

### DIFF
--- a/corehq/sql_db/__init__.py
+++ b/corehq/sql_db/__init__.py
@@ -1,7 +1,7 @@
 from django.apps import apps
 from django.conf import settings
 from django.core import checks
-from django.db import DEFAULT_DB_ALIAS
+from django.db import connections, DEFAULT_DB_ALIAS
 
 from corehq.sql_db.exceptions import PartitionValidationError
 

--- a/corehq/sql_db/__init__.py
+++ b/corehq/sql_db/__init__.py
@@ -120,8 +120,10 @@ def check_db_tables(app_configs, **kwargs):
     ]
 
     def _check_model(model_class, using=None):
+        db = using or DEFAULT_DB_ALIAS
         try:
-            model_class._default_manager.using(using).all().exists()
+            with connections[db].cursor() as cursor:
+                cursor.execute("SELECT %s::regclass", [model_class._meta.db_table])
         except Exception as e:
             return checks.Error('checks.Error querying model on database "{}": "{}.{}": {}.{}({})'.format(
                 using or DEFAULT_DB_ALIAS,


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This replaces our table existence checks with a much quicker alternative. Instead of querying the table for a row, which can be slow if there is heavy load on the table, this checks for the existence of a table by casting the string name to `regclass`, which causes postgres to look up the table under the hood, and raise a meaningful exception (`ProgrammingError: relation "bad_table" does not exist`) if the table is not found.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Used only in deploy checks

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
