### PR TITLE
add domain tag to schedule instance tasks

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
+++ b/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
@@ -427,10 +427,10 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
 
             # Send the first event, and schedule the next event for the next day
             utcnow_patch.return_value = datetime(2018, 7, 1, 13, 1)
-            handle_case_timed_schedule_instance(case.case_id, instance.schedule_instance_id)
+            handle_case_timed_schedule_instance(case.case_id, instance.schedule_instance_id, domain)
             self.assertEqual(send_patch.call_count, 1)
 
-            [instance] = get_case_timed_schedule_instances_for_schedule(case.case_id, schedule)
+            [instance] = get_case_timed_schedule_instances_for_schedule(case.case_id, schedule, domain)
             self.assertEqual(instance.case_id, case.case_id)
             self.assertEqual(instance.rule_id, rule.pk)
             self.assertEqual(instance.timed_schedule_id, schedule.schedule_id)

--- a/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
+++ b/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
@@ -430,7 +430,7 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
             handle_case_timed_schedule_instance(case.case_id, instance.schedule_instance_id, self.domain)
             self.assertEqual(send_patch.call_count, 1)
 
-            [instance] = get_case_timed_schedule_instances_for_schedule(case.case_id, schedule, self.domain)
+            [instance] = get_case_timed_schedule_instances_for_schedule(case.case_id, schedule)
             self.assertEqual(instance.case_id, case.case_id)
             self.assertEqual(instance.rule_id, rule.pk)
             self.assertEqual(instance.timed_schedule_id, schedule.schedule_id)
@@ -445,7 +445,7 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
 
             # Send the second event, and deactivate because the stop date has been reached
             utcnow_patch.return_value = datetime(2018, 7, 2, 13, 1)
-            handle_case_timed_schedule_instance(case.case_id, instance.schedule_instance_id)
+            handle_case_timed_schedule_instance(case.case_id, instance.schedule_instance_id, self.domain)
             self.assertEqual(send_patch.call_count, 2)
 
             [instance] = get_case_timed_schedule_instances_for_schedule(case.case_id, schedule)

--- a/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
+++ b/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
@@ -427,10 +427,10 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
 
             # Send the first event, and schedule the next event for the next day
             utcnow_patch.return_value = datetime(2018, 7, 1, 13, 1)
-            handle_case_timed_schedule_instance(case.case_id, instance.schedule_instance_id, domain)
+            handle_case_timed_schedule_instance(case.case_id, instance.schedule_instance_id, self.domain)
             self.assertEqual(send_patch.call_count, 1)
 
-            [instance] = get_case_timed_schedule_instances_for_schedule(case.case_id, schedule, domain)
+            [instance] = get_case_timed_schedule_instances_for_schedule(case.case_id, schedule, self.domain)
             self.assertEqual(instance.case_id, case.case_id)
             self.assertEqual(instance.rule_id, rule.pk)
             self.assertEqual(instance.timed_schedule_id, schedule.schedule_id)

--- a/corehq/messaging/management/commands/queue_schedule_instances.py
+++ b/corehq/messaging/management/commands/queue_schedule_instances.py
@@ -75,7 +75,7 @@ class Command(BaseCommand):
                 # that we only retry non-processed schedule instances once an hour.
                 enqueue_lock = self.get_enqueue_lock(cls, schedule_instance_id, next_event_due)
                 if enqueue_lock.acquire(blocking=False):
-                    self.get_task(cls).delay(schedule_instance_id)
+                    self.get_task(cls).delay(schedule_instance_id, domain)
 
         for cls in (CaseAlertScheduleInstance, CaseTimedScheduleInstance):
             for domain, case_id, schedule_instance_id, next_event_due in get_active_case_schedule_instance_ids(
@@ -86,7 +86,7 @@ class Command(BaseCommand):
                 # See comment above about why we use a non-blocking lock here.
                 enqueue_lock = self.get_enqueue_lock(cls, schedule_instance_id, next_event_due)
                 if enqueue_lock.acquire(blocking=False):
-                    self.get_task(cls).delay(case_id, schedule_instance_id)
+                    self.get_task(cls).delay(case_id, schedule_instance_id, domain)
 
     def handle(self, **options):
         while True:

--- a/corehq/messaging/scheduling/tasks.py
+++ b/corehq/messaging/scheduling/tasks.py
@@ -455,7 +455,7 @@ def update_broadcast_last_sent_timestamp(broadcast_class, schedule_id):
 
 
 @no_result_task(serializer='pickle', queue='reminder_queue')
-def handle_alert_schedule_instance(schedule_instance_id):
+def handle_alert_schedule_instance(schedule_instance_id, domain):
     with CriticalSection(['handle-alert-schedule-instance-%s' % schedule_instance_id.hex]):
         try:
             instance = get_alert_schedule_instance(schedule_instance_id)
@@ -467,7 +467,7 @@ def handle_alert_schedule_instance(schedule_instance_id):
 
 
 @no_result_task(serializer='pickle', queue='reminder_queue')
-def handle_timed_schedule_instance(schedule_instance_id):
+def handle_timed_schedule_instance(schedule_instance_id, domain):
     with CriticalSection(['handle-timed-schedule-instance-%s' % schedule_instance_id.hex]):
         try:
             instance = get_timed_schedule_instance(schedule_instance_id)
@@ -479,7 +479,7 @@ def handle_timed_schedule_instance(schedule_instance_id):
 
 
 @no_result_task(serializer='pickle', queue='reminder_queue')
-def handle_case_alert_schedule_instance(case_id, schedule_instance_id):
+def handle_case_alert_schedule_instance(case_id, schedule_instance_id, domain):
     # Use the same lock key as the tasks which refresh case schedule instances
     from corehq.messaging.tasks import get_sync_key
     with CriticalSection([get_sync_key(case_id)], timeout=5 * 60):
@@ -492,7 +492,7 @@ def handle_case_alert_schedule_instance(case_id, schedule_instance_id):
 
 
 @no_result_task(serializer='pickle', queue='reminder_queue')
-def handle_case_timed_schedule_instance(case_id, schedule_instance_id):
+def handle_case_timed_schedule_instance(case_id, schedule_instance_id, domain):
     # Use the same lock key as the tasks which refresh case schedule instances
     from corehq.messaging.tasks import get_sync_key
     with CriticalSection([get_sync_key(case_id)], timeout=5 * 60):


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Part 1 of https://dimagi-dev.atlassian.net/browse/SAAS-12676, just adds a domain arg to schedule instance (conditional alert) tasks. This will allow that tag to populate in our datadog celery metrics

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Unusued new argument, and I grepped for existing usages of the function.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There is test coverage these functions, and the behavior is unchanged.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
