### PR TITLE
Add lockouts to mobile workers

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -640,6 +640,12 @@ class PrivacySecurityForm(forms.Form):
             "<a href='https://help.commcarehq.org/display/commcarepublic/Project+Space+Settings'> "
             "Read more about restricting mobile endpoint access here.</a>")),
     )
+    disable_mobile_login_lockout = BooleanField(
+        label=ugettext_lazy("Disable Mobile Worker Lockout"),
+        required=False,
+        help_text=ugettext_lazy("Mobile Workers will never be locked out of their account, regardless"
+            "of the number of failed attempts")
+    )
 
     def __init__(self, *args, **kwargs):
         user_name = kwargs.pop('user_name')
@@ -700,6 +706,8 @@ class PrivacySecurityForm(forms.Form):
         domain_obj.ga_opt_out = self.cleaned_data.get('ga_opt_out', False)
         if RESTRICT_MOBILE_ACCESS.enabled(domain_obj.name):
             domain_obj.restrict_mobile_access = self.cleaned_data.get('restrict_mobile_access', False)
+
+        domain_obj.disable_mobile_login_lockout = self.cleaned_data.get('disable_mobile_login_lockout', False)
 
         domain_obj.save()
 

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -441,6 +441,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
 
     two_factor_auth = BooleanProperty(default=False)
     strong_mobile_passwords = BooleanProperty(default=False)
+    disable_mobile_login_lockout = BooleanProperty(default=False)
 
     requested_report_builder_subscription = StringListProperty()
 

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -1,0 +1,55 @@
+from django.test import SimpleTestCase
+from unittest.mock import patch
+
+from ..forms import PrivacySecurityForm
+from .. import forms
+
+
+class PrivacySecurityFormTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        patcher = patch.object(forms, 'domain_has_privilege')
+        self.mock_domain_has_privilege = patcher.start()
+        self.mock_domain_has_privilege.return_value = False
+        self.addCleanup(patcher.stop)
+
+    def test_visible_fields(self):
+        form = self.create_form()
+        visible_field_names = self.get_visible_fields(form)
+        self.assertEqual(visible_field_names, [
+            'restrict_superusers',
+            'secure_submissions',
+            'allow_domain_requests'
+        ])
+
+    @patch.object(forms.RESTRICT_MOBILE_ACCESS, 'enabled', return_value=True)
+    def test_restrict_mobile_access_toggle(self, mock_toggle):
+        form = self.create_form()
+        visible_field_names = self.get_visible_fields(form)
+        self.assertIn('restrict_mobile_access', visible_field_names)
+
+    @patch.object(forms.HIPAA_COMPLIANCE_CHECKBOX, 'enabled', return_value=True)
+    def test_hippa_compliance_toggle(self, mock_toggle):
+        form = self.create_form()
+        visible_field_names = self.get_visible_fields(form)
+        self.assertIn('hipaa_compliant', visible_field_names)
+
+    @patch.object(forms.SECURE_SESSION_TIMEOUT, 'enabled', return_value=True)
+    def test_secure_session_timeout(self, mock_toggle):
+        form = self.create_form()
+        visible_field_names = self.get_visible_fields(form)
+        self.assertIn('secure_sessions_timeout', visible_field_names)
+
+    def test_advanced_domain_security(self):
+        self.mock_domain_has_privilege.return_value = True
+        form = self.create_form()
+        visible_field_names = self.get_visible_fields(form)
+        advanced_security_fields = {'ga_opt_out', 'strong_mobile_passwords', 'two_factor_auth', 'secure_sessions'}
+        self.assertTrue(advanced_security_fields.issubset(set(visible_field_names)))
+
+    def create_form(self):
+        return PrivacySecurityForm(user_name='test_user', domain='test_domain')
+
+    def get_visible_fields(self, form):
+        fieldset = form.helper.layout.fields[0]
+        return [field[0] for field in fieldset.fields]

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -19,7 +19,8 @@ class PrivacySecurityFormTests(SimpleTestCase):
         self.assertEqual(visible_field_names, [
             'restrict_superusers',
             'secure_submissions',
-            'allow_domain_requests'
+            'allow_domain_requests',
+            'disable_mobile_login_lockout'
         ])
 
     @patch.object(forms.RESTRICT_MOBILE_ACCESS, 'enabled', return_value=True)

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -323,6 +323,7 @@ class EditPrivacySecurityView(BaseAdminProjectSettingsView):
             "strong_mobile_passwords": self.domain_object.strong_mobile_passwords,
             "ga_opt_out": self.domain_object.ga_opt_out,
             "restrict_mobile_access": self.domain_object.restrict_mobile_access,
+            "disable_mobile_login_lockout": self.domain_object.disable_mobile_login_lockout,
         }
         if self.request.method == 'POST':
             return PrivacySecurityForm(self.request.POST, initial=initial,

--- a/corehq/apps/hqwebapp/signals.py
+++ b/corehq/apps/hqwebapp/signals.py
@@ -49,6 +49,7 @@ def add_failed_attempt(sender, credentials, token_failure=False, **kwargs):
 
     if user.attempt_date != date.today():
         user.login_attempts = 0
+        user.attempt_date = date.today()
 
     user.login_attempts += 1
     user.save()

--- a/corehq/apps/hqwebapp/signals.py
+++ b/corehq/apps/hqwebapp/signals.py
@@ -47,10 +47,8 @@ def add_failed_attempt(sender, credentials, token_failure=False, **kwargs):
         'result': lockout_result
     })
 
-    if not locked_out and user.supports_lockout():
-        if user.attempt_date == date.today():
-            user.login_attempts += 1
-        else:
-            user.login_attempts = 1
-            user.attempt_date = date.today()
-        user.save()
+    if user.attempt_date != date.today():
+        user.login_attempts = 0
+
+    user.login_attempts += 1
+    user.save()

--- a/corehq/apps/hqwebapp/tests/test_signals.py
+++ b/corehq/apps/hqwebapp/tests/test_signals.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+from unittest.mock import patch
+from datetime import date, timedelta
+
+from corehq.apps.users.models import CouchUser
+
+from ..signals import add_failed_attempt
+from .. import signals
+
+
+class FakeUser(CouchUser):
+    def __init__(self, is_web_user=True, **kwargs):
+        super().__init__(**kwargs)
+        self.doc_type = 'WebUser' if is_web_user else 'CommCareUser'
+
+    def save(self):
+        pass
+
+
+class TestFailedLoginSignal(TestCase):
+    def test_failed_login_increments_failure_count(self):
+        user = FakeUser(attempt_date=date.today(), login_attempts=1)
+        credentials = {'username': 'test-user'}
+
+        with patch.object(signals.CouchUser, 'get_by_username', return_value=user):
+            add_failed_attempt(None, credentials)
+
+        self.assertEqual(user.login_attempts, 2)
+
+    def test_resets_login_failures_daily(self):
+        yesterday = date.today() - timedelta(days=1)
+        user = FakeUser(attempt_date=yesterday, login_attempts=4)
+        credentials = {'username': 'test-user'}
+
+        with patch.object(signals.CouchUser, 'get_by_username', return_value=user):
+            add_failed_attempt(None, credentials)
+
+        self.assertEqual(user.login_attempts, 1)
+
+    def test_failed_logins_increment_count_beyond_max(self):
+        user = FakeUser(attempt_date=date.today(), login_attempts=5000)
+        credentials = {'username': 'test-user'}
+
+        with patch.object(signals.CouchUser, 'get_by_username', return_value=user):
+            add_failed_attempt(None, credentials)
+
+        self.assertEqual(user.login_attempts, 5001)


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-11660.  This work is intended to apply a baseline to mobile worker lockouts that we can iterate on in the future.  Note that this work is still pending a mobile change, as mobile will always inform the user that their login/password is incorrect, even if they're locked out.

## Safety Assurance

### Safety story
Local testing and unit tests were performed.

### Automated test coverage

Test suites added for forms and signals. User tests updated.

### QA Plan

No QA needed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
