### PR TITLE
Generic Case Repeater

### DIFF
--- a/corehq/apps/userreports/ui/fields.py
+++ b/corehq/apps/userreports/ui/fields.py
@@ -47,6 +47,9 @@ class JsonField(forms.CharField):
             return value
 
     def to_python(self, value):
+        if isinstance(value, self.expected_type):
+            return json.loads(json.dumps(value))
+
         val = super(JsonField, self).to_python(value)
         try:
             return json.loads(val)
@@ -57,4 +60,6 @@ class JsonField(forms.CharField):
         if value in self.null_values and self.required:
             raise forms.ValidationError(self.error_messages['required'])
         if self.expected_type and not isinstance(value, self.expected_type):
-            raise forms.ValidationError(_('Expected {} but was {}'.format(self.expected_type, type(value))))
+            raise forms.ValidationError(
+                _('Expected {} but was {}'.format(self.expected_type.__name__, type(value).__name__))
+            )

--- a/corehq/apps/userreports/ui/fields.py
+++ b/corehq/apps/userreports/ui/fields.py
@@ -47,8 +47,8 @@ class JsonField(forms.CharField):
             return value
 
     def to_python(self, value):
-        if isinstance(value, self.expected_type):
-            return json.loads(json.dumps(value))
+        if value and isinstance(value, dict):
+            return value
 
         val = super(JsonField, self).to_python(value)
         try:

--- a/corehq/apps/userreports/ui/fields.py
+++ b/corehq/apps/userreports/ui/fields.py
@@ -61,5 +61,4 @@ class JsonField(forms.CharField):
             raise forms.ValidationError(self.error_messages['required'])
         if self.expected_type and not isinstance(value, self.expected_type):
             raise forms.ValidationError(
-                _('Expected {} but was {}'.format(self.expected_type.__name__, type(value).__name__))
-            )
+                _('Expected {} but was {}').format(self.expected_type.__name__, type(value).__name__))

--- a/corehq/motech/repeaters/expression/forms.py
+++ b/corehq/motech/repeaters/expression/forms.py
@@ -2,7 +2,6 @@ from django.forms import ValidationError
 
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
-from corehq.apps.userreports.expressions.specs import DictExpressionSpec
 from corehq.apps.userreports.filters.factory import FilterFactory
 from corehq.apps.userreports.specs import FactoryContext
 from corehq.apps.userreports.ui import help_text
@@ -20,11 +19,9 @@ class CaseExpressionRepeaterForm(GenericRepeaterForm):
 
     def clean_configured_expression(self):
         try:
-            parsed_expression = ExpressionFactory.from_spec(
+            ExpressionFactory.from_spec(
                 self.cleaned_data['configured_expression'], FactoryContext.empty()
             )
-            if not isinstance(parsed_expression, DictExpressionSpec):
-                raise ValidationError("The configured expression must be a dict expression")
         except BadSpecError as e:
             raise ValidationError(e)
 

--- a/corehq/motech/repeaters/expression/forms.py
+++ b/corehq/motech/repeaters/expression/forms.py
@@ -1,0 +1,39 @@
+from django.forms import ValidationError
+
+from corehq.apps.userreports.exceptions import BadSpecError
+from corehq.apps.userreports.expressions.factory import ExpressionFactory
+from corehq.apps.userreports.expressions.specs import DictExpressionSpec
+from corehq.apps.userreports.filters.factory import FilterFactory
+from corehq.apps.userreports.specs import FactoryContext
+from corehq.apps.userreports.ui import help_text
+from corehq.apps.userreports.ui.fields import JsonField
+from corehq.motech.repeaters.forms import GenericRepeaterForm
+
+
+class CaseExpressionRepeaterForm(GenericRepeaterForm):
+    configured_filter = JsonField(expected_type=dict, help_text=help_text.CONFIGURED_FILTER)
+    configured_expression = JsonField(expected_type=dict)
+
+    def get_ordered_crispy_form_fields(self):
+        fields = super().get_ordered_crispy_form_fields()
+        return fields + ['configured_filter', 'configured_expression']
+
+    def clean_configured_expression(self):
+        try:
+            parsed_expression = ExpressionFactory.from_spec(
+                self.cleaned_data['configured_expression'], FactoryContext.empty()
+            )
+            if not isinstance(parsed_expression, DictExpressionSpec):
+                raise ValidationError("The configured expression must be a dict expression")
+        except BadSpecError as e:
+            raise ValidationError(e)
+
+        return self.cleaned_data['configured_expression']
+
+    def clean_configured_filter(self):
+        try:
+            FilterFactory.from_spec(self.cleaned_data['configured_filter'])
+        except BadSpecError as e:
+            raise ValidationError(e)
+
+        return self.cleaned_data['configured_filter']

--- a/corehq/motech/repeaters/expression/repeater_generators.py
+++ b/corehq/motech/repeaters/expression/repeater_generators.py
@@ -2,8 +2,7 @@ import json
 
 from django.core.serializers.json import DjangoJSONEncoder
 
-from corehq.apps.userreports.expressions.factory import ExpressionFactory
-from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
+from corehq.apps.userreports.specs import EvaluationContext
 from corehq.motech.repeaters.repeater_generators import BasePayloadGenerator
 
 
@@ -12,7 +11,6 @@ class ExpressionPayloadGenerator(BasePayloadGenerator):
     def content_type(self):
         return 'application/json'
 
-    def get_payload(self, repeat_record, payload_doc, expression):
-        parsed_expression = ExpressionFactory.from_spec(expression, FactoryContext.empty())
+    def get_payload(self, repeat_record, payload_doc, parsed_expression):
         result = parsed_expression(payload_doc, EvaluationContext(payload_doc))
         return json.dumps(result, cls=DjangoJSONEncoder)

--- a/corehq/motech/repeaters/expression/repeater_generators.py
+++ b/corehq/motech/repeaters/expression/repeater_generators.py
@@ -1,0 +1,18 @@
+import json
+
+from django.core.serializers.json import DjangoJSONEncoder
+
+from corehq.apps.userreports.expressions.factory import ExpressionFactory
+from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
+from corehq.motech.repeaters.repeater_generators import BasePayloadGenerator
+
+
+class ExpressionPayloadGenerator(BasePayloadGenerator):
+    @property
+    def content_type(self):
+        return 'application/json'
+
+    def get_payload(self, repeat_record, payload_doc, expression):
+        parsed_expression = ExpressionFactory.from_spec(expression, FactoryContext.empty())
+        result = parsed_expression(payload_doc, EvaluationContext(payload_doc))
+        return json.dumps(result, cls=DjangoJSONEncoder)

--- a/corehq/motech/repeaters/expression/repeaters.py
+++ b/corehq/motech/repeaters/expression/repeaters.py
@@ -1,0 +1,47 @@
+from django.utils.translation import ugettext_lazy as _
+
+from memoized import memoized
+
+from dimagi.ext.couchdbkit import DictProperty
+
+from corehq.apps.userreports.filters.factory import FilterFactory
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.motech.repeaters.expression.repeater_generators import (
+    ExpressionPayloadGenerator,
+)
+from corehq.motech.repeaters.models import Repeater
+from corehq.toggles import EXPRESSION_REPEATER
+
+
+class BaseExpressionRepeater(Repeater):
+    """Uses a UCR dict expression to send a generic json response
+    """
+    class Meta:
+        app_label = 'repeaters'
+
+    configured_filter = DictProperty()
+    configured_expression = DictProperty()
+    payload_generator_classes = (ExpressionPayloadGenerator,)
+
+    @classmethod
+    def available_for_domain(cls, domain):
+        return EXPRESSION_REPEATER.enabled(domain)
+
+    def allowed_to_forward(self, payload):
+        return FilterFactory.from_spec(self.configured_filter)(payload.to_json())
+
+    @memoized
+    def get_payload(self, repeat_record):
+        return self.generator.get_payload(
+            repeat_record,
+            self.payload_doc(repeat_record),
+            self.configured_expression
+        )
+
+
+class CaseExpressionRepeater(BaseExpressionRepeater):
+    friendly_name = _("Configurable Case Repeater")
+
+    @memoized
+    def payload_doc(self, repeat_record):
+        return CaseAccessors(repeat_record.domain).get_case(repeat_record.payload_id).to_json()

--- a/corehq/motech/repeaters/expression/tests.py
+++ b/corehq/motech/repeaters/expression/tests.py
@@ -1,0 +1,93 @@
+import json
+from datetime import datetime, timedelta
+
+from django.test import TestCase
+
+from casexml.apps.case.mock import CaseFactory
+
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
+from corehq.apps.accounting.utils import clear_plan_version_cache
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.motech.models import ConnectionSettings
+from corehq.motech.repeaters.dbaccessors import delete_all_repeat_records
+from corehq.motech.repeaters.expression.repeaters import CaseExpressionRepeater
+from corehq.motech.repeaters.models import RepeatRecord
+from corehq.util.test_utils import flag_enabled
+
+
+@flag_enabled('EXPRESSION_REPEATER')
+class CaseExpressionRepeaterTest(TestCase, DomainSubscriptionMixin):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.domain = 'test'
+        cls.domain_obj = create_domain(cls.domain)
+        cls.setup_subscription(cls.domain, SoftwarePlanEdition.PRO)
+
+        cls.factory = CaseFactory(cls.domain)
+
+        url = 'fake-url'
+        cls.connection = ConnectionSettings.objects.create(domain=cls.domain, name=url, url=url)
+        cls.repeater = CaseExpressionRepeater(
+            domain=cls.domain,
+            connection_settings_id=cls.connection.id,
+            configured_filter={
+                "type": "boolean_expression",
+                "expression": {
+                    "type": "property_name",
+                    "property_name": "type",
+                },
+                "operator": "eq",
+                "property_value": "forward-me",
+            },
+            configured_expression={
+                "type": "dict",
+                "properties": {
+                    "case_id": {
+                        "type": "property_name",
+                        "property_name": "case_id",
+                    },
+                    "a-constant": {
+                        "type": "constant",
+                        "constant": "foo",
+                    }
+                }
+            }
+        )
+
+        cls.repeater.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.repeater.delete()
+        cls.connection.delete()
+        cls.teardown_subscriptions()
+        cls.domain_obj.delete()
+        clear_plan_version_cache()
+        super().tearDownClass()
+
+    def tearDown(self):
+        delete_all_repeat_records()
+
+    @classmethod
+    def repeat_records(cls, domain_name):
+        # Enqueued repeat records have next_check set 48 hours in the future.
+        later = datetime.utcnow() + timedelta(hours=48 + 1)
+        return RepeatRecord.all(domain=domain_name, due_before=later)
+
+    def test_filter_cases(self):
+        forwardable_case = self.factory.create_case(case_type='forward-me')
+        unforwardable_case = self.factory.create_case(case_type='dont-forward-me')  # noqa
+        repeat_records = self.repeat_records(self.domain).all()
+        self.assertEqual(RepeatRecord.count(domain=self.domain), 1)
+        self.assertEqual(repeat_records[0].payload_id, forwardable_case.case_id)
+
+    def test_payload(self):
+        forwardable_case = self.factory.create_case(case_type='forward-me')
+        repeat_record = self.repeat_records(self.domain).all()[0]
+        self.assertEqual(repeat_record.get_payload(), json.dumps({
+            "case_id": forwardable_case.case_id,
+            "a-constant": "foo",
+        }))

--- a/corehq/motech/repeaters/expression/views.py
+++ b/corehq/motech/repeaters/expression/views.py
@@ -1,0 +1,27 @@
+from django.urls import reverse
+from django.utils.translation import ugettext_lazy as _
+
+from corehq.motech.repeaters.expression.forms import CaseExpressionRepeaterForm
+from corehq.motech.repeaters.views import AddRepeaterView, EditRepeaterView
+
+
+class AddCaseExpressionRepeaterView(AddRepeaterView):
+    urlname = 'add_case_expression_repeater'
+    repeater_form_class = CaseExpressionRepeaterForm
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname, args=[self.domain])
+
+    def set_repeater_attr(self, repeater, cleaned_data):
+        repeater = super().set_repeater_attr(repeater, cleaned_data)
+        repeater.configured_filter = (
+            self.add_repeater_form.cleaned_data['configured_filter'])
+        repeater.configured_expression = (
+            self.add_repeater_form.cleaned_data['configured_expression'])
+        return repeater
+
+
+class EditCaseExpressionRepeaterView(EditRepeaterView, AddCaseExpressionRepeaterView):
+    urlname = 'edit_case_expression_repeater'
+    page_title = _("Edit Case Repeater")

--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -26,11 +26,13 @@ def create_form_repeat_records(sender, xform, **kwargs):
 
 def create_case_repeat_records(sender, case, **kwargs):
     from corehq.motech.repeaters.models import CaseRepeater
+    from corehq.motech.repeaters.expression.repeaters import CaseExpressionRepeater
     create_repeat_records(CaseRepeater, case)
     create_repeat_records(CreateCaseRepeater, case)
     create_repeat_records(UpdateCaseRepeater, case)
     create_repeat_records(ReferCaseRepeater, case)
     create_repeat_records(DataRegistryCaseUpdateRepeater, case)
+    create_repeat_records(CaseExpressionRepeater, case)
 
 
 def create_short_form_repeat_records(sender, xform, **kwargs):

--- a/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
+++ b/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
@@ -1,6 +1,7 @@
 hqDefine("repeaters/js/add_form_repeater", [
     'jquery',
     'hqwebapp/js/initial_page_data',
+    'hqwebapp/js/base_ace',     // expression repeaters use ace for the json editor
     'hqwebapp/js/widgets',       // case repeaters ("Forward Cases") use .hqwebapp-select2
     'locations/js/widgets',         // openmrs repeaters use the LocationSelectWidget
 ], function (

--- a/corehq/motech/urls.py
+++ b/corehq/motech/urls.py
@@ -26,6 +26,10 @@ from corehq.motech.repeaters.views import (
     pause_repeater,
     resume_repeater,
 )
+from corehq.motech.repeaters.expression.views import (
+    AddCaseExpressionRepeaterView,
+    EditCaseExpressionRepeaterView,
+)
 from corehq.motech.views import (
     ConnectionSettingsDetailView,
     ConnectionSettingsListView,
@@ -63,6 +67,8 @@ urlpatterns = [
         {'repeater_type': 'ReferCaseRepeater'}, name=AddCaseRepeaterView.urlname),
     url(r'^forwarding/new/DataRegistryCaseUpdateRepeater/$', AddCaseRepeaterView.as_view(),
         {'repeater_type': 'DataRegistryCaseUpdateRepeater'}, name=AddCaseRepeaterView.urlname),
+    url(r'^forwarding/new/CaseExpressionRepeater/$', AddCaseExpressionRepeaterView.as_view(),
+        {'repeater_type': 'CaseExpressionRepeater'}, name=AddCaseExpressionRepeaterView.urlname),
     url(r'^forwarding/new/(?P<repeater_type>\w+)/$', AddRepeaterView.as_view(), name=AddRepeaterView.urlname),
 
     url(r'^forwarding/edit/CaseRepeater/(?P<repeater_id>\w+)/$', EditCaseRepeaterView.as_view(),
@@ -81,6 +87,12 @@ urlpatterns = [
         {'repeater_type': 'Dhis2EntityRepeater'}, name=EditDhis2EntityRepeaterView.urlname),
     url(r'^forwarding/edit/FHIRRepeater/(?P<repeater_id>\w+)/$', EditFHIRRepeaterView.as_view(),
         {'repeater_type': 'FHIRRepeater'}, name=EditFHIRRepeaterView.urlname),
+    url(
+        r'^forwarding/edit/CaseExpressionRepeater/(?P<repeater_id>\w+)/$',
+        EditCaseExpressionRepeaterView.as_view(),
+        {'repeater_type': 'CaseExpressionRepeater'},
+        name=EditCaseExpressionRepeaterView.urlname
+    ),
     url(r'^forwarding/edit/(?P<repeater_type>\w+)/(?P<repeater_id>\w+)/$', EditRepeaterView.as_view(),
         name=EditRepeaterView.urlname),
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -2127,6 +2127,12 @@ COWIN_INTEGRATION = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
+EXPRESSION_REPEATER = StaticToggle(
+    'expression_repeater',
+    'Integrate with generic APIs using UCR expressions',
+    TAG_SOLUTIONS_OPEN,
+    namespaces=[NAMESPACE_DOMAIN],
+)
 
 TURN_IO_BACKEND = StaticToggle(
     'turn_io_backend',

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -2130,7 +2130,7 @@ COWIN_INTEGRATION = StaticToggle(
 EXPRESSION_REPEATER = StaticToggle(
     'expression_repeater',
     'Integrate with generic APIs using UCR expressions',
-    TAG_SOLUTIONS_OPEN,
+    TAG_SOLUTIONS_LIMITED,
     namespaces=[NAMESPACE_DOMAIN],
 )
 

--- a/settings.py
+++ b/settings.py
@@ -821,6 +821,7 @@ REPEATER_CLASSES = [
     'corehq.motech.dhis2.repeaters.Dhis2EntityRepeater',
     'custom.cowin.repeaters.BeneficiaryRegistrationRepeater',
     'custom.cowin.repeaters.BeneficiaryVaccinationRepeater',
+    'corehq.motech.repeaters.expression.repeaters.CaseExpressionRepeater',
 ]
 
 # Override this in localsettings to add new repeater types


### PR DESCRIPTION
## Product Description
Here's a big 🔨 

This allows you to create a case repeater based on UCR filters and expressions (with the open possibility to do the same thing with forms, but YAGNI).

This allows us to forward cases to any _existing_ API that has a well defined JSON spec without any custom dev work when app properties change, etc. The motivation for this was to integrate with [DIVOC](https://egovernments.github.io/DIVOC/developer-docs/api/admin-api.html#/vaccination-api.yaml). 

The expression must be a ~`dict`~ valid UCR expression that defines each property of the API. Thanks to the power of UCR expressions, this can also do related document lookups, etc. 

I believe that this can fulfill almost all of our custom API integration work, and pushes this down to end users. The experience of this will only get better as the tooling around UCR is developed.

The one major thing this is currently missing is how to handle a response (e.g. writing back to the case). However, this model could also be used in that scenario by creating a case update as long as the response is well formed JSON. 

I started writing this up as a spec, but realized it was a minimal amount of work to actually get it working, so opening this as a draft to get some feedback.

![Screenshot from 2021-11-15 17-00-25](https://user-images.githubusercontent.com/146896/141859936-a6aa0d25-30c8-4d04-95d3-8e51a2b11a13.png)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
