### PR TITLE
Add case list explorer and duplicate cases report exports to WAF allow

### DIFF
--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -3,6 +3,7 @@ import logging
 from django.conf.urls import include, url
 from django.core.exceptions import ImproperlyConfigured
 
+from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.reports.standard.forms.reports import ReprocessXFormErrorView
 from corehq.apps.reports.standard.tableau import TableauView
 from corehq.apps.userreports.reports.view import (
@@ -172,3 +173,8 @@ for module in get_installed_custom_modules():
         ]
     except ImproperlyConfigured:
         logging.info("Module %s does not provide urls" % module_name)
+
+
+# Exporting Case List Explorer reports with the word " on*" at the end of the search query
+# get filtered by the WAF
+waf_allow("XSS_BODY", hard_code_pattern=r'^/a/([\w\.:-]+)/reports/export/(case_list_explorer|duplicate_cases)/$')


### PR DESCRIPTION
## Technical Summary
<!-- For non-invisible changes, describe user-facing effects. -->
https://dimagi.slack.com/archives/C02QG63MU/p1642623995018900
https://dimagi-dev.atlassian.net/browse/SC-1888

When you try to export a Case List Explorer report with a search term where the last characters are ` on*`, the WAF filters out the request. 

I believe the alternative to this solution is to revamp how reports handles the export request by sending it a JSON payload instead of a url-encoded querystring... 


<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This doesn't actually do anything except allow me to run a management command to paste stuff elsewhere. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
