### PR TITLE
[USH] Enable users to load "unrelated" cases in case search results

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2158,7 +2158,7 @@ class CaseSearch(DocumentSchema):
     data_registry = StringProperty()
     data_registry_workflow = StringProperty()           # one of REGISTRY_WORKFLOW_*
     additional_registry_cases = StringListProperty()  # list of xpath expressions
-    expand_id_property = StringProperty()  # case property referencing another case's ID
+    custom_related_case_property = StringProperty()  # case property referencing another case's ID
 
     @property
     def case_session_var(self):

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -181,7 +181,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         'autoLaunch', 'blacklistedOwnerIdsExpression', 'defaultSearch', 'searchAgainLabel',
         'searchButtonDisplayCondition', 'searchLabel', 'searchFilter', 'searchDefaultRelevant',
         'searchAdditionalRelevant', 'dataRegistry', 'dataRegistryWorkflow', 'additionalRegistryCases',
-        'expandIdProperty',
+        'customRelatedCaseProperty',
     ];
     var searchConfigModel = function (options, lang, searchFilterObservable, saveButton) {
         hqImport("hqwebapp/js/assert_properties").assertRequired(options, searchConfigKeys);
@@ -288,7 +288,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 additional_registry_cases: self.dataRegistryWorkflow() === "load_case" ?  self.additionalRegistryCases().map((query) => {
                     return query.caseIdXpath();
                 }) : [],
-                expand_id_property: self.expandIdProperty(),
+                custom_related_case_property: self.customRelatedCaseProperty(),
             };
         };
 

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -181,6 +181,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         'autoLaunch', 'blacklistedOwnerIdsExpression', 'defaultSearch', 'searchAgainLabel',
         'searchButtonDisplayCondition', 'searchLabel', 'searchFilter', 'searchDefaultRelevant',
         'searchAdditionalRelevant', 'dataRegistry', 'dataRegistryWorkflow', 'additionalRegistryCases',
+        'expandIdProperty',
     ];
     var searchConfigModel = function (options, lang, searchFilterObservable, saveButton) {
         hqImport("hqwebapp/js/assert_properties").assertRequired(options, searchConfigKeys);
@@ -287,6 +288,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 additional_registry_cases: self.dataRegistryWorkflow() === "load_case" ?  self.additionalRegistryCases().map((query) => {
                     return query.caseIdXpath();
                 }) : [],
+                expand_id_property: self.expandIdProperty(),
             };
         };
 

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -50,6 +50,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
                     dataRegistry: options.data_registry,
                     dataRegistryWorkflow: options.data_registry_workflow,
                     additionalRegistryCases: options.additional_registry_cases,
+                    expandIdProperty: options.expand_id_property,
                 });
 
                 var $list_home = $("#" + detail.type + "-detail-screen-config-tab");

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -50,7 +50,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
                     dataRegistry: options.data_registry,
                     dataRegistryWorkflow: options.data_registry_workflow,
                     additionalRegistryCases: options.additional_registry_cases,
-                    expandIdProperty: options.expand_id_property,
+                    customRelatedCaseProperty: options.custom_related_case_property,
                 });
 
                 var $list_home = $("#" + detail.type + "-detail-screen-config-tab");

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -50,7 +50,7 @@ from corehq.apps.app_manager.xpath import (
 from corehq.apps.case_search.const import COMMCARE_PROJECT, EXCLUDE_RELATED_CASES_FILTER
 from corehq.apps.case_search.models import (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
-    CASE_SEARCH_EXPAND_ID_PROPERTY_KEY,
+    CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY,
     CASE_SEARCH_REGISTRY_ID_KEY,
 )
 from corehq.util.timer import time_method
@@ -222,11 +222,11 @@ class RemoteRequestFactory(object):
                     ref=f"'{self.module.search_config.data_registry}'",
                 )
             )
-        if self.module.search_config.expand_id_property:
+        if self.module.search_config.custom_related_case_property:
             datums.append(
                 QueryData(
-                    key=CASE_SEARCH_EXPAND_ID_PROPERTY_KEY,
-                    ref=f"'{self.module.search_config.expand_id_property}'",
+                    key=CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY,
+                    ref=f"'{self.module.search_config.custom_related_case_property}'",
                 )
             )
         return datums

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -308,14 +308,14 @@
               </div>
           </div>
           <div class="form-group">
-              <label for="expand-id-property" class="{% css_label_class %} control-label">
+              <label for="custom-related-case-property" class="{% css_label_class %} control-label">
                   {% trans "Custom related case ID property to include" %}
               </label>
               <div class="{% css_field_class %}">
-                  <input id="expand-id-property"
+                  <input id="custom-related-case-property"
                          type="text"
                          class="form-control"
-                         data-bind="value: expandIdProperty"/>
+                         data-bind="value: customRelatedCaseProperty"/>
               </div>
           </div>
           {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -307,6 +307,8 @@
                   </button>
               </div>
           </div>
+          {% endif %}
+          {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
           <div class="form-group">
               <label for="custom-related-case-property" class="{% css_label_class %} control-label">
                   {% trans "Custom related case ID property to include" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -311,7 +311,15 @@
           {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
           <div class="form-group">
               <label for="custom-related-case-property" class="{% css_label_class %} control-label">
-                  {% trans "Custom related case ID property to include" %}
+                  {% trans "Case property with additional case id to add to results" %}
+                  <span class="hq-help-template" data-title="{% trans "Custom Related Case Property" %}"
+                        data-content="{% blocktrans %}
+                               Enter in the name of a case property that contains the ID of another
+                               case you'd like included in the results instance.  This is to allow
+                               you to configure your case list display to show properties of that
+                               related case.
+                        {% endblocktrans %}">
+                  </span>
               </label>
               <div class="{% css_field_class %}">
                   <input id="custom-related-case-property"

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -307,6 +307,17 @@
                   </button>
               </div>
           </div>
+          <div class="form-group">
+              <label for="expand-id-property" class="{% css_label_class %} control-label">
+                  {% trans "Custom related case ID property to include" %}
+              </label>
+              <div class="{% css_field_class %}">
+                  <input id="expand-id-property"
+                         type="text"
+                         class="form-control"
+                         data-bind="value: expandIdProperty"/>
+              </div>
+          </div>
           {% endif %}
           <span class="hide" id="searchFilterXpathErrorHtml">
             {% blocktrans %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -317,7 +317,8 @@
                                Enter in the name of a case property that contains the ID of another
                                case you'd like included in the results instance.  This is to allow
                                you to configure your case list display to show properties of that
-                               related case.
+                               related case. Read more on the
+                                <a href='https://confluence.dimagi.com/display/USH/Case+Search+Configuration'>Help Site</a>.
                         {% endblocktrans %}">
                   </span>
               </label>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -399,16 +399,16 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         suite = self.app.create_suite()
         self.assertXmlPartialEqual(self.get_xml('search_config_default_only'), suite, "./remote-request[1]")
 
-    def test_expand_id_property(self, *args):
-        self.module.search_config.expand_id_property = "potential_duplicate_id"
+    def test_custom_related_case_property(self, *args):
+        self.module.search_config.custom_related_case_property = "potential_duplicate_id"
         suite = self.app.create_suite()
 
         expected = """
         <partial>
-          <data key="x_commcare_expand_id_property" ref="'potential_duplicate_id'"/>
+          <data key="x_commcare_custom_related_case_property" ref="'potential_duplicate_id'"/>
         </partial>
         """
-        xpath = "./remote-request[1]/session/query/data[@key='x_commcare_expand_id_property']"
+        xpath = "./remote-request[1]/session/query/data[@key='x_commcare_custom_related_case_property']"
         self.assertXmlPartialEqual(expected, suite, xpath)
 
     def test_blacklisted_owner_ids(self, *args):

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -244,6 +244,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
             'data_registry': module.search_config.data_registry,
             'data_registry_workflow': module.search_config.data_registry_workflow,
             'additional_registry_cases': module.search_config.additional_registry_cases,
+            'expand_id_property': module.search_config.expand_id_property,
         },
     }
     if toggles.CASE_DETAIL_PRINT.enabled(app.domain):
@@ -1258,6 +1259,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
                 data_registry=data_registry_slug,
                 data_registry_workflow=data_registry_workflow,
                 additional_registry_cases=additional_registry_cases,
+                expand_id_property=search_properties.get('expand_id_property', ""),
             )
 
     resp = {}

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -244,7 +244,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
             'data_registry': module.search_config.data_registry,
             'data_registry_workflow': module.search_config.data_registry_workflow,
             'additional_registry_cases': module.search_config.additional_registry_cases,
-            'expand_id_property': module.search_config.expand_id_property,
+            'custom_related_case_property': module.search_config.custom_related_case_property,
         },
     }
     if toggles.CASE_DETAIL_PRINT.enabled(app.domain):
@@ -1259,7 +1259,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
                 data_registry=data_registry_slug,
                 data_registry_workflow=data_registry_workflow,
                 additional_registry_cases=additional_registry_cases,
-                expand_id_property=search_properties.get('expand_id_property', ""),
+                custom_related_case_property=search_properties.get('custom_related_case_property', ""),
             )
 
     resp = {}

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -18,10 +18,10 @@ CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY = 'commcare_blacklisted_owner_ids'
 CASE_SEARCH_XPATH_QUERY_KEY = '_xpath_query'
 CONFIG_KEY_PREFIX = "x_commcare_"
 CASE_SEARCH_REGISTRY_ID_KEY = f'{CONFIG_KEY_PREFIX}data_registry'
-CASE_SEARCH_EXPAND_ID_PROPERTY_KEY = f'{CONFIG_KEY_PREFIX}expand_id_property'
+CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY = f'{CONFIG_KEY_PREFIX}custom_related_case_property'
 CONFIG_KEYS = (
     CASE_SEARCH_REGISTRY_ID_KEY,
-    CASE_SEARCH_EXPAND_ID_PROPERTY_KEY
+    CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY
 )
 LEGACY_CONFIG_KEYS = {
     CASE_SEARCH_REGISTRY_ID_KEY: "commcare_registry"
@@ -36,7 +36,7 @@ UNSEARCHABLE_KEYS = (
 @attr.s(frozen=True)
 class CaseSearchRequestConfig:
     data_registry = attr.ib(kw_only=True, default=None)
-    expand_id_property = attr.ib(kw_only=True, default=None)
+    custom_related_case_property = attr.ib(kw_only=True, default=None)
 
 
 def extract_search_request_config(search_criteria):

--- a/corehq/apps/case_search/tests/test_models.py
+++ b/corehq/apps/case_search/tests/test_models.py
@@ -6,7 +6,7 @@ from testil import assert_raises, eq
 
 from corehq.apps.case_search.exceptions import CaseSearchUserError
 from corehq.apps.case_search.models import (
-    CASE_SEARCH_EXPAND_ID_PROPERTY_KEY,
+    CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY,
     CASE_SEARCH_REGISTRY_ID_KEY,
     CaseSearchRequestConfig,
     disable_case_search,
@@ -47,15 +47,15 @@ class TestCaseSearch(TestCase):
     (None, ["dupe_id"], True),  # disallow list
     (["reg1"], None, True),  # disallow list
 ])
-def test_extract_criteria_config(self, data_registry, expand_id_property, expect_exception):
+def test_extract_criteria_config(self, data_registry, custom_related_case_property, expect_exception):
     with assert_raises(None if not expect_exception else CaseSearchUserError):
         config = extract_search_request_config({
             CASE_SEARCH_REGISTRY_ID_KEY: data_registry,
-            CASE_SEARCH_EXPAND_ID_PROPERTY_KEY: expand_id_property,
+            CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY: custom_related_case_property,
             "other_key": "jim",
             "case_type": "bob"
         })
-        eq(config, CaseSearchRequestConfig(data_registry=data_registry, expand_id_property=expand_id_property))
+        eq(config, CaseSearchRequestConfig(data_registry=data_registry, custom_related_case_property=custom_related_case_property))
 
 
 def test_extract_criteria_config_legacy():

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -79,7 +79,7 @@ def get_case_search_results(domain, criteria, app_id=None, couch_user=None):
 
     cases = [helper.wrap_case(hit, include_score=True) for hit in hits]
     if app_id:
-        cases.extend(get_related_cases(helper, app_id, case_types, cases, config.expand_id_property))
+        cases.extend(get_related_cases(helper, app_id, case_types, cases, config.custom_related_case_property))
     return cases
 
 
@@ -263,7 +263,7 @@ class CaseSearchCriteria:
         ]
 
 
-def get_related_cases(helper, app_id, case_types, cases, expand_id_property):
+def get_related_cases(helper, app_id, case_types, cases, custom_related_case_property):
     """
     Fetch related cases that are necessary to display any related-case
     properties in the app requesting this case search.
@@ -284,8 +284,8 @@ def get_related_cases(helper, app_id, case_types, cases, expand_id_property):
     ]
 
     expanded_case_results = []
-    if expand_id_property:
-        expanded_case_results.extend(get_expanded_case_results(helper, expand_id_property, cases))
+    if custom_related_case_property:
+        expanded_case_results.extend(get_expanded_case_results(helper, custom_related_case_property, cases))
 
     results = expanded_case_results
     top_level_cases = cases + expanded_case_results
@@ -375,9 +375,9 @@ def get_child_case_results(helper, parent_cases, case_types):
     return [helper.wrap_case(result, is_related_case=True) for result in results]
 
 
-def get_expanded_case_results(helper, expand_id_property, cases):
+def get_expanded_case_results(helper, custom_related_case_property, cases):
     expanded_case_ids = {
-        case.get_case_property(expand_id_property, dynamic_only=True) for case in cases
+        case.get_case_property(custom_related_case_property, dynamic_only=True) for case in cases
     }
     expanded_case_ids -= {None, ""}
     return _get_case_search_cases(helper, expanded_case_ids)

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -571,7 +571,7 @@ class TestCaseSearchLookups(TestCase):
 
     def test_get_related_case_results_expanded_results(self):
         """Test that `get_related_cases` includes related cases for cases loaded
-        via the 'expand_id_property'."""
+        via the 'custom_related_case_property'."""
 
         # Search for case type 'a'
         # - initial results a[1-4]


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-1445
https://dimagi-dev.atlassian.net/browse/USH-1431
This PR builds on the work of https://github.com/dimagi/commcare-hq/pull/30834 and https://github.com/dimagi/commcare-hq/pull/30838.  Neither of those contain user-facing elements, so they are merged already.  This PR is the main gate into that functionality.  It adds a new setting to the case list configuration, hidden behind the data registry feature flag

![image](https://user-images.githubusercontent.com/2367539/145636119-28b7bc1b-df0e-4680-8922-fb58dc5daf56.png)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
USH: Allow data registry repeater to be setup to update cases in other domains

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-3754

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change