### PR TITLE
strip deleted suffix when fetching doc

### DIFF
--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -15,6 +15,7 @@ from corehq.toggles import ENABLE_UCR_MIRRORS
 from corehq.util import reverse
 from corehq.util.couch import DocumentNotFound
 from corehq.util.metrics.load_counters import ucr_load_counter
+from dimagi.utils.couch.undo import DELETED_SUFFIX
 
 UCR_TABLE_PREFIX = 'ucr_'
 LEGACY_UCR_TABLE_PREFIX = 'config_report_'
@@ -307,10 +308,11 @@ def _wrap_data_source_by_doc_type(doc):
         DataSourceConfiguration,
         RegistryDataSourceConfiguration,
     )
+    doc_type = doc["doc_type"].replace(DELETED_SUFFIX, '')
     return {
         "DataSourceConfiguration": DataSourceConfiguration,
         "RegistryDataSourceConfiguration": RegistryDataSourceConfiguration,
-    }[doc["doc_type"]].wrap(doc)
+    }[doc_type].wrap(doc)
 
 
 def wrap_report_config_by_type(config):


### PR DESCRIPTION
## Technical Summary
Handle deleted doc types when wrapping.

Sentry: https://sentry.io/share/issue/489938bed9614b43974f4d43a8746ca2/

## Safety Assurance

### Safety story

### Automated test coverage
NA

### QA Plan
None

### Migrations
NA

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
