### PR TITLE
[mini refactor] split up analytics utils into module

### DIFF
--- a/corehq/apps/analytics/management/commands/audit_user_in_hubspot.py
+++ b/corehq/apps/analytics/management/commands/audit_user_in_hubspot.py
@@ -1,6 +1,6 @@
 from django.core.management import BaseCommand
 
-from corehq.apps.analytics.utils import (
+from corehq.apps.analytics.utils.hubspot import (
     get_blocked_hubspot_domains,
     get_first_conversion_status_for_emails,
     ALLOWED_CONVERSIONS,

--- a/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
+++ b/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
@@ -4,7 +4,7 @@ import requests
 from django.conf import settings
 from django.core.management import BaseCommand
 
-from corehq.apps.analytics.utils import (
+from corehq.apps.analytics.utils.hubspot import (
     get_blocked_hubspot_domains,
     MAX_API_RETRIES,
     get_first_conversion_status_for_emails,

--- a/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
+++ b/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
@@ -1,12 +1,10 @@
 import math
-import requests
 
 from django.conf import settings
 from django.core.management import BaseCommand
 
 from corehq.apps.analytics.utils.hubspot import (
     get_blocked_hubspot_domains,
-    MAX_API_RETRIES,
     get_first_conversion_status_for_emails,
 )
 from corehq.apps.es import UserES

--- a/corehq/apps/analytics/management/commands/list_blocked_from_hubspot.py
+++ b/corehq/apps/analytics/management/commands/list_blocked_from_hubspot.py
@@ -1,6 +1,6 @@
 from django.core.management import BaseCommand
 
-from corehq.apps.analytics.utils import (
+from corehq.apps.analytics.utils.hubspot import (
     get_blocked_hubspot_domains,
     get_blocked_hubspot_accounts,
 )

--- a/corehq/apps/analytics/management/commands/manually_cleanup_blocked_hubspot_contacts.py
+++ b/corehq/apps/analytics/management/commands/manually_cleanup_blocked_hubspot_contacts.py
@@ -1,6 +1,6 @@
 from django.core.management import BaseCommand
 
-from corehq.apps.analytics.utils import (
+from corehq.apps.analytics.utils.hubspot import (
     remove_blocked_domain_contacts_from_hubspot,
     remove_blocked_domain_invited_users_from_hubspot,
 )

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -35,6 +35,8 @@ from corehq.apps.analytics.utils import (
     analytics_enabled_for_email,
     get_instance_string,
     get_meta,
+)
+from corehq.apps.analytics.utils.hubspot import (
     get_blocked_hubspot_domains,
     hubspot_enabled_for_user,
     hubspot_enabled_for_email,

--- a/corehq/apps/analytics/tests/test_hubspot.py
+++ b/corehq/apps/analytics/tests/test_hubspot.py
@@ -10,7 +10,7 @@ from corehq.apps.accounting.models import (
     Subscription,
 )
 from corehq.apps.accounting.tests import generator
-from corehq.apps.analytics.utils import (
+from corehq.apps.analytics.utils.hubspot import (
     get_blocked_hubspot_domains,
     get_blocked_hubspot_accounts,
     is_domain_blocked_from_hubspot,

--- a/corehq/apps/analytics/tests/test_utils.py
+++ b/corehq/apps/analytics/tests/test_utils.py
@@ -5,7 +5,7 @@ from corehq.apps.accounting.models import (
     DefaultProductPlan,
     SoftwarePlanEdition,
 )
-from corehq.apps.analytics.utils import is_hubspot_js_allowed_for_request
+from corehq.apps.analytics.utils.hubspot import is_hubspot_js_allowed_for_request
 from corehq.apps.domain.models import Domain
 from corehq.apps.accounting.tests import generator as accounting_generator
 

--- a/corehq/apps/analytics/utils/__init__.py
+++ b/corehq/apps/analytics/utils/__init__.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+
+
+def get_meta(request):
+    return {
+        'HTTP_X_FORWARDED_FOR': request.META.get('HTTP_X_FORWARDED_FOR'),
+        'REMOTE_ADDR': request.META.get('REMOTE_ADDR'),
+    }
+
+
+def analytics_enabled_for_email(email_address):
+    from corehq.apps.users.models import CouchUser
+    user = CouchUser.get_by_username(email_address)
+    return user.analytics_enabled if user else True
+
+
+def get_instance_string():
+    instance = settings.ANALYTICS_CONFIG.get('HQ_INSTANCE', '')
+    env = '' if instance == 'www' else instance + '_'
+    return env

--- a/corehq/apps/analytics/utils/hubspot.py
+++ b/corehq/apps/analytics/utils/hubspot.py
@@ -29,19 +29,6 @@ ALLOWED_CONVERSIONS = [
 ]
 
 
-def get_meta(request):
-    return {
-        'HTTP_X_FORWARDED_FOR': request.META.get('HTTP_X_FORWARDED_FOR'),
-        'REMOTE_ADDR': request.META.get('REMOTE_ADDR'),
-    }
-
-
-def analytics_enabled_for_email(email_address):
-    from corehq.apps.users.models import CouchUser
-    user = CouchUser.get_by_username(email_address)
-    return user.analytics_enabled if user else True
-
-
 def is_domain_blocked_from_hubspot(domain):
     return Subscription.visible_objects.filter(
         is_active=True,
@@ -121,10 +108,7 @@ def get_blocked_hubspot_accounts():
     ]
 
 
-def get_instance_string():
-    instance = settings.ANALYTICS_CONFIG.get('HQ_INSTANCE', '')
-    env = '' if instance == 'www' else instance + '_'
-    return env
+
 
 
 def _delete_hubspot_contact(vid, retry_num=0):

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -9,7 +9,7 @@ from ws4redis.context_processors import default
 from corehq import feature_previews, privileges, toggles
 from corehq.apps.accounting.models import BillingAccount, SubscriptionType
 from corehq.apps.accounting.utils import domain_has_privilege
-from corehq.apps.analytics.utils import is_hubspot_js_allowed_for_request
+from corehq.apps.analytics.utils.hubspot import is_hubspot_js_allowed_for_request
 from corehq.apps.hqwebapp.utils import get_environment_friendly_name
 
 COMMCARE = 'commcare'


### PR DESCRIPTION
## Technical Summary
Splitting up `corehq.apps.analytics.utils` into a module, as I'm going to be adding some utils in here for partner analytics.
Pre-work for a forthcoming PR :)

## Safety Assurance

### Safety story
Super safe. Simple rename/refactor. Tests would fail if I missed anything.

### Automated test coverage
Yes

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
