### PR TITLE
Mobile access restriction GA setting form-not-saving-on-submit bug fix

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -699,7 +699,7 @@ class PrivacySecurityForm(forms.Form):
         domain.secure_submissions = secure_submissions
         domain.hipaa_compliant = self.cleaned_data.get('hipaa_compliant', False)
         domain.ga_opt_out = self.cleaned_data.get('ga_opt_out', False)
-        if RESTRICT_MOBILE_ACCESS.enabled(domain):
+        if RESTRICT_MOBILE_ACCESS.enabled(domain.name):
             domain.restrict_mobile_access = self.cleaned_data.get('restrict_mobile_access', False)
 
         domain.save()

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -680,29 +680,29 @@ class PrivacySecurityForm(forms.Form):
             )
         )
 
-    def save(self, domain):
-        domain.restrict_superusers = self.cleaned_data.get('restrict_superusers', False)
-        domain.allow_domain_requests = self.cleaned_data.get('allow_domain_requests', False)
-        domain.secure_sessions = self.cleaned_data.get('secure_sessions', False)
-        domain.secure_sessions_timeout = self.cleaned_data.get('secure_sessions_timeout', None)
-        domain.two_factor_auth = self.cleaned_data.get('two_factor_auth', False)
+    def save(self, domain_obj):
+        domain_obj.restrict_superusers = self.cleaned_data.get('restrict_superusers', False)
+        domain_obj.allow_domain_requests = self.cleaned_data.get('allow_domain_requests', False)
+        domain_obj.secure_sessions = self.cleaned_data.get('secure_sessions', False)
+        domain_obj.secure_sessions_timeout = self.cleaned_data.get('secure_sessions_timeout', None)
+        domain_obj.two_factor_auth = self.cleaned_data.get('two_factor_auth', False)
 
-        domain.strong_mobile_passwords = self.cleaned_data.get('strong_mobile_passwords', False)
+        domain_obj.strong_mobile_passwords = self.cleaned_data.get('strong_mobile_passwords', False)
         secure_submissions = self.cleaned_data.get(
             'secure_submissions', False)
         apps_to_save = []
-        if secure_submissions != domain.secure_submissions:
-            for app in get_apps_in_domain(domain.name):
+        if secure_submissions != domain_obj.secure_submissions:
+            for app in get_apps_in_domain(domain_obj.name):
                 if app.secure_submissions != secure_submissions:
                     app.secure_submissions = secure_submissions
                     apps_to_save.append(app)
-        domain.secure_submissions = secure_submissions
-        domain.hipaa_compliant = self.cleaned_data.get('hipaa_compliant', False)
-        domain.ga_opt_out = self.cleaned_data.get('ga_opt_out', False)
-        if RESTRICT_MOBILE_ACCESS.enabled(domain.name):
-            domain.restrict_mobile_access = self.cleaned_data.get('restrict_mobile_access', False)
+        domain_obj.secure_submissions = secure_submissions
+        domain_obj.hipaa_compliant = self.cleaned_data.get('hipaa_compliant', False)
+        domain_obj.ga_opt_out = self.cleaned_data.get('ga_opt_out', False)
+        if RESTRICT_MOBILE_ACCESS.enabled(domain_obj.name):
+            domain_obj.restrict_mobile_access = self.cleaned_data.get('restrict_mobile_access', False)
 
-        domain.save()
+        domain_obj.save()
 
         if apps_to_save:
             apps = [app for app in apps_to_save if isinstance(app, Application)]

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -21,9 +21,6 @@ from toggle.models import Toggle
 from toggle.shortcuts import set_toggle, toggle_enabled
 
 from corehq.util.quickcache import quickcache
-from corehq.util.soft_assert import soft_assert
-
-_soft_assert = soft_assert(notify_admins=False, send_to_ops=True)
 
 
 @attrs(frozen=True)
@@ -159,18 +156,6 @@ class StaticToggle(object):
         ):
             # Don't even bother looking it up in the cache
             return False
-
-        # item should be a string (None value is also allowed)
-        _soft_assert(
-            isinstance(item, str) or not item,
-            'StaticToggle.enabled() was passed something other than a string.', {
-                'toggle_slug': self.slug,
-                'toggle_description': self.description,
-                'item_type': type(item),
-                'namespace': namespace
-            }
-        )
-
         if item in self.always_enabled:
             return True
         elif item in self.always_disabled:

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -21,6 +21,7 @@ from toggle.models import Toggle
 from toggle.shortcuts import set_toggle, toggle_enabled
 
 from corehq.util.quickcache import quickcache
+from corehq.util.soft_assert import soft_assert
 
 
 @attrs(frozen=True)
@@ -156,6 +157,19 @@ class StaticToggle(object):
         ):
             # Don't even bother looking it up in the cache
             return False
+
+        # item should be a string
+        _soft_assert = soft_assert(notify_admins=False, send_to_ops=True)
+        _soft_assert(
+            isinstance(item, str),
+            'StaticToggle.enabled() was passed something other than a string.', {
+                'toggle_slug': self.slug,
+                'toggle_description': self.description,
+                'item_type': type(item),
+                'namespace': namespace
+            }
+        )
+
         if item in self.always_enabled:
             return True
         elif item in self.always_disabled:

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -23,6 +23,8 @@ from toggle.shortcuts import set_toggle, toggle_enabled
 from corehq.util.quickcache import quickcache
 from corehq.util.soft_assert import soft_assert
 
+_soft_assert = soft_assert(notify_admins=False, send_to_ops=True)
+
 
 @attrs(frozen=True)
 class Tag:
@@ -158,10 +160,9 @@ class StaticToggle(object):
             # Don't even bother looking it up in the cache
             return False
 
-        # item should be a string
-        _soft_assert = soft_assert(notify_admins=False, send_to_ops=True)
+        # item should be a string (None value is also allowed)
         _soft_assert(
-            isinstance(item, str),
+            isinstance(item, str) or not item,
             'StaticToggle.enabled() was passed something other than a string.', {
                 'toggle_slug': self.slug,
                 'toggle_description': self.description,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This GA setting for mobile access restrictions has already been released and successfully migrated from the feature flag. There was only an error with domains that have certain names (like those that have a '.' in their name) that prevent the setting from being changed. The privacy form would look like it was submitted but the setting would not update properly. This PR will fix that change so that the GA setting can be safely relied upon.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[This is the main related PR](https://github.com/dimagi/commcare-hq/pull/30783). The checkbox for the GA setting was not saving in certain domains. After investigation, we learned it was because `StaticToggle.enabled()` was being passed a domain object instead of a domain name. When it was passed an object, instead of throwing an error the `enabled` function checked the domain's `hr_name` (human-readable name).

In addition to the one-line fix, this PR also includes a change to the privacy form save method's argument to use the terminology `domain_obj` instead of `domain`, ~~and adding a `soft_assert` check to `StaticToggle.enabled()` that it is passed a string. The `soft_assert` email will be sent to the general ops listserv~~. The check that `StaticToggle.enabled()` is passed a string will be a separate PR because it has proven to be a more complicated fix (tests are failing due to `soft_assert` falling, `StaticToggle.enabled()` is passed non-string values in other parts of the codebase).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

RESTRICT_MOBILE_ACCESS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested locally with a domain name with a `.` in it to make sure the bug fix works as intended. The soft_assert email output also looks correct.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
