### PR TITLE
Fix columns check for case import

### DIFF
--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -1,12 +1,12 @@
 import uuid
 from contextlib import contextmanager
+from unittest.mock import patch
 
 from django.test import SimpleTestCase, TestCase
 from django.utils.dateparse import parse_datetime
 
 from celery import states
 from celery.exceptions import Ignore
-from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseFactory, CaseStructure
 from casexml.apps.case.tests.util import delete_all_cases
@@ -15,8 +15,11 @@ from corehq.apps.case_importer import exceptions
 from corehq.apps.case_importer.do_import import do_import
 from corehq.apps.case_importer.tasks import bulk_import_async
 from corehq.apps.case_importer.tracking.models import CaseUploadRecord
-from corehq.apps.case_importer.util import ImporterConfig, WorksheetWrapper, \
-    get_interned_exception
+from corehq.apps.case_importer.util import (
+    ImporterConfig,
+    WorksheetWrapper,
+    get_interned_exception,
+)
 from corehq.apps.case_importer.views import validate_column_names
 from corehq.apps.commtrack.tests.util import make_loc
 from corehq.apps.data_dictionary.tests.utils import setup_data_dictionary
@@ -27,7 +30,7 @@ from corehq.apps.locations.models import LocationType
 from corehq.apps.locations.tests.util import restrict_user_by_location
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.util.test_utils import flag_enabled, flag_disabled
+from corehq.util.test_utils import flag_disabled, flag_enabled
 from corehq.util.timezones.conversions import PhoneTime
 from corehq.util.workbook_reading import make_worksheet
 

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -1,7 +1,7 @@
 import uuid
 from contextlib import contextmanager
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.utils.dateparse import parse_datetime
 
 from celery import states
@@ -17,6 +17,7 @@ from corehq.apps.case_importer.tasks import bulk_import_async
 from corehq.apps.case_importer.tracking.models import CaseUploadRecord
 from corehq.apps.case_importer.util import ImporterConfig, WorksheetWrapper, \
     get_interned_exception
+from corehq.apps.case_importer.views import validate_column_names
 from corehq.apps.commtrack.tests.util import make_loc
 from corehq.apps.data_dictionary.tests.utils import setup_data_dictionary
 from corehq.apps.domain.shortcuts import create_domain
@@ -29,6 +30,16 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.util.test_utils import flag_enabled, flag_disabled
 from corehq.util.timezones.conversions import PhoneTime
 from corehq.util.workbook_reading import make_worksheet
+
+
+class TestValidColumnNames(SimpleTestCase):
+    def test_validate_column_names(self):
+        invalid_column_names = set()
+        validate_column_names([1, 'name', 'foo+bar', '?', 'parent/maternal'], invalid_column_names)
+        self.assertEqual(
+            invalid_column_names,
+            {'1', 'foo+bar', '?', 'parent/maternal'}
+        )
 
 
 class ImporterTest(TestCase):

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -51,7 +51,7 @@ def validate_column_names(column_names, invalid_column_names):
         try:
             validate_property(column_name, allow_parents=False)
         except (ValueError, TypeError):
-            invalid_column_names.add(column_name)
+            invalid_column_names.add(str(column_name))
 
 
 # Cobble together the context needed to render breadcrumbs that class-based views get from BasePageView

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -50,7 +50,7 @@ def validate_column_names(column_names, invalid_column_names):
     for column_name in column_names:
         try:
             validate_property(column_name, allow_parents=False)
-        except ValueError:
+        except (ValueError, TypeError):
             invalid_column_names.add(column_name)
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
If user uploads a sheet where the column name is not a string, it leads to a 500.
We would now consider non-string column names as invalid as well. We already inform the user for any invalid column names, with the following message
https://github.com/dimagi/commcare-hq/blob/93ed659416abb153dd691d44b2fab94489675e73/corehq/apps/case_importer/views.py#L130-L133

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-12939)
[Sentry error](https://sentry.io/organizations/dimagi/issues/2935665821/?environment=staging&project=136860)
If the column name in the sheet is not a string, it fails at the regex matching when we are validating column names and raise a `TypeError`. QA stumbled upon this when they were testing an upload without headers and the first column value was an integer.
We could have either converted the column name to a string instead, but I thought it was better to let the user make that change.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested this locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
