### PR TITLE
User must be admin in both domains to link domains

### DIFF
--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -32,6 +32,14 @@ def is_active_downstream_domain(domain):
     return DomainLink.objects.filter(linked_domain=domain).exists()
 
 
+def is_active_link(upstream_domain, downstream_domain):
+    return get_active_domain_link(upstream_domain, downstream_domain).exists()
+
+
+def get_active_domain_link(upstream_domain, downstream_domain):
+    return DomainLink.objects.filter(master_domain=upstream_domain, linked_domain=downstream_domain)
+
+
 @quickcache(['domain'], timeout=60 * 60)
 def get_linked_domains(domain, include_deleted=False):
     """

--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -32,15 +32,8 @@ def is_active_downstream_domain(domain):
     return DomainLink.objects.filter(linked_domain=domain).exists()
 
 
-def is_active_link(upstream_domain, downstream_domain):
-    return bool(get_active_domain_link(upstream_domain, downstream_domain))
-
-
 def get_active_domain_link(upstream_domain, downstream_domain):
-    try:
-        return DomainLink.objects.get(master_domain=upstream_domain, linked_domain=downstream_domain)
-    except DomainLink.DoesNotExist:
-        return None
+    return DomainLink.objects.filter(master_domain=upstream_domain, linked_domain=downstream_domain).first()
 
 
 @quickcache(['domain'], timeout=60 * 60)

--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -33,11 +33,14 @@ def is_active_downstream_domain(domain):
 
 
 def is_active_link(upstream_domain, downstream_domain):
-    return get_active_domain_link(upstream_domain, downstream_domain).exists()
+    return bool(get_active_domain_link(upstream_domain, downstream_domain))
 
 
 def get_active_domain_link(upstream_domain, downstream_domain):
-    return DomainLink.objects.filter(master_domain=upstream_domain, linked_domain=downstream_domain)
+    try:
+        return DomainLink.objects.get(master_domain=upstream_domain, linked_domain=downstream_domain)
+    except DomainLink.DoesNotExist:
+        return None
 
 
 @quickcache(['domain'], timeout=60 * 60)

--- a/corehq/apps/linked_domain/exceptions.py
+++ b/corehq/apps/linked_domain/exceptions.py
@@ -2,6 +2,14 @@ class DomainLinkError(Exception):
     pass
 
 
+class DomainLinkAlreadyExists(Exception):
+    pass
+
+
+class DomainLinkNotAllowed(Exception):
+    pass
+
+
 class MultipleDownstreamAppsError(Exception):
     pass
 

--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -91,6 +91,11 @@ class DomainLink(models.Model):
 
     @classmethod
     def link_domains(cls, linked_domain, master_domain, remote_details=None):
+        """
+        With the GAing of linked projects in the form of ERM/MRM, this will become an internal method in favor
+        of the link_domains method in linked_domain/views.py to allow for proper validation of domain and user
+        privileges before creating any links
+        """
         existing_links = cls.all_objects.filter(linked_domain=linked_domain)
         active_links_with_other_domains = [
             domain_link for domain_link in existing_links

--- a/corehq/apps/linked_domain/tests/test_views.py
+++ b/corehq/apps/linked_domain/tests/test_views.py
@@ -1,9 +1,13 @@
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 from django.test import SimpleTestCase
 
 from corehq.apps.domain.exceptions import DomainDoesNotExist
-from corehq.apps.linked_domain.exceptions import DomainLinkError, DomainLinkAlreadyExists, DomainLinkNotAllowed
+from corehq.apps.linked_domain.exceptions import (
+    DomainLinkAlreadyExists,
+    DomainLinkError,
+    DomainLinkNotAllowed,
+)
 from corehq.apps.linked_domain.views import link_domains
 
 

--- a/corehq/apps/linked_domain/tests/test_views.py
+++ b/corehq/apps/linked_domain/tests/test_views.py
@@ -1,0 +1,61 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from corehq.apps.linked_domain.exceptions import DomainLinkError
+from corehq.apps.linked_domain.views import handle_create_domain_link_request
+
+
+class CreateDomainLinkRequestTests(SimpleTestCase):
+
+    def test_fails_if_domain_does_not_exist(self):
+        upstream_domain = 'upstream'
+        downstream_domain = 'downstream'
+
+        def mock_handler(domain):
+            return domain != downstream_domain
+
+        with patch('corehq.apps.linked_domain.views.domain_exists') as mock_domainexists:
+            mock_domainexists.side_effect = mock_handler
+            error = handle_create_domain_link_request(upstream_domain, downstream_domain)
+
+        self.assertEqual(error, f"The project space {downstream_domain} does not exist. Make sure "
+                                f"the name is correct and that this domain hasn't been deleted.")
+
+    def test_fails_if_domain_link_already_exists(self):
+        upstream_domain = 'upstream'
+        downstream_domain = 'downstream'
+
+        with patch('corehq.apps.linked_domain.views.domain_exists', return_value=True),\
+             patch('corehq.apps.linked_domain.views.is_active_link', return_value=True):
+            error = handle_create_domain_link_request(upstream_domain, downstream_domain)
+
+        self.assertEqual(error, f"The project space {downstream_domain} is already a downstream "
+                                f"project space of {upstream_domain}.")
+
+    def test_fails_if_domain_link_error_raised(self):
+        upstream_domain = 'upstream'
+        downstream_domain = 'downstream'
+
+        def mock_handler(downstream, upstream):
+            raise DomainLinkError
+
+        with patch('corehq.apps.linked_domain.views.domain_exists', return_value=True),\
+             patch('corehq.apps.linked_domain.views.is_active_link', return_value=False),\
+             patch('corehq.apps.linked_domain.views.DomainLink.link_domains') as mock_linkdomains:
+            mock_linkdomains.side_effect = mock_handler
+            error = handle_create_domain_link_request(upstream_domain, downstream_domain)
+
+        self.assertEqual(error, f"An error was encountered while attempting to link {downstream_domain} to "
+                                f"{upstream_domain}.")
+
+    def test_successful(self):
+        upstream_domain = 'upstream'
+        downstream_domain = 'downstream'
+
+        with patch('corehq.apps.linked_domain.views.domain_exists', return_value=True),\
+             patch('corehq.apps.linked_domain.views.is_active_link', return_value=False),\
+             patch('corehq.apps.linked_domain.views.DomainLink.link_domains', return_value=True):
+            error = handle_create_domain_link_request(upstream_domain, downstream_domain)
+
+        self.assertIsNone(error)

--- a/corehq/apps/linked_domain/tests/test_views.py
+++ b/corehq/apps/linked_domain/tests/test_views.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from django.test import SimpleTestCase
 
@@ -11,13 +11,14 @@ class CreateDomainLinkRequestTests(SimpleTestCase):
     def test_fails_if_domain_does_not_exist(self):
         upstream_domain = 'upstream'
         downstream_domain = 'downstream'
+        user = Mock()
 
         def mock_handler(domain):
             return domain != downstream_domain
 
         with patch('corehq.apps.linked_domain.views.domain_exists') as mock_domainexists:
             mock_domainexists.side_effect = mock_handler
-            error = handle_create_domain_link_request(upstream_domain, downstream_domain)
+            error = handle_create_domain_link_request(user, upstream_domain, downstream_domain)
 
         self.assertEqual(error, f"The project space {downstream_domain} does not exist. Make sure "
                                 f"the name is correct and that this domain hasn't been deleted.")
@@ -25,10 +26,11 @@ class CreateDomainLinkRequestTests(SimpleTestCase):
     def test_fails_if_domain_link_already_exists(self):
         upstream_domain = 'upstream'
         downstream_domain = 'downstream'
+        user = Mock()
 
         with patch('corehq.apps.linked_domain.views.domain_exists', return_value=True),\
              patch('corehq.apps.linked_domain.views.is_active_link', return_value=True):
-            error = handle_create_domain_link_request(upstream_domain, downstream_domain)
+            error = handle_create_domain_link_request(user, upstream_domain, downstream_domain)
 
         self.assertEqual(error, f"The project space {downstream_domain} is already a downstream "
                                 f"project space of {upstream_domain}.")
@@ -36,6 +38,7 @@ class CreateDomainLinkRequestTests(SimpleTestCase):
     def test_fails_if_domain_link_error_raised(self):
         upstream_domain = 'upstream'
         downstream_domain = 'downstream'
+        user = Mock()
 
         def mock_handler(downstream, upstream):
             raise DomainLinkError
@@ -44,18 +47,32 @@ class CreateDomainLinkRequestTests(SimpleTestCase):
              patch('corehq.apps.linked_domain.views.is_active_link', return_value=False),\
              patch('corehq.apps.linked_domain.views.DomainLink.link_domains') as mock_linkdomains:
             mock_linkdomains.side_effect = mock_handler
-            error = handle_create_domain_link_request(upstream_domain, downstream_domain)
+            error = handle_create_domain_link_request(user, upstream_domain, downstream_domain)
 
         self.assertEqual(error, f"An error was encountered while attempting to link {downstream_domain} to "
                                 f"{upstream_domain}.")
 
-    def test_successful(self):
+    def test_fails_if_user_is_not_admin_in_both_domains(self):
         upstream_domain = 'upstream'
         downstream_domain = 'downstream'
+        user = Mock()
 
         with patch('corehq.apps.linked_domain.views.domain_exists', return_value=True),\
              patch('corehq.apps.linked_domain.views.is_active_link', return_value=False),\
-             patch('corehq.apps.linked_domain.views.DomainLink.link_domains', return_value=True):
-            error = handle_create_domain_link_request(upstream_domain, downstream_domain)
+             patch('corehq.apps.linked_domain.views.user_has_admin_access_in_all_domains', return_value=False):
+            error = handle_create_domain_link_request(user, upstream_domain, downstream_domain)
+
+        self.assertEqual(error, "The user must be an admin is both project spaces to successfully create a link.")
+
+    def test_successful(self):
+        upstream_domain = 'upstream'
+        downstream_domain = 'downstream'
+        user = Mock()
+
+        with patch('corehq.apps.linked_domain.views.domain_exists', return_value=True),\
+             patch('corehq.apps.linked_domain.views.is_active_link', return_value=False),\
+             patch('corehq.apps.linked_domain.views.DomainLink.link_domains', return_value=True),\
+             patch('corehq.apps.linked_domain.views.user_has_admin_access_in_all_domains', return_value=True):
+            error = handle_create_domain_link_request(user, upstream_domain, downstream_domain)
 
         self.assertIsNone(error)

--- a/corehq/apps/linked_domain/tests/test_views.py
+++ b/corehq/apps/linked_domain/tests/test_views.py
@@ -29,7 +29,7 @@ class CreateDomainLinkRequestTests(SimpleTestCase):
         user = Mock()
 
         with patch('corehq.apps.linked_domain.views.domain_exists', return_value=True),\
-             patch('corehq.apps.linked_domain.views.is_active_link', return_value=True):
+             patch('corehq.apps.linked_domain.views.get_active_domain_link', return_value=Mock()):
             error = handle_create_domain_link_request(user, upstream_domain, downstream_domain)
 
         self.assertEqual(error, f"The project space {downstream_domain} is already a downstream "
@@ -44,7 +44,7 @@ class CreateDomainLinkRequestTests(SimpleTestCase):
             raise DomainLinkError
 
         with patch('corehq.apps.linked_domain.views.domain_exists', return_value=True),\
-             patch('corehq.apps.linked_domain.views.is_active_link', return_value=False),\
+             patch('corehq.apps.linked_domain.views.get_active_domain_link', return_value=None),\
              patch('corehq.apps.linked_domain.views.DomainLink.link_domains') as mock_linkdomains:
             mock_linkdomains.side_effect = mock_handler
             error = handle_create_domain_link_request(user, upstream_domain, downstream_domain)
@@ -58,7 +58,7 @@ class CreateDomainLinkRequestTests(SimpleTestCase):
         user = Mock()
 
         with patch('corehq.apps.linked_domain.views.domain_exists', return_value=True),\
-             patch('corehq.apps.linked_domain.views.is_active_link', return_value=False),\
+             patch('corehq.apps.linked_domain.views.get_active_domain_link', return_value=None),\
              patch('corehq.apps.linked_domain.views.user_has_admin_access_in_all_domains', return_value=False):
             error = handle_create_domain_link_request(user, upstream_domain, downstream_domain)
 
@@ -70,7 +70,7 @@ class CreateDomainLinkRequestTests(SimpleTestCase):
         user = Mock()
 
         with patch('corehq.apps.linked_domain.views.domain_exists', return_value=True),\
-             patch('corehq.apps.linked_domain.views.is_active_link', return_value=False),\
+             patch('corehq.apps.linked_domain.views.get_active_domain_link', return_value=None),\
              patch('corehq.apps.linked_domain.views.DomainLink.link_domains', return_value=True),\
              patch('corehq.apps.linked_domain.views.user_has_admin_access_in_all_domains', return_value=True):
             error = handle_create_domain_link_request(user, upstream_domain, downstream_domain)

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -52,10 +52,15 @@ from corehq.apps.linked_domain.dbaccessors import (
     get_linked_domains,
     get_upstream_domain_link,
 )
-from corehq.apps.linked_domain.decorators import require_linked_domain, require_access_to_linked_domains
+from corehq.apps.linked_domain.decorators import (
+    require_access_to_linked_domains,
+    require_linked_domain,
+)
 from corehq.apps.linked_domain.exceptions import (
+    DomainLinkAlreadyExists,
     DomainLinkError,
-    UnsupportedActionError, DomainLinkAlreadyExists, DomainLinkNotAllowed,
+    DomainLinkNotAllowed,
+    UnsupportedActionError,
 )
 from corehq.apps.linked_domain.local_accessors import (
     get_auto_update_rules,
@@ -66,8 +71,8 @@ from corehq.apps.linked_domain.local_accessors import (
     get_fixture,
     get_hmac_callout_settings,
     get_otp_settings,
-    get_user_roles,
     get_tableau_server_and_visualizations,
+    get_user_roles,
 )
 from corehq.apps.linked_domain.models import (
     DomainLink,

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -30,6 +30,7 @@ from corehq.apps.domain.decorators import (
     domain_admin_required,
     login_or_api_key,
 )
+from corehq.apps.domain.exceptions import DomainDoesNotExist
 from corehq.apps.domain.views.base import DomainViewMixin
 from corehq.apps.domain.views.settings import BaseAdminProjectSettingsView
 from corehq.apps.fixtures.dbaccessors import get_fixture_data_type_by_tag
@@ -54,7 +55,7 @@ from corehq.apps.linked_domain.dbaccessors import (
 from corehq.apps.linked_domain.decorators import require_linked_domain, require_access_to_linked_domains
 from corehq.apps.linked_domain.exceptions import (
     DomainLinkError,
-    UnsupportedActionError,
+    UnsupportedActionError, DomainLinkAlreadyExists, DomainLinkNotAllowed,
 )
 from corehq.apps.linked_domain.local_accessors import (
     get_auto_update_rules,
@@ -400,27 +401,15 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
     @allow_remote_invocation
     def create_domain_link(self, in_data):
         domain_to_link = in_data['downstream_domain']
-
-        error = handle_create_domain_link_request(self.request.couch_user, self.domain, domain_to_link)
-        if error:
-            return {
-                'success': False,
-                'message': error
-            }
-
-        domain_link = get_active_domain_link(self.domain, domain_to_link)
-        if not domain_link:
-            return {
-                'success': False,
-                'message': ugettext("Failed to successfully save domain link.")
-            }
+        try:
+            domain_link = link_domains(self.request.couch_user, self.domain, domain_to_link)
+        except (DomainDoesNotExist, DomainLinkAlreadyExists, DomainLinkNotAllowed, DomainLinkError) as e:
+            return {'success': False, 'message': str(e)}
 
         track_workflow(self.request.couch_user.username, "Linked domain: domain link created")
-        timezone = get_timezone_for_request()
-        return {
-            'success': True,
-            'domain_link': build_domain_link_view_model(domain_link, timezone)
-        }
+
+        domain_link_view_model = build_domain_link_view_model(domain_link, get_timezone_for_request())
+        return {'success': True, 'domain_link': domain_link_view_model}
 
     @allow_remote_invocation
     def create_remote_report_link(self, in_data):
@@ -439,25 +428,23 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
             return {'success': False}
 
 
-def handle_create_domain_link_request(couch_user, upstream_domain, downstream_domain):
+def link_domains(couch_user, upstream_domain, downstream_domain):
     if not domain_exists(downstream_domain):
-        return ugettext("The project space {} does not exist. Make sure the name is correct and that "
-                        "this domain hasn't been deleted.").format(downstream_domain)
+        error = ugettext("The project space {} does not exist. Verify that the name is correct, and that the "
+                         "domain has not been deleted.").format(downstream_domain)
+        raise DomainDoesNotExist(error)
 
     if get_active_domain_link(upstream_domain, downstream_domain):
-        return ugettext(
+        error = ugettext(
             "The project space {} is already a downstream project space of {}."
         ).format(downstream_domain, upstream_domain)
+        raise DomainLinkAlreadyExists(error)
 
     if not user_has_admin_access_in_all_domains(couch_user, [upstream_domain, downstream_domain]):
-        return ugettext("The user must be an admin is both project spaces to successfully create a link.")
+        error = ugettext("You must be an admin in both project spaces to create a link.")
+        raise DomainLinkNotAllowed(error)
 
-    try:
-        DomainLink.link_domains(downstream_domain, upstream_domain)
-    except DomainLinkError:
-        return ugettext(
-            "An error was encountered while attempting to link {} to {}."
-        ).format(downstream_domain, upstream_domain)
+    return DomainLink.link_domains(downstream_domain, upstream_domain)
 
 
 class DomainLinkHistoryReport(GenericTabularReport):

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -50,7 +50,6 @@ from corehq.apps.linked_domain.dbaccessors import (
     get_available_upstream_domains,
     get_linked_domains,
     get_upstream_domain_link,
-    is_active_link,
 )
 from corehq.apps.linked_domain.decorators import require_linked_domain, require_access_to_linked_domains
 from corehq.apps.linked_domain.exceptions import (
@@ -445,7 +444,7 @@ def handle_create_domain_link_request(couch_user, upstream_domain, downstream_do
         return ugettext("The project space {} does not exist. Make sure the name is correct and that "
                         "this domain hasn't been deleted.").format(downstream_domain)
 
-    if is_active_link(upstream_domain, downstream_domain):
+    if get_active_domain_link(upstream_domain, downstream_domain):
         return ugettext(
             "The project space {} is already a downstream project space of {}."
         ).format(downstream_domain, upstream_domain)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
For ERM (Enterprise Release Management) and MRM (Multi-Environment Release Management) users, this enforces that a user must be an admin in both domains to successfully create a link.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SS-247

**Review by commit**

The 1st commit refactors existing functionality by abstracting a method that is more easily testable than the `create_domain_link` method in the RMI view. It also slightly changes an error message to no longer return the `DomainLinkError` exception as a string, but a more generic/explicit method.

The 2nd commit ensures a user must be an admin in both domains. From a user perspective, this has been the case because the dropdown containing available domains to link only contains domains the user is an admin in, but this ensures the backend is aligned in this behavior. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added automated tests for this new method. 
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
