### PR TITLE
generate_request_report management command bugfix

### DIFF
--- a/corehq/apps/auditcare/management/commands/generate_request_report.py
+++ b/corehq/apps/auditcare/management/commands/generate_request_report.py
@@ -93,7 +93,7 @@ class Command(BaseCommand):
             writer.writerow(['Date', 'User', 'Domain', 'IP Address', 'Request Path'])
             for user in users:
                 write_log_events(writer, user, domain, start_date=options['start'], end_date=options['end'])
-            if not username:
+            if username:
                 # no `removed_users` or `super_users` when `username` is provided
                 return
 


### PR DESCRIPTION
## Technical Summary

Fixes bug added in #30688.

## Safety Assurance

### Safety story

Utility only used by data admins.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
