### PR TITLE
Mentions support for fra rather than fr

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -265,7 +265,7 @@ class BaseUserInfoForm(forms.Form):
             "<i class=\"fa fa-info-circle\"></i> "
             "Becomes default language seen in Web Apps and reports (if applicable), "
             "but does not affect mobile applications. "
-            "Supported languages for reports are en, fr (partial), and hin (partial)."
+            "Supported languages for reports are en, fra (partial), and hin (partial)."
         )
     )
 


### PR DESCRIPTION
## Technical Summary
Came across this while working on another change. We mentioned partial support for 'fr', but only 'fra' is a valid option.  This just corrects which language we support.

## Safety Assurance

### Safety story
Just a word change

### Automated test coverage

No tests

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
