### PR TITLE
User filter update to support enterprise domains for User History Report

### DIFF
--- a/corehq/apps/enterprise/tests/test_enterprise_utils.py
+++ b/corehq/apps/enterprise/tests/test_enterprise_utils.py
@@ -1,0 +1,36 @@
+from django.test import TestCase
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.enterprise.tests.utils import create_enterprise_permissions
+from corehq.apps.enterprise.utils import get_enterprise_domains
+
+
+class TestEnterpriseUtils(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'domain'
+        cls.domain_obj = create_domain(cls.domain)
+        cls.source_domain = 'source-domain'
+        cls.source_domain_obj = create_domain(cls.source_domain)
+        create_enterprise_permissions("hello@world.com", cls.source_domain, [cls.domain])
+
+    def setUp(self):
+        super(TestEnterpriseUtils, self).setUp()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_obj.delete()
+        cls.source_domain_obj.delete()
+        super(TestEnterpriseUtils, cls).tearDownClass()
+
+    def test_get_enterprise_domains(self):
+        self.assertEqual(
+            set(['source-domain']),
+            set(get_enterprise_domains(self.source_domain))
+        )
+        self.assertEqual(
+            set(['domain', 'source-domain']),
+            set(get_enterprise_domains(self.domain))
+        )

--- a/corehq/apps/enterprise/tests/test_enterprise_utils.py
+++ b/corehq/apps/enterprise/tests/test_enterprise_utils.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.enterprise.tests.utils import create_enterprise_permissions
-from corehq.apps.enterprise.utils import get_enterprise_domains
+from corehq.apps.enterprise.utils import get_enterprise_domains, get_enterprise_controlled_domains
 
 
 class TestEnterpriseUtils(TestCase):
@@ -33,4 +33,14 @@ class TestEnterpriseUtils(TestCase):
         self.assertEqual(
             set(['domain', 'source-domain']),
             set(get_enterprise_domains(self.domain))
+        )
+
+    def test_get_enterprise_controlled_domains(self):
+        self.assertEqual(
+            set(['domain', 'source-domain']),
+            set(get_enterprise_controlled_domains(self.source_domain))
+        )
+        self.assertEqual(
+            set(['domain']),
+            set(get_enterprise_controlled_domains(self.domain))
         )

--- a/corehq/apps/enterprise/utils.py
+++ b/corehq/apps/enterprise/utils.py
@@ -8,3 +8,12 @@ def get_enterprise_domains(domain):
     if config.is_enabled and domain in config.domains:
         domain_list.append(config.source_domain)
     return domain_list
+
+
+def get_enterprise_controlled_domains(domain):
+    """Return list of domains containing the input domain and all domains controlled by the input domain"""
+    domain_list = [domain]
+    config = EnterprisePermissions.get_by_domain(domain)
+    if config.is_enabled:
+        domain_list += EnterprisePermissions.get_domains(domain)
+    return domain_list

--- a/corehq/apps/enterprise/utils.py
+++ b/corehq/apps/enterprise/utils.py
@@ -1,0 +1,10 @@
+from corehq.apps.enterprise.models import EnterprisePermissions
+
+
+def get_enterprise_domains(domain):
+    """Return list containing input domain and source domain for that input domain."""
+    domain_list = [domain]
+    config = EnterprisePermissions.get_by_domain(domain)
+    if config.is_enabled and domain in config.domains:
+        domain_list.append(config.source_domain)
+    return domain_list

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -64,14 +64,8 @@ class UserES(HQESQuery):
         return query.is_active(False)
 
 
-def domain(domain, allow_enterprise=False):
-    domain_list = [domain]
-    if allow_enterprise:
-        from corehq.apps.enterprise.models import EnterprisePermissions
-        config = EnterprisePermissions.get_by_domain(domain)
-        if config.is_enabled and domain in config.domains:
-            domain_list.append(config.source_domain)
-    return domains(domain_list)
+def domain(domain):
+    return domains(domain)
 
 
 def domains(domains):

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -125,7 +125,7 @@ class EmwfOptionsController(object):
 
     def _should_include_enterprise_controlled_domains(self):
         from corehq.apps.reports.standard.users.reports import UserHistoryReport
-        if UserHistoryReport.slug in self.request.META['HTTP_REFERER']:
+        if UserHistoryReport.slug in self.request.META.get('HTTP_REFERER', '/'):
             return True
         return False
 

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -125,7 +125,7 @@ class EmwfOptionsController(object):
 
     def _should_include_enterprise_controlled_domains(self):
         from corehq.apps.reports.standard.users.reports import UserHistoryReport
-        if UserHistoryReport.slug in self.request.META.get('HTTP_REFERER', '/'):
+        if f"/{UserHistoryReport.slug}/" in self.request.META.get('HTTP_REFERER', '/'):
             return True
         return False
 

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -1,5 +1,6 @@
 from memoized import memoized
 
+from corehq.apps.enterprise.utils import get_enterprise_controlled_domains
 from corehq.apps.es import GroupES, UserES, groups
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reports.const import DEFAULT_PAGE_LIMIT
@@ -122,10 +123,19 @@ class EmwfOptionsController(object):
         users = customize_user_query(self.request.couch_user, self.domain, users)
         return [self.utils.user_tuple(u) for u in users.run().hits]
 
+    def _should_include_enterprise_controlled_domains(self):
+        from corehq.apps.reports.standard.users.reports import UserHistoryReport
+        if UserHistoryReport.slug in self.request.META['HTTP_REFERER']:
+            return True
+        return False
+
     def active_user_es_query(self, query):
         search_fields = ["first_name", "last_name", "base_username"]
+        domains = self.domain
+        if self._should_include_enterprise_controlled_domains():
+            domains = get_enterprise_controlled_domains(self.domain)
         return (UserES()
-                .domain(self.domain)
+                .domain(domains)
                 .search_string_query(query, default_fields=search_fields))
 
     def all_user_es_query(self, query):

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -8,6 +8,7 @@ from django.utils.translation import ugettext_lazy, ugettext_noop
 from memoized import memoized
 
 from corehq.apps.domain.models import Domain
+from corehq.apps.enterprise.utils import get_enterprise_domains
 from corehq.apps.es import filters
 from corehq.apps.es import users as user_es
 from corehq.apps.groups.models import Group
@@ -348,7 +349,7 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
     @classmethod
     def user_es_query(cls, domain, mobile_user_and_group_slugs, request_user):
         # The queryset returned by this method is location-safe
-        q = user_es.UserES().domain(domain, allow_enterprise=True)
+        q = user_es.UserES().domain(get_enterprise_domains(domain))
         q = customize_user_query(request_user, domain, q)
         if (
             ExpandedMobileWorkerFilter.no_filters_selected(mobile_user_and_group_slugs)

--- a/corehq/apps/reports/standard/users/reports.py
+++ b/corehq/apps/reports/standard/users/reports.py
@@ -128,6 +128,7 @@ class UserHistoryReport(GetParamsMixin, DatespanMixin, GenericTabularReport, Pro
             self.domain,
             slugs,
             self.request.couch_user,
+            allow_enterprise_controlled_domains=True
         )
 
     def _build_query(self, user_ids, changed_by_user_ids, user_property, actions, user_upload_record_id):

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -893,6 +893,17 @@ class TestUserESAccessors(TestCase):
             metadata={PROFILE_SLUG: cls.profile.id, 'office': 'phone_booth'},
         )
         cls.user.save()
+        cls.source_domain_user = CommCareUser.create(
+            cls.source_domain,
+            'batman',
+            'crime fighting man',
+            None,
+            None,
+            first_name='bruce',
+            last_name='wayne',
+            is_active=True,
+        )
+        cls.source_domain_user.save()
 
     def setUp(self):
         super(TestUserESAccessors, self).setUp()
@@ -908,13 +919,13 @@ class TestUserESAccessors(TestCase):
         ensure_index_deleted(USER_INDEX)
         super(TestUserESAccessors, cls).tearDownClass()
 
-    def _send_user_to_es(self, is_active=True):
-        self.user.is_active = is_active
-        send_to_elasticsearch('users', transform_user_for_elasticsearch(self.user.to_json()))
+    def _send_user_to_es(self, user, is_active=True):
+        user.is_active = is_active
+        send_to_elasticsearch('users', transform_user_for_elasticsearch(user.to_json()))
         self.es.indices.refresh(USER_INDEX)
 
     def test_active_user_query(self):
-        self._send_user_to_es()
+        self._send_user_to_es(self.user)
         results = get_user_stubs([self.user._id], ['user_data_es'])
 
         self.assertEqual(len(results), 1)
@@ -938,7 +949,7 @@ class TestUserESAccessors(TestCase):
         })
 
     def test_inactive_user_query(self):
-        self._send_user_to_es(is_active=False)
+        self._send_user_to_es(self.user, is_active=False)
         results = get_user_stubs([self.user._id])
 
         self.assertEqual(len(results), 1)
@@ -953,13 +964,14 @@ class TestUserESAccessors(TestCase):
             'location_id': None
         })
 
-    def test_domain_allow_enterprise(self):
-        self._send_user_to_es()
+    def test_domain(self):
+        self._send_user_to_es(self.user)
+        self._send_user_to_es(self.source_domain_user)
         self.assertEqual(['superman'], UserES().domain(self.domain).values_list('username', flat=True))
-        self.assertEqual([], UserES().domain(self.source_domain).values_list('username', flat=True))
+        self.assertEqual(['batman'], UserES().domain(self.source_domain).values_list('username', flat=True))
         self.assertEqual(
-            ['superman'],
-            UserES().domain(self.domain, allow_enterprise=True).values_list('username', flat=True)
+            set(['superman', 'batman']),
+            set(UserES().domain([self.domain, self.source_domain]).values_list('username', flat=True))
         )
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
[ticket](https://dimagi-dev.atlassian.net/browse/USH-1316). This is "stage 1" of the changes to the user filter where we are just isolating this change to the User History report, and not other reports. The next stage will likely be having this available for all reports for enterprise domains, but that ticket has yet to be prioritized. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Started with refactoring.
Then for the correct options to appear, it will check for `user_history` in the request.
And for the results to show, the optional param is added to the `user_es_query` and is only set to `True` for the user history report
The functionality for `get_enterprise_domains` was already in place before this PR and returns the source domain if a mirrored domain. The new functionality of `get_enterprise_controlled_domains` returns all the mirrored domains if a source domain is inputted.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[USER_HISTORY_REPORT](https://confluence.dimagi.com/pages/viewpage.action?spaceKey=saas&title=User+History+Report) and [DOMAIN_PERMISSIONS_MIRROR](https://confluence.dimagi.com/display/saas/Enterprise+Permissions)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
full functionality was testing on staging for enterprise and non-enterprise domains and also within the source and mirrored domains. I confirmed no change for the user filter in other reports, and the correct information for the mirrored domains.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests in `test_enterprise_utils` and modified in `test_esaccessors.py`

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
