### PR TITLE
Only narrow the width of "Create new property" column...

### DIFF
--- a/corehq/apps/case_importer/templates/case_importer/excel_fields.html
+++ b/corehq/apps/case_importer/templates/case_importer/excel_fields.html
@@ -43,7 +43,9 @@
         <th>{% trans "Excel Field" %}</th>
         <th></th>
         <th>{% trans "Case Property" %}</th>
-        <th class="col-md-1">{% trans "Create new property" %}</th>
+        <th{% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %} class="col-md-1"{% endif %}>
+          {% trans "Create new property" %}
+        </th>
         {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
           <th>{% include "data_dictionary/partials/valid_values_th_content.html" %}</th>
         {% endif %}

--- a/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
@@ -69,7 +69,7 @@
     <!--/ko-->
   </td>
 
-  <td class="col-md-1">
+  <td>
     <div class="checkbox">
       <label>
         <input type="checkbox" class="new_property" style="margin-left: auto;" data-bind="checked: createNewChecked"/>

--- a/corehq/apps/data_dictionary/tests/utils.py
+++ b/corehq/apps/data_dictionary/tests/utils.py
@@ -11,4 +11,4 @@ def setup_data_dictionary(domain, case_type_name, prop_list=None, allowed_values
         prop.save()
         if prop_name in allowed_values:
             for value in allowed_values[prop_name]:
-                CasePropertyAllowedValue.objects.create(case_property=prop, allowed_value=value)
+                CasePropertyAllowedValue.objects.get_or_create(case_property=prop, allowed_value=value)


### PR DESCRIPTION
...when the validation feature flag is enabled. (Without the extra columns from the flag, the narrow width makes the remaining columns space out too much.)

Also fix a test utility to use get_or_create instead of simply create.

(not a PR into master => removed safety info -@orangejenny)