### PR TITLE
support POST reqeusts for registry_case endpoint

### DIFF
--- a/corehq/apps/ota/tests/test_registry_case_details.py
+++ b/corehq/apps/ota/tests/test_registry_case_details.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from defusedxml import ElementTree
-from django.test import TestCase
+from django.test import TestCase, Client
 from django.urls import reverse
 
 from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseIndex
@@ -77,6 +77,7 @@ class RegistryCaseDetailsTests(TestCase):
         super().tearDownClass()
 
     def setUp(self):
+        self.client = Client(enforce_csrf_checks=True)
         self.client.login(username="user", password="123")
 
     def test_get_case_details(self):
@@ -110,6 +111,16 @@ class RegistryCaseDetailsTests(TestCase):
         expected_cases = {"unrelated_case": self.other_case, **{case.case_id: case for case in self.cases}}
         self.assertEqual(set(actual_cases), set(expected_cases))
 
+    def test_get_case_details_post_request(self):
+        response_content = self._make_request({
+            "commcare_registry": self.registry.slug,
+            "case_id": self.parent_case_id,
+            "case_type": "parent",
+        }, 200, method="post")
+        actual_cases = self._get_cases_in_response(response_content)
+        expected_cases = {case.case_id: case for case in self.cases}
+        self.assertEqual(set(actual_cases), set(expected_cases))
+
     def test_get_case_details_missing_case(self):
         self._make_request({
             "commcare_registry": self.registry.slug, "case_id": "missing", "case_type": "parent",
@@ -120,9 +131,13 @@ class RegistryCaseDetailsTests(TestCase):
             "commcare_registry": "not-a-registry", "case_id": self.parent_case_id, "case_type": "parent",
         }, 404)
 
-    def _make_request(self, params, expected_response_code):
+    def _make_request(self, params, expected_response_code, method="get"):
+        request_method = {
+            "get": self.client.get,
+            "post": self.client.post,
+        }[method]
         with patch.object(DataRegistryHelper, '_check_user_has_access', return_value=True):
-            response = self.client.get(reverse('registry_case', args=[self.domain, self.app.get_id]), data=params)
+            response = request_method(reverse('registry_case', args=[self.domain, self.app.get_id]), data=params)
         content = response.content
         self.assertEqual(response.status_code, expected_response_code, content)
         return content.decode('utf8')

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -406,12 +406,13 @@ def recovery_measures(request, domain, build_id):
 
 
 @location_safe_bypass
+@csrf_exempt
 @mobile_auth
-@require_GET
 def registry_case(request, domain, app_id):
-    case_ids = request.GET.getlist("case_id")
-    case_types = request.GET.getlist("case_type")
-    registry = request.GET.get("commcare_registry")
+    request_dict = request.GET if request.method == 'GET' else request.POST
+    case_ids = request_dict.getlist("case_id")
+    case_types = request_dict.getlist("case_type")
+    registry = request_dict.get("commcare_registry")
 
     missing = [
         name


### PR DESCRIPTION
## Product Description
Continuation of https://github.com/dimagi/commcare-hq/pull/30486
https://dimagi-dev.atlassian.net/browse/USH-1308

## Technical Summary
We're anticipating USH cases exceeding the maximum URL length and will switch formplayer to use POST requests.

## Safety Assurance

### Safety story
### Automated test coverage
Covered by unit tests which were updated to also test this change

### QA Plan
None

### Migrations
NA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
