### PR TITLE
Case Rules: Limit damage of individual case failures

### DIFF
--- a/corehq/apps/data_interfaces/migrations/0025_domaincaserulerun_num_errors.py
+++ b/corehq/apps/data_interfaces/migrations/0025_domaincaserulerun_num_errors.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_interfaces', '0024_add_automaticupdaterule_upstream_id'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='domaincaserulerun',
+            name='num_errors',
+            field=models.IntegerField(default=0),
+        ),
+    ]

--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -999,15 +999,17 @@ class CaseRuleEndToEndTests(BaseCaseRuleTest):
         self.assertEqual(DomainCaseRuleRun.objects.count(), count)
 
     def assertLastRuleRun(self, cases_checked, num_updates=0, num_closes=0, num_related_updates=0,
-            num_related_closes=0, num_creates=0):
+            num_related_closes=0, num_creates=0, num_errors=0):
         last_run = DomainCaseRuleRun.objects.filter(domain=self.domain).order_by('-finished_on')[0]
-        self.assertEqual(last_run.status, DomainCaseRuleRun.STATUS_FINISHED)
+        expected_status = DomainCaseRuleRun.STATUS_HAD_ERRORS if num_errors else DomainCaseRuleRun.STATUS_FINISHED
+        self.assertEqual(last_run.status, expected_status)
         self.assertEqual(last_run.cases_checked, cases_checked)
         self.assertEqual(last_run.num_updates, num_updates)
         self.assertEqual(last_run.num_closes, num_closes)
         self.assertEqual(last_run.num_related_updates, num_related_updates)
         self.assertEqual(last_run.num_related_closes, num_related_closes)
         self.assertEqual(last_run.num_creates, num_creates)
+        self.assertEqual(last_run.num_errors, num_errors)
 
     def test_scheduled_task_run(self):
         rule = _create_empty_rule(self.domain)
@@ -1075,8 +1077,8 @@ class CaseRuleEndToEndTests(BaseCaseRuleTest):
             self.assertRuleRunCount(0)
             run_case_update_rules_for_domain(self.domain)
             self.assertRuleRunCount(1)
-            # Three cases were checked, one failed hard, two were updated
-            self.assertLastRuleRun(cases_checked=3, num_updates=2)
+            # Three cases were checked, two were updated, one failed hard
+            self.assertLastRuleRun(cases_checked=3, num_updates=2, num_errors=1)
 
 
 class TestParentCaseReferences(BaseCaseRuleTest):

--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -277,14 +277,15 @@ def run_rules_for_case(case, rules, now):
         try:
             last_result = rule.run_rule(case, now)
         except Exception:
+            last_result = CaseRuleActionResult(num_errors=1)
             notify_exception(None, "Error applying case update rule", {
                 'domain': case.domain,
                 'rule_pk': rule.pk,
                 'case_id': case.case_id,
             })
-        else:
-            aggregated_result.add_result(last_result)
-            if last_result.num_closes > 0:
-                break
+
+        aggregated_result.add_result(last_result)
+        if last_result.num_closes > 0:
+            break
 
     return aggregated_result

--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -244,16 +244,14 @@ def iter_cases_and_run_rules(domain, case_iterator, rules, now, run_id, case_typ
             notify_error("Halting rule run for domain %s and case type %s." % (domain, case_type))
 
             return DomainCaseRuleRun.done(
-                run_id, DomainCaseRuleRun.STATUS_HALTED, cases_checked, case_update_result, db=db
+                run_id, cases_checked, case_update_result, db=db, halted=True
             )
 
         case_update_result.add_result(run_rules_for_case(case, rules, now))
         if progress_helper is not None:
             progress_helper.increment_current_case_count()
         cases_checked += 1
-    return DomainCaseRuleRun.done(
-        run_id, DomainCaseRuleRun.STATUS_FINISHED, cases_checked, case_update_result, db=db
-    )
+    return DomainCaseRuleRun.done(run_id, cases_checked, case_update_result, db=db)
 
 
 def _check_data_migration_in_progress(domain, last_migration_check_time):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SUPPORT-11468
Related to https://github.com/dimagi/commcare-hq/pull/30744

## Product Description
It looks like when a rule is fired for an individual case and an exception is thrown, the task fails.  This means that the subsequent cases for that domain, case type, and db partition will not be processed, and the rule will be stuck in a "processing" state.  This PR will instead log that failure in sentry, but allow the rest of the cases to be processed and the rule run to be marked complete.  In my estimation, this is strictly better behavior, though you could argue that letting the runs be marked complete is misleading.  A longer-term fix would be to implement a more sophisticated form of error handling and logging that's accessible to the user.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
The change is pretty small, though it's in a scary area

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests included

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

This PR is not urgent, and deploy can be postponed if there are hesitations about running a migration
<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change