### PR TITLE
Added parens to XPath.not_

### DIFF
--- a/corehq/apps/app_manager/tests/data/suite/smart_link_remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/smart_link_remote_request.xml
@@ -1,0 +1,61 @@
+<partial>
+  <remote-request>
+    <post relevant="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/search_case_id]) = 0" url="https://www.example.com/a/test_domain/phone/claim-case/">
+      <data key="case_id" ref="instance('commcaresession')/session/data/search_case_id"/>
+    </post>
+    <command id="search_command.m1">
+      <display>
+        <text>
+          <locale id="case_search.m1"/>
+        </text>
+      </display>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
+    <session>
+      <query default_search="false" storage-instance="results" template="case" url="https://www.example.com/a/test_domain/phone/search/{app_id}/">
+        <data key="case_type" ref="'leaf'"/>
+        <data key="commcare_registry" ref="'a_registry'"/>
+        <prompt key="name">
+          <display>
+            <text>
+              <locale id="search_property.m1.name"/>
+            </text>
+          </display>
+        </prompt>
+        <prompt key="shape">
+          <display>
+            <text>
+              <locale id="search_property.m1.shape"/>
+            </text>
+          </display>
+        </prompt>
+      </query>
+      <datum detail-confirm="m1_search_long" detail-select="m1_search_short" id="search_case_id" nodeset="instance('results')/results/case[@case_type='leaf'][not(commcare_is_related_case=true())]" value="./@case_id"/>
+    </session>
+    <stack>
+      <push if="not(instance('results')/results/case[@case_id=instance('commcaresession')/session/data/search_case_id]/commcare_project = instance('commcaresession')/session/user/data/commcare_project)">
+        <jump>
+          <url>
+            <text>
+              <xpath function="concat('https://www.example.com/a/', $domain, '/app/v1/{app_id}/child_endpoint/', '?case_id_leaf=', $case_id_leaf, '&amp;case_id=', $case_id)">
+                <variable name="domain">
+                  <xpath function="instance('results')/results/case[@case_id=instance('commcaresession')/session/data/search_case_id]/commcare_project"/>
+                </variable>
+                <variable name="case_id">
+                  <xpath function="instance('commcaresession')/session/data/case_id"/>
+                </variable>
+                <variable name="case_id_leaf">
+                  <xpath function="instance('commcaresession')/session/data/search_case_id"/>
+                </variable>
+              </xpath>
+            </text>
+          </url>
+        </jump>
+      </push>
+      <push if="instance('results')/results/case[@case_id=instance('commcaresession')/session/data/search_case_id]/commcare_project = instance('commcaresession')/session/user/data/commcare_project">
+        <rewind value="instance('commcaresession')/session/data/search_case_id"/>
+      </push>
+    </stack>
+  </remote-request>
+</partial>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -73,9 +73,19 @@ class RemoteRequestSmartLinkTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     def testSmartLinkFunction(self):
         with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
             get_url_base_patch.return_value = 'https://www.example.com'
-            self.assertEqual(self.request_factory.get_smart_link_function(), f'''
-                concat('https://www.example.com/a/', $domain, '/app/v1/{self.app_id}/child_endpoint/', '?case_id_leaf=', $case_id_leaf, '&case_id=', $case_id)
-            '''.strip())
+            concat_params = [
+                "'https://www.example.com/a/'",
+                "$domain",
+                f"'/app/v1/{self.app_id}/child_endpoint/'",
+                "'?case_id_leaf='",
+                "$case_id_leaf",
+                "'&case_id='",
+                "$case_id",
+            ]
+            self.assertEqual(
+                self.request_factory.get_smart_link_function(),
+                f'concat({", ".join(concat_params)})'
+            )
 
     def testSmartLinkVariables(self):
         vars = self.request_factory.get_smart_link_variables()

--- a/corehq/apps/app_manager/tests/test_xpath.py
+++ b/corehq/apps/app_manager/tests/test_xpath.py
@@ -43,8 +43,8 @@ class XPathTest(SimpleTestCase):
         self.assertEqual('(a or b) or c', XPath.or_(XPath.or_('a', 'b'), XPath('c')))
 
     def test_not(self):
-        self.assertEqual('not a', XPath.not_('a'))
-        self.assertEqual('not (a or b)', XPath.not_(XPath.or_('a', 'b')))
+        self.assertEqual('not(a)', XPath.not_('a'))
+        self.assertEqual('not((a or b))', XPath.not_(XPath.or_('a', 'b')))
 
     def test_date(self):
         self.assertEqual('date(a)', XPath.date('a'))

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -183,7 +183,7 @@ class XPath(str):
 
     @staticmethod
     def not_(a):
-        return XPath.expr("not {}", [a])
+        return XPath.expr("not({})", [a])
 
     @staticmethod
     def date(a):


### PR DESCRIPTION
## Product Description
Fixes a web apps error in apps that use smart links.

<img width="1159" alt="Screen Shot 2021-11-23 at 5 01 12 PM" src="https://user-images.githubusercontent.com/1486591/143136125-fb66b26a-80d7-436f-9040-e0adfba887f5.png">

## Technical Summary
[This change](https://github.com/dimagi/commcare-hq/pull/30657/commits/bfc6710f02615389d2e27a7e1bfc8438d66c778e#diff-d74118b56d991c724d38a47675100af256863e5b7a321da12ecf6f0a1ba68c75R275) exposed that `XPath.not_` doesn't use parentheses, which broke an expression that was `not A = B` and needed to be `not(A = B)`

It also exposed that I didn't have a smart linking test that included the stack XML. Shame on me.

Review by commit.

## Feature Flag
Data registries

## Safety Assurance
This is a fix in a feature that's not being used by anyone in prod and is currently unusable. It changes a core app manager library, but in a pretty limited way.

### Automated test coverage

The XPath object has decent test coverage.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
