### PR TITLE
Revert rename from multiselectProperties back to multiselect

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -145,7 +145,7 @@ hqDefine('hqwebapp/js/multiselect_utils', [
      * The only dynamic part of this binding are the options
      * For a list of configurable properties, see http://loudev.com/ under Options
      */
-    ko.bindingHandlers.multiselectProperties = {
+    ko.bindingHandlers.multiselect = {
         init: function (element, valueAccessor) {
             var properties = valueAccessor();
             multiselect_utils.createFullMultiselectWidget(

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -249,7 +249,7 @@ hqDefine("linked_domain/js/domain_links", [
             }, []);
         });
 
-        self.multiselectProperties = {
+        self.domainMultiselect = {
             selectableHeaderTitle: gettext("All project spaces"),
             selectedHeaderTitle: gettext("Project spaces to push to"),
             searchItemTitle: gettext("Search project spaces"),

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
@@ -19,7 +19,7 @@
         <div class="col-sm-9 col-md-10 controls">
           <select multiple class="form-control"
                   data-bind="selectedOptions: modelsToPush,
-                             multiselectProperties: {
+                             multiselect: {
                                  selectableHeaderTitle: '{% trans_html_attr "All content" %}',
                                  selectedHeaderTitle: '{% trans_html_attr "Content to push" %}',
                                  searchItemTitle: '{% trans_html_attr "Search content" %}',
@@ -38,7 +38,7 @@
         </label>
         <div class="col-sm-9 col-md-10 controls">
           <select multiple class="form-control"
-                  data-bind="selectedOptions: domainsToPush, multiselectProperties: multiselectProperties">
+                  data-bind="selectedOptions: domainsToPush, multiselect: domainMultiselect">
           </select>
         </div>
       </div>

--- a/corehq/apps/registry/templates/registry/registry_edit.html
+++ b/corehq/apps/registry/templates/registry/registry_edit.html
@@ -391,7 +391,7 @@
           <div data-bind="visible: availableInviteDomains().length">
             <select multiple class="form-control" data-bind="
               selectedOptions: inviteDomains,
-              multiselectProperties: {
+              multiselect: {
                 selectableHeaderTitle: '{% trans_html_attr "Available Project Spaces" %}',
                 selectedHeaderTitle: '{% trans_html_attr "Selected" %}',
                 searchItemTitle: '{% trans_html_attr "Search" %}',
@@ -492,7 +492,7 @@
           <div data-bind="visible: availableGrantDomains().length">
             <select multiple class="form-control" data-bind="
                 selectedOptions: grantDomains,
-                multiselectProperties: {
+                multiselect: {
                   selectableHeaderTitle: '{% trans_html_attr "Available Project Spaces" %}',
                   selectedHeaderTitle: '{% trans_html_attr "Selected" %}',
                   searchItemTitle: '{% trans_html_attr "Search" %}',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Very minor, but at one point in time in my debugging adventures I wrongly thought there was some naming conflict with `multiselect` as a custom binding. Turns out there isn't, and it is a cleaner name that I am all in favor of. @orangejenny sorry this took me so long to revert!
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally. Very minor change.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
