### PR TITLE
replace custom toposort algorithm with library version

### DIFF
--- a/corehq/apps/hqcase/tasks.py
+++ b/corehq/apps/hqcase/tasks.py
@@ -63,7 +63,7 @@ def explode_cases(domain, user_id, factor, task=None):
             del queue[:]
         return progress
 
-    for old_case_id in topological_sort_cases(cases):
+    for old_case_id in topological_sort_case_blocks(cases):
         for explosion in range(factor - 1):
             new_case = copy(cases[old_case_id])
             new_case_id = new_case_ids[old_case_id][explosion]
@@ -96,7 +96,7 @@ def explode_cases(domain, user_id, factor, task=None):
     ]}
 
 
-def topological_sort_cases(cases):
+def topological_sort_case_blocks(cases):
     """returns all cases in topological order
 
     Using Kahn's algorithm from here:

--- a/corehq/apps/hqcase/tests/test_explode_cases.py
+++ b/corehq/apps/hqcase/tests/test_explode_cases.py
@@ -197,7 +197,7 @@ class ExplodeExtensionsDBTest(BaseSyncTest):
     def test_case_graph(self):
         cases = self.device.restore().cases
         self.assertEqual(
-            ['host', 'parent_host', 'extension', 'child'],
+            ['child', 'extension', 'parent_host', 'host'],
             topological_sort_case_blocks(cases)
         )
 

--- a/corehq/apps/hqcase/tests/test_explode_cases.py
+++ b/corehq/apps/hqcase/tests/test_explode_cases.py
@@ -13,7 +13,7 @@ from casexml.apps.phone.tests.test_sync_mode import BaseSyncTest
 from casexml.apps.stock.mock import Balance, Entry
 
 from corehq.apps.domain.models import Domain
-from corehq.apps.hqcase.tasks import explode_cases, topological_sort_cases
+from corehq.apps.hqcase.tasks import explode_cases, topological_sort_case_blocks
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import (
@@ -198,7 +198,7 @@ class ExplodeExtensionsDBTest(BaseSyncTest):
         cases = self.device.restore().cases
         self.assertEqual(
             ['host', 'parent_host', 'extension', 'child'],
-            topological_sort_cases(cases)
+            topological_sort_case_blocks(cases)
         )
 
     def test_child_extensions(self):


### PR DESCRIPTION
## Technical Summary
Use library function instead of custom algorithm.

See https://github.com/dimagi/commcare-hq/pull/30929#discussion_r782169671

## Safety Assurance

### Safety story
* Code is only used for exploding case restores which is quite a niche feature and only used for testing
* Covered by tests

### Automated test coverage
Already covered

### QA Plan
None

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
