### PR TITLE
Add support for LITE_RELEASE_MANAGEMENT privilege (take 2)

### DIFF
--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -7,7 +7,6 @@ from django_prbac.utils import has_privilege
 from dimagi.utils.couch.resource_conflict import retry_resource
 
 from corehq import privileges, toggles
-from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager import add_ons
 from corehq.apps.app_manager.const import APP_V1
 from corehq.apps.app_manager.dbaccessors import get_app
@@ -49,7 +48,7 @@ from corehq.apps.linked_domain.dbaccessors import (
     get_upstream_domain_link,
     is_active_downstream_domain,
 )
-from corehq.privileges import RELEASE_MANAGEMENT
+from corehq.apps.linked_domain.util import can_domain_access_release_management
 from corehq.util.soft_assert import soft_assert
 
 
@@ -272,7 +271,7 @@ def view_generic(request, domain, app_id, module_id=None, form_id=None,
                 and get_upstream_domain_link(request.domain).master_domain == d.name)
     }
     domain_names.add(request.domain)
-    if domain_has_privilege(request.domain, RELEASE_MANAGEMENT):
+    if can_domain_access_release_management(request.domain):
         linkable_domains = get_accessible_downstream_domains(domain, request.couch_user)
     else:
         # keep behavior the same as before for LINKED_DOMAINS toggle
@@ -280,7 +279,7 @@ def view_generic(request, domain, app_id, module_id=None, form_id=None,
     context.update({
         'domain_names': sorted(domain_names),
         'linkable_domains': sorted(linkable_domains),
-        'limit_to_linked_domains': (domain_has_privilege(request.domain, RELEASE_MANAGEMENT)
+        'limit_to_linked_domains': (can_domain_access_release_management(request.domain)
                                     and not request.couch_user.is_superuser)
     })
     context.update({

--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -8,6 +8,7 @@ from corehq.apps.linked_domain.util import (
     is_available_upstream_domain,
     is_domain_available_to_link,
     user_has_admin_access_in_all_domains,
+    can_domain_access_release_management,
 )
 from corehq.privileges import RELEASE_MANAGEMENT
 from corehq.util.quickcache import quickcache
@@ -124,7 +125,7 @@ def get_accessible_downstream_domains(upstream_domain_name, user):
     NOTE: if the RELEASE_MANAGEMENT privilege is enabled, ensure user has admin access
     """
     downstream_domains = [d.linked_domain for d in get_linked_domains(upstream_domain_name)]
-    if domain_has_privilege(upstream_domain_name, RELEASE_MANAGEMENT):
+    if can_domain_access_release_management(upstream_domain_name):
         return [domain for domain in downstream_domains
                 if user_has_admin_access_in_all_domains(user, [upstream_domain_name, domain])]
     return downstream_domains

--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -67,9 +67,9 @@ def get_available_domains_to_link(upstream_domain_name, user, billing_account=No
     if domain_has_privilege(upstream_domain_name, RELEASE_MANAGEMENT):
         return get_available_domains_to_link_for_account(upstream_domain_name, user, billing_account)
     elif domain_has_privilege(upstream_domain_name, LITE_RELEASE_MANAGEMENT):
-        return get_available_domains_to_link_for_user(upstream_domain_name, user, True)
+        return get_available_domains_to_link_for_user(upstream_domain_name, user, should_enforce_admin=True)
     elif toggles.LINKED_DOMAINS.enabled(upstream_domain_name):
-        return get_available_domains_to_link_for_user(upstream_domain_name, user, False)
+        return get_available_domains_to_link_for_user(upstream_domain_name, user, should_enforce_admin=False)
 
     return []
 

--- a/corehq/apps/linked_domain/decorators.py
+++ b/corehq/apps/linked_domain/decorators.py
@@ -15,7 +15,7 @@ def require_access_to_linked_domains(view_func):
 
         def call_view():
             return view_func(request, domain, *args, **kwargs)
-        if can_user_access_release_management(user, domain, check_toggle=True):
+        if can_user_access_release_management(user, domain, include_toggle=True):
             return call_view()
         else:
             return HttpResponseForbidden()

--- a/corehq/apps/linked_domain/decorators.py
+++ b/corehq/apps/linked_domain/decorators.py
@@ -3,7 +3,7 @@ from functools import wraps
 from django.http import HttpResponseBadRequest, HttpResponseForbidden
 
 from corehq.apps.linked_domain.dbaccessors import get_upstream_domain_link
-from corehq.apps.linked_domain.util import can_access_linked_domains
+from corehq.apps.linked_domain.util import can_user_access_release_management
 
 REMOTE_REQUESTER_HEADER = 'HTTP_HQ_REMOTE_REQUESTER'
 
@@ -15,7 +15,7 @@ def require_access_to_linked_domains(view_func):
 
         def call_view():
             return view_func(request, domain, *args, **kwargs)
-        if can_access_linked_domains(user, domain):
+        if can_user_access_release_management(user, domain):
             return call_view()
         else:
             return HttpResponseForbidden()

--- a/corehq/apps/linked_domain/decorators.py
+++ b/corehq/apps/linked_domain/decorators.py
@@ -15,7 +15,7 @@ def require_access_to_linked_domains(view_func):
 
         def call_view():
             return view_func(request, domain, *args, **kwargs)
-        if can_user_access_release_management(user, domain):
+        if can_user_access_release_management(user, domain, check_toggle=True):
             return call_view()
         else:
             return HttpResponseForbidden()

--- a/corehq/apps/linked_domain/tests/test_dbaccessors.py
+++ b/corehq/apps/linked_domain/tests/test_dbaccessors.py
@@ -6,10 +6,11 @@ from corehq.apps.linked_domain.dbaccessors import (
     get_available_domains_to_link,
     get_available_upstream_domains,
 )
+from corehq.privileges import LITE_RELEASE_MANAGEMENT
 from corehq.util.test_utils import flag_enabled
 
 
-class TestGetAvailableUpstreamDomainsForDownstreamDomain(SimpleTestCase):
+class TestGetAvailableUpstreamDomains(SimpleTestCase):
 
     @patch('corehq.apps.users.models.CouchUser')
     @patch('corehq.apps.accounting.models.BillingAccount')
@@ -17,9 +18,8 @@ class TestGetAvailableUpstreamDomainsForDownstreamDomain(SimpleTestCase):
         mock_account.get_domains.return_value = ['upstream', 'downstream-1', 'downstream-2']
         with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
-            upstream_domains = get_available_upstream_domains(
-                'downstream-1', mock_user, mock_account
-            )
+            upstream_domains = get_available_upstream_domains('downstream-1', mock_user, mock_account)
+
         self.assertFalse(upstream_domains)
 
     @flag_enabled("LINKED_DOMAINS")
@@ -31,35 +31,36 @@ class TestGetAvailableUpstreamDomainsForDownstreamDomain(SimpleTestCase):
         expected_upstream_domains = ['upstream']
         with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
              patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_account') \
-             as mock_account_domains,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_user') \
-             as mock_user_domains:
+             as mock_account_domains:
             mock_domain_has_privilege.return_value = True
             mock_account_domains.return_value = expected_upstream_domains
-            mock_user_domains.return_value = ['wrong']
-            upstream_domains = get_available_upstream_domains(
-                'downstream-1', mock_user, mock_account
-            )
+            upstream_domains = get_available_upstream_domains('downstream-1', mock_user, mock_account)
+
         self.assertEqual(expected_upstream_domains, upstream_domains)
 
     @flag_enabled("LINKED_DOMAINS")
     @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.accounting.models.BillingAccount')
-    def test_linked_domains_flag_returns_domains_for_user(self, mock_user, mock_account):
-        expected_upstream_domains = ['upstream']
+    def test_lite_release_management_privilege_returns_admin_domains_for_users(self, mock_user):
+        def mock_handler(domain, privilege):
+            return privilege == LITE_RELEASE_MANAGEMENT
+
         with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_account') \
-             as mock_account_domains,\
+             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_user') \
+             as mock_user_domains:
+            mock_domain_has_privilege.side_effect = mock_handler
+            get_available_upstream_domains('downstream-1', mock_user, None)
+        mock_user_domains.assert_called_with('downstream-1', mock_user, True)
+
+    @flag_enabled("LINKED_DOMAINS")
+    @patch('corehq.apps.users.models.CouchUser')
+    def test_linked_domains_flag_returns_domains_for_user(self, mock_user):
+        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
              patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_user') \
              as mock_user_domains:
             mock_domain_has_privilege.return_value = False
-            mock_account_domains.return_value = ['wrong']
-            mock_user_domains.return_value = expected_upstream_domains
-            upstream_domains = get_available_upstream_domains(
-                'downstream-1', mock_user, mock_account
-            )
+            get_available_upstream_domains('downstream-1', mock_user)
 
-        self.assertEqual(expected_upstream_domains, upstream_domains)
+        mock_user_domains.assert_called_with('downstream-1', mock_user, False)
 
 
 class TestGetAvailableDomainsToLink(SimpleTestCase):
@@ -94,17 +95,25 @@ class TestGetAvailableDomainsToLink(SimpleTestCase):
 
     @flag_enabled("LINKED_DOMAINS")
     @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.accounting.models.BillingAccount')
-    def test_linked_domains_flag_returns_domains_for_user(self, mock_user, mock_account):
-        expected_domains = ['downstream-1', 'downstream-2']
+    def test_lite_release_management_privilege_returns_admin_domains_for_users(self, mock_user):
+        def mock_handler(domain, privilege):
+            return privilege == LITE_RELEASE_MANAGEMENT
+
         with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_account') \
-             as mock_account_domains,\
+             patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_user') \
+             as mock_user_domains:
+            mock_domain_has_privilege.side_effect = mock_handler
+            get_available_domains_to_link('upstream', mock_user)
+
+        mock_user_domains.assert_called_with('upstream', mock_user, True)
+
+    @flag_enabled("LINKED_DOMAINS")
+    @patch('corehq.apps.users.models.CouchUser')
+    def test_linked_domains_flag_returns_domains_for_user(self, mock_user):
+        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
              patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_user') \
              as mock_user_domains:
             mock_domain_has_privilege.return_value = False
-            mock_account_domains.return_value = ['wrong']
-            mock_user_domains.return_value = expected_domains
-            domains = get_available_domains_to_link('upstream', mock_user, mock_account)
+            get_available_domains_to_link('upstream', mock_user)
 
-        self.assertEqual(expected_domains, domains)
+        mock_user_domains.assert_called_with('upstream', mock_user, False)

--- a/corehq/apps/linked_domain/tests/test_decorators.py
+++ b/corehq/apps/linked_domain/tests/test_decorators.py
@@ -43,9 +43,26 @@ class TestCanUserAccessReleaseManagement(SimpleTestCase):
 
     @flag_enabled("LINKED_DOMAINS")
     @patch('corehq.apps.users.models.CouchUser')
-    def test_returns_true_if_domain_has_linked_domain_toggle_enabled(self, mock_user):
+    def test_returns_false_if_domain_has_linked_domain_toggle_enabled_and_check_toggle_is_false(self, mock_user):
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
             result = can_user_access_release_management(mock_user, 'test')
+
+        self.assertFalse(result)
+
+    @patch('corehq.apps.users.models.CouchUser')
+    def test_returns_false_if_domain_has_no_linked_domain_toggle_enabled_and_check_toggle_is_true(self, mock_user):
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
+            result = can_user_access_release_management(mock_user, 'test', check_toggle=True)
+
+        self.assertFalse(result)
+
+    @flag_enabled("LINKED_DOMAINS")
+    @patch('corehq.apps.users.models.CouchUser')
+    def test_returns_true_if_domain_has_linked_domain_toggle_enabled_and_check_toggle_is_true(self, mock_user):
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
+            result = can_user_access_release_management(mock_user, 'test', check_toggle=True)
 
         self.assertTrue(result)

--- a/corehq/apps/linked_domain/tests/test_decorators.py
+++ b/corehq/apps/linked_domain/tests/test_decorators.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from django.test import SimpleTestCase
 
 from corehq.apps.linked_domain.util import can_user_access_release_management, can_domain_access_release_management
+from corehq.privileges import LITE_RELEASE_MANAGEMENT, RELEASE_MANAGEMENT
 from corehq.util.test_utils import flag_enabled
 
 
@@ -41,9 +42,35 @@ class TestCanUserAccessReleaseManagement(SimpleTestCase):
 
         self.assertTrue(result)
 
+    @patch('corehq.apps.users.models.CouchUser')
+    def test_returns_true_if_domain_has_lite_privilege_and_user_is_admin(self, mock_user):
+        mock_user.is_domain_admin.return_value = True
+
+        def mock_handler(domain, privilege):
+            return privilege == LITE_RELEASE_MANAGEMENT
+
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = True
+            result = can_user_access_release_management(mock_user, 'test')
+
+        self.assertTrue(result)
+
+    @patch('corehq.apps.users.models.CouchUser')
+    def test_false_if_domain_has_lite_privilege_and_user_is_admin_but_include_lite_is_false(self, mock_user):
+        mock_user.is_domain_admin.return_value = True
+
+        def mock_handler(domain, privilege):
+            return privilege == LITE_RELEASE_MANAGEMENT
+
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.side_effect = mock_handler
+            result = can_user_access_release_management(mock_user, 'test', include_lite_version=False)
+
+        self.assertFalse(result)
+
     @flag_enabled("LINKED_DOMAINS")
     @patch('corehq.apps.users.models.CouchUser')
-    def test_returns_false_if_domain_has_linked_domain_toggle_enabled_and_check_toggle_is_false(self, mock_user):
+    def test_returns_false_if_domain_has_linked_domain_toggle_enabled_and_include_toggle_is_false(self, mock_user):
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
             result = can_user_access_release_management(mock_user, 'test')
@@ -51,19 +78,19 @@ class TestCanUserAccessReleaseManagement(SimpleTestCase):
         self.assertFalse(result)
 
     @patch('corehq.apps.users.models.CouchUser')
-    def test_returns_false_if_domain_has_no_linked_domain_toggle_enabled_and_check_toggle_is_true(self, mock_user):
+    def test_false_if_domain_has_no_linked_domain_toggle_enabled_and_include_toggle_is_true(self, mock_user):
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
-            result = can_user_access_release_management(mock_user, 'test', check_toggle=True)
+            result = can_user_access_release_management(mock_user, 'test', include_toggle=True)
 
         self.assertFalse(result)
 
     @flag_enabled("LINKED_DOMAINS")
     @patch('corehq.apps.users.models.CouchUser')
-    def test_returns_true_if_domain_has_linked_domain_toggle_enabled_and_check_toggle_is_true(self, mock_user):
+    def test_returns_true_if_domain_has_linked_domain_toggle_enabled_and_include_toggle_is_true(self, mock_user):
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
-            result = can_user_access_release_management(mock_user, 'test', check_toggle=True)
+            result = can_user_access_release_management(mock_user, 'test', include_toggle=True)
 
         self.assertTrue(result)
 
@@ -75,31 +102,69 @@ class TestCanDomainAccessReleaseManagement(SimpleTestCase):
         self.assertFalse(result)
 
     def test_returns_true_if_domain_has_release_management_privilege(self):
+        def mock_handler(domain, privilege):
+            return privilege == RELEASE_MANAGEMENT
+
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = True
+            mock_domain_has_privilege.side_effect = mock_handler
             result = can_domain_access_release_management('test')
 
         self.assertTrue(result)
 
-    @flag_enabled("LINKED_DOMAINS")
-    def test_returns_false_if_domain_has_linked_domain_toggle_enabled_and_check_toggle_is_false(self):
+    def test_returns_false_if_domain_does_not_have_release_management_privilege(self):
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
             result = can_domain_access_release_management('test')
 
         self.assertFalse(result)
 
-    def test_returns_false_if_domain_has_no_linked_domain_toggle_enabled_and_check_toggle_is_true(self):
+    def test_returns_true_if_domain_has_lite_release_management_and_include_lite_version_is_true(self):
+        def mock_handler(domain, privilege):
+            return privilege == LITE_RELEASE_MANAGEMENT
+
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.side_effect = mock_handler
+            # include_lite_version is True by default
+            result = can_domain_access_release_management('test')
+
+        self.assertTrue(result)
+
+    def test_returns_false_if_domain_does_not_have_lite_release_management_and_include_lite_version_is_true(self):
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
-            result = can_domain_access_release_management('test', check_toggle=True)
+            # include_lite_version is True by default
+            result = can_domain_access_release_management('test')
+
+        self.assertFalse(result)
+
+    def test_returns_false_if_domain_has_lite_release_management_and_include_lite_version_is_false(self):
+        def mock_handler(domain, privilege):
+            return privilege == LITE_RELEASE_MANAGEMENT
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.side_effect = mock_handler
+            result = can_domain_access_release_management('test', include_lite_version=False)
 
         self.assertFalse(result)
 
     @flag_enabled("LINKED_DOMAINS")
-    def test_returns_true_if_domain_has_linked_domain_toggle_enabled_and_check_toggle_is_true(self):
+    def test_returns_false_if_domain_has_linked_domain_toggle_enabled_and_include_toggle_is_false(self):
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
-            result = can_domain_access_release_management('test', check_toggle=True)
+            result = can_domain_access_release_management('test')
+
+        self.assertFalse(result)
+
+    def test_returns_false_if_domain_has_no_linked_domain_toggle_enabled_and_include_toggle_is_true(self):
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
+            result = can_domain_access_release_management('test', include_toggle=True)
+
+        self.assertFalse(result)
+
+    @flag_enabled("LINKED_DOMAINS")
+    def test_returns_true_if_domain_has_linked_domain_toggle_enabled_and_include_toggle_is_true(self):
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
+            result = can_domain_access_release_management('test', include_toggle=True)
 
         self.assertTrue(result)

--- a/corehq/apps/linked_domain/tests/test_decorators.py
+++ b/corehq/apps/linked_domain/tests/test_decorators.py
@@ -2,23 +2,23 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
-from corehq.apps.linked_domain.util import can_access_linked_domains
+from corehq.apps.linked_domain.util import can_user_access_release_management
 from corehq.util.test_utils import flag_enabled
 
 
-class TestCanAccessLinkedDomains(SimpleTestCase):
+class TestCanUserAccessReleaseManagement(SimpleTestCase):
 
     def test_returns_false_if_no_user(self):
-        result = can_access_linked_domains(None, 'test')
+        result = can_user_access_release_management(None, 'test')
         self.assertFalse(result)
 
     @patch('corehq.apps.users.models.CouchUser')
     def test_returns_false_if_no_domain(self, mock_user):
-        result = can_access_linked_domains(mock_user, None)
+        result = can_user_access_release_management(mock_user, None)
         self.assertFalse(result)
 
     def test_returns_false_if_no_user_and_no_domain(self):
-        result = can_access_linked_domains(None, None)
+        result = can_user_access_release_management(None, None)
         self.assertFalse(result)
 
     @patch('corehq.apps.users.models.CouchUser')
@@ -27,7 +27,7 @@ class TestCanAccessLinkedDomains(SimpleTestCase):
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = True
-            result = can_access_linked_domains(mock_user, 'test')
+            result = can_user_access_release_management(mock_user, 'test')
 
         self.assertFalse(result)
 
@@ -37,7 +37,7 @@ class TestCanAccessLinkedDomains(SimpleTestCase):
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = True
-            result = can_access_linked_domains(mock_user, 'test')
+            result = can_user_access_release_management(mock_user, 'test')
 
         self.assertTrue(result)
 
@@ -46,6 +46,6 @@ class TestCanAccessLinkedDomains(SimpleTestCase):
     def test_returns_true_if_domain_has_linked_domain_toggle_enabled(self, mock_user):
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
-            result = can_access_linked_domains(mock_user, 'test')
+            result = can_user_access_release_management(mock_user, 'test')
 
         self.assertTrue(result)

--- a/corehq/apps/linked_domain/tests/test_decorators.py
+++ b/corehq/apps/linked_domain/tests/test_decorators.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
-from corehq.apps.linked_domain.util import can_user_access_release_management
+from corehq.apps.linked_domain.util import can_user_access_release_management, can_domain_access_release_management
 from corehq.util.test_utils import flag_enabled
 
 
@@ -64,5 +64,42 @@ class TestCanUserAccessReleaseManagement(SimpleTestCase):
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
             result = can_user_access_release_management(mock_user, 'test', check_toggle=True)
+
+        self.assertTrue(result)
+
+
+class TestCanDomainAccessReleaseManagement(SimpleTestCase):
+
+    def test_returns_false_if_no_domain(self):
+        result = can_domain_access_release_management(None)
+        self.assertFalse(result)
+
+    def test_returns_true_if_domain_has_release_management_privilege(self):
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = True
+            result = can_domain_access_release_management('test')
+
+        self.assertTrue(result)
+
+    @flag_enabled("LINKED_DOMAINS")
+    def test_returns_false_if_domain_has_linked_domain_toggle_enabled_and_check_toggle_is_false(self):
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
+            result = can_domain_access_release_management('test')
+
+        self.assertFalse(result)
+
+    def test_returns_false_if_domain_has_no_linked_domain_toggle_enabled_and_check_toggle_is_true(self):
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
+            result = can_domain_access_release_management('test', check_toggle=True)
+
+        self.assertFalse(result)
+
+    @flag_enabled("LINKED_DOMAINS")
+    def test_returns_true_if_domain_has_linked_domain_toggle_enabled_and_check_toggle_is_true(self):
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
+            result = can_domain_access_release_management('test', check_toggle=True)
 
         self.assertTrue(result)

--- a/corehq/apps/linked_domain/tests/test_decorators.py
+++ b/corehq/apps/linked_domain/tests/test_decorators.py
@@ -50,7 +50,7 @@ class TestCanUserAccessReleaseManagement(SimpleTestCase):
             return privilege == LITE_RELEASE_MANAGEMENT
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = True
+            mock_domain_has_privilege.side_effect = mock_handler
             result = can_user_access_release_management(mock_user, 'test')
 
         self.assertTrue(result)

--- a/corehq/apps/linked_domain/tests/test_release_manager.py
+++ b/corehq/apps/linked_domain/tests/test_release_manager.py
@@ -230,8 +230,8 @@ class TestReleaseReport(BaseReleaseManagerTest):
         )
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
+        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
+            mock_access_check.return_value = False
             errors = manager._release_report(self.domain_link, model, 'test-user')
         self.assertIsNone(errors)
 
@@ -254,8 +254,8 @@ class TestReleaseReport(BaseReleaseManagerTest):
         )
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = True
+        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
+            mock_access_check.return_value = True
             errors = manager._release_report(self.domain_link, model, 'test-user')
         self.assertIsNone(errors)
 
@@ -272,8 +272,8 @@ class TestReleaseReport(BaseReleaseManagerTest):
         )
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
+        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
+            mock_access_check.return_value = False
             errors = manager._release_report(self.domain_link, model, 'test-user')
         self.assertTrue('Could not find report. Please check that the report has been linked.' in errors)
 
@@ -286,8 +286,8 @@ class TestReleaseReport(BaseReleaseManagerTest):
         )
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = True
+        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
+            mock_access_check.return_value = True
             errors = manager._release_report(self.domain_link, model, 'test-user')
         self.assertIsNone(errors)
 
@@ -321,8 +321,8 @@ class TestReleaseKeyword(BaseReleaseManagerTest):
         )
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
+        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
+            mock_access_check.return_value = False
             errors = manager._release_keyword(self.domain_link, model, 'test-user')
         self.assertIsNone(errors)
 
@@ -344,8 +344,8 @@ class TestReleaseKeyword(BaseReleaseManagerTest):
         )
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = True
+        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
+            mock_access_check.return_value = True
             errors = manager._release_keyword(self.domain_link, model, 'test-user')
         self.assertIsNone(errors)
 
@@ -363,8 +363,8 @@ class TestReleaseKeyword(BaseReleaseManagerTest):
 
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
+        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
+            mock_access_check.return_value = False
             errors = manager._release_keyword(self.domain_link, model, 'test-user')
         self.assertTrue('Could not find linked keyword. Please check the keyword has been linked.' in errors)
 
@@ -377,8 +377,8 @@ class TestReleaseKeyword(BaseReleaseManagerTest):
 
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = True
+        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
+            mock_access_check.return_value = True
             errors = manager._release_keyword(self.domain_link, model, 'test-user')
         self.assertIsNone(errors)
 

--- a/corehq/apps/linked_domain/util.py
+++ b/corehq/apps/linked_domain/util.py
@@ -17,7 +17,7 @@ def can_user_access_release_management(user, domain, include_lite_version=True, 
     """
     :param include_lite_version: set to True if the LITE_RELEASE_MANAGEMENT privilege should be checked
     :param include_toggle: set to True if the deprecated linked domains toggle should be checked
-    NOTE: can remove check_toggle once the linked domains toggle is deleted
+    NOTE: can remove include_toggle once the linked domains toggle is deleted
     Checks if the current domain has any of the following enabled:
     - privileges.RELEASE_MANAGEMENT
     - privileges.LITE_RELEASE_MANAGEMENT
@@ -40,12 +40,11 @@ def can_domain_access_release_management(domain, include_lite_version=True, incl
     """
     :param include_lite_version: set to True if the LITE_RELEASE_MANAGEMENT privilege should be checked
     :param include_toggle: set to True if the deprecated linked domains toggle should be checked
-    NOTE: can remove check_toggle once the linked domains toggle is deleted
+    NOTE: can remove include_toggle once the linked domains toggle is deleted
     Checks if the current domain has any of the following enabled:
     - privileges.RELEASE_MANAGEMENT
     - privileges.LITE_RELEASE_MANAGEMENT
     - toggles.LINKED_DOMAINS
-    If yes, and the user meets the criteria needed, returns True
     """
     if not domain:
         return False

--- a/corehq/apps/linked_domain/util.py
+++ b/corehq/apps/linked_domain/util.py
@@ -9,7 +9,7 @@ from corehq.apps.app_manager.exceptions import MultimediaMissingError
 from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.linked_domain.remote_accessors import fetch_remote_media
-from corehq.privileges import RELEASE_MANAGEMENT
+from corehq.privileges import RELEASE_MANAGEMENT, LITE_RELEASE_MANAGEMENT
 from corehq.util.timezones.conversions import ServerTime
 
 
@@ -19,12 +19,13 @@ def can_user_access_release_management(user, domain, check_toggle=False):
     NOTE: can remove check_toggle once the linked domains toggle is deleted
     Checks if the current domain has any of the following enabled:
     - privileges.RELEASE_MANAGEMENT
+    - privileges.LITE_RELEASE_MANAGEMENT
     - toggles.LINKED_DOMAINS
     If yes, and the user meets the criteria needed, returns True
     """
     if not user or not domain:
         return False
-    if domain_has_privilege(domain, RELEASE_MANAGEMENT):
+    if domain_has_privilege(domain, RELEASE_MANAGEMENT) or domain_has_privilege(domain, LITE_RELEASE_MANAGEMENT):
         return user.is_domain_admin(domain)
     elif check_toggle:
         return toggles.LINKED_DOMAINS.enabled(domain)
@@ -35,10 +36,16 @@ def can_domain_access_release_management(domain, check_toggle=False):
     """
     :param check_toggle: set to True if the deprecated linked domains toggle should be checked
     NOTE: can remove check_toggle once the linked domains toggle is deleted
+    Checks if the current domain has any of the following enabled:
+    - privileges.RELEASE_MANAGEMENT
+    - privileges.LITE_RELEASE_MANAGEMENT
+    - toggles.LINKED_DOMAINS
+    If yes, and the user meets the criteria needed, returns True
     """
     if not domain:
         return False
-    is_privilege_granted = domain_has_privilege(domain, RELEASE_MANAGEMENT)
+    is_privilege_granted = (domain_has_privilege(domain, RELEASE_MANAGEMENT)
+                            or domain_has_privilege(domain, LITE_RELEASE_MANAGEMENT))
     is_toggle_enabled = check_toggle and toggles.LINKED_DOMAINS.enabled(domain)
     return is_privilege_granted or is_toggle_enabled
 

--- a/corehq/apps/linked_domain/util.py
+++ b/corehq/apps/linked_domain/util.py
@@ -31,6 +31,18 @@ def can_user_access_release_management(user, domain, check_toggle=False):
     return False
 
 
+def can_domain_access_release_management(domain, check_toggle=False):
+    """
+    :param check_toggle: set to True if the deprecated linked domains toggle should be checked
+    NOTE: can remove check_toggle once the linked domains toggle is deleted
+    """
+    if not domain:
+        return False
+    is_privilege_granted = domain_has_privilege(domain, RELEASE_MANAGEMENT)
+    is_toggle_enabled = check_toggle and toggles.LINKED_DOMAINS.enabled(domain)
+    return is_privilege_granted or is_toggle_enabled
+
+
 def _clean_json(doc):
     if not isinstance(doc, dict):
         return doc

--- a/corehq/apps/linked_domain/util.py
+++ b/corehq/apps/linked_domain/util.py
@@ -13,8 +13,10 @@ from corehq.privileges import RELEASE_MANAGEMENT
 from corehq.util.timezones.conversions import ServerTime
 
 
-def can_user_access_release_management(user, domain):
+def can_user_access_release_management(user, domain, check_toggle=False):
     """
+    :param check_toggle: set to True if the deprecated linked domains toggle should be checked
+    NOTE: can remove check_toggle once the linked domains toggle is deleted
     Checks if the current domain has any of the following enabled:
     - privileges.RELEASE_MANAGEMENT
     - toggles.LINKED_DOMAINS
@@ -24,12 +26,9 @@ def can_user_access_release_management(user, domain):
         return False
     if domain_has_privilege(domain, RELEASE_MANAGEMENT):
         return user.is_domain_admin(domain)
-    else:
+    elif check_toggle:
         return toggles.LINKED_DOMAINS.enabled(domain)
-
-
-def can_access_release_management_feature(user, domain):
-    return domain_has_privilege(domain, RELEASE_MANAGEMENT) and user.is_domain_admin(domain)
+    return False
 
 
 def _clean_json(doc):

--- a/corehq/apps/linked_domain/util.py
+++ b/corehq/apps/linked_domain/util.py
@@ -13,7 +13,13 @@ from corehq.privileges import RELEASE_MANAGEMENT
 from corehq.util.timezones.conversions import ServerTime
 
 
-def can_access_linked_domains(user, domain):
+def can_user_access_release_management(user, domain):
+    """
+    Checks if the current domain has any of the following enabled:
+    - privileges.RELEASE_MANAGEMENT
+    - toggles.LINKED_DOMAINS
+    If yes, and the user meets the criteria needed, returns True
+    """
     if not user or not domain:
         return False
     if domain_has_privilege(domain, RELEASE_MANAGEMENT):

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -12,7 +12,6 @@ from djng.views.mixins import JSONResponseMixin, allow_remote_invocation
 from memoized import memoized
 
 from corehq.apps.accounting.models import BillingAccount
-from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.app_manager.dbaccessors import (
     get_app,
@@ -91,6 +90,7 @@ from corehq.apps.linked_domain.util import (
     pull_missing_multimedia_for_app,
     server_to_user_time,
     user_has_admin_access_in_all_domains,
+    can_domain_access_release_management,
 )
 from corehq.apps.linked_domain.view_helpers import (
     build_domain_link_view_model,
@@ -112,7 +112,6 @@ from corehq.apps.userreports.models import (
 )
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions, WebUser
-from corehq.privileges import RELEASE_MANAGEMENT
 from corehq.util.timezones.utils import get_timezone_for_request
 
 
@@ -322,7 +321,7 @@ class DomainLinkView(BaseAdminProjectSettingsView):
         return {
             'domain': self.domain,
             'timezone': timezone.localize(datetime.utcnow()).tzname(),
-            'has_release_management_privilege': domain_has_privilege(self.domain, RELEASE_MANAGEMENT),
+            'has_release_management_privilege': can_domain_access_release_management(self.domain),
             'is_superuser': is_superuser,
             'view_data': {
                 'is_downstream_domain': bool(upstream_link),

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -14,7 +14,6 @@ from dimagi.utils.logging import notify_exception
 
 from corehq import privileges
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
-from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.hqwebapp.decorators import use_multiselect
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
@@ -22,11 +21,11 @@ from corehq.apps.linked_domain.dbaccessors import get_linked_domains
 from corehq.apps.linked_domain.exceptions import DomainLinkError
 from corehq.apps.linked_domain.keywords import create_linked_keyword
 from corehq.apps.linked_domain.models import DomainLink, KeywordLinkDetail
+from corehq.apps.linked_domain.util import can_domain_access_release_management
 from corehq.apps.reminders.forms import NO_RESPONSE, KeywordForm
 from corehq.apps.reminders.util import get_combined_id, split_combined_id
 from corehq.apps.sms.models import Keyword, KeywordAction
 from corehq.apps.sms.views import BaseMessagingSectionView
-from corehq.privileges import RELEASE_MANAGEMENT
 
 
 class AddStructuredKeywordView(BaseMessagingSectionView):
@@ -288,7 +287,7 @@ class KeywordsListView(BaseMessagingSectionView, CRUDPaginatedViewMixin):
             for domain_link in get_linked_domains(self.domain)
         ]
         context['linkable_keywords'] = self._linkable_keywords()
-        context['has_release_management_privilege'] = domain_has_privilege(self.domain, RELEASE_MANAGEMENT)
+        context['has_release_management_privilege'] = can_domain_access_release_management(self.domain)
         return context
 
     def _linkable_keywords(self):

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -351,4 +351,4 @@ class ReleaseManagementReportDispatcher(ReportDispatcher):
 
     def permissions_check(self, report, request, domain=None, is_navigation_check=False):
         from corehq.apps.linked_domain.util import can_user_access_release_management
-        return can_user_access_release_management(request.couch_user, domain, check_toggle=True)
+        return can_user_access_release_management(request.couch_user, domain, include_toggle=True)

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -350,7 +350,7 @@ class ReleaseManagementReportDispatcher(ReportDispatcher):
     map_name = 'RELEASE_MANAGEMENT_REPORTS'
 
     def permissions_check(self, report, request, domain=None, is_navigation_check=False):
-        from corehq.apps.linked_domain.util import can_access_linked_domains
+        from corehq.apps.linked_domain.util import can_user_access_release_management
         # will eventually only be accessible via the release_management privilege, but shared with linked domains
         # feature flag for now
-        return can_access_linked_domains(request.couch_user, domain)
+        return can_user_access_release_management(request.couch_user, domain)

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -351,6 +351,4 @@ class ReleaseManagementReportDispatcher(ReportDispatcher):
 
     def permissions_check(self, report, request, domain=None, is_navigation_check=False):
         from corehq.apps.linked_domain.util import can_user_access_release_management
-        # will eventually only be accessible via the release_management privilege, but shared with linked domains
-        # feature flag for now
-        return can_user_access_release_management(request.couch_user, domain)
+        return can_user_access_release_management(request.couch_user, domain, check_toggle=True)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -67,7 +67,7 @@ from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.linked_domain.models import DomainLink, ReportLinkDetail
 from corehq.apps.linked_domain.ucr import create_linked_ucr, linked_downstream_reports_by_domain
-from corehq.apps.linked_domain.util import is_linked_report
+from corehq.apps.linked_domain.util import is_linked_report, can_domain_access_release_management
 from corehq.apps.locations.permissions import conditionally_location_safe
 from corehq.apps.registry.helper import DataRegistryHelper
 from corehq.apps.registry.models import DataRegistry
@@ -150,7 +150,6 @@ from corehq.apps.userreports.util import (
 )
 from corehq.apps.users.decorators import get_permission_name, require_permission
 from corehq.apps.users.models import Permissions
-from corehq.privileges import RELEASE_MANAGEMENT
 from corehq.tabs.tabclasses import ProjectReportsTab
 from corehq.util import reverse
 from corehq.util.couch import get_document_or_404
@@ -260,7 +259,7 @@ class BaseEditConfigReportView(BaseUserConfigReportsView):
             'linked_report_domain_list': linked_downstream_reports_by_domain(
                 self.domain, self.report_id
             ),
-            'has_release_management_privilege': domain_has_privilege(self.domain, RELEASE_MANAGEMENT),
+            'has_release_management_privilege': can_domain_access_release_management(self.domain),
         }
 
     @property
@@ -640,7 +639,7 @@ class ConfigureReport(ReportBuilderView):
             'linked_report_domain_list': linked_downstream_reports_by_domain(
                 self.domain, self.existing_report.get_id
             ) if self.existing_report else {},
-            'has_release_management_privilege': domain_has_privilege(self.domain, RELEASE_MANAGEMENT),
+            'has_release_management_privilege': can_domain_access_release_management(self.domain),
         }
 
     def _get_bound_form(self, report_data):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1768,9 +1768,10 @@ class ProjectSettingsTab(UITab):
         if feature_flag_items and has_project_access:
             items.append((_('Pre-release Features'), feature_flag_items))
 
-        release_management_items = _get_release_management_items(self.couch_user, self.domain)
+        release_management_title, release_management_items = _get_release_management_items(self.couch_user,
+                                                                                           self.domain)
         if release_management_items:
-            items.append((_('Enterprise Release Management'), release_management_items))
+            items.append((release_management_title, release_management_items))
 
         from corehq.apps.users.models import WebUser
         if isinstance(self.couch_user, WebUser):
@@ -2049,18 +2050,27 @@ def _get_feature_flag_items(domain, couch_user):
 
 
 def _get_release_management_items(user, domain):
-    release_management_items = []
-    if can_user_access_release_management(user, domain):
-        release_management_items.append({
+    items = []
+    title = None
+    if not can_user_access_release_management(user, domain):
+        return title, items
+
+    if domain_has_privilege(domain, privileges.RELEASE_MANAGEMENT):
+        title = _('Enterprise Release Management')
+    elif domain_has_privilege(domain, privileges.LITE_RELEASE_MANAGEMENT):
+        title = _('Multi-Environment Release Management')
+
+    if title:
+        items.append({
             'title': _('Linked Project Spaces'),
             'url': reverse('domain_links', args=[domain])
         })
-        release_management_items.append({
+        items.append({
             'title': _('Linked Project Space History'),
             'url': reverse('domain_report_dispatcher', args=[domain, 'project_link_report'])
         })
 
-    return release_management_items
+    return title, items
 
 
 class MySettingsTab(UITab):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -49,7 +49,7 @@ from corehq.apps.integration.views import (
     GaenOtpServerSettingsView,
     HmacCalloutSettingsView,
 )
-from corehq.apps.linked_domain.util import can_user_access_release_management
+from corehq.apps.linked_domain.util import can_user_access_release_management, can_domain_access_release_management
 from corehq.apps.locations.analytics import users_have_locations
 from corehq.apps.receiverwrapper.rate_limiter import (
     SHOULD_RATE_LIMIT_SUBMISSIONS,
@@ -99,7 +99,7 @@ from corehq.messaging.scheduling.views import (
 from corehq.motech.dhis2.views import DataSetMapListView
 from corehq.motech.openmrs.views import OpenmrsImporterView
 from corehq.motech.views import ConnectionSettingsListView, MotechLogListView
-from corehq.privileges import DAILY_SAVED_EXPORT, EXCEL_DASHBOARD, RELEASE_MANAGEMENT
+from corehq.privileges import DAILY_SAVED_EXPORT, EXCEL_DASHBOARD
 from corehq.tabs.uitab import UITab
 from corehq.tabs.utils import (
     dropdown_dict,
@@ -2017,10 +2017,10 @@ def _get_feature_flag_items(domain, couch_user):
             'url': reverse(LocationFixtureConfigView.urlname, args=[domain])
         })
 
-    # show ERM version of linked projects if domain has privilege
+    # DEPRECATED: only show this is the domain does not have release_management access
     can_access_linked_domains = (
         user_is_admin and toggles.LINKED_DOMAINS.enabled(domain)
-        and not domain_has_privilege(domain, RELEASE_MANAGEMENT)
+        and not can_domain_access_release_management(domain)
     )
     if can_access_linked_domains:
         feature_flag_items.append({

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -49,7 +49,7 @@ from corehq.apps.integration.views import (
     GaenOtpServerSettingsView,
     HmacCalloutSettingsView,
 )
-from corehq.apps.linked_domain.util import can_access_release_management_feature
+from corehq.apps.linked_domain.util import can_user_access_release_management
 from corehq.apps.locations.analytics import users_have_locations
 from corehq.apps.receiverwrapper.rate_limiter import (
     SHOULD_RATE_LIMIT_SUBMISSIONS,
@@ -2050,8 +2050,7 @@ def _get_feature_flag_items(domain, couch_user):
 
 def _get_release_management_items(user, domain):
     release_management_items = []
-
-    if can_access_release_management_feature(user, domain):
+    if can_user_access_release_management(user, domain):
         release_management_items.append({
             'title': _('Linked Project Spaces'),
             'url': reverse('domain_links', args=[domain])

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -2018,7 +2018,7 @@ def _get_feature_flag_items(domain, couch_user):
             'url': reverse(LocationFixtureConfigView.urlname, args=[domain])
         })
 
-    # DEPRECATED: only show this is the domain does not have release_management access
+    # DEPRECATED: only show this if the domain does not have release_management access
     can_access_linked_domains = (
         user_is_admin and toggles.LINKED_DOMAINS.enabled(domain)
         and not can_domain_access_release_management(domain)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The LITE_RELEASE_MANAGEMENT privilege gives users access to a limited version of RELEASE_MANAGEMENT features like Linked Projects. This PR gives users with this privilege enabled access to those features.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
For those who may have reviewed the [previous PR](https://github.com/dimagi/commcare-hq/pull/30876): I botched the previous PR by rebasing `gh/mrm/base` and `gh/mrm/check-for-privilege` and then only pushing `gh/mrm/check-for-privilege`. If you happened to look at that PR but didn't leave any comments, there aren't any differences on this PR. I was only rebasing to get up to date changes from master that were applicable to other work being done off of this branch.

https://dimagi-dev.atlassian.net/browse/SS-267

I'm basing this off of a non-master branch so that all changes will be ready to go prior to being included in master.

Reviewing by commit might be easier. The first few commits lay the foundation to add the LITE_RELEASE_MANAGEMENT privilege to the mix. Since we still have to juggle the LINKED_DOMAINS feature flag, I added an include_toggle argument to the helper to make it easier to specify when to check the toggle and when not to. Additionally, this should be pretty easy to rip out once the toggle can be removed.

There are a couple cases where the lite version is handled differently from the full version. There are tests to back up these differences as well, but the two methods are get_available_domains_to_link and get_available_upstream_domains. Since Pro/Advanced plans are not guaranteed to be part of the same billing account, a user can link any domains in which they are admins in both.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added automated tests where applicable.


### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will request QA on base branch.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
