### PR TITLE
Simplify xform parsing

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_xform_case_ids.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_xform_case_ids.py
@@ -1,0 +1,51 @@
+from uuid import uuid4
+
+import attr
+from django.test import SimpleTestCase
+
+from casexml.apps.case.const import CASE_ATTR_ID
+from casexml.apps.case.xform import get_case_ids_from_form
+from casexml.apps.case.xml import V2_NAMESPACE
+from casexml.apps.case.xml.parser import XMLNS_ATTR
+
+
+class TestXformCaseIds(SimpleTestCase):
+
+    def test_basic(self):
+        case_id = uuid4().hex
+        xform = FakeForm({
+            'data': {'some': 'stuff'},
+            'case': case_block(case_id),
+        })
+        self.assertEqual(get_case_ids_from_form(xform), {case_id})
+
+    def test_blocks_in_list(self):
+        case_ids = {uuid4().hex for x in range(3)}
+        xform = FakeForm({'data': {'parent': {'parent': {
+            'case': [case_block(c) for c in case_ids]
+        }}}})
+        self.assertEqual(get_case_ids_from_form(xform), case_ids)
+
+    def test_blocks_in_repeat(self):
+        case_ids = {uuid4().hex for x in range(3)}
+        blocks = [case_block(c) for c in case_ids]
+        xform = FakeForm({
+            'data': {
+                'parent': {
+                    'repeats': [{'group': {'case': block}} for block in blocks]
+                }
+            }
+        })
+        self.assertEqual(get_case_ids_from_form(xform), case_ids)
+
+
+def case_block(case_id):
+    return {XMLNS_ATTR: V2_NAMESPACE, CASE_ATTR_ID: case_id}
+
+
+@attr.s
+class FakeForm:
+    form_data = attr.ib()
+
+    def get_xml_element(self):
+        return []

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -13,7 +13,7 @@ from corehq.util.soft_assert import soft_assert
 from casexml.apps.case.exceptions import InvalidCaseIndex, IllegalCaseId
 
 from casexml.apps.case import const
-from casexml.apps.case.xml.parser import case_update_from_block
+from casexml.apps.case.xml.parser import case_id_from_block, case_update_from_block
 from custom.covid.casesync import get_ush_extension_cases_to_close
 from dimagi.utils.logging import notify_exception
 
@@ -271,7 +271,7 @@ def _update_order_index(update):
 
 def get_case_ids_from_form(xform):
     from corehq.form_processor.parsers.ledgers.form import get_case_ids_from_stock_transactions
-    case_ids = set(cu.id for cu in get_case_updates(xform))
+    case_ids = set(case_id_from_block(b) for b in extract_case_blocks(xform))
     if xform:
         case_ids.update(get_case_ids_from_stock_transactions(xform))
     return case_ids

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -198,7 +198,7 @@ def extract_case_blocks(doc, include_path=False):
     else:
         form = doc.form_data
 
-    return [struct if include_path else struct.caseblock for struct in _extract_case_blocks(form)]
+    return list(_extract_case_blocks(form, [] if include_path else None))
 
 
 def _extract_case_blocks(data, path=None, form_id=Ellipsis):
@@ -211,14 +211,11 @@ def _extract_case_blocks(data, path=None, form_id=Ellipsis):
     if form_id is Ellipsis:
         form_id = extract_meta_instance_id(data)
 
-    path = path or []
     if isinstance(data, list):
         for item in data:
-            for case_block in _extract_case_blocks(item, path=path, form_id=form_id):
-                yield case_block
+            yield from _extract_case_blocks(item, path, form_id=form_id)
     elif isinstance(data, dict) and not is_device_report(data):
         for key, value in data.items():
-            new_path = path + [key]
             if const.CASE_TAG == key:
                 # it's a case block! Stop recursion and add to this value
                 if isinstance(value, list):
@@ -231,10 +228,13 @@ def _extract_case_blocks(data, path=None, form_id=Ellipsis):
                         validate_phone_datetime(
                             case_block.get('@date_modified'), none_ok=True, form_id=form_id
                         )
-                        yield CaseBlockWithPath(caseblock=case_block, path=path)
+                        if path is None:
+                            yield case_block
+                        else:
+                            yield CaseBlockWithPath(caseblock=case_block, path=path)
             else:
-                for case_block in _extract_case_blocks(value, path=new_path, form_id=form_id):
-                    yield case_block
+                new_path = None if path is None else path + [key]
+                yield from _extract_case_blocks(value, new_path, form_id=form_id)
 
 
 def get_case_updates(xform):

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -2,18 +2,15 @@ from collections import namedtuple
 from itertools import groupby
 
 import itertools
-from django.db.models import Q
-from casexml.apps.case.const import UNOWNED_EXTENSION_OWNER_ID, CASE_INDEX_EXTENSION
+from casexml.apps.case.const import UNOWNED_EXTENSION_OWNER_ID
 from casexml.apps.case.signals import cases_received
 from casexml.apps.case.util import validate_phone_datetime, prune_previous_log
 from corehq import toggles
-from corehq.apps.domain.models import Domain
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.util.soft_assert import soft_assert
 from casexml.apps.case.exceptions import InvalidCaseIndex, IllegalCaseId
-from django.conf import settings
 
 from casexml.apps.case import const
 from casexml.apps.case.xml.parser import case_update_from_block

--- a/corehq/ex-submodules/casexml/apps/case/xml/parser.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/parser.py
@@ -47,6 +47,10 @@ def case_update_from_block(case_block):
     return VERSION_FUNCTION_MAP[case_version](case_block)
 
 
+def case_id_from_block(case_block):
+    return CASE_ID_FUNCTION_MAP[get_version(case_block)](case_block)
+
+
 class CaseActionBase(object):
     action_type_slug = None
 
@@ -373,17 +377,9 @@ class CaseUpdate(object):
         Gets a case update from a version 1 case.
         Spec: https://bitbucket.org/javarosa/javarosa/wiki/casexml
         """
-        if const.CASE_TAG_ID not in case_block:
-            raise CaseGenerationException(
-                "No case_id element found in v1 case block, "
-                "this is a required property."
-            )
-
+        case_id = cls.v1_case_id_from(case_block)
         modified_on = case_block.get(const.CASE_TAG_MODIFIED, "")
-        return cls(id=case_block[const.CASE_TAG_ID],
-                   version=V1,
-                   block=case_block,
-                   modified_on_str=modified_on)
+        return cls(id=case_id, version=V1, block=case_block, modified_on_str=modified_on)
 
     @classmethod
     def from_v2(cls, case_block):
@@ -391,30 +387,47 @@ class CaseUpdate(object):
         Gets a case update from a version 2 case.
         Spec: https://github.com/dimagi/commcare/wiki/casexml20
         """
+        return cls(id=cls.v2_case_id_from(case_block),
+                   version=V2,
+                   block=case_block,
+                   user_id=case_block.get(_USER_ID_ATTR, ""),
+                   modified_on_str=case_block.get(_MODIFIED_ATTR, ""))
 
-        def _to_attr(val):
-            return "@%s" % val
+    @classmethod
+    def v1_case_id_from(cls, case_block):
+        try:
+            return case_block[const.CASE_TAG_ID]
+        except KeyError:
+            raise CaseGenerationException(
+                "No case_id element found in v1 case block, "
+                "this is a required property."
+            )
 
-        case_id_attr = _to_attr(const.CASE_TAG_ID)
-        if case_id_attr not in case_block:
+    @classmethod
+    def v2_case_id_from(cls, case_block):
+        try:
+            return case_block[_CASE_ID_ATTR]
+        except KeyError:
             raise CaseGenerationException(
                 "No case_id attribute found in v2 case block, "
                 "this is a required property."
             )
 
-        user_id = case_block.get(_to_attr(const.CASE_TAG_USER_ID), "")
-        modified_on = case_block.get(_to_attr(const.CASE_TAG_MODIFIED), "")
-        return cls(id=case_block[case_id_attr],
-                   version=V2,
-                   block=case_block,
-                   user_id=user_id,
-                   modified_on_str=modified_on)
+
+_CASE_ID_ATTR = "@" + const.CASE_TAG_ID
+_USER_ID_ATTR = "@" + const.CASE_TAG_USER_ID
+_MODIFIED_ATTR = "@" + const.CASE_TAG_MODIFIED
 
 
 # this section is what maps various things to their v1/v2 parsers
 VERSION_FUNCTION_MAP = {
     V1: CaseUpdate.from_v1,
     V2: CaseUpdate.from_v2
+}
+
+CASE_ID_FUNCTION_MAP = {
+    V1: CaseUpdate.v1_case_id_from,
+    V2: CaseUpdate.v2_case_id_from
 }
 
 NOOP_ACTION_FUNCTION_MAP = {

--- a/corehq/ex-submodules/casexml/apps/case/xml/parser.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/parser.py
@@ -2,7 +2,6 @@
 This isn't really a parser, but it's the code that generates case-like
 objects from things from xforms.
 """
-import os
 import datetime
 
 from casexml.apps.case import const
@@ -39,7 +38,7 @@ def get_version(case_block):
 class CaseGenerationException(Exception):
     """
     When anything illegal/unexpected happens while working with case parsing
-    """ 
+    """
     pass
 
 
@@ -52,7 +51,7 @@ class CaseActionBase(object):
     action_type_slug = None
 
     def __init__(self, block, type=None, name=None, external_id=None,
-                 user_id=None, owner_id=None, opened_on=None, 
+                 user_id=None, owner_id=None, opened_on=None,
                  dynamic_properties=None, indices=None, attachments=None):
         self.raw_block = block
         self.type = type
@@ -64,7 +63,7 @@ class CaseActionBase(object):
         self.dynamic_properties = dynamic_properties or {}
         self.indices = indices or []
         self.attachments = attachments or {}
-    
+
     def get_known_properties(self):
         return dict((p, getattr(self, p)) for p in KNOWN_PROPERTIES.keys()
                     if getattr(self, p) is not None)
@@ -76,11 +75,11 @@ class CaseActionBase(object):
     def _from_block_and_mapping(cls, block, mapping):
         def _normalize(val):
             if isinstance(val, list):
-                # if we get multiple updates, they look like a list. 
+                # if we get multiple updates, they look like a list.
                 # normalize these by taking the last item
                 return val[-1]
             return val
-        
+
         kwargs = {}
         dynamic_properties = {}
         # if not a dict, it's probably an empty close block
@@ -90,10 +89,10 @@ class CaseActionBase(object):
                     kwargs[mapping[k]] = v
                 else:
                     dynamic_properties[k] = _normalize(v)
-        
+
         return cls(block, dynamic_properties=dynamic_properties,
                    **kwargs)
-        
+
     @classmethod
     def from_v1(cls, block):
         mapping = {const.CASE_TAG_TYPE_ID: "type",
@@ -103,7 +102,7 @@ class CaseActionBase(object):
                    const.CASE_TAG_OWNER_ID: "owner_id",
                    const.CASE_TAG_DATE_OPENED: "opened_on"}
         return cls._from_block_and_mapping(block, mapping)
-                   
+
     @classmethod
     def from_v2(cls, block):
         # the only difference is the place where "type" is stored
@@ -128,7 +127,7 @@ class CaseNoopAction(CaseActionBase):
 
 class CaseCreateAction(CaseActionBase):
     action_type_slug = const.CASE_ACTION_CREATE
-        
+
 
 class CaseUpdateAction(CaseActionBase):
     action_type_slug = const.CASE_ACTION_UPDATE
@@ -237,19 +236,19 @@ class CaseIndexAction(CaseActionBase):
     Action describing updates to the case indices
     """
     action_type_slug = const.CASE_ACTION_INDEX
-    
+
     def __init__(self, block, indices):
         super(CaseIndexAction, self).__init__(block, indices=indices)
 
     def get_known_properties(self):
         # override this since the index action only cares about a list of indices
         return {}
-    
+
     @classmethod
     def from_v1(cls, block):
         # indices are not supported in v1
         return cls(block, [])
-                   
+
     @classmethod
     def from_v2(cls, block):
         indices = []
@@ -262,20 +261,20 @@ class CaseIndexAction(CaseActionBase):
             indices.append(CaseIndex(id, data["@case_type"], data.get("#text", ""),
                                      data.get("@relationship", 'child')))
         return cls(block, indices)
-    
+
 
 class CaseUpdate(object):
     """
     A temporary model that parses the data from the form consistently.
     The actual Case objects use this to update themselves.
     """
-    
+
     def __init__(self, id, version, block, user_id="", modified_on_str=""):
         self.id = id
         self.version = version
         self.user_id = user_id
         self.modified_on_str = modified_on_str
-        
+
         # deal with the various blocks
         self.raw_block = block
         self.create_block = block.get(const.CASE_ACTION_CREATE, {})
@@ -287,7 +286,7 @@ class CaseUpdate(object):
 
         # referrals? really? really???
         self.referral_block = block.get(const.REFERRAL_TAG, {})
-        
+
         # actions
         self.actions = []
         if self.creates_case():
@@ -312,19 +311,19 @@ class CaseUpdate(object):
 
     def creates_case(self):
         # creates have to have actual data in them so this is fine
-        return bool(self.create_block)    
-    
+        return bool(self.create_block)
+
     def updates_case(self):
         # updates have to have actual data in them so this is fine
-        return bool(self.update_block)    
-    
+        return bool(self.update_block)
+
     def closes_case(self):
         # closes might not have data and so we store this separately
-        return self._closes_case    
-    
+        return self._closes_case
+
     def has_indices(self):
         return bool(self.index_block)
-    
+
     def has_referrals(self):
         return bool(self.referral_block)
 
@@ -352,16 +351,16 @@ class CaseUpdate(object):
         if filtered:
             assert(len(filtered) == 1)
             return filtered[0]
-            
+
     def get_create_action(self):
         return self._filtered_action(lambda a: isinstance(a, CaseCreateAction))
-        
+
     def get_update_action(self):
         return self._filtered_action(lambda a: isinstance(a, CaseUpdateAction))
-    
+
     def get_close_action(self):
         return self._filtered_action(lambda a: isinstance(a, CaseCloseAction))
-    
+
     def get_index_action(self):
         return self._filtered_action(lambda a: isinstance(a, CaseIndexAction))
 
@@ -371,7 +370,7 @@ class CaseUpdate(object):
     @classmethod
     def from_v1(cls, case_block):
         """
-        Gets a case update from a version 1 case. 
+        Gets a case update from a version 1 case.
         Spec: https://bitbucket.org/javarosa/javarosa/wiki/casexml
         """
         if const.CASE_TAG_ID not in case_block:
@@ -379,30 +378,30 @@ class CaseUpdate(object):
                 "No case_id element found in v1 case block, "
                 "this is a required property."
             )
-        
+
         modified_on = case_block.get(const.CASE_TAG_MODIFIED, "")
         return cls(id=case_block[const.CASE_TAG_ID],
                    version=V1,
                    block=case_block,
                    modified_on_str=modified_on)
-    
+
     @classmethod
     def from_v2(cls, case_block):
         """
-        Gets a case update from a version 2 case. 
+        Gets a case update from a version 2 case.
         Spec: https://github.com/dimagi/commcare/wiki/casexml20
         """
-        
+
         def _to_attr(val):
             return "@%s" % val
-    
-        case_id_attr = _to_attr(const.CASE_TAG_ID) 
+
+        case_id_attr = _to_attr(const.CASE_TAG_ID)
         if case_id_attr not in case_block:
             raise CaseGenerationException(
                 "No case_id attribute found in v2 case block, "
                 "this is a required property."
             )
-        
+
         user_id = case_block.get(_to_attr(const.CASE_TAG_USER_ID), "")
         modified_on = case_block.get(_to_attr(const.CASE_TAG_MODIFIED), "")
         return cls(id=case_block[case_id_attr],


### PR DESCRIPTION
Came across this code (again) while investigating how case properties are extracted from form submission XML. I've wanted to change this numerous times in the past when I came across it, so finally decided to go for it. It may also yield a modest form processing performance improvement.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

Straightforward refactoring that should not change functional behavior in any way. Labeling as medium risk since this touches a core part of the form processor, although the risk is balanced by thorough test coverage.

### Automated test coverage

Added tests for `get_case_ids_from_form`. Existing tests cover `extract_case_blocks`. Many other tests in HQ exercise this code as well since it is a core part of the form processor.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
