### PR TITLE
Removed full-doc fetching from smart link requests

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -291,7 +291,7 @@ class RemoteRequestFactory(object):
         # Returns XPath that will evaluate to a URL.
         # For example, return value could be
         #   concat('https://www.cchq.org/a/', $domain, '/app/v1/123/smartlink/', '?arg1=', $arg1, '&arg2=', $arg2)
-        # Which could evalute to
+        # Which could evaluate to
         #   https://www.cchq.org/a/mydomain/app/v1/123/smartlink/?arg1=abd&arg2=def
         app_id = self.app.upstream_app_id if is_linked_app(self.app) else self.app.origin_id
         url = absolute_reverse("session_endpoint", args=["---", app_id, self.module.session_endpoint_id])

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -43,7 +43,9 @@ from corehq.apps.app_manager.dbaccessors import (
     get_current_app,
     get_current_app_doc,
     get_latest_build_doc,
+    get_latest_build_id,
     get_latest_released_app_doc,
+    get_latest_released_build_id,
     wrap_app,
 )
 from corehq.apps.app_manager.exceptions import (
@@ -222,6 +224,13 @@ def _fetch_build(domain, username, app_id):
         return get_latest_build_doc(domain, app_id)
     else:
         return get_latest_released_app_doc(domain, app_id)
+
+
+def _fetch_build_id(domain, username, app_id):
+    if (toggles.CLOUDCARE_LATEST_BUILD.enabled(domain) or toggles.CLOUDCARE_LATEST_BUILD.enabled(username)):
+        return get_latest_build_id(domain, app_id)
+    else:
+        return get_latest_released_build_id(domain, app_id)
 
 
 class FormplayerMainPreview(FormplayerMain):
@@ -587,8 +596,8 @@ def session_endpoint(request, domain, app_id, endpoint_id):
     if not toggles.SESSION_ENDPOINTS.enabled_for_request(request):
         return _fail(_("Linking directly into Web Apps has been disabled."))
 
-    build = _fetch_build(domain, request.couch_user.username, app_id)
-    if not build:
+    build_id = _fetch_build_id(domain, request.couch_user.username, app_id)
+    if not build_id:
         # These links can be used for cross-domain web apps workflows, where a link jumps to the
         # same screen but in another domain's corresponding app. This works if both the source and
         # target apps are downstream apps that share an upstream app - the link references the upstream app.
@@ -596,19 +605,9 @@ def session_endpoint(request, domain, app_id, endpoint_id):
         id_map = get_downstream_app_id_map(domain)
         if app_id in id_map:
             if len(id_map[app_id]) == 1:
-                build = _fetch_build(domain, request.couch_user.username, id_map[app_id][0])
-        if not build:
+                build_id = _fetch_build_id(domain, request.couch_user.username, id_map[app_id][0])
+        if not build_id:
             return _fail(_("Could not find application."))
-
-    valid_endpoint_ids = set()
-    for module in build.get("modules", []):
-        valid_endpoint_ids.add(module.get("session_endpoint_id"))
-        for form in module.get("forms", []):
-            valid_endpoint_ids.add(form.get("session_endpoint_id"))
-    valid_endpoint_ids = {i for i in valid_endpoint_ids if i}
-    if endpoint_id not in valid_endpoint_ids:
-        return _fail(_("This link does not exist. "
-                       "Your app may have changed so that the given link is no longer valid."))
 
     restore_as_user, set_cookie = FormplayerMain.get_restore_as_user(request, domain)
     force_login_as = not restore_as_user.is_commcare_user()
@@ -616,7 +615,7 @@ def session_endpoint(request, domain, app_id, endpoint_id):
         return _fail(_("This user cannot access this link."))
 
     cloudcare_state = json.dumps({
-        "appId": build["_id"],
+        "appId": build_id,
         "endpointId": endpoint_id,
         "endpointArgs": {
             urllib.parse.quote_plus(key): urllib.parse.quote_plus(value)


### PR DESCRIPTION
## Technical Summary
Another stab at improving smart link performance for https://dimagi-dev.atlassian.net/browse/USH-1341

[This comment](https://dimagi-dev.atlassian.net/browse/USH-1341?focusedCommentId=180625) describes that the python part of loading smart links (described as "v2/") is sometimes fast (1-5 sec), sometimes slow (15-25 sec). This view doesn't do a whole lot, so my best guess is that couch is sometimes struggling with the large app docs. This PR updates the view to not pull any full docs.

Reviewers: if anyone has a chance to review this before the Monday morning deploy and doesn't have feedback, please merge it.

## Feature Flag
Data registries

## Safety Assurance

### Safety story
This is a limited change in a feature not being used by any clients. Tested locally that smart links still load, with and without the `CLOUDCARE_LATEST_BUILD` flag enabled.

### Automated test coverage

None.

### QA Plan

None.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
