### PR TITLE
Management command to clear owner IDs on cases of a specific case type

### DIFF
--- a/custom/covid/management/commands/clear_owner_ids.py
+++ b/custom/covid/management/commands/clear_owner_ids.py
@@ -31,16 +31,16 @@ class Command(CaseUpdateCommand):
         total_cases_updated = 0
         count_already_blank = 0
         for case in accessor.iter_cases(case_ids):
-            if(case.get_case_property('owner_id') != '-'):
+            if case.get_case_property('owner_id') != '-':
                 case_blocks.append(self.case_block(case))
             else:
                 count_already_blank += 1
-            if(len(case_blocks) >= BATCH_SIZE):
+            if len(case_blocks) >= BATCH_SIZE:
                 submit_case_blocks(case_blocks, domain, device_id=DEVICE_ID, user_id=user_id)
                 case_blocks = []
                 total_cases_updated += BATCH_SIZE
 
-        if(case_blocks):
+        if case_blocks:
             submit_case_blocks(case_blocks, domain, device_id=DEVICE_ID, user_id=user_id)
             total_cases_updated += len(case_blocks)
 

--- a/custom/covid/management/commands/clear_owner_ids.py
+++ b/custom/covid/management/commands/clear_owner_ids.py
@@ -1,7 +1,6 @@
 from xml.etree import cElementTree as ElementTree
 
 from casexml.apps.case.mock import CaseBlock
-from dimagi.utils.chunked import chunked
 
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
@@ -16,7 +15,7 @@ class Command(CaseUpdateCommand):
 
     def case_block(self, case):
         blank_owner_id = {'owner_id': '-'}
-        return ElementTree.tostring(CaseBlock.deprecated_init(
+        return ElementTree.tostring(CaseBlock(
             create=False,
             case_id=case.case_id,
             update=blank_owner_id,
@@ -26,20 +25,27 @@ class Command(CaseUpdateCommand):
         case_ids = self.find_case_ids_by_type(domain, case_type)
         accessor = CaseAccessors(domain)
         case_blocks = []
-        errors = []
 
-        print(f"Found {len(case_ids)} {case_type} cases in {domain}")
-
-        for case in accessor.iter_cases(case_ids):
-            case_blocks.append(self.case_block(case))
+        print(f"Found {len(case_ids)} {case_type} cases in {domain}. Proceeding...")
 
         total_cases_updated = 0
-        for chunk in chunked(case_blocks, BATCH_SIZE):
-            submit_case_blocks(chunk, domain, device_id=DEVICE_ID, user_id=user_id)
-            total_cases_updated += len(chunk)
-            print("Updated {} cases on domain {}".format(total_cases_updated, domain))
+        count_already_blank = 0
+        for case in accessor.iter_cases(case_ids):
+            if(case.get_case_property('owner_id') != '-'):
+                case_blocks.append(self.case_block(case))
+            else:
+                count_already_blank += 1
+            if(len(case_blocks) >= BATCH_SIZE):
+                submit_case_blocks(case_blocks, domain, device_id=DEVICE_ID, user_id=user_id)
+                case_blocks = []
+                total_cases_updated += BATCH_SIZE
+
+        if(case_blocks):
+            submit_case_blocks(case_blocks, domain, device_id=DEVICE_ID, user_id=user_id)
+            total_cases_updated += len(case_blocks)
 
         print(f"{total_cases_updated} cases of case type {case_type} in domain {domain} had their owner ID"
-            " field cleared successfully.")
+            f" field cleared successfully. {count_already_blank} cases already had a blank owner ID and were"
+            " skipped.")
 
-        self.log_data(domain, "clear_owner_ids", case_type, len(case_ids), total_cases_updated, errors)
+        self.log_data(domain, "clear_owner_ids", case_type, len(case_ids), total_cases_updated, errors=[])

--- a/custom/covid/management/commands/clear_owner_ids.py
+++ b/custom/covid/management/commands/clear_owner_ids.py
@@ -1,0 +1,45 @@
+from xml.etree import cElementTree as ElementTree
+
+from casexml.apps.case.mock import CaseBlock
+from dimagi.utils.chunked import chunked
+
+from corehq.apps.hqcase.utils import submit_case_blocks
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from custom.covid.management.commands.update_cases import CaseUpdateCommand
+
+BATCH_SIZE = 100
+DEVICE_ID = __name__ + ".update_owner_ids"
+
+
+class Command(CaseUpdateCommand):
+    help = "Makes the owner_id for cases blank"
+
+    def case_block(self, case):
+        blank_owner_id = {'owner_id': '-'}
+        return ElementTree.tostring(CaseBlock.deprecated_init(
+            create=False,
+            case_id=case.case_id,
+            update=blank_owner_id,
+        ).as_xml(), encoding='utf-8').decode('utf-8')
+
+    def update_cases(self, domain, case_type, user_id):
+        case_ids = self.find_case_ids_by_type(domain, case_type)
+        accessor = CaseAccessors(domain)
+        case_blocks = []
+        errors = []
+
+        print(f"Found {len(case_ids)} {case_type} cases in {domain}")
+
+        for case in accessor.iter_cases(case_ids):
+            case_blocks.append(self.case_block(case))
+
+        total_cases_updated = 0
+        for chunk in chunked(case_blocks, BATCH_SIZE):
+            submit_case_blocks(chunk, domain, device_id=DEVICE_ID, user_id=user_id)
+            total_cases_updated += len(chunk)
+            print("Updated {} cases on domain {}".format(total_cases_updated, domain))
+
+        print(f"{total_cases_updated} cases of case type {case_type} in domain {domain} had their owner ID"
+            " field cleared successfully.")
+
+        self.log_data(domain, "clear_owner_ids", case_type, len(case_ids), total_cases_updated, errors)

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -343,3 +343,22 @@ class CaseCommandsTest(TestCase):
         call_command('add_assignment_cases', self.domain, 'patient', '--location=loc-thats-not-act')
         assignment_cases = self.case_accessor.get_case_ids_in_domain("assignment")
         self.assertEqual(len(assignment_cases), 0)
+
+    def test_clear_owner_ids(self):
+        patient1_case_id = uuid.uuid4().hex
+        self.submit_case_block(
+            True, patient1_case_id, user_id=self.user_id, owner_id='owner1', case_type='patient',
+        )
+
+        patient2_case_id = uuid.uuid4().hex
+        self.submit_case_block(
+            True, patient2_case_id, user_id=self.user_id, owner_id='owner1', case_type='patient',
+        )
+
+        call_command('clear_owner_ids', self.domain, 'patient')
+
+        patient1_case = self.case_accessor.get_case(patient1_case_id)
+        patient2_case = self.case_accessor.get_case(patient2_case_id)
+
+        self.assertEqual(patient1_case.get_case_property('owner_id'), '-')
+        self.assertEqual(patient2_case.get_case_property('owner_id'), '-')


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This management command that can be run by a developer will clear out the owner ID field for all cases of a given case type inside a given domain. 

The USH CI/CT Alaska project has requested for the owner IDs of certain case types inside their production domain to be cleared (that is, set to a dash "-"). This cannot be done properly via case importer and has a deadline of the end of the year. See the ticket linked below.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[USH-1469](https://dimagi-dev.atlassian.net/browse/USH-1469). 

Example command execution:
`./manage.py clear_owner_ids addison-test person`

This management command was added as a series of USH project-related commands in `custom/covid/management/commands` that use a base class `CaseUpdateCommand`.

The command is relatively simple and inherits much of its syntax and methods from the other Covid management commands. One item of note, I almost chose to use the `update_case` method from `corehq.apps.hqcase.utils` instead of creating a series of case blocks as many of the other `custom/covid` commands do. It was much simpler, but I thought it was more important to keep the code standardized in this part of the codebase and to specify the same device ID as other commands and keep the option open to specify the user ID (as the other Covid commands do).

This will require a private release to run this management command before 12/31/2021.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

I tested locally to make sure the command runs as expected and doesn't affect other case types. I'll be testing on staging before we privately release this.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
~~None~~ 
Test added.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None, as far as I know management commands are outside of QA's scope.

### Migrations

No migrations.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
