### PR TITLE
Updated accounting tests to cancel any existing subscription

### DIFF
--- a/corehq/apps/accounting/tests/utils.py
+++ b/corehq/apps/accounting/tests/utils.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from corehq.apps.accounting.models import (
     BillingAccount,
     DefaultProductPlan,
@@ -23,6 +25,13 @@ class DomainSubscriptionMixin(object):
         account = BillingAccount.get_or_create_account_by_domain(
             domain_name, created_by="automated-test" + cls.__name__
         )[0]
+
+        current_subscription = Subscription.get_active_subscription_by_domain(domain_name)
+        if current_subscription:
+            current_subscription.date_end = date.today()
+            current_subscription.is_active = False
+            current_subscription.save()
+
         subscription = Subscription.new_domain_subscription(account, domain_name, plan)
         subscription.is_active = True
         subscription.save()

--- a/corehq/apps/sms/tests/test_backends.py
+++ b/corehq/apps/sms/tests/test_backends.py
@@ -64,7 +64,7 @@ from corehq.messaging.smsbackends.vertex.models import VertexBackend
 from corehq.messaging.smsbackends.yo.models import SQLYoBackend
 from corehq.messaging.smsbackends.infobip.models import InfobipBackend
 from corehq.messaging.smsbackends.amazon_pinpoint.models import PinpointBackend
-from corehq.util.test_utils import create_test_case, flaky_slow
+from corehq.util.test_utils import create_test_case
 
 
 class AllBackendTest(DomainSubscriptionMixin, TestCase):
@@ -919,7 +919,6 @@ class OutgoingFrameworkTestCase(DomainSubscriptionMixin, TestCase):
         self.assertEqual(mock_send.call_count, 1)
         self.assertEqual(mock_send.call_args[0][0].pk, self.backend3.pk)
 
-    @flaky_slow
     def test_choosing_appropriate_backend_for_outgoing(self):
         with create_test_case(
                 self.domain,


### PR DESCRIPTION
## Technical Summary
I think this will fix the SMS backend tests that fail intermittently at places like [this](https://github.com/dimagi/commcare-hq/blob/9d533930a47450982ed90d33e7d95de00da88358/corehq/apps/sms/tests/test_backends.py#L762).

Adding logging [demonstrated](https://github.com/dimagi/commcare-hq/runs/4586794278) they fail due to software plan:
![Screen Shot 2021-12-20 at 3 53 24 PM](https://user-images.githubusercontent.com/1486591/146831427-71ce3382-98a1-4fb8-bd41-bb4c753e8aea.png)

Hypothesis: Somewhere there's another test that creates a domain named `test-domain` (there are ~250) and doesn't clean it up properly. Then the SMS tests run, re-create the domain, add a subscription, but there's already an active subscription, so the code (sometimes?) grabs the old subscription that doesn't have SMS permissions.

## Safety Assurance

### Safety story
It's test code.

### Automated test coverage

It's test code.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
