### PR TITLE
Remove CommCareCase from apps: casegroups, change_feed, commtrack, etc.

### DIFF
--- a/corehq/apps/casegroups/tests.py
+++ b/corehq/apps/casegroups/tests.py
@@ -1,7 +1,5 @@
 from django.test import TestCase
 
-from casexml.apps.case.models import CommCareCase
-
 from corehq.apps.casegroups.dbaccessors import (
     get_case_group_meta_in_domain,
     get_case_groups_in_domain,

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -1,4 +1,3 @@
-from casexml.apps.case.models import CommCareCase
 from pillowtop.checkpoints.manager import (
     PillowCheckpoint,
     PillowCheckpointEventHandler,
@@ -52,7 +51,7 @@ class KafkaProcessor(PillowProcessor):
 
 
 def get_default_couch_db_change_feed_pillow(pillow_id, **kwargs):
-    return get_change_feed_pillow_for_db(pillow_id, CommCareCase.get_db())
+    return get_change_feed_pillow_for_db(pillow_id, couch_config.get_db(None))
 
 
 def get_user_groups_db_kafka_pillow(pillow_id, **kwargs):

--- a/corehq/apps/cloudcare/tests/test_session.py
+++ b/corehq/apps/cloudcare/tests/test_session.py
@@ -2,8 +2,6 @@ import uuid
 
 from django.test import TestCase
 
-from casexml.apps.case.models import CommCareCase
-
 from corehq.apps.cloudcare.touchforms_api import (
     get_user_contributions_to_touchforms_session,
 )
@@ -15,6 +13,7 @@ from corehq.apps.custom_data_fields.models import (
 )
 from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
 from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.form_processor.models import CommCareCaseSQL
 
 
 class SessionUtilsTest(TestCase):
@@ -82,11 +81,11 @@ class SessionUtilsTest(TestCase):
         self.assertTrue(data['user_data']['commcare_project'], 'cloudcare-tests')
 
     def test_load_session_data_for_commconnect_case(self):
-        user = CommCareCase(
+        user = CommCareCaseSQL(
             name='A case',
-            _id=uuid.uuid4().hex
+            case_id=uuid.uuid4().hex
         )
         data = get_user_contributions_to_touchforms_session('cloudcare-tests', user)
         self.assertEqual('A case', data['username'])
-        self.assertEqual(user._id, data['user_id'])
+        self.assertEqual(user.case_id, data['user_id'])
         self.assertEqual({}, data['user_data'])

--- a/corehq/apps/commtrack/management/commands/update_supply_point_locations.py
+++ b/corehq/apps/commtrack/management/commands/update_supply_point_locations.py
@@ -3,12 +3,11 @@ from xml.etree import cElementTree as ElementTree
 from django.core.management.base import BaseCommand
 
 from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.models import CommCareCase
 from dimagi.utils.chunked import chunked
-from dimagi.utils.couch.database import iter_docs
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqcase.utils import submit_case_blocks
+from corehq.form_processor.backends.sql.supply import SupplyPointSQL
 
 
 def needs_update(case):
@@ -25,14 +24,8 @@ def case_block(case):
 
 
 def get_cases(domain):
-    supply_point_ids = (case['id'] for case in CommCareCase.get_db().view(
-        'supply_point_by_loc/view',
-        startkey=[domain],
-        endkey=[domain, {}],
-        reduce=False,
-        include_docs=False,
-    ).all())
-    return iter_docs(CommCareCase.get_db(), supply_point_ids)
+    ids = SupplyPointSQL.get_supply_point_ids_by_location(domain).values()
+    return SupplyPointSQL.get_supply_points(ids)
 
 
 def update_supply_points(domain):

--- a/corehq/apps/commtrack/tests/test_settings.py
+++ b/corehq/apps/commtrack/tests/test_settings.py
@@ -1,6 +1,5 @@
+import attr
 from django.test import TestCase
-
-from casexml.apps.case.models import CommCareCase
 
 from corehq.apps.commtrack.const import DAYS_IN_MONTH
 from corehq.apps.commtrack.models import (
@@ -43,12 +42,18 @@ class CommTrackSettingsTest(TestCase):
         self.assertEqual(10, restore_settings.consumption_config.min_periods)
         self.assertEqual(20, restore_settings.consumption_config.min_window)
         self.assertEqual(60, restore_settings.consumption_config.max_window)
-        self.assertEqual(150, restore_settings.consumption_config.default_monthly_consumption_function('foo', 'bar'))
-        self.assertFalse(restore_settings.force_consumption_case_filter(CommCareCase(type='force-type')))
+        self.assertEqual(150, restore_settings.consumption_config
+            .default_monthly_consumption_function('foo', 'bar'))
+        self.assertFalse(restore_settings.force_consumption_case_filter(Typish(type='force-type')))
         self.assertEqual(0, len(restore_settings.default_product_list))
 
         ct_settings.stockrestoreconfig.force_consumption_case_types = ['force-type']
         ct_settings.stockrestoreconfig.use_dynamic_product_list = True
         restore_settings = ct_settings.get_ota_restore_settings()
-        self.assertTrue(restore_settings.force_consumption_case_filter(CommCareCase(type='force-type')))
+        self.assertTrue(restore_settings.force_consumption_case_filter(Typish(type='force-type')))
         self.assertEqual(3, len(restore_settings.default_product_list))
+
+
+@attr.s
+class Typish:
+    type = attr.ib()

--- a/corehq/apps/data_interfaces/app_config.py
+++ b/corehq/apps/data_interfaces/app_config.py
@@ -7,12 +7,8 @@ class DataInterfacesAppConfig(AppConfig):
     name = 'corehq.apps.data_interfaces'
 
     def ready(self):
-        from casexml.apps.case.models import CommCareCase
-        from casexml.apps.case.signals import case_post_save
         from corehq.form_processor.models import CommCareCaseSQL
         from corehq.form_processor.signals import sql_case_post_save
 
-        case_post_save.connect(case_changed_receiver, CommCareCase,
-                               dispatch_uid="data_interfaces_case_receiver")
         sql_case_post_save.connect(case_changed_receiver, CommCareCaseSQL,
                                    dispatch_uid="data_interfaces_sql_case_receiver")


### PR DESCRIPTION
:blowfish: Review by commit.

## Safety Assurance

### Safety story

Nothing major going on here, just removing reference to the old Couch model. Includes some very simple updates to use the SQL model instead in a few places.

### Automated test coverage

None added, one updated.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
