### PR TITLE
Report linting

### DIFF
--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -121,8 +121,7 @@ def _get_case_counts_by_user(domain, datespan, case_types=None, is_opened=True, 
                 date_field,
                 gte=datespan.startdate.date(),
                 lte=datespan.enddate.date(),
-            )
-        )
+            ))
         .terms_aggregation(user_field, 'by_user')
         .size(0))
 
@@ -203,16 +202,15 @@ def get_last_forms_by_app(user_id):
     :return: last form submission for every app that user has submitted
     """
     query = (
-        FormES()
-            .user_id(user_id)
-            .aggregation(
-            TermsAggregation('app_id', 'app_id').aggregation(
-                TopHitsAggregation(
-                    'top_hits_last_form_submissions',
-                    'received_on',
-                    is_ascending=False,
-                )
-            )
+        FormES().user_id(user_id)
+                .aggregation(
+                    TermsAggregation('app_id', 'app_id').aggregation(
+                        TopHitsAggregation(
+                            'top_hits_last_form_submissions',
+                            'received_on',
+                            is_ascending=False,
+                        )
+                    )
         )
         .size(0)
     )
@@ -382,10 +380,8 @@ def _chunked_get_form_counts_by_user_xmlns(domain, startdate, enddate, user_ids=
                      TermsAggregation('app_id', 'app_id').aggregation(
                          TermsAggregation('xmlns', 'xmlns.exact')
                      )
-                 )
-             )
-             .size(0)
-    )
+                 ))
+             .size(0))
 
     if user_ids:
         query = (query

--- a/corehq/apps/reports/basic.py
+++ b/corehq/apps/reports/basic.py
@@ -157,8 +157,8 @@ class BasicTabularReport(GenericTabularReport, metaclass=ColumnCollector):
             row = self.View.get_result(key, **kwargs)
 
             yield [format_datatables_data(row[c], row[c]) if c in self.View.key_views
-                          else self.function_views[c].view(key, self)
-                   for c in self.default_column_order]
+                else self.function_views[c].view(key, self)
+                for c in self.default_column_order]
 
 
 class SummingTabularReport(BasicTabularReport):
@@ -171,6 +171,6 @@ class SummingTabularReport(BasicTabularReport):
         for i in range(num_cols):
             colrows = [cr[i] for cr in ret if isinstance(cr[i], dict)]
             colnums = [r.get('sort_key') for r in colrows if isinstance(r.get('sort_key'), int)]
-            total_row.append(reduce(lambda x, y: x+ y, colnums, 0))
+            total_row.append(reduce(lambda x, y: x + y, colnums, 0))
         self.total_row = total_row
         return ret

--- a/corehq/apps/reports/commtrack/maps.py
+++ b/corehq/apps/reports/commtrack/maps.py
@@ -59,7 +59,8 @@ class StockStatusMapReport(GenericMapReport, CommtrackReportMixin):
         if self.program_id:
             products = [c for c in products if c.program_id == self.program_id]
         for p in products:
-            col_id = lambda c: '%s-%s' % (p._id, c)
+            def col_id(c):
+                return '%s-%s' % (p._id, c)
 
             product_cols = []
             for c in ('category', 'current_stock', 'months_remaining', 'consumption'):

--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -233,7 +233,8 @@ class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
 class SimplifiedInventoryReport(GenericTabularReport, CommtrackReportMixin):
     name = ugettext_noop('Inventory by Location')
     slug = SimplifiedInventoryDataSource.slug
-    special_notice = ugettext_noop('A maximum of 100 locations will be shown. Filter by location if you need to see more.')
+    special_notice = ugettext_noop('A maximum of 100 locations will be shown. '
+        'Filter by location if you need to see more.')
     exportable = True
     emailable = True
     fields = [

--- a/corehq/apps/reports/datatables/__init__.py
+++ b/corehq/apps/reports/datatables/__init__.py
@@ -101,7 +101,10 @@ class DataTablesColumnGroup(object):
     def render_html(self):
         template = '<th%(css_class)s colspan="%(colspan)d"><strong>%(title)s</strong></th>'
         css_class = ' class="col-sm-%d"' % self.css_span if self.css_span > 0 else ''
-        return template % dict(title=self.html, css_class=css_class, colspan=len(self.columns)) if self.columns else ""
+        return (
+            template % dict(title=self.html, css_class=css_class, colspan=len(self.columns))
+            if self.columns else ""
+        )
 
     @property
     def render_group_html(self):

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.http import Http404, HttpResponseBadRequest, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -8,7 +7,6 @@ from django.views.generic.base import View
 from django_prbac.exceptions import PermissionDenied
 from django_prbac.utils import has_privilege
 
-from corehq.apps.domain.utils import get_custom_domain_module
 from corehq.apps.sso.utils.request_helpers import is_request_using_sso
 from dimagi.utils.decorators.datespan import datespan_in_request
 from dimagi.utils.modules import to_function
@@ -21,7 +19,6 @@ from corehq.apps.domain.decorators import (
     login_and_domain_required,
     track_domain_request,
 )
-from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.reports.exceptions import BadRequestError
 from corehq.apps.users.models import AnonymousCouchUser
@@ -35,7 +32,9 @@ datespan_default = datespan_in_request(
     default_days=7,
 )
 
-_ = lambda message: ugettext(message) if message is not None else None
+
+def _(message):
+    return ugettext(message) if message is not None else None
 
 
 class ReportDispatcher(View):
@@ -53,7 +52,7 @@ class ReportDispatcher(View):
 
         ReportDispatcher expects to serve a report that is a subclass of GenericReportView.
     """
-    prefix = None # string. ex: project, custom, billing, interface, admin
+    prefix = None  # string. ex: project, custom, billing, interface, admin
     map_name = None
 
     def __init__(self, **kwargs):
@@ -232,11 +231,12 @@ class ReportDispatcher(View):
         from django.conf.urls import url
         return url(cls.pattern(), cls.as_view(), name=cls.name())
 
+
 cls_to_view_login_and_domain = cls_to_view(additional_decorator=login_and_domain_required)
 
 
 class ProjectReportDispatcher(ReportDispatcher):
-    prefix = 'project_report' # string. ex: project, custom, billing, interface, admin
+    prefix = 'project_report'  # string. ex: project, custom, billing, interface, admin
     map_name = 'REPORTS'
 
     @property

--- a/corehq/apps/reports/display.py
+++ b/corehq/apps/reports/display.py
@@ -43,7 +43,7 @@ class FormDisplay(object):
         username = self.form["form"]["meta"].get("username")
         try:
             if username not in ['demo_user', 'admin']:
-                full_name = get_cached_property(CouchUser, uid, 'full_name', expiry=7*24*60*60)
+                full_name = get_cached_property(CouchUser, uid, 'full_name', expiry=7 * 24 * 60 * 60)
                 name = '"%s"' % full_name if full_name else ""
             else:
                 name = ""

--- a/corehq/apps/reports/dont_use/fields.py
+++ b/corehq/apps/reports/dont_use/fields.py
@@ -35,7 +35,8 @@ class ReportField(object):
         self.css_field = css_field or CSS_FIELD_CLASS
 
     def render(self):
-        if not self.template: return ""
+        if not self.template:
+            return ""
         self.context["slug"] = self.slug
         self.context['css_label_class'] = self.css_label
         self.context['css_field_class'] = self.css_field

--- a/corehq/apps/reports/filters/base.py
+++ b/corehq/apps/reports/filters/base.py
@@ -43,7 +43,8 @@ class BaseReportFilter(object):
     @property
     def is_disabled(self):
         """
-            If necessary, determine whether to show this filter based on the results of surrounding (related) filters.
+            If necessary, determine whether to show this filter based
+            on the results of surrounding (related) filters.
         """
         return False
 
@@ -165,7 +166,7 @@ class BaseMultipleOptionFilter(BaseSingleOptionFilter):
         Displays a multiselect field.
     """
     template = "reports/filters/multi_option.html"
-    default_options = [] # specify a list
+    default_options = []  # specify a list
 
     @classmethod
     def get_value(cls, request, domain):
@@ -293,7 +294,7 @@ class BaseDrilldownOptionFilter(BaseReportFilter):
             'val': val,
             'text': text,
             'next': next,
-            }
+        }
 
     @property
     def shared_pagination_GET_params(self):

--- a/corehq/apps/reports/filters/case_list.py
+++ b/corehq/apps/reports/filters/case_list.py
@@ -63,8 +63,8 @@ class CaseListFilter(ExpandedMobileWorkerFilter):
 
     @classmethod
     def selected_group_ids(cls, mobile_user_and_group_slugs):
-        return (super(CaseListFilter, cls).selected_group_ids(mobile_user_and_group_slugs) +
-                cls.selected_sharing_group_ids(mobile_user_and_group_slugs))
+        return (super(CaseListFilter, cls).selected_group_ids(mobile_user_and_group_slugs)
+        + cls.selected_sharing_group_ids(mobile_user_and_group_slugs))
 
     def _selected_group_entries(self, mobile_user_and_group_slugs):
         query_results = self._selected_groups_query(mobile_user_and_group_slugs)

--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -94,7 +94,7 @@ class FormsByApplicationFilter(BaseDrilldownOptionFilter):
     unknown_slug = "unknown"
     fuzzy_slug = "@@FUZZY"
     show_global_hide_fuzzy_checkbox = True
-    display_app_type = False # whether we're displaying the application type select box in the filter
+    display_app_type = False  # whether we're displaying the application type select box in the filter
 
     @property
     def display_lang(self):
@@ -114,13 +114,14 @@ class FormsByApplicationFilter(BaseDrilldownOptionFilter):
         labels = self.get_labels()
         if self.drilldown_map and self.drilldown_map[0]['val'] == PARAM_VALUE_STATUS_ACTIVE:
             labels = [
-                 (_('Application Type'),
-                  _("Select an Application Type") if self.use_only_last else _("Show all Application Types"),
-                  'status'),
-                 (_('Application'),
-                  _("Select Application...") if self.use_only_last else _("Show all Forms of this Application Type..."),
-                  PARAM_SLUG_APP_ID),
-             ] + labels[1:]
+                (_('Application Type'),
+                _("Select an Application Type") if self.use_only_last else _("Show all Application Types"),
+                'status'),
+                (_('Application'),
+                _("Select Application...") if self.use_only_last
+                    else _("Show all Forms of this Application Type..."),
+                PARAM_SLUG_APP_ID),
+            ] + labels[1:]
         return labels
 
     @property
@@ -145,7 +146,7 @@ class FormsByApplicationFilter(BaseDrilldownOptionFilter):
         })
 
         show_advanced = self.request.GET.get('show_advanced') == 'on'
-        
+
         #set Default app type to active only when advanced option is not selected
         if self.display_app_type and not context['selected'] and not show_advanced:
             context['selected'] = [PARAM_VALUE_STATUS_ACTIVE]
@@ -287,12 +288,15 @@ class FormsByApplicationFilter(BaseDrilldownOptionFilter):
             }
         """
         data = get_all_form_details(self.domain)
-        default_module = lambda num: {'module': None, 'forms': []}
+
+        def default_module(num):
+            return {'module': None, 'forms': []}
+
         app_forms = {}
         for app_structure in data:
             index_offset = 1 if app_structure.is_user_registration else 0
             app_id = app_structure.app.id
-            if not app_id in app_forms:
+            if app_id not in app_forms:
                 app_forms[app_id] = {
                     'app': app_structure.app,
                     'is_user_registration': app_structure.is_user_registration,

--- a/corehq/apps/reports/filters/location.py
+++ b/corehq/apps/reports/filters/location.py
@@ -29,8 +29,8 @@ class LocationGroupFilter(ExpandedMobileWorkerFilter):
     def selected(self):
         selected_ids = self.request.GET.getlist(self.slug)
 
-        selected = (self._selected_group_entries(selected_ids) +
-                    self._selected_location_entries(selected_ids))
+        selected = (self._selected_group_entries(selected_ids)
+        + self._selected_location_entries(selected_ids))
         known_ids = dict(selected)
 
         return [

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -194,7 +194,7 @@ class EmwfUtils(object):
             raise Exception("Unexpcted id: {}".format(id_))
 
         if hasattr(owner, 'is_deleted'):
-            if (callable(owner.is_deleted) and owner.is_deleted()) or owner.is_deleted == True:
+            if (callable(owner.is_deleted) and owner.is_deleted()) or owner.is_deleted is True:
                 # is_deleted may be an attr or callable depending on owner type
                 ret = (ret[0], 'Deleted - ' + ret[1])
 
@@ -265,7 +265,7 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
 
     @staticmethod
     def selected_location_ids(mobile_user_and_group_slugs):
-        return [l[3:] for l in mobile_user_and_group_slugs if l.startswith("l__")]
+        return [slug[3:] for slug in mobile_user_and_group_slugs if slug.startswith("l__")]
 
     @staticmethod
     def show_all_mobile_workers(mobile_user_and_group_slugs):
@@ -296,10 +296,10 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
             return [{'id': url_id, 'text': text}
                     for url_id, text in self.get_default_selections()]
 
-        selected = (self.selected_static_options(selected_ids) +
-                    self._selected_user_entries(selected_ids) +
-                    self._selected_group_entries(selected_ids) +
-                    self._selected_location_entries(selected_ids))
+        selected = (self.selected_static_options(selected_ids)
+            + self._selected_user_entries(selected_ids)
+            + self._selected_group_entries(selected_ids)
+            + self._selected_location_entries(selected_ids))
         return [
             {'id': entry[0], 'text': entry[1]} if len(entry) == 2 else
             {'id': entry[0], 'text': entry[1], 'is_active': entry[2]} for entry in selected

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -109,10 +109,10 @@ def strip_form_data(data):
     # remove all case, meta, attribute nodes from the top level
     for key in list(data.keys()):
         if (
-            not form_key_filter(key) or
-            key in ('meta', 'case', 'commcare_usercase') or
-            key.startswith('case_autoload_') or
-            key.startswith('case_load_')
+            not form_key_filter(key)
+            or key in ('meta', 'case', 'commcare_usercase')
+            or key.startswith('case_autoload_')
+            or key.startswith('case_load_')
         ):
             data.pop(key)
     return data

--- a/corehq/apps/reports/forms.py
+++ b/corehq/apps/reports/forms.py
@@ -8,7 +8,7 @@ from memoized import memoized
 
 from crispy_forms import layout as crispy
 from crispy_forms.helper import FormHelper
-from crispy_forms.bootstrap import InlineField, StrictButton
+from crispy_forms.bootstrap import StrictButton
 
 import langcodes
 from corehq.apps.hqwebapp.crispy import FormActions, HQFormHelper, LinkButton
@@ -221,11 +221,11 @@ class EmailReportForm(forms.Form):
 
 
 def _verify_email(cleaned_data):
-    if ('recipient_emails' in cleaned_data
-        and not (cleaned_data['recipient_emails'] or
-                     cleaned_data['send_to_owner'])):
-        raise forms.ValidationError("You must specify at least one "
-                                    "valid recipient")
+    if (
+        'recipient_emails' in cleaned_data
+        and not (cleaned_data['recipient_emails'] or cleaned_data['send_to_owner'])
+    ):
+        raise forms.ValidationError("You must specify at least one valid recipient")
 
 
 class TableauServerForm(forms.Form):

--- a/corehq/apps/reports/graph_models.py
+++ b/corehq/apps/reports/graph_models.py
@@ -47,7 +47,8 @@ class MultiBarChart(Chart):
         stacked: True to make default view stacked, False for grouped
         staggerLabels: True to stagger the X-Axis labels.
         groupSpacing: Used to adjust amount of space between X-Axis groups. Value between 0 and 1.
-        forceY: Used to force values into the Y scale domain. Useful to ensure max / min scales. Must be list of numbers
+        forceY: Used to force values into the Y scale domain.
+            Useful to ensure max / min scales. Must be list of numbers
         translateLabelsX: Pixels to move X-Axis labels in X direction
         translateLabelsY: Pixels to move X-Axis labels in Y direction
 
@@ -127,7 +128,8 @@ class PieChart(Chart):
     template_partial = 'reports/partials/graphs/pie_chart.html'
 
     def __init__(self, title, key, values, color=None):
-        if not color: color = []
+        if not color:
+            color = []
         self.title = title
         self.data = [dict(key=key, values=values)]
         self.marginTop = 30

--- a/corehq/apps/reports/management/commands/add_dynamic_report.py
+++ b/corehq/apps/reports/management/commands/add_dynamic_report.py
@@ -21,9 +21,12 @@ class Command(BaseCommand):
         parser.add_argument('reportname')
         parser.add_argument('reportclass')
         parser.add_argument('reportproperties', dest='config_raw', help='JSON (if "-" read from stdin)')
-        parser.add_argument('-u', '--update', action='store_true', help='update existing report config if already exists')
-        parser.add_argument('-x', '--execute', action='store_true', help='actually make the change; otherwise just a dry run')
-        parser.add_argument('-a', '--all', action='store_true', help='make report visible to all (otherwise just previewers')
+        parser.add_argument('-u', '--update', action='store_true',
+            help='update existing report config if already exists')
+        parser.add_argument('-x', '--execute', action='store_true',
+            help='actually make the change; otherwise just a dry run')
+        parser.add_argument('-a', '--all', action='store_true',
+            help='make report visible to all (otherwise just previewers')
 
     def handle(self, domainname, subsection, reportname, reportclass, config_raw, **options):
         domain = Domain.get_by_name(domainname)

--- a/corehq/apps/reports/management/commands/enable_case_search_for_ecd.py
+++ b/corehq/apps/reports/management/commands/enable_case_search_for_ecd.py
@@ -44,8 +44,8 @@ class Command(BaseCommand):
             is_active=True,
             is_trial=False,
         ).filter(
-            Q(plan_version__plan__edition=SoftwarePlanEdition.ADVANCED) |
-            Q(plan_version__plan__edition=SoftwarePlanEdition.PRO)
+            Q(plan_version__plan__edition=SoftwarePlanEdition.ADVANCED)
+            | Q(plan_version__plan__edition=SoftwarePlanEdition.PRO)
         ).all()
         return [sub.subscriber.domain for sub in relevant_subs]
 

--- a/corehq/apps/reports/management/commands/rollout_ecd_preview.py
+++ b/corehq/apps/reports/management/commands/rollout_ecd_preview.py
@@ -41,8 +41,8 @@ class Command(BaseCommand):
             is_active=True,
             is_trial=False,
         ).filter(
-            Q(plan_version__plan__edition=SoftwarePlanEdition.ADVANCED) |
-            Q(plan_version__plan__edition=SoftwarePlanEdition.PRO)
+            Q(plan_version__plan__edition=SoftwarePlanEdition.ADVANCED)
+            | Q(plan_version__plan__edition=SoftwarePlanEdition.PRO)
         ).all()
         domains = set([sub.subscriber.domain for sub in relevant_subs])
 

--- a/corehq/apps/reports/sqlreport.py
+++ b/corehq/apps/reports/sqlreport.py
@@ -17,7 +17,6 @@ from corehq.apps.reports.datatables import (
 )
 from corehq.apps.reports.util import format_datatables_data
 from corehq.sql_db.connections import DEFAULT_ENGINE_ID, connection_manager
-from corehq.util.soft_assert import soft_assert
 
 
 class SqlReportException(Exception):
@@ -68,8 +67,8 @@ class DatabaseColumn(Column):
                 Instance of sqlagg column class. See sqlagg.columns.BaseColumn
         Kwargs:
             :param header_group=None:
-                An instance of corehq.apps.reports.datatables.DataTablesColumnGroup to which this column header will
-                be added.
+                An instance of corehq.apps.reports.datatables.DataTablesColumnGroup to which this column header
+                will be added.
             :param sortable:
                 Indicates if the column should be sortable. If true and no format_fn is provided then
                 the default datatables format function is used. Defaults to True.
@@ -225,9 +224,9 @@ class SqlData(ReportDataSource):
     @memoized
     def keys(self):
         """
-        The list of report keys (e.g. users) or None to just display all the data returned from the query. Each value
-        in this list should be a list of the same dimension as the 'group_by' list. If group_by is None then keys
-        must also be None.
+        The list of report keys (e.g. users) or None to just display all the data returned from the query.
+        Each value in this list should be a list of the same dimension as the 'group_by' list.
+        If group_by is None then keys must also be None.
 
         These allow you to specify which rows you expect in the output data.
         Its main use is to add rows for keys that don’t exist in the data.

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -140,7 +140,7 @@ class ProjectReportParametersMixin(object):
                 if self.include_inactive:
                     cc_users += CommCareUser.by_domain(self.domain, is_active=False)
                 ids = [ccu._id for ccu in cc_users]
-                cache.set(cache_str, ids, 24*60*60)
+                cache.set(cache_str, ids, 24 * 60 * 60)
         return ids
 
     @property

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -24,10 +24,8 @@ from corehq.apps.reports.standard.cases.utils import (
     query_location_restricted_cases,
 )
 from corehq.apps.reports.standard.inspect import ProjectInspectionReport
-from corehq.const import USER_DATETIME_FORMAT_WITH_SEC
 from corehq.elastic import ESError
 from corehq.toggles import CASE_LIST_EXPLORER
-from corehq.util.timezones.conversions import PhoneTime
 
 from .data_sources import CaseDisplay
 
@@ -125,7 +123,8 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
             raise ValueError("Case object is not in search result %s" % row)
 
         if case_dict['domain'] != self.domain:
-            raise Exception("case.domain != self.domain; %r and %r, respectively" % (case_dict['domain'], self.domain))
+            raise Exception("case.domain != self.domain; %r and %r, respectively" % (case_dict['domain'],
+                self.domain))
 
         return case_dict
 
@@ -180,7 +179,9 @@ class CaseListReport(CaseListMixin, ProjectInspectionReport, ReportDataSource):
         if self.can_upgrade_to_case_list_explorer:
             messages.warning(
                 self.request,
-                'Hey Dimagi User! Have you tried out the <a href="https://confluence.dimagi.com/display/saas/Case+List+Explorer" target="_blank">Case List Explorer</a> yet? It might be just what you are looking for!',
+                'Hey Dimagi User! Have you tried out the '
+                '<a href="https://confluence.dimagi.com/display/saas/Case+List+Explorer" target="_blank">'
+                'Case List Explorer</a> yet? It might be just what you are looking for!',
                 extra_tags='html',
             )
         return super(CaseListReport, self).view_response

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -9,7 +9,6 @@ from django.utils.translation import ugettext as _
 
 import dateutil
 from couchdbkit import ResourceNotFound
-from memoized import memoized
 
 from casexml.apps.case.models import CommCareCaseAction
 

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -142,8 +142,8 @@ def get_case_owners(request, domain, mobile_user_and_group_slugs):
                              .domain(domain)
                              .doc_type("Group")
                              .term("case_sharing", True)
-                             .term("users", (selected_reporting_group_users +
-                                             selected_user_ids))
+                             .term("users", (selected_reporting_group_users
+                             + selected_user_ids))
                              .get_ids())
 
     owner_ids = list(set().union(

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -215,8 +215,8 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
     def user_query(self, pagination=True):
         mobile_user_and_group_slugs = set(
             # Cater for old ReportConfigs
-            self.request.GET.getlist('location_restricted_mobile_worker') +
-            self.request.GET.getlist(ExpandedMobileWorkerFilter.slug)
+            self.request.GET.getlist('location_restricted_mobile_worker')
+            + self.request.GET.getlist(ExpandedMobileWorkerFilter.slug)
         )
         user_query = ExpandedMobileWorkerFilter.user_es_query(
             self.domain,
@@ -437,8 +437,8 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
     def get_user_ids(self):
         mobile_user_and_group_slugs = set(
             # Cater for old ReportConfigs
-            self.request.GET.getlist('location_restricted_mobile_worker') +
-            self.request.GET.getlist(ExpandedMobileWorkerFilter.slug)
+            self.request.GET.getlist('location_restricted_mobile_worker')
+            + self.request.GET.getlist(ExpandedMobileWorkerFilter.slug)
         )
         user_ids = ExpandedMobileWorkerFilter.user_es_query(
             self.domain,
@@ -693,7 +693,6 @@ class AggregateUserStatusReport(ProjectReport, ProjectReportParametersMixin):
             def get_buckets(self):
                 return self.bucket_series.get_summary_data()
 
-
         class BucketSeries(namedtuple('Bucket', 'data_series total_series total user_count')):
             @property
             @memoized
@@ -789,8 +788,6 @@ class AggregateUserStatusReport(ProjectReport, ProjectReportParametersMixin):
                 }
             )
             return BucketSeries(daily_series, running_total_series, total, user_count)
-
-
 
         submission_series = SeriesData(
             id='submission',

--- a/corehq/apps/reports/standard/forms/filters.py
+++ b/corehq/apps/reports/standard/forms/filters.py
@@ -5,8 +5,7 @@ from corehq.apps.reports.models import HQToggle
 
 
 class SubmitToggle(HQToggle):
-    
-    def __init__(self,  type, show, name, doc_type):
+    def __init__(self, type, show, name, doc_type):
         super(SubmitToggle, self).__init__(type, show, name)
         self.doc_type = doc_type
 

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -6,7 +6,6 @@ from memoized import memoized
 
 from corehq.apps.es import filters as es_filters
 from corehq.apps.es import forms as form_es
-from corehq.apps.es.filters import match_all
 from corehq.apps.es.utils import track_es_report_load
 from corehq.apps.hqcase.utils import SYSTEM_FORM_XMLNS_MAP
 from corehq.apps.locations.permissions import location_safe
@@ -36,7 +35,8 @@ from corehq.const import MISSING_APP_ID
 from corehq.toggles import SUPPORT
 
 
-class ProjectInspectionReport(ProjectInspectionReportParamsMixin, GenericTabularReport, ProjectReport, ProjectReportParametersMixin):
+class ProjectInspectionReport(ProjectInspectionReportParamsMixin,
+        GenericTabularReport, ProjectReport, ProjectReportParametersMixin):
     """
         Base class for this reporting section
     """

--- a/corehq/apps/reports/standard/maps.py
+++ b/corehq/apps/reports/standard/maps.py
@@ -1,20 +1,14 @@
-import json
 import re
 
 from django.conf import settings
 
-import csv
-
-from casexml.apps.case.models import CommCareCase
 from dimagi.utils.modules import to_function
 
 from corehq.apps.reports.api import ReportDataSource
-from corehq.apps.reports.generic import GenericReportView, GenericTabularReport
 from corehq.apps.reports.standard import (
     ProjectReport,
     ProjectReportParametersMixin,
 )
-from corehq.apps.reports.standard.cases.basic import CaseListReport
 
 
 class GenericMapReport(ProjectReport, ProjectReportParametersMixin):
@@ -42,7 +36,7 @@ class GenericMapReport(ProjectReport, ProjectReportParametersMixin):
         def _parse_geopoint(raw):
             try:
                 latlon = [float(k) for k in re.split(' *,? *', raw)[:2]]
-                return [latlon[1], latlon[0]] # geojson is lon, lat
+                return [latlon[1], latlon[0]]  # geojson is lon, lat
             except ValueError:
                 return None
 
@@ -115,7 +109,8 @@ class GenericMapReport(ProjectReport, ProjectReportParametersMixin):
 
         DataSource = to_function(params['report'])
 
-        assert issubclass(DataSource, ReportDataSource), '[%s] does not implement the ReportDataSource API!' % params['report']
+        assert issubclass(DataSource, ReportDataSource), \
+            '[%s] does not implement the ReportDataSource API!' % params['report']
 
         return DataSource(config).get_data()
 

--- a/corehq/apps/reports/standard/message_event_display.py
+++ b/corehq/apps/reports/standard/message_event_display.py
@@ -36,9 +36,9 @@ def get_status_display(event, sms=None):
         return get_sms_status_display(sms)
 
     # If survey without error, short circuit to the survey status display
-    if (isinstance(event, MessagingSubEvent) and
-            event.status == MessagingEvent.STATUS_COMPLETED and
-            event.xforms_session_id):
+    if (isinstance(event, MessagingSubEvent)
+            and event.status == MessagingEvent.STATUS_COMPLETED
+            and event.xforms_session_id):
         return _(event.xforms_session.status)
 
     status = event.status
@@ -52,9 +52,9 @@ def get_status_display(event, sms=None):
     # If we have a MessagingEvent that's completed but it's tied to
     # unfinished surveys, then mark it as being in progress
     if (
-        isinstance(event, MessagingEvent) and
-        event.status == MessagingEvent.STATUS_COMPLETED and
-        MessagingSubEvent.objects.filter(
+        isinstance(event, MessagingEvent)
+        and event.status == MessagingEvent.STATUS_COMPLETED
+        and MessagingSubEvent.objects.filter(
             parent_id=event.pk,
             content_type=MessagingEvent.CONTENT_SMS_SURVEY,
             # without this line, django does a left join which is not what we want

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext_lazy, ugettext_noop
 import pytz
 from memoized import memoized
 from pygooglechart import ScatterChart
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 from dimagi.utils.chunked import chunked
 from dimagi.utils.couch.safe_index import safe_index
@@ -285,7 +285,6 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
             return DataTablesColumn(title, sort_type=DTSortType.NUMERIC,
                                     help_text=help_text.format(num_days),
                                     sortable=False if title == "Proportion" else True)
-
 
         columns = [DataTablesColumn(_("Users"))]
 
@@ -1187,9 +1186,10 @@ class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase
                     total_seconds += td_total
                     total += 1
         else:
-            rows.append(['No Submissions Available for this Date Range'] + ['--']*5)
+            rows.append(['No Submissions Available for this Date Range'] + ['--'] * 5)
 
-        self.total_row = [_("Average"), "-", "-", "-", "-", self._format_td_status(int(total_seconds // total), False) if total > 0 else "--"]
+        self.total_row = [_("Average"), "-", "-", "-", "-",
+            self._format_td_status(int(total_seconds // total), False) if total > 0 else "--"]
         return rows
 
     def get_user_link(self, username, user):
@@ -1216,9 +1216,10 @@ class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase
         if isinstance(td, datetime.timedelta):
             hours = td.seconds // 3600
             minutes = (td.seconds // 60) % 60
-            vals = [td.days, hours, minutes, (td.seconds - hours*3600 - minutes*60)]
+            vals = [td.days, hours, minutes, (td.seconds - hours * 3600 - minutes * 60)]
             names = [_("day"), _("hour"), _("minute"), _("second")]
-            status = ["%s %s%s" % (val, names[i], "s" if val != 1 else "") for (i, val) in enumerate(vals) if val > 0]
+            status = ["%s %s%s" % (val, names[i], "s"
+                if val != 1 else "") for (i, val) in enumerate(vals) if val > 0]
 
             if td.days > 1:
                 klass = "label-danger"
@@ -1229,7 +1230,7 @@ class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase
             if not status:
                 status.append("same")
             elif td.days < 0:
-                if abs(td).seconds > 15*60:
+                if abs(td).seconds > 15 * 60:
                     status = [_("submitted before completed [strange]")]
                     klass = "label-info"
                 else:
@@ -1252,7 +1253,7 @@ class WorkerMonitoringChartBase(ProjectReport, ProjectReportParametersMixin):
 
 @location_safe
 class WorkerActivityTimes(WorkerMonitoringChartBase,
-    MultiFormDrilldownMixin, CompletionOrSubmissionTimeMixin, DatespanMixin):
+        MultiFormDrilldownMixin, CompletionOrSubmissionTimeMixin, DatespanMixin):
     name = ugettext_noop("Worker Activity Times")
     slug = "worker_activity_times"
     is_cacheable = True
@@ -1341,7 +1342,7 @@ class WorkerActivityTimes(WorkerMonitoringChartBase,
 
         chart.add_data([(h % 24) for h in range(24 * 8)])
 
-        d=[]
+        d = []
         for i in range(8):
             d.extend([i] * 24)
         chart.add_data(d)
@@ -1352,7 +1353,7 @@ class WorkerActivityTimes(WorkerMonitoringChartBase,
         # i.e. Sun, Sat, Fri, Thu, etc
         days = (6, 5, 4, 3, 2, 1, 0)
 
-        sizes=[]
+        sizes = []
         for d in days:
             sizes.extend([data[(d, h)] for h in range(24)])
         sizes.extend([0] * 24)
@@ -1438,9 +1439,11 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
             DataTablesColumn(_("# Forms Submitted"), sort_type=DTSortType.NUMERIC,
                 help_text=_("Number of forms submitted in chosen date range. %s" % CASE_TYPE_MSG)),
             DataTablesColumn(_("Avg # Forms Submitted"), sort_type=DTSortType.NUMERIC,
-                help_text=_("Average number of forms submitted in the three preceding date ranges of the same length. %s" % CASE_TYPE_MSG)),
+                help_text=_("Average number of forms submitted in the three preceding date ranges "
+                    "of the same length. %s" % CASE_TYPE_MSG)),
             DataTablesColumn(_("Last Form Submission"),
-                help_text=_("Date of last form submission in time period.  Total row displays proportion of users submitting forms in date range")) \
+                help_text=_("Date of last form submission in time period."
+                    "  Total row displays proportion of users submitting forms in date range"))
             if not by_group else DataTablesColumn(_("# Active Users"), sort_type=DTSortType.NUMERIC,
                 help_text=_("Proportion of users in group who submitted forms in date range."))
         ))
@@ -1449,15 +1452,17 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
                 help_text=_("Number of cases created in the date range.")),
             DataTablesColumn(_("# Cases Closed"), sort_type=DTSortType.NUMERIC,
                 help_text=_("Number of cases closed in the date range.")),
-            ))
+        ))
         columns.append(DataTablesColumnGroup(_("Case Activity"),
             DataTablesColumn(_("# Active Cases"), sort_type=DTSortType.NUMERIC,
-                help_text=_("Number of cases owned by the user that were opened, modified or closed in date range.  This includes case sharing cases.")),
+                help_text=_("Number of cases owned by the user that were opened, modified or closed in date range."
+                "  This includes case sharing cases.")),
             DataTablesColumn(_("# Total Cases (Owned & Shared)"), sort_type=DTSortType.NUMERIC,
                 help_text=_("Total number of cases owned by the user.  This includes cases created by the user "
                             "and cases that were shared with this user.")),
             DataTablesColumn(_("% Active Cases"), sort_type=DTSortType.NUMERIC,
-                help_text=_("Percentage of cases owned by user that were active.  This includes case sharing cases.")),
+                help_text=_("Percentage of cases owned by user that were active."
+                "  This includes case sharing cases.")),
         ))
         return DataTablesHeader(*columns)
 
@@ -1668,7 +1673,8 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
 
             total_cases = sum([int(report_data.total_cases_by_owner.get(owner_id, 0)) for owner_id in owner_ids])
             if self.include_active_cases:
-                active_cases = sum([int(report_data.active_cases_by_owner.get(owner_id, 0)) for owner_id in owner_ids])
+                active_cases = sum([int(report_data.active_cases_by_owner.get(owner_id, 0))
+                    for owner_id in owner_ids])
                 active_cases_cell = util.numcell(active_cases)
                 pct_active = util.numcell(
                     (float(active_cases) / total_cases) * 100 if total_cases else 'nan', convert='float'
@@ -1730,7 +1736,8 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
             total_cases = sum([int(report_data.total_cases_by_owner.get(owner_id, 0)) for owner_id in owner_ids])
 
             if self.include_active_cases:
-                active_cases = sum([int(report_data.active_cases_by_owner.get(owner_id, 0)) for owner_id in owner_ids])
+                active_cases = sum([int(report_data.active_cases_by_owner.get(owner_id, 0))
+                    for owner_id in owner_ids])
                 if today_or_tomorrow(self.datespan.enddate):
                     active_cases_cell = util.numcell(
                         self._html_anchor_tag(self._case_list_url_active_cases(user['user_id']), active_cases),

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -471,7 +471,8 @@ class MessageLogReport(BaseCommConnectLogReport):
                 return phone_number[0:7] if phone_number[0] == "+" else phone_number[0:6]
             return phone_number
 
-        get_direction = lambda d: self._fmt_direction(d)['html']
+        def get_direction(d):
+            return self._fmt_direction(d)['html']
 
         def get_timestamp(date_):
             timestamp = ServerTime(date_).user_time(self.timezone).done()
@@ -713,9 +714,9 @@ class MessagingEventsReport(BaseMessagingEventReport):
         event_status = EventStatusFilter.get_value(self.request, self.domain)
         if event_status == MessagingEvent.STATUS_ERROR:
             event_status_filter = (
-                Q(status=event_status) |
-                Q(messagingsubevent__status=event_status) |
-                Q(messagingsubevent__sms__error=True)
+                Q(status=event_status)
+                | Q(messagingsubevent__status=event_status)
+                | Q(messagingsubevent__sms__error=True)
             )
         elif event_status == MessagingEvent.STATUS_IN_PROGRESS:
             # We need to check for id__isnull=False below because the
@@ -724,22 +725,22 @@ class MessagingEventsReport(BaseMessagingEventReport):
             # session_is_open=True if there actually are
             # subevent and xforms session records
             event_status_filter = (
-                Q(status=event_status) |
-                Q(messagingsubevent__status=event_status) |
-                (Q(messagingsubevent__xforms_session__id__isnull=False) &
-                 Q(messagingsubevent__xforms_session__session_is_open=True))
+                Q(status=event_status)
+                | Q(messagingsubevent__status=event_status)
+                | (Q(messagingsubevent__xforms_session__id__isnull=False)
+                & Q(messagingsubevent__xforms_session__session_is_open=True))
             )
         elif event_status == MessagingEvent.STATUS_NOT_COMPLETED:
             event_status_filter = (
-                Q(status=event_status) |
-                Q(messagingsubevent__status=event_status) |
-                (Q(messagingsubevent__xforms_session__session_is_open=False) &
-                 Q(messagingsubevent__xforms_session__submission_id__isnull=True))
+                Q(status=event_status)
+                | Q(messagingsubevent__status=event_status)
+                | (Q(messagingsubevent__xforms_session__session_is_open=False)
+                & Q(messagingsubevent__xforms_session__submission_id__isnull=True))
             )
         elif event_status == MessagingEvent.STATUS_EMAIL_DELIVERED:
             event_status_filter = (
-                Q(status=event_status) |
-                Q(messagingsubevent__status=event_status)
+                Q(status=event_status)
+                | Q(messagingsubevent__status=event_status)
             )
 
         return source_filter, content_type_filter, event_status_filter, error_code_filter
@@ -777,8 +778,8 @@ class MessagingEventsReport(BaseMessagingEventReport):
 
         if content_type_filter:
             data = data.filter(
-                (Q(content_type__in=content_type_filter) |
-                 Q(messagingsubevent__content_type__in=content_type_filter))
+                (Q(content_type__in=content_type_filter)
+                | Q(messagingsubevent__content_type__in=content_type_filter))
             )
 
         if event_status_filter:
@@ -915,11 +916,11 @@ class MessageEventDetailReport(BaseMessagingEventReport):
     def view_response(self):
         subevents = self.messaging_subevents
         if (
-            len(subevents) == 1 and
-            subevents[0].content_type in (MessagingEvent.CONTENT_SMS_SURVEY,
-                                          MessagingEvent.CONTENT_IVR_SURVEY) and
-            subevents[0].xforms_session_id and
-            subevents[0].status != MessagingEvent.STATUS_ERROR
+            len(subevents) == 1
+            and subevents[0].content_type in (MessagingEvent.CONTENT_SMS_SURVEY,
+                                          MessagingEvent.CONTENT_IVR_SURVEY)
+            and subevents[0].xforms_session_id
+            and subevents[0].status != MessagingEvent.STATUS_ERROR
         ):
             # There's only one survey to report on here - just redirect to the
             # survey detail page
@@ -1209,9 +1210,9 @@ class PhoneNumberReport(BaseCommConnectLogReport):
     @property
     def _show_users_without_phone_numbers(self):
         return (
-            self.filter_type == 'contact' and
-            self.contact_type == 'users' and
-            self.has_phone_number != 'has_phone_number'
+            self.filter_type == 'contact'
+            and self.contact_type == 'users'
+            and self.has_phone_number != 'has_phone_number'
         )
 
     @property
@@ -1233,9 +1234,9 @@ class PhoneNumberReport(BaseCommConnectLogReport):
         elif number.pending_verification:
             return "Verification Pending"
         elif (
-                not (number.is_two_way or number.pending_verification) and
-                PhoneNumber.get_reserved_number(number.phone_number)
-             ):
+                not (number.is_two_way or number.pending_verification)
+                and PhoneNumber.get_reserved_number(number.phone_number)
+        ):
             return "Already In Use"
         return "Not Verified"
 

--- a/corehq/apps/reports/tests/sql_fixture.py
+++ b/corehq/apps/reports/tests/sql_fixture.py
@@ -33,36 +33,24 @@ def load_data():
     metadata.create_all()
 
     user_data = [
-        {"user": "user1", "date": date(2013, 1, 1),
-            "indicator_a": 1, "indicator_b": 0, "indicator_c": 1, "indicator_d": 1},
-        {"user": "user1", "date": date(2013, 2, 1),
-            "indicator_a": 0, "indicator_b": 1, "indicator_c": 1, "indicator_d": 1},
-        {"user": "user2", "date": date(2013, 1, 1),
-            "indicator_a": 0, "indicator_b": 1, "indicator_c": 1, "indicator_d": 2},
-        {"user": "user2", "date": date(2013, 2, 1),
-            "indicator_a": 1, "indicator_b": 0, "indicator_c": 1, "indicator_d": 2},
+        {"user": "user1", "date": date(2013, 1, 1), "indicator_a": 1, "indicator_b": 0, "indicator_c": 1, "indicator_d": 1},  # noqa: E501
+        {"user": "user1", "date": date(2013, 2, 1), "indicator_a": 0, "indicator_b": 1, "indicator_c": 1, "indicator_d": 1},  # noqa: E501
+        {"user": "user2", "date": date(2013, 1, 1), "indicator_a": 0, "indicator_b": 1, "indicator_c": 1, "indicator_d": 2},  # noqa: E501
+        {"user": "user2", "date": date(2013, 2, 1), "indicator_a": 1, "indicator_b": 0, "indicator_c": 1, "indicator_d": 2},  # noqa: E501
     ]
 
     region_data = [
-        {"region": "region1", "sub_region": "region1_a", "date": date(2013, 1, 1),
-            "indicator_a": 1, "indicator_b": 0},
-        {"region": "region1", "sub_region": "region1_a", "date": date(2013, 2, 1),
-            "indicator_a": 1, "indicator_b": 1},
+        {"region": "region1", "sub_region": "region1_a", "date": date(2013, 1, 1), "indicator_a": 1, "indicator_b": 0},  # noqa: E501
+        {"region": "region1", "sub_region": "region1_a", "date": date(2013, 2, 1), "indicator_a": 1, "indicator_b": 1},  # noqa: E501
 
-        {"region": "region1", "sub_region": "region1_b", "date": date(2013, 1, 1),
-            "indicator_a": 0, "indicator_b": 1},
-        {"region": "region1", "sub_region": "region1_b", "date": date(2013, 2, 1),
-            "indicator_a": 0, "indicator_b": 0},
+        {"region": "region1", "sub_region": "region1_b", "date": date(2013, 1, 1), "indicator_a": 0, "indicator_b": 1},  # noqa: E501
+        {"region": "region1", "sub_region": "region1_b", "date": date(2013, 2, 1), "indicator_a": 0, "indicator_b": 0},  # noqa: E501
 
-        {"region": "region2", "sub_region": "region2_a", "date": date(2013, 1, 1),
-            "indicator_a": 0, "indicator_b": 1},
-        {"region": "region2", "sub_region": "region2_a", "date": date(2013, 2, 1),
-            "indicator_a": 1, "indicator_b": 1},
+        {"region": "region2", "sub_region": "region2_a", "date": date(2013, 1, 1), "indicator_a": 0, "indicator_b": 1},  # noqa: E501
+        {"region": "region2", "sub_region": "region2_a", "date": date(2013, 2, 1), "indicator_a": 1, "indicator_b": 1},  # noqa: E501
 
-        {"region": "region2", "sub_region": "region2_b", "date": date(2013, 1, 1),
-            "indicator_a": 1, "indicator_b": 0},
-        {"region": "region2", "sub_region": "region2_b", "date": date(2013, 2, 1),
-            "indicator_a": 0, "indicator_b": 0},
+        {"region": "region2", "sub_region": "region2_b", "date": date(2013, 1, 1), "indicator_a": 1, "indicator_b": 0},  # noqa: E501
+        {"region": "region2", "sub_region": "region2_b", "date": date(2013, 2, 1), "indicator_a": 0, "indicator_b": 0},  # noqa: E501
     ]
 
     connection = engine.connect()

--- a/corehq/apps/reports/tests/sql_fixture.py
+++ b/corehq/apps/reports/tests/sql_fixture.py
@@ -1,7 +1,7 @@
 from datetime import date
 
 import sqlalchemy
-from sqlalchemy import *
+from sqlalchemy import Column, Table, String, DATE, INT
 
 from corehq.sql_db.connections import connection_manager, DEFAULT_ENGINE_ID
 
@@ -14,8 +14,7 @@ user_table = Table("user_report_data",
                    Column("indicator_a", INT),
                    Column("indicator_b", INT),
                    Column("indicator_c", INT),
-                   Column("indicator_d", INT)
-)
+                   Column("indicator_d", INT))
 
 region_table = Table("region_report_data",
                      metadata,
@@ -23,8 +22,7 @@ region_table = Table("region_report_data",
                      Column("sub_region", String(50), primary_key=True, autoincrement=False),
                      Column("date", DATE, primary_key=True, autoincrement=False),
                      Column("indicator_a", INT),
-                     Column("indicator_b", INT)
-)
+                     Column("indicator_b", INT))
 
 
 def load_data():
@@ -35,25 +33,37 @@ def load_data():
     metadata.create_all()
 
     user_data = [
-        {"user": "user1", "date": date(2013, 1, 1), "indicator_a": 1, "indicator_b": 0, "indicator_c": 1, "indicator_d": 1},
-        {"user": "user1", "date": date(2013, 2, 1), "indicator_a": 0, "indicator_b": 1, "indicator_c": 1, "indicator_d": 1},
-        {"user": "user2", "date": date(2013, 1, 1), "indicator_a": 0, "indicator_b": 1, "indicator_c": 1, "indicator_d": 2},
-        {"user": "user2", "date": date(2013, 2, 1), "indicator_a": 1, "indicator_b": 0, "indicator_c": 1, "indicator_d": 2},
+        {"user": "user1", "date": date(2013, 1, 1),
+            "indicator_a": 1, "indicator_b": 0, "indicator_c": 1, "indicator_d": 1},
+        {"user": "user1", "date": date(2013, 2, 1),
+            "indicator_a": 0, "indicator_b": 1, "indicator_c": 1, "indicator_d": 1},
+        {"user": "user2", "date": date(2013, 1, 1),
+            "indicator_a": 0, "indicator_b": 1, "indicator_c": 1, "indicator_d": 2},
+        {"user": "user2", "date": date(2013, 2, 1),
+            "indicator_a": 1, "indicator_b": 0, "indicator_c": 1, "indicator_d": 2},
     ]
 
     region_data = [
-        {"region": "region1", "sub_region": "region1_a", "date": date(2013, 1, 1), "indicator_a": 1, "indicator_b": 0},
-        {"region": "region1", "sub_region": "region1_a", "date": date(2013, 2, 1), "indicator_a": 1, "indicator_b": 1},
+        {"region": "region1", "sub_region": "region1_a", "date": date(2013, 1, 1),
+            "indicator_a": 1, "indicator_b": 0},
+        {"region": "region1", "sub_region": "region1_a", "date": date(2013, 2, 1),
+            "indicator_a": 1, "indicator_b": 1},
 
-        {"region": "region1", "sub_region": "region1_b", "date": date(2013, 1, 1), "indicator_a": 0, "indicator_b": 1},
-        {"region": "region1", "sub_region": "region1_b", "date": date(2013, 2, 1), "indicator_a": 0, "indicator_b": 0},
+        {"region": "region1", "sub_region": "region1_b", "date": date(2013, 1, 1),
+            "indicator_a": 0, "indicator_b": 1},
+        {"region": "region1", "sub_region": "region1_b", "date": date(2013, 2, 1),
+            "indicator_a": 0, "indicator_b": 0},
 
-        {"region": "region2", "sub_region": "region2_a", "date": date(2013, 1, 1), "indicator_a": 0, "indicator_b": 1},
-        {"region": "region2", "sub_region": "region2_a", "date": date(2013, 2, 1), "indicator_a": 1, "indicator_b": 1},
+        {"region": "region2", "sub_region": "region2_a", "date": date(2013, 1, 1),
+            "indicator_a": 0, "indicator_b": 1},
+        {"region": "region2", "sub_region": "region2_a", "date": date(2013, 2, 1),
+            "indicator_a": 1, "indicator_b": 1},
 
-        {"region": "region2", "sub_region": "region2_b", "date": date(2013, 1, 1), "indicator_a": 1, "indicator_b": 0},
-        {"region": "region2", "sub_region": "region2_b", "date": date(2013, 2, 1), "indicator_a": 0, "indicator_b": 0},
-        ]
+        {"region": "region2", "sub_region": "region2_b", "date": date(2013, 1, 1),
+            "indicator_a": 1, "indicator_b": 0},
+        {"region": "region2", "sub_region": "region2_b", "date": date(2013, 2, 1),
+            "indicator_a": 0, "indicator_b": 0},
+    ]
 
     connection = engine.connect()
     try:

--- a/corehq/apps/reports/tests/sql_reports.py
+++ b/corehq/apps/reports/tests/sql_reports.py
@@ -2,8 +2,8 @@ from numbers import Number
 
 from memoized import memoized
 from nose.tools import nottest
-from sqlagg import *
-from sqlagg.columns import *
+from sqlagg import SumColumn
+from sqlagg.columns import SimpleColumn
 
 from corehq.apps.reports.filters.dates import DatespanFilter
 from corehq.apps.reports.standard import CustomProjectReport, DatespanMixin

--- a/corehq/apps/reports/tests/test_filters.py
+++ b/corehq/apps/reports/tests/test_filters.py
@@ -39,7 +39,7 @@ class TestEmwfPagination(SimpleTestCase):
             return len(matching_objects(query))
 
         def get_objects(query, start, size):
-            return matching_objects(query)[start:start+size]
+            return matching_objects(query)[start:start + size]
 
         return (get_size, get_objects)
 

--- a/corehq/apps/reports/tests/test_project_health.py
+++ b/corehq/apps/reports/tests/test_project_health.py
@@ -15,7 +15,7 @@ from corehq.apps.reports.standard.project_health import (
     MonthlyPerformanceSummary,
     ProjectHealthDashboard,
 )
-from corehq.apps.users.models import CommCareUser, DomainMembership, WebUser
+from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.const import MISSING_APP_ID
 
 

--- a/corehq/apps/reports/tests/test_readable_formdata.py
+++ b/corehq/apps/reports/tests/test_readable_formdata.py
@@ -162,7 +162,8 @@ class ReadableFormdataTest(SimpleTestCase):
                 "timeEnd": "2014-04-28T18:27:05Z",
                 "appVersion": {
                     "@xmlns": "http://commcarehq.org/xforms",
-                    "#text": "CommCare ODK, version \"2.11.0\"(29272). App v8. CommCare Version 2.11. Build 29272, built on: February-14-2014"
+                    "#text": "CommCare ODK, version \"2.11.0\"(29272). App v8. CommCare Version 2.11. Build 29272,"
+                    " built on: February-14-2014"
                 },
                 "timeStart": "2014-04-28T18:26:38Z",
                 "deviceID": "990004280784863"
@@ -280,7 +281,8 @@ class ReadableFormdataTest(SimpleTestCase):
                 "timeEnd": "2014-04-28T18:27:05Z",
                 "appVersion": {
                     "@xmlns": "http://commcarehq.org/xforms",
-                    "#text": "CommCare ODK, version \"2.11.0\"(29272). App v8. CommCare Version 2.11. Build 29272, built on: February-14-2014"
+                    "#text": "CommCare ODK, version \"2.11.0\"(29272). App v8. CommCare Version 2.11. Build 29272,"
+                    " built on: February-14-2014"
                 },
                 "timeStart": "2014-04-28T18:26:38Z",
                 "deviceID": "990004280784863"

--- a/corehq/apps/reports/tests/test_report_api.py
+++ b/corehq/apps/reports/tests/test_report_api.py
@@ -15,7 +15,9 @@ from .sql_reports import combine_indicator
 
 DOMAIN = "test"
 
-unity = lambda x: x
+
+def unity(x):
+    return x
 
 
 class UserDataSource(SqlData):

--- a/corehq/apps/reports/tests/test_sql_reports.py
+++ b/corehq/apps/reports/tests/test_sql_reports.py
@@ -9,7 +9,6 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser
 from corehq.sql_db.connections import Session
 from corehq.util.dates import iso_string_to_date
-from corehq.util.test_utils import softer_assert
 
 from .sql_fixture import load_data
 from .sql_reports import RegionTestReport, UserTestReport, test_report

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -168,7 +168,7 @@ for module in get_installed_custom_modules():
     module_name = module.__name__.split('.')[-1]
     try:
         custom_report_urls += [
-             url(r"^%s/" % module_name, include('{0}.urls'.format(module.__name__))),
+            url(r"^%s/" % module_name, include('{0}.urls'.format(module.__name__))),
         ]
     except ImproperlyConfigured:
         logging.info("Module %s does not provide urls" % module_name)

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -44,7 +44,7 @@ def get_all_users_by_domain(domain=None, group=None, user_ids=None,
                             user_filter=None, simplified=False, CommCareUser=None, include_inactive=False):
     """
         WHEN THERE ARE A LOT OF USERS, THIS IS AN EXPENSIVE OPERATION.
-        Returns a list of CommCare Users based on domain, group, and user 
+        Returns a list of CommCare Users based on domain, group, and user
         filter (demo_user, admin, registered, unknown)
     """
     def _create_temp_user(user_id):
@@ -69,9 +69,9 @@ def get_all_users_by_domain(domain=None, group=None, user_ids=None,
             users = []
             for id in user_ids:
                 user = CommCareUser.get_by_user_id(id)
-                if not user and (user_filter[HQUserType.ADMIN].show or
-                      user_filter[HQUserType.DEMO_USER].show or
-                      user_filter[HQUserType.UNKNOWN].show):
+                if not user and (user_filter[HQUserType.ADMIN].show
+                        or user_filter[HQUserType.DEMO_USER].show
+                        or user_filter[HQUserType.UNKNOWN].show):
                     user = _create_temp_user(id)
                 if user:
                     users.append(user)
@@ -93,10 +93,14 @@ def get_all_users_by_domain(domain=None, group=None, user_ids=None,
             if user_id in registered_users_by_id and user_filter[HQUserType.ACTIVE].show:
                 user = registered_users_by_id[user_id]
                 users.append(user)
-            elif (user_id not in registered_users_by_id and
-                 (user_filter[HQUserType.ADMIN].show or
-                  user_filter[HQUserType.DEMO_USER].show or
-                  user_filter[HQUserType.UNKNOWN].show)):
+            elif (
+                user_id not in registered_users_by_id
+                and (
+                    user_filter[HQUserType.ADMIN].show
+                    or user_filter[HQUserType.DEMO_USER].show
+                    or user_filter[HQUserType.UNKNOWN].show
+                )
+            ):
                 user = _create_temp_user(user_id)
                 if user:
                     users.append(user)
@@ -238,8 +242,8 @@ def get_possible_reports(domain_name):
     from corehq.apps.reports.dispatcher import (ProjectReportDispatcher, CustomProjectReportDispatcher)
 
     # todo: exports should be its own permission at some point?
-    report_map = (ProjectReportDispatcher().get_reports(domain_name) +
-                  CustomProjectReportDispatcher().get_reports(domain_name))
+    report_map = (ProjectReportDispatcher().get_reports(domain_name)
+        + CustomProjectReportDispatcher().get_reports(domain_name))
     reports = []
     domain_obj = Domain.get_by_name(domain_name)
     for heading, models in report_map:

--- a/corehq/apps/reports/v2/formatters/cases.py
+++ b/corehq/apps/reports/v2/formatters/cases.py
@@ -1,5 +1,4 @@
 from django.urls import NoReverseMatch
-from django.utils import html
 from django.utils.translation import ugettext as _
 
 from couchdbkit import ResourceNotFound

--- a/corehq/apps/reports/v2/reports/explore_case_data.py
+++ b/corehq/apps/reports/v2/reports/explore_case_data.py
@@ -76,8 +76,8 @@ class ExploreCaseDataReport(BaseReport):
 
     @property
     def can_view_ecd_preview(self):
-        return (EXPLORE_CASE_DATA_PREVIEW.enabled_for_request(self.request) and
-                is_eligible_for_ecd_preview(self.request))
+        return (EXPLORE_CASE_DATA_PREVIEW.enabled_for_request(self.request)
+            and is_eligible_for_ecd_preview(self.request))
 
     @property
     def has_permission(self):

--- a/corehq/apps/reports_core/exceptions.py
+++ b/corehq/apps/reports_core/exceptions.py
@@ -1,7 +1,3 @@
-
-
-
-
 class FilterException(Exception):
     """
     Exceptions involving report filters.

--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -26,7 +26,7 @@ from couchdbkit.ext.django.schema import (
 )
 from django_prbac.exceptions import PermissionDenied
 from memoized import memoized
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 from sqlalchemy.util import immutabledict
 
 from dimagi.ext.couchdbkit import Document
@@ -361,10 +361,9 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
 
         if getattr(self.report, 'is_deprecated', False):
             return ReportContent(
-                self.report.deprecation_email_message or
-                _("[DEPRECATED] %s report has been deprecated and will stop working soon. "
-                  "Please update your saved reports email settings if needed." % self.report.name
-                  ),
+                self.report.deprecation_email_message
+                or _("[DEPRECATED] %s report has been deprecated and will stop working soon. "
+                  "Please update your saved reports email settings if needed." % self.report.name),
                 None,
             )
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
This is just a pure linting change, removing all the flake8 warnings and errors from reporting. A separate PR will have to be made for user reports.

## Safety Assurance

### Safety story
There were too many changes to individually test, although very few involved more than shifting lines around or deleting spaces. I'm going to leave this on staging for a bit to see if anything breaks

### Automated test coverage

No additional coverage added

### QA Plan

QA might be good after user reports is also complete, to ensure reports are still functional

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
