### PR TITLE
management commands to aid in the undo processing of case rule submissions

### DIFF
--- a/corehq/apps/data_interfaces/management/commands/get_case_rule_submissions.py
+++ b/corehq/apps/data_interfaces/management/commands/get_case_rule_submissions.py
@@ -1,0 +1,83 @@
+import csv
+from datetime import datetime
+
+from django.core.management.base import BaseCommand, CommandError
+
+from corehq.apps.data_interfaces.models import CaseRuleSubmission
+from corehq.util.argparse_types import date_type
+from corehq.util.log import with_progress_bar
+
+
+class Command(BaseCommand):
+    help = "Output form IDs for forms created by case rules"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'domains',
+            metavar='domain',
+            nargs='+',
+        )
+
+        parser.add_argument(
+            '--rule-id',
+            type=int,
+            default=None,
+            help='Limit output to the rule with this ID only.'
+        )
+
+        parser.add_argument(
+            '--rule-name',
+            default=None,
+            help='Limit output to the rule with this name only.'
+        )
+
+        parser.add_argument('-a', '--archived', action='store_true', help='Only include archived forms.')
+        parser.add_argument('-s', '--startdate', type=date_type, help='Start date, inclusive. Format YYYY-MM-DD')
+        parser.add_argument('-e', '--enddate', type=date_type, help='End date, exclusive. Format YYYY-MM-DD')
+
+    def handle(self, *args, **options):
+        domains = options['domains']
+        rule_id = options['rule_id']
+        rule_name = options['rule_name']
+        if rule_id and rule_name:
+            raise CommandError("Specify either 'rule-id' or 'rule-name' but not both.")
+
+        start = options['startdate']
+        end = options['enddate']
+        archived = options['archived']
+
+        qs = CaseRuleSubmission.objects.filter(
+            domain__in=domains,
+        )
+
+        if rule_id:
+            qs = qs.filter(rule_id=rule_id)
+        if rule_name:
+            qs = qs.filter(rule__name=rule_name)
+        if archived:
+            qs = qs.filter(archived=True)
+
+        if start:
+            qs = qs.filter(created_on__gte=start)
+        if end:
+            qs = qs.filter(created_on__lt=end)
+
+        count = qs.count()
+
+        if count == 0:
+            print("No rule submissions match the given criteria")
+            return
+
+        filename = f"rule_submissions_{datetime.utcnow().strftime('%Y-%m-%dT%H-%M-%S',)}.csv"
+        print(f"Writing data for {count} submissions to {filename}")
+        with open(filename, "w") as f:
+            writer = csv.writer(f)
+            writer.writerow(["domain", "rule_id", "created_on", "form_id", "archived"])
+            for submission in with_progress_bar(qs, count):
+                writer.writerow([
+                    submission.domain,
+                    submission.rule_id,
+                    submission.created_on,
+                    submission.form_id,
+                    submission.archived
+                ])

--- a/corehq/apps/data_interfaces/management/commands/get_case_rule_submissions.py
+++ b/corehq/apps/data_interfaces/management/commands/get_case_rule_submissions.py
@@ -6,6 +6,7 @@ from django.core.management.base import BaseCommand, CommandError
 from corehq.apps.data_interfaces.models import CaseRuleSubmission
 from corehq.util.argparse_types import date_type
 from corehq.util.log import with_progress_bar
+from corehq.util.queries import queryset_to_iterator
 
 
 class Command(BaseCommand):
@@ -73,7 +74,8 @@ class Command(BaseCommand):
         with open(filename, "w") as f:
             writer = csv.writer(f)
             writer.writerow(["domain", "rule_id", "created_on", "form_id", "archived"])
-            for submission in with_progress_bar(qs, count):
+            iterator = queryset_to_iterator(qs, CaseRuleSubmission, limit=10000)
+            for submission in with_progress_bar(iterator, count):
                 writer.writerow([
                     submission.domain,
                     submission.rule_id,

--- a/corehq/form_processor/management/commands/get_case_ids_from_forms.py
+++ b/corehq/form_processor/management/commands/get_case_ids_from_forms.py
@@ -27,6 +27,7 @@ class Command(BaseCommand):
         print(f"Writing data to {output_path}")
         with open(output_path, 'w') as out:
             writer = csv.writer(out)
+            writer.writerow(["form_id", "case_id"])
             for form_id, case_ids in _get_case_ids(with_progress_bar(form_ids)):
                 for case_id in case_ids:
                     writer.writerow([form_id, case_id])

--- a/corehq/form_processor/management/commands/get_case_ids_from_forms.py
+++ b/corehq/form_processor/management/commands/get_case_ids_from_forms.py
@@ -1,0 +1,51 @@
+import csv
+import logging
+from datetime import datetime
+
+from django.core.management.base import BaseCommand
+
+from casexml.apps.case.xform import get_case_ids_from_form
+from corehq.form_processor.backends.sql.dbaccessors import FormAccessorSQL
+from corehq.util.log import with_progress_bar
+from dimagi.utils.chunked import chunked
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Output all case IDs from the given form IDs"
+
+    def add_arguments(self, parser):
+        parser.add_argument('file_path', help='Path to the list of form IDs. One ID per line.')
+
+    def handle(self, file_path, **options):
+        with open(file_path, 'r') as f:
+            form_ids = [line.strip() for line in f.readlines()]
+
+        output_path = f"case_ids_{datetime.utcnow().strftime('%Y-%m-%dT%H-%M-%S', )}.csv"
+        print(f"Writing data to {output_path}")
+        with open(output_path, 'w') as out:
+            writer = csv.writer(out)
+            for form_id, case_ids in _get_case_ids(with_progress_bar(form_ids)):
+                for case_id in case_ids:
+                    writer.writerow([form_id, case_id])
+
+
+def _get_case_ids(form_ids):
+    for form_id_chunk in chunked(form_ids, 100):
+        form_id_chunk = list(form_id_chunk)
+        try:
+            forms = FormAccessorSQL.get_forms_with_attachments_meta(form_id_chunk)
+        except Exception:
+            logger.exception("Error fetching bulk forms")
+            for form_id in form_id_chunk:
+                try:
+                    form = FormAccessorSQL.get_form(form_id)
+                except Exception as e:
+                    yield form_id, [f"Unable to get form: {e}"]
+                else:
+                    yield form.form_id, get_case_ids_from_form(form)
+        else:
+            for form in forms:
+                yield form.form_id, get_case_ids_from_form(form)

--- a/corehq/motech/management/commands/create_repeat_records.py
+++ b/corehq/motech/management/commands/create_repeat_records.py
@@ -1,0 +1,76 @@
+import logging
+import re
+
+from django.core.management import CommandError
+from django.core.management.base import BaseCommand
+
+from corehq.form_processor.backends.sql.dbaccessors import (
+    CaseAccessorSQL,
+    FormAccessorSQL,
+)
+from corehq.motech.repeaters.management.commands.find_missing_repeat_records import (
+    get_repeaters_for_type_in_domain,
+)
+from corehq.motech.repeaters.models import Repeater, get_all_repeater_types
+from corehq.util.log import with_progress_bar
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+class Command(BaseCommand):
+
+    help = "Create repeat records for cases and forms"
+
+    def add_arguments(self, parser):
+        parser.add_argument('file_path', help='Path to the list of IDs. One ID per line.')
+        parser.add_argument('-t', '--doc-type', choices=['form', 'case'])
+        parser.add_argument('--repeater-type', choices=get_all_repeater_types(),
+                            help='Only create records for this repeater type')
+        parser.add_argument('--repeater-id', help='Only create records for this repeater')
+        parser.add_argument('--repeater-name',
+                            help='Only create records for repeaters whose name matches this regex')
+
+    def handle(self, file_path, *args, **options):
+        with open(file_path, 'r') as file:
+            doc_ids = [line.strip() for line in file.readlines()]
+
+        repeater_type = options['repeater_type']
+        repeater_id = options['repeater_id']
+        repeater_name_re = None
+        if options['repeater_name']:
+            repeater_name_re = re.compile(options['repeater_name'])
+
+        if repeater_id:
+            repeater = Repeater.get(repeater_id)
+            if repeater_type and repeater_type != repeater.doc_type:
+                raise CommandError(f"Repeater type does not match: {repeater_type} != {repeater.doc_type}")
+            if repeater_name_re and not repeater_name_re.match(repeater.name):
+                raise CommandError(f"Repeater name does not match: {repeater.name}")
+
+            def _get_repeaters(doc):
+                assert doc.domain == repeater.domain
+                return [repeater]
+        else:
+            by_domain = {}
+
+            def _get_repeaters(doc):
+                if doc.domain not in by_domain:
+                    repeater_class = get_all_repeater_types()[repeater_type] if repeater_type else None
+                    repeaters = get_repeaters_for_type_in_domain(doc.domain, repeater_class)
+                    if repeater_name_re:
+                        repeaters = [r for r in repeaters if repeater_name_re.match(r.name)]
+
+                    if not repeaters:
+                        logger.info(f"No repeaters matched for domain '{doc.domain}'")
+                    by_domain[doc.domain] = repeaters
+                return by_domain[doc.domain]
+
+        accessor = FormAccessorSQL.get_form if options['doc_type'] == 'form' else CaseAccessorSQL.get_case
+        for doc_id in with_progress_bar(doc_ids):
+            try:
+                form_or_case = accessor(doc_id)
+                for repeater in _get_repeaters(form_or_case):
+                    repeater.register(form_or_case)
+            except Exception:
+                logger.exception(f"Unable to process doc '{doc_id}")

--- a/corehq/motech/repeaters/management/commands/find_missing_repeat_records.py
+++ b/corehq/motech/repeaters/management/commands/find_missing_repeat_records.py
@@ -494,8 +494,7 @@ def get_repeaters_for_type_in_domain(domain, repeater_types):
     """
     repeaters = get_repeaters_by_domain(domain)
     if repeater_types:
-        return [repeater for repeater in get_repeaters_by_domain(domain)
-                if isinstance(repeater, repeater_types)]
+        return [repeater for repeater in repeaters if isinstance(repeater, repeater_types)]
     return repeaters
 
 


### PR DESCRIPTION
## Technical Summary
Some utility management commands created for https://dimagi-dev.atlassian.net/browse/SUPPORT-12223

I've split them up into separate commands since I think each one is potentially useful on it's own:

**get_case_rule_submissions**
* Write form IDs (and other metadata) for forms created by case rules to a CSV file
* Offers some basic filtering based on rule, date, archived status

**get_case_ids_from_forms**
* read form IDs from a file
* write case IDs to an output file

**create_repeat_records**
* Reads form / case IDs from a file and creates repeat records for them
* Offers basic filtering of repeaters based on type, name or ID  

## Safety Assurance

### Safety story
Changes isolated to management commands (and code only called by management commands)

### Automated test coverage
None

### QA Plan
None

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
