### PR TITLE
Re-implement removing pickling from messaging module

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -8,6 +8,8 @@ from django.utils.translation import ungettext
 
 from couchdbkit import ResourceConflict
 
+from dimagi.utils.parsing import json_format_date
+
 from corehq import privileges
 from corehq.apps.accounting.utils import get_privileges, log_accounting_error
 from corehq.apps.cloudcare.dbaccessors import get_cloudcare_apps
@@ -20,10 +22,10 @@ from corehq.apps.userreports.exceptions import (
 )
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.role_utils import (
-    get_custom_roles_for_domain,
     archive_custom_roles_for_domain,
-    unarchive_roles_for_domain,
+    get_custom_roles_for_domain,
     reset_initial_roles_for_domain,
+    unarchive_roles_for_domain,
 )
 from corehq.const import USER_DATE_FORMAT
 from corehq.messaging.scheduling.models import (
@@ -130,7 +132,7 @@ def get_refresh_timed_schedule_instances_call(broadcast):
         refresh_timed_schedule_instances.delay(
             broadcast.schedule_id,
             broadcast.recipients,
-            start_date=broadcast.start_date
+            start_date=json_format_date(broadcast.start_date)
         )
 
     return refresh
@@ -307,14 +309,19 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
 
     @staticmethod
     def response_practice_mobile_workers(project, new_plan_version):
-        from corehq.apps.app_manager.views.utils import unset_practice_mode_configured_apps
+        from corehq.apps.app_manager.views.utils import (
+            unset_practice_mode_configured_apps,
+        )
         unset_practice_mode_configured_apps(project.name)
 
     @staticmethod
     def response_mobile_worker_creation(domain, new_plan_version):
         """ Deactivates users if there are too many for a community plan """
         from corehq.apps.accounting.models import (
-            DefaultProductPlan, FeatureType, UNLIMITED_FEATURE_USAGE)
+            UNLIMITED_FEATURE_USAGE,
+            DefaultProductPlan,
+            FeatureType,
+        )
 
         # checks for community plan
         if (new_plan_version != DefaultProductPlan.get_default_plan_version()):
@@ -584,7 +591,11 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         """
         Get the allowed number of mobile workers based on plan version.
         """
-        from corehq.apps.accounting.models import FeatureType, FeatureRate, UNLIMITED_FEATURE_USAGE
+        from corehq.apps.accounting.models import (
+            UNLIMITED_FEATURE_USAGE,
+            FeatureRate,
+            FeatureType,
+        )
         num_users = CommCareUser.total_by_domain(self.domain.name, is_active=True)
         try:
             user_rate = self.new_plan_version.feature_rates.filter(
@@ -684,8 +695,8 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         in the future.
         """
         from corehq.apps.accounting.models import (
-            Subscription,
             SoftwarePlanEdition,
+            Subscription,
         )
         later_subs = Subscription.visible_objects.filter(
             subscriber__domain=self.domain.name,
@@ -771,7 +782,9 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
 
     @staticmethod
     def response_practice_mobile_workers(project, new_plan_version):
-        from corehq.apps.app_manager.views.utils import get_practice_mode_configured_apps
+        from corehq.apps.app_manager.views.utils import (
+            get_practice_mode_configured_apps,
+        )
         apps = get_practice_mode_configured_apps(project.name)
         if not apps:
             return None

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -5,6 +5,8 @@ from django.test import SimpleTestCase, TransactionTestCase
 
 from unittest.mock import Mock, call, patch
 
+from dimagi.utils.parsing import json_format_date
+
 from corehq.apps.accounting.exceptions import SubscriptionAdjustmentError
 from corehq.apps.accounting.models import (
     BillingAccount,
@@ -389,7 +391,11 @@ class DeactivateScheduleTest(TransactionTestCase):
             self.assertEqual(p1.call_count, 2)
             p1.assert_has_calls(
                 [
-                    call(broadcast.schedule_id, broadcast.recipients, start_date=broadcast.start_date)
+                    call(
+                        broadcast.schedule_id,
+                        broadcast.recipients,
+                        start_date=json_format_date(broadcast.start_date)
+                    )
                     for broadcast in (self.domain_1_sms_schedules[0], self.domain_1_survey_schedules[0])
                 ],
                 any_order=True
@@ -431,7 +437,7 @@ class DeactivateScheduleTest(TransactionTestCase):
             _deactivate_schedules(self.domain_obj_1, survey_only=True)
 
             b = self.domain_1_survey_schedules[0]
-            p1.assert_called_once_with(b.schedule_id, b.recipients, start_date=b.start_date)
+            p1.assert_called_once_with(b.schedule_id, b.recipients, start_date=json_format_date(b.start_date))
 
             b = self.domain_1_survey_schedules[1]
             p2.assert_called_once_with(b.schedule_id, b.recipients)

--- a/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
+++ b/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
@@ -427,7 +427,7 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
 
             # Send the first event, and schedule the next event for the next day
             utcnow_patch.return_value = datetime(2018, 7, 1, 13, 1)
-            handle_case_timed_schedule_instance(case.case_id, instance.schedule_instance_id, self.domain)
+            handle_case_timed_schedule_instance(case.case_id, instance.schedule_instance_id.hex, self.domain)
             self.assertEqual(send_patch.call_count, 1)
 
             [instance] = get_case_timed_schedule_instances_for_schedule(case.case_id, schedule)
@@ -445,7 +445,7 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
 
             # Send the second event, and deactivate because the stop date has been reached
             utcnow_patch.return_value = datetime(2018, 7, 2, 13, 1)
-            handle_case_timed_schedule_instance(case.case_id, instance.schedule_instance_id, self.domain)
+            handle_case_timed_schedule_instance(case.case_id, instance.schedule_instance_id.hex, self.domain)
             self.assertEqual(send_patch.call_count, 2)
 
             [instance] = get_case_timed_schedule_instances_for_schedule(case.case_id, schedule)

--- a/corehq/messaging/management/commands/queue_schedule_instances.py
+++ b/corehq/messaging/management/commands/queue_schedule_instances.py
@@ -75,7 +75,7 @@ class Command(BaseCommand):
                 # that we only retry non-processed schedule instances once an hour.
                 enqueue_lock = self.get_enqueue_lock(cls, schedule_instance_id, next_event_due)
                 if enqueue_lock.acquire(blocking=False):
-                    self.get_task(cls).delay(schedule_instance_id, domain)
+                    self.get_task(cls).delay(schedule_instance_id.hex, domain)
 
         for cls in (CaseAlertScheduleInstance, CaseTimedScheduleInstance):
             for domain, case_id, schedule_instance_id, next_event_due in get_active_case_schedule_instance_ids(
@@ -86,7 +86,7 @@ class Command(BaseCommand):
                 # See comment above about why we use a non-blocking lock here.
                 enqueue_lock = self.get_enqueue_lock(cls, schedule_instance_id, next_event_due)
                 if enqueue_lock.acquire(blocking=False):
-                    self.get_task(cls).delay(case_id, schedule_instance_id, domain)
+                    self.get_task(cls).delay(case_id, schedule_instance_id.hex, domain)
 
     def handle(self, **options):
         while True:

--- a/corehq/messaging/scheduling/tasks.py
+++ b/corehq/messaging/scheduling/tasks.py
@@ -1,39 +1,44 @@
+from datetime import datetime
+
+from django.conf import settings
+
 from celery.task import task
+
+from dimagi.utils.couch import CriticalSection
+
 from corehq.messaging.scheduling.models import (
+    AlertSchedule,
     ImmediateBroadcast,
     ScheduledBroadcast,
-    AlertSchedule,
     TimedSchedule,
-)
-from corehq.messaging.scheduling.scheduling_partitioned.models import (
-    AlertScheduleInstance,
-    TimedScheduleInstance,
-    CaseAlertScheduleInstance,
-    CaseTimedScheduleInstance,
-    CaseScheduleInstanceMixin,
 )
 from corehq.messaging.scheduling.scheduling_partitioned.dbaccessors import (
     delete_alert_schedule_instance,
-    delete_timed_schedule_instance,
-    get_alert_schedule_instances_for_schedule,
-    get_timed_schedule_instances_for_schedule,
-    get_alert_schedule_instance,
-    save_alert_schedule_instance,
-    get_timed_schedule_instance,
-    save_timed_schedule_instance,
-    get_case_alert_schedule_instances_for_schedule,
-    get_case_timed_schedule_instances_for_schedule,
-    get_case_schedule_instance,
-    save_case_schedule_instance,
-    delete_case_schedule_instance,
     delete_alert_schedule_instances_for_schedule,
-    delete_timed_schedule_instances_for_schedule,
+    delete_case_schedule_instance,
     delete_schedule_instances_by_case_id,
+    delete_timed_schedule_instance,
+    delete_timed_schedule_instances_for_schedule,
+    get_alert_schedule_instance,
+    get_alert_schedule_instances_for_schedule,
+    get_case_alert_schedule_instances_for_schedule,
+    get_case_schedule_instance,
+    get_case_timed_schedule_instances_for_schedule,
+    get_timed_schedule_instance,
+    get_timed_schedule_instances_for_schedule,
+    save_alert_schedule_instance,
+    save_case_schedule_instance,
+    save_timed_schedule_instance,
+)
+from corehq.messaging.scheduling.scheduling_partitioned.models import (
+    AlertScheduleInstance,
+    CaseAlertScheduleInstance,
+    CaseScheduleInstanceMixin,
+    CaseTimedScheduleInstance,
+    TimedScheduleInstance,
 )
 from corehq.util.celery_utils import no_result_task
-from datetime import datetime
-from dimagi.utils.couch import CriticalSection
-from django.conf import settings
+from corehq.util.dates import iso_string_to_date
 
 
 class ScheduleInstanceRefresher(object):
@@ -286,7 +291,7 @@ class CaseTimedScheduleInstanceRefresher(ScheduleInstanceRefresher):
         return False
 
 
-@task(serializer='pickle', queue=settings.CELERY_REMINDER_RULE_QUEUE, ignore_result=True)
+@task(queue=settings.CELERY_REMINDER_RULE_QUEUE, ignore_result=True)
 def refresh_alert_schedule_instances(schedule_id, recipients):
     """
     :param schedule_id: the AlertSchedule schedule_id
@@ -302,14 +307,15 @@ def refresh_alert_schedule_instances(schedule_id, recipients):
         ).refresh()
 
 
-@task(serializer='pickle', queue=settings.CELERY_REMINDER_RULE_QUEUE, ignore_result=True)
-def refresh_timed_schedule_instances(schedule_id, recipients, start_date=None):
+@task(queue=settings.CELERY_REMINDER_RULE_QUEUE, ignore_result=True)
+def refresh_timed_schedule_instances(schedule_id, recipients, start_date_iso_string=None):
     """
     :param schedule_id: the TimedSchedule schedule_id
-    :param start_date: the date to start the TimedSchedule
     :param recipients: a list of (recipient_type, recipient_id) tuples; the
     recipient type should be one of the values checked in ScheduleInstance.recipient
+    :param start_date_iso_string: the date to start the TimedSchedule formatted as an iso string
     """
+    start_date = iso_string_to_date(start_date_iso_string) if start_date_iso_string else None
     with CriticalSection(['refresh-timed-schedule-instances-for-%s' % schedule_id.hex], timeout=5 * 60):
         schedule = TimedSchedule.objects.get(schedule_id=schedule_id)
         TimedScheduleInstanceRefresher(
@@ -320,7 +326,7 @@ def refresh_timed_schedule_instances(schedule_id, recipients, start_date=None):
         ).refresh()
 
 
-@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_RULE_QUEUE, acks_late=True,
+@no_result_task(queue=settings.CELERY_REMINDER_RULE_QUEUE, acks_late=True,
                 default_retry_delay=60 * 60, max_retries=24, bind=True)
 def delete_alert_schedule_instances(self, schedule_id):
     """
@@ -333,7 +339,7 @@ def delete_alert_schedule_instances(self, schedule_id):
         self.retry(exc=e)
 
 
-@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_RULE_QUEUE, acks_late=True,
+@no_result_task(queue=settings.CELERY_REMINDER_RULE_QUEUE, acks_late=True,
                 default_retry_delay=60 * 60, max_retries=24, bind=True)
 def delete_timed_schedule_instances(self, schedule_id):
     """
@@ -346,7 +352,7 @@ def delete_timed_schedule_instances(self, schedule_id):
         self.retry(exc=e)
 
 
-@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_RULE_QUEUE, acks_late=True,
+@no_result_task(queue=settings.CELERY_REMINDER_RULE_QUEUE, acks_late=True,
                 default_retry_delay=60 * 60, max_retries=24, bind=True)
 def delete_case_alert_schedule_instances(self, schedule_id):
     """
@@ -358,7 +364,7 @@ def delete_case_alert_schedule_instances(self, schedule_id):
         self.retry(exc=e)
 
 
-@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_RULE_QUEUE, acks_late=True,
+@no_result_task(queue=settings.CELERY_REMINDER_RULE_QUEUE, acks_late=True,
                 default_retry_delay=60 * 60, max_retries=24, bind=True)
 def delete_case_timed_schedule_instances(self, schedule_id):
     """
@@ -454,7 +460,7 @@ def update_broadcast_last_sent_timestamp(broadcast_class, schedule_id):
     broadcast_class.objects.filter(schedule_id=schedule_id).update(last_sent_timestamp=datetime.utcnow())
 
 
-@no_result_task(serializer='pickle', queue='reminder_queue')
+@no_result_task(queue='reminder_queue')
 def handle_alert_schedule_instance(schedule_instance_id, domain):
     with CriticalSection(['handle-alert-schedule-instance-%s' % schedule_instance_id.hex]):
         try:
@@ -466,7 +472,7 @@ def handle_alert_schedule_instance(schedule_instance_id, domain):
             update_broadcast_last_sent_timestamp(ImmediateBroadcast, instance.alert_schedule_id)
 
 
-@no_result_task(serializer='pickle', queue='reminder_queue')
+@no_result_task(queue='reminder_queue')
 def handle_timed_schedule_instance(schedule_instance_id, domain):
     with CriticalSection(['handle-timed-schedule-instance-%s' % schedule_instance_id.hex]):
         try:
@@ -478,8 +484,9 @@ def handle_timed_schedule_instance(schedule_instance_id, domain):
             update_broadcast_last_sent_timestamp(ScheduledBroadcast, instance.timed_schedule_id)
 
 
-@no_result_task(serializer='pickle', queue='reminder_queue')
+@no_result_task(queue='reminder_queue')
 def handle_case_alert_schedule_instance(case_id, schedule_instance_id, domain):
+
     # Use the same lock key as the tasks which refresh case schedule instances
     from corehq.messaging.tasks import get_sync_key
     with CriticalSection([get_sync_key(case_id)], timeout=5 * 60):
@@ -491,7 +498,7 @@ def handle_case_alert_schedule_instance(case_id, schedule_instance_id, domain):
         _handle_schedule_instance(instance, save_case_schedule_instance)
 
 
-@no_result_task(serializer='pickle', queue='reminder_queue')
+@no_result_task(queue='reminder_queue')
 def handle_case_timed_schedule_instance(case_id, schedule_instance_id, domain):
     # Use the same lock key as the tasks which refresh case schedule instances
     from corehq.messaging.tasks import get_sync_key
@@ -504,7 +511,7 @@ def handle_case_timed_schedule_instance(case_id, schedule_instance_id, domain):
         _handle_schedule_instance(instance, save_case_schedule_instance)
 
 
-@no_result_task(serializer='pickle', queue='background_queue', acks_late=True)
+@no_result_task(queue='background_queue', acks_late=True)
 def delete_schedule_instances_for_cases(domain, case_ids):
     for case_id in case_ids:
         delete_schedule_instances_by_case_id(domain, case_id)

--- a/corehq/messaging/scheduling/tests/test_schedules.py
+++ b/corehq/messaging/scheduling/tests/test_schedules.py
@@ -1,38 +1,42 @@
+from datetime import date, datetime, time
+
+from django.test import TestCase
+from unittest.mock import patch
+
 from casexml.apps.case.tests.util import create_case
+from dimagi.utils.parsing import json_format_date
+
 from corehq.apps.domain.models import Domain
+from corehq.apps.hqcase.utils import update_case
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.tests.utils import sharded
-from corehq.apps.hqcase.utils import update_case
-from corehq.messaging.scheduling.scheduling_partitioned.dbaccessors import (
-    save_alert_schedule_instance,
-    save_timed_schedule_instance,
-    delete_timed_schedule_instance,
-    get_alert_schedule_instances_for_schedule,
-    get_timed_schedule_instances_for_schedule,
-    delete_alert_schedule_instances_for_schedule,
-    delete_timed_schedule_instances_for_schedule,
-)
-from corehq.messaging.scheduling.scheduling_partitioned.models import (
-    AlertScheduleInstance,
-    TimedScheduleInstance,
-    CaseTimedScheduleInstance,
-)
 from corehq.messaging.scheduling.models import (
-    AlertSchedule,
     AlertEvent,
-    TimedSchedule,
-    TimedEvent,
+    AlertSchedule,
     CasePropertyTimedEvent,
     RandomTimedEvent,
     SMSContent,
+    TimedEvent,
+    TimedSchedule,
+)
+from corehq.messaging.scheduling.scheduling_partitioned.dbaccessors import (
+    delete_alert_schedule_instances_for_schedule,
+    delete_timed_schedule_instance,
+    delete_timed_schedule_instances_for_schedule,
+    get_alert_schedule_instances_for_schedule,
+    get_timed_schedule_instances_for_schedule,
+    save_alert_schedule_instance,
+    save_timed_schedule_instance,
+)
+from corehq.messaging.scheduling.scheduling_partitioned.models import (
+    AlertScheduleInstance,
+    CaseTimedScheduleInstance,
+    TimedScheduleInstance,
 )
 from corehq.messaging.scheduling.tasks import (
     refresh_alert_schedule_instances,
     refresh_timed_schedule_instances,
 )
-from datetime import datetime, date, time
-from django.test import TestCase
-from unittest.mock import patch
 
 
 class BaseScheduleTest(TestCase):
@@ -104,8 +108,9 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 16))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 16, 0), True, date(2017, 3, 16),
@@ -115,8 +120,9 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
         # Deactivate
         self.schedule.active = False
         self.schedule.save()
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 16))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 16, 0), False, date(2017, 3, 16),
@@ -129,8 +135,9 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 16))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 16, 0), False, date(2017, 3, 16),
@@ -141,8 +148,9 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
         self.schedule.active = True
         self.schedule.save()
         utcnow_patch.return_value = datetime(2017, 3, 16, 7, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 16))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 16, 0), True, date(2017, 3, 16),
@@ -155,8 +163,9 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 16))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 16, 0), False, date(2017, 3, 16),
@@ -167,8 +176,9 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
         self.schedule.active = True
         self.schedule.save()
         utcnow_patch.return_value = datetime(2017, 3, 16, 17, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 16))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 2, datetime(2017, 3, 17, 16, 0), True, date(2017, 3, 16),
@@ -181,8 +191,9 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 16))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 16, 0), False, date(2017, 3, 16),
@@ -199,7 +210,7 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
         utcnow_patch.return_value = datetime(2017, 4, 1, 17, 0)
         for i in range(2):
             refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-                date(2017, 3, 16))
+                                             json_format_date(date(2017, 3, 16)))
             self.assertNumInstancesForSchedule(1)
             [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
             self.assertTimedScheduleInstance(instance, 0, 3, datetime(2017, 3, 18, 16, 0), False,
@@ -455,8 +466,9 @@ class DailyScheduleTest(BaseScheduleTest):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 16))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 16, 0), True, date(2017, 3, 16),
@@ -486,8 +498,9 @@ class DailyScheduleTest(BaseScheduleTest):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 16))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 16, 0), True, date(2017, 3, 16),
@@ -495,8 +508,9 @@ class DailyScheduleTest(BaseScheduleTest):
         self.assertEqual(send_patch.call_count, 0)
 
         # Set start date one day back
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 15))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 15))
+        )
         old_id = instance.schedule_instance_id
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -506,8 +520,9 @@ class DailyScheduleTest(BaseScheduleTest):
         self.assertEqual(send_patch.call_count, 0)
 
         # Set start date one more day back
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 14))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 14))
+        )
         old_id = instance.schedule_instance_id
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -521,16 +536,19 @@ class DailyScheduleTest(BaseScheduleTest):
 
         # Schedule the instance for user1
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 16))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 16, 0), True, date(2017, 3, 16),
             self.user1)
 
         # Add user2
-        refresh_timed_schedule_instances(self.schedule.schedule_id,
-            (('CommCareUser', self.user1.get_id), ('CommCareUser', self.user2.get_id)), date(2017, 3, 16))
+        recipients = (('CommCareUser', self.user1.get_id), ('CommCareUser', self.user2.get_id))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, recipients, json_format_date(date(2017, 3, 16))
+        )
 
         self.assertNumInstancesForSchedule(2)
         [instance1, instance2] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -547,8 +565,9 @@ class DailyScheduleTest(BaseScheduleTest):
             date(2017, 3, 16), self.user2)
 
         # Remove user1
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user2.get_id),),
-            date(2017, 3, 16))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user2.get_id),), json_format_date(date(2017, 3, 16))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 16, 0), True, date(2017, 3, 16),
@@ -589,8 +608,9 @@ class CustomDailyScheduleTest(BaseScheduleTest):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 16))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 16, 0), True, date(2017, 3, 16),
@@ -663,8 +683,9 @@ class RandomTimedEventTest(BaseScheduleTest):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 16))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertRandomTimedScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 16, 0),
@@ -719,8 +740,9 @@ class RandomTimedEventSpanningTwoDaysTest(BaseScheduleTest):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 16))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertRandomTimedScheduleInstance(instance, 0, 1, datetime(2017, 3, 17, 3, 0),
@@ -772,8 +794,9 @@ class StartDayOfWeekTest(BaseScheduleTest):
         # Schedule the instance using an explicit start date (a Thursday).
         # Based on the schedule we should start sending on the next Monday
         utcnow_patch.return_value = datetime(2017, 8, 2, 7, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 8, 3))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 8, 3))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 8, 7, 16, 0), True, date(2017, 8, 3),
@@ -812,8 +835,9 @@ class StartDayOfWeekTest(BaseScheduleTest):
         # Schedule the instance using an explicit start date in the past.
         # Since the date is so far back, the schedule is automatically deactivated.
         utcnow_patch.return_value = datetime(2017, 8, 9, 7, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 7, 1))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 7, 1))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 3, datetime(2017, 7, 5, 16, 0), False, date(2017, 7, 1),
@@ -883,8 +907,9 @@ class StartDayOfWeekWithStartOffsetTest(BaseScheduleTest):
         # Schedule the instance using an explicit start date (a Sunday)
         # Based on the schedule (with start offset 3) we should start sending on the next Monday
         utcnow_patch.return_value = datetime(2017, 8, 2, 7, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 8, 6))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 8, 6))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 8, 14, 16, 0), True, date(2017, 8, 6),
@@ -960,8 +985,9 @@ class MonthlyScheduleTest(TestCase):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 4, 1, 6, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 4, 1))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 4, 1))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 4, 1, 16, 0), True, date(2017, 4, 1))
@@ -1004,16 +1030,18 @@ class MonthlyScheduleTest(TestCase):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 4, 15, 6, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 4, 15))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 4, 15))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 1, 1, datetime(2017, 4, 15, 16, 0), True, date(2017, 4, 15))
         self.assertEqual(send_patch.call_count, 0)
 
         # Set start date in previous month
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 3, 14))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 14))
+        )
         old_id = instance.schedule_instance_id
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -1022,8 +1050,9 @@ class MonthlyScheduleTest(TestCase):
         self.assertEqual(send_patch.call_count, 0)
 
         # Set start date two months back
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 2, 1))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 2, 1))
+        )
         old_id = instance.schedule_instance_id
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -1082,8 +1111,9 @@ class EndOfMonthScheduleTest(TestCase):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 4, 1, 6, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2017, 4, 1))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 4, 1))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 4, 30, 16, 0), True, date(2017, 4, 1))
@@ -1137,8 +1167,9 @@ class DailyRepeatEveryTest(BaseScheduleTest):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2018, 3, 1, 0, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2018, 3, 1))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2018, 3, 1))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2018, 3, 1, 17, 0), True, date(2018, 3, 1),
@@ -1206,8 +1237,9 @@ class WeeklyRepeatEveryTest(BaseScheduleTest):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2018, 3, 5, 0, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2018, 3, 5))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2018, 3, 5))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2018, 3, 5, 17, 0), True, date(2018, 3, 5),
@@ -1301,8 +1333,9 @@ class MonthlyRepeatEveryTest(BaseScheduleTest):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2018, 1, 1, 0, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-            date(2018, 1, 1))
+        refresh_timed_schedule_instances(
+            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2018, 1, 1))
+        )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2018, 1, 1, 17, 0), True, date(2018, 1, 1),

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -1,71 +1,89 @@
-from functools import wraps
+import io
 from datetime import datetime, timedelta
+
 from django.conf import settings
 from django.contrib import messages
 from django.db import transaction
 from django.http import (
     Http404,
-    HttpResponse,
-    HttpResponseRedirect,
     HttpResponseBadRequest,
+    HttpResponseRedirect,
     JsonResponse,
 )
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext as _, ugettext_lazy
+from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy
+
+from six.moves.urllib.parse import quote_plus
+
+from couchexport.export import export_raw
+from couchexport.models import Format
+from couchexport.shortcuts import export_response
+from dimagi.utils.couch import CriticalSection
+from dimagi.utils.parsing import json_format_date
+
 from corehq import privileges
-from corehq import toggles
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
-from corehq.apps.data_interfaces.models import AutomaticUpdateRule, CreateScheduleInstanceActionDefinition
-from corehq.apps.domain.models import Domain
-from corehq.apps.sms.filters import EventTypeFilter, EventStatusFilter
-from corehq.apps.sms.models import QueuedSMS, SMS, INCOMING, OUTGOING, MessagingEvent
-from corehq.apps.sms.tasks import time_within_windows, OutboundDailyCounter
-from corehq.apps.sms.views import BaseMessagingSectionView
+from corehq.apps.data_interfaces.models import (
+    AutomaticUpdateRule,
+)
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
-from corehq.apps.hqwebapp.decorators import use_datatables, use_jquery_ui, use_timepicker, use_nvd3
+from corehq.apps.hqwebapp.decorators import (
+    use_datatables,
+    use_jquery_ui,
+    use_nvd3,
+    use_timepicker,
+)
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
-from corehq.apps.users.decorators import require_permission
-from corehq.apps.users.models import Permissions
-from corehq.messaging.scheduling.async_handlers import MessagingRecipientHandler, ConditionalAlertAsyncHandler
+from corehq.apps.sms.filters import EventStatusFilter, EventTypeFilter
+from corehq.apps.sms.models import (
+    INCOMING,
+    OUTGOING,
+    SMS,
+    MessagingEvent,
+    QueuedSMS,
+)
+from corehq.apps.sms.tasks import OutboundDailyCounter, time_within_windows
+from corehq.apps.sms.views import BaseMessagingSectionView
+from corehq.const import SERVER_DATETIME_FORMAT
+from corehq.messaging.scheduling.async_handlers import (
+    ConditionalAlertAsyncHandler,
+    MessagingRecipientHandler,
+)
 from corehq.messaging.scheduling.forms import (
     BroadcastForm,
-    ConditionalAlertForm,
     ConditionalAlertCriteriaForm,
+    ConditionalAlertForm,
     ConditionalAlertScheduleForm,
 )
 from corehq.messaging.scheduling.models import (
     AlertSchedule,
     ImmediateBroadcast,
     ScheduledBroadcast,
-    SMSContent,
     TimedSchedule,
 )
 from corehq.messaging.scheduling.scheduling_partitioned.dbaccessors import (
     get_count_of_active_schedule_instances_due,
 )
-from corehq.messaging.scheduling.tasks import refresh_alert_schedule_instances, refresh_timed_schedule_instances
-from corehq.messaging.tasks import initiate_messaging_rule_run
-from corehq.messaging.util import MessagingRuleProgressHelper
+from corehq.messaging.scheduling.tasks import (
+    refresh_alert_schedule_instances,
+    refresh_timed_schedule_instances,
+)
 from corehq.messaging.scheduling.view_helpers import (
+    TranslatedConditionalAlertUploader,
+    UntranslatedConditionalAlertUploader,
     get_conditional_alert_headers,
     get_conditional_alert_rows,
     get_conditional_alerts_queryset_by_domain,
-    TranslatedConditionalAlertUploader,
-    UntranslatedConditionalAlertUploader,
     upload_conditional_alert_workbook,
 )
-from corehq.const import SERVER_DATETIME_FORMAT
+from corehq.messaging.tasks import initiate_messaging_rule_run
+from corehq.messaging.util import MessagingRuleProgressHelper
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_user
-from corehq.util.workbook_json.excel import get_workbook, WorkbookJSONError
-from couchexport.export import export_raw
-from couchexport.models import Format
-from couchexport.shortcuts import export_response
-from dimagi.utils.couch import CriticalSection
-import io
-from six.moves.urllib.parse import quote_plus
+from corehq.util.workbook_json.excel import WorkbookJSONError, get_workbook
 
 
 def get_broadcast_edit_critical_section(broadcast_type, broadcast_id):
@@ -103,9 +121,9 @@ class MessagingDashboardView(BaseMessagingSectionView):
     @property
     def page_context(self):
         from corehq.apps.reports.standard.sms import (
-            ScheduleInstanceReport,
             MessageLogReport,
             MessagingEventsReport,
+            ScheduleInstanceReport,
         )
 
         scheduled_events_url = reverse(ScheduleInstanceReport.dispatcher.name(), args=[],
@@ -374,7 +392,7 @@ class BroadcastListView(BaseMessagingSectionView):
         refresh_timed_schedule_instances.delay(
             broadcast.schedule_id,
             broadcast.recipients,
-            start_date=broadcast.start_date
+            start_date=json_format_date(broadcast.start_date)
         )
 
         return JsonResponse({
@@ -477,8 +495,11 @@ class CreateScheduleView(BaseMessagingSectionView, AsyncHandlerMixin):
             if isinstance(schedule, AlertSchedule):
                 refresh_alert_schedule_instances.delay(schedule.schedule_id, broadcast.recipients)
             elif isinstance(schedule, TimedSchedule):
-                refresh_timed_schedule_instances.delay(schedule.schedule_id, broadcast.recipients,
-                    start_date=broadcast.start_date)
+                refresh_timed_schedule_instances.delay(
+                    schedule.schedule_id,
+                    broadcast.recipients,
+                    start_date=json_format_date(broadcast.start_date)
+                )
             else:
                 raise TypeError("Expected AlertSchedule or TimedSchedule")
 

--- a/corehq/messaging/smsbackends/telerivet/tasks.py
+++ b/corehq/messaging/smsbackends/telerivet/tasks.py
@@ -19,7 +19,7 @@ CELERY_QUEUE = ("sms_queue" if settings.SMS_QUEUE_ENABLED else
     settings.CELERY_MAIN_QUEUE)
 
 
-@task(serializer='pickle', queue=CELERY_QUEUE, ignore_result=True)
+@task(queue=CELERY_QUEUE, ignore_result=True)
 def process_incoming_message(*args, **kwargs):
     try:
         from corehq.messaging.smsbackends.telerivet.views import TELERIVET_INBOUND_FIELD_MAP

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -1,31 +1,35 @@
+from django.conf import settings
+from django.db import transaction
+from django.db.models import Q
+
+from dimagi.utils.chunked import chunked
+from dimagi.utils.couch import CriticalSection
+
 from corehq.apps.data_interfaces.models import AutomaticUpdateRule
-from corehq.apps.sms import tasks as sms_tasks
 from corehq.apps.es import CaseES
+from corehq.apps.sms import tasks as sms_tasks
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCaseSQL
-from corehq.messaging.scheduling.tasks import delete_schedule_instances_for_cases
+from corehq.messaging.scheduling.tasks import (
+    delete_schedule_instances_for_cases,
+)
 from corehq.messaging.scheduling.util import utcnow
 from corehq.messaging.util import MessagingRuleProgressHelper
 from corehq.sql_db.util import (
     get_db_aliases_for_partitioned_query,
     paginate_query,
-    paginate_query_across_partitioned_databases
+    paginate_query_across_partitioned_databases,
 )
 from corehq.util.celery_utils import no_result_task
 from corehq.util.metrics.load_counters import case_load_counter
-from dimagi.utils.chunked import chunked
-from dimagi.utils.couch import CriticalSection
-from django.conf import settings
-from django.db.models import Q
-from django.db import transaction
 
 
 def get_sync_key(case_id):
     return 'sync-case-for-messaging-%s' % case_id
 
 
-@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, acks_late=True,
+@no_result_task(queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, acks_late=True,
                 default_retry_delay=5 * 60, max_retries=12, bind=True)
 def sync_case_for_messaging(self, domain, case_id):
     try:
@@ -35,7 +39,7 @@ def sync_case_for_messaging(self, domain, case_id):
         self.retry(exc=e)
 
 
-@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE, acks_late=True,
+@no_result_task(queue=settings.CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE, acks_late=True,
                 default_retry_delay=5 * 60, max_retries=12, bind=True)
 def sync_case_for_messaging_rule(self, domain, case_id, rule_id):
     try:
@@ -45,7 +49,7 @@ def sync_case_for_messaging_rule(self, domain, case_id, rule_id):
         self.retry(exc=e)
 
 
-@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE, acks_late=True)
+@no_result_task(queue=settings.CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE, acks_late=True)
 def sync_case_chunk_for_messaging_rule(domain, case_id_chunk, rule_id):
     for case_id in case_id_chunk:
         try:
@@ -132,13 +136,13 @@ def get_case_ids_for_messaging_rule(domain, case_type):
     return paginated_case_ids(domain, case_type)
 
 
-@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE)
+@no_result_task(queue=settings.CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE)
 def set_rule_complete(rule_id):
     AutomaticUpdateRule.objects.filter(pk=rule_id).update(locked_for_editing=False)
     MessagingRuleProgressHelper(rule_id).set_rule_complete()
 
 
-@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE, acks_late=True,
+@no_result_task(queue=settings.CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE, acks_late=True,
                 soft_time_limit=15 * settings.CELERY_TASK_SOFT_TIME_LIMIT)
 def run_messaging_rule(domain, rule_id):
     rule = _get_cached_rule(domain, rule_id)
@@ -154,7 +158,7 @@ def run_messaging_rule(domain, rule_id):
         run_messaging_rule_for_shard.delay(domain, rule_id, db_alias)
 
 
-@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE, acks_late=True,
+@no_result_task(queue=settings.CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE, acks_late=True,
                 soft_time_limit=15 * settings.CELERY_TASK_SOFT_TIME_LIMIT)
 def run_messaging_rule_for_shard(domain, rule_id, db_alias):
     rule = _get_cached_rule(domain, rule_id)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Reverted [this revert](https://github.com/dimagi/commcare-hq/pull/30629) which involved resolving conflicts, and fixed [the original bug](https://sentry.io/organizations/dimagi/issues/2734523716/?environment=production&project=136860&query=is%3Aunresolved+handle&statsPeriod=14d) on [this commit](https://github.com/dimagi/commcare-hq/commit/3bcf42be9cbae38879aa612155249ffd66c28a8a). Basically the `schedule_instance_id` is expected to be a `UUID` in the various schedule instance tasks, but the removal of pickling meant this variable was no longer passed into the task as a python object, but just a string. Interestingly, it was successfully converted to a json serializable type when being passed into the task despite `json.dumps(UUID.uuid4())` raising a `TypeError: Object of type 'UUID' is not JSON serializable`. I chose to be explicit about converting the UUID type to a json serializable type before passing into the task, and used `.hex` to achieve this. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-3804
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
