### PR TITLE
Fix parse_xml test

### DIFF
--- a/corehq/apps/app_manager/tests/test_xform.py
+++ b/corehq/apps/app_manager/tests/test_xform.py
@@ -1,7 +1,7 @@
 from django.test import SimpleTestCase
 
 from ..xform import parse_xml
-from ..exceptions import XFormException
+from ..exceptions import DangerousXmlException
 
 
 class ParseXMLTests(SimpleTestCase):
@@ -36,5 +36,5 @@ class ParseXMLTests(SimpleTestCase):
         </html>
         '''.strip()
 
-        with self.assertRaises(XFormException):
+        with self.assertRaises(DangerousXmlException):
             parse_xml(xml)


### PR DESCRIPTION
## Technical Summary
Fixes a test broken in #30750 

## Safety Assurance

### Safety story

### Automated test coverage

This is a test-only change, motivated by the failing test in #30750.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
