### PR TITLE
Revert "Revert "Tabular structure for more than one check box question""

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -419,20 +419,23 @@
   <legend aria-hidden="true" class="sr-only">{% trans "Answer Choices" %}</legend>
     <div class="sel clear">
       <div data-bind="foreach: choices, as: 'choice'">
-        <div data-bind="css: { checkbox: $parent.isMulti, radio: !$parent.isMulti }">
+        <div data-bind="css: { checkbox: $parent.isMulti, radio: !$parent.isMulti }, class: $parent.colStyleIfHideLabel">
           <label>
-            <input data-bind="
-                        checked: $parent.rawAnswer,
-                        checkedValue: $index() + 1,
-                        attr: {
-                            id: 'group-' + $parent.entryId + '-choice-' + $index(),
-                            type: $parent.isMulti ? 'checkbox' : 'radio',
-                            name: $parent.entryId,
-                            class: 'group-' + $parent.entryId,
-                        },
-                    "/>
-            <span data-bind="renderMarkdown: $data"></span>
+              <input data-bind="
+                          checked: $parent.rawAnswer,
+                          checkedValue: $index() + 1,
+                          attr: {
+                              id: 'group-' + $parent.entryId + '-choice-' + $index(),
+                              type: $parent.isMulti ? 'checkbox' : 'radio',
+                              name: $parent.entryId,
+                              class: 'group-' + $parent.entryId,
+                          },
+                      "/>
+            <!-- ko ifnot: $parent.hideLabel -->
+              <span data-bind="renderMarkdown: $data"></span>
+            <!-- /ko -->
           </label>
+          </div>
         </div>
       </div>
       <button class="btn btn-default btn-xs pull-right" data-bind="click: onClear, fadeVisible: !isMulti && rawAnswer()">


### PR DESCRIPTION
Reverts [dimagi/commcare-hq#30762](https://github.com/dimagi/commcare-hq/pull/30762).

[Original PR.](https://github.com/dimagi/commcare-hq/pull/30710)

I reverted the original "tabular stucture for checkbox questions" PR because we may want to announce the new feature before releasing it. This will un-revert the original PR so that it can be re-deployed to staging and can be used for testing and a demo later today. I will wait to merge it when it is ready to be seen on production.