### PR TITLE
[Hubspot] Ensure that users who have ever accepted an invitation from a blocked domain continue to stay blocked from hubspot

### DIFF
--- a/corehq/apps/analytics/management/commands/manually_cleanup_blocked_hubspot_contacts.py
+++ b/corehq/apps/analytics/management/commands/manually_cleanup_blocked_hubspot_contacts.py
@@ -2,6 +2,7 @@ from django.core.management import BaseCommand
 
 from corehq.apps.analytics.utils import (
     remove_blocked_domain_contacts_from_hubspot,
+    remove_blocked_domain_invited_users_from_hubspot,
 )
 
 
@@ -10,3 +11,4 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         remove_blocked_domain_contacts_from_hubspot(self.stdout)
+        remove_blocked_domain_invited_users_from_hubspot(self.stdout)

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -41,6 +41,7 @@ from corehq.apps.analytics.utils import (
     remove_blocked_domain_contacts_from_hubspot,
     MAX_API_RETRIES,
     emails_that_accepted_invitations_to_blocked_hubspot_domains,
+    remove_blocked_domain_invited_users_from_hubspot,
 )
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import get_domains_created_by_user
@@ -855,3 +856,4 @@ def cleanup_blocked_hubspot_contacts():
         return
 
     remove_blocked_domain_contacts_from_hubspot()
+    remove_blocked_domain_invited_users_from_hubspot()

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -211,16 +211,19 @@ def _get_user_hubspot_id(web_user, retry_num=0):
             if retry_num <= MAX_API_RETRIES:
                 return _get_user_hubspot_id(web_user, retry_num + 1)
             else:
+                metrics_counter(
+                    'commcare.hubspot.get_user_hubspot_id.retry_fail'
+                )
                 logger.error(f"Failed to get Hubspot user id for WebUser "
                              f"{web_user.username} due to {str(e)}.")
         else:
+            metrics_counter(
+                'commcare.hubspot.get_user_hubspot_id.success'
+            )
             return req.json().get("vid", None)
-    elif api_key:
+    elif api_key and retry_num == 0:
         metrics_counter(
-            'commcare.hubspot_data.rejected.get_user_hubspot_id',
-            tags={
-                'username': web_user.username,
-            }
+            'commcare.hubspot.get_user_hubspot_id.rejected'
         )
     return None
 
@@ -243,10 +246,7 @@ def _send_form_to_hubspot(form_id, webuser, hubspot_cookie, meta, extra_fields=N
             or (not webuser and not hubspot_enabled_for_email(email))):
         # This user has analytics disabled
         metrics_counter(
-            'commcare.hubspot_data.rejected.send_form_to_hubspot',
-            tags={
-                'username': webuser.username if webuser else email,
-            }
+            'commcare.hubspot.sent_form.rejected'
         )
         return
 
@@ -548,6 +548,9 @@ def track_periodic_data():
                 # User had accepted an invitation to a project space whose
                 # Billing Account has blocked HubSpot analytics, so we
                 # should not send any data about them going forward
+                metrics_counter(
+                    'commcare.hubspot_data.rejected.periodic_task.invitation',
+                )
                 hubspot_number_of_users_blocked += 1
                 continue
 

--- a/corehq/apps/analytics/tests/test_hubspot.py
+++ b/corehq/apps/analytics/tests/test_hubspot.py
@@ -16,6 +16,7 @@ from corehq.apps.analytics.utils import (
     is_domain_blocked_from_hubspot,
     hubspot_enabled_for_user,
     hubspot_enabled_for_email,
+    emails_that_accepted_invitations_to_blocked_hubspot_domains,
 )
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import (
@@ -178,6 +179,12 @@ class TestBlockedHubspotData(TestCase):
         self.blocked_invitation_user.delete_domain_membership(self.blocked_domain.name)
         self.blocked_invitation_user.save()
         self.assertFalse(hubspot_enabled_for_email(self.blocked_invitation_user.username))
+
+    def test_emails_that_accepted_invitations_to_blocked_hubspot_domains(self):
+        self.assertListEqual(
+            [self.blocked_invitation_user.username],
+            list(emails_that_accepted_invitations_to_blocked_hubspot_domains())
+        )
 
     def test_couch_user_is_blocked(self):
         """

--- a/corehq/apps/analytics/tests/test_hubspot.py
+++ b/corehq/apps/analytics/tests/test_hubspot.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.test import RequestFactory, TestCase, override_settings
 
 import mock
@@ -16,7 +18,12 @@ from corehq.apps.analytics.utils import (
     hubspot_enabled_for_email,
 )
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.users.models import WebUser, CouchUser, CommCareUser
+from corehq.apps.users.models import (
+    WebUser,
+    CouchUser,
+    CommCareUser,
+    Invitation,
+)
 
 from ..tasks import (
     HUBSPOT_COOKIE,
@@ -119,6 +126,18 @@ class TestBlockedHubspotData(TestCase):
             cls.second_blocked_user.username
         )
 
+        cls.blocked_invitation_user = WebUser.create(
+            cls.blocked_domain.name, 'blocked-by-invitation@gmail.com', '*****', None, None
+        )
+        invite_to_blocked_domain = Invitation(
+            email=cls.blocked_invitation_user.username,
+            is_accepted=True,
+            domain=cls.blocked_domain.name,
+            invited_on=datetime.now(),
+            invited_by="system@dimagi.com",
+        )
+        invite_to_blocked_domain.save()
+
         cls.blocked_commcare_user = CommCareUser.create(
             cls.blocked_domain.name, 'testuser', '****', None, None
         )
@@ -150,6 +169,16 @@ class TestBlockedHubspotData(TestCase):
         self.assertFalse(hubspot_enabled_for_email(self.second_blocked_user.username))
         self.assertTrue(hubspot_enabled_for_email(self.allowed_user.username))
 
+    def test_removed_user_is_still_blocked(self):
+        """
+        Ensure that users who have previously accepted an invitation to a domain
+        blocking hubspot data, continue to be blocked from hubspot once their
+        membership has been removed from that domain.
+        """
+        self.blocked_invitation_user.delete_domain_membership(self.blocked_domain.name)
+        self.blocked_invitation_user.save()
+        self.assertFalse(hubspot_enabled_for_email(self.blocked_invitation_user.username))
+
     def test_couch_user_is_blocked(self):
         """
         Make sure that hubspot_enabled_for_user does not throw an error if a
@@ -161,6 +190,7 @@ class TestBlockedHubspotData(TestCase):
     def tearDownClass(cls):
         cls.blocked_user.delete(cls.blocked_domain.name, deleted_by=None)
         cls.second_blocked_user.delete(cls.second_blocked_domain.name, deleted_by=None)
+        cls.blocked_invitation_user.delete(cls.blocked_domain.name, deleted_by=None)
         cls.allowed_user.delete(cls.allowed_domain.name, deleted_by=None)
         cls.blocked_domain.delete()
         cls.second_blocked_domain.delete()

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -259,11 +259,7 @@ def remove_blocked_domain_contacts_from_hubspot(stdout=None):
             num_deleted = sum(_delete_hubspot_contact(vid) for vid in ids_to_delete)
             metrics_counter(
                 'commcare.hubspot_data.deleted_user.blocked_domain',
-                num_deleted,
-                tags={
-                    'domain': domain,
-                    'ids_deleted': ids_to_delete,
-                }
+                num_deleted
             )
 
 

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -84,6 +84,14 @@ def has_user_accepted_invitation_to_blocked_hubspot_domain(web_user):
     ).exists()
 
 
+def emails_that_accepted_invitations_to_blocked_hubspot_domains():
+    blocked_domains = get_blocked_hubspot_domains()
+    return Invitation.objects.filter(
+        domain__in=blocked_domains,
+        is_accepted=True,
+    ).values_list('email', flat=True)
+
+
 def hubspot_enabled_for_email(email_address):
     from corehq.apps.users.models import CouchUser
     user = CouchUser.get_by_username(email_address)

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -259,7 +259,10 @@ def remove_blocked_domain_contacts_from_hubspot(stdout=None):
             num_deleted = sum(_delete_hubspot_contact(vid) for vid in ids_to_delete)
             metrics_counter(
                 'commcare.hubspot_data.deleted_user.blocked_domain',
-                num_deleted
+                num_deleted,
+                tags={
+                    'domain': domain,
+                }
             )
 
 

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -278,7 +278,7 @@ def remove_blocked_domain_invited_users_from_hubspot(stdout=None):
     num_chunks = int(math.ceil(float(total_users) / float(chunk_size)))
 
     if stdout:
-        stdout.write(f"\n\nChecking Invited Users...")
+        stdout.write("\n\nChecking Invited Users...")
 
     for chunk in range(num_chunks):
         start = chunk * chunk_size


### PR DESCRIPTION
## Product Description
This PR addresses the question posed in [this ticket](https://dimagi-dev.atlassian.net/browse/SS-249), which asks whether users who have been removed from Hubspot-blocked domains then get resynced with Hubspot after their domain membership is revoked. Prior to this PR, the answer was yes. Now, users who have accepted invitations from blocked hubspot domains continue to remain off of our Hubspot mailing list unless they have interacted with Dimagi outside of CommCare HQ.

## Technical Summary
Adds two new analytics utilities and tests for utilities:
- `has_user_accepted_invitation_to_blocked_hubspot_domain`
- `emails_that_accepted_invitations_to_blocked_hubspot_domains`

Also adds an additional cleanup task called `remove_blocked_domain_invited_users_from_hubspot` which will run after `remove_blocked_domain_contacts_from_hubspot`.


## Safety Assurance

### Safety story
Tests for new code. Not a super user-facing critical part of HQ. Lots of metrics to monitor whether tasks are running properly.

### Automated test coverage
yes.

### QA Plan
None needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
