### PR TITLE
Check for fixture_tag before creating SessionDatum

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -40,6 +40,7 @@ from corehq.apps.app_manager.xpath import (
 from corehq.apps.case_search.models import CASE_SEARCH_REGISTRY_ID_KEY
 from corehq.util.timer import time_method
 from corehq.util.view_utils import absolute_reverse
+from corehq.apps.app_manager.suite_xml.xml_models import SessionDatum
 
 
 @attr.s(repr=False)

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -653,19 +653,20 @@ class EntriesHelper(object):
                 requires_selection=True,
                 action=action,
             ))
-        datums.append(FormDatumMeta(
-            datum=SessionDatum(
-                id=load_case_from_fixture.fixture_tag,
-                nodeset=load_case_from_fixture.fixture_nodeset,
-                value=load_case_from_fixture.fixture_variable,
-                detail_select=self.details_helper.get_detail_id_safe(target_module, 'case_short'),
-                detail_confirm=self.details_helper.get_detail_id_safe(target_module, 'case_long'),
-                autoselect=load_case_from_fixture.auto_select_fixture,
-            ),
-            case_type=action.case_type,
-            requires_selection=True,
-            action=action,
-        ))
+        if load_case_from_fixture.fixture_tag:
+            datums.append(FormDatumMeta(
+                datum=SessionDatum(
+                    id=load_case_from_fixture.fixture_tag,
+                    nodeset=load_case_from_fixture.fixture_nodeset,
+                    value=load_case_from_fixture.fixture_variable,
+                    detail_select=self.details_helper.get_detail_id_safe(target_module, 'case_short'),
+                    detail_confirm=self.details_helper.get_detail_id_safe(target_module, 'case_long'),
+                    autoselect=load_case_from_fixture.auto_select_fixture,
+                ),
+                case_type=action.case_type,
+                requires_selection=True,
+                action=action,
+            ))
 
         if action.case_tag:
             if action.case_index.tag:


### PR DESCRIPTION
## Product Description
No visible changes

## Technical Summary
#### Problem
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-1904)
When using the [Advanced Modules'](https://confluence.dimagi.com/pages/viewpage.action?spaceKey=saas&title=Advanced+Modules) [Load from case fixture](https://staging.commcarehq.org/a/shubhamgoyaltest/apps/view/b0db0c5c1bd6455a96f02f283bf4f217/form/e2a66377ffe64e19966a78210a1ef1f6/) action, there exist a bug that causes a parsing issue in the `suite.xml` file when some of the fields are not filled in.

When the `Fixture Nodeset`, `Fixture tag` and `Fixture Variable` fields are not completed, the `get_load_case_from_fixture_datums` function creates a datum element (`SessionDatum`, child of `session` element in `suite.xml` file) which does not have the necessary attributes, hence the app fails to load. This is clearly an issue.

#### Solution
Add a check for the necessary data to be filled in before creating the `SessionDatum` object.

## Feature Flag
[Advanced Modules](https://confluence.dimagi.com/pages/viewpage.action?spaceKey=saas&title=Advanced+Modules) 

## Safety Assurance

### Safety story
All current tests are still passing.

### Automated test coverage
Many tests already exist in this area of the code.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
