### PR TITLE
Add expand_id_property to case search model and suite xml

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2158,6 +2158,7 @@ class CaseSearch(DocumentSchema):
     data_registry = StringProperty()
     data_registry_workflow = StringProperty()           # one of REGISTRY_WORKFLOW_*
     additional_registry_cases = StringListProperty()  # list of xpath expressions
+    expand_id_property = StringProperty()  # case property referencing another case's ID
 
     @property
     def case_session_var(self):

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -49,6 +49,7 @@ from corehq.apps.app_manager.xpath import (
 from corehq.apps.case_search.const import COMMCARE_PROJECT, EXCLUDE_RELATED_CASES_FILTER
 from corehq.apps.case_search.models import (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
+    CASE_SEARCH_EXPAND_ID_PROPERTY_KEY,
     CASE_SEARCH_REGISTRY_ID_KEY,
 )
 from corehq.util.timer import time_method
@@ -219,6 +220,13 @@ class RemoteRequestFactory(object):
                 QueryData(
                     key=CASE_SEARCH_REGISTRY_ID_KEY,
                     ref=f"'{self.module.search_config.data_registry}'",
+                )
+            )
+        if self.module.search_config.expand_id_property:
+            datums.append(
+                QueryData(
+                    key=CASE_SEARCH_EXPAND_ID_PROPERTY_KEY,
+                    ref=f"'{self.module.search_config.expand_id_property}'",
                 )
             )
         return datums

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -411,6 +411,21 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             suite = self.app.create_suite()
         self.assertXmlPartialEqual(self.get_xml('search_config_default_only'), suite, "./remote-request[1]")
 
+    def test_expand_id_property(self, *args):
+        self.module.search_config.expand_id_property = "potential_duplicate_id"
+
+        with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
+            get_url_base_patch.return_value = 'https://www.example.com'
+            suite = self.app.create_suite()
+
+        expected = """
+        <partial>
+          <data key="commcare_expand_id_property" ref="'potential_duplicate_id'"/>
+        </partial>
+        """
+        xpath = "./remote-request[1]/session/query/data[@key='commcare_expand_id_property']"
+        self.assertXmlPartialEqual(expected, suite, xpath)
+
     def test_blacklisted_owner_ids(self, *args):
         self.module.search_config = CaseSearch(
             properties=[

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -38,6 +38,7 @@ from corehq.util.test_utils import flag_enabled
 DOMAIN = 'test_domain'
 
 
+@patch('corehq.util.view_utils.get_url_base', new=lambda: "https://www.example.com")
 @patch_get_xform_resource_overrides()
 @patch.object(Application, 'supports_data_registry', lambda: True)
 class RemoteRequestSmartLinkTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
@@ -71,21 +72,19 @@ class RemoteRequestSmartLinkTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         self.request_factory = RemoteRequestFactory(generator.suite, child_module, detail_section_elements)
 
     def testSmartLinkFunction(self):
-        with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
-            get_url_base_patch.return_value = 'https://www.example.com'
-            concat_params = [
-                "'https://www.example.com/a/'",
-                "$domain",
-                f"'/app/v1/{self.app_id}/child_endpoint/'",
-                "'?case_id_leaf='",
-                "$case_id_leaf",
-                "'&case_id='",
-                "$case_id",
-            ]
-            self.assertEqual(
-                self.request_factory.get_smart_link_function(),
-                f'concat({", ".join(concat_params)})'
-            )
+        concat_params = [
+            "'https://www.example.com/a/'",
+            "$domain",
+            f"'/app/v1/{self.app_id}/child_endpoint/'",
+            "'?case_id_leaf='",
+            "$case_id_leaf",
+            "'&case_id='",
+            "$case_id",
+        ]
+        self.assertEqual(
+            self.request_factory.get_smart_link_function(),
+            f'concat({", ".join(concat_params)})'
+        )
 
     def testSmartLinkVariables(self):
         vars = self.request_factory.get_smart_link_variables()
@@ -98,9 +97,7 @@ class RemoteRequestSmartLinkTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         ])
 
     def testSuite(self):
-        with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
-            get_url_base_patch.return_value = 'https://www.example.com'
-            suite = self.factory.app.create_suite()
+        suite = self.factory.app.create_suite()
         self.assertXmlPartialEqual(
             self.get_xml('smart_link_remote_request').decode('utf-8').format(app_id=self.app_id),
             suite,
@@ -108,7 +105,7 @@ class RemoteRequestSmartLinkTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         )
 
 
-
+@patch('corehq.util.view_utils.get_url_base', new=lambda: "https://www.example.com")
 @patch_get_xform_resource_overrides()
 class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     file_path = ('data', 'suite')
@@ -211,9 +208,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         """
         Suite should include remote-request if searching is configured
         """
-        with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
-            get_url_base_patch.return_value = 'https://www.example.com'
-            suite = self.app.create_suite()
+        suite = self.app.create_suite()
         self.assertXmlPartialEqual(
             self.get_xml('remote_request').decode('utf-8').format(module_id="m0"),
             suite,
@@ -225,9 +220,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         """Remote requests for modules with custom details point to the custom detail
         """
         self.module.case_details.short.custom_xml = '<detail id="m0_case_short"></detail>'
-        with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
-            get_url_base_patch.return_value = 'https://www.example.com'
-            suite = self.app.create_suite()
+        suite = self.app.create_suite()
         self.assertXmlPartialEqual(self.get_xml('remote_request_custom_detail'), suite, "./remote-request[1]")
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
@@ -238,9 +231,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         """
         copy_app = Application.wrap(self.app.to_json())
         copy_app.modules.append(Module.wrap(copy_app.modules[0].to_json()))
-        with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
-            get_url_base_patch.return_value = 'https://www.example.com'
-            suite = copy_app.create_suite()
+        suite = copy_app.create_suite()
         self.assertXmlPartialEqual(
             self.get_xml('remote_request').decode('utf-8').format(module_id="m0"),
             suite,
@@ -405,18 +396,12 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
 
         # wrap to have assign_references called
         self.app = Application.wrap(self.app.to_json())
-
-        with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
-            get_url_base_patch.return_value = 'https://www.example.com'
-            suite = self.app.create_suite()
+        suite = self.app.create_suite()
         self.assertXmlPartialEqual(self.get_xml('search_config_default_only'), suite, "./remote-request[1]")
 
     def test_expand_id_property(self, *args):
         self.module.search_config.expand_id_property = "potential_duplicate_id"
-
-        with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
-            get_url_base_patch.return_value = 'https://www.example.com'
-            suite = self.app.create_suite()
+        suite = self.app.create_suite()
 
         expected = """
         <partial>
@@ -436,10 +421,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
 
         # wrap to have assign_references called
         self.app = Application.wrap(self.app.to_json())
-
-        with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
-            get_url_base_patch.return_value = 'https://www.example.com'
-            suite = self.app.create_suite()
+        suite = self.app.create_suite()
         self.assertXmlPartialEqual(self.get_xml('search_config_blacklisted_owners'), suite, "./remote-request[1]")
 
     def test_prompt_hint(self, *args):

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -15,6 +15,7 @@ FUZZY_PROPERTIES = "fuzzy_properties"
 CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY = 'commcare_blacklisted_owner_ids'
 CASE_SEARCH_XPATH_QUERY_KEY = '_xpath_query'
 CASE_SEARCH_REGISTRY_ID_KEY = 'commcare_registry'
+CASE_SEARCH_EXPAND_ID_PROPERTY_KEY = 'commcare_expand_id_property'
 UNSEARCHABLE_KEYS = (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
     'owner_id',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-1431
This PR adds expand_id_property to the `CaseSearch` model and sets the datum in the suite XML when present.  Robert is working on putting this in the app manager UI (and there gating behind the feature flag), and Steph is tackling the case search backend change.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Data Registries

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage
Added a new test for the suite changes
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
