### PR TITLE
Revert "Removed @flaky_slow from offending test"

### DIFF
--- a/corehq/apps/sms/tests/test_backends.py
+++ b/corehq/apps/sms/tests/test_backends.py
@@ -64,7 +64,7 @@ from corehq.messaging.smsbackends.vertex.models import VertexBackend
 from corehq.messaging.smsbackends.yo.models import SQLYoBackend
 from corehq.messaging.smsbackends.infobip.models import InfobipBackend
 from corehq.messaging.smsbackends.amazon_pinpoint.models import PinpointBackend
-from corehq.util.test_utils import create_test_case
+from corehq.util.test_utils import create_test_case, flaky_slow
 
 
 class AllBackendTest(DomainSubscriptionMixin, TestCase):
@@ -919,6 +919,7 @@ class OutgoingFrameworkTestCase(DomainSubscriptionMixin, TestCase):
         self.assertEqual(mock_send.call_count, 1)
         self.assertEqual(mock_send.call_args[0][0].pk, self.backend3.pk)
 
+    @flaky_slow
     def test_choosing_appropriate_backend_for_outgoing(self):
         with create_test_case(
                 self.domain,


### PR DESCRIPTION
The test failures plaguing https://github.com/dimagi/commcare-hq/pull/30885 suggest that https://github.com/dimagi/commcare-hq/pull/30883 did not work.

## Safety Assurance

### Safety story
it's tests

### Automated test coverage

it's tests

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
