### PR TITLE
combine celery checks so both print

### DIFF
--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -157,8 +157,7 @@ def check_blobdb():
 
 
 def check_celery():
-    blocked_queues = []
-    slow_queues = []
+    bad_queues = []
 
     for queue, threshold in settings.CELERY_HEARTBEAT_THRESHOLDS.items():
         if threshold:
@@ -174,21 +173,17 @@ def check_celery():
                 # so to make actionable, we never alert on blockage under 5 minutes
                 # It is still counted as out of SLA for the celery uptime metric in datadog
                 if blockage_duration > max(threshold, datetime.timedelta(minutes=5)):
-                    blocked_queues.append((queue, blockage_duration, threshold))
+                    bad_queues.append(
+                        f"{queue} has been blocked for {blockage_duration} (max allowed is {threshold})"
+                    )
                 elif (heartbeat_time_to_start is not None and
                       heartbeat_time_to_start > max(threshold, datetime.timedelta(minutes=5))):
-                    slow_queues.append(queue, heartbeat_time_to_start, threshold)
+                    bad_queues.append(
+                        f"{queue} is delayed for {blockage_duration} (max allowed is {threshold})"
+                    )
 
-    if blocked_queues:
-        return ServiceStatus(False, '\n'.join(
-            "{} has been blocked for {} (max allowed is {})".format(
-                queue, blockage_duration, threshold
-            ) for queue, blockage_duration, threshold in blocked_queues))
-    elif slow_queues:
-        return ServiceStatus(False, '\n'.join(
-            "{} is delayed for {} (max allowed is {})".format(
-                queue, blockage_duration, threshold
-            ) for queue, blockage_duration, threshold in slow_queues))
+    if bad_queues:
+        return ServiceStatus(False, '\n'.join(bad_queues))
     else:
         return ServiceStatus(True, "OK")
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Fixed the celery check so that it would not error when the time to start exceeds the threshold, but also took the opportunity to refactor a bit. It is now the case that if there is a mix of time to start and blockage errors, both will print rather than just the blockages.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Service checks only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
