### PR TITLE
Fix 500 error on 'Enable Privileges on Mobile' page

### DIFF
--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -560,7 +560,7 @@ class EnableMobilePrivilegesView(BaseMyAccountView):
 
     def dispatch(self, request, *args, **kwargs):
         # raises a 404 if a user tries to access this page without the right authorizations
-        if self.is_user_authorized(request.couch_user):
+        if hasattr(request, 'couch_user') and self.is_user_authorized(request.couch_user):
             return super(BaseMyAccountView, self).dispatch(request, *args, **kwargs)
         return not_found(request)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This PR fixes a bug that shows a 500 error page when a user not logged into commcare navigates to [commcarehq.org/account/mobile_privileges](https://www.commcarehq.org/account/mobile_privileges/).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-12616) (see comments). On top of checking for right user credentials, it now checks that the request for that page has a 'couch_user' attribute as well, returning a 404 if it doesn't (meaning the user isn't logged in). 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

Offer "Enable Privileges on Mobile" flag.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested locally and on staging (navigating to .../account/mobile_privileges/ in an incognito window) and confirmed it now shows a 404 page instead of a 500. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
