### PR TITLE
[data registry repeater] Require specifying the index identifier for index removal

### DIFF
--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -384,6 +384,7 @@ class CaseUpdateConfig:
         "index_create_relationship": "target_index_create_relationship",
         # index remove
         "index_remove_case_id": "target_index_remove_case_id",
+        "index_remove_identifier": "target_index_remove_identifier",
         "index_remove_relationship": "target_index_remove_relationship",
         # copy from other case
         "copy_domain": "target_copy_properties_from_case_domain",
@@ -413,6 +414,7 @@ class CaseUpdateConfig:
     index_create_case_type = attr.ib()
     index_create_relationship = attr.ib()
     index_remove_case_id = attr.ib()
+    index_remove_identifier = attr.ib()
     index_remove_relationship = attr.ib()
     copy_domain = attr.ib()
     copy_case_id = attr.ib()
@@ -434,10 +436,6 @@ class CaseUpdateConfig:
         config = CaseUpdateConfig(**kwargs)
         config.validate()
         return config
-
-    @property
-    def index_remove_identifier(self):
-        return "parent" if self.index_remove_relationship == "child" else "host"
 
     @property
     def index_create_identifier(self):
@@ -563,16 +561,21 @@ class CaseUpdateConfig:
         return index_spec
 
     def get_remove_case_index(self, target_case):
-        identifier = "parent" if self.index_remove_relationship == "child" else "host"
-        indices = [index for index in target_case.live_indices if index.identifier == identifier]
+        indices = [
+            index for index in target_case.live_indices
+            if index.identifier == self.index_remove_identifier
+        ]
         if not indices:
             return {}
         assert len(indices) == 1
         index = indices[0]
         if index.referenced_id != self.index_remove_case_id:
             raise DataRegistryCaseUpdateError("Index case ID does not match for index to remove")
+        if self.index_remove_relationship and self.index_remove_relationship != index.relationship_id:
+            raise DataRegistryCaseUpdateError("Index relationship does not match for index to remove")
+
         return {
-            identifier: (index.referenced_type, "", self.index_remove_relationship)
+            index.identifier: (index.referenced_type, "", index.relationship_id)
         }
 
     @staticmethod

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -178,23 +178,37 @@ def test_generator_update_create_index_bad_relationship():
 
 
 def test_generator_update_remove_index_bad_relationship():
-    builder = IntentCaseBuilder().remove_index("case2", "cousin")
+    builder = IntentCaseBuilder().remove_index("case2", "parent", relationship="cousin")
     msg = "Index relationships must be either 'child' or 'extension'"
     with assert_raises(DataRegistryCaseUpdateError, msg=msg):
         _test_payload_generator(intent_case=builder.get_case())
 
 
 def test_generator_update_remove_index():
-    builder = IntentCaseBuilder().remove_index("parent_case_id", "child")
+    builder = IntentCaseBuilder().remove_index("parent_case_id", "parent_c")
 
     _test_payload_generator(intent_case=builder.get_case(), expected_indices={
-        "1": {"parent": IndexAttrs("parent_type", None, "child")}})
+        "1": {"parent_c": IndexAttrs("parent_type", None, "child")}})
+
+
+def test_generator_update_remove_index_extension():
+    builder = IntentCaseBuilder().remove_index("host_case_id", "host_c")
+
+    _test_payload_generator(intent_case=builder.get_case(), expected_indices={
+        "1": {"host_c": IndexAttrs("host_type", None, "extension")}})
+
+
+def test_generator_update_remove_index_check_relationship():
+    builder = IntentCaseBuilder().remove_index("parent_case_id", "parent_c", relationship="extension")
+    msg = "Index relationship does not match for index to remove"
+    with assert_raises(DataRegistryCaseUpdateError, msg=msg):
+        _test_payload_generator(intent_case=builder.get_case())
 
 
 def test_generator_update_create_and_remove_index():
     builder = IntentCaseBuilder() \
         .create_index("case2", "host_type", "extension") \
-        .remove_index("parent_case_id", "child")
+        .remove_index("parent_case_id", "parent_c")
 
     def _get_case(case_id):
         assert case_id == "case2"
@@ -204,7 +218,7 @@ def test_generator_update_create_and_remove_index():
         _test_payload_generator(intent_case=builder.get_case(), expected_indices={
             "1": {
                 "host": IndexAttrs("host_type", "case2", "extension"),
-                "parent": IndexAttrs("parent_type", None, "child")
+                "parent_c": IndexAttrs("parent_type", None, "child")
             }})
 
 
@@ -439,9 +453,10 @@ class IntentCaseBuilder:
         })
         return self
 
-    def remove_index(self, case_id, relationship):
+    def remove_index(self, case_id, identifier, relationship=None):
         self.props.update({
             "target_index_remove_case_id": case_id,
+            "target_index_remove_identifier": identifier,
             "target_index_remove_relationship": relationship,
         })
         return self
@@ -508,8 +523,12 @@ def _mock_case(case_id, props=None, domain=TARGET_DOMAIN, case_type="patient"):
         case_json=props,
         live_indices=[
             Mock(
-                identifier="parent", referenced_type="parent_type",
+                identifier="parent_c", referenced_type="parent_type",
                 referenced_id="parent_case_id", relationship_id="child"
+            ),
+            Mock(
+                identifier="host_c", referenced_type="host_type",
+                referenced_id="host_case_id", relationship_id="extension"
             )
         ])
     mock_case.name = None


### PR DESCRIPTION
## Product Description
Since index identifiers can be user defined it is necessary for the user to specify the identifier of the index to remove.
Typically index identifiers are either `parent` or `host` but if the app uses 'save-to-case' or an integration then the identifiers can be anything.

Updated docs:

> * Remove an index (optional):
>   * 'target_index_remove_case_id': The expected case ID of the parent / host case. Must match the existing index in order to successfully remove the index.
>   * 'target_index_remove_identifier': The identifier of the to remove. Usually 'parent' or 'host' but can be user defined if the index was created using 'save-to-case' or an integration.
>   * 'target_index_remove_relationship': (optional) The index relationship to remove. Either 'child' or 'extension'.
>     * This can be used to validate the index relationship before removal. An error will result if this field is provided but it does not match the relationship of the index.

## Technical Summary
Require that the intent case specifies the `target_index_remove_identifier` case property and use it to find the index for removal.

## Feature Flag
DATA REGISTRY

## Safety Assurance

### Safety story
Changes only impact the DR repeater

### Automated test coverage
Tests updated

### QA Plan
None

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
