### PR TITLE
Revert "Revert "restrict login-as users access during restore""

### DIFF
--- a/corehq/apps/cloudcare/tests/test_esaccessors.py
+++ b/corehq/apps/cloudcare/tests/test_esaccessors.py
@@ -16,11 +16,11 @@ from corehq.util.elastic import ensure_index_deleted
 
 
 @es_test
-class TestCloudcareESAccessors(SimpleTestCase):
+class TestLoginAsUserQuery(SimpleTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestCloudcareESAccessors, cls).setUpClass()
+        super(TestLoginAsUserQuery, cls).setUpClass()
         cls.username = 'superman'
         cls.first_name = 'clark'
         cls.last_name = 'kent'
@@ -36,7 +36,7 @@ class TestCloudcareESAccessors(SimpleTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super(TestCloudcareESAccessors, cls).tearDownClass()
+        super(TestLoginAsUserQuery, cls).tearDownClass()
 
     def _send_user_to_es(self, _id=None, username=None, user_data=None):
         user = CommCareUser(

--- a/corehq/apps/cloudcare/tests/test_esaccessors.py
+++ b/corehq/apps/cloudcare/tests/test_esaccessors.py
@@ -101,6 +101,38 @@ class TestCloudcareESAccessors(SimpleTestCase):
                 1
             )
 
+    def test_limited_users_case_insensitive(self):
+        self._send_user_to_es(username='superman')
+        self._send_user_to_es(username='robin', user_data={'login_as_user': 'BATMAN'})
+
+        with patch('corehq.apps.cloudcare.esaccessors._limit_login_as', return_value=True):
+            self.assertEqual(
+                login_as_user_query(
+                    self.domain,
+                    MagicMock(username='batman'),
+                    None,
+                    10,
+                    0
+                ).values_list("username", flat=True),
+                ["robin"]
+            )
+
+    def test_limited_users_partial_match(self):
+        self._send_user_to_es(username='superman')
+        self._send_user_to_es(username='robin', user_data={'login_as_user': 'batman and robin'})
+
+        with patch('corehq.apps.cloudcare.esaccessors._limit_login_as', return_value=True):
+            self.assertEqual(
+                login_as_user_query(
+                    self.domain,
+                    MagicMock(username='batman'),
+                    None,
+                    10,
+                    0
+                ).values_list("username", flat=True),
+                ["robin"]
+            )
+
     def test_default_user(self):
         self._send_user_to_es(username='superman')
         self._send_user_to_es(username='robin', user_data={'login_as_user': 'batman'})

--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -1,7 +1,8 @@
+from unittest.mock import patch
+
 from django.test import TestCase
 
 from casexml.apps.phone.models import OTARestoreCommCareUser, OTARestoreWebUser
-
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.tests.util import LocationHierarchyTestCase
 from corehq.apps.ota.utils import get_restore_user, is_permitted_to_restore
@@ -213,6 +214,99 @@ class RestorePermissionsTest(LocationHierarchyTestCase):
         )
         self.assertFalse(is_permitted)
         self.assertRegex(message, 'not in allowed locations')
+
+
+class RestorePermissionsTestLimitLoginAs(TestCase):
+    domain = 'goats_do_roam'
+
+    @classmethod
+    def setUpClass(cls):
+        super(RestorePermissionsTestLimitLoginAs, cls).setUpClass()
+
+        cls.project = Domain(name=cls.domain)
+        cls.project.save()
+
+        cls.restore_user = WebUser.create(
+            username=format_username('malbec', cls.domain),
+            domain=cls.domain,
+            password='***',
+            created_by=None,
+            created_via=None,
+        )
+        cls.commcare_user = CommCareUser.create(
+            username=format_username('shiraz', cls.domain),
+            domain=cls.domain,
+            password='***',
+            created_by=None,
+            created_via=None,
+        )
+        cls.commcare_user_login_as = CommCareUser.create(
+            username=format_username('merlot', cls.domain),
+            domain=cls.domain,
+            password='***',
+            created_by=None,
+            created_via=None,
+            metadata={
+                "login_as_user": cls.restore_user.username
+            },
+        )
+        cls.commcare_user_default_login_as = CommCareUser.create(
+            username=format_username('pinotage', cls.domain),
+            domain=cls.domain,
+            password='***',
+            created_by=None,
+            created_via=None,
+            metadata={
+                "login_as_user": 'default'
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        delete_all_users()
+        Domain.get_db().delete_doc(cls.project)
+        super(RestorePermissionsTestLimitLoginAs, cls).tearDownClass()
+
+    def test_user_limited_login_as_denied(self):
+        with patch("corehq.apps.ota.utils._limit_login_as", return_value=True):
+            is_permitted, message = is_permitted_to_restore(
+                self.domain,
+                self.restore_user,
+                self.commcare_user,
+            )
+            self.assertFalse(is_permitted)
+            self.assertRegex(message, "not available as login-as user")
+
+    def test_user_limited_login_as_permitted(self):
+        with patch("corehq.apps.ota.utils._limit_login_as", return_value=True):
+            is_permitted, message = is_permitted_to_restore(
+                self.domain,
+                self.restore_user,
+                self.commcare_user_login_as,
+            )
+            self.assertIsNone(message)
+            self.assertTrue(is_permitted)
+
+    def test_user_limited_login_as_default_denied(self):
+        with patch("corehq.apps.ota.utils._limit_login_as", return_value=True):
+            is_permitted, message = is_permitted_to_restore(
+                self.domain,
+                self.restore_user,
+                self.commcare_user_default_login_as,
+            )
+            self.assertFalse(is_permitted)
+            self.assertRegex(message, "not available as login-as user")
+
+    def test_user_limited_login_as_default_permitted(self):
+        with patch("corehq.apps.ota.utils._limit_login_as", return_value=True), \
+             patch("corehq.apps.ota.utils._can_access_default_login_as_user", return_value=True):
+            is_permitted, message = is_permitted_to_restore(
+                self.domain,
+                self.restore_user,
+                self.commcare_user_default_login_as,
+            )
+            self.assertIsNone(message)
+            self.assertTrue(is_permitted)
 
 
 class GetRestoreUserTest(TestCase):

--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -250,14 +250,14 @@ class RestorePermissionsTestLimitLoginAs(TestCase):
                 "login_as_user": cls.restore_user.username
             },
         )
-        cls.commcare_user_login_as_different_case = CommCareUser.create(
+        cls.commcare_user_login_as_multiple_upper_case = CommCareUser.create(
             username=format_username('cabernet', cls.domain),
             domain=cls.domain,
             password='***',
             created_by=None,
             created_via=None,
             metadata={
-                "login_as_user": cls.restore_user.username.upper()
+                "login_as_user": f"{format_username('ruby', cls.domain)} {cls.restore_user.username.upper()}"
             },
         )
         cls.commcare_user_default_login_as = CommCareUser.create(
@@ -267,7 +267,7 @@ class RestorePermissionsTestLimitLoginAs(TestCase):
             created_by=None,
             created_via=None,
             metadata={
-                "login_as_user": 'deFAUlt'  # intentionally mixed case to test case sensitivity
+                "login_as_user": "someone@else deFAUlt"  # intentionally mixed case to test case sensitivity
             },
         )
 
@@ -297,12 +297,12 @@ class RestorePermissionsTestLimitLoginAs(TestCase):
             self.assertIsNone(message)
             self.assertTrue(is_permitted)
 
-    def test_user_limited_login_as_permitted_case_insensitive_match(self):
+    def test_user_limited_login_as_permitted_case_insensitive_match_multiple_users(self):
         with patch("corehq.apps.ota.utils._limit_login_as", return_value=True):
             is_permitted, message = is_permitted_to_restore(
                 self.domain,
                 self.restore_user,
-                self.commcare_user_login_as_different_case,
+                self.commcare_user_login_as_multiple_upper_case,
             )
             self.assertIsNone(message)
             self.assertTrue(is_permitted)

--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -250,6 +250,16 @@ class RestorePermissionsTestLimitLoginAs(TestCase):
                 "login_as_user": cls.restore_user.username
             },
         )
+        cls.commcare_user_login_as_different_case = CommCareUser.create(
+            username=format_username('cabernet', cls.domain),
+            domain=cls.domain,
+            password='***',
+            created_by=None,
+            created_via=None,
+            metadata={
+                "login_as_user": cls.restore_user.username.upper()
+            },
+        )
         cls.commcare_user_default_login_as = CommCareUser.create(
             username=format_username('pinotage', cls.domain),
             domain=cls.domain,
@@ -257,7 +267,7 @@ class RestorePermissionsTestLimitLoginAs(TestCase):
             created_by=None,
             created_via=None,
             metadata={
-                "login_as_user": 'default'
+                "login_as_user": 'deFAUlt'  # intentionally mixed case to test case sensitivity
             },
         )
 
@@ -283,6 +293,16 @@ class RestorePermissionsTestLimitLoginAs(TestCase):
                 self.domain,
                 self.restore_user,
                 self.commcare_user_login_as,
+            )
+            self.assertIsNone(message)
+            self.assertTrue(is_permitted)
+
+    def test_user_limited_login_as_permitted_case_insensitive_match(self):
+        with patch("corehq.apps.ota.utils._limit_login_as", return_value=True):
+            is_permitted, message = is_permitted_to_restore(
+                self.domain,
+                self.restore_user,
+                self.commcare_user_login_as_different_case,
             )
             self.assertIsNone(message)
             self.assertTrue(is_permitted)

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -143,9 +143,13 @@ def _ensure_valid_restore_as_user(domain, couch_user, as_user_obj):
 
     if _limit_login_as(domain, couch_user):
         login_as_username = as_user_obj.metadata.get('login_as_user')
-        if login_as_username != couch_user.username:
-            if not _can_access_default_login_as_user(domain, couch_user) or login_as_username != 'default':
-                raise RestorePermissionDenied(_("{} not available as login-as user").format(as_user_obj.username))
+        error_message = _("{} not available as login-as user").format(as_user_obj.username)
+        if login_as_username is None:
+            raise RestorePermissionDenied(error_message)
+        if login_as_username.lower() != couch_user.username.lower():
+            is_default = login_as_username.lower() == 'default'
+            if not _can_access_default_login_as_user(domain, couch_user) or not is_default:
+                raise RestorePermissionDenied(error_message)
 
 
 def _limit_login_as(domain, couch_user):

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -143,8 +143,9 @@ def _ensure_valid_restore_as_user(domain, couch_user, as_user_obj):
 
     if _limit_login_as(domain, couch_user):
         login_as_username = as_user_obj.metadata.get('login_as_user') or ''
-        if login_as_username.lower() != couch_user.username.lower():
-            is_default = login_as_username.lower() == 'default'
+        candidates = login_as_username.lower().split()
+        if couch_user.username.lower() not in candidates:
+            is_default = 'default' in candidates
             if not _can_access_default_login_as_user(domain, couch_user) or not is_default:
                 raise RestorePermissionDenied(_("{} not available as login-as user").format(as_user_obj.username))
 

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -142,6 +142,8 @@ def _ensure_valid_restore_as_user(domain, couch_user, as_user_obj):
         raise RestorePermissionDenied(_("{} was not in the domain {}").format(as_user_obj.username, domain))
 
     if _limit_login_as(domain, couch_user):
+        # Functionality should match the ES query.
+        # See corehq.apps.cloudcare.esaccessors.login_as_user_query
         login_as_username = as_user_obj.metadata.get('login_as_user') or ''
         candidates = login_as_username.lower().split()
         if couch_user.username.lower() not in candidates:

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -142,14 +142,11 @@ def _ensure_valid_restore_as_user(domain, couch_user, as_user_obj):
         raise RestorePermissionDenied(_("{} was not in the domain {}").format(as_user_obj.username, domain))
 
     if _limit_login_as(domain, couch_user):
-        login_as_username = as_user_obj.metadata.get('login_as_user')
-        error_message = _("{} not available as login-as user").format(as_user_obj.username)
-        if login_as_username is None:
-            raise RestorePermissionDenied(error_message)
+        login_as_username = as_user_obj.metadata.get('login_as_user') or ''
         if login_as_username.lower() != couch_user.username.lower():
             is_default = login_as_username.lower() == 'default'
             if not _can_access_default_login_as_user(domain, couch_user) or not is_default:
-                raise RestorePermissionDenied(error_message)
+                raise RestorePermissionDenied(_("{} not available as login-as user").format(as_user_obj.username))
 
 
 def _limit_login_as(domain, couch_user):


### PR DESCRIPTION
Reverts dimagi/commcare-hq#30794

## Product Description
When using the `RESTRICT_LOGIN_AS` feature flat the login-as restrictions are only applied on the Web Apps UI. This PR also applies those restrictions in the restore endpoint making it impossible to bypass the restrictions when the are enabled.

Jira: https://dimagi-dev.atlassian.net/browse/USH-1411

## Technical Summary
Check login-as user restrictions during restore requests.

## Feature Flag
RESTRICT_LOGIN_AS

## Safety Assurance

### Safety story
Changes only applied based on user permissions which are limited to FF enabled domains. Changes are tested and the restore endpoint is well tested elsewhere.

### Automated test coverage
Added

### QA Plan
None

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
