### PR TITLE
Disable Add Downstream Domain button if nothing selected

### DIFF
--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -353,6 +353,9 @@ hqDefine("linked_domain/js/domain_links", [
         self.parent = data.parent;
         self.availableDomains = ko.observableArray(data.availableDomains.sort());
         self.domainToAdd = ko.observable();
+        self.didSelectDomain = ko.computed(function() {
+            return self.domainToAdd() !== null && self.domainToAdd() !== undefined;;
+        });
 
         self.addDownstreamDomain = function (viewModel) {
             _private.RMI("create_domain_link", {

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -353,8 +353,8 @@ hqDefine("linked_domain/js/domain_links", [
         self.parent = data.parent;
         self.availableDomains = ko.observableArray(data.availableDomains.sort());
         self.domainToAdd = ko.observable();
-        self.didSelectDomain = ko.computed(function() {
-            return self.domainToAdd() !== null && self.domainToAdd() !== undefined;;
+        self.didSelectDomain = ko.computed(function () {
+            return self.domainToAdd() !== null && self.domainToAdd() !== undefined;
         });
 
         self.addDownstreamDomain = function (viewModel) {

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -84,7 +84,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
-          <button type="button" class="btn btn-primary" data-dismiss="modal" data-bind="click: addDownstreamDomain">{% trans 'Add' %}</button>
+          <button type="button" class="btn btn-primary" data-dismiss="modal" data-bind="click: addDownstreamDomain, enable: didSelectDomain()">{% trans 'Add' %}</button>
         </div>
       </div>
     </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -84,7 +84,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
-          <button type="button" class="btn btn-primary" data-dismiss="modal" data-bind="click: addDownstreamDomain, enable: didSelectDomain()">{% trans 'Add' %}</button>
+          <button type="button" class="btn btn-primary" data-dismiss="modal" data-bind="click: addDownstreamDomain, enable: didSelectDomain">{% trans 'Add' %}</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
There is currently no logic for whether or not the _Add Downstream Domain_ button should be enabled/disabled. This can lead to a scenario where an empty value for `downstream_domain` is sent up to the server, resulting in an internal error. The better approach is to disable the button until a value has actually been selected, which is what this PR accomplishes.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This is a bug I noticed while doing some other work. I added a computed knockout property based on the `domainToAdd` observable to determine if a value has been selected.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
UI change.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
