### PR TITLE
Updated is_domain_admin kwarg to default to False

### DIFF
--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -52,7 +52,7 @@ _soft_assert_registration_issues = soft_assert(
 )
 
 
-def activate_new_user_via_reg_form(form, created_by, created_via, is_domain_admin=True, domain=None, ip=None):
+def activate_new_user_via_reg_form(form, created_by, created_via, is_domain_admin=False, domain=None, ip=None):
     full_name = form.cleaned_data['full_name']
     new_user = activate_new_user(
         username=form.cleaned_data['email'],
@@ -71,7 +71,7 @@ def activate_new_user_via_reg_form(form, created_by, created_via, is_domain_admi
 
 def activate_new_user(
     username, password, created_by, created_via, first_name=None, last_name=None,
-    is_domain_admin=True, domain=None, ip=None, atypical_user=False
+    is_domain_admin=False, domain=None, ip=None, atypical_user=False
 ):
     now = datetime.utcnow()
 

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -84,7 +84,11 @@ class ProcessRegistrationView(JSONResponseMixin, View):
 
     def _create_new_account(self, reg_form, additional_hubspot_data=None):
         activate_new_user_via_reg_form(
-            reg_form, created_by=None, created_via=USER_CHANGE_VIA_WEB, ip=get_ip(self.request))
+            reg_form,
+            created_by=None,
+            created_via=USER_CHANGE_VIA_WEB,
+            ip=get_ip(self.request)
+        )
         new_user = authenticate(
             username=reg_form.cleaned_data['email'],
             password=reg_form.cleaned_data['password'],


### PR DESCRIPTION
## Technical Summary
Let's not default people to admin privileges.

Followup for https://github.com/dimagi/commcare-hq/pull/30901/

## Safety Assurance

### Safety story
`activate_new_user` is only called once, [here](https://github.com/dimagi/commcare-hq/blob/7eca680e60c4ca5994cdac5a7853ea9d82ca1cff/corehq/apps/sso/backends.py#L103-L114). `domain` is only passed in if the user is being created due to an invitation, which is the situation where they should **not** be an admin. Their role and admin status are later set by `_process_invitation`. The pre-existing code looks vulnerable to the same issue as 30901, where a user is added with admin privileges and the request can fail later on, before their role is updated correctly.

`activate_new_user_via_reg_form` is called twice:
1. [This call](https://github.com/dimagi/commcare-hq/blob/7eca680e60c4ca5994cdac5a7853ea9d82ca1cff/corehq/apps/users/views/web.py#L152-L158) is the one updated in 30901 to explicitly pass False.
2. [This call](https://github.com/dimagi/commcare-hq/blob/7eca680e60c4ca5994cdac5a7853ea9d82ca1cff/corehq/apps/registration/views.py#L86-L87) doesn't pass in a domain, which means `WebUser.create` doesn't add a domain membership [here](https://github.com/dimagi/commcare-hq/blob/a27f6d2f8428a78af8b2942ee732f8519aa6acc9/corehq/apps/users/models.py#L2377-L2378), which is the only place that `is_domain_admin` would have been used.

### Automated test coverage

Didn't find test coverage for this.

### QA Plan

Not planning to QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
