### PR TITLE
related case lookup fixups

### DIFF
--- a/corehq/apps/ota/tests/test_registry_case_details.py
+++ b/corehq/apps/ota/tests/test_registry_case_details.py
@@ -124,6 +124,17 @@ class RegistryCaseDetailsTests(TestCase):
         expected_cases = {case.case_id: case for case in self.cases}
         self.assertEqual(set(actual_cases), set(expected_cases))
 
+    def test_get_case_details_post_request_legacy_param(self):
+        response_content = self._make_request({
+            "commcare_registry": self.registry.slug,
+            "case_id": self.parent_case_id,
+            "case_type": "parent",
+        }, 200, method="post")
+        actual_cases = self._get_cases_in_response(response_content)
+        expected_cases = {case.case_id: case for case in self.cases}
+        self.assertEqual(set(actual_cases), set(expected_cases))
+
+
     def test_get_case_details_missing_case(self):
         self._make_request({
             CASE_SEARCH_REGISTRY_ID_KEY: self.registry.slug, "case_id": "missing", "case_type": "parent",

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -419,6 +419,9 @@ def registry_case(request, domain, app_id):
     case_ids = request_dict.getlist("case_id")
     case_types = request_dict.getlist("case_type")
     registry = request_dict.get(CASE_SEARCH_REGISTRY_ID_KEY)
+    if not registry:
+        # legacy name
+        registry = request_dict.get("commcare_registry")
 
     missing = [
         name


### PR DESCRIPTION
## Technical Summary
* Support legacy param name in `registry_case` view

## Feature Flag
data registry

## Safety Assurance

### Safety story
Small changes covered by tests that only impacts the data registry feature flag

### Automated test coverage
Updated

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
