### PR TITLE
Add view to play form attachment audio in browser

### DIFF
--- a/corehq/apps/api/object_fetch_api.py
+++ b/corehq/apps/api/object_fetch_api.py
@@ -20,16 +20,13 @@ from dimagi.utils.django.cached_object import (
 )
 
 from corehq.apps.domain.decorators import api_auth
-from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.views import (
     can_view_attachments,
-    require_form_view_permission,
-    safely_get_form,
+    BaseFormAttachmentView,
 )
-from corehq.form_processor.exceptions import AttachmentNotFound, CaseNotFound
+from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
-    FormAccessors,
     get_cached_case_attachment,
 )
 
@@ -135,27 +132,10 @@ class CaseAttachmentAPI(View):
                                      content_type=mime_type)
 
 
-@location_safe
-class FormAttachmentAPI(View):
-
+class FormAttachmentAPI(BaseFormAttachmentView):
     @method_decorator(api_auth)
-    @method_decorator(require_form_view_permission)
-    def get(self, request, domain, form_id=None, attachment_id=None):
-        if not form_id or not attachment_id:
-            raise Http404
-
-        # this raises a PermissionDenied error if necessary
-        safely_get_form(request, domain, form_id)
-
-        try:
-            content = FormAccessors(domain).get_attachment_content(form_id, attachment_id)
-        except AttachmentNotFound:
-            raise Http404
-
-        return StreamingHttpResponse(
-            streaming_content=FileWrapper(content.content_stream),
-            content_type=content.content_type
-        )
+    def dispatch(self, request, *args, **kwargs):
+        return super().dispatch(request, *args, **kwargs)
 
 
 def fetch_case_image(domain, case_id, attachment_id, filesize_limit=0, width_limit=0, height_limit=0, fixed_size=None):

--- a/corehq/apps/api/object_fetch_api.py
+++ b/corehq/apps/api/object_fetch_api.py
@@ -20,9 +20,11 @@ from dimagi.utils.django.cached_object import (
 )
 
 from corehq.apps.domain.decorators import api_auth
+from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.views import (
     can_view_attachments,
-    BaseFormAttachmentView,
+    get_form_attachment_response,
+    require_form_view_permission,
 )
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import (
@@ -132,10 +134,11 @@ class CaseAttachmentAPI(View):
                                      content_type=mime_type)
 
 
-class FormAttachmentAPI(BaseFormAttachmentView):
-    @method_decorator(api_auth)
-    def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
+@require_form_view_permission
+@location_safe
+@api_auth
+def view_form_attachment(request, domain, instance_id, attachment_id):
+    return get_form_attachment_response(request, domain, instance_id, attachment_id)
 
 
 def fetch_case_image(domain, case_id, attachment_id, filesize_limit=0, width_limit=0, height_limit=0, fixed_size=None):

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -124,7 +124,8 @@ def api_url_patterns():
     yield url(r'v0\.6/case(?:/(?P<case_id>[\w-]+))?/?$', case_api, name='case_api')
     yield from versioned_apis(API_LIST)
     yield url(r'^case/attachment/(?P<case_id>[\w\-:]+)/(?P<attachment_id>.*)$', CaseAttachmentAPI.as_view(), name="api_case_attachment")
-    yield url(r'^form/attachment/(?P<form_id>[\w\-:]+)/(?P<attachment_id>.*)$', FormAttachmentAPI.as_view(), name="api_form_attachment")
+    yield url(r'^form/attachment/(?P<instance_id>[\w\-:]+)/(?P<attachment_id>.*)$', FormAttachmentAPI.as_view(),
+              name="api_form_attachment")
 
 
 urlpatterns = list(api_url_patterns())

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -11,7 +11,7 @@ from corehq.apps.api.domain_metadata import (
 )
 from corehq.apps.api.object_fetch_api import (
     CaseAttachmentAPI,
-    FormAttachmentAPI,
+    view_form_attachment,
 )
 from corehq.apps.api.odata.views import (
     ODataCaseMetadataView,
@@ -124,7 +124,7 @@ def api_url_patterns():
     yield url(r'v0\.6/case(?:/(?P<case_id>[\w-]+))?/?$', case_api, name='case_api')
     yield from versioned_apis(API_LIST)
     yield url(r'^case/attachment/(?P<case_id>[\w\-:]+)/(?P<attachment_id>.*)$', CaseAttachmentAPI.as_view(), name="api_case_attachment")
-    yield url(r'^form/attachment/(?P<instance_id>[\w\-:]+)/(?P<attachment_id>.*)$', FormAttachmentAPI.as_view(),
+    yield url(r'^form/attachment/(?P<instance_id>[\w\-:]+)/(?P<attachment_id>.*)$', view_form_attachment,
               name="api_form_attachment")
 
 

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -320,9 +320,9 @@
               {% if not forloop.first %}<br>{% endif %}
               <dt>{{ key }}</dt>
               {% if attachment.is_image %}
-                <dd><img src="{% url "api_form_attachment" domain=domain form_id=instance.form_id attachment_id=key %}"></dd>
+                <dd><img src="{% url "form_attachment_view" domain=domain form_id=instance.form_id attachment_id=key %}"></dd>
               {% else %}
-                <dd><a href="{% url "api_form_attachment" domain instance.form_id key %}" download="{{ key }}">{% trans "Download" %}</a></dd>
+                <dd><a href="{% url "form_attachment_view" domain instance.form_id key %}" download="{{ key }}">{% trans "Download" %}</a></dd>
               {% endif %}
             </dl>
           </td></tr>

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -30,6 +30,7 @@ from .views import (
     AddSavedReportConfigView,
     CaseAttachmentsView,
     CaseDataView,
+    FormAttachmentView,
     EditFormInstance,
     FormDataView,
     MySavedReportsView,
@@ -120,6 +121,8 @@ urlpatterns = [
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/archive/$', archive_form, name='archive_form'),
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/unarchive/$', unarchive_form, name='unarchive_form'),
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/rebuild/$', resave_form_view, name='resave_form'),
+    url(r'^form_data/(?P<instance_id>[\w\-:]+)/attachment/(?P<attachment_id>.*)$', FormAttachmentView.as_view(),
+        name=FormAttachmentView.urlname),
 
     # project health ajax
     url(r'^project_health/ajax/(?P<user_id>[\w\-]+)/$', project_health_user_details,

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -30,7 +30,6 @@ from .views import (
     AddSavedReportConfigView,
     CaseAttachmentsView,
     CaseDataView,
-    FormAttachmentView,
     EditFormInstance,
     FormDataView,
     MySavedReportsView,
@@ -59,6 +58,7 @@ from .views import (
     send_test_scheduled_report,
     unarchive_form,
     undo_close_case_view,
+    view_form_attachment,
     view_scheduled_report,
 )
 
@@ -121,8 +121,8 @@ urlpatterns = [
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/archive/$', archive_form, name='archive_form'),
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/unarchive/$', unarchive_form, name='unarchive_form'),
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/rebuild/$', resave_form_view, name='resave_form'),
-    url(r'^form_data/(?P<instance_id>[\w\-:]+)/attachment/(?P<attachment_id>.*)$', FormAttachmentView.as_view(),
-        name=FormAttachmentView.urlname),
+    url(r'^form_data/(?P<instance_id>[\w\-:]+)/attachment/(?P<attachment_id>.*)$', view_form_attachment,
+        name='form_attachment_view'),
 
     # project health ajax
     url(r'^project_health/ajax/(?P<user_id>[\w\-]+)/$', project_health_user_details,

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1869,6 +1869,17 @@ class BaseFormAttachmentView(View):
         )
 
 
+class FormAttachmentView(BaseFormAttachmentView):
+    """
+        Open form attachment in browser
+    """
+    urlname = "form_attachment_view"
+
+    @method_decorator(login_and_domain_required)
+    def dispatch(self, request, *args, **kwargs):
+        return super().dispatch(request, *args, **kwargs)
+
+
 @location_safe
 @require_form_view_permission
 @login_and_domain_required

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -75,7 +75,6 @@ from corehq.apps.cloudcare.touchforms_api import (
 )
 from corehq.apps.domain.decorators import (
     login_and_domain_required,
-    login_or_digest,
 )
 from corehq.apps.domain.models import Domain, DomainAuditRecordEntry
 from corehq.apps.domain.views.base import BaseDomainView


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/INDIV-28
[CommCare App PR](https://github.com/dimagi/commcare-android/pull/2533/files)

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Adds a new link to view form attachment on web browsers using usual domain login page in case user needs to login, instead of inbuilt browser prompt, for better experience for mobile users.
The view currently available to view form attachment uses [api auth](https://github.com/dimagi/commcare-hq/blob/1b4a2a6c08ca3b50a4e6e86e2c57220a64f32b5c/corehq/apps/api/object_fetch_api.py#L141), requires mobile users to enter their full username (`<username>@<domain>.commcarehq.org`) in case it's accessed directly and user needs to login. 
Try accessing [this](https://staging.commcarehq.org/a/ccqa-mk/api/form/attachment/74042dfe-4145-4725-99fc-4c767e106752/1636569790636custom.mp3) attachment, on a private window.

A project requested that mobile users should not need to enter their full qualified name for this and enter just the username. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
When we use api_auth, we hand it over to Django to handle the auth for us, so there isn't much we can modify there.
I thought it was better to just add a new view that uses our default HQ workflow, which redirects the user to the domain login page, where mobile users can enter just their username along with their password and then are redirect back to the originally requested page.

We are working towards form attachments to play in the browser instead of user needing to download it. So this is for that usecase. The app would create the link and user would open it in browser and listen to the audio form attachment.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance
Tested locally that auth works as expected. The access for form check was retained as it is.

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
