### PR TITLE
add domain and status tagging for submission reprocess metrics

### DIFF
--- a/corehq/apps/cleanup/management/commands/reprocess_incomplete_submissions.py
+++ b/corehq/apps/cleanup/management/commands/reprocess_incomplete_submissions.py
@@ -89,7 +89,11 @@ class Command(BaseCommand):
                 page = paginator.page(page_number)
                 for stub in page.object_list:
                     result = reprocess_unfinished_stub(stub, save=not dryrun)
-                    if result:
+                    if not result:
+                        logger.info("Processing skipped")
+                    elif result.error:
+                        logger.info(f"Form re-processed failed: {stub.xform_id}: {result.error}")
+                    else:
                         cases = ', '.join([c.case_id for c in result.cases])
                         ledgers = ', '.join([l.ledger_reference for l in result.ledgers])
                         logger.info("Form re-processed successfully: {}:{}".format(

--- a/corehq/apps/cleanup/management/commands/reprocess_incomplete_submissions.py
+++ b/corehq/apps/cleanup/management/commands/reprocess_incomplete_submissions.py
@@ -96,7 +96,7 @@ class Command(BaseCommand):
                     else:
                         cases = ', '.join([c.case_id for c in result.cases])
                         ledgers = ', '.join([l.ledger_reference for l in result.ledgers])
-                        logger.info("Form re-processed successfully: {}:{}".format(
+                        logger.info("Form re-processed successfully: {}:{} cases={} ledgers={}".format(
                             result.form.domain, result.form.form_id, cases, ledgers
                         ))
                 if not page.has_next():

--- a/corehq/form_processor/reprocess.py
+++ b/corehq/form_processor/reprocess.py
@@ -40,7 +40,7 @@ def reprocess_unfinished_stub(stub, save=True):
                 'domain': stub.domain
             })
         save and stub.delete()
-        return
+        return ReprocessingResult(None, None, None, "Form not found for reprocessing")
 
     return reprocess_unfinished_stub_with_form(stub, form, save)
 

--- a/corehq/form_processor/tasks.py
+++ b/corehq/form_processor/tasks.py
@@ -26,7 +26,9 @@ def reprocess_submission(submssion_stub_id):
             return
 
         reprocess_unfinished_stub(stub)
-        metrics_counter('commcare.submission_reprocessing.count')
+        metrics_counter('commcare.submission_reprocessing.count', tags={
+            'domain': stub.domain
+        })
 
 
 @periodic_task(run_every=crontab(minute='*/5'), queue=settings.CELERY_PERIODIC_QUEUE)

--- a/corehq/form_processor/tasks.py
+++ b/corehq/form_processor/tasks.py
@@ -29,6 +29,7 @@ def reprocess_submission(submssion_stub_id):
         if result:
             metrics_counter('commcare.submission_reprocessing.count', tags={
                 'domain': stub.domain,
+                'status': 'error' if result.error else 'success'
             })
 
 

--- a/corehq/form_processor/tasks.py
+++ b/corehq/form_processor/tasks.py
@@ -25,10 +25,11 @@ def reprocess_submission(submssion_stub_id):
         except UnfinishedSubmissionStub.DoesNotExist:
             return
 
-        reprocess_unfinished_stub(stub)
-        metrics_counter('commcare.submission_reprocessing.count', tags={
-            'domain': stub.domain
-        })
+        result = reprocess_unfinished_stub(stub)
+        if result:
+            metrics_counter('commcare.submission_reprocessing.count', tags={
+                'domain': stub.domain,
+            })
 
 
 @periodic_task(run_every=crontab(minute='*/5'), queue=settings.CELERY_PERIODIC_QUEUE)

--- a/corehq/form_processor/tests/test_reprocess_errors.py
+++ b/corehq/form_processor/tests/test_reprocess_errors.py
@@ -12,7 +12,7 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.products.models import SQLProduct
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.backends.sql.dbaccessors import FormAccessorSQL
-from corehq.form_processor.exceptions import CaseNotFound
+from corehq.form_processor.exceptions import CaseNotFound, XFormNotFound
 from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
     FormAccessors,
@@ -333,6 +333,40 @@ class ReprocessSubmissionStubTests(TestCase):
         case = self.casedb.get_case(case_id)
         transactions = case.actions
         self.assertEqual([trans.form_id for trans in transactions], [form.form_id])
+
+    def test_processing_skipped_when_migrations_are_in_progress(self):
+        case_id = uuid.uuid4().hex
+        with _patch_save_to_raise_error(self):
+            self.factory.create_or_update_cases([
+                CaseStructure(case_id=case_id, attrs={'case_type': 'parent', 'create': True})
+            ])
+
+        stubs = UnfinishedSubmissionStub.objects.filter(domain=self.domain, saved=False).all()
+        self.assertEqual(1, len(stubs))
+
+        with patch('corehq.form_processor.reprocess.any_migrations_in_progress', return_value=True):
+            result = reprocess_unfinished_stub(stubs[0])
+            self.assertIsNone(result)
+
+        result = reprocess_unfinished_stub(stubs[0])
+        self.assertEqual(1, len(result.cases))
+
+    def test_processing_retuns_error_for_missing_form(self):
+        case_id = uuid.uuid4().hex
+        with _patch_save_to_raise_error(self):
+            self.factory.create_or_update_cases([
+                CaseStructure(case_id=case_id, attrs={'case_type': 'parent', 'create': True})
+            ])
+
+        stubs = UnfinishedSubmissionStub.objects.filter(domain=self.domain, saved=False).all()
+        self.assertEqual(1, len(stubs))
+
+        FormProcessorTestUtils.delete_all_cases_forms_ledgers(self.domain)
+        with self.assertRaises(XFormNotFound):
+            self.formdb.get_form(stubs[0].xform_id)
+
+        result = reprocess_unfinished_stub(stubs[0])
+        self.assertIsNotNone(result.error)
 
 
 @sharded


### PR DESCRIPTION
## Technical Summary
This improves the DD metrics for `commcare.submission_reprocessing.count` and `commcare.submission_reprocessing.queue_size` by adding domain tags.

A `status` tag is also added to the `count` metric.

I also found that the count metric was incorrectly counting even if the processing was being skipped.

## Safety Assurance

### Safety story
These changes only affect an async queue, celery task and a management command. None of these are vital processes to CommCare.

The code changes covered by automated tests.

### Automated test coverage
Updated tests to cover the change and also test a case that wasn't tested before.

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
