### PR TITLE
Drop unused get_case_ids_modified_with_owner_since

### DIFF
--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -1100,16 +1100,6 @@ class CaseAccessorSQL(AbstractCaseAccessor):
             return [result.case_id for result in results]
 
     @staticmethod
-    def get_case_ids_modified_with_owner_since(domain, owner_id, reference_date):
-        with CommCareCaseSQL.get_plproxy_cursor(readonly=True) as cursor:
-            cursor.execute(
-                'SELECT case_id FROM get_case_ids_modified_with_owner_since(%s, %s, %s)',
-                [domain, owner_id, reference_date]
-            )
-            results = fetchall_as_namedtuple(cursor)
-            return [result.case_id for result in results]
-
-    @staticmethod
     def get_extension_case_ids(domain, case_ids, include_closed=True, exclude_for_case_type=None):
         """
         Given a base list of case ids, get all ids of all extension cases that reference them

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -311,11 +311,6 @@ class AbstractCaseAccessor(metaclass=ABCMeta):
 
     @staticmethod
     @abstractmethod
-    def get_case_ids_modified_with_owner_since(domain, owner_id, reference_date):
-        raise NotImplementedError
-
-    @staticmethod
-    @abstractmethod
     def get_extension_case_ids(domain, case_ids, include_closed, exclude_for_case_type=None):
         raise NotImplementedError
 
@@ -461,9 +456,6 @@ class CaseAccessors(object):
         since sync date/log id
         """
         return self.db_accessor.get_modified_case_ids(self, case_ids, sync_log)
-
-    def get_case_ids_modified_with_owner_since(self, owner_id, reference_date):
-        return self.db_accessor.get_case_ids_modified_with_owner_since(self.domain, owner_id, reference_date)
 
     def get_extension_case_ids(self, case_ids, exclude_for_case_type=None):
         return self.db_accessor.get_extension_case_ids(

--- a/corehq/form_processor/tests/test_case_dbaccessor.py
+++ b/corehq/form_processor/tests/test_case_dbaccessor.py
@@ -451,27 +451,6 @@ class CaseAccessorTestsSQL(TestCase):
             {case1.case_id, case2.case_id}
         )
 
-    def test_get_case_ids_modified_with_owner_since(self):
-        case1 = _create_case(user_id="user1")
-        date1 = datetime(1992, 1, 30)
-        case1.server_modified_on = date1
-        CaseAccessorSQL.save_case(case1)
-
-        case2 = _create_case(user_id="user2")
-        date2 = datetime(2015, 12, 28, 5, 48)
-        case2.server_modified_on = date2
-        CaseAccessorSQL.save_case(case2)
-
-        case3 = _create_case(user_id="user1")
-        date3 = datetime(1992, 1, 1)
-        case3.server_modified_on = date3
-        CaseAccessorSQL.save_case(case3)
-
-        self.assertEqual(
-            CaseAccessorSQL.get_case_ids_modified_with_owner_since(DOMAIN, "user1", datetime(1992, 1, 15)),
-            [case1.case_id]
-        )
-
     def test_get_extension_case_ids(self):
         # Create case and index
         referenced_id = uuid.uuid4().hex

--- a/corehq/sql_accessors/migrations/0066_drop_unused_function.py
+++ b/corehq/sql_accessors/migrations/0066_drop_unused_function.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+from corehq.sql_db.operations import RawSQLMigration
+
+migrator = RawSQLMigration(('corehq', 'sql_accessors', 'sql_templates'), {})
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sql_accessors', '0065_get_ledger_values_for_cases_3'),
+    ]
+
+    operations = [
+        migrator.get_migration(
+            'drop_get_case_ids_modified_with_owner_since.sql',
+            'get_case_ids_modified_with_owner_since_1.sql',
+        ),
+    ]

--- a/corehq/sql_accessors/sql_templates/drop_get_case_ids_modified_with_owner_since.sql
+++ b/corehq/sql_accessors/sql_templates/drop_get_case_ids_modified_with_owner_since.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS get_case_ids_modified_with_owner_since(TEXT, TEXT, TIMESTAMP WITH TIME ZONE);

--- a/corehq/sql_proxy_accessors/migrations/0049_drop_unused_function.py
+++ b/corehq/sql_proxy_accessors/migrations/0049_drop_unused_function.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+from django.db import migrations
+
+from corehq.sql_db.operations import RawSQLMigration
+
+migrator = RawSQLMigration(('corehq', 'sql_proxy_accessors', 'sql_templates'), {
+    'PL_PROXY_CLUSTER_NAME': settings.PL_PROXY_CLUSTER_NAME
+})
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sql_proxy_accessors', '0048_get_ledger_values_for_cases_3'),
+    ]
+
+    operations = [
+        migrator.get_migration(
+            'drop_get_case_ids_modified_with_owner_since.sql',
+            'get_case_ids_modified_with_owner_since.sql',
+        ),
+    ]

--- a/corehq/sql_proxy_accessors/sql_templates/drop_get_case_ids_modified_with_owner_since.sql
+++ b/corehq/sql_proxy_accessors/sql_templates/drop_get_case_ids_modified_with_owner_since.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS get_case_ids_modified_with_owner_since(TEXT, TEXT, TIMESTAMP WITH TIME ZONE);

--- a/migrations.lock
+++ b/migrations.lock
@@ -828,6 +828,7 @@ sql_accessors
  0063_get_ledger_values_for_cases_2
  0064_remove_get_case_models_functions
  0065_get_ledger_values_for_cases_3
+ 0066_drop_unused_function
 sql_proxy_accessors
  0001_initial
  0002_add_sync_functions
@@ -877,6 +878,7 @@ sql_proxy_accessors
  0046_get_ledger_values_for_cases_2
  0047_remove_get_case_models_functions
  0048_get_ledger_values_for_cases_3
+ 0049_drop_unused_function
 sql_proxy_standby_accessors
  0001_initial
 sso


### PR DESCRIPTION
## Safety Assurance

### Safety story

The function is unused.

### Automated test coverage

Removed with the function.

### QA Plan

No QA.

### Migrations
- [x] The migrations in this code can be safely applied first independently of the code

It is unnecessary, but would be fine to apply the migration first since no code exists that calls the function.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

If it must be rolled back, new migrations should be made that does the opposite of the migrations in this PR. It should be a matter of reversing the order of the arguments of `migrator.get_migration(...)` to recreate the SQL functions.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
