### PR TITLE
Updated search and list fields for SyncLogSQLAdmin

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/admin.py
+++ b/corehq/ex-submodules/casexml/apps/phone/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import *
+from .models import SyncLogSQL
 
 
 class SyncLogSQLAdmin(admin.ModelAdmin):

--- a/corehq/ex-submodules/casexml/apps/phone/admin.py
+++ b/corehq/ex-submodules/casexml/apps/phone/admin.py
@@ -5,8 +5,8 @@ from .models import *
 class SyncLogSQLAdmin(admin.ModelAdmin):
     model = SyncLogSQL
     list_display = ['synclog_id', 'domain', 'user_id', 'date']
-    list_filter = ['domain', 'user_id', 'date']
-    search_fields = ['domain', 'user_id']
+    list_filter = ['date']
+    search_fields = ['domain', 'user_id', 'auth_type']
 
 
 admin.site.register(SyncLogSQL, SyncLogSQLAdmin)


### PR DESCRIPTION
## Technical Summary
Minor updates to make this page easier for the AE team to use.

Remove user id and domain from the filter attributes, because there are so many options that this page takes forever to load on prod.

Add a filter for auth type so that we can find syncs that were done by the nightly formplayer prime restore task: https://github.com/dimagi/commcare-hq/blob/779b8f8c0138e4193a0137a05c2e3a2b6e186512/custom/covid/tasks.py#L124

## Safety Assurance

### Safety story
Minor change to admin-only page.

### Automated test coverage

None

### QA Plan

None

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
