### PR TITLE
Migration to add domain field for mobile endpoint restriction setting (1 of 2 PRs)

### DIFF
--- a/corehq/apps/domain/migrations/0009_restrict_mob_access_from_FF.py
+++ b/corehq/apps/domain/migrations/0009_restrict_mob_access_from_FF.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+from corehq.apps.domain.models import Domain
+from corehq.util.django_migrations import skip_on_fresh_install
+
+from corehq.toggles import RESTRICT_MOBILE_ACCESS
+
+
+@skip_on_fresh_install
+def _enable_restrict_mobile_access(apps, schema_editor):
+    for domain in RESTRICT_MOBILE_ACCESS.get_enabled_domains():
+        domain_obj = Domain.get_by_name(domain)
+        domain_obj.restrict_mobile_access = True
+        domain_obj.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('domain', '0008_use_livequery'),
+    ]
+
+    operations = [
+        migrations.RunPython(_enable_restrict_mobile_access, migrations.RunPython.noop)
+    ]

--- a/corehq/apps/domain/migrations/0009_restrict_mob_access_from_FF.py
+++ b/corehq/apps/domain/migrations/0009_restrict_mob_access_from_FF.py
@@ -10,8 +10,9 @@ from corehq.toggles import RESTRICT_MOBILE_ACCESS
 def _enable_restrict_mobile_access(apps, schema_editor):
     for domain in RESTRICT_MOBILE_ACCESS.get_enabled_domains():
         domain_obj = Domain.get_by_name(domain)
-        domain_obj.restrict_mobile_access = True
-        domain_obj.save()
+        if domain_obj and not domain_obj.restrict_mobile_access:
+            domain_obj.restrict_mobile_access = True
+            domain_obj.save()
 
 
 class Migration(migrations.Migration):

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -450,6 +450,8 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
 
     ga_opt_out = BooleanProperty(default=False)
 
+    restrict_mobile_access = BooleanProperty(default=False)
+
     @classmethod
     def wrap(cls, data):
         # for domains that still use original_doc


### PR DESCRIPTION
## Product Description

This is part of a push to improve security around mobile endpoints. [Here is the description](https://docs.google.com/document/d/1aVDHalKJvtTc8FVkMmFb0fxzxO5UaW2-_4g2MTQlrz0/edit?usp=sharing) of the vulnerabilities and proposed changes written up by Ethan. Here is the [Jira epic](https://dimagi-dev.atlassian.net/browse/USH-1408).

The feature flag RESTRICT_MOBILE_ENDPOINTS currently restricts mobile workers' access to the mobile app (and thus the mobile endpoints) by allowing administrators to it turn on/off on the Roles & Permissions page.

 **This PR is one of 2 PRs that will cause that feature flag to become just a switch to display a new GA setting**. 

## Technical Summary

[USH-1409](https://dimagi-dev.atlassian.net/browse/USH-1409).

This preliminary migration will add a new field to the Domain model and set this field to True if the relevant feature flag is turned on. The hope is that this can be merged before tonight's deploy so that we can see that the migration has been applied before adding the second PR next week.

This is step 1. Step 2 will include UI changes and a transition from the existing FF to the GA setting.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

RESTRICT_MOBILE_ACCESS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

I tested that this properly works locally and on staging (domain.restrict_mobile_access = true when the FF is on, false if not). No major errors in the process.

### Automated test coverage

No relevant tests I could find.

### QA Plan

None planned for this migration _or_ the next PR.

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

Code that depends on this migration will be deployed in the following PR.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
