### PR TITLE
Removed safe from accept_invite

### DIFF
--- a/corehq/apps/users/templates/users/accept_invite.html
+++ b/corehq/apps/users/templates/users/accept_invite.html
@@ -70,7 +70,7 @@
               {% endif %}
             </div>
             <div class="well sign-up-bubble form-bubble-purple">
-              <h2 class="text-center" style="word-wrap: break-word">
+              <h2 class="text-center break-all-words">
                 {% blocktrans with formatted_username as username %}
                   Not {{ username }}?
                 {% endblocktrans %}

--- a/corehq/apps/users/templates/users/accept_invite.html
+++ b/corehq/apps/users/templates/users/accept_invite.html
@@ -70,8 +70,8 @@
               {% endif %}
             </div>
             <div class="well sign-up-bubble form-bubble-purple">
-              <h2 class="text-center">
-                {% blocktrans with formatted_username|safe as username %}
+              <h2 class="text-center" style="word-wrap: break-word">
+                {% blocktrans with formatted_username as username %}
                   Not {{ username }}?
                 {% endblocktrans %}
               </h2>

--- a/corehq/apps/users/views/web.py
+++ b/corehq/apps/users/views/web.py
@@ -12,6 +12,7 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
+from django.utils.html import format_html
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.http import require_POST
 
@@ -75,10 +76,11 @@ class UserInvitationView(object):
         if invitation.is_expired:
             return HttpResponseRedirect(reverse("no_permissions"))
 
+        userhalf, domainhalf = self.request.user.username.split('@')
         # Add zero-width space to username for better line breaking
-        username = self.request.user.username.replace("@", "&#x200b;@")
+        formatted_username = format_html('{}&#x200b;@{}', userhalf, domainhalf)
         context = {
-            'formatted_username': username,
+            'formatted_username': formatted_username,
             'domain': self.domain,
             'invite_to': self.domain,
             'invite_type': _('Project'),


### PR DESCRIPTION
## Technical Summary
This is one of a bunch of XSS fixes from https://dimagi-dev.atlassian.net/browse/SAAS-12098. Basically we shouldn't be using the `safe` filter within templates. Throwing this up as I'm fairly positive that adding a raw style attribute is not how we want to handle this, but I'm not sure the correct way to go about it.

## Safety Assurance

### Safety story
Local testing

### Automated test coverage

No tests

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
