### PR TITLE
Add docstring to `deprecated_init` for clarity

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
@@ -59,6 +59,14 @@ class CaseBlock(object):
 
     @classmethod
     def deprecated_init(cls, *args, **kwargs):
+        """
+        You almost certainly don't need this - it defaults date_opened to today
+        at midnight, instead of now(). This method exists so we don't have to
+        update a bunch of tests built on the old, bad behavior.
+
+        Replace any CaseBlock.deprecated_init(...) with CaseBlock(...) and just
+        make sure tests pass
+        """
         return cls(date_opened_deprecated_behavior=True, *args, **kwargs)
 
     def _updatable_built_ins(self):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Hopefully this'll enable people to start dropping these opportunistically

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
docstring only

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change