### PR TITLE
Fixed edit web page from 500ing when user doesn't have role

### DIFF
--- a/corehq/apps/users/exceptions.py
+++ b/corehq/apps/users/exceptions.py
@@ -1,5 +1,3 @@
-
-
 class NoAccountException(Exception):
     """
     Raised when trying to access the account of someone without one
@@ -12,4 +10,11 @@ class InvalidMobileWorkerRequest(Exception):
 
 
 class IllegalAccountConfirmation(Exception):
+    pass
+
+
+class MissingRoleException(Exception):
+    """
+    Raised when encountering a WebUser without a role
+    """
     pass

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -189,6 +189,12 @@ class BaseUpdateUserForm(forms.Form):
 class UpdateUserRoleForm(BaseUpdateUserForm):
     role = forms.ChoiceField(choices=(), required=False)
 
+    def clean_role(self):
+        role = self.cleaned_data.get('role')
+        if not role and self.existing_user.is_web_user():
+            raise forms.ValidationError(_('Role is required for web users.'))
+        return role
+
     def update_user(self, metadata_updated=False, profile_updated=False):
         is_update_successful, props_updated = super(UpdateUserRoleForm, self).update_user(save=False)
         role_updated = False
@@ -247,10 +253,14 @@ class UpdateUserRoleForm(BaseUpdateUserForm):
     def load_roles(self, role_choices=None, current_role=None):
         if role_choices is None:
             role_choices = []
-        self.fields['role'].choices = role_choices
 
         if current_role:
             self.initial['role'] = current_role
+        else:
+            # Admin is likely to be first in the list and is a bad default
+            role_choices = [('', '')] + role_choices
+
+        self.fields['role'].choices = role_choices
 
 
 class BaseUserInfoForm(forms.Form):

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -191,7 +191,7 @@ class UpdateUserRoleForm(BaseUpdateUserForm):
 
     def clean_role(self):
         role = self.cleaned_data.get('role')
-        if not role and self.existing_user.is_web_user():
+        if role == 'none' and self.existing_user.is_web_user():
             raise forms.ValidationError(_('Role is required for web users.'))
         return role
 
@@ -253,14 +253,10 @@ class UpdateUserRoleForm(BaseUpdateUserForm):
     def load_roles(self, role_choices=None, current_role=None):
         if role_choices is None:
             role_choices = []
+        self.fields['role'].choices = role_choices
 
         if current_role:
             self.initial['role'] = current_role
-        else:
-            # Admin is likely to be first in the list and is a bad default
-            role_choices = [('', '')] + role_choices
-
-        self.fields['role'].choices = role_choices
 
 
 class BaseUserInfoForm(forms.Form):

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -391,7 +391,12 @@ class EditWebUserView(BaseEditUserView):
 
     @property
     def user_role_choices(self):
-        return get_editable_role_choices(self.domain, self.request.couch_user, allow_admin_role=True)
+        role_choices = get_editable_role_choices(self.domain, self.request.couch_user, allow_admin_role=True)
+        try:
+            self.existing_role
+        except MissingRoleException:
+            role_choices = [('none', _('(none)'))] + role_choices
+        return role_choices
 
     @property
     @memoized

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -87,6 +87,7 @@ from corehq.apps.users.decorators import (
     require_can_view_roles,
     require_permission_to_edit_user,
 )
+from corehq.apps.users.exceptions import MissingRoleException
 from corehq.apps.users.forms import (
     BaseUserInfoForm,
     CommtrackUserForm,
@@ -260,7 +261,7 @@ class BaseEditUserView(BaseUserSettingsView):
 
         if role is None:
             if isinstance(self.editable_user, WebUser):
-                raise ValueError("WebUser is always expected to have a role")
+                raise MissingRoleException()
             return None
         else:
             return role.get_qualified_id()
@@ -375,7 +376,14 @@ class EditWebUserView(BaseEditUserView):
                                   request=self.request)
 
         if self.can_change_user_roles:
-            form.load_roles(current_role=self.existing_role, role_choices=self.user_role_choices)
+            try:
+                existing_role = self.existing_role
+            except MissingRoleException:
+                existing_role = None
+                messages.error(self.request, _("""
+                    This user has no role. Please assign this user a role and save.
+                """))
+            form.load_roles(current_role=existing_role, role_choices=self.user_role_choices)
         else:
             del form.fields['role']
 


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/SUPPORT-12255 reminded me of this

As of https://github.com/dimagi/commcare-hq/pull/30900, users who encounter a ResourceConflict while accepting an invitation now end up without a role. This is safer but causes the edit web user page to 500, so they can't be given a role: https://sentry.io/organizations/dimagi/issues/2911867482/

This PR addresses that 500 so the page will display, and it makes the role dropdown on that page required for web users.

When the page loads, there's an error:

![Screen Shot 2022-01-13 at 6 16 18 PM](https://user-images.githubusercontent.com/1486591/149423924-994434ac-edeb-4460-9737-dd417dd24646.png)

The user has to pick a role:

![Screen Shot 2022-01-13 at 6 16 34 PM](https://user-images.githubusercontent.com/1486591/149423943-c5bd0bb9-9878-4dc9-a352-9fade3ebea8e.png)

## Safety Assurance

### Safety story
This is a pretty small change and limited to the edit user pages.

### Automated test coverage

No test coverage at the view level.

### QA Plan

[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-3821)

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
