### PR TITLE
check correct DB

### DIFF
--- a/corehq/sql_db/__init__.py
+++ b/corehq/sql_db/__init__.py
@@ -125,12 +125,12 @@ def check_db_tables(app_configs, **kwargs):
             with connections[db].cursor() as cursor:
                 cursor.execute("SELECT %s::regclass", [model_class._meta.db_table])
         except Exception as e:
-            return checks.Error('checks.Error querying model on database "{}": "{}.{}": {}.{}({})'.format(
+            errors.append(checks.Error('checks.Error querying model on database "{}": "{}.{}": {}.{}({})'.format(
                 using or DEFAULT_DB_ALIAS,
                 model_class._meta.app_label, model_class.__name__,
                 e.__class__.__module__, e.__class__.__name__,
                 e
-            ))
+            )))
 
     for model in apps.get_models():
         app_label = model._meta.app_label
@@ -143,9 +143,7 @@ def check_db_tables(app_configs, **kwargs):
 
         if issubclass(model, PartitionedModel):
             for db in get_db_aliases_for_partitioned_query():
-                checks.Error = _check_model(model, using=db)
-                checks.Error and errors.append(checks.Error)
+                _check_model(model, using=db)
         else:
-            checks.Error = _check_model(model)
-            checks.Error and errors.append(checks.Error)
+            _check_model(model)
     return errors

--- a/corehq/sql_db/__init__.py
+++ b/corehq/sql_db/__init__.py
@@ -1,7 +1,7 @@
 from django.apps import apps
 from django.conf import settings
 from django.core import checks
-from django.db import connections, DEFAULT_DB_ALIAS
+from django.db import connections, DEFAULT_DB_ALIAS, router
 
 from corehq.sql_db.exceptions import PartitionValidationError
 
@@ -120,7 +120,7 @@ def check_db_tables(app_configs, **kwargs):
     ]
 
     def _check_model(model_class, using=None):
-        db = using or DEFAULT_DB_ALIAS
+        db = using or router.db_for_read(model_class)
         try:
             with connections[db].cursor() as cursor:
                 cursor.execute("SELECT %s::regclass", [model_class._meta.db_table])

--- a/corehq/sql_db/__init__.py
+++ b/corehq/sql_db/__init__.py
@@ -1,7 +1,7 @@
 from django.apps import apps
 from django.conf import settings
 from django.core import checks
-from django.db import connections, DEFAULT_DB_ALIAS, router
+from django.db import connections as django_connections, DEFAULT_DB_ALIAS, router
 
 from corehq.sql_db.exceptions import PartitionValidationError
 
@@ -122,7 +122,7 @@ def check_db_tables(app_configs, **kwargs):
     def _check_model(model_class, using=None):
         db = using or router.db_for_read(model_class)
         try:
-            with connections[db].cursor() as cursor:
+            with django_connections[db].cursor() as cursor:
                 cursor.execute("SELECT %s::regclass", [model_class._meta.db_table])
         except Exception as e:
             errors.append(checks.Error('checks.Error querying model on database "{}": "{}.{}": {}.{}({})'.format(


### PR DESCRIPTION
## Technical Summary
Use the DB from the Django router when it is not already supplied. This fixes the check for apps like `auditcare` which use separate databases.

This also fixes a bug with the error collecting.

## Safety Assurance

### Safety story
Used only in deploy checks.

Will be tested on staging.

### Migrations
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
