### PR TITLE
Refs QA-3629 Refine behavior of matching excel fields to deprecated p…

### DIFF
--- a/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
+++ b/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
@@ -63,12 +63,12 @@ hqDefine('case_importer/js/excel_fields', [
                 return row.caseFieldSpec().values_hints || [];
             });
             row.createNewChecked = ko.computed({
-                read: function() {
+                read: function () {
                     return _.isEmpty(row.caseFieldSpec());
                 },
                 write: row.isCustom,
             });
-            row.isDeprecated = ko.computed(function() {
+            row.isDeprecated = ko.computed(function () {
                 return row.caseFieldSpec().deprecated === true;
             });
 

--- a/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
+++ b/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
@@ -14,10 +14,10 @@ hqDefine('case_importer/js/excel_fields', [
             excelFields: excelFields,
             caseFieldSpecs: caseFieldSpecs,
         };
-        self.caseFieldSpecsInMenu = _(caseFieldSpecs).where({show_in_menu: true});
-
+        self.caseFieldSpecsInMenu = _(caseFieldSpecs).where({show_in_menu: true, deprecated: false});
         self.caseFieldsInMenu = _(self.caseFieldSpecsInMenu).pluck('field');
-        self.caseFieldSuggestions = _.chain(self.caseFieldSpecs).where({discoverable: true}).pluck('field').value();
+        self.caseFieldSuggestions = _.chain(self.caseFieldSpecs).where({discoverable: true, deprecated: false}).pluck('field').value();
+        self.deprecatedFields = _(caseFieldSpecs).where({deprecated: true});
         self.mappingRows = ko.observableArray();
         self.removeRow = function (row) {
             self.mappingRows.remove(row);
@@ -61,6 +61,15 @@ hqDefine('case_importer/js/excel_fields', [
             });
             row.valuesHints = ko.computed(function () {
                 return row.caseFieldSpec().values_hints || [];
+            });
+            row.createNewChecked = ko.computed({
+                read: function() {
+                    return _.isEmpty(row.caseFieldSpec());
+                },
+                write: row.isCustom,
+            });
+            row.isDeprecated = ko.computed(function() {
+                return row.caseFieldSpec().deprecated === true;
             });
 
             row.reset = function () {

--- a/corehq/apps/case_importer/static/case_importer/js/main.js
+++ b/corehq/apps/case_importer/static/case_importer/js/main.js
@@ -30,14 +30,14 @@ hqDefine("case_importer/js/main", [
         $('input:file').change(function () {
             const fileName = $(this).val();
             if (fileName) {
-                $(':submit').attr('disabled', false).removeClass('disabled');
+                $(':submit').enableButton();
             } else {
-                $(':submit').attr('disabled', true).addClass('disabled');
+                $(':submit').disableButtonNoSpinner();
             }
         });
         // enable button in case of "Back" pressed, file chosen
         if ($('input:file').val()) {
-            $(':submit').attr('disabled', false).removeClass('disabled');
+            $(':submit').enableButton();
         }
     };
 

--- a/corehq/apps/case_importer/static/case_importer/js/main.js
+++ b/corehq/apps/case_importer/static/case_importer/js/main.js
@@ -26,6 +26,19 @@ hqDefine("case_importer/js/main", [
         _.delay(function () {
             recentUploads.goToPage(1);
         });
+
+        $('input:file').change(function () {
+            const fileName = $(this).val();
+            if (fileName) {
+                $(':submit').attr('disabled', false).removeClass('disabled');
+            } else {
+                $(':submit').attr('disabled', true).addClass('disabled');
+            }
+        });
+        // enable button in case of "Back" pressed, file chosen
+        if ($('input:file').val()) {
+            $(':submit').attr('disabled', false).removeClass('disabled');
+        }
     };
 
     var behaviorForExcelMappingPage = function () {

--- a/corehq/apps/case_importer/suggested_fields.py
+++ b/corehq/apps/case_importer/suggested_fields.py
@@ -40,7 +40,7 @@ def get_suggested_case_fields(domain, case_type, exclude=None):
     dynamic_field_specs = (
         FieldSpec(field=field, show_in_menu=True, values_hints=hints_dict[field],
                   deprecated=field in deprecated_fields)
-        for field in get_all_case_properties_for_case_type(domain, case_type))
+        for field in get_all_case_properties_for_case_type(domain, case_type, exclude_deprecated_properties=False))
 
     return _combine_field_specs(
         itertools.chain(special_field_specs, dynamic_field_specs),

--- a/corehq/apps/case_importer/templates/case_importer/import_cases.html
+++ b/corehq/apps/case_importer/templates/case_importer/import_cases.html
@@ -37,7 +37,7 @@
 
     <div class="form-actions">
       <div class="col-sm-offset-3">
-        <button type="submit" class="btn btn-primary">
+        <button type="submit" class="btn btn-primary disabled" disabled="disabled">
           <i class="fa fa-forward"></i> {% trans "Next step" %}
         </button>
       </div>

--- a/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
@@ -64,12 +64,15 @@
       </p>
     </div>
     <!--/ko-->
+    <div class="has-warning" data-bind="visible: isDeprecated()">
+        <p class="help-block">{% trans "This is a deprecated property" %}</p>
+    </div>
   </td>
 
   <td class="col-md-1">
     <div class="checkbox">
       <label>
-        <input type="checkbox" class="new_property" style="margin-left: auto;" data-bind="checked: isCustom"/>
+        <input type="checkbox" class="new_property" style="margin-left: auto;" data-bind="checked: createNewChecked"/>
       </label>
     </div>
   </td>

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -119,8 +119,8 @@ hqDefine("data_dictionary/js/data_dictionary", [
                 var currentGroup = '';
                 _.each(self.casePropertyList(), function (element) {
                     if (!element.isGroup) {
-                        allowedValues = element.allowedValues.val()
-                        pureAllowedValues = {}
+                        const allowedValues = element.allowedValues.val();
+                        let pureAllowedValues = {};
                         for (const key in allowedValues) {
                             pureAllowedValues[DOMPurify.sanitize(key)] = DOMPurify.sanitize(allowedValues[key]);
                         }

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -6,6 +6,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
     "hqwebapp/js/main",
     "analytix/js/google",
     "hqwebapp/js/ui_elements/ui-element-key-val-list",
+    "DOMPurify/dist/purify.min",
     "hqwebapp/js/knockout_bindings.ko",
 ], function (
     $,
@@ -14,7 +15,8 @@ hqDefine("data_dictionary/js/data_dictionary", [
     initialPageData,
     hqMain,
     googleAnalytics,
-    uiElementKeyValueList
+    uiElementKeyValueList,
+    DOMPurify
 ) {
     var caseType = function (name, fhirResourceType) {
         var self = {};
@@ -117,6 +119,11 @@ hqDefine("data_dictionary/js/data_dictionary", [
                 var currentGroup = '';
                 _.each(self.casePropertyList(), function (element) {
                     if (!element.isGroup) {
+                        allowedValues = element.allowedValues.val()
+                        pureAllowedValues = {}
+                        for (const key in allowedValues) {
+                            pureAllowedValues[DOMPurify.sanitize(key)] = DOMPurify.sanitize(allowedValues[key]);
+                        }
                         var data = {
                             'caseType': element.caseType,
                             'name': element.name,
@@ -127,7 +134,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                                 element.fhirResourcePropPath() ? element.fhirResourcePropPath().trim() : element.fhirResourcePropPath()),
                             'deprecated': element.deprecated(),
                             'removeFHIRResourcePropertyPath': element.removeFHIRResourcePropertyPath(),
-                            'allowed_values': element.allowedValues.val(),
+                            'allowed_values': pureAllowedValues,
                         };
                         postProperties.push(data);
                     } else {

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -139,6 +139,14 @@ def get_values_hints_dict(domain, case_type_name):
     return values_hints_dict
 
 
+def get_deprecated_fields(domain, case_type_name):
+    deprecated_fields = set()
+    case_type = CaseType.objects.filter(domain=domain, name=case_type_name).first()
+    if case_type:
+        deprecated_fields = set(case_type.properties.filter(deprecated=True).values_list('name', flat=True))
+    return deprecated_fields
+
+
 def save_case_property(name, case_type, domain=None, data_type=None,
                        description=None, group=None, deprecated=None,
                        fhir_resource_prop_path=None, fhir_resource_type=None, remove_path=False,
@@ -196,7 +204,7 @@ def get_data_dict_props_by_case_type(domain):
     return {
         case_type: {prop.name for prop in props} for case_type, props in groupby(
             CaseProperty.objects
-            .filter(case_type__domain=domain, deprecated=False)
+            .filter(case_type__domain=domain)
             .select_related("case_type")
             .order_by('case_type__name'),
             key=attrgetter('case_type.name')

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -199,12 +199,15 @@ def save_case_property(name, case_type, domain=None, data_type=None,
         return ugettext('Unable to save valid values longer than {} characters').format(max_len)
 
 
-@quickcache(vary_on=['domain'], timeout=24 * 60 * 60)
-def get_data_dict_props_by_case_type(domain):
+@quickcache(vary_on=['domain', 'exclude_deprecated'], timeout=24 * 60 * 60)
+def get_data_dict_props_by_case_type(domain, exclude_deprecated=True):
+    filter_kwargs = {'case_type__domain': domain}
+    if exclude_deprecated:
+        filter_kwargs['deprecated'] = False
     return {
         case_type: {prop.name for prop in props} for case_type, props in groupby(
             CaseProperty.objects
-            .filter(case_type__domain=domain)
+            .filter(**filter_kwargs)
             .select_related("case_type")
             .order_by('case_type__name'),
             key=attrgetter('case_type.name')


### PR DESCRIPTION
…roperties

Do not list deprecated properties in dropdown, but allow them to be typed and auto-suggested
When a deprecated property has been typed/suggested, show a warning that it is a deprecated property
Also show any formats/valid values in this case
Uncheck the "Create new property" in this case as well, since the property exists

In addition, this PR sanitizes allowed values input into the data dictionary before sending to the backend.
(Having script tags (for example) in the backend for suggested valid values causes the importer matching page
to not work as expected -- it seems the js initial data doesn't get deserialied properly -- so stripping in
the same way as is done for display on data dictiony seemed easist to fix this oddity.)

Finally, as requested by Daniel, disable the Next button on the initial upload page when there is no file
chosen.

[safety info removed because this isn't a PR into master]