### PR TITLE
Remove references to linked_projects privilege

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -124,7 +124,6 @@ advanced_v0 = pro_v1 + [
 enterprise_v0 = advanced_v0 + [
     privileges.GEOCODER,
     privileges.DEFAULT_EXPORT_SETTINGS,
-    privileges.LINKED_PROJECTS,
 ]
 
 enterprise_v1 = enterprise_v0 + [

--- a/corehq/apps/accounting/migrations/0055_linked_projects.py
+++ b/corehq/apps/accounting/migrations/0055_linked_projects.py
@@ -2,15 +2,13 @@ from django.db import migrations
 from django.core.management import call_command
 from corehq.util.django_migrations import skip_on_fresh_install
 
-from corehq.privileges import LINKED_PROJECTS
-
 
 @skip_on_fresh_install
 def _grandfather_basic_privs(apps, schema_editor):
     call_command('cchq_prbac_bootstrap')
     call_command(
         'cchq_prbac_grandfather_privs',
-        LINKED_PROJECTS,
+        'linked_projects',
         skip_edition='Paused,Community,Standard,Pro,Advanced',
         noinput=True,
     )

--- a/corehq/apps/accounting/migrations/0058_delete_linked_projects_role.py
+++ b/corehq/apps/accounting/migrations/0058_delete_linked_projects_role.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+from django.core.management import call_command
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _revoke_linked_project_priv(apps, schema_editor):
+    call_command(
+        'cchq_prbac_revoke_privs',
+        'linked_projects',
+        delete_privs=True,
+        noinput=True,
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('accounting', '0057_add_sms_report_toggle'),
+    ]
+
+    operations = [
+        migrations.RunPython(_revoke_linked_project_priv),
+    ]

--- a/corehq/apps/accounting/migrations/0058_delete_linked_projects_role.py
+++ b/corehq/apps/accounting/migrations/0058_delete_linked_projects_role.py
@@ -9,6 +9,7 @@ def _revoke_linked_project_priv(apps, schema_editor):
         'cchq_prbac_revoke_privs',
         'linked_projects',
         delete_privs=True,
+        check_privs_exist=False,
         noinput=True,
     )
 

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -169,9 +169,6 @@ class Command(BaseCommand):
         Role(slug=privileges.DEFAULT_EXPORT_SETTINGS,
              name='Default Export Settings',
              description='Allows ability to set default values for newly created exports.'),
-        Role(slug=privileges.LINKED_PROJECTS,
-             name='Linked Projects',
-             description='Allows admin users to push and/or pull content between linked projects.'),
         Role(slug=privileges.RELEASE_MANAGEMENT,
              name='Release Management',
              description='Allows access to features that help manage releases between projects, like the linked '

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_revoke_privs.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_revoke_privs.py
@@ -71,13 +71,17 @@ class Command(BaseCommand):
                 )
                 return
             for priv in privs:
-                if not dry_run:
+                try:
                     role_to_delete = Role.objects.get(slug=priv)
-                    role_to_delete.delete()
-                logger.info(
-                    f"{dry_run_tag}Deleted role for privilege {priv} from database. To ensure the role is not "
-                    f"recreated, remove remaining references in the codebase."
-                )
+                    if not dry_run:
+                        role_to_delete.delete()
+                except Role.DoesNotExist:
+                    logger.warning(f"{dry_run_tag}Role for privilege {priv} does not exist. Nothing to delete.")
+                else:
+                    logger.info(
+                        f"{dry_run_tag}Deleted role for privilege {priv} from database. To ensure the role is not "
+                        f"recreated, remove remaining references in the codebase."
+                    )
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_revoke_privs.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_revoke_privs.py
@@ -20,6 +20,7 @@ class Command(BaseCommand):
         noinput = kwargs.get('noinput')
         skip_edition = kwargs.get('skip_edition')
         delete_revoked_privs = kwargs.get('delete_privs')
+        check_privs_exist = kwargs.get('check_privs_exist')
 
         logger.setLevel(logging.INFO if verbose else logging.WARNING)
         dry_run_tag = "[DRY RUN] " if dry_run else ""
@@ -55,7 +56,7 @@ class Command(BaseCommand):
             logger.error('Aborting')
             return
 
-        if not all(priv in MAX_PRIVILEGES for priv in privs):
+        if check_privs_exist and not all(priv in MAX_PRIVILEGES for priv in privs):
             logger.error('Not all specified privileges are valid: {}'.format(', '.join(privs)))
             return
 
@@ -119,4 +120,10 @@ class Command(BaseCommand):
             action='store_true',
             default=False,
             help='If privilege has been revoked for all plans, delete the Role object associated with it'
+        ),
+        parser.add_argument(
+            '--check-privs-exist',
+            action='store_true',
+            default=True,
+            help='Ensure all privileges are valid before attempting to revoke.'
         )

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -81,8 +81,6 @@ APP_USER_PROFILES = 'app_user_profiles'
 
 DEFAULT_EXPORT_SETTINGS = 'default_export_settings'
 
-LINKED_PROJECTS = 'linked_projects'
-
 RELEASE_MANAGEMENT = 'release_management'
 
 MAX_PRIVILEGES = [
@@ -129,7 +127,6 @@ MAX_PRIVILEGES = [
     APP_USER_PROFILES,
     GEOCODER,
     DEFAULT_EXPORT_SETTINGS,
-    LINKED_PROJECTS,
     RELEASE_MANAGEMENT,
 ]
 
@@ -187,6 +184,5 @@ class Titles(object):
             APP_USER_PROFILES: _("App User Profiles"),
             GEOCODER: _("Geocoder"),
             DEFAULT_EXPORT_SETTINGS: _("Default Export Settings"),
-            LINKED_PROJECTS: _("Linked Projects"),
             RELEASE_MANAGEMENT: _("Release Management"),
         }.get(privilege, privilege)

--- a/migrations.lock
+++ b/migrations.lock
@@ -65,6 +65,7 @@ accounting
  0055_linked_projects
  0056_add_release_management
  0057_add_sms_report_toggle
+ 0058_delete_linked_projects_role
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SS-246)

I added this privilege a few months ago, only to quickly realize I would not be using it. We didn't have a great process for removing privileges, so [this PR](https://github.com/dimagi/commcare-hq/pull/30075) was created to provide a management command for this purpose. Now that the command is merged, I can run that and remove references to this privilege in HQ.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The previously mentioned PR handles removing the Role and associated Grants from the database, 
but we still need to ensure references to this role are removed. That's all this PR does. 

I replaced the `LINKED_PROJECTS` variable with the hardcoded slug string to avoid having to delete migrations.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally, and on staging.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

Reverting this PR increases the likelihood that the `linked_projects` role is recreated. This isn't a showstopper because this role isn't depended on in any context. We just need to ensure we run the associated migration that deletes this role at some point.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
