### PR TITLE
make EmailAddressRecipient support lang_code and timezone

### DIFF
--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -526,7 +526,8 @@ class TimedScheduleInstance(AbstractTimedScheduleInstance):
 
 @attr.s
 class EmailAddressRecipient(object):
-    email_address = attr.ib()
+    case = attr.ib()
+    email_property = attr.ib()
 
     @property
     def doc_type(self):
@@ -534,13 +535,16 @@ class EmailAddressRecipient(object):
 
     @property
     def get_id(self):
-        return self.email_address
+        return self.get_email()
 
     def get_email(self):
-        return self.email_address
+        return self.case.get_case_property(self.email_property)
 
     def get_language_code(self):
-        return None
+        return self.case.get_language_code()
+
+    def get_time_zone(self):
+        return self.case.get_time_zone()
 
 
 class CaseScheduleInstanceMixin(object):
@@ -632,8 +636,7 @@ class CaseScheduleInstanceMixin(object):
             full_username = format_username(username, self.domain)
             return CommCareUser.get_by_username(full_username)
         elif self.recipient_type == self.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL:
-            email = self.case.get_case_property(self.recipient_id)
-            return EmailAddressRecipient(email)
+            return EmailAddressRecipient(self.case, self.recipient_id)
         else:
             return super(CaseScheduleInstanceMixin, self).recipient
 

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -648,7 +648,7 @@ class SchedulingRecipientTest(TestCase):
                 self.domain,
                 'person',
                 owner_id=self.city_location.location_id,
-                update={'recipient': 'fake@mail.com'}
+                update={'recipient': 'fake@mail.com', 'language_code': 'en', 'time_zone': 'sast'}
         ) as case:
             instance = CaseTimedScheduleInstance(
                 domain=self.domain,
@@ -657,7 +657,10 @@ class SchedulingRecipientTest(TestCase):
                 recipient_id='recipient'
             )
             self.assertEqual(instance.recipient.get_email(), 'fake@mail.com')
+            self.assertEqual(instance.recipient.get_language_code(), 'en')
+            self.assertEqual(instance.recipient.get_time_zone(), 'sast')
 
+        # test that cases without the properties don't fail
         with create_case(
                 self.domain,
                 'person',
@@ -670,6 +673,8 @@ class SchedulingRecipientTest(TestCase):
                 recipient_id='recipient'
             )
             self.assertIsNone(instance.recipient.get_email())
+            self.assertIsNone(instance.recipient.get_language_code())
+            self.assertIsNone(instance.recipient.get_time_zone())
 
     def create_usercase(self, user):
         create_case_kwargs = {


### PR DESCRIPTION
## Product Description
This is mostly a bug fix for an error I noticed while investigating something else:
```
'EmailAddressRecipient' object has no attribute 'get_time_zone'
```

But I think it should also have the effect of making the "Email Specified via Case Property" messaging rules support timezones and multiple languages. This feature was originally added here: https://github.com/dimagi/commcare-hq/pull/28535

## Technical Summary
Sentry: https://sentry.io/share/issue/bc868a53b8964c63807efeff9d584018/

Instead of passing the email address directly this wraps the full case which gives access to other data in the case including timezone and language code.

I did some digging to find out why this wasn't an issue when the feature was originally built and the code path is only called for 'timed' schedules and not 'alert' schedules. 

## Safety Assurance

### Safety story
This brings the `EmailAddressRecipient` class more in line with the expected interface for messaging classes (see [CommCareMobileContactMixin](https://github.com/dimagi/commcare-hq/blob/6ee6a33ef0166fcca518b2ba8954b61ccb0cf0d1/corehq/apps/sms/mixin.py#L60))

### Automated test coverage
Updated.

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
