### PR TITLE
[SAMVEG] notify unexpected errors

### DIFF
--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -173,3 +173,8 @@ class CaseNameTooLong(CaseRowError):
 class ExternalIdTooLong(CaseRowError):
     title = ugettext_noop('External ID Too Long')
     message = ugettext_lazy(f"The external id cannot be longer than {STANDARD_CHARFIELD_LENGTH} characters")
+
+
+class UnexpectedError(CaseRowError):
+    title = ugettext_noop('Unexpected error')
+    message = ugettext_lazy('Could not process case. If this persists, Please report an issue to CommCareHQ')


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Only applicable to SAMVEG project domains.
In case there is an exception in extensions, it is caught and `None` is returned.
It lead to an error here because the code expected a Tuple to be returned.

So this PR changes to let user know if there was an error during the custom operations and does not import the case.

![Screenshot from 2022-01-17 18-22-23](https://user-images.githubusercontent.com/3864163/149772731-a143a30a-e21b-4435-8c9b-dd802764b8da.png)
Note: the message was later modified to say "Could not process case" instead of "Could not import case"

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/QA-3822
QA reported an improvement for https://github.com/dimagi/commcare-hq/pull/30921

This PR updates the code 
1. to call extensions only if there any present that are valid for the domain
2. and then ensure there is a response from the extensions

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance
This should in fact make things more safer than earlier because the extensions are not invoked at all for non applicable domains. Plus, this is undergoing QA.

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally and also undergoing QA.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
