### PR TITLE
exclude related cases from query results

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -38,6 +38,7 @@ from corehq.apps.app_manager.xpath import (
     interpolate_xpath,
     session_var,
 )
+from corehq.apps.case_search.const import EXCLUDE_RELATED_CASES_FILTER
 from corehq.apps.case_search.models import CASE_SEARCH_REGISTRY_ID_KEY
 from corehq.util.timer import time_method
 from corehq.util.view_utils import absolute_reverse
@@ -503,6 +504,7 @@ class EntriesHelper(object):
             instance_name, root_element = "casedb", "casedb"
             if module_loads_registry_case(detail_module):
                 instance_name, root_element = "results", "results"
+                filter_xpath += EXCLUDE_RELATED_CASES_FILTER
 
             nodeset = EntriesHelper._get_nodeset_xpath(
                 instance_name, root_element,

--- a/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
@@ -30,7 +30,7 @@
               </itemset>
             </prompt>
           </query>
-          <datum detail-confirm="m0_case_long" detail-select="m0_case_short" id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open']" value="./@case_id"/>
+          <datum detail-confirm="m0_case_long" detail-select="m0_case_short" id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]" value="./@case_id"/>
           <query default_search="true" storage-instance="registry" template="case" url="http://localhost:8000/a/test_domain/phone/registry_case/123/">
             <data key="x_commcare_data_registry" ref="'myregistry'"/>
             <data key="case_type" ref="'case'"/>

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -111,7 +111,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 </itemset>
               </prompt>
             </query>
-            <datum id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open']"
+            <datum id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
                 value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
             <query url="http://localhost:8000/a/test_domain/phone/registry_case/123/"
                 storage-instance="registry" template="case" default_search="true">


### PR DESCRIPTION
## Product Description
Exclude related cases from the being displayed in the case list when using data registry case search.

## Technical Summary
Apply the change from https://github.com/dimagi/commcare-hq/pull/30323 to the nodesets for data registry detail screens.

## Feature Flag
DATA REGISTRY

## Safety Assurance

### Safety story
Only impacts apps using data registries.

### Automated test coverage
Updated

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
