### PR TITLE
Improve view of data forwarding records in case data report

### DIFF
--- a/corehq/apps/reports/templates/reports/reportdata/case_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_data.html
@@ -15,7 +15,6 @@
 
   {% initial_page_data 'context_case_id' case.case_id %}
   {% initial_page_data 'dynamic_properties' dynamic_properties %}
-  {% initial_page_data 'timezone_offset' timezone_offset %}
   {% initial_page_data 'xform_api_url' xform_api_url %}
   {% initial_page_data 'xform_ids' case.xform_ids %}
   {% registerurl "case_form_data" case.domain case.case_id '---' %}

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1178,7 +1178,6 @@ class CaseDataView(BaseProjectReportSectionView):
             dynamic_properties = None
 
         the_time_is_now = datetime.utcnow()
-        tz_offset_ms = int(timezone.utcoffset(the_time_is_now).total_seconds()) * 1000
         tz_abbrev = timezone.localize(the_time_is_now).tzname()
 
         product_name_by_id = {
@@ -1220,7 +1219,6 @@ class CaseDataView(BaseProjectReportSectionView):
             "timezone": timezone,
             "tz_abbrev": tz_abbrev,
             "ledgers": ledger_map,
-            "timezone_offset": tz_offset_ms,
             "show_transaction_export": show_transaction_export,
             "xform_api_url": reverse('single_case_forms', args=[self.domain, self.case_id]),
             "repeat_records": repeat_records,

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -148,7 +148,7 @@ from corehq.form_processor.utils.xform import resave_form
 from corehq.motech.repeaters.dbaccessors import (
     get_repeat_records_by_payload_id,
 )
-from corehq.motech.repeaters.views.repeat_record_format import SimpleFormat
+from corehq.motech.repeaters.views.repeat_record_display import RepeatRecordDisplay
 from corehq.tabs.tabclasses import ProjectReportsTab
 from corehq.util.couch import get_document_or_404
 from corehq.util.timezones.conversions import ServerTime
@@ -1200,9 +1200,8 @@ class CaseDataView(BaseProjectReportSectionView):
             product_tuples.sort(key=lambda x: x[0])
             ledger_map[section] = product_tuples
 
-        formatter = SimpleFormat(timezone, date_format=DATE_FORMAT)
         repeat_records = [
-            formatter.format_record(record)
+            RepeatRecordDisplay(record, timezone, date_format=DATE_FORMAT)
             for record in get_repeat_records_by_payload_id(self.domain, self.case_id)
         ]
 

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/repeat_records.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/repeat_records.html
@@ -8,7 +8,7 @@
 <table class="table table-striped table-hover">
   <thead>
     <tr>
-      <th>{% trans "Last Sent" %}</th>
+      <th>{% trans "Last Sent" %} ({{ tz_abbrev }})</th>
       <th>{% trans "URL" %}</th>
       <th>{% trans "Status" %}</th>
       <th>{% trans "Attempts" %}</th>
@@ -20,16 +20,14 @@
     <tr>
       <td>{{ repeat_record.last_checked }}</td>
       <td>{{ repeat_record.url }}</td>
-      <td>{{ repeat_record.state|lower }}</td>
+      <td>{{ repeat_record.state }}</td>
       <td>
-        {% for attempt in repeat_record.attempts %}
-          <div>{{ attempt.created_at }}: {{ attempt.message }}</div>
-        {% endfor %}
+        {{ repeat_record.attempts }}
       </td>
       <td>
         <a class="btn btn-default requeue-record-payload"
            role="button"
-           data-record-id="{{ repeat_record.record_id }}">
+           data-record-id="{{ repeat_record.id }}">
           {% trans "Requeue Request" %}
         </a>
       </td>

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/repeat_records.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/repeat_records.html
@@ -27,7 +27,7 @@
       <td>
         <a class="btn btn-default requeue-record-payload"
            role="button"
-           data-record-id="{{ repeat_record.id }}">
+           data-record-id="{{ repeat_record.record_id }}">
           {% trans "Requeue Request" %}
         </a>
       </td>

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -223,6 +223,9 @@ class SQLRepeater(models.Model):
     def repeater(self):
         return Repeater.get(self.repeater_id)
 
+    def get_url(self, record):
+        return self.repeater.get_url(record),
+
     @property
     def repeat_records_ready(self):
         return self.repeat_records.filter(state__in=(RECORD_PENDING_STATE,
@@ -904,6 +907,10 @@ class RepeatRecord(Document):
     def record_id(self):
         return self._id
 
+    @property
+    def next_attempt_at(self):
+        return self.next_check
+
     @classmethod
     def wrap(cls, data):
         should_bootstrap_attempts = ('attempts' not in data)
@@ -1257,6 +1264,10 @@ class SQLRepeatRecord(models.Model):
     def last_checked(self):
         # Used by .../case/partials/repeat_records.html
         return self.repeater.last_attempt_at
+
+    @property
+    def next_attempt_at(self):
+        return self.repeater.next_attempt_at
 
     @property
     def url(self):

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -224,7 +224,7 @@ class SQLRepeater(models.Model):
         return Repeater.get(self.repeater_id)
 
     def get_url(self, record):
-        return self.repeater.get_url(record),
+        return self.repeater.get_url(record)
 
     @property
     def repeat_records_ready(self):

--- a/corehq/motech/repeaters/tests/test_display.py
+++ b/corehq/motech/repeaters/tests/test_display.py
@@ -1,0 +1,95 @@
+from datetime import datetime
+
+from django.test import TestCase
+
+import pytz
+
+from corehq.motech.models import ConnectionSettings
+
+from ..const import RECORD_SUCCESS_STATE
+from ..models import (
+    FormRepeater,
+    RepeatRecord,
+    RepeatRecordAttempt,
+    SQLRepeater,
+)
+from ..views.repeat_record_display import RepeatRecordDisplay
+from .test_models import make_repeat_record
+
+DOMAIN = 'test-domain-display'
+
+
+class RepeaterTestCase(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.url = 'https://www.example.com/api/'
+        conn = ConnectionSettings.objects.create(domain=DOMAIN, name=self.url, url=self.url)
+        self.repeater = FormRepeater(
+            domain=DOMAIN,
+            url=self.url,
+            connection_settings_id=conn.id,
+            include_app_id_param=False
+        )
+        self.repeater.save()
+        self.date_format = "%Y-%m-%d %H:%M:%S"
+        self.last_checked_str = "2022-01-12 09:04:15"
+        self.next_check_str = "2022-01-12 11:04:15"
+        self.last_checked = datetime.strptime(self.last_checked_str, self.date_format)
+        self.next_check = datetime.strptime(self.next_check_str, self.date_format)
+        self.sql_repeater = SQLRepeater.objects.create(
+            domain=DOMAIN,
+            repeater_id=self.repeater.get_id,
+            connection_settings=conn,
+            last_attempt_at=self.last_checked,
+            next_attempt_at=self.next_check,
+        )
+
+    def tearDown(self):
+        self.repeater.delete()
+        super().tearDown()
+
+    def test_record_display_couch(self):
+        record = RepeatRecord(
+            _id='record_id_123',
+            domain=DOMAIN,
+            succeeded=True,
+            repeater_id=self.repeater.get_id,
+            last_checked=self.last_checked,
+            next_check=self.next_check,
+            payload_id='123',
+        )
+        record.attempts.append(
+            RepeatRecordAttempt(
+                cancelled=False,
+                datetime=self.last_checked,
+                failure_reason=None,
+                success_response="",
+                next_check=None,
+                succeeded=True,
+                info=None,
+            )
+        )
+        self._check_display(record)
+
+    def test_record_display_sql(self):
+        with make_repeat_record(self.sql_repeater, RECORD_SUCCESS_STATE) as record:
+            record.sqlrepeatrecordattempt_set.create(
+                state=RECORD_SUCCESS_STATE,
+                message='',
+            )
+            self._check_display(record)
+
+    def _check_display(self, record):
+        display = RepeatRecordDisplay(record, pytz.UTC, date_format=self.date_format)
+        self.assertEqual(display.record_id, record.record_id)
+        self.assertEqual(display.last_checked, self.last_checked_str)
+        self.assertEqual(display.next_attempt_at, self.next_check_str)
+        self.assertEqual(display.url, self.url)
+        self.assertEqual(display.state, '<span class="label label-success">Success</span>')
+        self.assertHTMLEqual(display.attempts, """
+            <ul class="list-unstyled">
+                <li><strong>Attempt #1</strong>
+                    <br/><i class="fa fa-check"></i> Success
+                </li>
+            </ul>""")

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -49,8 +49,7 @@ class RepeaterTestCase(TestCase):
         conn = ConnectionSettings.objects.create(domain=DOMAIN, name=url, url=url)
         self.repeater = FormRepeater(
             domain=DOMAIN,
-            url=url,
-            connection_settings_id=conn.id,
+            url=url
         )
         self.repeater.save()
         self.sql_repeater = SQLRepeater.objects.create(

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -50,7 +50,7 @@ class RepeaterTestCase(TestCase):
         self.repeater = FormRepeater(
             domain=DOMAIN,
             url=url,
-            connections_settings_id=conn.id
+            connection_settings_id=conn.id,
         )
         self.repeater.save()
         self.sql_repeater = SQLRepeater.objects.create(

--- a/corehq/motech/repeaters/views/repeat_record_format.py
+++ b/corehq/motech/repeaters/views/repeat_record_format.py
@@ -1,0 +1,53 @@
+from django.template.loader import render_to_string
+from django.utils.html import format_html
+from django.utils.translation import ugettext as _
+
+from corehq.motech.repeaters.const import (
+    RECORD_CANCELLED_STATE,
+    RECORD_FAILURE_STATE,
+    RECORD_PENDING_STATE,
+    RECORD_SUCCESS_STATE,
+)
+from corehq.util.timezones.conversions import ServerTime
+
+
+class SimpleFormat:
+    def __init__(self, timezone, date_format="%Y-%m-%d %H:%M"):
+        self.timezone = timezone
+        self.date_format = date_format
+
+    def format_record(self, record):
+        url = record.repeater.get_url(record) if record.repeater else _('Unable to generate url for record')
+        return {
+            'id': record.record_id,
+            'last_checked': self._format_date(record.last_checked),
+            'next_attempt_at': self._format_date(record.next_attempt_at),
+            'url': url,
+            'state': format_html('<span class="label label-{}">{}</span>', *_get_state(record)),
+            'attempts': render_to_string('repeaters/partials/attempt_history.html', {'record': record}),
+        }
+
+    def _format_date(self, date):
+        if not date:
+            return '---'
+        return ServerTime(date).user_time(self.timezone).done().strftime(self.date_format)
+
+
+def _get_state(record):
+    if record.state == RECORD_SUCCESS_STATE:
+        label_cls = 'success'
+        label_text = _('Success')
+    elif record.state == RECORD_PENDING_STATE:
+        label_cls = 'warning'
+        label_text = _('Pending')
+    elif record.state == RECORD_CANCELLED_STATE:
+        label_cls = 'danger'
+        label_text = _('Cancelled')
+    elif record.state == RECORD_FAILURE_STATE:
+        label_cls = 'danger'
+        label_text = _('Failed')
+    else:
+        label_cls = ''
+        label_text = ''
+
+    return label_cls, label_text

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -260,7 +260,7 @@ class DomainForwardingRepeatRecords(BaseRepeatRecordReport):
         formatted = formatter.format_record(record)
         checkbox = format_html(
             '<input type="checkbox" class="xform-checkbox" data-id="{}" name="xform_ids"/>',
-            record.get_id)
+            record.record_id)
         row = [
             checkbox,
             formatted['state'],
@@ -268,14 +268,14 @@ class DomainForwardingRepeatRecords(BaseRepeatRecordReport):
             formatted['last_checked'],
             formatted['next_attempt_at'],
             formatted['attempts'],
-            self._make_view_payload_button(record.get_id),
-            self._make_resend_payload_button(record.get_id),
+            self._make_view_payload_button(record.record_id),
+            self._make_resend_payload_button(record.record_id),
         ]
 
         if record.cancelled and not record.succeeded:
-            row.append(self._make_requeue_payload_button(record.get_id))
+            row.append(self._make_requeue_payload_button(record.record_id))
         elif not record.cancelled and not record.succeeded:
-            row.append(self._make_cancel_payload_button(record.get_id))
+            row.append(self._make_cancel_payload_button(record.record_id))
         else:
             row.append(None)
 
@@ -292,7 +292,7 @@ class SQLRepeatRecordReport(BaseRepeatRecordReport):
         formatted = formatter.format_record(record)
         checkbox = format_html(
             '<input type="checkbox" class="xform-checkbox" data-id="{}" name="xform_ids"/>',
-            record.pk)
+            record.record_id)
         row = [
             checkbox,
             formatted['state'],
@@ -300,14 +300,14 @@ class SQLRepeatRecordReport(BaseRepeatRecordReport):
             formatted['last_checked'],
             formatted['next_attempt_at'],
             formatted['attempts'],
-            self._make_view_payload_button(record.pk),
-            self._make_resend_payload_button(record.pk),
+            self._make_view_payload_button(record.record_id),
+            self._make_resend_payload_button(record.record_id),
         ]
 
         if record.state == RECORD_CANCELLED_STATE:
-            row.append(self._make_requeue_payload_button(record.pk))
+            row.append(self._make_requeue_payload_button(record.record_id))
         elif is_queued(record):
-            row.append(self._make_cancel_payload_button(record.pk))
+            row.append(self._make_cancel_payload_button(record.record_id))
         else:
             row.append(None)
 

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -34,7 +34,7 @@ from corehq.apps.users.decorators import require_can_edit_web_users
 from corehq.form_processor.exceptions import XFormNotFound
 from corehq.motech.utils import pformat_json
 from corehq.util.xml_utils import indent_xml
-from .repeat_record_format import SimpleFormat
+from .repeat_record_display import RepeatRecordDisplay
 
 from ..const import (
     RECORD_CANCELLED_STATE,
@@ -198,18 +198,17 @@ class BaseRepeatRecordReport(GenericTabularReport):
         )
 
     def _make_row(self, record):
-        formatter = SimpleFormat(self.timezone, date_format='%b %d, %Y %H:%M:%S %Z')
-        formatted = formatter.format_record(record)
+        display = RepeatRecordDisplay(record, self.timezone, date_format='%b %d, %Y %H:%M:%S %Z')
         checkbox = format_html(
             '<input type="checkbox" class="xform-checkbox" data-id="{}" name="xform_ids"/>',
             record.record_id)
         row = [
             checkbox,
-            formatted['state'],
-            formatted['url'],
-            formatted['last_checked'],
-            formatted['next_attempt_at'],
-            formatted['attempts'],
+            display.state,
+            display.url,
+            display.last_checked,
+            display.next_attempt_at,
+            display.attempts,
             self._make_view_payload_button(record.record_id),
             self._make_resend_payload_button(record.record_id),
         ]


### PR DESCRIPTION
After doing some data forwarding debugging I really wanted to make the date on the case data page be consistent with other dates on that page. This was the result.

## Product Description
This applies the same formatting that is used in the Data Forwarding Records report to the table of records shown on the case data page.

**Before**
![image](https://user-images.githubusercontent.com/249606/149521938-d81c3104-179c-4cc0-a0f4-280317de0989.png)

**After**
![image](https://user-images.githubusercontent.com/249606/149521649-c06d72af-bc3e-4f7e-bd2c-6a2199f23a1c.png)

The same record as shown in the report: 
![image](https://user-images.githubusercontent.com/249606/149521736-db4fc0ae-20a6-4bf6-b863-ed46624499fb.png)

## Technical Summary
Extract the display conversion to a helper class which can be used by both the couch and sql reports as well as in the case data view.

## Safety Assurance

### Safety story
Tested locally (only on couch). This is mostly just moving code around.

### Automated test coverage
Added tests for the display wrapper that test both SQL and Couch

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
