### PR TITLE
Remove unused mobile lockout toggle

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1042,7 +1042,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         return self._get_user_type() == 'web'
 
     def supports_lockout(self):
-        return self.is_web_user() or toggles.MOBILE_LOGIN_LOCKOUT.enabled(self.domain)
+        return self.is_web_user()
 
     def _get_user_type(self):
         if self.doc_type == 'WebUser':

--- a/corehq/apps/users/tests/test_user_model.py
+++ b/corehq/apps/users/tests/test_user_model.py
@@ -174,23 +174,10 @@ class UserModelTest(TestCase):
         definition.delete()
         web_user.delete(self.domain, deleted_by=None)
 
-    @patch('corehq.apps.users.models.toggles.MOBILE_LOGIN_LOCKOUT.enabled')
-    def test_commcare_user_is_locked_only_with_toggle(self, mock_lockout_enabled_for_domain):
-        # Web Users should always be locked out when they go beyond
-        # the the max login attempts,
-        # but Commcare Users need an additional domain toggle
-        commcare_user = self.create_commcare_user('test_user')
-        commcare_user.login_attempts = MAX_LOGIN_ATTEMPTS
-        mock_lockout_enabled_for_domain.return_value = False
-
-        self.assertFalse(commcare_user.is_locked_out())
-
-    @patch('corehq.apps.users.models.toggles.MOBILE_LOGIN_LOCKOUT.enabled')
-    def test_commcare_user_should_be_locked_out(self, mock_lockout_enabled_for_domain):
+    def test_commcare_user_should_be_locked_out(self):
         # Make sure the we know the user should be locked, if not for the toggle
         commcare_user = self.create_commcare_user('test_user')
         commcare_user.login_attempts = MAX_LOGIN_ATTEMPTS
-        mock_lockout_enabled_for_domain.return_value = False
 
         self.assertTrue(commcare_user.should_be_locked_out())
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1574,13 +1574,6 @@ COMPARE_UCR_REPORTS = DynamicallyPredictablyRandomToggle(
     description='Reports for comparison must be listed in settings.UCR_COMPARISONS.'
 )
 
-MOBILE_LOGIN_LOCKOUT = StaticToggle(
-    'mobile_user_login_lockout',
-    "On too many wrong password attempts, lock out mobile users",
-    TAG_CUSTOM,
-    [NAMESPACE_DOMAIN],
-)
-
 LINKED_DOMAINS = StaticToggle(
     'linked_domains',
     'Allow linking project spaces (successor to linked apps)',


### PR DESCRIPTION
## Technical Summary
In the process of working on https://dimagi-dev.atlassian.net/browse/SAAS-11660, which dropped the idea of separate treatment for web and mobile logins, I noticed that this toggle was unused and would be redundant/obsolete with that work. This ticket removes the toggle entirely.

## Safety Assurance

### Safety story
Ran/adjusted unit tests. Verified toggle page still works. Also verified that this toggle was not used in any production environment, so removing it won't affect any users.

### Automated test coverage

Updated the tests in _test_user_model_ to remove references to the toggle.

### QA Plan

No QA required.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
