### PR TITLE
add util for getting the start and end dates of a given month and year (with tests)

### DIFF
--- a/corehq/ex-submodules/dimagi/utils/dates.py
+++ b/corehq/ex-submodules/dimagi/utils/dates.py
@@ -481,12 +481,12 @@ def safe_strftime(val, fmt):
                              .replace("%y", str(val.year)[-2:]))
 
 
-def get_start_and_end_dates_of_month(month, year):
+def get_start_and_end_dates_of_month(year, month):
     """
     Returns two Dates that represent the first day and the last day of a given
     month and year.
-    :param month: integer value for month (1-12)
     :param year: integer value for year
+    :param month: integer value for month (1-12)
     :return: start_date, end_date (Dates)
     """
     date_start = datetime.date(year, month, 1)

--- a/corehq/ex-submodules/dimagi/utils/dates.py
+++ b/corehq/ex-submodules/dimagi/utils/dates.py
@@ -479,3 +479,16 @@ def safe_strftime(val, fmt):
     return safe_val.strftime(fmt
                              .replace("%Y", str(val.year))
                              .replace("%y", str(val.year)[-2:]))
+
+
+def get_start_and_end_dates_of_month(month, year):
+    """
+    Returns two Dates that represent the first day and the last day of a given
+    month and year.
+    :param month: integer value for month (1-12)
+    :param year: integer value for year
+    :return: start_date, end_date (Dates)
+    """
+    date_start = datetime.date(year, month, 1)
+    date_end = add_months_to_date(date_start, 1) - datetime.timedelta(days=1)
+    return date_start, date_end

--- a/corehq/ex-submodules/dimagi/utils/tests/dates.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/dates.py
@@ -2,7 +2,11 @@ import pickle
 from datetime import datetime, timedelta, date
 from six.moves.urllib.parse import urlencode
 import pytz
-from dimagi.utils.dates import DateSpan, add_months_to_date
+from dimagi.utils.dates import (
+    DateSpan,
+    add_months_to_date,
+    get_start_and_end_dates_of_month,
+)
 from django.test import SimpleTestCase
 from django.http import HttpRequest, QueryDict
 from dimagi.utils.decorators.datespan import datespan_in_request
@@ -179,3 +183,25 @@ class DateSpanPickleTest(SimpleTestCase):
             ),
 
         )
+
+
+class StartAndEndDatesOfMonthTest(SimpleTestCase):
+    def ensure_start_and_end_dates_are_correct_for_30_days(self):
+        date_start, date_end = get_start_and_end_dates_of_month(6, 2020)
+        self.assertEqual(date_start, date(2020, 6, 1))
+        self.assertEqual(date_end, date(2020, 6, 30))
+
+    def ensure_start_and_end_dates_are_correct_for_31_days(self):
+        date_start, date_end = get_start_and_end_dates_of_month(7, 2020)
+        self.assertEqual(date_start, date(2020, 7, 1))
+        self.assertEqual(date_end, date(2020, 7, 31))
+
+    def ensure_start_and_end_dates_are_correct_feb_leap_year(self):
+        date_start, date_end = get_start_and_end_dates_of_month(2, 2020)
+        self.assertEqual(date_start, date(2020, 2, 1))
+        self.assertEqual(date_end, date(2020, 2, 29))
+
+    def ensure_start_and_end_dates_are_correct_feb_no_leap_year(self):
+        date_start, date_end = get_start_and_end_dates_of_month(2, 2021)
+        self.assertEqual(date_start, date(2021, 2, 1))
+        self.assertEqual(date_end, date(2021, 2, 28))

--- a/corehq/ex-submodules/dimagi/utils/tests/dates.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/dates.py
@@ -187,21 +187,21 @@ class DateSpanPickleTest(SimpleTestCase):
 
 class StartAndEndDatesOfMonthTest(SimpleTestCase):
     def ensure_start_and_end_dates_are_correct_for_30_days(self):
-        date_start, date_end = get_start_and_end_dates_of_month(6, 2020)
+        date_start, date_end = get_start_and_end_dates_of_month(2020, 6)
         self.assertEqual(date_start, date(2020, 6, 1))
         self.assertEqual(date_end, date(2020, 6, 30))
 
     def ensure_start_and_end_dates_are_correct_for_31_days(self):
-        date_start, date_end = get_start_and_end_dates_of_month(7, 2020)
+        date_start, date_end = get_start_and_end_dates_of_month(2020, 7)
         self.assertEqual(date_start, date(2020, 7, 1))
         self.assertEqual(date_end, date(2020, 7, 31))
 
     def ensure_start_and_end_dates_are_correct_feb_leap_year(self):
-        date_start, date_end = get_start_and_end_dates_of_month(2, 2020)
+        date_start, date_end = get_start_and_end_dates_of_month(2020, 2)
         self.assertEqual(date_start, date(2020, 2, 1))
         self.assertEqual(date_end, date(2020, 2, 29))
 
     def ensure_start_and_end_dates_are_correct_feb_no_leap_year(self):
-        date_start, date_end = get_start_and_end_dates_of_month(2, 2021)
+        date_start, date_end = get_start_and_end_dates_of_month(2021, 2)
         self.assertEqual(date_start, date(2021, 2, 1))
         self.assertEqual(date_end, date(2021, 2, 28))


### PR DESCRIPTION
## Technical Summary
as the title says, adds a new date util for returning the `date_start` and `date_end` of a given `month` and `year` combo. Some pre-work for partner analytics tasks that I'm writing

## Safety Assurance

### Safety story
Super safe. Adds tests. No current usage in code (yet)

### Automated test coverage
Yes

### QA Plan
None needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
