### PR TITLE
Make post_api handle its own auth

### DIFF
--- a/corehq/apps/receiverwrapper/tests/test_auth.py
+++ b/corehq/apps/receiverwrapper/tests/test_auth.py
@@ -1,11 +1,11 @@
 import os
 import uuid
+from unittest import mock
 
 from django.http import HttpResponse
 from django.test import TestCase
 from django.urls import reverse
 
-import mock
 from six.moves.urllib.parse import urlencode
 
 from couchforms import openrosa_response

--- a/corehq/apps/receiverwrapper/tests/test_auth.py
+++ b/corehq/apps/receiverwrapper/tests/test_auth.py
@@ -359,7 +359,7 @@ class TestAPIEndpoint(TestCase):
         )
         web_user = WebUser.create(self.domain, self.username, self.password,
                                   None, None, role_id=role.get_id)
-        self.addCleanup(lambda: web_user.delete(None, None))
+        self.addCleanup(web_user.delete, None, None)
         return web_user
 
     def test_no_auth_fails_with_401(self):

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -211,8 +211,17 @@ def _record_metrics(tags, submission_type, response, timer=None, xform=None):
 @api_auth
 @require_permission(Permissions.edit_data)
 @require_permission(Permissions.access_api)
-def post_api(request, domain, app_id=None):
-    return secure_post(request, domain, app_id)
+@require_POST
+@check_domain_migration
+@set_request_duration_reporting_threshold(60)
+def post_api(request, domain):
+    return _process_form(
+        request=request,
+        domain=domain,
+        app_id=None,
+        user_id=request.couch_user.get_id,
+        authenticated=True,
+    )
 
 
 @waf_allow('XSS_BODY')


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
From https://github.com/dimagi/commcare-hq/pull/30820#discussion_r764634603
It's now got a whopping 8 decorators, but now this view handles authentication and authorization in a much more "normal" way.  Consider it a baby step in the right direction for the receiverwrapper views.  I also added some basic tests because we've already made a couple mistakes here, and I found myself doing manual testing in a shell session.
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage
This PR introduces tests for this functionality
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
