### PR TITLE
Release management decorator does not check for admin of specific domain

### DIFF
--- a/corehq/apps/linked_domain/util.py
+++ b/corehq/apps/linked_domain/util.py
@@ -17,13 +17,13 @@ def can_access_linked_domains(user, domain):
     if not user or not domain:
         return False
     if domain_has_privilege(domain, RELEASE_MANAGEMENT):
-        return user.is_domain_admin()
+        return user.is_domain_admin(domain)
     else:
         return toggles.LINKED_DOMAINS.enabled(domain)
 
 
 def can_access_release_management_feature(user, domain):
-    return domain_has_privilege(domain, RELEASE_MANAGEMENT) and user.is_domain_admin()
+    return domain_has_privilege(domain, RELEASE_MANAGEMENT) and user.is_domain_admin(domain)
 
 
 def _clean_json(doc):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The `is_domain_admin` method does check for the `current_domain` attribute on a user, but it is better to be explicit about the domain we are checking for. Not sure how I missed this the first time around.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Rather than rely on the `current_domain` attribute, this is just more explicit, and more accurate with what we want this decorator/access method to check.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
I was going to add a test for this case, but since I'm mocking `is_domain_admin` in the current tests, it makes it tricky to test this behavior.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
