### PR TITLE
Smh/user report enterprise domain support

### DIFF
--- a/corehq/apps/enterprise/tests/test_enterprise_utils.py
+++ b/corehq/apps/enterprise/tests/test_enterprise_utils.py
@@ -1,0 +1,46 @@
+from django.test import TestCase
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.enterprise.tests.utils import create_enterprise_permissions
+from corehq.apps.enterprise.utils import get_enterprise_domains, get_enterprise_controlled_domains
+
+
+class TestEnterpriseUtils(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'domain'
+        cls.domain_obj = create_domain(cls.domain)
+        cls.source_domain = 'source-domain'
+        cls.source_domain_obj = create_domain(cls.source_domain)
+        create_enterprise_permissions("hello@world.com", cls.source_domain, [cls.domain])
+
+    def setUp(self):
+        super(TestEnterpriseUtils, self).setUp()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_obj.delete()
+        cls.source_domain_obj.delete()
+        super(TestEnterpriseUtils, cls).tearDownClass()
+
+    def test_get_enterprise_domains(self):
+        self.assertEqual(
+            set(['source-domain']),
+            set(get_enterprise_domains(self.source_domain))
+        )
+        self.assertEqual(
+            set(['domain', 'source-domain']),
+            set(get_enterprise_domains(self.domain))
+        )
+
+    def test_get_enterprise_controlled_domains(self):
+        self.assertEqual(
+            set(['domain', 'source-domain']),
+            set(get_enterprise_controlled_domains(self.source_domain))
+        )
+        self.assertEqual(
+            set(['domain']),
+            set(get_enterprise_controlled_domains(self.domain))
+        )

--- a/corehq/apps/enterprise/utils.py
+++ b/corehq/apps/enterprise/utils.py
@@ -1,0 +1,19 @@
+from corehq.apps.enterprise.models import EnterprisePermissions
+
+
+def get_enterprise_domains(domain):
+    """Return list containing input domain and source domain for that input domain."""
+    domain_list = [domain]
+    config = EnterprisePermissions.get_by_domain(domain)
+    if config.is_enabled and domain in config.domains:
+        domain_list.append(config.source_domain)
+    return domain_list
+
+
+def get_enterprise_controlled_domains(domain):
+    """Return list containing input domain and all domains controlled by the input domain."""
+    domain_list = [domain]
+    config = EnterprisePermissions.get_by_domain(domain)
+    if config.is_enabled:
+        domain_list += EnterprisePermissions.get_domains(domain)
+    return domain_list

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -72,9 +72,7 @@ def domain(domain, allow_enterprise=False, allow_enterprise_controlled_domains=F
         if config.is_enabled and domain in config.domains:
             domain_list.append(config.source_domain)
     if allow_enterprise_controlled_domains:
-        config = EnterprisePermissions.get_by_domain(domain)
-        if config.is_enabled:
-            domain_list += config.get_domains(domain)
+        domain_list += EnterprisePermissions.get_domains(domain)
     return domains(domain_list)
 
 

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -64,16 +64,8 @@ class UserES(HQESQuery):
         return query.is_active(False)
 
 
-def domain(domain, allow_enterprise=False, allow_enterprise_controlled_domains=False):
-    from corehq.apps.enterprise.models import EnterprisePermissions
-    domain_list = [domain]
-    if allow_enterprise:
-        config = EnterprisePermissions.get_by_domain(domain)
-        if config.is_enabled and domain in config.domains:
-            domain_list.append(config.source_domain)
-    if allow_enterprise_controlled_domains:
-        domain_list += EnterprisePermissions.get_domains(domain)
-    return domains(domain_list)
+def domain(domain):
+    return domains(domain)
 
 
 def domains(domains):

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -64,13 +64,16 @@ class UserES(HQESQuery):
         return query.is_active(False)
 
 
-def domain(domain, allow_enterprise=False):
+def domain(domain, allow_enterprise=False, allow_enterprise_controlled_domains=False):
+    from corehq.apps.enterprise.models import EnterprisePermissions
     domain_list = [domain]
     if allow_enterprise:
-        from corehq.apps.enterprise.models import EnterprisePermissions
         config = EnterprisePermissions.get_by_domain(domain)
         if config.is_enabled and domain in config.domains:
             domain_list.append(config.source_domain)
+    if allow_enterprise_controlled_domains:
+        config = EnterprisePermissions.get_by_domain(domain)
+        domain_list += config.get_domains(domain)
     return domains(domain_list)
 
 

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -73,7 +73,8 @@ def domain(domain, allow_enterprise=False, allow_enterprise_controlled_domains=F
             domain_list.append(config.source_domain)
     if allow_enterprise_controlled_domains:
         config = EnterprisePermissions.get_by_domain(domain)
-        domain_list += config.get_domains(domain)
+        if config.is_enabled:
+            domain_list += config.get_domains(domain)
     return domains(domain_list)
 
 

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -1,5 +1,6 @@
 from memoized import memoized
 
+from corehq.apps.enterprise.models import EnterprisePermissions
 from corehq.apps.es import GroupES, UserES, groups
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reports.const import DEFAULT_PAGE_LIMIT
@@ -125,7 +126,8 @@ class EmwfOptionsController(object):
     def active_user_es_query(self, query):
         search_fields = ["first_name", "last_name", "base_username"]
         return (UserES()
-                .domain(self.domain)
+                .domain(self.domain, allow_enterprise_controlled_domains=EnterprisePermissions.
+                        get_by_domain(self.domain).is_enabled)
                 .search_string_query(query, default_fields=search_fields))
 
     def all_user_es_query(self, query):

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -1,5 +1,6 @@
 from memoized import memoized
 
+from corehq.apps.enterprise.utils import get_enterprise_controlled_domains
 from corehq.apps.es import GroupES, UserES, groups
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reports.const import DEFAULT_PAGE_LIMIT
@@ -125,7 +126,7 @@ class EmwfOptionsController(object):
     def active_user_es_query(self, query):
         search_fields = ["first_name", "last_name", "base_username"]
         return (UserES()
-                .domain(self.domain, allow_enterprise_controlled_domains=True)
+                .domain(get_enterprise_controlled_domains(self.domain))
                 .search_string_query(query, default_fields=search_fields))
 
     def all_user_es_query(self, query):

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -126,8 +126,7 @@ class EmwfOptionsController(object):
     def active_user_es_query(self, query):
         search_fields = ["first_name", "last_name", "base_username"]
         return (UserES()
-                .domain(self.domain, allow_enterprise_controlled_domains=EnterprisePermissions.
-                        get_by_domain(self.domain).is_enabled)
+                .domain(self.domain, allow_enterprise_controlled_domains=True)
                 .search_string_query(query, default_fields=search_fields))
 
     def all_user_es_query(self, query):

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -1,6 +1,5 @@
 from memoized import memoized
 
-from corehq.apps.enterprise.models import EnterprisePermissions
 from corehq.apps.es import GroupES, UserES, groups
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reports.const import DEFAULT_PAGE_LIMIT

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -33,6 +33,8 @@ from .base import (
 )
 
 #TODO: replace with common code
+from ...enterprise.utils import get_enterprise_domains
+
 mark_safe_lazy = lazy(mark_safe, str)
 
 
@@ -346,10 +348,9 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         return context
 
     @classmethod
-    def user_es_query(cls, domain, mobile_user_and_group_slugs, request_user, include_enterprise_users=False):
+    def user_es_query(cls, domain, mobile_user_and_group_slugs, request_user):
         # The queryset returned by this method is location-safe
-        q = user_es.UserES().domain(domain, allow_enterprise=True,
-                                    allow_enterprise_controlled_domains=include_enterprise_users)
+        q = user_es.UserES().domain(get_enterprise_domains(domain))
         q = customize_user_query(request_user, domain, q)
         if (
             ExpandedMobileWorkerFilter.no_filters_selected(mobile_user_and_group_slugs)

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -346,9 +346,10 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         return context
 
     @classmethod
-    def user_es_query(cls, domain, mobile_user_and_group_slugs, request_user):
+    def user_es_query(cls, domain, mobile_user_and_group_slugs, request_user, include_enterprise_users=False):
         # The queryset returned by this method is location-safe
-        q = user_es.UserES().domain(domain, allow_enterprise=True)
+        q = user_es.UserES().domain(domain, allow_enterprise=True,
+                                    allow_enterprise_controlled_domains=include_enterprise_users)
         q = customize_user_query(request_user, domain, q)
         if (
             ExpandedMobileWorkerFilter.no_filters_selected(mobile_user_and_group_slugs)

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -31,10 +31,9 @@ from .base import (
     BaseReportFilter,
     BaseSingleOptionFilter,
 )
-
-#TODO: replace with common code
 from ...enterprise.utils import get_enterprise_domains
 
+#TODO: replace with common code
 mark_safe_lazy = lazy(mark_safe, str)
 
 

--- a/corehq/apps/reports/standard/users/reports.py
+++ b/corehq/apps/reports/standard/users/reports.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext_lazy
 
 from memoized import memoized
 
-from corehq import privileges
+from corehq import privileges, toggles
 from corehq.apps.accounting.models import BillingAccount
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
@@ -129,6 +129,7 @@ class UserHistoryReport(GetParamsMixin, DatespanMixin, GenericTabularReport, Pro
             self.domain,
             slugs,
             self.request.couch_user,
+            include_enterprise_users=toggles.DOMAIN_PERMISSIONS_MIRROR.enabled(self.domain),
         )
 
     def _build_query(self, user_ids, changed_by_user_ids, user_property, actions, user_upload_record_id):

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -19,7 +19,6 @@ from corehq.apps.custom_data_fields.models import (
 )
 from corehq.apps.domain.calculations import cases_in_last, inactive_cases_in_last
 from corehq.apps.enterprise.tests.utils import create_enterprise_permissions
-from corehq.apps.enterprise.utils import get_enterprise_domains, get_enterprise_controlled_domains
 from corehq.apps.es import CaseES, UserES
 from corehq.apps.es.aggregations import MISSING_KEY
 from corehq.apps.es.tests.utils import es_test
@@ -966,34 +965,14 @@ class TestUserESAccessors(TestCase):
             'location_id': None
         })
 
-    def test_domain_get_enterprise_source_domain(self):
+    def test_domain(self):
         self._send_user_to_es(self.user)
         self._send_user_to_es(self.source_domain_user)
         self.assertEqual(['superman'], UserES().domain(self.domain).values_list('username', flat=True))
         self.assertEqual(['batman'], UserES().domain(self.source_domain).values_list('username', flat=True))
         self.assertEqual(
             set(['superman', 'batman']),
-            set(UserES().domain(get_enterprise_domains(self.domain)).values_list('username', flat=True))
-        )
-
-    def test_domain_get_enterprise_controlled_domains_on_source_domain(self):
-        self._send_user_to_es(self.user)
-        self._send_user_to_es(self.source_domain_user)
-        self.assertEqual(['batman'], UserES().domain(self.source_domain).values_list('username', flat=True))
-        self.assertEqual(['superman'], UserES().domain(self.domain).values_list('username', flat=True))
-        self.assertEqual(
-            set(['batman', 'superman']),
-            set(UserES().domain(get_enterprise_controlled_domains(self.source_domain)).values_list('username', flat=True))
-        )
-
-    def test_domain_get_enterprise_controlled_domains_on_mirrored_domain(self):
-        self._send_user_to_es(self.user)
-        self._send_user_to_es(self.source_domain_user)
-        self.assertEqual(['batman'], UserES().domain(self.source_domain).values_list('username', flat=True))
-        self.assertEqual(['superman'], UserES().domain(self.domain).values_list('username', flat=True))
-        self.assertEqual(
-            set(['superman']),
-            set(UserES().domain(get_enterprise_controlled_domains(self.domain)).values_list('username', flat=True))
+            set(UserES().domain([self.domain, self.source_domain]).values_list('username', flat=True))
         )
 
 

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -19,6 +19,7 @@ from corehq.apps.custom_data_fields.models import (
 )
 from corehq.apps.domain.calculations import cases_in_last, inactive_cases_in_last
 from corehq.apps.enterprise.tests.utils import create_enterprise_permissions
+from corehq.apps.enterprise.utils import get_enterprise_domains, get_enterprise_controlled_domains
 from corehq.apps.es import CaseES, UserES
 from corehq.apps.es.aggregations import MISSING_KEY
 from corehq.apps.es.tests.utils import es_test
@@ -965,36 +966,34 @@ class TestUserESAccessors(TestCase):
             'location_id': None
         })
 
-    def test_domain_allow_enterprise(self):
+    def test_domain_get_enterprise_source_domain(self):
         self._send_user_to_es(self.user)
         self._send_user_to_es(self.source_domain_user)
         self.assertEqual(['superman'], UserES().domain(self.domain).values_list('username', flat=True))
         self.assertEqual(['batman'], UserES().domain(self.source_domain).values_list('username', flat=True))
         self.assertEqual(
             set(['superman', 'batman']),
-            set(UserES().domain(self.domain, allow_enterprise=True).values_list('username', flat=True))
+            set(UserES().domain(get_enterprise_domains(self.domain)).values_list('username', flat=True))
         )
 
-    def test_domain_allow_enterprise_controlled_domains_on_source_domain(self):
+    def test_domain_get_enterprise_controlled_domains_on_source_domain(self):
         self._send_user_to_es(self.user)
         self._send_user_to_es(self.source_domain_user)
         self.assertEqual(['batman'], UserES().domain(self.source_domain).values_list('username', flat=True))
         self.assertEqual(['superman'], UserES().domain(self.domain).values_list('username', flat=True))
         self.assertEqual(
             set(['batman', 'superman']),
-            set(UserES().domain(self.source_domain,
-                                allow_enterprise_controlled_domains=True).values_list('username', flat=True))
+            set(UserES().domain(get_enterprise_controlled_domains(self.source_domain)).values_list('username', flat=True))
         )
 
-    def test_domain_allow_enterprise_controlled_domains_on_mirrored_domain(self):
+    def test_domain_get_enterprise_controlled_domains_on_mirrored_domain(self):
         self._send_user_to_es(self.user)
         self._send_user_to_es(self.source_domain_user)
         self.assertEqual(['batman'], UserES().domain(self.source_domain).values_list('username', flat=True))
         self.assertEqual(['superman'], UserES().domain(self.domain).values_list('username', flat=True))
         self.assertEqual(
             set(['superman']),
-            set(UserES().domain(self.domain,
-                                allow_enterprise_controlled_domains=True).values_list('username', flat=True))
+            set(UserES().domain(get_enterprise_controlled_domains(self.domain)).values_list('username', flat=True))
         )
 
 

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -894,6 +894,18 @@ class TestUserESAccessors(TestCase):
         )
         cls.user.save()
 
+        cls.source_domain_user = CommCareUser.create(
+            cls.source_domain,
+            'batman',
+            'crime fighting man',
+            None,
+            None,
+            first_name='bruce',
+            last_name='wayne',
+            is_active=True,
+        )
+        cls.source_domain_user.save()
+
     def setUp(self):
         super(TestUserESAccessors, self).setUp()
         self.es = get_es_new()
@@ -908,13 +920,13 @@ class TestUserESAccessors(TestCase):
         ensure_index_deleted(USER_INDEX)
         super(TestUserESAccessors, cls).tearDownClass()
 
-    def _send_user_to_es(self, is_active=True):
-        self.user.is_active = is_active
-        send_to_elasticsearch('users', transform_user_for_elasticsearch(self.user.to_json()))
+    def _send_user_to_es(self, user, is_active=True):
+        user.is_active = is_active
+        send_to_elasticsearch('users', transform_user_for_elasticsearch(user.to_json()))
         self.es.indices.refresh(USER_INDEX)
 
     def test_active_user_query(self):
-        self._send_user_to_es()
+        self._send_user_to_es(self.user)
         results = get_user_stubs([self.user._id], ['user_data_es'])
 
         self.assertEqual(len(results), 1)
@@ -938,7 +950,7 @@ class TestUserESAccessors(TestCase):
         })
 
     def test_inactive_user_query(self):
-        self._send_user_to_es(is_active=False)
+        self._send_user_to_es(self.user, is_active=False)
         results = get_user_stubs([self.user._id])
 
         self.assertEqual(len(results), 1)
@@ -954,22 +966,35 @@ class TestUserESAccessors(TestCase):
         })
 
     def test_domain_allow_enterprise(self):
-        self._send_user_to_es()
+        self._send_user_to_es(self.user)
+        self._send_user_to_es(self.source_domain_user)
         self.assertEqual(['superman'], UserES().domain(self.domain).values_list('username', flat=True))
-        self.assertEqual([], UserES().domain(self.source_domain).values_list('username', flat=True))
+        self.assertEqual(['batman'], UserES().domain(self.source_domain).values_list('username', flat=True))
         self.assertEqual(
-            ['superman'],
-            UserES().domain(self.domain, allow_enterprise=True).values_list('username', flat=True)
+            set(['superman', 'batman']),
+            set(UserES().domain(self.domain, allow_enterprise=True).values_list('username', flat=True))
         )
 
-    def test_domain_allow_enterprise_controlled_domains(self):
-        self._send_user_to_es()
-        self.assertEqual([], UserES().domain(self.source_domain).values_list('username', flat=True))
+    def test_domain_allow_enterprise_controlled_domains_on_source_domain(self):
+        self._send_user_to_es(self.user)
+        self._send_user_to_es(self.source_domain_user)
+        self.assertEqual(['batman'], UserES().domain(self.source_domain).values_list('username', flat=True))
         self.assertEqual(['superman'], UserES().domain(self.domain).values_list('username', flat=True))
         self.assertEqual(
-            ['superman'],
-            UserES().domain(self.source_domain,
-                            allow_enterprise_controlled_domains=True).values_list('username', flat=True)
+            set(['batman', 'superman']),
+            set(UserES().domain(self.source_domain,
+                                allow_enterprise_controlled_domains=True).values_list('username', flat=True))
+        )
+
+    def test_domain_allow_enterprise_controlled_domains_on_mirrored_domain(self):
+        self._send_user_to_es(self.user)
+        self._send_user_to_es(self.source_domain_user)
+        self.assertEqual(['batman'], UserES().domain(self.source_domain).values_list('username', flat=True))
+        self.assertEqual(['superman'], UserES().domain(self.domain).values_list('username', flat=True))
+        self.assertEqual(
+            set(['superman']),
+            set(UserES().domain(self.domain,
+                                allow_enterprise_controlled_domains=True).values_list('username', flat=True))
         )
 
 

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -962,6 +962,16 @@ class TestUserESAccessors(TestCase):
             UserES().domain(self.domain, allow_enterprise=True).values_list('username', flat=True)
         )
 
+    def test_domain_allow_enterprise_controlled_domains(self):
+        self._send_user_to_es()
+        self.assertEqual([], UserES().domain(self.source_domain).values_list('username', flat=True))
+        self.assertEqual(['superman'], UserES().domain(self.domain).values_list('username', flat=True))
+        self.assertEqual(
+            ['superman'],
+            UserES().domain(self.source_domain,
+                            allow_enterprise_controlled_domains=True).values_list('username', flat=True)
+        )
+
 
 @es_test
 class TestGroupESAccessors(SimpleTestCase):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
[Ticket](https://dimagi-dev.atlassian.net/browse/USH-1316)
For the user filter, enable users to select users from all enterprise domains and not just the current domain

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This only affects the filter when accessed within the source domain (and not the mirrored domains) from the user history report. 


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[USER_HISTORY_REPORT](https://confluence.dimagi.com/pages/viewpage.action?spaceKey=saas&title=User+History+Report) and [DOMAIN_PERMISSIONS_MIRROR](https://confluence.dimagi.com/display/saas/Enterprise+Permissions)
--


<br class="Apple-interchange-newline">

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
test added in TestUserESAccessors

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
