### PR TITLE
[SAMVEG] Support parsed date

### DIFF
--- a/custom/samveg/tests/case_importer/validators.py
+++ b/custom/samveg/tests/case_importer/validators.py
@@ -7,6 +7,7 @@ from dateutil.relativedelta import relativedelta
 
 from corehq.apps.case_importer.util import get_spreadsheet
 from corehq.util.test_utils import TestFileMixin
+from custom.samveg.case_importer.exceptions import CallValueInvalidError
 from custom.samveg.case_importer.validators import (
     CallValidator,
     RequiredColumnsValidator,
@@ -112,6 +113,21 @@ class TestCallValidator(SimpleTestCase, TestFileMixin):
         self.assertEqual(
             [error.title for error in errors],
             ['Latest call value not a date']
+        )
+
+    def test_valid_call_value_type(self):
+        raw_row = _sample_valid_rch_upload()
+        row_num = 1
+
+        fields_to_update, errors = CallValidator.run(row_num, raw_row, raw_row, {})
+        self.assertFalse(
+            any(isinstance(error, CallValueInvalidError) for error in errors)
+        )
+
+        raw_row['Call1'] = datetime.date.today()
+        fields_to_update, errors = CallValidator.run(row_num, raw_row, raw_row, {})
+        self.assertFalse(
+            any(isinstance(error, CallValueInvalidError) for error in errors)
         )
 
     def test_call_value_not_in_last_month(self):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Till now we were expecting the Call columns, which are dates, to be a string of a certain format.
It seems to be very likely that when someone would configure those as dates in the sheet itself which leads to an error in the code because we are just supporting strings.
Ultimately, we need a date anyway, so it makes sense to support date type as well.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/QA-3830?focusedCommentId=187142

Simply, load the value as date if it is already a date type, else try to parse it as date in the expected format.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Added tests and also tested locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added new tests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Same as parent PR

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
