### PR TITLE
USH: Fix custom case rules

### DIFF
--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -141,6 +141,8 @@ def case_property_query(case_property_name, value, fuzzy=False):
     """
     Search for all cases where case property with name `case_property_name`` has text value `value`
     """
+    if value is None:
+        raise TypeError("You cannot pass 'None' as a case property value")
     if value == '':
         return case_property_missing(case_property_name)
     if fuzzy:

--- a/custom/covid/rules/custom_actions.py
+++ b/custom/covid/rules/custom_actions.py
@@ -41,11 +41,11 @@ def close_cases_assigned_to_checkin(checkin_case, rule):
         "assigned_to_primary_username": "",
     }
     num_related_updates = 0
-    for assigned_case in _get_assigned_cases(checkin_case):
+    for assigned_case_domain, assigned_case_id in _get_assigned_cases(checkin_case):
         num_related_updates += 1
         (submission, cases) = update_case(
-            assigned_case.domain,
-            assigned_case.case_id,
+            assigned_case_domain,
+            assigned_case_id,
             case_properties=blank_properties,
             xmlns=AUTO_UPDATE_XMLNS,
             device_id=__name__ + ".close_cases_assigned_to_checkin",
@@ -68,11 +68,10 @@ def close_cases_assigned_to_checkin(checkin_case, rule):
 
 
 def _get_assigned_cases(checkin_case):
-    query = (
+    return (
         CaseSearchES()
         .domain(checkin_case.domain)
         .filter(filters.OR(case_type("patient"), case_type("contact")))
         .case_property_query("assigned_to_primary_checkin_case_id", checkin_case.case_id)
+        .values_list('domain', '_id')
     )
-
-    return [CommCareCase.wrap(flatten_result(hit)) for hit in query.run().hits]

--- a/custom/covid/rules/custom_criteria.py
+++ b/custom/covid/rules/custom_criteria.py
@@ -40,6 +40,8 @@ def associated_usercase_closed(case, now):
 
 def get_usercase_from_checkin(checkin_case):
     username = checkin_case.get_case_property("username")
+    if not username:
+        return None
     query = (
         CaseSearchES()
         .domain(checkin_case.domain)

--- a/custom/covid/rules/custom_criteria.py
+++ b/custom/covid/rules/custom_criteria.py
@@ -11,31 +11,17 @@ from corehq.apps.app_manager.const import USERCASE_TYPE
 
 def associated_usercase_closed(case, now):
     """
-    Only cases that match all of the following criteria pass the filter:
-
-    - the case is open
-    - the case is an associated checkin case of a mobile worker
-    - the corresponding user case is closed
-
+    Is this an open checkin case where the associated usercase has been closed?
     """
-    if case.closed:
-        return False
-
-    if case.type != "checkin":
+    if case.closed or case.type != "checkin":
         return False
 
     usercase = get_usercase_from_checkin(case)
-
-    if usercase is None:
-        return False
-
-    if case.domain != usercase.domain:
-        return False
-
-    if usercase.closed:
-        return True
-
-    return False
+    return (
+        usercase is not None
+        and case.domain == usercase.domain
+        and usercase.closed
+    )
 
 
 def get_usercase_from_checkin(checkin_case):

--- a/custom/covid/tests/test_custom_rules.py
+++ b/custom/covid/tests/test_custom_rules.py
@@ -43,16 +43,6 @@ class DeactivatedMobileWorkersTest(BaseCaseRuleTest):
         self.mobile_worker = CommCareUser.create(self.domain, username, "123", None, None)
         sync_usercases(self.mobile_worker)
 
-        self.checkin_case = CaseFactory(self.domain).create_case(
-            case_type="checkin",
-            owner_id=self.mobile_worker.get_id,
-            update={"username": self.mobile_worker.raw_username},
-        )
-        send_to_elasticsearch(
-            "case_search", transform_case_for_elasticsearch(self.checkin_case.to_json())
-        )
-        self.es.indices.refresh(CASE_SEARCH_INDEX_INFO.index)
-
         self.case_accessor = CaseAccessors(self.domain)
 
     def tearDown(self):
@@ -61,8 +51,20 @@ class DeactivatedMobileWorkersTest(BaseCaseRuleTest):
         ensure_index_deleted(CASE_SEARCH_INDEX_INFO.index)
         super().tearDown()
 
-    def test_associated_usercase_closed(self):
+    def make_checkin_case(self, properties=None):
+        properties = properties if properties is not None else {"username": self.mobile_worker.raw_username}
+        checkin_case = CaseFactory(self.domain).create_case(
+            case_type="checkin",
+            owner_id=self.mobile_worker.get_id,
+            update=properties,
+        )
+        send_to_elasticsearch(
+            "case_search", transform_case_for_elasticsearch(checkin_case.to_json())
+        )
+        self.es.indices.refresh(CASE_SEARCH_INDEX_INFO.index)
+        return checkin_case
 
+    def close_all_usercases(self):
         usercase_ids = self.case_accessor.get_case_ids_in_domain(type=USERCASE_TYPE)
         for usercase_id in usercase_ids:
             CaseFactory(self.domain).close_case(usercase_id)
@@ -72,14 +74,23 @@ class DeactivatedMobileWorkersTest(BaseCaseRuleTest):
             )
         self.es.indices.refresh(CASE_SEARCH_INDEX_INFO.index)
 
-        self.assertTrue(associated_usercase_closed(self.checkin_case, None))
+    def test_associated_usercase_closed(self):
+        checkin_case = self.make_checkin_case()
+        self.close_all_usercases()
+        self.assertTrue(associated_usercase_closed(checkin_case, None))
+
+    def test_checkin_case_no_username_skipped(self):
+        checkin_case = self.make_checkin_case(properties={})
+        self.close_all_usercases()
+        self.assertFalse(associated_usercase_closed(checkin_case, None))
 
     def test_custom_action(self):
+        checkin_case = self.make_checkin_case()
         rule = create_empty_rule(
             self.domain, AutomaticUpdateRule.WORKFLOW_CASE_UPDATE, case_type="checkin",
         )
         case_properties = {
-            "assigned_to_primary_checkin_case_id": self.checkin_case.case_id,
+            "assigned_to_primary_checkin_case_id": checkin_case.case_id,
             "is_assigned_primary": "foo",
             "assigned_to_primary_name": "bar",
             "assigned_to_primary_username": "baz",
@@ -95,15 +106,15 @@ class DeactivatedMobileWorkersTest(BaseCaseRuleTest):
         other_case = CaseFactory(self.domain).create_case(
             case_type="other",
             owner_id=self.mobile_worker.get_id,
-            update={"assigned_to_primary_checkin_case_id": self.checkin_case.case_id},
+            update={"assigned_to_primary_checkin_case_id": checkin_case.case_id},
         )
         for case in [patient_case, other_patient_case, other_case]:
             send_to_elasticsearch("case_search", transform_case_for_elasticsearch(case.to_json()))
         self.es.indices.refresh(CASE_SEARCH_INDEX_INFO.index)
 
-        close_cases_assigned_to_checkin(self.checkin_case, rule)
+        close_cases_assigned_to_checkin(checkin_case, rule)
 
-        self.assertTrue(self.case_accessor.get_case(self.checkin_case.case_id).closed)
+        self.assertTrue(self.case_accessor.get_case(checkin_case.case_id).closed)
 
         patient_case = self.case_accessor.get_case(patient_case.case_id)
         self.assertFalse(patient_case.closed)
@@ -114,7 +125,7 @@ class DeactivatedMobileWorkersTest(BaseCaseRuleTest):
         self.assertFalse(other_case.closed)
         self.assertEqual(
             other_case.get_case_property("assigned_to_primary_checkin_case_id"),
-            self.checkin_case.case_id,
+            checkin_case.case_id,
         )
 
         other_patient_case = self.case_accessor.get_case(other_patient_case.case_id)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
https://dimagi-dev.atlassian.net/browse/SUPPORT-11468
https://sentry.io/organizations/dimagi/issues/2787537621/?project=136860&query=run_case_update_rules_for_domain_and_db&statsPeriod=14d
https://sentry.io/organizations/dimagi/issues/2787221048/?project=136860&query=run_case_update_rules_for_domain_and_db&statsPeriod=14d


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The two errors above are caused by bad case data, but we should be more failure tolerant, so this PR anticipates those particular failures and handles them better.  As-is, any hard failure on a single case will break out of the loop [here](https://github.com/dimagi/commcare-hq/blob/e98c3dd91acde69015bdf46cd6f33f0a3a82b57b/corehq/apps/data_interfaces/utils.py#L250-L250), meaning that the remaining cases of the same domain, case type, and db partition will not be processed, and the DomainCaseRuleRun will never be marked as finished.  Furthermore, depending on the rules configured, it's likely the case with bad data will be picked up in every subsequent rule run (since it still matches), causing this failure to be sticky.  We have many DomainCaseRuleRuns like this, some where every run has failed for over a year.  We should definitely build some fault tolerance into this framework, but I'm starting here and going to recommend that as a separate task.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests included

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
