### PR TITLE
Require edit data and API permission for submit api

### DIFF
--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -209,8 +209,10 @@ def _record_metrics(tags, submission_type, response, timer=None, xform=None):
 @waf_allow('XSS_BODY')
 @csrf_exempt
 @api_auth
+@require_permission(Permissions.edit_data)
+@require_permission(Permissions.access_api)
 def post_api(request, domain, app_id=None):
-    return post(request, domain, app_id)
+    return secure_post(request, domain, app_id)
 
 
 @waf_allow('XSS_BODY')


### PR DESCRIPTION
## Product Description
Require edit data and API permission for the new submission api endpoint.  [John noticed this](https://dimagi-dev.atlassian.net/browse/USH-1458) while trying out the new endpoint.

## Technical Summary
The `@api_auth` decorator doesn't actually check the api access permission (might be nice to reconcile that someday).  I saw that `_secure_post_api_key` actually already checks these two permissions, but that only applies if you use api key auth.  This change will make those permissions mandatory whenever submitting forms via the api endpoint.

<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This is a pretty simple change - I tried it out locally and it works as I'd expect.  This endpoint isn't yet in use, either.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change