### PR TITLE
Updated invitation flow to create user as non-admin

### DIFF
--- a/corehq/apps/users/views/web.py
+++ b/corehq/apps/users/views/web.py
@@ -153,7 +153,8 @@ class UserInvitationView(object):
                         form,
                         created_by=invited_by_user,
                         created_via=USER_CHANGE_VIA_INVITATION,
-                        domain=invitation.domain
+                        domain=invitation.domain,
+                        is_domain_admin=False,
                     )
                     user.save()
                     messages.success(request, _("User account for %s created!") % form.cleaned_data["email"])


### PR DESCRIPTION
Merging into hotfix branch which is based off of `2021-12-23_20.50-production-deploy`

https://dimagi-dev.atlassian.net/browse/SUPPORT-12088

https://dimagi-dev.atlassian.net/browse/USH-1497

In the invitation workflow, initially create user as a non-admin. The call to `accept_invitation_and_join_domain` [here](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/users/views/web.py#L160) will then set both their role and is_admin as needed in set_role [here](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/users/models.py#L629-L638). In the event that something goes wrong before reaching `accept_invitation_and_join_domain`, the user will be a non-admin without a role, which is not allowed and will cause errors in HQ.
