### PR TITLE
Replace celery.chunks with our own chunking

### DIFF
--- a/corehq/apps/data_analytics/tasks.py
+++ b/corehq/apps/data_analytics/tasks.py
@@ -1,6 +1,5 @@
 import datetime
 
-from celery import group
 from django.conf import settings
 
 from celery.schedules import crontab
@@ -29,8 +28,6 @@ def build_last_month_MALT():
     for chunk in chunked(domains, 1000):
         task_results.append(update_current_MALT_for_domains.delay(last_month, chunk))
 
-    # celery 4.1 does not have support for disable_sync_subtasks in a GroupResult.get()
-    # this is a workaround until we upgrade
     for result in task_results:
         result.get(disable_sync_subtasks=False)
 

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -49,7 +49,7 @@ def update_calculated_properties():
     ).fields(["name", "_id"]).run().hits
 
     for chunk in chunked(domains_to_update, 5000):
-        update_calculated_properties_for_domains.delay(list(chunk))
+        update_calculated_properties_for_domains.delay(chunk)
 
 
 @task(queue='background_queue')


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Fixes bugs introduced on the following PRs:
- https://github.com/dimagi/commcare-hq/pull/30819
- https://github.com/dimagi/commcare-hq/pull/30549

I had a misunderstanding of Celery's `chunks` method and how to use it. The bugs resolved in this PR are not directly related to Celery's chunks method, but just misuse of passing arguments into the `chunks` method with `zip`. The malt related tasks will only run on 1 domain, and the calculated properties task fails due to not zipping the list of domains. We could use celery's chunks if we want, but you can read below to understand the difference.

It seems like Celery's philosophy is rather than have a task iterate through a given list of inputs, have the task be able to handle one entry of that list at a time. Throughout their docs, they use the example task:
```
def add(a , b):
  return a + b
```
which can only handle one (a, b) combo at a time. This results in lots of tasks being called but short run times. Our typical pattern would be to write something like:
```
def add(list_of_args):
  return [a + b for a, b in list_of_args]
```
This results in fewer tasks being called, but a longer time to run.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally. Much more straightforward to understand what is happening here as well since we aren't depending on celery's chunking.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Reverting this PR will break the `update_calculated_properties` task and the `update_current_MALT` and `build_last_month_MALT` tasks.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
