### PR TITLE
Add Docker setup group for Github Actions

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -77,6 +77,7 @@ function python_preheat {
 }
 
 function run_tests {
+    [ -n "$GITHUB_ACTIONS" ] && echo "::endgroup::"  # "Docker setup" begins in scripts/docker
     TEST="$1"
     shift
     suite_pat=$(printf '%s|' "${VALID_TEST_SUITES[@]}" | sed -E 's/\|$//')

--- a/scripts/docker
+++ b/scripts/docker
@@ -258,6 +258,7 @@ case $CMD in
 esac
 
 if [ "$CMD" == "test" ]; then
+    [ -n "$GITHUB_ACTIONS" ] && echo "::group::Docker setup"  # ends in docker/run.sh
     echo "Pulling docker containers..."
     docker-compose pull --quiet
     docker-compose run --rm web run_tests "${TEST:-python}" "$@"


### PR DESCRIPTION
Capturing docker setup in a group makes it easier to find the groups below it.

![image](https://user-images.githubusercontent.com/464726/145461991-8d14ed38-5834-41f8-9dcd-efc7300697bd.png)

Design decisions:
- Even though the group delimiters span two files, it feels worth it because of the usability improvement when reading test logs.
- I did not use the standard `log_group_begin` and `log_group_end` functions because they are not available in `scripts/docker`, and it is non-trivial to include `scripts/bash-utils.sh` there in a platform-agnostic way, especially given that `scripts/docker` may not always be run from the same directory (unlike other test automation scripts).
- The output is conditional on the `$GITHUB_ACTIONS` environment variable (as with `log_group_begin` and `log_group_end`) so it will not muddy the output in other contexts.

### Safety story

This change affects tests only.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
