### PR TITLE
permit indexing a case that's being created in the data registry case update repeater

### DIFF
--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -555,7 +555,7 @@ class CaseUpdateConfig:
         if not self.index_remove_case_id:
             return indices
 
-        if self.index_remove_identifier not in indices:
+        if not target_case or self.index_remove_identifier not in indices:
             indices.update(self.get_remove_case_index(target_case))
 
         return indices

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -555,7 +555,7 @@ class CaseUpdateConfig:
         if not self.index_remove_case_id:
             return indices
 
-        if not target_case or self.index_remove_identifier not in indices:
+        if target_case and self.index_remove_identifier not in indices:
             indices.update(self.get_remove_case_index(target_case))
 
         return indices

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -488,7 +488,7 @@ class CaseUpdateConfig:
         if value and value not in ("child", "extension"):
             raise DataRegistryCaseUpdateError("Index relationships must be either 'child' or 'extension'")
 
-    def get_case_block(self, registry_helper, repeat_record, couch_user):
+    def get_case_block(self, registry_helper, repeat_record, couch_user, configs_by_case_id):
         kwargs = {}
         if self.create_case:
             if not self.owner_id:
@@ -501,7 +501,7 @@ class CaseUpdateConfig:
 
         target_case = self._get_target_case(couch_user, registry_helper, repeat_record)
         updates = self.get_case_updates(couch_user, registry_helper, repeat_record)
-        indices = self.get_case_indices(self.domain, target_case)
+        indices = self.get_case_indices(self.domain, target_case, configs_by_case_id)
         return CaseBlock(
             case_id=self.case_id,
             owner_id=self.owner_id,
@@ -550,8 +550,8 @@ class CaseUpdateConfig:
             for prop in update_props
         }
 
-    def get_case_indices(self, target_domain, target_case):
-        indices = self.get_create_case_index(target_domain)
+    def get_case_indices(self, target_domain, target_case, configs_by_case_id):
+        indices = self.get_create_case_index(target_domain, configs_by_case_id)
         if not self.index_remove_case_id:
             return indices
 
@@ -560,9 +560,22 @@ class CaseUpdateConfig:
 
         return indices
 
-    def get_create_case_index(self, target_domain):
+    def get_create_case_index(self, target_domain, configs_by_case_id):
         if not (self.index_create_case_id and self.index_create_case_type):
             return {}
+
+        index_spec = {
+            self.index_create_identifier: (
+                self.index_create_case_type, self.index_create_case_id, self.index_create_relationship
+            )
+        }
+        # check if we are indexing a case that is also being created
+        config = configs_by_case_id.get(self.index_create_case_id)
+        if config and config.create_case:
+            if self.index_create_case_type != config.case_type:
+                raise DataRegistryCaseUpdateError("Index case type does not match")
+            else:
+                return index_spec
 
         try:
             index_case = CaseAccessors(self.domain).get_case(self.index_create_case_id)
@@ -575,11 +588,7 @@ class CaseUpdateConfig:
         if index_case.type != self.index_create_case_type:
             raise DataRegistryCaseUpdateError("Index case type does not match")
 
-        return {
-            self.index_create_identifier: (
-                self.index_create_case_type, self.index_create_case_id, self.index_create_relationship
-            )
-        }
+        return index_spec
 
     def get_remove_case_index(self, target_case):
         identifier = "parent" if self.index_remove_relationship == "child" else "host"
@@ -664,8 +673,11 @@ class DataRegistryCaseUpdatePayloadGenerator(BasePayloadGenerator):
         main_config = configs[0]
         registry_slug = main_config.registry_slug
         helper = DataRegistryHelper(main_config.intent_case.domain, registry_slug=registry_slug)
+        configs_by_case_id = {
+            config.case_id: config for config in configs
+        }
         return [
-            config.get_case_block(helper, repeat_record, couch_user)
+            config.get_case_block(helper, repeat_record, couch_user, configs_by_case_id)
             for config in configs
         ]
 

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -348,10 +348,10 @@ def _test_payload_generator(intent_case, registry_mock_cases=None,
 
 
 class DataRegistryUpdateForm:
-    def __init__(self, form, intent_case):
+    def __init__(self, form, primary_intent_case):
         self.intent_cases = {
             case.case_json['target_case_id']: case
-            for case in [intent_case] + intent_case.get_subcases()
+            for case in [primary_intent_case] + primary_intent_case.get_subcases()
         }
         self.formxml = ElementTree.fromstring(form)
         self.cases = {

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -74,6 +74,30 @@ def test_generator_create_case_with_index():
             expected_indices={"1": {"parent": IndexAttrs("parent_type", "case2", "child")}})
 
 
+def test_generator_create_case_with_index_to_another_case_being_created():
+    create_parent = IntentCaseBuilder()\
+        .target_case(case_id="1", case_type="patient")\
+        .create_case(owner_id="123")
+
+    create_child = (
+        IntentCaseBuilder()
+        .target_case(case_id="sub1", case_type="child")
+        .create_case(owner_id="123")
+        .create_index(case_id="1", case_type="patient")
+        .get_case()
+    )
+    create_parent.set_subcases([create_child])
+
+    _test_payload_generator(
+        intent_case=create_parent.get_case(),
+        registry_mock_cases={},
+        expected_creates={
+            "1": {"case_type": "patient", "owner_id": "123"},
+            "sub1": {"case_type": "child", "owner_id": "123"}
+        },
+        expected_indices={"sub1": {"parent": IndexAttrs("patient", "1", "child")}})
+
+
 def test_generator_create_case_target_exists():
     builder = IntentCaseBuilder().case_properties(new_prop="new_prop_val").create_case("123")
 

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -349,7 +349,10 @@ def _test_payload_generator(intent_case, registry_mock_cases=None,
 
 class DataRegistryUpdateForm:
     def __init__(self, form, intent_case):
-        self.intent_case = intent_case
+        self.intent_cases = {
+            case.case_json['target_case_id']: case
+            for case in [intent_case] + intent_case.get_subcases()
+        }
         self.formxml = ElementTree.fromstring(form)
         self.cases = {
             case.get('case_id'): CaseBlock.from_xml(case)
@@ -365,7 +368,7 @@ class DataRegistryUpdateForm:
         """
         for case_id, updates in expected_updates.items():
             case = self.cases[case_id]
-            case.date_modified = self.intent_case.modified_on
+            case.date_modified = self.intent_cases[case_id].modified_on
             eq(case.update, updates)
 
     def assert_case_index(self, expected_indices):
@@ -388,7 +391,7 @@ class DataRegistryUpdateForm:
         for case_id, create in expected_creates.items():
             case = self.cases[case_id]
             eq(case.create, True)
-            eq(case.date_opened, self.intent_case.opened_on)
+            eq(case.date_opened, self.intent_cases[case_id].opened_on)
             for key, val in create.items():
                 eq(getattr(case, key), val)
 

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
@@ -115,7 +115,8 @@ class DataRegistryCaseUpdateRepeaterTest(TestCase, TestXmlMixin, DomainSubscript
         repeat_records = self.repeat_records(self.domain).all()
         self.assertEqual(len(repeat_records), 1)
         payload = repeat_records[0].get_payload()
-        form = DataRegistryUpdateForm(payload, cases[0])
+        host_case = cases[1]
+        form = DataRegistryUpdateForm(payload, host_case)
         form.assert_case_updates({
             self.target_case_id_1: {"new_prop": "new_val_case1"},
             self.target_case_id_2: {"new_prop": "new_val_case2"}


### PR DESCRIPTION
## Product Description
When using the Data Registry Case Update repeater:
* Allow creating a child case of another case that's also being created in the same trasaction.

Jira: https://dimagi-dev.atlassian.net/browse/USH-1467

## Technical Summary
Check for other cases that are also being created when validating the index config.

## Feature Flag
DATA_REGISTRY_CASE_UPDATE_REPEATER

## Safety Assurance

### Safety story
Only affects the one repeater class which is feature flagged. The code is well covered by tests.

### Automated test coverage
Updated

### QA Plan
None

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
