### PR TITLE
Update template response email to use pause instead of the community plan

### DIFF
--- a/corehq/apps/accounting/templates/accounting/email/subscription_ending_reminder_dimagi.html
+++ b/corehq/apps/accounting/templates/accounting/email/subscription_ending_reminder_dimagi.html
@@ -6,7 +6,7 @@
 </p>
 
 <p>
-  This project has a subscription that is ending on {{ end_date }}. After that date, the subscription will automatically downgrade to the Community Plan.
+  This project has a subscription that is ending on {{ end_date }}. After that date, the subscription will automatically pause and this space will lose access to all features until it is re-subscribed to a new paid plan.
 </p>
 <p>
   If you haven't already, can you follow up with the partner to confirm they are aware of this? If relevant, you can use the subscription with an upcoming end date email <a href="https://confluence.dimagi.com/display/commcarehq/CommCare+HQ+Billing+-+Email+Templates#CommCareHQBilling-EmailTemplates-SubscriptionEnding">template</a> to follow up.

--- a/corehq/apps/accounting/templates/accounting/email/subscription_ending_reminder_dimagi.txt
+++ b/corehq/apps/accounting/templates/accounting/email/subscription_ending_reminder_dimagi.txt
@@ -3,7 +3,7 @@ Dear {{ dimagi_contact }}
 You have been identified as the dimagi point of contact for the project space {{ domain }}.
 
 
-This project has a subscription that is ending on {{ end_date }}. After that date, the subscription will automatically downgrade to the Community Plan.
+This project has a subscription that is ending on {{ end_date }}. After that date, the subscription will automatically pause and this space will lose access to all features until it is re-subscribed to a new paid plan.
 
 
 If you haven't already, can you follow up with the partner to confirm they are aware of this? If relevant, you can use the subscription with an upcoming end date email template to follow up.


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
https://dimagi-dev.atlassian.net/browse/SS-190
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The email response that goes out to Dimagi POCs of Project Spaces when their plan is about to expire, mentions that their subscription will be downgraded to Community plan. This is not true at present because the project spaces are paused. 
The PR updates the email text.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
No code changes. Only static text is changed.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
