### PR TITLE
fix creating case with index

### DIFF
--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -501,7 +501,7 @@ class CaseUpdateConfig:
 
         target_case = self._get_target_case(couch_user, registry_helper, repeat_record)
         updates = self.get_case_updates(couch_user, registry_helper, repeat_record)
-        indices = self.get_case_indices(target_case)
+        indices = self.get_case_indices(self.domain, target_case)
         return CaseBlock(
             case_id=self.case_id,
             owner_id=self.owner_id,
@@ -550,8 +550,8 @@ class CaseUpdateConfig:
             for prop in update_props
         }
 
-    def get_case_indices(self, target_case):
-        indices = self.get_create_case_index(target_case)
+    def get_case_indices(self, target_domain, target_case):
+        indices = self.get_create_case_index(target_domain)
         if not self.index_remove_case_id:
             return indices
 
@@ -560,7 +560,7 @@ class CaseUpdateConfig:
 
         return indices
 
-    def get_create_case_index(self, target_case):
+    def get_create_case_index(self, target_domain):
         if not (self.index_create_case_id and self.index_create_case_type):
             return {}
 
@@ -569,7 +569,7 @@ class CaseUpdateConfig:
         except CaseNotFound:
             raise DataRegistryCaseUpdateError(f"Index case not found: {self.index_create_case_id}")
 
-        if index_case.domain != target_case.domain:
+        if index_case.domain != target_domain:
             raise DataRegistryCaseUpdateError(f"Index case not found: {self.index_create_case_id}")
 
         if index_case.type != self.index_create_case_type:

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -60,6 +60,20 @@ def test_generator_create_case():
     )
 
 
+def test_generator_create_case_with_index():
+    builder = IntentCaseBuilder().create_case("123").create_index("case2", "parent_type", "child")
+
+    def _get_case(case_id):
+        assert case_id == "case2"
+        return Mock(domain=TARGET_DOMAIN, type="parent_type")
+
+    with patch.object(CaseAccessorSQL, 'get_case', new=_get_case):
+        _test_payload_generator(
+            intent_case=builder.get_case(), registry_mock_cases={},
+            expected_creates={"1": {"case_type": "patient", "owner_id": "123"}},
+            expected_indices={"1": {"parent": IndexAttrs("parent_type", "case2", "child")}})
+
+
 def test_generator_create_case_target_exists():
     builder = IntentCaseBuilder().case_properties(new_prop="new_prop_val").create_case("123")
 


### PR DESCRIPTION
## Technical Summary
Fix bug for creating cases with an index in the data registry repeater.

https://sentry.io/share/issue/7383511024f147ab9b6feb024ed189e6/

https://dimagi-dev.atlassian.net/browse/USH-1309

## Feature Flag
DATA REGISTRY

## Safety Assurance

### Safety story
Only affects the data registry repeater which is feature flagged.

### Automated test coverage
Added tests.

### QA Plan
None


### Migrations
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
