### PR TITLE
Make the first attempt of DataRegistryCaseUpdateRepeater happen synchronously

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -369,6 +369,12 @@ class Repeater(QuickCachedDocumentMixin, Document):
             'mode': 'sync' if fire_synchronously else 'async'
         })
         repeat_record.save()
+
+        if fire_synchronously:
+            # Prime the cache to prevent unnecessary lookup. Only do this for synchronous repeaters
+            # to prevent serializing the repeater in the celery task payload
+            RepeatRecord.repeater.fget.get_cache(repeat_record)[()] = self
+
         repeat_record.attempt_forward_now(fire_synchronously)
         return repeat_record
 

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -365,7 +365,8 @@ class Repeater(QuickCachedDocumentMixin, Document):
         )
         metrics_counter('commcare.repeaters.new_record', tags={
             'domain': self.domain,
-            'doc_type': self.doc_type
+            'doc_type': self.doc_type,
+            'mode': 'sync' if fire_synchronously else 'async'
         })
         repeat_record.save()
         repeat_record.attempt_forward_now(fire_synchronously)

--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -67,6 +67,9 @@ def create_location_repeat_records(sender, raw=False, **kwargs):
 
 @receiver(sql_case_post_save, sender=CommCareCaseSQL, dispatch_uid="fire_synchronous_repeaters")
 def fire_synchronous_case_repeaters(sender, case, **kwargs):
+    """These repeaters need to fire synchronously since the changes they make to cases
+    must reflect by the end of form submission processing
+    """
     create_repeat_records(DataRegistryCaseUpdateRepeater, case, fire_synchronously=True)
 
 

--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -30,7 +30,6 @@ def create_case_repeat_records(sender, case, **kwargs):
     create_repeat_records(CreateCaseRepeater, case)
     create_repeat_records(UpdateCaseRepeater, case)
     create_repeat_records(ReferCaseRepeater, case)
-    create_repeat_records(DataRegistryCaseUpdateRepeater, case)
     create_repeat_records(CaseExpressionRepeater, case)
 
 
@@ -40,7 +39,7 @@ def create_short_form_repeat_records(sender, xform, **kwargs):
         create_repeat_records(ShortFormRepeater, xform)
 
 
-def create_repeat_records(repeater_cls, payload):
+def create_repeat_records(repeater_cls, payload, fire_synchronously=False):
     repeater_name = repeater_cls.__module__ + '.' + repeater_cls.__name__
     if settings.REPEATERS_WHITELIST is not None and repeater_name not in settings.REPEATERS_WHITELIST:
         return
@@ -49,7 +48,7 @@ def create_repeat_records(repeater_cls, payload):
     if domain_can_forward(domain):
         repeaters = repeater_cls.by_domain(domain, stale_query=True)
         for repeater in repeaters:
-            repeater.register(payload)
+            repeater.register(payload, fire_synchronously=fire_synchronously)
 
 
 @receiver(commcare_user_post_save, dispatch_uid="create_user_repeat_records")
@@ -64,6 +63,11 @@ def create_location_repeat_records(sender, raw=False, **kwargs):
     if raw:
         return
     create_repeat_records(LocationRepeater, kwargs['instance'])
+
+
+@receiver(sql_case_post_save, sender=CommCareCaseSQL, dispatch_uid="fire_synchronous_repeaters")
+def fire_synchronous_case_repeaters(sender, case, **kwargs):
+    create_repeat_records(DataRegistryCaseUpdateRepeater, case, fire_synchronously=True)
 
 
 successful_form_received.connect(create_form_repeat_records)

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
@@ -125,6 +125,9 @@ class DataRegistryCaseUpdateRepeaterTest(TestCase, TestXmlMixin, DomainSubscript
         url = self.repeater.get_url(repeat_records[0])
         self.assertEqual(url, f"case-repeater-url/{self.target_domain}/")
 
+        # check that the synchronous attempt of the repeat record happened
+        self.assertEqual(1, len(repeat_records[0].attempts))
+
     @classmethod
     def repeat_records(cls, domain_name):
         # Enqueued repeat records have next_check set 48 hours in the future.


### PR DESCRIPTION
## Product Description
This changes the `DataRegistryCaseUpdateRepeater` so that the first attempt is made synchronously during form submission. If the first attempt fails, subsequent attempts will happen via the repeat record queue.

This change is necessary to support the USH app workflows which are using the repeater to make updates to cases in other domains. The current workflow is as follows:

1. Select potential duplicate cases
2. Complete deduplication identification form
   - This makes some updates to the cases that are required by the next form
3. Use end of form navigation to redirect the user to the next form
   - This could be one of three forms depending on the cases selected in step 1
4. Complete the final form to resolve the duplicate cases

The case changes from step 2 need to be 'live' on the cases by the time step 3 happens. The only way to guarantee this is to ensure that the changes happen during the form submission process.

Jira: 
* https://dimagi-dev.atlassian.net/browse/SUPPORT-12244
* https://dimagi-dev.atlassian.net/browse/USH-1522

## Technical Summary
Create a new signal handler for 'synchronous' repeaters which will attempt to forward the record immediately instead of via a celery task.

## Feature Flag
Currently this only applies to the data registry case update forwarder: DATA_REGISTRY_CASE_UPDATE_REPEATER

## Safety Assurance

### Safety story
This does have the potential to impact form submission processing but only for domains with the FF active. In the case of USH the deduplication workflow is not one of the highly used workflows so I do not expect that the additional processing should significantly impact the web workers.

### Automated test coverage
Repeater tests are updated to test the synchronous repeater.

### QA Plan
I will put this on staging for testing by the USH team


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
