### PR TITLE
Hopefully fix intermittent sms test error

### DIFF
--- a/corehq/apps/sms/tests/test_backends.py
+++ b/corehq/apps/sms/tests/test_backends.py
@@ -64,7 +64,7 @@ from corehq.messaging.smsbackends.vertex.models import VertexBackend
 from corehq.messaging.smsbackends.yo.models import SQLYoBackend
 from corehq.messaging.smsbackends.infobip.models import InfobipBackend
 from corehq.messaging.smsbackends.amazon_pinpoint.models import PinpointBackend
-from corehq.util.test_utils import create_test_case, flaky_slow
+from corehq.util.test_utils import create_test_case
 
 
 class AllBackendTest(DomainSubscriptionMixin, TestCase):
@@ -919,7 +919,6 @@ class OutgoingFrameworkTestCase(DomainSubscriptionMixin, TestCase):
         self.assertEqual(mock_send.call_count, 1)
         self.assertEqual(mock_send.call_args[0][0].pk, self.backend3.pk)
 
-    @flaky_slow
     def test_choosing_appropriate_backend_for_outgoing(self):
         with create_test_case(
                 self.domain,

--- a/corehq/apps/sms/tests/test_backends.py
+++ b/corehq/apps/sms/tests/test_backends.py
@@ -584,8 +584,8 @@ class OutgoingFrameworkTestCase(DomainSubscriptionMixin, TestCase):
     @classmethod
     def setUpClass(cls):
         super(OutgoingFrameworkTestCase, cls).setUpClass()
-        cls.domain = "test-domain"
-        cls.domain2 = "test-domain2"
+        cls.domain = "outgoing-framework-test"
+        cls.domain2 = "outgoing-framework-test-2"
 
         cls.domain_obj = Domain(name=cls.domain)
         cls.domain_obj.save()


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Jenny's research in https://github.com/dimagi/commcare-hq/pull/30883 suggested that this was caused by using a domain name that was used in another test (`test-domain`) and not cleaned up properly.  This attempts to inelegantly workaround that problem by using a unique domain name.

```
======================================================================
  FAIL: corehq.apps.sms.tests.test_backends:OutgoingFrameworkTestCase.test_choosing_appropriate_backend_for_outgoing
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/mnt/commcare-hq-ro/corehq/apps/sms/tests/test_backends.py", line 932, in test_choosing_appropriate_backend_for_outgoing
      self.__test_global_backend_map()
    File "/mnt/commcare-hq-ro/corehq/apps/sms/tests/test_backends.py", line 762, in __test_global_backend_map
      self.assertTrue(send_sms(self.domain, None, '15551234567', 'Test for BACKEND2'))
  AssertionError: False is not true
```
with this in the log output:
```
  notify: ERROR: Notify Exception: [SMS OUT] Error processing SMS
  Traceback (most recent call last):
    File "/mnt/commcare-hq-ro/corehq/apps/sms/api.py", line 300, in send_message_via_backend
      raise Exception(
  Exception: Domain 'test-domain' does not have permission to send SMS.  Please investigate why this function was called.
```

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
tests only

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
it _is_ a test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
