### PR TITLE
Remove all markup from export labels

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -108,6 +108,8 @@ from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors
 from corehq.util.global_request import get_request_domain
 from corehq.util.timezones.utils import get_timezone_for_domain
 from corehq.util.view_utils import absolute_reverse
+from corehq.util.html_utils import strip_tags
+
 
 DAILY_SAVED_EXPORT_ATTACHMENT_NAME = "payload"
 
@@ -225,7 +227,7 @@ class ExportItem(DocumentSchema, ReadablePathMixin):
     def create_from_question(cls, question, app_id, app_version, repeats):
         return cls(
             path=_question_path_to_path_nodes(question['value'], repeats),
-            label=question['label'],
+            label=strip_tags(question['label']),
             last_occurrences={app_id: app_version},
             datatype=get_form_indicator_data_type(question['type'])
         )

--- a/corehq/apps/export/tests/test_export_item.py
+++ b/corehq/apps/export/tests/test_export_item.py
@@ -66,3 +66,15 @@ class TestExportItemGeneration(SimpleTestCase):
         wrapped = ExportItem.wrap(item.to_json())
         self.assertEqual(type(wrapped), type(item))
         self.assertEqual(wrapped.to_json(), item.to_json())
+
+
+class CreateFromQuestionTests(SimpleTestCase):
+    def test_removes_html_from_label(self):
+        question = {
+            'label': '<span style="color:#ffffff">Enter a number</span>',
+            'value': '/data/enter_number',
+            'type': 'Int',
+        }
+
+        item = ExportItem.create_from_question(question, 'app_id', 'app_ersion', [])
+        self.assertEqual(item.label, 'Enter a number')

--- a/corehq/util/html_utils.py
+++ b/corehq/util/html_utils.py
@@ -1,0 +1,25 @@
+from io import StringIO
+from html.parser import HTMLParser
+
+
+# Inspired by: https://stackoverflow.com/questions/753052/strip-html-from-strings-in-python
+# Note that this should not be used where Sanitization is required, as removing one tag
+# could create a new tag in the new output
+def strip_tags(html):
+    s = HTMLRemover()
+    s.feed(html)
+    return s.get_data()
+
+
+class HTMLRemover(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.strict = False
+        self.convert_charrefs = True
+        self.text = StringIO()
+
+    def handle_data(self, data):
+        self.text.write(data)
+
+    def get_data(self):
+        return self.text.getvalue()

--- a/corehq/util/tests/test_html_utils.py
+++ b/corehq/util/tests/test_html_utils.py
@@ -1,0 +1,13 @@
+from django.test import SimpleTestCase
+from ..html_utils import strip_tags
+
+
+class StripTagsTests(SimpleTestCase):
+    def test_leaves_plain_text_alone(self):
+        self.assertEqual(strip_tags('plain text'), 'plain text')
+
+    def test_strips_embedded_tag(self):
+        self.assertEqual(strip_tags('This is <b>important</b>!'), 'This is important!')
+
+    def test_removes_tags_with_attributes(self):
+        self.assertEqual(strip_tags('<span style="color:#ffffff">Colored Text</span>'), 'Colored Text')


### PR DESCRIPTION
## Technical Summary
This ticket is a response to https://dimagi-dev.atlassian.net/browse/SAAS-12849. By removing the markup on labels, these exports will pass the XSS checks that the WAF was previously denying.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
This was tested locally and on staging.

### Automated test coverage

Tests created in _test_export_item.py_ and _test_html_utils.py_

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA should test other export areas that might be impacted by this change. Form Exports work from my testing (but another look wouldn't hurt).


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
