### PR TITLE
don't assume that cases referenced by indices are already on the device

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -1018,7 +1018,7 @@ class SimplifiedSyncLog(AbstractSyncLog):
                     self.case_ids_on_phone.add(update.case_id)
                     for index in update.indices_to_add:
                         self._add_index(index, update)
-                        made_changes = True
+                    made_changes = True
 
         _get_logger().debug('case ids mid update: {}'.format(', '.join(self.case_ids_on_phone)))
         _get_logger().debug('dependent case ids mid update: {}'.format(

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -691,7 +691,7 @@ class SimplifiedSyncLog(AbstractSyncLog):
         - it is owned and available or,
         - it has a live child or,
         - it has a live extension or,
-        - it is the exension of a live case.
+        - it is the extension of a live case.
 
         Algorithm:
         ----------

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -522,7 +522,7 @@ class IndexTree(DocumentSchema):
 
     @staticmethod
     def get_all_dependencies(case_id, child_index_tree, extension_index_tree):
-        """Takes a child and extension index tree and returns returns a set of all dependencies of <case_id>
+        """Takes a child and extension index tree and returns a set of all dependencies of <case_id>
 
         Traverse each incoming index, return each touched case.
         Traverse each outgoing index in the extension tree, return each touched case

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -112,6 +112,7 @@ stripe
 suds-py3
 text-unidecode
 tinys3
+toposort
 tropo-webapi-python
 turn-python
 twilio

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -598,6 +598,8 @@ tinys3==0.1.12
     # via -r base-requirements.in
 toml==0.10.2
     # via pep517
+toposort==1.7
+    # via -r base-requirements.in
 traitlets==4.3.3
     # via ipython
 transifex-client==0.14.3

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -481,6 +481,8 @@ text-unidecode==1.3
     #   faker
 tinys3==0.1.12
     # via -r base-requirements.in
+toposort==1.7
+    # via -r base-requirements.in
 tropo-webapi-python==0.1.3
     # via -r base-requirements.in
 turn-python==0.0.1

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -477,6 +477,8 @@ text-unidecode==1.3
     #   faker
 tinys3==0.1.12
     # via -r base-requirements.in
+toposort==1.7
+    # via -r base-requirements.in
 tornado==4.5.3
     # via flower
 traitlets==4.3.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -433,6 +433,8 @@ text-unidecode==1.3
     #   faker
 tinys3==0.1.12
     # via -r base-requirements.in
+toposort==1.7
+    # via -r base-requirements.in
 tropo-webapi-python==0.1.3
     # via -r base-requirements.in
 turn-python==0.0.1

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -484,6 +484,8 @@ tinys3==0.1.12
     # via -r base-requirements.in
 toml==0.10.2
     # via pep517
+toposort==1.7
+    # via -r base-requirements.in
 tropo-webapi-python==0.1.3
     # via -r base-requirements.in
 turn-python==0.0.1


### PR DESCRIPTION
## Technical Summary
Changes to the algorithm that tracks which cases are on a device in the synclog. This is used by the incremental sync code to determine what data to send to the device during the next sync.

Previously it was assumed that if a case index was created then the referenced case must also be on the device. This assumption breaks down once case search is in use which enabled referencing cases that are not on the device. The result is that the device will fail to process the restore response since it does not contain the case 'create' block and only the case 'update' block.

The changes in this PR drop the previous assumption and only mark the case as being 'on the device' if there was also a case update for the case in the form.

The core changes are in https://github.com/dimagi/commcare-hq/commit/07ce6e998da4f4484be7ae21156f53103199b7d3 and the next commit (https://github.com/dimagi/commcare-hq/commit/00ab44d7267a57f228e251f73f3dc39a5fd912e4) updates the loop to process cases in topological order to ensure that all dependencies are taken into account.

Jira: [synclog case search indexes](https://dimagi-dev.atlassian.net/browse/USH-1500)

Note: this does add a new dependency: https://pypi.org/project/toposort/, https://gitlab.com/ericvsmith/toposort

## Safety Assurance

### Safety story
This code is well tested which gives me significant confidence that we won't break existing workflows. The failure mode is also not terrible. If there is a state hash mismatch the device will clear the case DB and perform a fresh sync.

Monitoring the frequency of 412 responses will also give an indication of any issues (current average is around 50 per hour during peak on prod).

### Automated test coverage
New test added for the specific issue. Code already covered by a good number of other tests.

### QA Plan
I don't believe we could meaningfully QA this to give us any more confidence than the unit test are currently providing.

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
