### PR TITLE
add test file missing from 30838

### DIFF
--- a/corehq/apps/case_search/tests/test_utils.py
+++ b/corehq/apps/case_search/tests/test_utils.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch
+
+from corehq.apps.case_search.utils import get_expanded_case_results
+from corehq.form_processor.models import CommCareCaseSQL
+
+
+@patch("corehq.apps.case_search.utils._get_case_search_cases")
+def test_get_expanded_case_results(get_cases_mock):
+    cases = [
+        CommCareCaseSQL(case_json={}),
+        CommCareCaseSQL(case_json={"potential_duplicate_id": "123"}),
+        CommCareCaseSQL(case_json={"potential_duplicate_id": "456"}),
+        CommCareCaseSQL(case_json={"potential_duplicate_id": ""}),
+        CommCareCaseSQL(case_json={"potential_duplicate_id": None}),
+    ]
+    helper = None
+    get_expanded_case_results(helper, "potential_duplicate_id", cases)
+    get_cases_mock.assert_called_with(helper, {"123", "456"})


### PR DESCRIPTION
## Technical Summary
Adding a test file that was left out of https://github.com/dimagi/commcare-hq/pull/30838

## Safety Assurance

### Safety story
Tests only

### Migrations
NA

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
