### PR TITLE
Allow adding case property descriptions from form settings

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -486,10 +486,10 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 self.caseType = ko.computed(function () {
                     return self.case_transaction.case_type();
                 });
-                self.updatedDescription = ko.observable('');
+                self.updatedDescription = ko.observable();
                 self.description = ko.computed({
                     read: function () {
-                        if (self.updatedDescription()) {
+                        if (self.updatedDescription() !== undefined) {
                             return self.updatedDescription();
                         }
                         var config = self.case_transaction.caseConfig;

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -252,7 +252,7 @@
           <p class="help-block"
              data-bind="html: validate,
                         visible: validate"></p>
-          <!-- ko if: $data.description() && $parent.hasPrivilege -->
+          <!-- ko if: $parent.hasPrivilege -->
           <inline-edit params="value: $data.description,
                                rows: 3,
                                cols: 30,

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -162,7 +162,7 @@ def save_case_property(name, case_type, domain=None, data_type=None,
     )
     if data_type:
         prop.data_type = data_type
-    if description:
+    if description is not None:
         prop.description = description
     if group:
         prop.group = group

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/ko_inline_edit.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/ko_inline_edit.html
@@ -12,7 +12,7 @@
       <!-- ko if: lang -->
       <span class="btn btn-xs btn-info btn-langcode-preprocessed" data-bind="text: lang, visible: !value()"></span>
       <!-- /ko -->
-      <span data-bind="text: value, attr: {'class': containerClass + ' ' + readOnlyClass + ' text'}"></span>
+      <span data-bind="text: value, visible: value, attr: {'class': containerClass + ' ' + readOnlyClass + ' text'}"></span>
       <span class="placeholder text-muted" data-bind="text: placeholder, css: containerClass, visible: !value()"></span>
       <span class="inline-edit-icon" data-bind="css: containerClass, visible: !disallow_edit"><i class="fa fa-pencil"></i></span>
     </div>


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-1437

![Screen Shot 2021-12-21 at 1 21 22 PM](https://user-images.githubusercontent.com/1486591/146979601-1446c07d-dc56-497a-87e6-2ae380ec9e63.png)

I was not able to get the pencils icons to align vertically. There are [static widths](https://github.com/dimagi/commcare-hq/blob/013db83e920d6ec75d0e8969f63a16af74d609c2/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/select2s.less#L29-L53) in this area that don't play nicely with the inline edit widget. I think we can live with the misalignment.

## Feature Flag
Data dictionary

## Safety Assurance

### Safety story
This is a pretty small change to an internal-only feature. These descriptions can also be edited in the data dictionary itself. Any issues with this are likely to be minor and non-urgent.

### Automated test coverage
Little if any at the UI level.

### QA Plan

Not requesting QA, see above.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
