### PR TITLE
Transition mobile access restrictions from FF to GA setting (PR 2 of 2)

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -110,7 +110,7 @@ from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput, Select2Ajax, Ge
 from corehq.apps.sms.phonenumbers_helper import parse_phone_number
 from corehq.apps.users.models import CouchUser, WebUser
 from corehq.toggles import HIPAA_COMPLIANCE_CHECKBOX, MOBILE_UCR, \
-    SECURE_SESSION_TIMEOUT
+    SECURE_SESSION_TIMEOUT, RESTRICT_MOBILE_ACCESS
 from corehq.util.timezones.fields import TimeZoneField
 from corehq.util.timezones.forms import TimeZoneChoiceField
 
@@ -585,7 +585,7 @@ class PrivacySecurityForm(forms.Form):
         label=ugettext_lazy("Secure submissions"),
         required=False,
         help_text=mark_safe_lazy(ugettext_lazy(  # nosec: no user input
-            "Secure Submissions prevents others from impersonating your mobile workers."
+            "Secure Submissions prevents others from impersonating your mobile workers. "
             "This setting requires all deployed applications to be using secure "
             "submissions as well. "
             "<a href='https://help.commcarehq.org/display/commcarepublic/Project+Space+Settings'>"
@@ -627,6 +627,19 @@ class PrivacySecurityForm(forms.Form):
         label=ugettext_lazy("Disable Google Analytics"),
         required=False,
     )
+    # Enabled by a specific feature flag:
+    # https://confluence.dimagi.com/display/saas/COVID%3A+Require+explicit+permissions+to+access+mobile+app+endpoints
+    restrict_mobile_access = BooleanField(
+        label=ugettext_lazy("Restrict Mobile Endpoint Access"),
+        required=False,
+        help_text=mark_safe_lazy(ugettext_lazy(
+            "When this setting is turned on, the Roles and Permissions page will display a new "
+            "\"Mobile App Access\" option under \"Other Settings.\" With this permission disabled, "
+            "the user account will be unable to login or sync from a mobile application, and will only "
+            "be able to use apps via the Web Apps interface."
+            "<a href='https://help.commcarehq.org/display/commcarepublic/Project+Space+Settings'> "
+            "Read more about restricting mobile endpoint access here.</a>")),
+    )
 
     def __init__(self, *args, **kwargs):
         user_name = kwargs.pop('user_name')
@@ -642,7 +655,10 @@ class PrivacySecurityForm(forms.Form):
         self.helper[6] = twbscrispy.PrependedText('two_factor_auth', '')
         self.helper[7] = twbscrispy.PrependedText('strong_mobile_passwords', '')
         self.helper[8] = twbscrispy.PrependedText('ga_opt_out', '')
+        self.helper[9] = twbscrispy.PrependedText('restrict_mobile_access', '')
 
+        if not RESTRICT_MOBILE_ACCESS.enabled(domain):
+            self.helper.layout.pop(9)
         if not domain_has_privilege(domain, privileges.ADVANCED_DOMAIN_SECURITY):
             self.helper.layout.pop(8)
             self.helper.layout.pop(7)
@@ -683,6 +699,7 @@ class PrivacySecurityForm(forms.Form):
         domain.secure_submissions = secure_submissions
         domain.hipaa_compliant = self.cleaned_data.get('hipaa_compliant', False)
         domain.ga_opt_out = self.cleaned_data.get('ga_opt_out', False)
+        domain.restrict_mobile_access = self.cleaned_data.get('restrict_mobile_access', False)
 
         domain.save()
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -699,7 +699,8 @@ class PrivacySecurityForm(forms.Form):
         domain.secure_submissions = secure_submissions
         domain.hipaa_compliant = self.cleaned_data.get('hipaa_compliant', False)
         domain.ga_opt_out = self.cleaned_data.get('ga_opt_out', False)
-        domain.restrict_mobile_access = self.cleaned_data.get('restrict_mobile_access', False)
+        if RESTRICT_MOBILE_ACCESS.enabled(domain):
+            domain.restrict_mobile_access = self.cleaned_data.get('restrict_mobile_access', False)
 
         domain.save()
 

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -322,6 +322,7 @@ class EditPrivacySecurityView(BaseAdminProjectSettingsView):
             "two_factor_auth": self.domain_object.two_factor_auth,
             "strong_mobile_passwords": self.domain_object.strong_mobile_passwords,
             "ga_opt_out": self.domain_object.ga_opt_out,
+            "restrict_mobile_access": self.domain_object.restrict_mobile_access,
         }
         if self.request.method == 'POST':
             return PrivacySecurityForm(self.request.POST, initial=initial,

--- a/corehq/apps/ota/decorators.py
+++ b/corehq/apps/ota/decorators.py
@@ -1,6 +1,7 @@
 import logging
 
 from corehq import toggles
+from corehq.apps.domain.models import Domain
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 
@@ -19,7 +20,7 @@ ORIGIN_TOKEN_SLUG = 'OriginToken'
 def require_mobile_access(fn):
     @wraps(fn)
     def _inner(request, domain, *args, **kwargs):
-        if toggles.RESTRICT_MOBILE_ACCESS.enabled(domain):
+        if Domain.get_by_name(domain).restrict_mobile_access:
             origin_token = request.META.get(ORIGIN_TOKEN_HEADER, None)
             if origin_token:
                 if _test_token_valid(origin_token):

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -349,7 +349,7 @@
               </div>
               </div>
             {% endif %}
-            {% if request|toggle_enabled:"RESTRICT_MOBILE_ACCESS" %}
+            {% if request.project.restrict_mobile_access %}
             {# BEGIN MOBILE permission #}
             <div class="form-group">
               <label class="col-sm-4 control-label">

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1870,7 +1870,7 @@ SKIP_UPDATING_USER_REPORTING_METADATA = StaticToggle(
 
 RESTRICT_MOBILE_ACCESS = StaticToggle(
     'restrict_mobile_endpoints',
-    'USH: Require explicit permissions to access mobile app endpoints',
+    'USH: Displays a security setting option to require explicit permissions to access mobile app endpoints',
     TAG_CUSTOM,
     [NAMESPACE_DOMAIN],
     help_link="https://confluence.dimagi.com/display/saas/COVID%3A+Require+explicit+permissions+to+access+mobile+app+endpoints",


### PR DESCRIPTION
## Product Description

I will limit details around context here because PR descriptions are public-facing and this isn't something we want to announce to the public yet. This is part of a push to restrict users' access to mobile endpoints. [Here is the description](https://docs.google.com/document/d/1aVDHalKJvtTc8FVkMmFb0fxzxO5UaW2-_4g2MTQlrz0/edit?usp=sharing) of the vulnerabilities and proposed changes written up by Ethan.

The feature flag RESTRICT_MOBILE_ENDPOINTS currently restricts mobile workers' access to the mobile app (and thus the mobile endpoints) by allowing administrators to it turn on/off on the Roles & Permissions page.

<img width="542" alt="Screen Shot 2021-11-23 at 4 29 49 PM" src="https://user-images.githubusercontent.com/6729291/143132227-70e6b1c8-963d-40e3-a9a6-472c28785f87.png">

 **This PR will cause that feature flag to become just a switch to display a new GA setting**. When the feature flag is on it will display the setting. When it is off the setting will be hidden. The GA setting will take over the what the feature flag was doing before this change and allow admins to turn access on/off for a mobile worker on the Roles & Permissions page.

A note: the feature flag will hide the checkbox but not disable the setting. This means that if the setting was enabled when the FF was on and then the FF is turned off, the mobile access restrictions may continue and the setting will be enabled in the background. This was how the spec laid it out but I'd like to hear if this was unintentional or if someone thinks the FF being turned off should also turn off the setting.

The setting will be the last checkbox at the bottom under "Project Settings" -> "Privacy and Security".

<img width="275" alt="Screen Shot 2021-11-23 at 3 42 07 PM" src="https://user-images.githubusercontent.com/6729291/143108116-7a7a126a-096c-4ff2-b50d-41e62e4deb23.png">
<img width="812" alt="Screen Shot 2021-11-23 at 4 24 17 PM" src="https://user-images.githubusercontent.com/6729291/143131465-c4d27279-098b-441c-a647-d96245955797.png">

The link in the description above currently directs to the general ["project space settings" documentation](https://help.commcarehq.org/display/commcarepublic/Project+Space+Settings) but I will update this once we have more thorough documentation around mobile access endpoints (maybe from [USH-1410](https://dimagi-dev.atlassian.net/browse/USH-1410)).

## Technical Summary

This is part of a [Jira epic](https://dimagi-dev.atlassian.net/browse/USH-1408) to modify mobile access endpoint restrictions. [USH-1409](https://dimagi-dev.atlassian.net/browse/USH-1409) is the relevant ticket that lays out a detailed specification.

This PR is a second of two that simply adds UI and transitions existing code from using the FF to using the GA setting instead.

[PR 1 of 2](https://github.com/dimagi/commcare-hq/pull/30769) did the preliminary migrations to make this possible.

@esoergel there is a small merge conflict with your branch es/mobile-auth so we will want to coordinate merges.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

RESTRICT_MOBILE_ENDPOINTS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

I tested that the feature flag and setting works properly and enables/disables the mobile access setting under the Roles & Permissions page. I tested that turning the setting on/off does indeed still affect mobile access restrictions by viewing/getting a permission denial error on a mobile worker's restore file on my local machine (I.e. http://localhost:8000/a/addison-test/phone/restore/).

Before and after deployment I will double check to make sure that domains currently using the feature flag have the GA setting on.

### Automated test coverage
<!-- Identify the related test coverage and the tests it would catch -->

No tests

### QA Plan

No QA

### Migrations

Preliminary migration happened in [#30769](https://github.com/dimagi/commcare-hq/pull/30769)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change