### PR TITLE
Re-implement "Consolidate optional multiselect args into a properties dictionary"

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/software_plan_version_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/software_plan_version_handler.js
@@ -146,12 +146,11 @@ hqDefine("accounting/js/software_plan_version_handler", [
 
         self.init = function () {
             if (options.multiSelectField) {
-                multiselectUtils.createFullMultiselectWidget(
-                    'id_' + options.multiSelectField.slug,
-                    options.multiSelectField.titleSelect,
-                    options.multiSelectField.titleSelected,
-                    options.multiSelectField.titleSearch
-                );
+                multiselectUtils.createFullMultiselectWidget('id_' + options.multiSelectField.slug, {
+                    selectableHeaderTitle: options.multiSelectField.titleSelect,
+                    selectedHeaderTitle: options.multiSelectField.titleSelected,
+                    searchItemTitle: options.multiSelectField.titleSearch,
+                });
             }
             self.existingRoles(_.map(options.existingRoles, function (data) {
                 return role(data);

--- a/corehq/apps/domain/static/domain/js/internal_settings.js
+++ b/corehq/apps/domain/static/domain/js/internal_settings.js
@@ -74,11 +74,10 @@ hqDefine("domain/js/internal_settings", [
             numberOfMonths: 2,
         });
 
-        multiselectUtils.createFullMultiselectWidget(
-            'id_countries',
-            gettext("Available Countries"),
-            gettext("Active Countries"),
-            gettext("Search Countries...")
-        );
+        multiselectUtils.createFullMultiselectWidget('id_countries', {
+            selectableHeaderTitle: gettext("Available Countries"),
+            selectedHeaderTitle: gettext("Active Countries"),
+            searchItemTitle: gettext("Search Countries..."),
+        });
     });
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -54,7 +54,7 @@ hqDefine('hqwebapp/js/multiselect_utils', [
     };
 
     multiselect_utils.createFullMultiselectWidget = function (elementOrId, properties) {
-        assertProperties.assert(properties, [], ['selectableHeaderTitle', 'selectedHeaderTitle', 'searchItemTitle', 'options']);
+        assertProperties.assert(properties, [], ['selectableHeaderTitle', 'selectedHeaderTitle', 'searchItemTitle']);
         var selectableHeaderTitle = properties.selectableHeaderTitle || gettext("Items");
         var selectedHeaderTitle = properties.selectedHeaderTitle || gettext("Selected items");
         var searchItemTitle = properties.searchItemTitle || gettext("Search items");
@@ -132,12 +132,6 @@ hqDefine('hqwebapp/js/multiselect_utils', [
             },
         });
 
-        if (properties.options) {
-            // add the `options` binding to the element, valueAccessor() should return an observable
-            // NOTE: apply bindings after the multiselect has been setup
-            ko.applyBindingsToNode($element[0], {options: properties.options});
-        }
-
         $('#' + selectAllId).click(function () {
             $element.multiSelect('select_all');
             return false;
@@ -149,25 +143,32 @@ hqDefine('hqwebapp/js/multiselect_utils', [
     };
 
     /*
-     * A custom binding for setting multiselect properties in knockout content.
+     * A custom binding for setting multiselect properties and additional knockout bindings
      * The only dynamic part of this binding are the options
-     * For a list of configurable properties, see http://loudev.com/ under Options
+     * For a list of configurable multiselect properties, see http://loudev.com/ under Options
      */
     ko.bindingHandlers.multiselect = {
         init: function (element, valueAccessor) {
-            var properties = valueAccessor();
-            multiselect_utils.createFullMultiselectWidget(element, properties);
+            var model = valueAccessor();
+            assertProperties.assert(model, [], ['properties', 'options', 'selectableHeaderTitle', 'selectedHeaderTitle', 'searchItemTitle']);
+            multiselect_utils.createFullMultiselectWidget(element, model.properties);
+
+            if (model.options) {
+                // add the `options` binding to the element, valueAccessor() should return an observable
+                // NOTE: apply bindings after the multiselect has been setup
+                ko.applyBindingsToNode(element, {options: model.options});
+            }
         },
         update: function (element, valueAccessor) {
-            var properties = valueAccessor();
-            if (properties.options) {
+            var model = valueAccessor();
+            if (model.options) {
                 // have to access the observable to get the `update` method to fire on changes to options
-                ko.unwrap(properties.options());
+                ko.unwrap(model.options());
             }
 
             // multiSelect('refresh') breaks existing click handlers, so the alternative is to destroy and rebuild
             $(element).multiSelect('destroy');
-            multiselect_utils.createFullMultiselectWidget(element, properties);
+            multiselect_utils.createFullMultiselectWidget(element, model.properties);
         },
     };
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -2,12 +2,14 @@ hqDefine('hqwebapp/js/multiselect_utils', [
     "jquery",
     "knockout",
     "underscore",
+    "hqwebapp/js/assert_properties",
     "multiselect/js/jquery.multi-select",
     "quicksearch/dist/jquery.quicksearch.min",
 ], function (
     $,
     ko,
-    _
+    _,
+    assertProperties
 ) {
     var multiselect_utils = {};
 
@@ -51,12 +53,12 @@ hqDefine('hqwebapp/js/multiselect_utils', [
         });
     };
 
-    multiselect_utils.createFullMultiselectWidget = function (
-        elementOrId,
-        selectableHeaderTitle,
-        selectedHeaderTitle,
-        searchItemTitle,
-    ) {
+    multiselect_utils.createFullMultiselectWidget = function (elementOrId, properties) {
+        assertProperties.assert(properties, [], ['selectableHeaderTitle', 'selectedHeaderTitle', 'searchItemTitle', 'options']);
+        var selectableHeaderTitle = properties.selectableHeaderTitle || gettext("Items");
+        var selectedHeaderTitle = properties.selectedHeaderTitle || gettext("Selected items");
+        var searchItemTitle = properties.searchItemTitle || gettext("Search items");
+
         var $element = _.isString(elementOrId) ? $('#' + elementOrId) : $(elementOrId),
             baseId = _.isString(elementOrId) ? elementOrId : "multiselect-" + String(Math.random()).substring(2),
             selectAllId = baseId + '-select-all',
@@ -130,6 +132,12 @@ hqDefine('hqwebapp/js/multiselect_utils', [
             },
         });
 
+        if (properties.options) {
+            // add the `options` binding to the element, valueAccessor() should return an observable
+            // NOTE: apply bindings after the multiselect has been setup
+            ko.applyBindingsToNode($element[0], {options: properties.options});
+        }
+
         $('#' + selectAllId).click(function () {
             $element.multiSelect('select_all');
             return false;
@@ -148,16 +156,7 @@ hqDefine('hqwebapp/js/multiselect_utils', [
     ko.bindingHandlers.multiselect = {
         init: function (element, valueAccessor) {
             var properties = valueAccessor();
-            multiselect_utils.createFullMultiselectWidget(
-                element,
-                properties.selectableHeaderTitle || gettext("Items"),
-                properties.selectedHeaderTitle || gettext("Selected items"),
-                properties.searchItemTitle || gettext("Search items"),
-            );
-            if (properties.options) {
-                // add the `options` binding to the element, valueAccessor() should return an observable
-                ko.applyBindingsToNode(element, {options: properties.options});
-            }
+            multiselect_utils.createFullMultiselectWidget(element, properties);
         },
         update: function (element, valueAccessor) {
             var properties = valueAccessor();
@@ -168,12 +167,7 @@ hqDefine('hqwebapp/js/multiselect_utils', [
 
             // multiSelect('refresh') breaks existing click handlers, so the alternative is to destroy and rebuild
             $(element).multiSelect('destroy');
-            multiselect_utils.createFullMultiselectWidget(
-                element,
-                properties.selectableHeaderTitle || gettext("Items"),
-                properties.selectedHeaderTitle || gettext("Selected items"),
-                properties.searchItemTitle || gettext("Search items")
-            );
+            multiselect_utils.createFullMultiselectWidget(element, properties);
         },
     };
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -150,7 +150,7 @@ hqDefine('hqwebapp/js/multiselect_utils', [
     ko.bindingHandlers.multiselect = {
         init: function (element, valueAccessor) {
             var model = valueAccessor();
-            assertProperties.assert(model, [], ['properties', 'options', 'selectableHeaderTitle', 'selectedHeaderTitle', 'searchItemTitle']);
+            assertProperties.assert(model, [], ['properties', 'options']);
             multiselect_utils.createFullMultiselectWidget(element, model.properties);
 
             if (model.options) {

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -250,9 +250,11 @@ hqDefine("linked_domain/js/domain_links", [
         });
 
         self.domainMultiselect = {
-            selectableHeaderTitle: gettext("All project spaces"),
-            selectedHeaderTitle: gettext("Project spaces to push to"),
-            searchItemTitle: gettext("Search project spaces"),
+            properties: {
+                selectableHeaderTitle: gettext("All project spaces"),
+                selectedHeaderTitle: gettext("Project spaces to push to"),
+                searchItemTitle: gettext("Search project spaces"),
+            },
             options: self.localDownstreamDomains,
         };
 

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
@@ -20,9 +20,11 @@
           <select multiple class="form-control"
                   data-bind="selectedOptions: modelsToPush,
                              multiselect: {
-                                 selectableHeaderTitle: '{% trans_html_attr "All content" %}',
-                                 selectedHeaderTitle: '{% trans_html_attr "Content to push" %}',
-                                 searchItemTitle: '{% trans_html_attr "Search content" %}',
+                                 properties: {
+                                    selectableHeaderTitle: '{% trans_html_attr "All content" %}',
+                                    selectedHeaderTitle: '{% trans_html_attr "Content to push" %}',
+                                    searchItemTitle: '{% trans_html_attr "Search content" %}',
+                                 }
                             }">
             {% for model in view_data.view_models_to_push %}
               <option value="{% html_attr model %}" {% if not model.is_linkable %} disabled {% endif %}>

--- a/corehq/apps/registry/templates/registry/registry_edit.html
+++ b/corehq/apps/registry/templates/registry/registry_edit.html
@@ -392,9 +392,11 @@
             <select multiple class="form-control" data-bind="
               selectedOptions: inviteDomains,
               multiselect: {
-                selectableHeaderTitle: '{% trans_html_attr "Available Project Spaces" %}',
-                selectedHeaderTitle: '{% trans_html_attr "Selected" %}',
-                searchItemTitle: '{% trans_html_attr "Search" %}',
+                properties: {
+                  selectableHeaderTitle: '{% trans_html_attr "Available Project Spaces" %}',
+                  selectedHeaderTitle: '{% trans_html_attr "Selected" %}',
+                  searchItemTitle: '{% trans_html_attr "Search" %}',
+                },
                 options: availableInviteDomains
               }"></select>
           </div>
@@ -493,9 +495,11 @@
             <select multiple class="form-control" data-bind="
                 selectedOptions: grantDomains,
                 multiselect: {
-                  selectableHeaderTitle: '{% trans_html_attr "Available Project Spaces" %}',
-                  selectedHeaderTitle: '{% trans_html_attr "Selected" %}',
-                  searchItemTitle: '{% trans_html_attr "Search" %}',
+                  properties: {
+                    selectableHeaderTitle: '{% trans_html_attr "Available Project Spaces" %}',
+                    selectedHeaderTitle: '{% trans_html_attr "Selected" %}',
+                    searchItemTitle: '{% trans_html_attr "Search" %}',
+                  },
                   options: availableGrantDomains
                 }"></select>
           </div>

--- a/corehq/apps/reminders/static/reminders/js/keywords_list.js
+++ b/corehq/apps/reminders/static/reminders/js/keywords_list.js
@@ -4,18 +4,16 @@ hqDefine('reminders/js/keywords_list', [
     "hqwebapp/js/crud_paginated_list_init", // needed to initialize the page
 ], function ($, multiselectUtils) {
     $(function () {
-        multiselectUtils.createFullMultiselectWidget(
-            'keyword-selector',
-            gettext("Keywords"),
-            gettext("Keywords to copy"),
-            gettext("Search keywords")
-        );
-        multiselectUtils.createFullMultiselectWidget(
-            'domain-selector',
-            gettext("Linked Project Spaces"),
-            gettext("Projects to copy to"),
-            gettext("Search projects")
-        );
+        multiselectUtils.createFullMultiselectWidget('keyword-selector', {
+            selectableHeaderTitle: gettext("Keywords"),
+            selectedHeaderTitle: gettext("Keywords to copy"),
+            searchItemTitle: gettext("Search keywords"),
+        });
 
+        multiselectUtils.createFullMultiselectWidget('domain-selector', {
+            selectableHeaderTitle: gettext("Linked Project Spaces"),
+            selectedHeaderTitle: gettext("Projects to copy to"),
+            searchItemTitle: gettext("Search projects"),
+        });
     });
 });

--- a/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
+++ b/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
@@ -130,12 +130,11 @@ hqDefine("reports/js/edit_scheduled_report", [
         );
     }
     else {
-        multiselectUtils.createFullMultiselectWidget(
-            'id_config_ids',
-            gettext("Available Reports"),
-            gettext("Included Reports"),
-            gettext("Search Reports...")
-        );
+        multiselectUtils.createFullMultiselectWidget('id_config_ids', {
+            selectableHeaderTitle: gettext("Available Reports"),
+            selectedHeaderTitle: gettext("Included Reports"),
+            searchItemTitle: gettext("Search Reports..."),
+        });
     }
     updateUcrElements($("#id_config_ids").val());
 

--- a/corehq/apps/styleguide/templates/styleguide/examples/multiselect.html
+++ b/corehq/apps/styleguide/templates/styleguide/examples/multiselect.html
@@ -9,11 +9,10 @@
 <script>
   $(function () {
     var multiselect_utils = hqImport('hqwebapp/js/multiselect_utils');
-    multiselect_utils.createFullMultiselectWidget(
-      'example-multiselect',
-      gettext("Available Letters"),
-      gettext("Letters Selected"),
-      gettext("Search Letters...")
-    );
+    multiselect_utils.createFullMultiselectWidget('example-multiselect', {
+      selectableHeaderTitle: gettext("Available Letters"),
+      selectedHeaderTitle: gettext("Letters Selected"),
+      searchItemTitle: gettext("Search Letters..."),
+    });
   });
 </script>

--- a/corehq/apps/userreports/static/userreports/js/configure_report.js
+++ b/corehq/apps/userreports/static/userreports/js/configure_report.js
@@ -33,12 +33,11 @@ hqDefine('userreports/js/configure_report', function () {
                 (initialPageData.get('at_report_limit') && !existing_report)),
         });
         $("#reportConfig").koApplyBindings(reportConfig);
-        multiselectUtils.createFullMultiselectWidget(
-            'domain-selector',
-            gettext("Linked projects"),
-            gettext("Projects to copy to"),
-            gettext("Search projects")
-        );
+        multiselectUtils.createFullMultiselectWidget('domain-selector', {
+            selectableHeaderTitle: gettext("Linked projects"),
+            selectedHeaderTitle: gettext("Projects to copy to"),
+            searchItemTitle: gettext("Search projects"),
+        });
         window._bindingsApplied = true;
     });
 });

--- a/corehq/apps/userreports/static/userreports/js/edit_report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/edit_report_config.js
@@ -6,11 +6,10 @@ hqDefine('userreports/js/edit_report_config', [
     multiselectUtils
 ) {
     $(function () {
-        multiselectUtils.createFullMultiselectWidget(
-            'domain-selector',
-            gettext("Linked projects"),
-            gettext("Projects to copy to"),
-            gettext("Search projects")
-        );
+        multiselectUtils.createFullMultiselectWidget('domain-selector', {
+            selectableHeaderTitle: gettext("Linked projects"),
+            selectedHeaderTitle: gettext("Projects to copy to"),
+            searchItemTitle: gettext("Search projects"),
+        });
     });
 });

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -857,12 +857,11 @@ class MultipleSelectionForm(forms.Form):
             // Multiselect widget
             $(function () {
                 var multiselect_utils = hqImport('hqwebapp/js/multiselect_utils');
-                multiselect_utils.createFullMultiselectWidget(
-                    'id_of_multiselect_field',
-                    gettext("Available Things"),
-                    gettext("Things Selected"),
-                    gettext("Search Things...")
-                );
+                multiselect_utils.createFullMultiselectWidget('id_of_multiselect_field', {
+                    selectableHeaderTitle: gettext("Available Things"),
+                    selectedHeaderTitle: gettext("Things Selected"),
+                    searchItemTitle: gettext("Search Things..."),
+                });
             });
         });
     """

--- a/corehq/apps/users/static/users/js/edit_commcare_user.js
+++ b/corehq/apps/users/static/users/js/edit_commcare_user.js
@@ -86,12 +86,11 @@ hqDefine('users/js/edit_commcare_user', [
     }
 
     // Groups form
-    multiselectUtils.createFullMultiselectWidget(
-        'id_selected_ids',
-        gettext("Available Groups"),
-        gettext("Groups with this User"),
-        gettext("Search Group...")
-    );
+    multiselectUtils.createFullMultiselectWidget('id_selected_ids', {
+        selectableHeaderTitle: gettext("Available Groups"),
+        selectedHeaderTitle: gettext("Groups with this User"),
+        searchItemTitle: gettext("Search Group..."),
+    });
 
     // "are you sure?" stuff
     var unsavedChanges = false;


### PR DESCRIPTION
Reverts dimagi/commcare-hq#30907 which reverted dimagi/commcare-hq#30897. [This commit](https://github.com/dimagi/commcare-hq/pull/30909/commits/e641832eac8d49abab275a8cf266f6f63b0c643f) reverted applying the `options` knockout binding within the `createFullMultiselectWidget` back to within the `init` method of the `multiselect` knockout binding. This was an issue because the knockout bindings are separate from the properties related to the multiselect lib. So calling `multiSelect('destroy')` does not tear down knockout bindings, and then we attempt to apply the same bindings again.

The alternative solution is to lean into this distinction between multiselect related properties, and knockout binding related properties when setting up the `multiselect` binding in the first place. There is now a nested dictionary passed into this binding with `properties` key that holds the multiselect related properties, and an `options` key that holds the array of options to apply the `options` binding with. This adds a slight inconvenience on the caller side, specifically with callers that are not using the `options` key, but I think it makes up for it in the clean separation within the multiselect code itself.