### PR TITLE
Use an evaluation context with the filter

### DIFF
--- a/corehq/motech/repeaters/expression/repeaters.py
+++ b/corehq/motech/repeaters/expression/repeaters.py
@@ -6,7 +6,7 @@ from dimagi.ext.couchdbkit import DictProperty
 
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.filters.factory import FilterFactory
-from corehq.apps.userreports.specs import FactoryContext
+from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.repeaters.expression.repeater_generators import (
     ExpressionPayloadGenerator,
@@ -28,7 +28,7 @@ class BaseExpressionRepeater(Repeater):
     @property
     @memoized
     def parsed_filter(self):
-        return FilterFactory.from_spec(self.configured_filter)
+        return FilterFactory.from_spec(self.configured_filter, FactoryContext.empty())
 
     @property
     @memoized
@@ -40,7 +40,8 @@ class BaseExpressionRepeater(Repeater):
         return EXPRESSION_REPEATER.enabled(domain)
 
     def allowed_to_forward(self, payload):
-        return self.parsed_filter(payload.to_json())
+        payload_json = payload.to_json()
+        return self.parsed_filter(payload_json, EvaluationContext(payload_json))
 
     @memoized
     def get_payload(self, repeat_record):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This was preventing using filters that used an evaluation context (e.g. `get_case_forms`)

FYI @avazirna

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Case expression repeater

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Modified a test to catch this issue.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
