### PR TITLE
Add kenya-vca for VectorLink reports

### DIFF
--- a/custom/abt/reports/data_sources/late_pmt.json
+++ b/custom/abt/reports/data_sources/late_pmt.json
@@ -12,6 +12,7 @@
     "airstanzania",
     "airszambia",
     "airszimbabwe",
+    "kenya-vca",
     "vectorlink-benin",
     "vectorlink-burkina-faso",
     "vectorlink-ethiopia",

--- a/custom/abt/reports/data_sources/sms_case.json
+++ b/custom/abt/reports/data_sources/sms_case.json
@@ -12,6 +12,7 @@
     "airstanzania",
     "airszambia",
     "airszimbabwe",
+    "kenya-vca",
     "vectorlink-benin",
     "vectorlink-burkina-faso",
     "vectorlink-ethiopia",

--- a/custom/abt/reports/data_sources/supervisory_v2.json
+++ b/custom/abt/reports/data_sources/supervisory_v2.json
@@ -13,6 +13,7 @@
         "airsrwanda",
         "airszimbabwe",
         "airsmozambique",
+        "kenya-vca",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/data_sources/supervisory_v2019.json
+++ b/custom/abt/reports/data_sources/supervisory_v2019.json
@@ -13,6 +13,7 @@
         "airsrwanda",
         "airszimbabwe",
         "airsmozambique",
+        "kenya-vca",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/data_sources/supervisory_v2020.json
+++ b/custom/abt/reports/data_sources/supervisory_v2020.json
@@ -13,6 +13,7 @@
         "airsrwanda",
         "airszimbabwe",
         "airsmozambique",
+        "kenya-vca",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/sms_indicator_report.json
+++ b/custom/abt/reports/sms_indicator_report.json
@@ -12,6 +12,7 @@
         "airsmozambique",
         "airskenya",
         "airs-testing",
+        "kenya-vca",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/spray_progress_country.json
+++ b/custom/abt/reports/spray_progress_country.json
@@ -12,6 +12,7 @@
         "airsmozambique",
         "airskenya",
         "airs-testing",
+        "kenya-vca",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/spray_progress_level_1.json
+++ b/custom/abt/reports/spray_progress_level_1.json
@@ -12,6 +12,7 @@
         "airsmozambique",
         "airskenya",
         "airs-testing",
+        "kenya-vca",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/spray_progress_level_2.json
+++ b/custom/abt/reports/spray_progress_level_2.json
@@ -12,6 +12,7 @@
         "airsmozambique",
         "airskenya",
         "airs-testing",
+        "kenya-vca",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/spray_progress_level_3.json
+++ b/custom/abt/reports/spray_progress_level_3.json
@@ -11,6 +11,7 @@
         "airsbenin",
         "airskenya",
         "airs-testing",
+        "kenya-vca",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/spray_progress_level_4.json
+++ b/custom/abt/reports/spray_progress_level_4.json
@@ -11,6 +11,7 @@
         "airsbenin",
         "airskenya",
         "airs-testing",
+        "kenya-vca",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/supervisory_report_v2.json
+++ b/custom/abt/reports/supervisory_report_v2.json
@@ -13,6 +13,7 @@
         "airsrwanda",
         "airszimbabwe",
         "airsmozambique",
+        "kenya-vca",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/supervisory_report_v2019.json
+++ b/custom/abt/reports/supervisory_report_v2019.json
@@ -13,6 +13,7 @@
         "airsrwanda",
         "airszimbabwe",
         "airsmozambique",
+        "kenya-vca",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/supervisory_report_v2020.json
+++ b/custom/abt/reports/supervisory_report_v2020.json
@@ -13,6 +13,7 @@
         "airsrwanda",
         "airszimbabwe",
         "airsmozambique",
+        "kenya-vca",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/settings.py
+++ b/settings.py
@@ -1960,7 +1960,7 @@ DOMAIN_MODULE_MAP = {
     'champ-cameroon': 'custom.champ',
     'onse-iss': 'custom.onse',
 
-    #vectorlink domains
+    # vectorlink domains
     'abtmali': 'custom.abt',
     'airs': 'custom.abt',
     'airs-testing': 'custom.abt',
@@ -1973,6 +1973,7 @@ DOMAIN_MODULE_MAP = {
     'airstanzania': 'custom.abt',
     'airszambia': 'custom.abt',
     'airszimbabwe': 'custom.abt',
+    'kenya-vca': 'custom.abt',
     'vectorlink-benin': 'custom.abt',
     'vectorlink-burkina-faso': 'custom.abt',
     'vectorlink-ethiopia': 'custom.abt',


### PR DESCRIPTION
## Technical Summary

Gives the "kenya-vca" domain access to the VectorLink reports, and the data sources it needs for the "Late PMT" custom reports.

## Safety Assurance

### Safety story

* Configuration-only, non-code change.
* Created a "kenya-vca" domain locally, and verified that the VectorLink reports became available after this change.

### Automated test coverage

Configuration-only, non-code change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
