### PR TITLE
Notify and count V1 case blocks

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/xml/parser.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/parser.py
@@ -6,7 +6,11 @@ import datetime
 
 from casexml.apps.case import const
 from casexml.apps.case.xml import DEFAULT_VERSION, V1, V2, NS_REVERSE_LOOKUP_MAP
+from dimagi.utils.logging import notify_error
 from dimagi.utils.parsing import string_to_utc_datetime
+
+from corehq.util.global_request import get_request_domain
+from corehq.util.metrics import metrics_counter
 
 XMLNS_ATTR = "@xmlns"
 KNOWN_PROPERTIES = {
@@ -31,6 +35,10 @@ def get_version(case_block):
                 "We don't know how to handle this version." % xmlns
             )
         return NS_REVERSE_LOOKUP_MAP[xmlns]
+    domain = get_request_domain()
+    tags = {"domain": domain} if domain else {}
+    metrics_counter("commcare.deprecated.v1caseblock", tags=tags)
+    notify_error("encountered deprecated V1 case block")
     return DEFAULT_VERSION
 
 


### PR DESCRIPTION
Follow-up for https://github.com/dimagi/commcare-hq/pull/30373#discussion_r705947578

Counting in addition to sending to Sentry because while Sentry collects a lot of details about the request, history not as limited for counters.

The app manager has not supported V1 case blocks [since 2016](https://github.com/dimagi/commcare-hq/pull/12915).

## Safety Assurance

### Safety story

Adding monitoring, nothing more.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
