### PR TITLE
Add lite release management privilege

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -98,6 +98,7 @@ pro_v1 = standard_v1 + [
     privileges.TEMPLATED_INTENTS,
     privileges.CASE_SHARING_GROUPS,
     privileges.CHILD_CASES,
+    privileges.LITE_RELEASE_MANAGEMENT,
 ]
 
 

--- a/corehq/apps/accounting/migrations/0059_add_lite_release_management_priv.py
+++ b/corehq/apps/accounting/migrations/0059_add_lite_release_management_priv.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+from django.core.management import call_command
+
+from corehq.privileges import LITE_RELEASE_MANAGEMENT
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _grandfather_basic_privs(apps, schema_editor):
+    call_command('cchq_prbac_bootstrap')
+    call_command(
+        'cchq_prbac_grandfather_privs',
+        LITE_RELEASE_MANAGEMENT,
+        skip_edition='Paused,Community,Standard',
+        noinput=True,
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('accounting', '0058_delete_linked_projects_role'),
+    ]
+
+    operations = [
+        migrations.RunPython(_grandfather_basic_privs),
+    ]

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -173,6 +173,9 @@ class Command(BaseCommand):
              name='Release Management',
              description='Allows access to features that help manage releases between projects, like the linked '
                          'projects feature.'),
+        Role(slug=privileges.LITE_RELEASE_MANAGEMENT,
+             name='Lite Release Management',
+             description='A limited version of Release Management'),
     ]
 
     BOOTSTRAP_PLANS = [

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -83,6 +83,8 @@ DEFAULT_EXPORT_SETTINGS = 'default_export_settings'
 
 RELEASE_MANAGEMENT = 'release_management'
 
+LITE_RELEASE_MANAGEMENT = 'lite_release_management'
+
 MAX_PRIVILEGES = [
     LOOKUP_TABLES,
     API_ACCESS,
@@ -128,6 +130,7 @@ MAX_PRIVILEGES = [
     GEOCODER,
     DEFAULT_EXPORT_SETTINGS,
     RELEASE_MANAGEMENT,
+    LITE_RELEASE_MANAGEMENT,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -184,5 +187,6 @@ class Titles(object):
             APP_USER_PROFILES: _("App User Profiles"),
             GEOCODER: _("Geocoder"),
             DEFAULT_EXPORT_SETTINGS: _("Default Export Settings"),
-            RELEASE_MANAGEMENT: _("Release Management"),
+            RELEASE_MANAGEMENT: _("Enterprise Release Management"),
+            LITE_RELEASE_MANAGEMENT: _("Multi-Environment Release Management"),
         }.get(privilege, privilege)

--- a/migrations.lock
+++ b/migrations.lock
@@ -78,6 +78,7 @@ accounting
  0056_add_release_management
  0057_add_sms_report_toggle
  0058_delete_linked_projects_role
+ 0059_add_lite_release_management_priv
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Multi-Environment Release Management is a limited version of Enterprise Release Management. At the moment, this is only comprised of the Linked Projects feature, and MRM is limited in only being able to push to one project space at a time. I'm choosing to name the privileges in code `Release Management` and `Lite Release Management` to better convey the difference between the two as opposed to Enterprise Release Management and Multi-Environment Release Management. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SS-228

Simply adding a new privilege.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Just adding a privilege.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Software plans will be updated to include this privilege after this is deployed. Reverting this would mean software plans would reference a role that no longer exists, though still exists in the DB. 

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
