### PR TITLE
Saved Reports now uses standarized date picker

### DIFF
--- a/corehq/apps/reports/static/reports/js/report_config_models.js
+++ b/corehq/apps/reports/static/reports/js/report_config_models.js
@@ -11,7 +11,7 @@ hqDefine("reports/js/report_config_models", [
     _,
     googleAnalytics,
     standardHQReportModule,
-    dateRangePicker  // jshint ignore:line
+    dateRangePicker  // eslint-disable-line no-unused-vars
 ) {
     var reportConfig = function (data) {
         var self = ko.mapping.fromJS(data, {

--- a/corehq/apps/reports/static/reports/js/report_config_models.js
+++ b/corehq/apps/reports/static/reports/js/report_config_models.js
@@ -4,13 +4,14 @@ hqDefine("reports/js/report_config_models", [
     'underscore',
     'analytix/js/google',
     'reports/js/standard_hq_report',
-    'jquery-ui/ui/widgets/datepicker',
+    'bootstrap-daterangepicker/daterangepicker',
 ], function (
     $,
     ko,
     _,
     googleAnalytics,
-    standardHQReportModule
+    standardHQReportModule,
+    dateRangePicker  // jshint ignore:line
 ) {
     var reportConfig = function (data) {
         var self = ko.mapping.fromJS(data, {
@@ -18,6 +19,7 @@ hqDefine("reports/js/report_config_models", [
         });
 
         self.error = ko.observable(false);
+        self.errorMessage = ko.observable();
 
         self.isNew = ko.computed(function () {
             return typeof self._id === "undefined";
@@ -29,22 +31,34 @@ hqDefine("reports/js/report_config_models", [
         });
 
         self.validate = function () {
-            var date_range = self.date_range(),
+            let dateRange = self.date_range(),
                 error = false;
+
+            let errorMessage = gettext("Some required fields are missing. Please complete them before saving.");
 
             if (_.isEmpty(self.name())) {
                 error = true;
-            } else if (date_range === 'lastn') {
+            } else if (dateRange === 'lastn') {
                 var days = parseInt(self.days());
                 if (!_.isNumber(days) || _.isNaN(days)) {
                     error = true;
                 }
-            } else if ((date_range === 'since' || date_range === 'range') && _.isEmpty(ko.utils.unwrapObservable(self.start_date))) {
+            } else if ((dateRange === 'since' || dateRange === 'range') && _.isEmpty(ko.utils.unwrapObservable(self.start_date))) {
                 error = true;
-            } else if (date_range === 'range' && _.isEmpty(ko.utils.unwrapObservable(self.end_date))) {
-                error = true;
+            } else if (dateRange === 'range') {
+                let startDate = ko.utils.unwrapObservable(self.start_date);
+                let endDate = ko.utils.unwrapObservable(self.end_date);
+                if (_.isEmpty(endDate) || (startDate > endDate)) {
+                    error = true;
+                    if (startDate > endDate) {
+                        errorMessage = gettext("Start date cannot be after end date.");
+                    }
+                }
             }
             self.error(error);
+            if (error) {
+                self.errorMessage(errorMessage);
+            }
             return !error;
         };
 
@@ -62,17 +76,6 @@ hqDefine("reports/js/report_config_models", [
             }
             return data;
         };
-
-        self.dateRangeSubs = self.date_range.subscribe(function (newValue) {
-            if (newValue === 'since' || newValue === 'range') {
-                $('.date-picker').datepicker({
-                    changeMonth: true,
-                    changeYear: true,
-                    showButtonPanel: true,
-                    dateFormat: 'yy-mm-dd',
-                });
-            }
-        });
 
         return self;
     };
@@ -214,12 +217,11 @@ hqDefine("reports/js/report_config_models", [
             self.configBeingEdited(self.configBeingViewed());
             self.modalSaveButton.state('save');
 
-            // Required to initialise datepicker if modal opened with date_range in ('since', 'range')
-            $(".date-picker").datepicker({
-                changeMonth: true,
-                changeYear: true,
-                showButtonPanel: true,
-                dateFormat: 'yy-mm-dd',
+            $(".date-picker").daterangepicker({
+                locale: {
+                    format: 'YYYY-MM-DD',
+                },
+                singleDatePicker: true,
             });
         };
 
@@ -242,6 +244,12 @@ hqDefine("reports/js/report_config_models", [
             state: ko.observable(),
             saveOptions: function () {
                 var configData = self.configBeingEdited().unwrap();
+
+                if (configData['date_range'] === 'since') {
+                    // if the range was changed from 'range', a previous end_date might still be present
+                    configData['end_date'] = null;
+                }
+
                 for (var key in configData.filters) {
                     // remove null filters
                     if (configData.filters.hasOwnProperty(key)) {
@@ -250,6 +258,7 @@ hqDefine("reports/js/report_config_models", [
                         }
                     }
                 }
+
                 return {
                     url: options.saveUrl,
                     type: 'post',

--- a/corehq/apps/reports/templates/reports/partials/save_reports_modal.html
+++ b/corehq/apps/reports/templates/reports/partials/save_reports_modal.html
@@ -10,8 +10,7 @@
       </div>
       <form class="form form-horizontal">
         <div class="modal-body">
-          <div class="alert alert-danger" data-bind="visible: error">
-            {% trans "Some required fields are missing. Please complete them before saving." %}
+          <div class="alert alert-danger" id="error_message" data-bind="visible: error, text: errorMessage">
           </div>
           <div class="form-group">
             <label class="control-label col-xs-3" for="name">{% trans "Name" %}</label>
@@ -91,7 +90,6 @@
               <label class="control-label col-xs-3" for="end_date">{% trans "End Date" %}</label>
               <div class="col-xs-9">
                 <input type="text"
-                       id="save-end"
                        class="date-picker form-control"
                        name="end_date"
                        data-bind="value: end_date"

--- a/corehq/apps/reports/templates/reports/partials/save_reports_modal.html
+++ b/corehq/apps/reports/templates/reports/partials/save_reports_modal.html
@@ -10,7 +10,7 @@
       </div>
       <form class="form form-horizontal">
         <div class="modal-body">
-          <div class="alert alert-danger" id="error_message" data-bind="visible: error, text: errorMessage">
+          <div class="alert alert-danger" data-bind="visible: error, text: errorMessage">
           </div>
           <div class="form-group">
             <label class="control-label col-xs-3" for="name">{% trans "Name" %}</label>

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -88,6 +88,7 @@ from corehq.apps.hqcase.utils import (
 )
 from corehq.apps.hqwebapp.decorators import (
     use_datatables,
+    use_daterangepicker,
     use_jquery_ui,
     use_multiselect,
 )
@@ -230,6 +231,7 @@ class MySavedReportsView(BaseProjectReportSectionView):
 
     @use_jquery_ui
     @use_datatables
+    @use_daterangepicker
     def dispatch(self, request, *args, **kwargs):
         return super(MySavedReportsView, self).dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
## Technical Summary
[Associated Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-12917). This is an initial fix for the specific problem. I'd like to address other instances where the old date picker is used, but wanted to make sure that my approach here was correct first.

## Safety Assurance

### Safety story
Performed local testing. Some of the validation fixes I included are probably worthy of tests, but I'm not sure of our javascript testing environment.

### Automated test coverage

See above.

### QA Plan

No QA necessary.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
