### PR TITLE
Cs/sc 1551 hourly scheduled reports

### DIFF
--- a/corehq/apps/reports/forms.py
+++ b/corehq/apps/reports/forms.py
@@ -104,7 +104,11 @@ class SavedReportConfigForm(forms.Form):
 
 
 class ScheduledReportForm(forms.Form):
-    INTERVAL_CHOICES = [("daily", "Daily"), ("weekly", "Weekly"), ("monthly", "Monthly")]
+    INTERVAL_CHOICES = [
+        ("daily", ugettext("Daily")),
+        ("weekly", ugettext("Weekly")),
+        ("monthly", ugettext("Monthly"))
+    ]
 
     config_ids = forms.MultipleChoiceField(
         label=_("Saved report(s)"),
@@ -172,8 +176,8 @@ class ScheduledReportForm(forms.Form):
 
         domain = kwargs.get('initial', {}).get('domain', None)
         if domain is not None and HOURLY_SCHEDULED_REPORT.enabled(domain, NAMESPACE_DOMAIN):
-            self.fields['interval'].choices.insert(0, ("hourly", "Hourly"))
-            self.fields['interval'].widget.choices.insert(0, ("hourly", "Hourly"))
+            self.fields['interval'].choices.insert(0, ("hourly", ugettext("Hourly")))
+            self.fields['interval'].widget.choices.insert(0, ("hourly", ugettext("Hourly")))
 
         self.helper.add_layout(
             crispy.Layout(

--- a/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
+++ b/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
@@ -27,10 +27,10 @@ hqDefine("reports/js/edit_scheduled_report", [
         return $select;
     };
 
-    var update_day_input = function (weekly_options, monthly_options, day_value) {
+    var update_interval_aux_input = function (weekly_options, monthly_options, day_value) {
         var $interval = $interval || $('[name="interval"]');
         $('#div_id_day').remove();
-        if ($interval.val() !== 'daily') {
+        if ($interval.val() !== 'hourly' && $interval.val() !== 'daily') {
             var opts = $interval.val() === 'weekly' ? weekly_options : monthly_options;
             var $day_select = $('<select id="id_day" class="select form-control" name="day" />');
             $day_select = add_options_to_select($day_select, opts, day_value);
@@ -38,6 +38,11 @@ hqDefine("reports/js/edit_scheduled_report", [
                 .append($('<label for="id_day" class="control-label col-sm-3 col-md-2 requiredField">Day<span class="asteriskField">*</span></label>'))
                 .append($('<div class="controls col-sm-9 col-md-8 col-lg-6" />').append($day_select));
             $interval.closest('.form-group').after($day_control_group);
+        }
+
+        $('#div_id_hour').hide();
+        if ($interval.val() !== 'hourly') {
+            $('#div_id_hour').show();
         }
     };
 
@@ -51,10 +56,10 @@ hqDefine("reports/js/edit_scheduled_report", [
             $(function () {
                 _.delay(function () {
                     // Delay initialization so that widget is created by the time this code is called
-                    update_day_input(self.weekly_options, self.monthly_options, self.day_value);
+                    update_interval_aux_input(self.weekly_options, self.monthly_options, self.day_value);
                 });
                 $(document).on('change', '[name="interval"]', function () {
-                    update_day_input(self.weekly_options, self.monthly_options);
+                    update_interval_aux_input(self.weekly_options, self.monthly_options);
                 });
                 $("#id_start_date").datepicker({
                     dateFormat: "yy-mm-dd",
@@ -141,7 +146,7 @@ hqDefine("reports/js/edit_scheduled_report", [
     var scheduled_report_form_helper = new ScheduledReportFormHelper({
         weekly_options: initialPageData.get('weekly_day_options'),
         monthly_options: initialPageData.get('monthly_day_options'),
-        day_value: initialPageData.get('day_value'),
+        day_value: initialPageData.get('day_value')
     });
     scheduled_report_form_helper.init();
 

--- a/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
+++ b/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
@@ -146,7 +146,7 @@ hqDefine("reports/js/edit_scheduled_report", [
     var scheduled_report_form_helper = new ScheduledReportFormHelper({
         weekly_options: initialPageData.get('weekly_day_options'),
         monthly_options: initialPageData.get('monthly_day_options'),
-        day_value: initialPageData.get('day_value')
+        day_value: initialPageData.get('day_value'),
     });
     scheduled_report_form_helper.init();
 

--- a/corehq/apps/reports/templates/reports/partials/scheduled_reports_table.html
+++ b/corehq/apps/reports/templates/reports/partials/scheduled_reports_table.html
@@ -64,7 +64,10 @@
       </td>
 
       <td>
-        <!-- ko text: day_name --><!-- /ko --> at <!-- ko text: hour --><!-- /ko -->:00
+        <!-- ko text: day_name --><!-- /ko -->
+        <!-- ko if: hour -->
+          at <!-- ko text: hour --><!-- /ko -->:00
+        <!-- /ko -->
       </td>
 
       <td>

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -366,7 +366,7 @@ class MySavedReportsView(BaseProjectReportSectionView):
             'recipient_emails': report.recipient_emails,
             'config_ids': report.config_ids,
             'send_to_owner': report.send_to_owner,
-            'hour': report.hour,
+            'hour': report.hour if report.interval != 'hourly' else None,
             'minute': report.minute,
             'day': report.day,
             'uuid': report.uuid,

--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -526,7 +526,7 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
     hour = IntegerProperty(default=8)
     minute = IntegerProperty(default=0)
     day = IntegerProperty(default=1)
-    interval = StringProperty(choices=["daily", "weekly", "monthly"])
+    interval = StringProperty(choices=["hourly", "daily", "weekly", "monthly"])
     uuid = StringProperty()
     start_date = DateProperty(default=None)
 
@@ -635,6 +635,8 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
 
     @property
     def day_name(self):
+        if self.interval == 'hourly':
+            return _("Every hour")
         if self.interval == 'weekly':
             return calendar.day_name[self.day]
         return {

--- a/corehq/apps/saved_reports/scheduled.py
+++ b/corehq/apps/saved_reports/scheduled.py
@@ -18,7 +18,7 @@ _soft_assert = soft_assert(
 def _make_all_notification_view_keys(period, target):
     """
 
-    :param period: 'daily', 'weekly', or 'monthly'
+    :param period: 'hourly', 'daily', 'weekly', or 'monthly'
     :param target: The 15-minute-aligned point in time we are targeting for a match
     :return: generator of couch view kwargs to use in view query for 'reportconfig/all_notifications'
     """
@@ -31,6 +31,10 @@ def _make_all_notification_view_keys(period, target):
         minutes = (None, target.minute)
     else:
         minutes = (target.minute,)
+
+    if period == 'hourly':
+        # Todo
+        pass
 
     if period == 'daily':
         for minute in minutes:
@@ -67,7 +71,7 @@ def create_records_for_scheduled_reports(fake_now_for_tests=None):
         start_datetime = _get_default_start_datetime(end_datetime)
     new_checkpoint = ScheduledReportsCheckpoint(start_datetime=start_datetime, end_datetime=end_datetime)
     report_ids = []
-    for period in ('daily', 'weekly', 'monthly'):
+    for period in ('hourly', 'daily', 'weekly', 'monthly'):
         for report_id in get_scheduled_report_ids(period, start_datetime, end_datetime):
             report_ids.append(report_id)
     new_checkpoint.save()
@@ -81,7 +85,7 @@ def _get_default_start_datetime(end_datetime):
 
 def get_scheduled_report_ids(period, start_datetime=None, end_datetime=None):
     end_datetime = end_datetime or datetime.utcnow()
-    assert period in ('daily', 'weekly', 'monthly'), period
+    assert period in ('hourly', 'daily', 'weekly', 'monthly'), period
     if not start_datetime:
         start_datetime = _get_default_start_datetime(end_datetime)
 

--- a/corehq/apps/saved_reports/scheduled.py
+++ b/corehq/apps/saved_reports/scheduled.py
@@ -32,11 +32,12 @@ def _make_all_notification_view_keys(period, target):
     else:
         minutes = (target.minute,)
 
-    if period == 'hourly':
-        # Todo
-        pass
-
-    if period == 'daily':
+    if period == 'hourly' and target.minute == 0:
+        yield {
+            'startkey': [period],
+            'endkey': [period, {}]
+        }
+    elif period == 'daily':
         for minute in minutes:
             yield {
                 'startkey': [period, target.hour, minute],
@@ -90,6 +91,9 @@ def get_scheduled_report_ids(period, start_datetime=None, end_datetime=None):
         start_datetime = _get_default_start_datetime(end_datetime)
 
     for target_point_in_time in _iter_15_minute_marks_in_range(start_datetime, end_datetime):
+        if period == 'hourly' and target_point_in_time.minute != 0:
+            # Don't care if not on hour
+            continue
         keys = _make_all_notification_view_keys(period, target_point_in_time)
         for key in keys:
             for result in ReportNotification.view(

--- a/corehq/apps/saved_reports/tests/test_scheduled_reports.py
+++ b/corehq/apps/saved_reports/tests/test_scheduled_reports.py
@@ -74,6 +74,46 @@ class ScheduledReportTest(TestCase):
         as_of += timedelta(microseconds=1)
         self.assertEqual(count, len(list(get_scheduled_report_ids(period, end_datetime=as_of))))
 
+    def testHourlyReportWithMinuteZero(self):
+        ReportNotification(hour=1, minute=0, interval='hourly').save()
+        self._check('hourly', datetime(2014, 10, 31, 1, 0), 1)
+        self._check('hourly', datetime(2014, 10, 31, 1, 30), 0)
+
+    def testHourlyReportWithMinuteHalfHour(self):
+        # We don't currently cater for minute-specific hourly reporting;
+        # every report with 'hourly' interval will be sent on the zero-minute hour
+        ReportNotification(hour=1, minute=30, interval='hourly').save()
+        self._check('hourly', datetime(2014, 10, 31, 1, 0), 1)
+        self._check('hourly', datetime(2014, 10, 31, 1, 30), 0)
+
+    def testHourlyReportWithoutMinute(self):
+        # We don't currently cater for minute-specific hourly reporting;
+        # every report with 'hourly' interval will be sent on the zero-minute hour
+        ReportNotification(hour=1, minute=None, interval='hourly').save()
+        self._check('hourly', datetime(2014, 10, 31, 1, 0), 1)
+
+    def testHourlyReportHourDontMatter(self):
+        ReportNotification(hour=1, minute=0, interval='hourly').save()
+        self._check('hourly', datetime(2014, 10, 31, 1, 0), 1)
+        self._check('hourly', datetime(2014, 10, 31, 12, 0), 1)
+        self._check('hourly', datetime(2014, 10, 31, 23, 0), 1)
+
+    def testHourlyReportOtherTypesDontCount(self):
+        ReportNotification(hour=1, minute=0, interval='hourly').save()
+        self._check('daily', datetime(2014, 10, 31, 1, 0), 0)
+        self._check('weekly', datetime(2014, 10, 31, 1, 0), 0)
+        self._check('monthly', datetime(2014, 10, 31, 1, 0), 0)
+
+    def testIntervalReportDontIncludeOtherIntervals(self):
+        ReportNotification(hour=1, minute=0, interval='hourly').save()
+        ReportNotification(hour=1, minute=0, interval='daily').save()
+        ReportNotification(hour=12, minute=0, day=4, interval='weekly').save()
+        ReportNotification(hour=1, minute=0, interval='monthly').save()
+        self._check('hourly', datetime(2014, 10, 1, 1, 0), 1)
+        self._check('daily', datetime(2014, 10, 1, 1, 0), 1)
+        self._check('weekly', datetime(2014, 10, 31, 12, 0), 1)
+        self._check('monthly', datetime(2014, 10, 1, 1, 0), 1)
+
     def testDailyReportEmptyMinute(self):
         ReportNotification(hour=12, minute=None, interval='daily').save()
         self._check('daily', datetime(2014, 10, 31, 12, 0), 1)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -2162,3 +2162,10 @@ DO_NOT_REPUBLISH_DOCS = StaticToggle(
     TAG_INTERNAL,
     namespaces=[NAMESPACE_DOMAIN],
 )
+
+HOURLY_SCHEDULED_REPORT = StaticToggle(
+    'hourly-scheduled-report',
+    'Add ability to send a scheduled report hourly',
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN],
+)


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-1551)

## Product Description
This PR includes some work done for a partner which sits behind a new feature flag which allows the user to send scheduled reports on an hourly basis in addition to the already existing daily, weekly and monthly time frames.

## Technical Summary
Currently the new hourly option only allows the sending of reports on the hour (i.e. on the zero-minute), thus hiding the `Time*` input option on the UI when `Hourly` option is selected (see [example](https://staging.commcarehq.org/a/charlsmit-testy/reports/scheduled_reports/0791b16e3dc26414e5cadaa9a9cb1727)). 

The function `get_scheduled_report_ids` was expanded to account for an hourly interval and ignores any further processing if the `target_point_in_time`'s (the time frame value which pulls reports to be sent for that time frame) minute is not 0. `_make_all_notification_view_keys` was also expanded to include the hourly interval and returns couch view keys that would fetch all relevant reports with interval set to `hourly` (the `minute`, `hour` and `day` fields on ReportNotification is thus redundant when `interval` is set to `hourly`).

## Feature Flag
New `Custom/Once-off` [feature flag](https://staging.commcarehq.org/hq/flags/edit/hourly-scheduled-report/)

## Safety Assurance

### Safety story
Manual testing locally as well as automated test coverage.

### Automated test coverage
Tests included to cover new changes

### QA Plan

- Automated tests included
- Tested manually on staging
- QA team testing 


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
