### PR TITLE
Removed param from format_odata_error

### DIFF
--- a/corehq/apps/api/odata/utils.py
+++ b/corehq/apps/api/odata/utils.py
@@ -78,11 +78,10 @@ def record_feed_access_in_datadog(request, config_id, duration, response):
     )
 
 
-def format_odata_error(code, message, target):
+def format_odata_error(code, message):
     error_message = {"error": {
         "code": code,
         "message": message,
-        "target": target,
     }}
 
     return error_message


### PR DESCRIPTION
## Technical Summary
https://sentry.io/organizations/dimagi/issues/2812356431/

Followup for https://github.com/dimagi/commcare-hq/commit/53c25cc7edd8816d916f687e1d3ecd3f00bf121d

There's only one call to `format_odata_error`, and it doesn't pass `target`.

## Safety Assurance

### Safety story
Small, straightforward change in an error workflow.

### Automated test coverage

No

### QA Plan

None


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
