### PR TITLE
Additional alias for submission API with @api_auth

### DIFF
--- a/corehq/apps/receiverwrapper/urls.py
+++ b/corehq/apps/receiverwrapper/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
     # odk urls
     url(r'^submission/?$', post, name="receiver_odk_post"),
     url(r'^(?P<app_id>[\w-]+)/$', post, name='receiver_post_with_app_id'),
+    url(r'^api/(?P<app_id>[\w-]+)/$', post_api, name='receiver_post_api_with_app_id'),
 ]


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-1412

Followup for https://github.com/dimagi/commcare-hq/pull/30784

Noticed while updating docs that we also have a URL that includes the app id.

I left the other alias, `/a/demo/receiver/submission/` alone. I don't quite understand the purpose of that one. Docs say it's "for compatibility with CommCare ODK."

## Safety Assurance

### Safety story
Purely additive and pretty trivial

### Automated test coverage

No

### QA Plan

No QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
