### PR TITLE
[HubSpot] Management command to audit a user's hubspot status

### DIFF
--- a/corehq/apps/analytics/management/commands/audit_user_in_hubspot.py
+++ b/corehq/apps/analytics/management/commands/audit_user_in_hubspot.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
     def show_status_of_possibly_unblocked_user(self, email, blocked_domains):
         self.stdout.write(
             f"\n{email} is not a member of any projects actively blocking "
-            f"data from HubSpot."
+            f"data from HubSpot.\n"
         )
         blocked_domains_invited = Invitation.objects.filter(
             domain__in=list(blocked_domains),
@@ -71,7 +71,7 @@ class Command(BaseCommand):
             first_conversion = hubspot_contact_info[email]
             self.stdout.write(
                 f"\n{email} found in HubSpot with First Conversion "
-                f"(clustered) as '{first_conversion}'."
+                f"(clustered) as '{first_conversion}'.\n"
             )
             if first_conversion in ALLOWED_CONVERSIONS:
                 self.stdout.write(

--- a/corehq/apps/analytics/management/commands/audit_user_in_hubspot.py
+++ b/corehq/apps/analytics/management/commands/audit_user_in_hubspot.py
@@ -1,0 +1,89 @@
+from django.core.management import BaseCommand
+
+from corehq.apps.analytics.utils import (
+    get_blocked_hubspot_domains,
+    get_first_conversion_status_for_emails,
+    ALLOWED_CONVERSIONS,
+)
+from corehq.apps.users.models import WebUser, Invitation
+
+
+class Command(BaseCommand):
+    help = "Audit a web user's HubSpot status in HubSpot and CommCare HQ"
+
+    def add_arguments(self, parser):
+        parser.add_argument('email')
+
+    def handle(self, email, **options):
+        web_user = WebUser.get_by_username(email)
+        if not web_user:
+            self.stdout.write(self.style.ERROR(
+                "User not does not exist on CommCare HQ."
+            ))
+            return
+
+        blocked_domains = set(get_blocked_hubspot_domains())
+
+        user_domains = set(web_user.get_domains())
+        blocked_memberships = user_domains.intersection(blocked_domains)
+
+        if not blocked_memberships:
+            self.show_status_of_possibly_unblocked_user(email, blocked_domains)
+        else:
+            self.show_status_of_blocked_user(email, blocked_memberships)
+
+        self.display_first_conversion_status(email)
+
+    def show_status_of_possibly_unblocked_user(self, email, blocked_domains):
+        self.stdout.write(
+            f"\n{email} is not a member of any projects actively blocking "
+            f"data from HubSpot."
+        )
+        blocked_domains_invited = Invitation.objects.filter(
+            domain__in=list(blocked_domains),
+            is_accepted=True,
+            email=email,
+        ).values_list('email', flat=True)
+        if blocked_domains_invited:
+            self.stdout.write(
+                "However, it looks like they have previously accepted "
+                "invitations to the following project(s) blocking HubSpot data:"
+            )
+            self.stdout.write("\n".join(blocked_domains_invited))
+        else:
+            self.stdout.write(
+                "They also have never accepted an invitation from a project "
+                "that is actively blocking HubSpot data."
+            )
+        self.stdout.write("\n")
+
+    def show_status_of_blocked_user(self, email, blocked_memberships):
+        self.stdout.write(
+            f"\n{email} is a member of the following project(s) actively "
+            f"blocking data from HubSpot:"
+        )
+        self.stdout.write("\n".join(blocked_memberships))
+        self.stdout.write("\n")
+
+    def display_first_conversion_status(self, email):
+        hubspot_contact_info = get_first_conversion_status_for_emails([email])
+        if hubspot_contact_info:
+            first_conversion = hubspot_contact_info[email]
+            self.stdout.write(
+                f"\n{email} found in HubSpot with First Conversion "
+                f"(clustered) as '{first_conversion}'."
+            )
+            if first_conversion in ALLOWED_CONVERSIONS:
+                self.stdout.write(
+                    "This is fully acceptable according to our policy."
+                )
+            else:
+                self.stdout.write(
+                    "If the user is part of a project blocking HubSpot data, "
+                    "then this is not allowed."
+                )
+        else:
+            self.stdout.write(
+                f"{email} not found in HubSpot."
+            )
+        self.stdout.write("\n")

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -233,30 +233,6 @@ def get_first_conversion_status_for_emails(list_of_emails):
     return status_summary
 
 
-def _get_contact_ids_to_delete(list_of_emails):
-    """
-    Gets a list of Contact IDs be deleted from Hubspot based on the
-    allowed First Conversion (clustered) property set on those contacts.
-    :param list_of_emails:
-    :return: list of contact ids
-    """
-    hubspot_contacts = _get_contacts_from_hubspot(list_of_emails)
-    ids_to_delete = []
-    for contact_id, data in hubspot_contacts.items():
-        first_conversion_status = data.get(
-            'properties', {}
-        ).get('first_conversion_clustered_', {}).get('value')
-
-        # If a user's first conversion IS in the allowed list, it means
-        # they have directly interacted with us and we want to keep them
-        # in the email list. However, we will not send project data
-        # about them to HubSpot as they will still be blocked from
-        # updates in track_periodic_data.
-        if first_conversion_status not in ALLOWED_CONVERSIONS:
-            ids_to_delete.append(contact_id)
-    return ids_to_delete
-
-
 def remove_blocked_domain_contacts_from_hubspot(stdout=None):
     """
     Removes contacts from Hubspot that are members of blocked domains.
@@ -324,6 +300,30 @@ def remove_blocked_domain_invited_users_from_hubspot(stdout=None):
             'commcare.hubspot_data.deleted_user.blocked_domain_invitation',
             num_deleted
         )
+
+
+def _get_contact_ids_to_delete(list_of_emails):
+    """
+    Gets a list of Contact IDs be deleted from Hubspot based on the
+    allowed First Conversion (clustered) property set on those contacts.
+    :param list_of_emails:
+    :return: list of contact ids
+    """
+    hubspot_contacts = _get_contacts_from_hubspot(list_of_emails)
+    ids_to_delete = []
+    for contact_id, data in hubspot_contacts.items():
+        first_conversion_status = data.get(
+            'properties', {}
+        ).get('first_conversion_clustered_', {}).get('value')
+
+        # If a user's first conversion IS in the allowed list, it means
+        # they have directly interacted with us and we want to keep them
+        # in the email list. However, we will not send project data
+        # about them to HubSpot as they will still be blocked from
+        # updates in track_periodic_data.
+        if first_conversion_status not in ALLOWED_CONVERSIONS:
+            ids_to_delete.append(contact_id)
+    return ids_to_delete
 
 
 def is_hubspot_js_allowed_for_request(request):

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -229,7 +229,8 @@ def get_first_conversion_status_for_emails(list_of_emails):
         email = data.get(
             'properties', {}
         ).get('email', {}).get('value')
-        status_summary[email] = first_conversion_status
+        if email:
+            status_summary[email] = first_conversion_status
     return status_summary
 
 

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -211,6 +211,26 @@ def _get_contacts_from_hubspot(list_of_emails, retry_num=0, record_metrics=True)
     return {}
 
 
+def get_first_conversion_status_for_emails(list_of_emails):
+    """
+    This returns the First Conversion (clustered) property for each contact in
+    list_of_emails if that email is present in HubSpot
+    :param list_of_emails:
+    :return: list of contact ids
+    """
+    hubspot_contacts = _get_contacts_from_hubspot(list_of_emails)
+    status_summary = {}
+    for contact_id, data in hubspot_contacts.items():
+        first_conversion_status = data.get(
+            'properties', {}
+        ).get('first_conversion_clustered_', {}).get('value')
+        email = data.get(
+            'properties', {}
+        ).get('email', {}).get('value')
+        status_summary[email] = first_conversion_status
+    return status_summary
+
+
 def _get_contact_ids_to_delete(list_of_emails):
     """
     Gets a list of Contact IDs be deleted from Hubspot based on the

--- a/corehq/apps/analytics/utils.py
+++ b/corehq/apps/analytics/utils.py
@@ -218,7 +218,9 @@ def get_first_conversion_status_for_emails(list_of_emails):
     :param list_of_emails:
     :return: list of contact ids
     """
-    hubspot_contacts = _get_contacts_from_hubspot(list_of_emails)
+    hubspot_contacts = _get_contacts_from_hubspot(
+        list_of_emails, record_metrics=False
+    )
     status_summary = {}
     for contact_id, data in hubspot_contacts.items():
         first_conversion_status = data.get(


### PR DESCRIPTION
## Technical Summary
This introduces a new management command `audit_user_in_hubspot <username>` to see whether a user is:
- a member of a project space blocking hubspot data
- whether the user is present in hubspot
- if the user is present, what their "First Conversion (clustered)" status is and whether this value is allowed according to our policy

## Safety Assurance

### Safety story
Adds a new management command. Tested changes to `_get_contact_ids_to_delete` locally, and everything checks out.

### Automated test coverage
None for these API calls

### QA Plan
Not needed. Small, isolated change. Low-risk area as this is still being approved by the division requiring that we block certain data from Hubspot and is not currently active. We also have plenty of datadog metrics to catch any issues.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
