### PR TITLE
Restrict lite release management level domain links to be pushed individually

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -24,9 +24,9 @@ hqDefine('hqwebapp/js/multiselect_utils', [
         });
     };
 
-    var _renderAction = function (buttonId, buttonClass, buttonIcon, text) {
+    var _renderAction = function (buttonId, buttonClass, buttonIcon, text, disabled=false) {
         var action = _.template(
-            '<button class="btn <%-actionButtonClass %> btn-xs pull-right" id="<%- actionButtonId %>">' +
+            '<button class="btn <%-actionButtonClass %> btn-xs pull-right" id="<%- actionButtonId %>" <% if (actionDisabled) { %> disabled <% } %>>' +
                 '<i class="<%- actionButtonIcon %>"></i> <%- actionButtonText %>' +
             '</button>'
         );
@@ -35,6 +35,7 @@ hqDefine('hqwebapp/js/multiselect_utils', [
             actionButtonClass: buttonClass,
             actionButtonIcon: buttonIcon,
             actionButtonText: text,
+            actionDisabled: disabled,
         });
     };
 
@@ -54,11 +55,12 @@ hqDefine('hqwebapp/js/multiselect_utils', [
     };
 
     multiselect_utils.createFullMultiselectWidget = function (elementOrId, properties) {
-        assertProperties.assert(properties, [], ['selectableHeaderTitle', 'selectedHeaderTitle', 'searchItemTitle', 'willSelectAllListener']);
+        assertProperties.assert(properties, [], ['selectableHeaderTitle', 'selectedHeaderTitle', 'searchItemTitle', 'willSelectAllListener', 'disableModifyAllActions']);
         var selectableHeaderTitle = properties.selectableHeaderTitle || gettext("Items");
         var selectedHeaderTitle = properties.selectedHeaderTitle || gettext("Selected items");
         var searchItemTitle = properties.searchItemTitle || gettext("Search items");
         var willSelectAllListener = properties.willSelectAllListener;
+        var disableModifyAllActions = properties['disableModifyAllActions'] || false;
 
         var $element = _.isString(elementOrId) ? $('#' + elementOrId) : $(elementOrId),
             baseId = _.isString(elementOrId) ? elementOrId : "multiselect-" + String(Math.random()).substring(2),
@@ -70,12 +72,12 @@ hqDefine('hqwebapp/js/multiselect_utils', [
         $element.multiSelect({
             selectableHeader: _renderHeader(
                 selectableHeaderTitle,
-                _renderAction(selectAllId, 'btn-default', 'fa fa-plus', gettext("Add All")),
+                _renderAction(selectAllId, 'btn-default', 'fa fa-plus', gettext("Add All"), disableModifyAllActions),
                 _renderSearch(searchSelectableId, searchItemTitle)
             ),
             selectionHeader: _renderHeader(
                 selectedHeaderTitle,
-                _renderAction(removeAllId, 'btn-default', 'fa fa-remove', gettext("Remove All")),
+                _renderAction(removeAllId, 'btn-default', 'fa fa-remove', gettext("Remove All"), disableModifyAllActions),
                 _renderSearch(searchSelectedId, searchItemTitle)
             ),
             afterInit: function () {
@@ -97,7 +99,9 @@ hqDefine('hqwebapp/js/multiselect_utils', [
                         if (that.search_left.val().length > 0) {
                             $('#' + selectAllId).addClass('disabled').prop('disabled', true);
                         } else {
-                            $('#' + selectAllId).removeClass('disabled').prop('disabled', false);
+                            if (!disableModifyAllActions) {
+                                $('#' + selectAllId).removeClass('disabled').prop('disabled', false);
+                            }
                         }
                     });
 
@@ -112,7 +116,7 @@ hqDefine('hqwebapp/js/multiselect_utils', [
                     // disable remove all functionality so that user is not confused
                         if (that.search_right.val().length > 0) {
                             $('#' + removeAllId).addClass('disabled').prop('disabled', true);
-                        } else {
+                        } else if (!disableModifyAllActions) {
                             $('#' + removeAllId).removeClass('disabled').prop('disabled', false);
                         }
                     });
@@ -121,13 +125,17 @@ hqDefine('hqwebapp/js/multiselect_utils', [
                 this.search_left.cache();
                 // remove search option so that user doesn't get confused
                 this.search_right.val('').search('');
-                $('#' + removeAllId).removeClass('disabled').prop('disabled', false);
+                if (!disableModifyAllActions) {
+                    $('#' + removeAllId).removeClass('disabled').prop('disabled', false);
+                }
                 this.search_right.cache();
             },
             afterDeselect: function () {
                 // remove search option so that user doesn't get confused
                 this.search_left.val('').search('');
-                $('#' + selectAllId).removeClass('disabled').prop('disabled', false);
+                if (!disableModifyAllActions) {
+                    $('#' + selectAllId).removeClass('disabled').prop('disabled', false);
+                }
                 this.search_left.cache();
                 this.search_right.cache();
             },

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -54,10 +54,11 @@ hqDefine('hqwebapp/js/multiselect_utils', [
     };
 
     multiselect_utils.createFullMultiselectWidget = function (elementOrId, properties) {
-        assertProperties.assert(properties, [], ['selectableHeaderTitle', 'selectedHeaderTitle', 'searchItemTitle']);
+        assertProperties.assert(properties, [], ['selectableHeaderTitle', 'selectedHeaderTitle', 'searchItemTitle', 'willSelectAllListener']);
         var selectableHeaderTitle = properties.selectableHeaderTitle || gettext("Items");
         var selectedHeaderTitle = properties.selectedHeaderTitle || gettext("Selected items");
         var searchItemTitle = properties.searchItemTitle || gettext("Search items");
+        var willSelectAllListener = properties.willSelectAllListener;
 
         var $element = _.isString(elementOrId) ? $('#' + elementOrId) : $(elementOrId),
             baseId = _.isString(elementOrId) ? elementOrId : "multiselect-" + String(Math.random()).substring(2),
@@ -132,7 +133,17 @@ hqDefine('hqwebapp/js/multiselect_utils', [
             },
         });
 
+        multiselect_utils.rebuildMultiselect = function (elementId, multiselectProperties) {
+            var $element = _.isString(elementOrId) ? $('#' + elementOrId) : $(elementOrId);
+            // multiSelect('refresh') breaks existing click handlers, so the alternative is to destroy and rebuild
+            $element.multiSelect('destroy');
+            multiselect_utils.createFullMultiselectWidget(elementId, multiselectProperties);
+        };
+
         $('#' + selectAllId).click(function () {
+            if (willSelectAllListener) {
+                willSelectAllListener();
+            }
             $element.multiSelect('select_all');
             return false;
         });
@@ -166,9 +177,7 @@ hqDefine('hqwebapp/js/multiselect_utils', [
                 ko.unwrap(model.options());
             }
 
-            // multiSelect('refresh') breaks existing click handlers, so the alternative is to destroy and rebuild
-            $(element).multiSelect('destroy');
-            multiselect_utils.createFullMultiselectWidget(element, model.properties);
+            multiselect_utils.rebuildMultiselect(element, model.properties);
         },
     };
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -24,7 +24,7 @@ hqDefine('hqwebapp/js/multiselect_utils', [
         });
     };
 
-    var _renderAction = function (buttonId, buttonClass, buttonIcon, text, disabled=false) {
+    var _renderAction = function (buttonId, buttonClass, buttonIcon, text, disabled = false) {
         var action = _.template(
             '<button class="btn <%-actionButtonClass %> btn-xs pull-right" id="<%- actionButtonId %>" <% if (actionDisabled) { %> disabled <% } %>>' +
                 '<i class="<%- actionButtonIcon %>"></i> <%- actionButtonText %>' +

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -54,6 +54,15 @@ hqDefine('hqwebapp/js/multiselect_utils', [
         });
     };
 
+    /**
+     * Given an element, configures multiselect functionality based on the multiselect.js library
+     * @param {object} properties - a key-value object that expects the following optional keys:
+     * selectableHeaderTitle -  String title for items yet to be selected. Defaults to "Items".
+     * selectedHeaderTitle - String for selected items title. Defaults to "Selected items".
+     * searchItemTitle - String for search bar placeholder title. Defaults to "Search items".
+     * willSelectAllListener - Function to call before the multiselect processes the Add All action.
+     * disableModifyAllActions - Boolean value to enable/disable Add All and Remove All buttons. Defaults to false.
+     */
     multiselect_utils.createFullMultiselectWidget = function (elementOrId, properties) {
         assertProperties.assert(properties, [], ['selectableHeaderTitle', 'selectedHeaderTitle', 'searchItemTitle', 'willSelectAllListener', 'disableModifyAllActions']);
         var selectableHeaderTitle = properties.selectableHeaderTitle || gettext("Items");
@@ -141,13 +150,6 @@ hqDefine('hqwebapp/js/multiselect_utils', [
             },
         });
 
-        multiselect_utils.rebuildMultiselect = function (elementId, multiselectProperties) {
-            var $element = _.isString(elementOrId) ? $('#' + elementOrId) : $(elementOrId);
-            // multiSelect('refresh') breaks existing click handlers, so the alternative is to destroy and rebuild
-            $element.multiSelect('destroy');
-            multiselect_utils.createFullMultiselectWidget(elementId, multiselectProperties);
-        };
-
         $('#' + selectAllId).click(function () {
             if (willSelectAllListener) {
                 willSelectAllListener();
@@ -159,6 +161,13 @@ hqDefine('hqwebapp/js/multiselect_utils', [
             $element.multiSelect('deselect_all');
             return false;
         });
+    };
+
+    multiselect_utils.rebuildMultiselect = function (elementOrId, multiselectProperties) {
+        var $element = _.isString(elementOrId) ? $('#' + elementOrId) : $(elementOrId);
+        // multiSelect('refresh') breaks existing click handlers, so the alternative is to destroy and rebuild
+        $element.multiSelect('destroy');
+        multiselect_utils.createFullMultiselectWidget(elementOrId, multiselectProperties);
     };
 
     /*

--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -69,7 +69,7 @@ class DomainLink(models.Model):
         return bool(self.remote_base_url) or 'http' in self.linked_domain
 
     @property
-    def has_full_privilege(self):
+    def has_full_access(self):
         return (domain_has_privilege(self.master_domain, RELEASE_MANAGEMENT)
                 and domain_has_privilege(self.linked_domain, RELEASE_MANAGEMENT))
 

--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -9,8 +9,10 @@ from django.utils.translation import ugettext as _
 
 import jsonobject
 
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.linked_domain.const import ALL_LINKED_MODELS
 from corehq.apps.linked_domain.exceptions import DomainLinkError
+from corehq.privileges import RELEASE_MANAGEMENT
 
 
 class RemoteLinkDetails(namedtuple('RemoteLinkDetails', 'url_base username api_key')):
@@ -65,6 +67,12 @@ class DomainLink(models.Model):
     @property
     def is_remote(self):
         return bool(self.remote_base_url) or 'http' in self.linked_domain
+
+    @property
+    def has_full_privilege(self):
+        return (domain_has_privilege(self.master_domain, RELEASE_MANAGEMENT)
+                and domain_has_privilege(self.linked_domain, RELEASE_MANAGEMENT))
+
 
     @atomic
     def update_last_pull(self, model, user_id, date=None, model_detail=None):

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -277,13 +277,7 @@ hqDefine("linked_domain/js/domain_links", [
                 }
             }
 
-            // need to rebuild the multiselect on each update
-            $('#domain-multiselect').multiSelect('destroy');
-            multiselect_utils.createFullMultiselectWidget($('#domain-multiselect'), {
-                selectableHeaderTitle: self.domainMultiselect.selectableHeaderTitle,
-                selectedHeaderTitle: self.domainMultiselect.selectedHeaderTitle,
-                searchItemTitle: self.domainMultiselect.searchItemTitle,
-            });
+            multiselect_utils.rebuildMultiselect('domain-multiselect', self.domainMultiselect.properties);
         });
 
         self.localDownstreamDomains = ko.computed(function () {
@@ -300,6 +294,19 @@ hqDefine("linked_domain/js/domain_links", [
                 selectableHeaderTitle: gettext("All project spaces"),
                 selectedHeaderTitle: gettext("Project spaces to push to"),
                 searchItemTitle: gettext("Search project spaces"),
+                willSelectAllListener: function () {
+                    var requiresRebuild = false;
+                    for (var option of $('#domain-multiselect')[0].options) {
+                        var tempLink = self.parent.domainLinksByNames()[option.value];
+                        if (!option.selected && !option.disabled && !tempLink.hasFullAccess) {
+                            option.disabled = true;
+                            requiresRebuild = true;
+                        }
+                    }
+                    if (requiresRebuild) {
+                        multiselect_utils.rebuildMultiselect('domain-multiselect', self.domainMultiselect.properties);
+                    }
+                }
             },
             options: self.localDownstreamDomains,
         };

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -249,10 +249,18 @@ hqDefine("linked_domain/js/domain_links", [
         self.enablePushButton = ko.computed(function () {
             return self.domainsToPush().length && self.modelsToPush().length && !self.pushInProgress();
         });
+        self.shouldShowSelectedERMDomain = ko.observable(false);
+        self.shouldShowSelectedMRMDomain = ko.observable(false);
 
         self.domainsToPushSubscription = self.domainsToPush.subscribe(function (newValue) {
             // receives updates every time a domain is selected/unselected from the multiselect
             if (newValue.length > 1) {
+                for (var option of $('#domain-multiselect')[0].options) {
+                    var tempLink = self.parent.domainLinksByNames()[option.value];
+                    if (option.selected && tempLink.hasFullAccess) {
+                        self.shouldShowSelectedERMDomain(true);
+                    }
+                }
                 // no need to rebuild multiselect
                 return;
             }
@@ -264,16 +272,22 @@ hqDefine("linked_domain/js/domain_links", [
                     if (!newValue.includes(option.value)) {
                         if (pushedNonEnterpriseLink) {
                             option.disabled = true;
+                            self.shouldShowSelectedMRMDomain(true);
                         } else {
                             // disable if link does not have full access
                             var tempLink = self.parent.domainLinksByNames()[option.value];
-                            option.disabled = !tempLink.hasFullAccess;
+                            if (!tempLink.hasFullAccess) {
+                                option.disabled = !tempLink.hasFullAccess;
+                                self.shouldShowSelectedERMDomain(true);
+                            }
                         }
                     }
                 }
             } else {
                 for (var option of $('#domain-multiselect')[0].options) {
                     option.disabled = false;
+                    self.shouldShowSelectedERMDomain(false);
+                    self.shouldShowSelectedMRMDomain(false);
                 }
             }
 

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -254,7 +254,7 @@ hqDefine("linked_domain/js/domain_links", [
                 return false;
             }
             // check if both values for hasFullAccess are present within the current domainLinks
-            return _.uniq(_.pluck(self.parent.domainLinks(), 'hasFullAccess')).length == 2;
+            return _.uniq(_.pluck(self.parent.domainLinks(), 'hasFullAccess')).length === 2;
         });
 
         self.domainsToPushSubscription = self.domainsToPush.subscribe(function (newValue) {

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -226,6 +226,7 @@ hqDefine("linked_domain/js/domain_links", [
         self.lastUpdate = link.last_update;
         self.upstreamUrl = link.upstream_url;
         self.downstreamUrl = link.downstream_url;
+        self.hasFullAccess = link.has_full_access;
         return self;
     };
 

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -87,7 +87,7 @@ hqDefine("linked_domain/js/domain_links", [
 
         // General data
         self.domain = data.domain;
-        self.domain_links = ko.observableArray(_.map(data.linked_domains, DomainLink));
+        self.domainLinks = ko.observableArray(_.map(data.linked_domains, DomainLink));
         self.showRemoteReports = function () {
             if (data.linkable_ucr) {
                 return data.linkable_ucr.length > 0;
@@ -96,7 +96,7 @@ hqDefine("linked_domain/js/domain_links", [
         };
 
         self.isUpstreamDomain = ko.computed(function () {
-            return self.domain_links().length > 0;
+            return self.domainLinks().length > 0;
         });
         // doesn't need to be observable because it is impossible to update the existing page to change this property
         self.isDownstreamDomain = data.is_downstream_domain;
@@ -145,7 +145,7 @@ hqDefine("linked_domain/js/domain_links", [
             return !self.query() || domainLink.downstreamDomain().toLowerCase().indexOf(self.query().toLowerCase()) !== -1;
         };
         self.filter = function () {
-            self.filteredDomainLinks(_.filter(self.domain_links(), self.matchesQuery));
+            self.filteredDomainLinks(_.filter(self.domainLinks(), self.matchesQuery));
             self.goToPage(1);
         };
 
@@ -153,7 +153,7 @@ hqDefine("linked_domain/js/domain_links", [
         self.paginatedDomainLinks = ko.observableArray([]);
         self.itemsPerPage = ko.observable(5);
         self.totalItems = ko.computed(function () {
-            return self.query() ? self.filteredDomainLinks().length : self.domain_links().length;
+            return self.query() ? self.filteredDomainLinks().length : self.domainLinks().length;
         });
         self.currentPage = 1;
 
@@ -161,7 +161,7 @@ hqDefine("linked_domain/js/domain_links", [
             self.currentPage = page;
             self.paginatedDomainLinks.removeAll();
             var skip = (self.currentPage - 1) * self.itemsPerPage();
-            var visibleDomains = self.query() ? self.filteredDomainLinks() : self.domain_links();
+            var visibleDomains = self.query() ? self.filteredDomainLinks() : self.domainLinks();
             self.paginatedDomainLinks(visibleDomains.slice(skip, skip + self.itemsPerPage()));
         };
 
@@ -197,7 +197,7 @@ hqDefine("linked_domain/js/domain_links", [
             _private.RMI("delete_domain_link", {
                 "linked_domain": link.downstreamDomain(),
             }).done(function () {
-                self.domain_links.remove(link);
+                self.domainLinks.remove(link);
                 var availableDomains = self.addDownstreamDomainViewModel.availableDomains();
                 availableDomains.push(link.downstreamDomain());
                 self.addDownstreamDomainViewModel.availableDomains(availableDomains.sort());
@@ -241,7 +241,7 @@ hqDefine("linked_domain/js/domain_links", [
         });
 
         self.localDownstreamDomains = ko.computed(function () {
-            return self.parent.domain_links().reduce(function (result, link) {
+            return self.parent.domainLinks().reduce(function (result, link) {
                 if (!link.isRemote) {
                     return result.concat(link.downstreamDomain());
                 }
@@ -367,7 +367,7 @@ hqDefine("linked_domain/js/domain_links", [
                     self.availableDomains(_.filter(self.availableDomains(), function (item) {
                         return item !== viewModel.domainToAdd();
                     }));
-                    self.parent.domain_links.unshift(DomainLink(response.domain_link));
+                    self.parent.domainLinks.unshift(DomainLink(response.domain_link));
                     self.parent.goToPage(1);
                 } else {
                     var errorMessage = _.template(

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -88,6 +88,14 @@ hqDefine("linked_domain/js/domain_links", [
         // General data
         self.domain = data.domain;
         self.domainLinks = ko.observableArray(_.map(data.linked_domains, DomainLink));
+        self.domainLinksByNames = ko.computed(function () {
+            tmp = {};
+            for (link of self.domainLinks()) {
+                tmp[link.downstreamDomain()] = link;
+            }
+            return tmp;
+        });
+
         self.showRemoteReports = function () {
             if (data.linkable_ucr) {
                 return data.linkable_ucr.length > 0;

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -91,9 +91,7 @@ hqDefine("linked_domain/js/domain_links", [
         self.hasFullAccess = data.has_full_access;
         self.domainLinks = ko.observableArray(_.map(data.linked_domains, DomainLink));
         self.domainLinksByName = ko.computed(function () {
-            var linkByNameMap = {};
-            self.domainLinks().forEach(link => linkByNameMap[link.downstreamDomain()] = link);
-            return linkByNameMap;
+            return _.indexBy(self.domainLinks(), 'downstreamDomain');
         });
 
         self.showRemoteReports = function () {
@@ -150,7 +148,7 @@ hqDefine("linked_domain/js/domain_links", [
         self.query = ko.observable();
         self.filteredDomainLinks = ko.observableArray([]);
         self.matchesQuery = function (domainLink) {
-            return !self.query() || domainLink.downstreamDomain().toLowerCase().indexOf(self.query().toLowerCase()) !== -1;
+            return !self.query() || domainLink.downstreamDomain.toLowerCase().indexOf(self.query().toLowerCase()) !== -1;
         };
         self.filter = function () {
             self.filteredDomainLinks(_.filter(self.domainLinks(), self.matchesQuery));
@@ -184,7 +182,7 @@ hqDefine("linked_domain/js/domain_links", [
         self.createRemoteReportLink = function (reportId) {
             _private.RMI("create_remote_report_link", {
                 "master_domain": self.upstreamLink.upstreamDomain,
-                "linked_domain": self.upstreamLink.downstreamDomain(),
+                "linked_domain": self.upstreamLink.downstreamDomain,
                 "report_id": reportId,
             }).done(function (data) {
                 if (data.success) {
@@ -203,11 +201,11 @@ hqDefine("linked_domain/js/domain_links", [
 
         self.deleteLink = function (link) {
             _private.RMI("delete_domain_link", {
-                "linked_domain": link.downstreamDomain(),
+                "linked_domain": link.downstreamDomain,
             }).done(function () {
                 self.domainLinks.remove(link);
                 var availableDomains = self.addDownstreamDomainViewModel.availableDomains();
-                availableDomains.push(link.downstreamDomain());
+                availableDomains.push(link.downstreamDomain);
                 self.addDownstreamDomainViewModel.availableDomains(availableDomains.sort());
                 self.goToPage(self.currentPage);
             }).fail(function () {
@@ -228,7 +226,7 @@ hqDefine("linked_domain/js/domain_links", [
 
     var DomainLink = function (link) {
         var self = {};
-        self.downstreamDomain = ko.observable(link.downstream_domain);
+        self.downstreamDomain = link.downstream_domain;
         self.isRemote = link.is_remote;
         self.upstreamDomain = link.upstream_domain;
         self.lastUpdate = link.last_update;
@@ -303,7 +301,7 @@ hqDefine("linked_domain/js/domain_links", [
         self.localDownstreamDomains = ko.computed(function () {
             return self.parent.domainLinks().reduce(function (result, link) {
                 if (!link.isRemote) {
-                    return result.concat(link.downstreamDomain());
+                    return result.concat(link.downstreamDomain);
                 }
                 return result;
             }, []);
@@ -403,7 +401,7 @@ hqDefine("linked_domain/js/domain_links", [
         self.createLink = function () {
             _private.RMI("create_remote_report_link", {
                 "master_domain": upstreamLink.upstreamDomain,
-                "linked_domain": upstreamLink.downstreamDomain(),
+                "linked_domain": upstreamLink.downstreamDomain,
                 "report_id": self.id,
             }).done(function (data) {
                 if (data.success) {

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -88,6 +88,7 @@ hqDefine("linked_domain/js/domain_links", [
 
         // General data
         self.domain = data.domain;
+        self.hasFullAccess = data.has_full_access;
         self.domainLinks = ko.observableArray(_.map(data.linked_domains, DomainLink));
         self.domainLinksByNames = ko.computed(function () {
             tmp = {};
@@ -308,6 +309,7 @@ hqDefine("linked_domain/js/domain_links", [
                 selectableHeaderTitle: gettext("All project spaces"),
                 selectedHeaderTitle: gettext("Project spaces to push to"),
                 searchItemTitle: gettext("Search project spaces"),
+                disableModifyAllActions: !self.parent.hasFullAccess,
                 willSelectAllListener: function () {
                     var requiresRebuild = false;
                     for (var option of $('#domain-multiselect')[0].options) {

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -90,7 +90,7 @@ hqDefine("linked_domain/js/domain_links", [
         self.domain = data.domain;
         self.hasFullAccess = data.has_full_access;
         self.domainLinks = ko.observableArray(_.map(data.linked_domains, DomainLink));
-        self.domainLinksByNames = ko.computed(function () {
+        self.domainLinksByName = ko.computed(function () {
             var linkByNameMap = {};
             self.domainLinks().forEach(link => linkByNameMap[link.downstreamDomain()] = link);
             return linkByNameMap;
@@ -255,15 +255,8 @@ hqDefine("linked_domain/js/domain_links", [
                 // should not contain both
                 return false;
             }
-            const accessSet = new Set();
-            for (const link of Object.values(self.parent.domainLinksByNames())) {
-                // if any link is limited, contains both
-                accessSet.add(link.hasFullAccess);
-                if (accessSet.size >= 2) {
-                    return true;
-                }
-            }
-            return false;
+            // check if both values for hasFullAccess are present within the current domainLinks
+            return _.uniq(_.pluck(self.parent.domainLinks(), 'hasFullAccess')).length == 2;
         });
 
         self.domainsToPushSubscription = self.domainsToPush.subscribe(function (newValue) {
@@ -278,7 +271,7 @@ hqDefine("linked_domain/js/domain_links", [
             }
 
             if (newValue.length > 0) {
-                var selectedDomainLink = self.parent.domainLinksByNames()[newValue[0]];
+                var selectedDomainLink = self.parent.domainLinksByName()[newValue[0]];
                 var pushedNonEnterpriseLink = !selectedDomainLink.hasFullAccess;
                 for (const option of $('#domain-multiselect')[0].options) {
                     if (!newValue.includes(option.value)) {
@@ -287,7 +280,7 @@ hqDefine("linked_domain/js/domain_links", [
                             self.shouldShowSelectedMRMDomain(true);
                         } else {
                             // disable if link does not have full access
-                            const tempLink = self.parent.domainLinksByNames()[option.value];
+                            const tempLink = self.parent.domainLinksByName()[option.value];
                             if (!tempLink.hasFullAccess) {
                                 option.disabled = !tempLink.hasFullAccess;
                                 self.shouldShowSelectedERMDomain(true);
@@ -325,7 +318,7 @@ hqDefine("linked_domain/js/domain_links", [
                 willSelectAllListener: function () {
                     var requiresRebuild = false;
                     for (var option of $('#domain-multiselect')[0].options) {
-                        var tempLink = self.parent.domainLinksByNames()[option.value];
+                        var tempLink = self.parent.domainLinksByName()[option.value];
                         if (!option.selected && !option.disabled && !tempLink.hasFullAccess) {
                             option.disabled = true;
                             requiresRebuild = true;

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/manage_downstream_domains.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/manage_downstream_domains.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 <div id="ko-tabs-manage-downstream" data-bind="with: $root">
-  <div data-bind="if: domain_links().length">
+  <div data-bind="if: domainLinks().length">
     <h3>{% trans "Manage Downstream Project Spaces" %}</h3>
     <p>
       {% blocktrans trimmed %}

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
@@ -42,6 +42,19 @@
           <select multiple class="form-control" id="domain-multiselect"
                   data-bind="selectedOptions: domainsToPush, multiselect: domainMultiselect">
           </select>
+          <div class="spacer"></div>
+          <p data-bind="visible: shouldShowSelectedMRMDomain">
+            <i class="fa fa-info-circle" aria-hidden="true"></i>
+            {% blocktrans %}
+              The selected project can only be pushed individually. See <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Linked Project Spaces</a> documentation for more information.
+            {% endblocktrans %}
+          </p>
+          <p data-bind="visible: shouldShowSelectedERMDomain">
+            <i class="fa fa-info-circle" aria-hidden="true"></i>
+            {% blocktrans %}
+              Disabled project spaces can only be pushed individually. See <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Linked Project Spaces</a> documentation for more information.
+            {% endblocktrans %}
+          </p>
         </div>
       </div>
       <div class="form-group">

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
@@ -17,7 +17,7 @@
           {% trans "Content" %}
         </label>
         <div class="col-sm-9 col-md-10 controls">
-          <select multiple class="form-control"
+          <select multiple class="form-control" id="model-multiselect"
                   data-bind="selectedOptions: modelsToPush,
                              multiselect: {
                                  properties: {
@@ -39,7 +39,7 @@
           {% trans "Project Spaces" %}
         </label>
         <div class="col-sm-9 col-md-10 controls">
-          <select multiple class="form-control"
+          <select multiple class="form-control" id="domain-multiselect"
                   data-bind="selectedOptions: domainsToPush, multiselect: domainMultiselect">
           </select>
         </div>

--- a/corehq/apps/linked_domain/view_helpers.py
+++ b/corehq/apps/linked_domain/view_helpers.py
@@ -40,7 +40,7 @@ def build_domain_link_view_model(link, timezone):
         'downstream_url': link.downstream_url,
         'is_remote': link.is_remote,
         'last_update': server_to_user_time(link.last_pull, timezone) if link.last_pull else _('Never'),
-        'has_full_access': link.has_full_privilege,
+        'has_full_access': link.has_full_access,
     }
 
 

--- a/corehq/apps/linked_domain/view_helpers.py
+++ b/corehq/apps/linked_domain/view_helpers.py
@@ -40,6 +40,7 @@ def build_domain_link_view_model(link, timezone):
         'downstream_url': link.downstream_url,
         'is_remote': link.is_remote,
         'last_update': server_to_user_time(link.last_pull, timezone) if link.last_pull else _('Never'),
+        'has_full_access': link.has_full_privilege,
     }
 
 

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -332,6 +332,7 @@ class DomainLinkView(BaseAdminProjectSettingsView):
                 'view_models_to_push': sorted(view_models_to_push, key=lambda m: m['name']),
                 'linked_domains': sorted(linked_domains, key=lambda d: d['downstream_domain']),
                 'linkable_ucr': remote_linkable_ucr,
+                'has_full_access': can_domain_access_release_management(self.domain, include_lite_version=False),
             },
         }
 

--- a/corehq/apps/styleguide/templates/styleguide/_includes/molecules/selections.html
+++ b/corehq/apps/styleguide/templates/styleguide/_includes/molecules/selections.html
@@ -57,9 +57,29 @@
   <h2>Multiselects</h2>
   <p>
     This is a custom widget we built. It can be useful in situations where the user is adding/removing
-    items from a list and wants to be able to see both the included and excluded items. It's more complicated
-    than a dropdown and takes up much more space. Be cautious adding it to new pages - be sure that
-    the visual weight and potential learning curve is worthwhile for the workflow you're creating.
+    items from a list and wants to be able to see both the included and excluded items.
+  </p>
+  <p>
+    It's more complicated than a dropdown and takes up much more space. <strong>Be cautious adding it to new
+    pages</strong> - be sure that the visual weight and potential learning curve is worthwhile for the workflow
+    you're creating.
+  </p>
+  <h4>Optional Properties</h4>
+  <p>
+    In addition to the optional title properties, the following properties can be useful in situations where more
+    control is needed.
+  </p>
+  <p>
+    <dl>
+      <dd>
+        <strong>disableModifyAllActions</strong> - defaults to false, useful when the preferred workflow is to disable
+        the ability to select and remove all items at once
+      </dd>
+      <dd>
+        <strong>willSelectAllListener</strong> - provides an opportunity to execute code prior to all items being
+        selected
+      </dd>
+    </dl>
   </p>
   {% include 'styleguide/example_html.html' with slug='multiselect' title='Multiselect' content=examples.selections.multiselect %}
 

--- a/corehq/apps/styleguide/templates/styleguide/examples/multiselect.html
+++ b/corehq/apps/styleguide/templates/styleguide/examples/multiselect.html
@@ -7,12 +7,18 @@
 </select>
 
 <script>
+  let listener = function() {
+    console.log("Triggered willSelectAllListener");
+  };
+
   $(function () {
     var multiselect_utils = hqImport('hqwebapp/js/multiselect_utils');
     multiselect_utils.createFullMultiselectWidget('example-multiselect', {
       selectableHeaderTitle: gettext("Available Letters"),
       selectedHeaderTitle: gettext("Letters Selected"),
       searchItemTitle: gettext("Search Letters..."),
+      disableModifyAllActions: false,
+      willSelectAllListener: listener,
     });
   });
 </script>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Enterprise Release Management (ERM) is enabled on domains with the `RELEASE_MANAGEMENT` privilege. Multi-Environment Release Management (MRM) is enabled on domains with the `LITE_RELEASE_MANAGEMENT` privilege. **The main difference between these privileges is the ability to push to multiple domains at once**. 

This PR tackles that difference. As the demo shows, full access links and limited links can co-exist under a domain with `RELEASE_MANAGEMENT` privilege since an admin in that domain could link to any domain they are also an admin in. 

### Demo

I gave loom a try: https://www.loom.com/share/f5e92268fc3442568a0de35bd4ffa291
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SS-229

A lot of changes were specific to the domain multiselect and could therefore live in `domain_links.js`, but some changes were better suited/needed to be made to the multiselect itself. As a by-product of this PR, the multiselect now supports a willSelectAllListener callback, and the ability to disable the Add All/Remove All buttons, which may never apply to any other situation. This felt borderline hacky, but I tried to make the conventions as clean as I could. Open to suggestions to simplify things. 

The first 3 commits refactor/lay the foundation for things to come. The meat of this PR is in these 4 commits:

c000c13dc6b065460965ce2508d6fedb5645f2d3 - subscribe to `domainsToPush` so we can enable/disable the appropriate options every time a domain is selected/deselected

4abab6b62b5ef93e2ef1d8b2219233e9208cb180 - add willSelectAllListener to register a function in the multiselect when the "Add All" button is clicked. This way, we can disable an options that should be disabled _before_ the `.multiSelect('select_all')` is called.

ea112af24c185779e08d40d1f6e6c3bbcafb7c1f - add info blurbs below the multiselect when options are disabled explaining why that is the case

1b320d3f148ed32cc40ef12d1b59c07a4d245ab7 - add property to multiselect that can disable add all/remove all buttons. Applicable for MRM level upstream domains that will never be able to push to multiple domains at once.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Lots of UI changes.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will definitely put through QA on the base branch `gh/mrm/base`.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

Not applicable to this PR as it will be merged into `gh/mrm/base`.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
