### PR TITLE
Retry repeat record creation

### DIFF
--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -45,14 +45,10 @@ def create_short_form_repeat_records(sender, xform, **kwargs):
 
 
 def create_repeat_records(repeater_cls, payload):
-    # Since this is called from a signal
-    # the object to be forwarded has already been saved to the db
-    # so we try _really_ hard to save a repeat record
-    # even if there's an error the first time.
-    # Unless there's a complete outage this should be enough.
-    # A somewhat more robust fix would be to queue this somewhere else on failure,
-    # but at the end of the day the only real fix would be
-    # to make this somehow transactional with the original object save
+    # As a temporary fix for https://dimagi-dev.atlassian.net/browse/SUPPORT-12244
+    # Make a serious attempt to retry creating the repeat record
+    # The real fix is to figure out why the form reprocessing system
+    # isn't resulting in the signal getting re-fired and the repeat record getting created.
     for sleep_length in [.5, 1, 2, 4, 8]:
         try:
             _create_repeat_records(repeater_cls, payload)

--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -49,7 +49,7 @@ def create_repeat_records(repeater_cls, payload):
     # Make a serious attempt to retry creating the repeat record
     # The real fix is to figure out why the form reprocessing system
     # isn't resulting in the signal getting re-fired and the repeat record getting created.
-    for sleep_length in [.5, 1, 2, 4, 8]:
+    for sleep_length in [.5, 1, 2, 4, 8] if not settings.UNIT_TESTING else [0, 0]:
         try:
             _create_repeat_records(repeater_cls, payload)
         except Exception:


### PR DESCRIPTION
## Product Description
Reduce the number of repeat records that fail to get created.

## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12931 / https://dimagi-dev.atlassian.net/browse/SUPPORT-12244

The real issue is that somehow the form reprocessing system isn't resulting in the repeat record getting created like it should. When a signal errors, we raise an error that should result in the `UnfinishedSubmissionStub` remaining in the db and getting processed by the form reprocessing queue, which refires the signals. Something in that process seems to be breaking down (occasionally?) and we haven't figured out where yet.

## Feature Flag
None

## Safety Assurance

### Safety story
Tests cover this path, so if tests pass, there should be no issues in the happy path. In the failure path, it's already just failing so if it fails there it's still as good as before.

### Automated test coverage



### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
