### PR TITLE
set default values for system properties just in time

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
@@ -44,9 +44,9 @@ class CaseBlock(object):
                                 else date_opened)
         else:
             self.date_opened = date_opened
-        self.case_type = "" if create and case_type is CaseBlock.undefined else case_type
-        self.case_name = "" if create and case_name is CaseBlock.undefined else case_name
-        self.owner_id = "" if create and owner_id is CaseBlock.undefined else owner_id
+        self.case_type = case_type
+        self.case_name = case_name
+        self.owner_id = owner_id
         self.close = close
         self.case_id = case_id
         self.user_id = user_id
@@ -106,6 +106,8 @@ class CaseBlock(object):
         create_or_update = {key: val for key, val in self._updatable_built_ins()
                             if val is not CaseBlock.undefined}
         if self.create:
+            for key in self._built_ins:
+                create_or_update.setdefault(key, "")
             result['create'] = create_or_update
         else:
             result['update'].update(create_or_update)

--- a/corehq/ex-submodules/casexml/apps/case/mock/tests/test_case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/tests/test_case_block.py
@@ -40,7 +40,7 @@ class CaseBlockTest(SimpleTestCase):
         self.assertEqual(six.text_type(context.exception), "Key 'case_name' specified twice")
 
     def test_let_you_specify_system_props_for_create_via_updates(self):
-        actual = ElementTree.tostring(CaseBlock.deprecated_init(
+        actual = ElementTree.tostring(CaseBlock(
             case_id=self.CASE_ID,
             create=True,
             update={'case_name': 'Johnny'},

--- a/corehq/ex-submodules/casexml/apps/case/mock/tests/test_case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/tests/test_case_block.py
@@ -39,6 +39,22 @@ class CaseBlockTest(SimpleTestCase):
             ).as_xml()
         self.assertEqual(six.text_type(context.exception), "Key 'case_name' specified twice")
 
+    def test_let_you_specify_system_props_for_create_via_updates(self):
+        actual = ElementTree.tostring(CaseBlock.deprecated_init(
+            case_id=self.CASE_ID,
+            create=True,
+            update={'case_name': 'Johnny'},
+            date_modified=self.NOW,
+        ).as_xml(), encoding='utf-8').decode('utf-8')
+        expected = (
+            '<case case_id="test-case-id" date_modified="2012-01-24T00:00:00.000000Z" '
+            'xmlns="http://commcarehq.org/case/transaction/v2">'
+            '<create><case_type /><case_name /><owner_id /></create>'
+            '<update><case_name>Johnny</case_name><date_opened>2021-12-06</date_opened></update>'
+            '</case>'
+        )
+        self.assertEqual(actual, expected)
+
     def test_buggy_behavior(self):
         """The following is a BUG; should fail!! Should fix and change tests"""
         expected = ElementTree.tostring(CaseBlock.deprecated_init(

--- a/corehq/ex-submodules/casexml/apps/case/mock/tests/test_case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/tests/test_case_block.py
@@ -4,6 +4,7 @@ import six
 from django.test import SimpleTestCase
 from xml.etree import cElementTree as ElementTree
 from casexml.apps.case.mock import CaseBlock, CaseBlockError
+from corehq.tests.util.xml import assert_xml_equal
 
 
 class CaseBlockTest(SimpleTestCase):
@@ -27,7 +28,7 @@ class CaseBlockTest(SimpleTestCase):
             '<update><date_opened>2012-01-24T00:00:00.000000Z</date_opened></update>'
             '</case>'
         )
-        self.assertEqual(actual, expected)
+        assert_xml_equal(actual, expected)
 
     def test_does_not_let_you_specify_a_keyword_twice(self):
         """Doesn't let you specify a keyword twice (here 'case_name')"""
@@ -50,7 +51,7 @@ class CaseBlockTest(SimpleTestCase):
             '<case case_id="test-case-id" date_modified="2012-01-24T00:00:00.000000Z" '
             'xmlns="http://commcarehq.org/case/transaction/v2">'
             '<create><case_type /><case_name /><owner_id /></create>'
-            '<update><case_name>Johnny</case_name><date_opened>2021-12-06</date_opened></update>'
+            '<update><case_name>Johnny</case_name></update>'
             '</case>'
         )
         self.assertEqual(actual, expected)


### PR DESCRIPTION
## Technical Summary

Setting defaults early on breaks other code in this
class that checks whether the values are 'defined'.
In particular the `_check_for_duplicate_properties` method
fails if a 'system' property is defined in 'updates' even
if it is not passed in as a kwarg.

https://sentry.io/share/issue/9144e0dc47fe4b88a7f28375fa3b4c80/

This appears to fix logic that was intended to work this way. Code like https://github.com/dimagi/commcare-hq/blob/c432e798b4e8183d235be16fbeaf985055e610ad/corehq/ex-submodules/casexml/apps/case/mock/case_block.py#L76-L78 and https://github.com/dimagi/commcare-hq/blob/c432e798b4e8183d235be16fbeaf985055e610ad/corehq/ex-submodules/casexml/apps/case/mock/case_block.py#L106-L107 indicate that values that are not passed via kwargs should remain as `CaseBlock.undefined` when set as class properties.

This code has been like this since https://github.com/dimagi/commcare-hq/pull/13883. 

We have worked around this in the past by removing the values from the 'updates' and setting the kwargs:

```python
CaseBlock(case_name=updates.pop('case_name', None), updates=updates)
```

Although this is fairly straight forward it seems unnecessary.

## Safety Assurance

### Safety story
This changes one of the internal classes we use to create case XML. That has the potential to impact any system form that is generated.

These changes do not change any of the existing functionality. They do allow future uses of the class to be more flexible.

### Automated test coverage
Test case added. This code is also used by a lot of other test cases already.

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
