### PR TITLE
Does not error it if request includes registry LEGACY_CONFIG_KEYS

### DIFF
--- a/corehq/apps/ota/tests/test_registry_case_details.py
+++ b/corehq/apps/ota/tests/test_registry_case_details.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseIndex
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.case_search.const import COMMCARE_PROJECT
-from corehq.apps.case_search.models import CASE_SEARCH_REGISTRY_ID_KEY
+from corehq.apps.case_search.models import CASE_SEARCH_REGISTRY_ID_KEY, LEGACY_CONFIG_KEYS
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.registry.helper import DataRegistryHelper
@@ -133,6 +133,12 @@ class RegistryCaseDetailsTests(TestCase):
         self._make_request({
             CASE_SEARCH_REGISTRY_ID_KEY: "not-a-registry", "case_id": self.parent_case_id, "case_type": "parent",
         }, 404)
+
+    def test_legacy_registry_param(self):
+        self._make_request({
+            LEGACY_CONFIG_KEYS[CASE_SEARCH_REGISTRY_ID_KEY]: self.registry.slug, "case_id": self.parent_case_id,
+            "case_type": "parent",
+        }, 200)
 
     def _make_request(self, params, expected_response_code, method="get"):
         request_method = {

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -41,7 +41,7 @@ from corehq.apps.app_manager.models import GlobalAppConfig
 from corehq.apps.builds.utils import get_default_build_spec
 from corehq.apps.case_search.const import COMMCARE_PROJECT
 from corehq.apps.case_search.exceptions import CaseSearchUserError
-from corehq.apps.case_search.models import CASE_SEARCH_REGISTRY_ID_KEY
+from corehq.apps.case_search.models import CASE_SEARCH_REGISTRY_ID_KEY, LEGACY_CONFIG_KEYS
 from corehq.apps.case_search.utils import get_case_search_results
 from corehq.apps.domain.auth import formplayer_auth
 from corehq.apps.domain.decorators import check_domain_migration
@@ -419,6 +419,8 @@ def registry_case(request, domain, app_id):
     case_ids = request_dict.getlist("case_id")
     case_types = request_dict.getlist("case_type")
     registry = request_dict.get(CASE_SEARCH_REGISTRY_ID_KEY)
+    if registry is None:
+        registry = request_dict.get(LEGACY_CONFIG_KEYS[CASE_SEARCH_REGISTRY_ID_KEY])
 
     missing = [
         name


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
found in [QA](https://dimagi-dev.atlassian.net/browse/QA-3754)
followup to https://github.com/dimagi/commcare-hq/pull/30838

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
tested locally, added new test, and being verified by QA

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
added test for this edge case

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
to be verified by QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
