### PR TITLE
[data registry] form linking multiple case types

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -200,7 +200,7 @@ class RemoteRequestFactory(object):
         additional_types = set(self.module.search_config.additional_case_types) - {self.module.case_type}
         datums = [
             QueryData(key='case_type', ref=f"'{case_type}'")
-            for case_type in [self.module.case_type] + list(additional_types)
+            for case_type in [self.module.case_type] + sorted(additional_types)
         ]
 
         datums.extend(

--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -173,6 +173,8 @@ class WorkflowHelper(PostProcessor):
                         workflow_meta_from_session_datum(session_children[next_index], None)
                         if next_index < len(session_children) else None
                     )
+                    if next_meta and not next_meta.case_type:
+                        self._add_missing_case_types(module_id, form_id, [next_meta])
                     datums[module_id][form_id].append(workflow_meta_from_session_datum(d, next_meta))
 
         for module_id, form_datum_map in datums.items():

--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -754,9 +754,9 @@ class WorkflowQueryMeta(WorkflowSessionMeta):
 
     def to_stack_datum(self):
         wanted = ("commcare_registry", "case_type", "case_id")
-        data_by_key = {el.key: el.ref for el in self.query.data}
-        data = [QueryData(key=key, ref=data_by_key[key]) for key in wanted if key in data_by_key]
-        if "case_id" not in data_by_key and self.next_datum:
+        keys = {el.key for el in self.query.data}
+        data = [QueryData(key=el.key, ref=el.ref) for el in self.query.data if el.key in wanted]
+        if "case_id" not in keys and self.next_datum:
             data.append(QueryData(key="case_id", ref=session_var(self.source_id)))
         url = self.query.url
         if self.is_case_search:

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -126,9 +126,10 @@ class EntriesHelper(object):
     @staticmethod
     def _get_nodeset_xpath(instance_name, root_element, case_type, filter_xpath='', additional_types=None):
         if additional_types:
+            additional_types = set(additional_types) - {case_type}
             case_type_filter = " or ".join([
                 "@case_type='{case_type}'".format(case_type=case_type)
-                for case_type in sorted(set(additional_types).union({case_type}))
+                for case_type in [case_type] + sorted(additional_types)
             ])
         else:
             case_type_filter = "@case_type='{case_type}'".format(case_type=case_type)
@@ -552,14 +553,14 @@ class EntriesHelper(object):
         """
         from corehq.apps.app_manager.suite_xml.post_process.remote_requests import REGISTRY_INSTANCE
 
-        case_types = set(module.search_config.additional_case_types) | {datum.case_type}
+        additional_types = set(module.search_config.additional_case_types) - {datum.case_type}
         case_ids_expressions = {session_var(datum.datum.id)} | set(module.search_config.additional_registry_cases)
         data = [
             QueryData(key=CASE_SEARCH_REGISTRY_ID_KEY, ref=f"'{module.search_config.data_registry}'")
         ]
         data.extend([
             QueryData(key='case_type', ref=f"'{case_type}'")
-            for case_type in sorted(case_types)
+            for case_type in [datum.case_type] + sorted(additional_types)
         ])
         data.extend([
             QueryData(key='case_id', ref=case_id_xpath)

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -128,7 +128,7 @@ class EntriesHelper(object):
         if additional_types:
             case_type_filter = " or ".join([
                 "@case_type='{case_type}'".format(case_type=case_type)
-                for case_type in set(additional_types).union({case_type})
+                for case_type in sorted(set(additional_types).union({case_type}))
             ])
         else:
             case_type_filter = "@case_type='{case_type}'".format(case_type=case_type)

--- a/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
@@ -34,6 +34,7 @@
           <query default_search="true" storage-instance="registry" template="case" url="http://localhost:8000/a/test_domain/phone/registry_case/123/">
             <data key="commcare_registry" ref="'myregistry'"/>
             <data key="case_type" ref="'case'"/>
+            <data key="case_id" ref="'another case ID'"/>
             <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
           </query>
         </session>

--- a/corehq/apps/app_manager/tests/test_form_workflow_multipe_case_types.py
+++ b/corehq/apps/app_manager/tests/test_form_workflow_multipe_case_types.py
@@ -1,0 +1,79 @@
+from testil import eq, Regex
+
+from corehq.apps.app_manager.const import (
+    WORKFLOW_FORM,
+)
+from corehq.apps.app_manager.models import FormLink
+from corehq.apps.app_manager.tests.app_factory import AppFactory
+from corehq.apps.app_manager.tests.util import patch_get_xform_resource_overrides
+from corehq.tests.util.xml import assert_xml_partial_equal, extract_xml_partial
+
+
+@patch_get_xform_resource_overrides()
+def test_form_linking_multiple_case_types():
+    factory = AppFactory(build_version='2.9.0')
+    m0, m0f0 = factory.new_basic_module('m0', 'frog')
+    factory.form_opens_case(m0f0)
+
+    m1, m1f0 = factory.new_basic_module('m1', 'frog')
+    factory.form_requires_case(m1f0)
+    m1.search_config.additional_case_types = ['tadpole']
+
+    m0f0.post_form_workflow = WORKFLOW_FORM
+    m0f0.form_links = [
+        FormLink(form_id=m1f0.unique_id),
+    ]
+
+    suite = factory.app.create_suite()
+    print(suite.decode('utf8'))
+
+    # ensure that target datum contains both case types
+    datum = extract_xml_partial(suite, "./entry[2]/session/datum[@id='case_id']", wrap=False).decode('utf8')
+    eq(datum, Regex(r"\[@case_type='frog' or @case_type='tadpole'\]"))
+
+    expected_stack = """
+    <partial>
+      <create>
+        <command value="'m1'"/>
+        <datum id="case_id" value="instance('commcaresession')/session/data/case_id_new_frog_0"/>
+        <command value="'m1-f0'"/>
+      </create>
+    </partial>"""
+    assert_xml_partial_equal(expected_stack, suite, "./entry[1]/stack/create")
+
+
+@patch_get_xform_resource_overrides()
+def test_form_linking_multiple_case_types_child_module():
+    factory = AppFactory(build_version='2.9.0')
+    m0, m0f0 = factory.new_basic_module('register', 'jelly_baby')
+    factory.form_opens_case(m0f0)
+
+    m1, m1f0 = factory.new_basic_module('eat', 'jelly_baby')
+    factory.form_requires_case(m1f0)
+    factory.form_opens_case(m1f0, case_type='taste', is_subcase=True)
+    m1.search_config.additional_case_types = ['liquorice']
+
+    m2, m2f0 = factory.new_basic_module('taste history', 'taste', parent_module=m1)
+    factory.form_requires_case(m2f0, 'taste', parent_case_type='jelly_baby')
+    m2.search_config.additional_case_types = ['smell']
+
+    m1f0.post_form_workflow = WORKFLOW_FORM
+    m1f0.form_links = [
+        FormLink(form_id=m2f0.unique_id),
+    ]
+
+    suite = factory.app.create_suite()
+    print(suite.decode('utf8'))
+
+    expected_stack = """
+    <partial>
+      <create>
+        <command value="'m1'"/>
+        <datum id="case_id" value="instance('commcaresession')/session/data/case_id"/>
+        <datum id="case_id_new_taste_0" value="uuid()"/>
+        <command value="'m2'"/>
+        <datum id="case_id_taste" value="instance('commcaresession')/session/data/case_id_new_taste_0"/>
+        <command value="'m2-f0'"/>
+      </create>
+    </partial>"""
+    assert_xml_partial_equal(expected_stack, suite, "./entry[2]/stack/create")

--- a/corehq/apps/app_manager/tests/test_shadow_forms.py
+++ b/corehq/apps/app_manager/tests/test_shadow_forms.py
@@ -8,9 +8,9 @@ from corehq.apps.app_manager.models import (
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     TestXmlMixin,
-    extract_xml_partial,
     patch_get_xform_resource_overrides,
 )
+from corehq.tests.util.xml import extract_xml_partial
 
 
 @patch_get_xform_resource_overrides()

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -184,20 +184,23 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             './detail[@id="m0_case_long"]')
 
     def test_form_linking_to_registry_module_from_registration_form(self):
+        self.module.search_config.additional_case_types = ["other_case"]
         suite = self.app.create_suite()
         expected = """
         <partial>
           <create>
             <command value="'m0'"/>
             <query id="results" value="http://localhost:8000/a/test_domain/phone/registry_case/123/">
-              <data key="commcare_registry" ref="'myregistry'"/>
               <data key="case_type" ref="'case'"/>
+              <data key="case_type" ref="'other_case'"/>
+              <data key="commcare_registry" ref="'myregistry'"/>
               <data key="case_id" ref="instance('commcaresession')/session/data/case_id_new_case_0"/>
             </query>
             <datum id="case_id" value="instance('commcaresession')/session/data/case_id_new_case_0"/>
             <query id="registry" value="http://localhost:8000/a/test_domain/phone/registry_case/123/">
               <data key="commcare_registry" ref="'myregistry'"/>
               <data key="case_type" ref="'case'"/>
+              <data key="case_type" ref="'other_case'"/>
               <data key="case_id" ref="instance('commcaresession')/session/data/case_id_new_case_0"/>
             </query>
             <command value="'m0-f0'"/>

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -59,7 +59,8 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 )
             ],
             data_registry="myregistry",
-            data_registry_workflow=REGISTRY_WORKFLOW_LOAD_CASE
+            data_registry_workflow=REGISTRY_WORKFLOW_LOAD_CASE,
+            additional_registry_cases=["'another case ID'"],
         )
 
         self.reg_module = self.app.add_module(Module.new_module("Registration", None))
@@ -115,6 +116,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 storage-instance="registry" template="case" default_search="true">
               <data key="commcare_registry" ref="'myregistry'"/>
               <data key="case_type" ref="'case'"/>
+              <data key="case_id" ref="'another case ID'"/>
               <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
             </query>
           </session>
@@ -201,6 +203,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
               <data key="commcare_registry" ref="'myregistry'"/>
               <data key="case_type" ref="'case'"/>
               <data key="case_type" ref="'other_case'"/>
+              <data key="case_id" ref="'another case ID'"/>
               <data key="case_id" ref="instance('commcaresession')/session/data/case_id_new_case_0"/>
             </query>
             <command value="'m0-f0'"/>

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -257,8 +257,8 @@ class RemoteRequestSuiteFormLinkChildModuleTest(SimpleTestCase, TestXmlMixin, Su
             <datum id="case_id" value="instance('commcaresession')/session/data/case_id"/>
             <command value="'m1'"/>
             <query id="results" value="http://localhost:8000/a/test_domain/phone/registry_case/123/">
-              <data key="commcare_registry" ref="'myregistry'"/>
               <data key="case_type" ref="'case'"/>
+              <data key="commcare_registry" ref="'myregistry'"/>
               <data key="case_id" ref="instance('commcaresession')/session/data/case_id_case"/>
             </query>
             <datum id="case_id_case" value="instance('commcaresession')/session/data/case_id_case"/>

--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -16,7 +16,7 @@ from corehq.apps.builds.models import (
 from corehq.tests.util.xml import (
     assert_html_equal,
     assert_xml_equal,
-    parse_normalize,
+    parse_normalize, assert_xml_partial_equal,
 )
 from corehq.util.test_utils import TestFileMixin, unit_testing_only
 
@@ -25,14 +25,7 @@ class TestXmlMixin(TestFileMixin):
     root = os.path.dirname(__file__)
 
     def assertXmlPartialEqual(self, expected, actual, xpath):
-        """
-        Extracts a section of XML using the xpath and compares it to the expected
-
-        Extracted XML is placed inside a <partial/> element prior to comparison.
-        """
-        expected = parse_normalize(expected)
-        actual = extract_xml_partial(actual, xpath)
-        self.assertXmlEqual(expected, actual, normalize=False)
+        assert_xml_partial_equal(expected, actual, xpath)
 
     def assertXmlEqual(self, expected, actual, normalize=True):
         assert_xml_equal(expected, actual, normalize)
@@ -85,15 +78,6 @@ class SuiteMixin(TestFileMixin):
         app_strings = app.create_app_strings('default')
 
         self._assertHasAllStrings(app_xml, app_strings)
-
-
-def extract_xml_partial(xml, xpath):
-    actual = parse_normalize(xml, to_string=False)
-    nodes = actual.findall(xpath)
-    root = etree.Element('partial')
-    for node in nodes:
-        root.append(node)
-    return etree.tostring(root, pretty_print=True, encoding='utf-8')
 
 
 def add_build(version, build_number):

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -17,7 +17,6 @@ from casexml.apps.phone.tests.utils import (
 
 from corehq.apps.app_manager.tests.util import (
     TestXmlMixin,
-    extract_xml_partial,
 )
 from corehq.apps.commtrack.tests.util import bootstrap_domain
 from corehq.apps.custom_data_fields.models import (

--- a/corehq/tests/util/xml.py
+++ b/corehq/tests/util/xml.py
@@ -75,9 +75,13 @@ def _check_shared(expected, actual, checker, extension):
             raise AssertionError(message)
 
 
-def extract_xml_partial(xml, xpath):
+def extract_xml_partial(xml, xpath, wrap=True):
     actual = parse_normalize(xml, to_string=False)
     nodes = actual.findall(xpath)
+    if not wrap:
+        assert len(nodes) == 1, 'result must be wrapped if more than 1 node is matched'
+        return lxml.etree.tostring(nodes[0], pretty_print=True, encoding='utf-8')
+
     root = lxml.etree.Element('partial')
     for node in nodes:
         root.append(node)

--- a/corehq/tests/util/xml.py
+++ b/corehq/tests/util/xml.py
@@ -12,6 +12,17 @@ def assert_xml_equal(expected, actual, normalize=True):
     _check_shared(expected, actual, LXMLOutputChecker(), "xml")
 
 
+def assert_xml_partial_equal(expected, actual, xpath):
+    """
+    Extracts a section of XML using the xpath and compares it to the expected
+
+    Extracted XML is placed inside a <partial/> element prior to comparison.
+    """
+    expected = parse_normalize(expected)
+    actual = extract_xml_partial(actual, xpath)
+    assert_xml_equal(expected, actual, normalize=False)
+
+
 def assert_html_equal(expected, actual, normalize=True):
     if normalize:
         expected = parse_normalize(expected, is_html=True)
@@ -62,3 +73,12 @@ def _check_shared(expected, actual, checker, extension):
             # check that there was actually a diff, because checker.check_output
             # doesn't work with unicode characters in xml node names
             raise AssertionError(message)
+
+
+def extract_xml_partial(xml, xpath):
+    actual = parse_normalize(xml, to_string=False)
+    nodes = actual.findall(xpath)
+    root = lxml.etree.Element('partial')
+    for node in nodes:
+        root.append(node)
+    return lxml.etree.tostring(root, pretty_print=True, encoding='utf-8')


### PR DESCRIPTION
## Product Description
Bug fix for using form linking in conjunction with data registries and multiple case types for case search.

## Technical Summary
With multiple case types in play the datum matching for data registry queries was failing. 

There are two commits with fixes related to this which address the issue in different parts of the code. Other commits are non-functional changes / refactors.

### [infer case type for 'next_meta'](https://github.com/dimagi/commcare-hq/commit/cb6bbd8e7b84bb0db122d546fca4480139c73fc1)

Normally the case types of workflow datums are parsed from the datum nodeset. In cases where this isn't possible the case type is set to that of the module (this happens in a post construction step). This step was being skipped for datums used when constructing `WorkflowQueryMeta` objects. The impact of this was that the datum matching was failing due to the missing case type in the datum passed to `WorkflowQueryMeta`.

Jira: https://dimagi-dev.atlassian.net/browse/USH-1446

### [support multiple data elements with the same ID](https://github.com/dimagi/commcare-hq/commit/0e050caa118bb75484b829718a7ff2bdddede952)

This commit fixes a bug where data elements in query datums were overwriting previously seen elements with the same ID. This was impacting both 'multiple case types' as well as 'additional registry cases'.

Jira: https://dimagi-dev.atlassian.net/browse/USH-1450

**Best reviewed by commit**

## Feature Flag
DATA_REGISTRY, USH_CASE_CLAIM_UPDATES

## Safety Assurance

### Safety story
The code is well covered by tests and the changes only impact feature flagged areas.

### Automated test coverage
Added new tests to cover the changes.

### QA Plan
This feature is not currently in use by any live applications. The USH delivery team is in the process of testing / building these features into their apps.

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
