### PR TITLE
Check all mobile endpoints besides submissions

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -3,7 +3,6 @@ from functools import wraps
 
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth.decorators import permission_required
 from django.http import (
     Http404,
     HttpRequest,
@@ -21,16 +20,8 @@ from django.views import View
 from django_otp import match_token
 from django_prbac.utils import has_privilege
 from oauth2_provider.oauth2_backends import get_oauthlib_core
-
 from tastypie.http import HttpUnauthorized
 
-from corehq.apps.sso.utils.request_helpers import (
-    is_request_blocked_from_viewing_domain_due_to_sso,
-    is_request_using_sso,
-)
-from corehq.apps.sso.utils.view_helpers import (
-    render_untrusted_identity_provider_for_domain_view,
-)
 from dimagi.utils.django.request import mutable_querydict
 from dimagi.utils.web import json_response
 
@@ -41,16 +32,23 @@ from corehq.apps.domain.auth import (
     DIGEST,
     FORMPLAYER,
     OAUTH2,
+    HQApiKeyAuthentication,
     basic_or_api_key,
     basicauth,
     determine_authtype_from_request,
     formplayer_as_user_auth,
     get_username_and_password_from_request,
-    HQApiKeyAuthentication,
 )
 from corehq.apps.domain.models import Domain, DomainAuditRecordEntry
 from corehq.apps.domain.utils import normalize_domain_name
 from corehq.apps.hqwebapp.signals import clear_login_attempts
+from corehq.apps.sso.utils.request_helpers import (
+    is_request_blocked_from_viewing_domain_due_to_sso,
+    is_request_using_sso,
+)
+from corehq.apps.sso.utils.view_helpers import (
+    render_untrusted_identity_provider_for_domain_view,
+)
 from corehq.apps.users.models import CouchUser
 from corehq.toggles import (
     DATA_MIGRATION,

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -351,7 +351,7 @@ def login_or_oauth2_ex(allow_cc_users=False, allow_sessions=True, require_domain
     )
 
 
-def _get_multi_auth_decorator(default, allow_formplayer=False):
+def get_multi_auth_decorator(default, allow_formplayer=False):
     """
     :param allow_formplayer: If True this will allow one additional auth mechanism which is used
          by Formplayer:
@@ -391,22 +391,9 @@ def two_factor_exempt(view_func):
     return wraps(view_func, assigned=available_attrs(view_func))(wrapped_view)
 
 
-# This decorator should be used for any endpoints used by CommCare mobile
-# It supports basic, session, and apikey auth, but not digest
-# Endpoints with this decorator will not enforce two factor authentication
-def mobile_auth(view_func):
-    return _get_multi_auth_decorator(default=BASIC)(two_factor_exempt(view_func))
-
-
-# This decorator is used only for anonymous web apps and SMS forms
-# Endpoints with this decorator will not enforce two factor authentication
-def mobile_auth_or_formplayer(view_func):
-    return _get_multi_auth_decorator(default=BASIC, allow_formplayer=True)(two_factor_exempt(view_func))
-
-
 # Use this decorator to allow any auth type -
 # basic, digest, session, or apikey
-api_auth = _get_multi_auth_decorator(default=DIGEST)
+api_auth = get_multi_auth_decorator(default=DIGEST)
 
 # Use these decorators on views to allow sesson-auth or an extra authorization method
 login_or_digest = login_or_digest_ex()

--- a/corehq/apps/mobile_auth/views.py
+++ b/corehq/apps/mobile_auth/views.py
@@ -6,17 +6,14 @@ from django.views.decorators.http import require_GET
 from dimagi.utils.parsing import string_to_datetime
 
 from corehq.apps.domain.auth import BASIC
-from corehq.apps.domain.decorators import (
-    api_auth,
-    domain_admin_required,
-    mobile_auth,
-)
+from corehq.apps.domain.decorators import api_auth, domain_admin_required
 from corehq.apps.mobile_auth.models import MobileAuthKeyRecord
 from corehq.apps.mobile_auth.utils import (
     bump_expiry,
     get_mobile_auth_payload,
     new_key_record,
 )
+from corehq.apps.ota.decorators import mobile_auth
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import update_device_meta
 

--- a/corehq/apps/ota/decorators.py
+++ b/corehq/apps/ota/decorators.py
@@ -1,15 +1,13 @@
 import logging
-
-from corehq import toggles
-from corehq.apps.domain.models import Domain
-from corehq.apps.users.decorators import require_permission
-from corehq.apps.users.models import Permissions
-
-from dimagi.utils.couch.cache.cache_core import get_redis_client
-
 from functools import wraps
 
 from django.http import HttpResponseForbidden
+
+from dimagi.utils.couch.cache.cache_core import get_redis_client
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.users.decorators import require_permission
+from corehq.apps.users.models import Permissions
 
 auth_logger = logging.getLogger("commcare_auth")
 

--- a/corehq/apps/ota/decorators.py
+++ b/corehq/apps/ota/decorators.py
@@ -55,10 +55,18 @@ def _test_token_valid(origin_token):
 # It supports basic, session, and apikey auth, but not digest
 # Endpoints with this decorator will not enforce two factor authentication
 def mobile_auth(view_func):
-    return get_multi_auth_decorator(default=BASIC)(two_factor_exempt(view_func))
+    return get_multi_auth_decorator(default=BASIC)(
+        two_factor_exempt(
+            require_mobile_access(view_func)
+        )
+    )
 
 
 # This decorator is used only for anonymous web apps and SMS forms
 # Endpoints with this decorator will not enforce two factor authentication
 def mobile_auth_or_formplayer(view_func):
-    return get_multi_auth_decorator(default=BASIC, allow_formplayer=True)(two_factor_exempt(view_func))
+    return get_multi_auth_decorator(default=BASIC, allow_formplayer=True)(
+        two_factor_exempt(
+            require_mobile_access(view_func)
+        )
+    )

--- a/corehq/apps/ota/decorators.py
+++ b/corehq/apps/ota/decorators.py
@@ -6,6 +6,11 @@ from django.http import HttpResponseForbidden
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 
 from corehq.apps.domain.models import Domain
+from corehq.apps.domain.auth import BASIC
+from corehq.apps.domain.decorators import (
+    get_multi_auth_decorator,
+    two_factor_exempt,
+)
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 
@@ -44,3 +49,16 @@ def _test_token_valid(origin_token):
         return test_result.decode("UTF-8") == '"valid"'
 
     return False
+
+
+# This decorator should be used for any endpoints used by CommCare mobile
+# It supports basic, session, and apikey auth, but not digest
+# Endpoints with this decorator will not enforce two factor authentication
+def mobile_auth(view_func):
+    return get_multi_auth_decorator(default=BASIC)(two_factor_exempt(view_func))
+
+
+# This decorator is used only for anonymous web apps and SMS forms
+# Endpoints with this decorator will not enforce two factor authentication
+def mobile_auth_or_formplayer(view_func):
+    return get_multi_auth_decorator(default=BASIC, allow_formplayer=True)(two_factor_exempt(view_func))

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -43,16 +43,13 @@ from corehq.apps.builds.utils import get_default_build_spec
 from corehq.apps.case_search.const import COMMCARE_PROJECT
 from corehq.apps.case_search.exceptions import CaseSearchUserError
 from corehq.apps.case_search.utils import get_case_search_results
-from corehq.apps.domain.decorators import (
-    check_domain_migration,
-    mobile_auth,
-    mobile_auth_or_formplayer,
-)
+from corehq.apps.domain.decorators import check_domain_migration
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.permissions import (
     location_safe,
     location_safe_bypass,
 )
+from corehq.apps.ota.decorators import mobile_auth, mobile_auth_or_formplayer
 from corehq.apps.registry.exceptions import (
     RegistryAccessException,
     RegistryNotFound,

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -62,7 +62,6 @@ from corehq.form_processor.utils.xform import adjust_text_to_datetime
 from corehq.middleware import OPENROSA_VERSION_HEADER
 from corehq.util.quickcache import quickcache
 
-from .decorators import require_mobile_access
 from .models import DeviceLogRequest, MobileRecoveryMeasure, SerialIdBucket
 from .rate_limiter import rate_limit_restore
 from .utils import (
@@ -80,7 +79,6 @@ PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else 1
 @location_safe
 @handle_401_response
 @mobile_auth_or_formplayer
-@require_mobile_access
 @check_domain_migration
 def restore(request, domain, app_id=None):
     """


### PR DESCRIPTION
## Product Description
Make the mobile access restrictions block all mobile endpoints besides form submissions (currently it blocks only the restore endpoint)
https://dimagi-dev.atlassian.net/browse/USH-1399

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Extracted from https://github.com/dimagi/commcare-hq/pull/30761
Rolling out the restrictions on form submissions will require a bit more legwork, so I'm hoping to merge everything else first.

## Feature Flag
USH: Require explicit permissions to access mobile app endpoints

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
A version of this has been in use for months on just the restore endpoint.  This PR has been on staging for a while now, and I've tested it out as described below, without issue.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

I tested this on staging and found the expected behavior (though the form submissions changes aren't in _this_ version of the PR)

| | restore | case search | form submission |
|-|-----------|------------------|-----------------------|
Web Apps (setting disabled) | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
Mobile (setting disabled) | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
Web Apps (setting enabled) | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
Mobile (setting enabled) | :x: | :x: | :x: |
Mobile (setting enabled, with permission) | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
