### PR TITLE
Handle repeater url that cannot be resolved

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -153,7 +153,8 @@ from .repeater_generators import (
     DataRegistryCaseUpdatePayloadGenerator,
 )
 from ..repeater_helpers import RepeaterResponse
-from ...util.urlvalidate.urlvalidate import PossibleSSRFAttempt
+from corehq.util.urlvalidate.urlvalidate import PossibleSSRFAttempt
+from corehq.util.urlvalidate.ip_resolver import CannotResolveHost
 
 
 def log_repeater_timeout_in_datadog(domain):
@@ -529,9 +530,9 @@ class Repeater(QuickCachedDocumentMixin, Document):
             return self.handle_response(RequestConnectionError(error), repeat_record)
         except RequestException as err:
             return self.handle_response(err, repeat_record)
-        except PossibleSSRFAttempt:
+        except (PossibleSSRFAttempt, CannotResolveHost):
             return self.handle_response(Exception("Invalid URL"), repeat_record)
-        except Exception as e:
+        except Exception:
             # This shouldn't ever happen in normal operation and would mean code broke
             # we want to notify ourselves of the error detail and tell the user something vague
             notify_exception(None, "Unexpected error sending repeat record request")


### PR DESCRIPTION
## Technical Summary
This addresses this [sentry error](https://sentry.io/organizations/dimagi/issues/2843027030/events/056c8033591d4cb59475e31ae01a8ab1/?environment=production&project=136860&query=is%3Aunresolved).  If a repeater URL cannot be resolved, this is an expected/normal error, so this attempts to handle it, rather than create new sentry errors. In this case, the URL in question was _jrvupi96xk.execute-api.us-east-2.amazonaws.com_, which likely just means that a previously valid AWS domain was decommissioned, and thus can no longer be resolved.

## Safety Assurance

### Safety story
Because this was basically just a one-line change, shifting words around, I just made sure that the app still launched correctly.

### Automated test coverage

No tests

### QA Plan

No QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
