### PR TITLE
Updated celery logger to prevent duplicate messages

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1391,7 +1391,7 @@ LOGGING = {
             'propagate': True,
         },
         'celery.task': {
-            'handlers': ['console', 'file'],
+            'handlers': ['file'],
             'level': 'INFO',
             'propagate': True
         },


### PR DESCRIPTION


## Technical Summary
I stumbled on this while working on https://github.com/dimagi/commcare-hq/pull/30860. The logging messages in that PR would write to the console twice. This occurs because the celery logger is set to propagate its messages, but both itself and the root logger are configured to write to the console.  I believe this is likely in error, and that we should delegate writing to the console to the root logger only here.

## Safety Assurance

### Safety story
Local testing fixed the behavior I was seeing, but I'm not sure the same configuration will work on a server.  I should verify the previous PRs changes with this change on staging to make sure everything works as expected. Regardless, I isolated this change so it would be easy to roll back if we had a good reason for having the celery logger write to the console.

### Automated test coverage

No tests

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
