### PR TITLE
Change default mobile access permissions to False

### DIFF
--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -331,7 +331,7 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
 
         expected_object_counts = Counter({
             UserRole: 2,
-            RolePermission: 11,
+            RolePermission: 9,
             RoleAssignableBy: 1
         })
 

--- a/corehq/apps/users/management/commands/remove_mobile_permissions.py
+++ b/corehq/apps/users/management/commands/remove_mobile_permissions.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
     def _delete_mobile_access_permissions_on_domain(domain):
         affected_roles = UserRole.objects.filter(
             domain=domain, rolepermission__permission_fk__value='access_mobile_endpoints')
-        atleast_one_role_deleted = 0 < len(affected_roles)
+        atleast_one_permission_deleted = 0 < len(affected_roles)
         for role in affected_roles:
             logger.info("Deleting RolePermission object with permission=access_mobile_endpoints"
             f" and related role {role.name} from domain \"{domain}\"...")
@@ -43,7 +43,7 @@ class Command(BaseCommand):
             permission_fk__value='access_mobile_endpoints'
         ).delete()
         logger.info('Roles successfully deleted.')
-        return atleast_one_role_deleted
+        return atleast_one_permission_deleted
 
     @staticmethod
     def _get_domains_with_mobile_permission():

--- a/corehq/apps/users/management/commands/remove_mobile_permissions.py
+++ b/corehq/apps/users/management/commands/remove_mobile_permissions.py
@@ -4,33 +4,54 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.users.models_role import RolePermission, UserRole
 from corehq.toggles import RESTRICT_MOBILE_ACCESS
 
+import logging
+
+logger = logging.getLogger('app_migration')
+logger.setLevel('INFO')
+
 
 class Command(BaseCommand):
     help = "Removes the mobile access permission from roles not in Domains with" \
            " the RESTRICT_MOBILE_ACCESS feature flag"
 
     def handle(self, **options):
-        num_domains_with_their_roles_changed = 0
-        domains_with_restriction_on = RESTRICT_MOBILE_ACCESS.get_enabled_domains()
-        for domain in Domain.get_all_names():
-            if domain not in domains_with_restriction_on and not Domain.get_by_name(domain).restrict_mobile_access:
-                permission_was_removed_for_domain = None
-                for role in UserRole.objects.get_by_domain(domain):
-                    did_mobile_access_permission_exist = self._delete_mobile_access_permission_if_exists(role)
-                    if(did_mobile_access_permission_exist):
-                        permission_was_removed_for_domain = True
-                if(permission_was_removed_for_domain):
-                    num_domains_with_their_roles_changed += 1
+        domains_with_mobile_permission = self._get_domains_with_mobile_permission()
+        num_domains_with_their_roles_changed = self._delete_mobile_permissions_from_domains(
+            domains_with_mobile_permission)
         print(f"Done: {num_domains_with_their_roles_changed} domains out of {len(Domain.get_all_names())} total"
             " domains had permissions for their roles changed by this command execution.")
 
+    def _delete_mobile_permissions_from_domains(self, domains):
+        num_domains_with_their_roles_changed = 0
+        for domain in domains:
+            did_delete_permisisons_from_domain = self._delete_mobile_access_permissions_on_domain(domain)
+            if did_delete_permisisons_from_domain:
+                num_domains_with_their_roles_changed += 1
+        return num_domains_with_their_roles_changed
+
     @staticmethod
-    def _delete_mobile_access_permission_if_exists(role):
-        did_mobile_access_permission_exist = None
-        mobile_endpoints_rp = ([rp for rp in role.rolepermission_set.all()
-                                if rp.permission == 'access_mobile_endpoints'])
-        if mobile_endpoints_rp:
-            did_mobile_access_permission_exist = True
-            mobile_endpoints_rp_id = mobile_endpoints_rp[0].id
-            RolePermission.objects.filter(id=mobile_endpoints_rp_id).delete()
-        return did_mobile_access_permission_exist
+    def _delete_mobile_access_permissions_on_domain(domain):
+        affected_roles = UserRole.objects.filter(
+            domain=domain, rolepermission__permission_fk__value='access_mobile_endpoints')
+        atleast_one_role_deleted = 0 < len(affected_roles)
+        for role in affected_roles:
+            logger.info("Deleting RolePermission object with permission=access_mobile_endpoints"
+            f" and related role {role.name} from domain \"{domain}\"...")
+        role_ids = [role.id for role in affected_roles]
+        RolePermission.objects.filter(
+            role__id__in=role_ids,
+            permission_fk__value='access_mobile_endpoints'
+        ).delete()
+        logger.info('Roles successfully deleted.')
+        return atleast_one_role_deleted
+
+    @staticmethod
+    def _get_domains_with_mobile_permission():
+        domains_with_restriction_on = RESTRICT_MOBILE_ACCESS.get_enabled_domains()
+        domains_with_mobile_permission_unfiltered = UserRole.objects.filter(
+            rolepermission__permission_fk__value='access_mobile_endpoints'
+        ).values_list('domain', flat=True).distinct()
+        return [domain for domain in domains_with_mobile_permission_unfiltered if (
+            domain not in domains_with_restriction_on
+            and not Domain.get_by_name(domain).restrict_mobile_access
+        )]

--- a/corehq/apps/users/management/commands/remove_mobile_permissions.py
+++ b/corehq/apps/users/management/commands/remove_mobile_permissions.py
@@ -1,0 +1,36 @@
+from django.core.management.base import BaseCommand
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.users.models_role import RolePermission, UserRole
+from corehq.toggles import RESTRICT_MOBILE_ACCESS
+
+
+class Command(BaseCommand):
+    help = "Removes the mobile access permission from roles not in Domains with" \
+           " the RESTRICT_MOBILE_ACCESS feature flag"
+
+    def handle(self, **options):
+        num_domains_with_their_roles_changed = 0
+        domains_with_restriction_on = RESTRICT_MOBILE_ACCESS.get_enabled_domains()
+        for domain in Domain.get_all_names():
+            if domain not in domains_with_restriction_on and not Domain.get_by_name(domain).restrict_mobile_access:
+                permission_was_removed_for_domain = None
+                for role in UserRole.objects.get_by_domain(domain):
+                    did_mobile_access_permission_exist = self._delete_mobile_access_permission_if_exists(role)
+                    if(did_mobile_access_permission_exist):
+                        permission_was_removed_for_domain = True
+                if(permission_was_removed_for_domain):
+                    num_domains_with_their_roles_changed += 1
+        print(f"Done: {num_domains_with_their_roles_changed} domains out of {len(Domain.get_all_names())} total"
+            " domains had permissions for their roles changed by this command execution.")
+
+    @staticmethod
+    def _delete_mobile_access_permission_if_exists(role):
+        did_mobile_access_permission_exist = None
+        mobile_endpoints_rp = ([rp for rp in role.rolepermission_set.all()
+                                if rp.permission == 'access_mobile_endpoints'])
+        if mobile_endpoints_rp:
+            did_mobile_access_permission_exist = True
+            mobile_endpoints_rp_id = mobile_endpoints_rp[0].id
+            RolePermission.objects.filter(id=mobile_endpoints_rp_id).delete()
+        return did_mobile_access_permission_exist

--- a/corehq/apps/users/management/commands/remove_mobile_permissions.py
+++ b/corehq/apps/users/management/commands/remove_mobile_permissions.py
@@ -1,20 +1,26 @@
+from datetime import datetime
+import logging
+import csv
+
 from django.core.management.base import BaseCommand
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models_role import RolePermission, UserRole
 from corehq.toggles import RESTRICT_MOBILE_ACCESS
 
-import logging
-
 logger = logging.getLogger('app_migration')
 logger.setLevel('INFO')
 
 
 class Command(BaseCommand):
-    help = "Removes the mobile access permission from roles not in Domains with" \
-           " the RESTRICT_MOBILE_ACCESS feature flag"
+    help = "Removes the mobile access permission from roles not in Domains with the" \
+           " RESTRICT_MOBILE_ACCESS feature flag and outputs details of deleted RolePermission" \
+           " objects to a csv file."
+
 
     def handle(self, **options):
+        self.outfile = f"Mobile_access_permission_deleted_{datetime.today().strftime('%m-%d-%Y')}.csv"
+
         domains_with_mobile_permission = self._get_domains_with_mobile_permission()
         num_domains_with_their_roles_changed = self._delete_mobile_permissions_from_domains(
             domains_with_mobile_permission)
@@ -23,20 +29,26 @@ class Command(BaseCommand):
 
     def _delete_mobile_permissions_from_domains(self, domains):
         num_domains_with_their_roles_changed = 0
+        csvfile = open(self.outfile, "wt")
+        self.writer = csv.writer(csvfile)
+        self.writer.writerow(["Mobile access permission has been deleted for the following roles."])
+        self.writer.writerow(["Related Role", "Domain"])
         for domain in domains:
             did_delete_permisisons_from_domain = self._delete_mobile_access_permissions_on_domain(domain)
             if did_delete_permisisons_from_domain:
                 num_domains_with_their_roles_changed += 1
+        csvfile.close()
         return num_domains_with_their_roles_changed
 
-    @staticmethod
-    def _delete_mobile_access_permissions_on_domain(domain):
+    def _delete_mobile_access_permissions_on_domain(self, domain):
         affected_roles = UserRole.objects.filter(
             domain=domain, rolepermission__permission_fk__value='access_mobile_endpoints')
         atleast_one_permission_deleted = 0 < len(affected_roles)
         for role in affected_roles:
-            logger.info("Deleting RolePermission object with permission=access_mobile_endpoints"
-            f" and related role {role.name} from domain \"{domain}\"...")
+            self.writer.writerow([
+                role.name,
+                domain
+            ])
         role_ids = [role.id for role in affected_roles]
         RolePermission.objects.filter(
             role__id__in=role_ids,

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -187,7 +187,7 @@ class Permissions(DocumentSchema):
     edit_billing = BooleanProperty(default=False)
     report_an_issue = BooleanProperty(default=True)
 
-    access_mobile_endpoints = BooleanProperty(default=True)
+    access_mobile_endpoints = BooleanProperty(default=False)
 
     view_file_dropzone = BooleanProperty(default=False)
     edit_file_dropzone = BooleanProperty(default=False)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Domains that are not using the RESTRICT_MOBILE_ACCESS feature flag or related GA setting will not be affected in a significant way. Domains that are using the FF or setting will have mobile access permission removed from users that do not have roles. If you’re curious, see [this Jira ticket](https://dimagi-dev.atlassian.net/browse/USH-1463) about how that is being addressed. A small warning to app managers will be sent out ahead of this PR being deployed about this permission change.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[This is the related Jira ticket](https://dimagi-dev.atlassian.net/browse/USH-1457).

This PR has two parts:

1. The default value for the `access_mobile_endpoints` field on the `Permissions` model will be changed from `True` to `False`. This will mean when new roles are created, they will by default not have access to the mobile app/mobile endpoints if they are using the related FF/setting. It will also mean that users without roles will lose access since they use a freshly created `Permissions()` object when their permissions are checked.
2. Since many domains were created to have `access_mobile_endpoints` as `True` by default, a management command is written here to convert permissions on all roles on domains not using the related FF/setting to the new default. This way, when a domain turns on the FF/setting, they will not give mobile access to all their roles by default (this is unsafe, as you would think turning on this FF/setting would immediately restrict access, not require an extra step to turn it off inside “roles & permissions”).

Why a management command? This migration is too large to have it run with a regular deploy, and it needs to be run after the code change. By having it as a management command, we can run it right after next Wednesday night’s regular deploy. There will be a 2nd PR to run this management command inside a Django migration so that the other environments (Swiss, India) will have this code deployed at a later date.

We are open to a discussion about the above plan on implementing this code change/migration.

Some comments about the actual code:

- If the list comprehension to get a `RolePermission` object ID from a role looks odd to you:
`mobile_endpoints_rp = ([rp for rp in role.rolepermission_set.all()
                                if rp.permission == 'access_mobile_endpoints'])`
     It’s because the permission field on the `RolePermission` class is a `ForiegnValue` and I was thus unable to filter on it. Open to comments on the querying here if you can see how the code could be more efficient.

A note: if you didn’t know, the RESTRICT_MOBILE_ACCESS feature flag now only enables a new GA setting, and the setting is what actually turns on/off mobile access permissions. See [this related Jira ticket](https://dimagi-dev.atlassian.net/browse/USH-1409). 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

RESTRICT_MOBILE_ACCESS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

I’ve run tests locally to make sure thing works out as planned. Changing the default value on the Permissions field does indeed remove access from users without roles, and the management command successfully turns off mobile access by default for domains that then turn on the FF and setting. I'll also be running testing on staging.

### Automated test coverage

None.

### QA Plan

None, this is entirely back-end.

### Migrations

No migrations in this PR, please see the data change plan via a management command described above.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
