### PR TITLE
replace `case_post_save` with `sql_case_post_save`

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -6,7 +6,6 @@ from django.test import TestCase, override_settings
 from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseFactory
-from casexml.apps.case.signals import case_post_save
 
 from corehq.apps import hqcase
 from corehq.apps.data_interfaces.models import (
@@ -39,7 +38,7 @@ from corehq.util.test_utils import set_parent_case as set_actual_parent_case
 
 @contextmanager
 def _with_case(domain, case_type, last_modified, **kwargs):
-    with drop_connected_signals(case_post_save), drop_connected_signals(sql_case_post_save):
+    with drop_connected_signals(sql_case_post_save):
         case = CaseFactory(domain).create_case(case_type=case_type, **kwargs)
 
     _update_case(domain, case.case_id, last_modified)

--- a/corehq/apps/reports/signals.py
+++ b/corehq/apps/reports/signals.py
@@ -1,14 +1,12 @@
 from django.dispatch.dispatcher import receiver
 
-from casexml.apps.case.signals import case_post_save
-
 from corehq.apps.reports.analytics.esaccessors import (
     get_case_types_for_domain_es,
 )
 from corehq.form_processor.signals import sql_case_post_save
 
 
-@receiver([case_post_save, sql_case_post_save])
+@receiver([sql_case_post_save])
 def clear_case_type_cache(sender, case, **kwargs):
     case_types = get_case_types_for_domain_es.get_cached_value(case.domain)
     if case_types != Ellipsis and case.type not in case_types:

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -1251,8 +1251,8 @@ class TestCaseESAccessors(BaseESAccessorsTest):
         self.assertEqual({'t1'}, get_case_types_for_domain_es(self.domain))
 
         # simulate a save
-        from casexml.apps.case.signals import case_post_save
-        case_post_save.send(self, case=CommCareCaseSQL(domain=self.domain, type='t2'))
+        from corehq.form_processor.signals import sql_case_post_save
+        sql_case_post_save.send(self, case=CommCareCaseSQL(domain=self.domain, type='t2'))
 
         self.assertEqual({'t1', 't2'}, get_case_types_for_domain_es(self.domain))
 

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -8,11 +8,11 @@ from unittest import mock
 from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.signals import case_post_save
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 from casexml.apps.case.util import post_case_blocks
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.pillow_utils import rebuild_table
+from corehq.form_processor.signals import sql_case_post_save
 from pillow_retry.models import PillowError
 
 from corehq.apps.userreports.data_source_providers import (
@@ -911,7 +911,7 @@ class IndicatorConfigFilterTest(SimpleTestCase):
 
 def _save_sql_case(doc):
     system_props = ['_id', '_rev', 'opened_on', 'owner_id', 'doc_type', 'domain', 'type']
-    with drop_connected_signals(case_post_save):
+    with drop_connected_signals(sql_case_post_save):
         form, cases = post_case_blocks(
             [
                 CaseBlock.deprecated_init(

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -6,7 +6,6 @@ from django.test import TestCase
 from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.signals import case_post_save
 from casexml.apps.case.tests.util import delete_all_cases
 from casexml.apps.case.util import post_case_blocks
 
@@ -21,6 +20,7 @@ from corehq.apps.userreports.models import (
 from corehq.apps.userreports.reports.view import ConfigurableReportView
 from corehq.apps.users.models import Permissions, UserRole, WebUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.signals import sql_case_post_save
 from corehq.sql_db.connections import Session
 from corehq.util.context_managers import drop_connected_signals
 
@@ -38,7 +38,7 @@ class ConfigurableReportTestMixin(object):
             case_type=cls.case_type,
             update=properties,
         ).as_xml()
-        with drop_connected_signals(case_post_save):
+        with drop_connected_signals(sql_case_post_save):
             post_case_blocks([case_block], {'domain': cls.domain})
         return CaseAccessors(cls.domain).get_case(id)
 

--- a/corehq/ex-submodules/casexml/apps/case/signals.py
+++ b/corehq/ex-submodules/casexml/apps/case/signals.py
@@ -18,6 +18,7 @@ xform_archived.connect(rebuild_form_cases)
 xform_unarchived.connect(rebuild_form_cases)
 
 # any time a case is saved
+# deprecated and to be removed along with CommCareCase couch model
 case_post_save = Signal(providing_args=["case"])
 
 # only when one or more cases are updated as the result of an xform submission

--- a/corehq/ex-submodules/pillowtop/tests/test_bulk.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_bulk.py
@@ -3,7 +3,6 @@ import uuid
 from django.test import SimpleTestCase, TestCase
 from unittest.mock import Mock, patch
 
-from casexml.apps.case.signals import case_post_save
 from corehq.apps.change_feed.data_sources import SOURCE_COUCH
 from corehq.apps.es.tests.utils import es_test
 from corehq.elastic import get_es_new
@@ -62,7 +61,7 @@ class TestBulkDocOperations(TestCase):
         cls.case_ids = [
             uuid.uuid4().hex for i in range(4)
         ]
-        with drop_connected_signals(case_post_save), drop_connected_signals(sql_case_post_save):
+        with drop_connected_signals(sql_case_post_save):
             for case_id in cls.case_ids:
                 create_form_for_test(cls.domain, case_id)
 
@@ -161,7 +160,7 @@ class TestBulkOperationsCaseToSQL(TestCase):
         cls.case_ids = [
             uuid.uuid4().hex for i in range(4)
         ]
-        with drop_connected_signals(case_post_save), drop_connected_signals(sql_case_post_save):
+        with drop_connected_signals(sql_case_post_save):
             for case_id in cls.case_ids:
                 create_and_save_a_case(cls.domain, case_id, case_id)
 

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -152,7 +152,7 @@ class FormProcessorSQL(object):
         publish_form_saved(processed_forms.submitted)
         cases = cases or []
         for case in cases:
-            publish_case_saved(case)
+            publish_case_saved(case, send_post_save_signal=False)
 
         if stock_result:
             for ledger in stock_result.models_to_save:

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -480,14 +480,14 @@ class SubmissionPost(object):
 
     @staticmethod
     def _fire_post_save_signals(instance, cases):
-        from casexml.apps.case.signals import case_post_save
+        from corehq.form_processor.signals import sql_case_post_save
         error_message = "Error occurred during form submission post save (%s)"
         error_details = {'domain': instance.domain, 'form_id': instance.form_id}
         results = successful_form_received.send_robust(None, xform=instance)
         has_errors = log_signal_errors(results, error_message, error_details)
 
         for case in cases:
-            results = case_post_save.send_robust(case.__class__, case=case)
+            results = sql_case_post_save.send_robust(case.__class__, case=case)
             has_errors |= log_signal_errors(results, error_message, error_details)
         if has_errors:
             raise PostSaveError

--- a/corehq/form_processor/tests/test_reprocess_errors.py
+++ b/corehq/form_processor/tests/test_reprocess_errors.py
@@ -6,7 +6,6 @@ from django.test import TestCase, TransactionTestCase
 from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseBlock, CaseFactory, CaseStructure
-from casexml.apps.case.signals import case_post_save
 from casexml.apps.case.util import post_case_blocks
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.products.models import SQLProduct
@@ -23,6 +22,7 @@ from corehq.form_processor.reprocess import (
     reprocess_unfinished_stub,
     reprocess_xform_error,
 )
+from corehq.form_processor.signals import sql_case_post_save
 from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
     sharded,
@@ -308,7 +308,8 @@ class ReprocessSubmissionStubTests(TestCase):
 
         form = self.formdb.get_form(form_id)
 
-        with catch_signal(successful_form_received) as form_handler, catch_signal(case_post_save) as case_handler:
+        with catch_signal(successful_form_received) as form_handler, \
+             catch_signal(sql_case_post_save) as case_handler:
             submit_form_locally(
                 instance=form.get_xml(),
                 domain=self.domain,

--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from casexml.apps.case.signals import case_post_save
+from corehq.form_processor.signals import sql_case_post_save
 from couchforms.signals import successful_form_received
 
 from corehq.apps.locations.models import SQLLocation
@@ -68,4 +68,4 @@ def create_location_repeat_records(sender, raw=False, **kwargs):
 
 successful_form_received.connect(create_form_repeat_records)
 successful_form_received.connect(create_short_form_repeat_records)
-case_post_save.connect(create_case_repeat_records, CommCareCaseSQL)
+sql_case_post_save.connect(create_case_repeat_records, CommCareCaseSQL)

--- a/corehq/util/context_managers.py
+++ b/corehq/util/context_managers.py
@@ -12,7 +12,7 @@ def drop_connected_signals(signal):
     """
     Use as a context manager to temporarily drop signals. Useful in tests.
 
-    with drop_connected_signals(case_post_save):
+    with drop_connected_signals(sql_case_post_save):
        case.save()  # signals won't be called
     case.save()  # signals will be called again
     """

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -583,7 +583,6 @@ def _create_case(domain, **kwargs):
 
 def create_and_save_a_case(domain, case_id, case_name, case_properties=None, case_type=None,
         drop_signals=True, owner_id=None, user_id=None, index=None):
-    from casexml.apps.case.signals import case_post_save
     from corehq.form_processor.signals import sql_case_post_save
 
     kwargs = {
@@ -605,7 +604,7 @@ def create_and_save_a_case(domain, case_id, case_name, case_properties=None, cas
 
     if drop_signals:
         # this avoids having to deal with all the reminders code bootstrap
-        with drop_connected_signals(case_post_save), drop_connected_signals(sql_case_post_save):
+        with drop_connected_signals(sql_case_post_save):
             form, cases = _create_case(domain, **kwargs)
     else:
         form, cases = _create_case(domain, **kwargs)

--- a/custom/cowin/signals.py
+++ b/custom/cowin/signals.py
@@ -1,6 +1,6 @@
 from django.dispatch import receiver
 
-from casexml.apps.case.signals import case_post_save
+from corehq.form_processor.signals import sql_case_post_save
 
 from corehq.motech.repeaters.signals import create_repeat_records
 from custom.cowin.repeaters import (
@@ -9,7 +9,7 @@ from custom.cowin.repeaters import (
 )
 
 
-@receiver(case_post_save, dispatch_uid="create_cowin_repeat_records")
+@receiver(sql_case_post_save, dispatch_uid="create_cowin_repeat_records")
 def create_cowin_repeat_records(sender, case, **kwargs):
     create_repeat_records(BeneficiaryRegistrationRepeater, case)
     create_repeat_records(BeneficiaryVaccinationRepeater, case)

--- a/docs/messaging/schedules.rst
+++ b/docs/messaging/schedules.rst
@@ -49,7 +49,7 @@ to denote that it has completed the defined schedule and should not be sent agai
 
 In order to keep messaging responsive to case changes, every time a case is saved, a
 `corehq.messaging.tasks.sync_case_for_messaging <https://github.com/dimagi/commcare-hq/blob/master/corehq/messaging/tasks.py>`_
-task is spawned to handle any changes. This is controlled via the ``case_post_save`` signal.
+task is spawned to handle any changes. This is controlled via the ``sql_case_post_save`` signal.
 
 Similarly, any time a rule is updated, a
 `corehq.messaging.tasks.run_messaging_rule <https://github.com/dimagi/commcare-hq/blob/master/corehq/messaging/tasks.py>`_


### PR DESCRIPTION
## Technical Summary
The main goal for this PR was to ensure the the repeater signal handlers are called after cases are rebuilt (e.g. after form archiving). The rebuild code calls `publish_case_saved` which in turn calls `sql_case_post_save`.

Previously the repeater signal handlers were only listening to the `case_post_save` signal and not the `sql_case_post_save`.

Considering that we are in the process of removing the couch case models and code it seemed reasonable to consolidate the signals by only using the `sql_case_post_save`.

The `case_post_signal` is now only used in the `save` method of the `CommCareCase` couch model.

One other change in this PR is to prevent firing the `sql_case_post_save` signal from `publish_case_saved` during form processing. The reason for this is that the form processing code calls `sql_case_post_save` directly so there is no need to have it called twice.

Related Jira: https://dimagi-dev.atlassian.net/browse/SUPPORT-12223

## Safety Assurance

### Safety story
Replaces all usages of the `case_post_save` with the `sql_case_post_save`.

### Automated test coverage
Update the tests for form archiving to ensure that the `sql_case_post_save` signal is called.

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
