### PR TITLE
remove config that ignores HMAC auth when in DEBUG mode

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -179,7 +179,7 @@ def basic_or_api_key(realm=''):
 
 
 def formplayer_auth(view):
-    return validate_request_hmac('FORMPLAYER_INTERNAL_AUTH_KEY', ignore_if_debug=True)(view)
+    return validate_request_hmac('FORMPLAYER_INTERNAL_AUTH_KEY')(view)
 
 
 def formplayer_as_user_auth(view):
@@ -215,7 +215,7 @@ def formplayer_as_user_auth(view):
 
         return view(request, *args, **kwargs)
 
-    return validate_request_hmac('FORMPLAYER_INTERNAL_AUTH_KEY', ignore_if_debug=True)(_inner)
+    return validate_request_hmac('FORMPLAYER_INTERNAL_AUTH_KEY')(_inner)
 
 
 class ApiKeyFallbackBackend(object):

--- a/corehq/ex-submodules/dimagi/utils/logging.py
+++ b/corehq/ex-submodules/dimagi/utils/logging.py
@@ -7,7 +7,6 @@ notify_logger = logging.getLogger('notify')
 
 
 def notify_error(message, details=None):
-    print({'details': details})
     notify_logger.error(message, extra={'details': details})
 
 

--- a/corehq/util/hmac_request.py
+++ b/corehq/util/hmac_request.py
@@ -23,7 +23,7 @@ def get_hmac_digest(shared_key, data):
     return digest.decode('utf-8')
 
 
-def validate_request_hmac(setting_name, ignore_if_debug=False, audit_user='system'):
+def validate_request_hmac(setting_name, audit_user='system'):
     """
     Decorator to validate request sender using a shared secret
     to compare the HMAC of the request body or query string with
@@ -44,7 +44,6 @@ def validate_request_hmac(setting_name, ignore_if_debug=False, audit_user='syste
 
 
     :param setting_name: The name of the Django setting that holds the secret key
-    :param ignore_if_debug: If set to True this is completely ignored if settings.DEBUG is True
     :param audit_user: The username to report to an auditing system, since these requests are anonymous but auth'd.
     """
     def _outer(fn):
@@ -52,10 +51,6 @@ def validate_request_hmac(setting_name, ignore_if_debug=False, audit_user='syste
 
         @wraps(fn)
         def _inner(request, *args, **kwargs):
-            if ignore_if_debug and settings.DEBUG:
-                request.audit_user = audit_user
-                return fn(request, *args, **kwargs)
-
             data = request.get_full_path() if request.method == 'GET' else request.body
 
             _soft_assert(shared_key, 'Missing shared auth setting: {}'.format(setting_name))

--- a/settings.py
+++ b/settings.py
@@ -1234,7 +1234,7 @@ LOGGING = {
             'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
         },
         'simple': {
-            'format': '%(asctime)s %(levelname)s %(message)s'
+            'format': '%(asctime)s %(levelname)s [%(name)s] %(message)s'
         },
         'pillowtop': {
             'format': '%(asctime)s %(levelname)s %(module)s %(message)s'

--- a/settings.py
+++ b/settings.py
@@ -1452,7 +1452,7 @@ LOGGING = {
         },
         'commcare_auth': {
             'handlers': ['file'],
-            'level': 'ERROR',
+            'level': 'INFO',
             'propagate': False,
         }
     }


### PR DESCRIPTION
## Technical Summary
This only impacts local dev environments.

When HMAC auth was first introduced this setting was added to allow formplayer to continue working locally even without the formplayer changes. Since formplayer now always includes the correct auth headers there is no need to keep this config and having it present makes it more likely that auth issues will go undetected as in https://dimagi-dev.atlassian.net/browse/SAAS-12830

This PR also includes some changes to logging to make the auth failure logs visible (and actually get logged to file in production).

## Safety Assurance

### Safety story
Only impacts local dev.

### Automated test coverage
Tests are updated.

### QA Plan
Since this only impacts local dev (and tests) I do not plan to do any more formal QA. I have tested that Web Apps still works locally.

### Migrations
NA
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
