### PR TITLE
Adding logging for export to excel parameters

### DIFF
--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -35,7 +35,7 @@ from .analytics.esaccessors import (
     scroll_case_names,
 )
 
-logging = get_task_logger(__name__)
+logger = get_task_logger(__name__)
 EXPIRE_TIME = ONE_DAY
 
 _calc_props_soft_assert = soft_assert(to='{}@{}'.format('dmore', 'dimagi.com'), exponential_backoff=False)
@@ -172,10 +172,12 @@ def export_all_rows_task(ReportClass, report_state, recipient_list=None, subject
         report.domain = report.request.couch_user.get_domains()[0]
 
     hash_id = _store_excel_in_blobdb(report_class, file, report.domain, report.slug)
+    logger.info(f'Stored report {report.name} with parameters: {report_state["request_params"]} in hash {hash_id}')
     if not recipient_list:
         recipient_list = [report.request.couch_user.get_email()]
     for recipient in recipient_list:
         _send_email(report.request.couch_user, report, hash_id, recipient=recipient, subject=subject)
+        logger.info(f'Sent {report.name} with hash {hash_id} to {recipient}')
 
 
 def _send_email(user, report, hash_id, recipient, subject=None):


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12667.  These logs should give us the ability to reconstruct the query in the future, as well as determine who received the export link (although anyone could access then access that link).  I'm not sure if the scope of this ticket should include the parameters for ALL types of reports, and not sure excel exports.

## Safety Assurance

### Safety story
I tested this locally, but it is just logging statements.

### Automated test coverage

No tests.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
