### PR TITLE
Rc/user history populate reprs

### DIFF
--- a/corehq/apps/reports/standard/users/reports.py
+++ b/corehq/apps/reports/standard/users/reports.py
@@ -32,7 +32,6 @@ from corehq.apps.users.audit.change_messages import (
     get_messages,
 )
 from corehq.apps.users.models import UserHistory
-from corehq.apps.users.util import cached_user_id_to_username
 from corehq.const import USER_DATETIME_FORMAT
 from corehq.util.timezones.conversions import ServerTime
 
@@ -195,8 +194,8 @@ class UserHistoryReport(GetParamsMixin, DatespanMixin, GenericTabularReport, Pro
 
     def _user_history_row(self, record, domain, timezone):
         return [
-            cached_user_id_to_username(record.user_id),
-            cached_user_id_to_username(record.changed_by),
+            record.user_repr,
+            record.changed_by_repr,
             _get_action_display(record.action),
             record.changed_via,
             self._user_history_details_cell(record.changes, domain),

--- a/corehq/apps/users/management/commands/migrate_reprs.py
+++ b/corehq/apps/users/management/commands/migrate_reprs.py
@@ -1,0 +1,40 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+from corehq.apps.users.models import UserHistory
+from corehq.apps.users.util import cached_user_id_to_username
+
+from corehq.apps.users.util import SYSTEM_USER_ID
+from corehq.util.log import with_progress_bar
+
+
+class Command(BaseCommand):
+    help = "Adds user_repr and changed_by_repr to UserHistory log if not already present"
+
+    def handle(self, **options):
+        records = UserHistory.objects.filter(Q(user_repr__isnull=True) | Q(changed_by_repr__isnull=True))
+        for user_history in with_progress_bar(records.order_by('pk').iterator(), records.count()):
+            try:
+                migrate(user_history)
+            except Exception as e:
+                logging.error(f"{user_history.pk}: {e}")
+
+
+def migrate(user_history):
+    was_change = False
+    if user_history.changed_by == SYSTEM_USER_ID:
+        changed_by_repr = SYSTEM_USER_ID
+    else:
+        changed_by_repr = cached_user_id_to_username(user_history.changed_by)
+
+    user_repr = cached_user_id_to_username(user_history.user_id)
+
+    if changed_by_repr and user_history.changed_by_repr != changed_by_repr:
+        user_history.changed_by_repr = changed_by_repr
+        was_change = True
+    if user_repr and user_history.user_repr != user_repr:
+        user_history.user_repr = user_repr
+        was_change = True
+    if was_change:
+        user_history.save()

--- a/corehq/apps/users/management/commands/migrate_reprs.py
+++ b/corehq/apps/users/management/commands/migrate_reprs.py
@@ -7,6 +7,7 @@ from corehq.apps.users.util import cached_user_id_to_username
 
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.util.log import with_progress_bar
+from corehq.util.queries import queryset_to_iterator
 
 
 class Command(BaseCommand):
@@ -14,7 +15,8 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         records = UserHistory.objects.filter(Q(user_repr__isnull=True) | Q(changed_by_repr__isnull=True))
-        for user_history in with_progress_bar(records.order_by('pk').iterator(), records.count()):
+
+        for user_history in with_progress_bar(queryset_to_iterator(records, UserHistory), records.count()):
             try:
                 migrate(user_history)
             except Exception as e:

--- a/corehq/apps/users/migrations/0041_migrate_reprs.py
+++ b/corehq/apps/users/migrations/0041_migrate_reprs.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+from corehq.util.django_migrations import run_once_off_migration
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0040_add_repr_and_changed_by_repr'),
+    ]
+
+    operations = [
+        run_once_off_migration('migrate_reprs')
+    ]


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[USH-1315](https://dimagi-dev.atlassian.net/browse/USH-1315)
This PR replaces management command and migration from the commits in https://github.com/dimagi/commcare-hq/pull/30588
(management command and migration were removed from those commits in the process of separating two migrations into two PR's)
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_HISTORY_REPORT`
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
not requesting QA

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
