### PR TITLE
Use CommCareCaseSQL instead of CommCareCase for case search results

### DIFF
--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -13,19 +13,23 @@ from corehq.apps.es import case_search as case_search_es
 from warnings import warn
 
 from django.utils.dateparse import parse_date
+from memoized import memoized
 
 from corehq.apps.case_search.const import (
     CASE_PROPERTIES_PATH,
     IDENTIFIER,
+    INDEXED_ON,
     INDICES_PATH,
     IS_RELATED_CASE,
     REFERENCED_ID,
     RELEVANCE_SCORE,
     SPECIAL_CASE_PROPERTIES,
+    SPECIAL_CASE_PROPERTIES_MAP,
     SYSTEM_PROPERTIES,
     VALUE,
 )
 from corehq.apps.es.cases import CaseES, owner
+from corehq.util.dates import iso_string_to_datetime
 
 from . import filters, queries
 
@@ -283,7 +287,7 @@ def external_id(external_id):
 
 
 def indexed_on(gt=None, gte=None, lt=None, lte=None):
-    return filters.date_range('@indexed_on', gt, gte, lt, lte)
+    return filters.date_range(INDEXED_ON, gt, gte, lt, lte)
 
 
 def flatten_result(hit, include_score=False, is_related_case=False):
@@ -292,6 +296,23 @@ def flatten_result(hit, include_score=False, is_related_case=False):
 
     i.e. instead of {'name': 'blah', 'case_properties':{'key':'foo', 'value':'bar'}} we return
     {'name': 'blah', 'foo':'bar'}
+
+    Note that some dynamic case properties, if present, will overwrite
+    internal case properties:
+
+        domain
+        type
+        opened_on
+        opened_by
+        modified_on
+        server_modified_on
+        modified_by         -> also overwrites user_id
+        closed
+        closed_on
+        closed_by
+        deleted
+        deleted_on
+        deletion_id
     """
     try:
         result = hit['_source']
@@ -312,3 +333,69 @@ def flatten_result(hit, include_score=False, is_related_case=False):
     for key in SYSTEM_PROPERTIES:
         result.pop(key, None)
     return result
+
+
+def wrap_case_search_hit(hit, include_score=False, is_related_case=False):
+    """Convert case search index hit to CommCareCaseSQL
+
+    Nearly the opposite of
+    `corehq.pillows.case_search.transform_case_for_elasticsearch`.
+
+    The "case_properties" list of key/value pairs is converted to a dict
+    and assigned to `case_json`. 'Secial' case properties are excluded
+    from `case_json`, even if they were present in the original case's
+    dynamic properties.
+
+    All fields excluding "case_properties" and its contents are assigned
+    as attributes on the case object if `CommCareCaseSQL` has a field
+    with a matching name. Fields like "doc_type" and "@indexed_on" are
+    ignored.
+
+    Warning: `include_score=True` or `is_related_case=True` may cause
+    the relevant user-defined properties to be overwritten.
+
+    :returns: A `CommCareCaseSQL` instance.
+    """
+    from corehq.form_processor.models import CommCareCaseSQL
+    data = hit.get("_source", hit)
+    _SPECIAL_PROPERTIES = SPECIAL_CASE_PROPERTIES_MAP
+    _VALUE = VALUE
+    case = CommCareCaseSQL(
+        case_id=data.get("_id", None),
+        case_json={
+            prop["key"]: prop[_VALUE]
+            for prop in data.get(CASE_PROPERTIES_PATH, {})
+            if prop["key"] not in _SPECIAL_PROPERTIES
+        },
+        indices=data.get("indices", []),
+    )
+    _CONVERSIONS = CONVERSIONS
+    _setattr = setattr
+    case_fields = _case_fields()
+    for key, value in data.items():
+        if key in case_fields:
+            if value is not None and key in _CONVERSIONS:
+                value = _CONVERSIONS[key](value)
+            _setattr(case, key, value)
+    if include_score:
+        case.case_json[RELEVANCE_SCORE] = hit['_score']
+    if is_related_case:
+        case.case_json[IS_RELATED_CASE] = "true"
+    return case
+
+
+@memoized
+def _case_fields():
+    from corehq.form_processor.models import CommCareCaseSQL
+    fields = {f.attname for f in CommCareCaseSQL._meta.concrete_fields}
+    fields.add("user_id")  # synonym for "modified_by"
+    return fields
+
+
+CONVERSIONS = {
+    "closed_on": iso_string_to_datetime,
+    "modified_on": iso_string_to_datetime,
+    "opened_on": iso_string_to_datetime,
+    "server_modified_on": iso_string_to_datetime,
+    "closed_on": iso_string_to_datetime,
+}

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -254,13 +254,20 @@ class TestCaseSearchES(ElasticTestMixin, SimpleTestCase):
 
     def test_blacklisted_owner_ids(self):
         query = self.es.domain('swashbucklers').blacklist_owner_id('123').owner('234')
-        expected = {'query': {'bool': {'filter': [{'term': {'domain.exact': 'swashbucklers'}},
-                            {'bool': {'must_not': {'term': {'owner_id': '123'}}}},
-                            {'term': {'owner_id': '234'}},
-                            {'match_all': {}}],
-                'must': {'match_all': {}}}},
-                'size': SIZE_LIMIT}
-
+        expected = {
+            'query': {
+                'bool': {
+                    'filter': [
+                        {'term': {'domain.exact': 'swashbucklers'}},
+                        {'bool': {'must_not': {'term': {'owner_id': '123'}}}},
+                        {'term': {'owner_id': '234'}},
+                        {'match_all': {}}
+                    ],
+                    'must': {'match_all': {}},
+                },
+            },
+            'size': SIZE_LIMIT,
+        }
         self.checkQuery(query, expected, validate_query=False)
 
 
@@ -467,7 +474,11 @@ class TestCaseSearchLookups(TestCase):
                 {'_id': 'c3', 'dob': date(2020, 3, 3)},
                 {'_id': 'c4', 'dob': date(2020, 3, 4)},
             ],
-            CaseSearchCriteria(self.domain, [self.case_type], {'dob': '__range__2020-03-02__2020-03-03'}).search_es,
+            CaseSearchCriteria(
+                self.domain,
+                [self.case_type],
+                {'dob': '__range__2020-03-02__2020-03-03'},
+            ).search_es,
             None,
             ['c2', 'c3']
         )
@@ -621,7 +632,11 @@ class TestCaseSearchLookups(TestCase):
             {'_id': 'c3', 'case_type': 'show', 'description': 'Boston'},
         ]
         config = self._create_case_search_config()
-        fuzzy_properties = FuzzyProperties.objects.create(domain=self.domain, case_type='song', properties=['description'])
+        fuzzy_properties = FuzzyProperties.objects.create(
+            domain=self.domain,
+            case_type='song',
+            properties=['description'],
+        )
         config.fuzzy_properties.add(fuzzy_properties)
         self.addCleanup(fuzzy_properties.delete)
         self._assert_query_runs_correctly(

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -1,13 +1,12 @@
 import uuid
 from collections import Counter
-from datetime import date
+from datetime import date, datetime
 
 from django.test import TestCase
 from django.test.testcases import SimpleTestCase
 
 from unittest.mock import MagicMock, patch
 
-from casexml.apps.case.models import CommCareCase
 from pillowtop.es_utils import initialize_index_and_mapping
 
 from corehq.apps.app_manager.models import (
@@ -16,7 +15,7 @@ from corehq.apps.app_manager.models import (
     DetailColumn,
     Module,
 )
-from corehq.apps.case_search.const import RELEVANCE_SCORE
+from corehq.apps.case_search.const import IS_RELATED_CASE, RELEVANCE_SCORE
 from corehq.apps.case_search.models import (
     CaseSearchConfig,
     FuzzyProperties,
@@ -36,9 +35,11 @@ from corehq.apps.es.case_search import (
     case_property_range_query,
     case_property_text_query,
     flatten_result,
+    wrap_case_search_hit,
 )
 from corehq.apps.es.tests.utils import ElasticTestMixin, es_test
 from corehq.elastic import SIZE_LIMIT, get_es_new
+from corehq.form_processor.models import CommCareCaseIndexSQL
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.pillows.case_search import CaseSearchReindexerFactory
 from corehq.pillows.mappings.case_search_mapping import (
@@ -269,6 +270,106 @@ class TestCaseSearchES(ElasticTestMixin, SimpleTestCase):
             'size': SIZE_LIMIT,
         }
         self.checkQuery(query, expected, validate_query=False)
+
+
+class TestCaseSearchHitConversions(SimpleTestCase):
+    maxDiff = None
+
+    def test_wrap_case_search_hit(self):
+        case = wrap_case_search_hit(self.make_hit())
+        self.assertEqual(case.case_id, '2a3341db-0ca4-444b-a44c-3bde3a16954e')
+        self.assertEqual(case.closed, False)
+        self.assertEqual(case.closed_by, None)
+        self.assertEqual(case.closed_on, None)
+        self.assertEqual(case.doc_type, 'CommCareCase')
+        self.assertEqual(case.domain, 'healsec')
+        self.assertEqual(case.external_id, None)
+        self.assertEqual(case.location_id, None)
+        self.assertEqual(case.modified_on, datetime(2019, 6, 21, 17, 32, 48))
+        self.assertEqual(case.name, 'blah')
+        self.assertEqual(case.opened_by, '29383d6a335847f985aeeeca94031f82')
+        self.assertEqual(case.opened_on, datetime(2019, 6, 21, 17, 31, 18, 349000))
+        self.assertEqual(case.owner_id, '29383d6a335847f985aeeeca94031f82')
+        self.assertEqual(case.server_modified_on, datetime(2019, 6, 21, 17, 32, 48, 437901))
+        self.assertEqual(case.type, 'mother')
+        self.assertEqual(case.user_id, '29383d6a335847f985aeeeca94031f82')
+        self.assertEqual(case.indices, [
+            CommCareCaseIndexSQL(
+                case_id=case.case_id,
+                domain='healsec',
+                identifier='host',
+                referenced_type='person',
+                referenced_id='abc123',
+                relationship_id=CommCareCaseIndexSQL.EXTENSION,
+            )
+        ])
+        self.assertEqual(case.case_json, {
+            'closed': 'nope',
+            'doc_type': 'frankle',
+            'domain': 'batter',
+            'foo': 'bar',
+            'baz': 'buzz',
+        })
+
+    def test_wrap_case_search_hit_include_score(self):
+        case = wrap_case_search_hit(self.make_hit(), include_score=True)
+        self.assertEqual(case.case_json[RELEVANCE_SCORE], "1.095")
+
+    def test_wrap_case_search_hit_is_related_case(self):
+        case = wrap_case_search_hit(self.make_hit(), is_related_case=True)
+        self.assertEqual(case.case_json[IS_RELATED_CASE], 'true')
+
+    @staticmethod
+    def make_hit():
+        return {
+            "_score": "1.095",
+            "_source": {
+                '_id': '2a3341db-0ca4-444b-a44c-3bde3a16954e',
+                'closed': False,
+                'closed_by': None,
+                'closed_on': None,
+                'doc_type': 'CommCareCase',
+                'domain': 'healsec',
+                'external_id': None,
+                'location_id': None,
+                'modified_on': '2019-06-21T17:32:48Z',
+                'name': 'blah',
+                'opened_by': '29383d6a335847f985aeeeca94031f82',
+                'opened_on': '2019-06-21T17:31:18.349000Z',
+                'owner_id': '29383d6a335847f985aeeeca94031f82',
+                'server_modified_on': '2019-06-21T17:32:48.437901Z',
+                'type': 'mother',
+                'user_id': '29383d6a335847f985aeeeca94031f82',
+                '@indexed_on': '2020-04-18T12:34:56.332000Z',
+                'indices': [
+                    {
+                        'case_id': '2a3341db-0ca4-444b-a44c-3bde3a16954e',
+                        'domain': 'healsec',
+                        'identifier': 'host',
+                        'referenced_type': 'person',
+                        'referenced_id': 'abc123',
+                        'relationship': 'extension',
+                    },
+                ],
+                'case_properties': [
+                    {'key': '@case_id', 'value': '2a3341db-0ca4-444b-a44c-3bde3a16954e'},
+                    {'key': '@case_type', 'value': 'mother'},
+                    {'key': '@owner_id', 'value': '29383d6a335847f985aeeeca94031f82'},
+                    {'key': '@status', 'value': 'open'},
+                    {'key': 'name', 'value': 'blah'},
+                    {'key': 'case_name', 'value': 'blah'},
+                    {'key': 'external_id', 'value': None},
+                    {'key': 'date_opened', 'value': '2019-06-21T17:31:18.349000Z'},
+                    {'key': 'closed_on', 'value': None},
+                    {'key': 'last_modified', 'value': '2019-06-21T17:32:48.332000Z'},
+                    {'key': 'closed', 'value': 'nope'},
+                    {'key': 'doc_type', 'value': 'frankle'},
+                    {'key': 'domain', 'value': 'batter'},
+                    {'key': 'foo', 'value': 'bar'},
+                    {'key': 'baz', 'value': 'buzz'},
+                ],
+            },
+        }
 
 
 @es_test
@@ -529,7 +630,7 @@ class TestCaseSearchLookups(TestCase):
         self._bootstrap_cases_in_es_for_domain(self.domain, cases)
 
         hits = CaseSearchES().domain(self.domain).case_type(self.case_type).run().hits
-        cases = [CommCareCase.wrap(flatten_result(result)) for result in hits]
+        cases = [wrap_case_search_hit(result) for result in hits]
         self.assertEqual({case.case_id for case in cases}, {'c5', 'c6'})
 
         self._assert_related_case_ids(cases, set(), set())
@@ -567,7 +668,7 @@ class TestCaseSearchLookups(TestCase):
         self._bootstrap_cases_in_es_for_domain(self.domain, cases)
 
         hits = CaseSearchES().domain(self.domain).case_type("c").run().hits
-        cases = [CommCareCase.wrap(flatten_result(result)) for result in hits]
+        cases = [wrap_case_search_hit(result) for result in hits]
         self.assertEqual({case.case_id for case in cases}, {'c1', 'c2'})
 
         with patch("corehq.apps.case_search.utils.get_related_case_relationships",
@@ -605,7 +706,7 @@ class TestCaseSearchLookups(TestCase):
         self._bootstrap_cases_in_es_for_domain(self.domain, cases)
 
         hits = CaseSearchES().domain(self.domain).case_type("a").run().hits
-        cases = [CommCareCase.wrap(flatten_result(result)) for result in hits]
+        cases = [wrap_case_search_hit(result) for result in hits]
         self.assertEqual({case.case_id for case in cases}, {'a1', 'a2', 'a3', 'a4'})
 
         with patch("corehq.apps.case_search.utils.get_related_case_relationships",
@@ -620,7 +721,7 @@ class TestCaseSearchLookups(TestCase):
 
     def _assert_related_case_ids(self, cases, paths, ids):
         results = get_related_case_results(_QueryHelper(self.domain), cases, paths)
-        result_ids = Counter([result['_id'] for result in results])
+        result_ids = Counter([result.case_id for result in results])
         self.assertEqual(ids, set(result_ids))
         if result_ids:
             self.assertEqual(1, max(result_ids.values()), result_ids)  # no duplicates

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -469,7 +469,7 @@ class CaseClaimEndpointTests(TestCase):
             '<external_id>Jamie Hand</external_id>'
             '<date_opened>2016-04-17</date_opened>'
             '<commcare_search_score>xxx</commcare_search_score>'
-            '<location_id>None</location_id>'
+            '<opened_by>nerc</opened_by>'
             '</case>'
             '</results>'.format(
                 case_id=self.case_id,

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_fixtures.py
@@ -1,11 +1,11 @@
 import datetime
-
 import os.path
-from casexml.apps.case.fixtures import CaseDBFixture
-from casexml.apps.case.models import CommCareCase
-from casexml.apps.case.sharedmodels import CommCareCaseIndex
-from corehq.apps.app_manager.tests.util import TestXmlMixin
+
 from django.test import SimpleTestCase
+
+from casexml.apps.case.fixtures import CaseDBFixture
+from corehq.apps.app_manager.tests.util import TestXmlMixin
+from corehq.form_processor.models import CommCareCaseSQL
 
 
 class TestFixtures(TestXmlMixin, SimpleTestCase):
@@ -14,8 +14,9 @@ class TestFixtures(TestXmlMixin, SimpleTestCase):
 
     domain = 'winterfell'
 
-    def setUp(self):
-        self.case = CommCareCase(
+    def create_case(self):
+        return CommCareCaseSQL(
+            case_id='redwoman',
             domain=self.domain,
             opened_on=datetime.datetime(2016, 5, 31),
             modified_on=datetime.datetime(2016, 5, 31),
@@ -23,17 +24,16 @@ class TestFixtures(TestXmlMixin, SimpleTestCase):
             closed=False,
             name='melisandre',
             owner_id='lordoflight',
-            indices=[CommCareCaseIndex(
-                identifier='advisor',
-                referenced_type='human',
-                referenced_id='stannis',
-                relationship='extension',
-            )]
+            indices=[{
+                'identifier': 'advisor',
+                'referenced_type': 'human',
+                'referenced_id': 'stannis',
+                'relationship': 'extension',
+            }],
+            case_json={'power': 'prophecy', 'hometown': 'asshai'},
         )
-        self.case._id = 'redwoman'
-        self.case.power = 'prophecy'
-        self.case.hometown = 'asshai'
 
     def test_fixture(self):
-        fixture = CaseDBFixture([self.case, self.case]).fixture
-        self.assertXmlEqual(fixture, self.get_xml('case_fixture'))
+        case = self.create_case()
+        fixture = CaseDBFixture([case, case]).fixture
+        self.assertXmlEqual(self.get_xml('case_fixture'), fixture)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_xml.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_xml.py
@@ -3,10 +3,9 @@ import os.path
 from django.test import SimpleTestCase
 
 import casexml.apps.phone.xml as xml
-from casexml.apps.case.models import CommCareCase
-from casexml.apps.case.sharedmodels import CommCareCaseIndex
 
 from corehq.apps.app_manager.tests.util import TestXmlMixin
+from corehq.form_processor.models import CommCareCaseSQL
 
 
 class TestCaseDBElement(TestXmlMixin, SimpleTestCase):
@@ -15,8 +14,9 @@ class TestCaseDBElement(TestXmlMixin, SimpleTestCase):
 
     domain = 'winterfell'
 
-    def setUp(self):
-        self.case = CommCareCase(
+    def create_case(self):
+        return CommCareCaseSQL(
+            case_id='redwoman',
             domain=self.domain,
             opened_on=datetime.datetime(2016, 5, 31),
             modified_on=datetime.datetime(2016, 5, 31),
@@ -24,17 +24,16 @@ class TestCaseDBElement(TestXmlMixin, SimpleTestCase):
             closed=False,
             name='melisandre',
             owner_id='lordoflight',
-            indices=[CommCareCaseIndex(
-                identifier='advisor',
-                referenced_type='human',
-                referenced_id='stannis',
-                relationship='extension',
-            )]
+            indices=[{
+                'identifier': 'advisor',
+                'referenced_type': 'human',
+                'referenced_id': 'stannis',
+                'relationship': 'extension',
+            }],
+            case_json={'power': 'prophecy', 'hometown': 'asshai'},
         )
-        self.case._id = 'redwoman'
-        self.case.power = 'prophecy'
-        self.case.hometown = 'asshai'
 
     def test_generate_xml(self):
-        casedb_xml = xml.tostring(xml.get_casedb_element(self.case))
-        self.assertXmlEqual(casedb_xml, self.get_xml('case_db_block'))
+        case = self.create_case()
+        case_xml = xml.tostring(xml.get_casedb_element(case))
+        self.assertXmlEqual(self.get_xml('case_db_block'), case_xml)

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -737,6 +737,11 @@ class CommCareCaseSQL(PartitionedModel, models.Model, RedisLockableMixIn,
 
     case_json = JSONField(default=dict)
 
+    def __init__(self, *args, **kwargs):
+        if "indices" in kwargs:
+            self._set_indices(kwargs.pop("indices"))
+        super().__init__(*args, **kwargs)
+
     def natural_key(self):
         # necessary for dumping models from a sharded DB so that we exclude the
         # SQL 'id' field which won't be unique across all the DB's
@@ -856,6 +861,20 @@ class CommCareCaseSQL(PartitionedModel, models.Model, RedisLockableMixIn,
             return getattr(self, cached_indices)
 
         return CaseAccessorSQL.get_indices(self.domain, self.case_id) if self.is_saved() else []
+
+    def _set_indices(self, value):
+        """Set previously-saved indices
+
+        Private setter used by the class constructor to populate indices
+        from a source such as ElasticSearch. This setter does not update
+        tracked models, and therefore is not intended for use with cases
+        whose state is being mutated.
+
+        :param value: A list of dicts that will be used to construct
+        `CommCareCaseIndexSQL` objects.
+        """
+        cache = self._saved_indices.get_cache(self)
+        cache[()] = [CommCareCaseIndexSQL(**x) for x in value]
 
     @property
     def indices(self):

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -873,8 +873,7 @@ class CommCareCaseSQL(PartitionedModel, models.Model, RedisLockableMixIn,
         :param value: A list of dicts that will be used to construct
         `CommCareCaseIndexSQL` objects.
         """
-        cache = self._saved_indices.get_cache(self)
-        cache[()] = [CommCareCaseIndexSQL(**x) for x in value]
+        self.cached_indices = [CommCareCaseIndexSQL(**x) for x in value]
 
     @property
     def indices(self):

--- a/custom/covid/rules/custom_actions.py
+++ b/custom/covid/rules/custom_actions.py
@@ -4,8 +4,7 @@ COVID: Available Actions
 
 The following actions can be used in messaging in projects using the ``covid`` custom module.
 """
-from corehq.apps.es.case_search import CaseSearchES, flatten_result
-from casexml.apps.case.models import CommCareCase
+from corehq.apps.es.case_search import CaseSearchES
 from corehq.apps.es.cases import case_type
 from corehq.apps.data_interfaces.models import CaseRuleActionResult, AUTO_UPDATE_XMLNS
 from corehq.apps.hqcase.utils import update_case

--- a/custom/covid/rules/custom_criteria.py
+++ b/custom/covid/rules/custom_criteria.py
@@ -4,8 +4,7 @@ COVID: Available Criteria
 
 The following criteria can be used in messaging in projects using the ``covid`` custom module.
 """
-from corehq.apps.es.case_search import CaseSearchES, flatten_result
-from casexml.apps.case.models import CommCareCase
+from corehq.apps.es.case_search import CaseSearchES, wrap_case_search_hit
 from corehq.apps.app_manager.const import USERCASE_TYPE
 
 
@@ -39,4 +38,4 @@ def get_usercase_from_checkin(checkin_case):
     if not results:
         return None
 
-    return CommCareCase.wrap(flatten_result(results[0]))
+    return wrap_case_search_hit(results[0])


### PR DESCRIPTION
Since all forms and cases have been migrated to SQL it is time to stop using `CommCareCase`.

The most important change here is the new `wrap_case_search_hit` function, which was written with inner loop performance of large case search result sets in mind. To that end, it skips the intermediate dict transformation as done by `flatten_result` and instead constructs a `CommCareCaseSQL` instance directly. It uses a different algorithm than `flatten_result` to avoid collisions between user-defined case properties and system case properties since `CommCareCaseSQL` uses separate namespaces for those things anyway.

Unfortunately `flatten_result` cannot be removed because it is still used by (two different versions of) the case list explorer, where cases are expected to be dicts rather than model objects. It may work, but also may be be less performant, to do something like `wrap_case_search_hit(data).to_json()` in places that currently use `flatten_result(data)`. In the mean time, the bugs related to non-standard case property naming and user/system property collisions still exist in the case list explorer.

:tropical_fish: Review by commit.

## Safety Assurance

### Safety story

A lot of time was spent discovering the extend and then thinking through the implications of this change, particularly around the consequences of changing the code in a way that avoids overwriting system properties with user properties. That is, whether there is any chance of dependence on existing arguably buggy behavior? Hopefully not, but it's hard to know for certain. The new behavior is more predictable and almost certainly better.

As noted below, the code paths that call `wrap_case_search_hit` are well covered by tests.

### Automated test coverage

Tests were added for the new `wrap_case_search_hit` function. Existing tests were changed to verify that case XML is generated from `CommCareCaseSQL` where it previously used `CommCareCase` on the code paths that use `wrap_case_search_hit`.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
