### PR TITLE
Refs QA-3629 some final tweaks to case importer validation

### DIFF
--- a/corehq/apps/case_importer/templates/case_importer/excel_fields.html
+++ b/corehq/apps/case_importer/templates/case_importer/excel_fields.html
@@ -44,7 +44,9 @@
         <th></th>
         <th>{% trans "Case Property" %}</th>
         <th class="col-md-1">{% trans "Create new property" %}</th>
-        <th>{% include "data_dictionary/partials/valid_values_th_content.html" %}</th>
+        {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
+          <th>{% include "data_dictionary/partials/valid_values_th_content.html" %}</th>
+        {% endif %}
         </thead>
         <tbody id="excel-field-rows" class="ko-template">
         {% include "case_importer/partials/excel_field_rows.html" %}

--- a/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
@@ -55,6 +55,9 @@
         <span data-bind="text: caseFieldSpec().description"></span>
       </p>
     </div>
+    <div class="has-warning" data-bind="visible: isDeprecated()">
+        <p class="help-block">{% trans "This is a deprecated property" %}</p>
+    </div>
     <!--ko if: caseFieldSuggestions().length-->
     <div class="has-warning">
       <p class="help-block">
@@ -64,9 +67,6 @@
       </p>
     </div>
     <!--/ko-->
-    <div class="has-warning" data-bind="visible: isDeprecated()">
-        <p class="help-block">{% trans "This is a deprecated property" %}</p>
-    </div>
   </td>
 
   <td class="col-md-1">
@@ -77,12 +77,14 @@
     </div>
   </td>
 
+  {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
   <td>
       <ul class="list-unstyled" data-bind="visible: valuesHints().length, foreach: valuesHints">
         <!--ko if: $data--><li data-bind="text: $data"></li><!--/ko-->
         <!--ko if: !$data--><li data-bind="html: '<i>{% trans "blank" %}</i>'"></li><!--/ko-->
       </ul>
   </td>
+  {% endif %}
 
 </tr>
 <!--/ko-->


### PR DESCRIPTION
Reverse the order of the warning messages around suggested/deprecated properties
Suppress the the appearance of the Valid Values and Formats column entirely when the toggle to validate data is not enabled.
