### PR TITLE
Replace web apps progress bar with spinner when progress is unknown

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -557,8 +557,8 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         var progressView = FormplayerFrontend.regions.getRegion('loadingProgress').currentView,
             progressFinishTimeout = 200;
 
-        if (progressView) {
-            progressView.setProgress(1, progressFinishTimeout);
+        if (progressView && progressView.hasProgress()) {
+            progressView.setProgress(1, 1, progressFinishTimeout);
             setTimeout(function () {
                 FormplayerFrontend.regions.getRegion('loadingProgress').empty();
             }, progressFinishTimeout);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/progress_bar.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/progress_bar.js
@@ -14,7 +14,19 @@ hqDefine("cloudcare/js/formplayer/layout/views/progress_bar", function () {
             };
         },
 
+        hasProgress: function () {
+            return +$(this.el).find('.js-progress-bar').width() > 0;
+        },
+
         setProgress: function (done, total, duration) {
+            if (done === 0) {
+                $(this.el).find('.progress').addClass("hide");
+                $(this.el).find('.js-loading').removeClass("hide");
+            } else {
+                $(this.el).find('.progress').removeClass("hide");
+                $(this.el).find('.js-loading').addClass("hide");
+            }
+
             var progress = total === 0 ? 0 : done / total;
             // Due to jQuery bug, can't use .animate() with % until jQuery 3.0
             $(this.el).find('.js-progress-bar').css('transition', duration + 'ms');

--- a/corehq/apps/cloudcare/templates/formplayer/progress.html
+++ b/corehq/apps/cloudcare/templates/formplayer/progress.html
@@ -2,10 +2,13 @@
   <div id="formplayer-progress">
     <div class="progress-container">
       <div class="progress-title">
-        <h1><%- progressMessage %></h1>
+        <h1>
+          <i class="fa fa-spinner fa-spin js-loading"></i>
+          <%- progressMessage %>
+        </h1>
         <h2 class="subtext text-left js-subtext"><small></small></h2>
       </div>
-      <div class="progress">
+      <div class="progress hide">
         <div
           style="width: 0%"
           class="js-progress-bar progress-bar progress-bar-striped active"


### PR DESCRIPTION
## Product Description
Followup for https://github.com/dimagi/commcare-hq/pull/30847 which doesn't have any data to represent "progress" so the bar was just sitting at zero. It looks like this was also how the progress bar behaved while getting the user's browser location.

The progress screen will now display a spinner and no progress bar...until it receives a progress notification. Then it will hide the spinner and show the progress bar.

## Safety Assurance

### Safety story
This is the web apps UI, but just it's a loading screen and we don't show it that often.

### Automated test coverage

None.

### QA Plan

Tested for a while locally, but not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
