### PR TITLE
Replaced case management sync button with ajaxComplete listener

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
@@ -49,7 +49,7 @@ hqDefine('app_manager/js/case_config_utils', function () {
             return options;
         },
         // This function depends on initial page data, so it should be called within a document ready handler
-        initRefreshQuestions: function (questions_observable) {
+        initRefreshQuestions: function (questionsObservable) {
             var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
                 formUniqueId = initialPageData.get("form_unique_id");
             if (formUniqueId) {
@@ -66,7 +66,7 @@ hqDefine('app_manager/js/case_config_utils', function () {
                                     form_unique_id: formUniqueId,
                                 },
                                 success: function (data) {
-                                    questions_observable(data);
+                                    questionsObservable(data);
                                 },
                             });
                         }

--- a/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
@@ -48,24 +48,31 @@ hqDefine('app_manager/js/case_config_utils', function () {
             }
             return options;
         },
-        refreshQuestions: function (questions_observable, url, formUniqueId, event) {
-            var $el = $(event.currentTarget);
-            $el.find('i').addClass('fa-spin');
-            $.get({
-                url: url,
-                data: {
-                    form_unique_id: formUniqueId,
-                },
-                success: function (data) {
-                    questions_observable(data);
-                    $el.find('i').removeClass('fa-spin');
-                },
-                error: function () {
-                    $el.find('i').removeClass('fa-spin');
-                    hqImport("hqwebapp/js/alert_user").alert_user(gettext("Something went wrong refreshing "
-                               + "your form properties. Please refresh the page and try again", "danger"));
-                },
-            });
+        // This function depends on initial page data, so it should be called within a document ready handler
+        initRefreshQuestions: function (questions_observable) {
+            var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
+                formUniqueId = initialPageData.get("form_unique_id");
+            if (formUniqueId) {
+                var currentAppUrl = initialPageData.reverse("current_app_version"),
+                    oldVersion = initialPageData.get("app_subset").version;
+                $(document).on("ajaxComplete", function (e, xhr, options) {
+                    if (options.url === currentAppUrl) {
+                        var newVersion = xhr.responseJSON.currentVersion;
+                        if (newVersion > oldVersion) {
+                            oldVersion = newVersion;
+                            $.get({
+                                url: initialPageData.reverse('get_form_questions'),
+                                data: {
+                                    form_unique_id: formUniqueId,
+                                },
+                                success: function (data) {
+                                    questions_observable(data);
+                                },
+                            });
+                        }
+                    }
+                });
+            }
         },
         filteredSuggestedProperties: function (suggestedProperties, properties) {
             var used_properties = _.map(properties, function (x) {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
@@ -159,10 +159,6 @@ hqDefine('app_manager/js/forms/advanced/case_config_ui', function () {
                 return caseConfigUtils.getQuestions(self.questions(), filter, excludeHidden, includeRepeat);
             };
 
-            self.refreshQuestions = function (url, formUniqueId, event) {
-                return caseConfigUtils.refreshQuestions(self.questions, url, formUniqueId, event);
-            };
-
             self.getAnswers = function (condition) {
                 return caseConfigUtils.getAnswers(self.questions(), condition);
             };
@@ -221,6 +217,8 @@ hqDefine('app_manager/js/forms/advanced/case_config_ui', function () {
                     $('.hq-help-template').each(function () {
                         hqImport("hqwebapp/js/main").transformHelpTemplate($(this), true);
                     });
+
+                    caseConfigUtils.initRefreshQuestions(self.questions);
                 });
             };
             return self;

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -135,9 +135,6 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 return caseConfigUtils.getQuestions(self.questions(), filter, excludeHidden, includeRepeat, excludeTrigger);
             };
 
-            self.refreshQuestions = function (url, formUniqueId, event) {
-                return caseConfigUtils.refreshQuestions(self.questions, url, formUniqueId, event);
-            };
             self.getAnswers = function (condition) {
                 return caseConfigUtils.getAnswers(self.questions(), condition);
             };
@@ -199,6 +196,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                         self.forceRefreshTextchangeBinding($usercaseMgmt);
                     }
 
+                    caseConfigUtils.initRefreshQuestions(self.questions);
                 });
 
             };

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -136,6 +136,7 @@
   {% initial_page_data 'form_filter_patterns' form_filter_patterns %}
   {% initial_page_data 'form_name' form.name|trans:app.langs %}
   {% initial_page_data 'form_requires' form.requires %}
+  {% initial_page_data 'form_unique_id' form.unique_id %}
   {% initial_page_data 'has_form_source' form.source|yesno:"1," %}
   {% initial_page_data 'is_case_list_form' is_case_list_form %}
   {% initial_page_data 'is_usercase_in_use' is_usercase_in_use %}
@@ -153,6 +154,7 @@
     {% initial_page_data 'apps_modules' apps_modules %}
   {% endif %}
   {% registerurl "enable_usercase" domain %}
+  {% registerurl "get_form_questions" domain app.id %}
   {% registerurl "validate_form_for_build" domain app.id form.unique_id %}
 
   {# End of form navigation #}

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
@@ -85,8 +85,6 @@
 
 <div id="case-config-ko">
 
-  <div class="refresh-form-questions-container"
-       data-bind="template: 'case-config:refresh-form-questions'"></div>
   <div data-bind="saveButton: saveButton"></div>
 
   <div data-bind="with: caseConfigViewModel">

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_advanced.html
@@ -492,7 +492,6 @@
 </script>
 
 <div id="case-config-ko">
-  <div class="refresh-form-questions-container" data-bind="template: 'case-config:refresh-form-questions'"></div>
   <div data-bind="saveButton: saveButton"></div>
   <div data-bind="with: caseConfigViewModel">
     <div class="btn-group" data-bind="visible: actionOptions().length">

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -306,17 +306,3 @@
     <!-- /ko -->
   </div>
 </script>
-
-<script type="text/html"
-        id="case-config:refresh-form-questions">
-  <p class="pull-right">
-    <button class="btn btn-default refresh-form-questions"
-            type="button"
-            data-bind="click: function(data, event){
-                         refreshQuestions('{% url 'get_form_questions' domain app.id %}', '{{form.unique_id}}', event);
-                         hqImport('analytix/js/google').track.event('Refresh case management', 'Button Clicked');
-                       }">
-      <i class="fa fa-refresh"></i>
-    </button>
-  </p>
-</script>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/usercase_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/usercase_config.html
@@ -8,6 +8,11 @@
 </script>
 
 <div id="usercase-config-ko">
+  <div class="clearfix">
+    {% if allow_usercase %}
+      <div data-bind="saveButton: saveUsercaseButton"></div>
+    {% endif %}
+  </div>
   <p class="lead">
     {% blocktrans %}
       <strong>User Properties</strong> allow you to store data about the user and use that data in forms.

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/usercase_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/usercase_config.html
@@ -8,12 +8,6 @@
 </script>
 
 <div id="usercase-config-ko">
-  <div class="clearfix">
-    {% if allow_usercase %}
-      <div class="refresh-form-questions-container" data-bind="template: 'case-config:refresh-form-questions'"></div>
-      <div data-bind="saveButton: saveUsercaseButton"></div>
-    {% endif %}
-  </div>
   <p class="lead">
     {% blocktrans %}
       <strong>User Properties</strong> allow you to store data about the user and use that data in forms.


### PR DESCRIPTION
## Product Description
Removes the refresh button in the top right of this screenshot, which is used to refresh the options in the question dropdowns (useful if you're working on the form in another tab).

Instead, automatically check for new versions of the app, and when one is detected, refresh the dropdowns. We already do this polling - it powers the light purple "Updates available to publish" notification - I'm just adding some logic to it to make it also update the question dropdowns.

This should be a smoother experience. We've had people ask for something like the sync button before, not having noticed it or understanding what it does. The button itself doesn't get a ton of use. Analytics say that it gets clicked 2-3 times a day.

I thought about having some kind of "refreshing" indicator during the refresh request but decided that would be more distracting/confusing than useful.

![Screen Shot 2022-01-06 at 5 10 14 PM](https://user-images.githubusercontent.com/1486591/148459388-ee5cc1c9-1e59-49e1-bc19-854ef5c9ef68.png)

## Safety Assurance

### Safety story

This changes a non-essential feature that isn't used that much. Negative side effects should be limited to that feature.

The biggest risk is of a js error. I tested this on staging in a followup form in the case management and usercase tabs, and also in an advanced form.

### Automated test coverage

None.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
