### PR TITLE
SMS user registration alerts

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -377,6 +377,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
     count_messages_as_read_by_anyone = BooleanProperty(default=False)
     enable_registration_welcome_sms_for_case = BooleanProperty(default=False)
     enable_registration_welcome_sms_for_mobile_worker = BooleanProperty(default=False)
+    sms_worker_registration_alert_emails = StringListProperty()
     sms_survey_date_format = StringProperty()
 
     granted_messaging_access = BooleanProperty(default=False)

--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -446,15 +446,13 @@ def process_username(username, domain):
 
 def send_admin_registration_alert(domain, recipients, user, msg):
     from corehq.apps.users.views.mobile.users import EditCommCareUserView
-    subject = _("New user {username} registered for {domain} through SMS from number {number}").format(
+    subject = _("New user {username} registered for {domain} through SMS").format(
         username=user.username,
         domain=domain,
-        number=msg.phone_number
     )
     html_content = render_to_string('sms/email/new_sms_user.html', {
         "username": user.username,
         "domain": domain,
-        "number": msg.phone_number,
         "message_text": msg.text,
         "url": absolute_reverse(EditCommCareUserView.urlname, args=[domain, user.get_id])
     })

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -637,8 +637,10 @@ class SettingsForm(Form):
     def set_admin_email_choices(self, data, kwargs):
         email_choices = []
         if 'initial' in kwargs and 'sms_worker_registration_alert_emails' in kwargs['initial']:
+            # for a GET request, the form is populated by 'initial'
             email_choices = kwargs['initial']['sms_worker_registration_alert_emails']
-        elif data:
+        if data:
+            # for a POST request, we should return the list of emails that was given
             email_choices = data.getlist('sms_worker_registration_alert_emails')
 
         self.fields['sms_worker_registration_alert_emails'].choices = [

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -395,7 +395,7 @@ class SettingsForm(Form):
             crispy.Div(
                 hqcrispy.FieldWithHelpBubble(
                     "sms_worker_registration_alert_emails",
-                    help_bubble_text=_("Email these people when new users sign register through SMS"),
+                    help_bubble_text=_("Email these people when new users register through SMS"),
                 ),
                 data_bind="visible: showAdminAlertEmails",
             ),

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -21,7 +21,6 @@ from crispy_forms.layout import Div
 from dimagi.utils.django.fields import TrimmedCharField
 
 from corehq import toggles
-from corehq.toggles import TURN_IO_BACKEND
 from corehq.apps.commtrack.models import AlertConfig
 from corehq.apps.domain.models import DayTimeWindow
 from corehq.apps.groups.models import Group
@@ -1187,7 +1186,7 @@ class InitiateAddSMSBackendForm(Form):
 
     def backend_classes_for_domain(self, domain):
         backends = copy.deepcopy(get_sms_backend_classes())
-        if (domain is not None) and (not TURN_IO_BACKEND.enabled(domain)):
+        if (domain is not None) and (not toggles.TURN_IO_BACKEND.enabled(domain)):
             backends.pop('TURN')
 
         return backends

--- a/corehq/apps/sms/static/sms/js/settings.js
+++ b/corehq/apps/sms/static/sms/js/settings.js
@@ -82,7 +82,7 @@ hqDefine("sms/js/settings", [
                 return self.sms_case_registration_enabled() === "ENABLED";
             });
 
-            self.showAdminAlertEmails = ko.computed(function() {
+            self.showAdminAlertEmails = ko.computed(function () {
                 return self.sms_mobile_worker_registration_enabled() === "ENABLED";
             });
 

--- a/corehq/apps/sms/static/sms/js/settings.js
+++ b/corehq/apps/sms/static/sms/js/settings.js
@@ -5,6 +5,7 @@ hqDefine("sms/js/settings", [
     'hqwebapp/js/select2_handler',
     'hqwebapp/js/components.ko',    // select toggle widget
     'bootstrap-timepicker/js/bootstrap-timepicker',
+    'hqwebapp/js/widgets', //multi-emails
 ], function(
     $,
     ko,
@@ -48,6 +49,7 @@ hqDefine("sms/js/settings", [
             self.sms_conversation_times = ko.observableArray();
             self.use_custom_chat_template = ko.observable();
             self.sms_case_registration_enabled = ko.observable();
+            self.sms_mobile_worker_registration_enabled = ko.observable();
             self.sms_case_registration_owner_id = settingsSelect2Handler(
                 initial.sms_case_registration_owner_id,
                 'sms_case_registration_owner_id'
@@ -78,6 +80,10 @@ hqDefine("sms/js/settings", [
 
             self.showRegistrationOptions = ko.computed(function() {
                 return self.sms_case_registration_enabled() === "ENABLED";
+            });
+
+            self.showAdminAlertEmails = ko.computed(function() {
+                return self.sms_mobile_worker_registration_enabled() === "ENABLED";
             });
 
             self.addRestrictedSMSTime = function() {
@@ -132,6 +138,7 @@ hqDefine("sms/js/settings", [
                 self.use_sms_conversation_times(initial.use_sms_conversation_times);
                 self.use_custom_chat_template(initial.use_custom_chat_template);
                 self.sms_case_registration_enabled(initial.sms_case_registration_enabled);
+                self.sms_mobile_worker_registration_enabled(initial.sms_mobile_worker_registration_enabled);
                 self.override_daily_outbound_sms_limit(initial.override_daily_outbound_sms_limit);
 
                 var i, window;

--- a/corehq/apps/sms/templates/sms/email/new_sms_user.html
+++ b/corehq/apps/sms/templates/sms/email/new_sms_user.html
@@ -5,10 +5,6 @@
   </p>
 
   <p>
-    Here is the full content of their registration message: {{ message_text }}
-  </p>
-
-  <p>
     To modify, update or remove this user click <a href="{{ url }}">here</a>
   </p>
 

--- a/corehq/apps/sms/templates/sms/email/new_sms_user.html
+++ b/corehq/apps/sms/templates/sms/email/new_sms_user.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% blocktrans %}
   <p>
-    A new user {{ username }} registered for project {{ domain }} through SMS from the number {{ number }}.
+    A new user {{ username }} registered for project {{ domain }} through SMS.
   </p>
 
   <p>

--- a/corehq/apps/sms/templates/sms/email/new_sms_user.html
+++ b/corehq/apps/sms/templates/sms/email/new_sms_user.html
@@ -1,0 +1,19 @@
+{% load i18n %}
+{% blocktrans %}
+  <p>
+    A new user {{ username }} registered for project {{ domain }} through SMS from the number {{ number }}.
+  </p>
+
+  <p>
+    Here is the full content of their registration message: {{ message_text }}
+  </p>
+
+  <p>
+    To modify, update or remove this user click <a href="{{ url }}">here</a>
+  </p>
+
+  <p>
+    Thanks,<br />
+    CommCareHQ
+  </p>
+{% endblocktrans %}

--- a/corehq/apps/sms/tests/test_registration.py
+++ b/corehq/apps/sms/tests/test_registration.py
@@ -26,9 +26,8 @@ class RegistrationTestCase(BaseSMSTest):
 
     def setUp(self):
         super(RegistrationTestCase, self).setUp()
-        delete_all_users()
 
-        self.domain = 'sms-reg-test-domain-1'
+        self.domain = 'sms-reg-test-domain'
         self.domain_obj = Domain(name=self.domain)
         self.domain_obj.save()
 

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -1801,6 +1801,7 @@ class SMSSettingsView(BaseMessagingSectionView, AsyncHandlerMixin):
                     domain_obj.sms_case_registration_user_id,
                 "sms_mobile_worker_registration_enabled":
                     enabled_disabled(domain_obj.sms_mobile_worker_registration_enabled),
+                "sms_worker_registration_alert_emails": domain_obj.sms_worker_registration_alert_emails,
                 "registration_welcome_message":
                     self.get_welcome_message_recipient(domain_obj),
                 "language_fallback":
@@ -1855,6 +1856,7 @@ class SMSSettingsView(BaseMessagingSectionView, AsyncHandlerMixin):
                  "sms_conversation_times_json"),
                 ("sms_mobile_worker_registration_enabled",
                  "sms_mobile_worker_registration_enabled"),
+                ("sms_worker_registration_alert_emails", "sms_worker_registration_alert_emails"),
             ]
             if self.previewer:
                 field_map.extend([


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This allows admins to add a list of emails that will be alerted whenever a new mobile worker is registered via SMS. 

![Screenshot from 2021-11-19 12-18-21](https://user-images.githubusercontent.com/146896/142664222-967052a0-b6f4-4d49-b6fa-d93ef94cc4a3.png)

https://docs.google.com/document/d/1qgKxA-xCvhvSnbrZy4scSbmjOsZA9KYgpbqBAce01sI/edit#heading=h.ry3kp26qtvh9
https://dimagi-dev.atlassian.net/browse/SC-1827

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This adds a new domain property which stores a list of emails. If that list is present, an email alert is sent whenever a new user is registered via SMS. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This area seems generally well tested.

### Automated test coverage
Modified and added some tests. 
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
