### PR TITLE
Requires Python 3.9

### DIFF
--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -805,12 +805,11 @@ class CommCareCaseSQL(PartitionedModel, models.Model, RedisLockableMixIn,
             lazy_serialize_case_xform_ids, lazy_serialize_case_attachments
         )
         serializer = CommCareCaseSQLSerializer(self)
-        ret = dict(serializer.data)
+        ret = self.case_json | dict(serializer.data)
         ret['indices'] = lazy_serialize_case_indices(self)
         ret['actions'] = lazy_serialize_case_transactions(self)
         ret['xform_ids'] = lazy_serialize_case_xform_ids(self)
         ret['case_attachments'] = lazy_serialize_case_attachments(self)
-        ret = self.case_json | ret
         ret['backend_id'] = 'sql'
         return ret
 

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -810,9 +810,7 @@ class CommCareCaseSQL(PartitionedModel, models.Model, RedisLockableMixIn,
         ret['actions'] = lazy_serialize_case_transactions(self)
         ret['xform_ids'] = lazy_serialize_case_xform_ids(self)
         ret['case_attachments'] = lazy_serialize_case_attachments(self)
-        for key in self.case_json:
-            if key not in ret:
-                ret[key] = self.case_json[key]
+        ret = self.case_json | ret
         ret['backend_id'] = 'sql'
         return ret
 

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -805,13 +805,13 @@ class CommCareCaseSQL(PartitionedModel, models.Model, RedisLockableMixIn,
             lazy_serialize_case_xform_ids, lazy_serialize_case_attachments
         )
         serializer = CommCareCaseSQLSerializer(self)
-        ret = self.case_json | dict(serializer.data)
-        ret['indices'] = lazy_serialize_case_indices(self)
-        ret['actions'] = lazy_serialize_case_transactions(self)
-        ret['xform_ids'] = lazy_serialize_case_xform_ids(self)
-        ret['case_attachments'] = lazy_serialize_case_attachments(self)
-        ret['backend_id'] = 'sql'
-        return ret
+        return self.case_json | dict(serializer.data) | {
+            'indices': lazy_serialize_case_indices(self),
+            'actions': lazy_serialize_case_transactions(self),
+            'xform_ids': lazy_serialize_case_xform_ids(self),
+            'case_attachments': lazy_serialize_case_attachments(self),
+            'backend_id': 'sql',
+        }
 
     def dumps(self, pretty=False):
         indent = 4 if pretty else None

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -810,14 +810,18 @@ class CommCareCaseSQL(PartitionedModel, models.Model, RedisLockableMixIn,
             lazy_serialize_case_transactions,
             lazy_serialize_case_xform_ids,
         )
+
+        def union(*dicts):
+            return {k: v for d in dicts for k, v in d.items()}
+
         serializer = CommCareCaseSQLSerializer(self)
-        return self.case_json | dict(serializer.data) | {
+        return union(self.case_json, serializer.data, {
             'indices': lazy_serialize_case_indices(self),
             'actions': lazy_serialize_case_transactions(self),
             'xform_ids': lazy_serialize_case_xform_ids(self),
             'case_attachments': lazy_serialize_case_attachments(self),
             'backend_id': 'sql',
-        }
+        })
 
     def dumps(self, pretty=False):
         indent = 4 if pretty else None

--- a/corehq/form_processor/tests/test_models.py
+++ b/corehq/form_processor/tests/test_models.py
@@ -3,11 +3,13 @@ from uuid import uuid4
 
 from django.test import SimpleTestCase, TestCase
 
+from nose.tools import assert_equal
+
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import Attachment
+from corehq.form_processor.models import Attachment, CommCareCaseSQL
 
 DOMAIN = 'test-domain'
 
@@ -129,3 +131,54 @@ class TestIndices(TestCase):
 def are_cases_equal(a, b):  # or at least equal enough for our test
     attrs = ('domain', 'case_id', 'type', 'name', 'owner_id')
     return all(getattr(a, attr) == getattr(b, attr) for attr in attrs)
+
+
+def test_case_to_json():
+    case_id = str(uuid4())
+    case = CommCareCaseSQL(
+        case_id=case_id,
+        domain=DOMAIN,
+        type='case',
+        name='Justin Case',
+        case_json={
+            'given_name': 'Justin',
+            'family_name': 'Case',
+            'actions': 'eating sleeping typing',
+            'indices': 'Dow_Jones_Industrial_Average S&P_500',
+        },
+    )
+    case_dict = case.to_json()
+    assert_equal(case_dict, {
+        '_id': case_id,
+        'actions': [],  # Not replaced by case_json
+        'backend_id': 'sql',
+        'case_attachments': {},
+        'case_id': case_id,
+        'case_json': {
+            'actions': 'eating sleeping typing',
+            'family_name': 'Case',
+            'given_name': 'Justin',
+            'indices': 'Dow_Jones_Industrial_Average S&P_500',
+        },
+        'closed': False,
+        'closed_by': None,
+        'closed_on': None,
+        'deleted': False,
+        'doc_type': 'CommCareCase',
+        'domain': DOMAIN,
+        'external_id': None,
+        'family_name': 'Case',
+        'given_name': 'Justin',
+        'indices': [],  # Not replaced by case_json
+        'location_id': None,
+        'modified_by': '',
+        'modified_on': None,
+        'name': 'Justin Case',
+        'opened_by': None,
+        'opened_on': None,
+        'owner_id': '',
+        'server_modified_on': None,
+        'type': 'case',
+        'user_id': '',
+        'xform_ids': [],
+    })


### PR DESCRIPTION
## Technical Summary

I noticed this `for` loop, and thought, :thinking: That looks clumsy. Don't we have a better way to do that?

Uses [PEP 584](https://www.python.org/dev/peps/pep-0584/) ... because we can. :tada: 

This change replaces a `for` loop with `dict`'s union operator, released with Python 3.9, which does what the `for` loop does.

## Safety Assurance

### Safety story

Like it says in the title, **Requires Python 3.9**.

#### Do not merge until environments have been given enough time to upgrade.

Small change, covered by a test to verify behavior.

### Automated test coverage

Includes test

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
