### PR TITLE
Enforce password policy

### DIFF
--- a/corehq/apps/domain/templates/login_and_password/password_reset_confirm.html
+++ b/corehq/apps/domain/templates/login_and_password/password_reset_confirm.html
@@ -36,7 +36,8 @@
           </div>
         {% endfor %}
         <div class="form-bubble-actions">
-          <button type="submit" class="btn btn-lg btn-primary" data-bind="enable: passwordSufficient">
+          <button type="submit" class="btn btn-lg btn-primary"
+                  data-bind="enable: passwordSufficient, click: submitCheck">
             {% trans "Reset Password" %}
           </button>
         </div>

--- a/corehq/apps/domain/templates/login_and_password/password_reset_confirm.html
+++ b/corehq/apps/domain/templates/login_and_password/password_reset_confirm.html
@@ -35,14 +35,12 @@
             </div>
           </div>
         {% endfor %}
+        <div class="form-bubble-actions">
+          <button type="submit" class="btn btn-lg btn-primary" data-bind="enable: passwordSufficient">
+            {% trans "Reset Password" %}
+          </button>
+        </div>
       </fieldset>
-
-      <div class="form-bubble-actions">
-        <button type="submit" class="btn btn-lg btn-primary">
-          {% trans "Reset Password" %}
-        </button>
-      </div>
-
     </form>
   {% else %}
 

--- a/corehq/apps/registration/static/registration/js/password.js
+++ b/corehq/apps/registration/static/registration/js/password.js
@@ -33,14 +33,14 @@ hqDefine('registration/js/password', [
             if (suggestionClick < 1) {
                 self.isSuggestedPassword(true);
             }
-        }
+        };
         self.password.subscribe(function () {
             self.isSuggestedPassword(false);
         });
         self.color = ko.computed(function () {
             if (self.strength() < 1) {
                 return "text-error text-danger";
-            } else if (self.strength() == 1 || self.isSuggestedPassword()) {
+            } else if (self.strength() === 1 || self.isSuggestedPassword()) {
                 return "text-warning";
             } else {
                 return "text-success";
@@ -68,7 +68,7 @@ hqDefine('registration/js/password', [
             if (self.passwordSufficient()) {
                 return true;
             }
-        }
+        };
         return self;
     };
 

--- a/corehq/apps/registration/static/registration/js/password.js
+++ b/corehq/apps/registration/static/registration/js/password.js
@@ -23,7 +23,7 @@ hqDefine('registration/js/password', [
             return 0;
         });
         var suggestionClick = 0;
-        $(document).ready(function() {
+        $(document).ready(function () {
             $("#help_text").trigger('click');
             suggestionClick += 1;
         });
@@ -64,6 +64,11 @@ hqDefine('registration/js/password', [
         self.passwordSufficient = ko.computed(function () {
             return self.strength() > 1;
         });
+        self.submitCheck = function (formElement) {
+            if (self.passwordSufficient()) {
+                return true;
+            }
+        }
         return self;
     };
 

--- a/corehq/apps/registration/static/registration/js/password.js
+++ b/corehq/apps/registration/static/registration/js/password.js
@@ -22,10 +22,25 @@ hqDefine('registration/js/password', [
             }
             return 0;
         });
+        var suggestionClick = 0;
+        $(document).ready(function() {
+            $("#help_text").trigger('click');
+            suggestionClick += 1;
+        });
+
+        self.isSuggestedPassword = ko.observable(false);
+        self.firstSuggestion = function () {
+            if (suggestionClick < 1) {
+                self.isSuggestedPassword(true);
+            }
+        }
+        self.password.subscribe(function () {
+            self.isSuggestedPassword(false);
+        });
         self.color = ko.computed(function () {
             if (self.strength() < 1) {
                 return "text-error text-danger";
-            } else if (self.strength() == 1) {
+            } else if (self.strength() == 1 || self.isSuggestedPassword()) {
                 return "text-warning";
             } else {
                 return "text-success";
@@ -34,6 +49,10 @@ hqDefine('registration/js/password', [
         self.passwordHelp = ko.computed(function () {
             if (!self.password()) {
                 return '';
+            } else if (self.strength() > 1 && self.isSuggestedPassword()) {
+                return gettext("<i class='fa fa-warning'></i>" +
+                    "This password is automatically generated. " +
+                    "Please copy it or create your own. It will not be shown again.");
             } else if (self.strength() < 1) {
                 return gettext("Your password is too weak! Try adding numbers or symbols!");
             } else if (self.strength() === 1) {

--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -55,7 +55,7 @@ class HQPasswordChangeForm(PasswordChangeForm):
                         _('Change Password'),
                         css_class='btn-primary',
                         type='submit',
-                        data_bind="enable: passwordSufficient()"
+                        data_bind="enable: passwordSufficient(), click: submitCheck"
                     )
                 ),
                 css_class='check-password',

--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -50,15 +50,16 @@ class HQPasswordChangeForm(PasswordChangeForm):
                     data_bind="value: password, valueUpdate: 'input'",
                 ),
                 'new_password2',
+                hqcrispy.FormActions(
+                    twbscrispy.StrictButton(
+                        _('Change Password'),
+                        css_class='btn-primary',
+                        type='submit',
+                        data_bind="enable: passwordSufficient()"
+                    )
+                ),
                 css_class='check-password',
-            ),
-            hqcrispy.FormActions(
-                twbscrispy.StrictButton(
-                    _('Change Password'),
-                    css_class='btn-primary',
-                    type='submit',
-                )
-            ),
+            )
         )
 
     def save(self, commit=True):

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -437,7 +437,6 @@ class SetUserPasswordForm(SetPasswordForm):
             self.fields['new_password1'].widget = forms.TextInput()
             self.fields['new_password1'].help_text = format_html_lazy(
                 '<span id="help_text" data-bind="html: passwordHelp, css: color, click: firstSuggestion">')
-
             initial_password = generate_strong_password()
 
         self.helper = FormHelper()
@@ -448,6 +447,19 @@ class SetUserPasswordForm(SetPasswordForm):
         self.helper.label_class = 'col-sm-3 col-md-2'
         self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
         self.helper.form_action = reverse("change_password", args=[project.name, user_id])
+        if self.project.strong_mobile_passwords:
+            submitButton = hqcrispy.FormActions(
+                crispy.ButtonHolder(
+                    Submit('submit', _('Reset Password'),
+                           data_bind="enable: passwordSufficient(), click: submitCheck")
+                )
+            )
+        else:
+            submitButton = hqcrispy.FormActions(
+                crispy.ButtonHolder(
+                    Submit('submit', _('Reset Password'))
+                )
+            )
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
                 _("Reset Password for Mobile Worker"),
@@ -460,11 +472,7 @@ class SetUserPasswordForm(SetPasswordForm):
                     'new_password2',
                     value=initial_password,
                 ),
-                hqcrispy.FormActions(
-                    crispy.ButtonHolder(
-                        Submit('submit', _('Reset Password'))
-                    )
-                ),
+                submitButton,
                 css_class="check-password",
             ),
         )

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -426,7 +426,6 @@ class SetUserPasswordForm(SetPasswordForm):
     new_password1 = forms.CharField(
         label=ugettext_noop("New password"),
         widget=forms.PasswordInput(),
-        help_text='<span data-bind="text: passwordHelp, css: color">',
     )
 
     def __init__(self, project, user_id, **kwargs):
@@ -437,11 +436,8 @@ class SetUserPasswordForm(SetPasswordForm):
         if self.project.strong_mobile_passwords:
             self.fields['new_password1'].widget = forms.TextInput()
             self.fields['new_password1'].help_text = format_html_lazy(
-                ('<i class="fa fa-warning"></i>{}<br />'
-                    '<span data-bind="text: passwordHelp, css: color">'),
-                ugettext_lazy(
-                    "This password is automatically generated. "
-                    "Please copy it or create your own. It will not be shown again."))
+                '<span id="help_text" data-bind="html: passwordHelp, css: color, click: firstSuggestion">')
+
             initial_password = generate_strong_password()
 
         self.helper = FormHelper()
@@ -466,9 +462,7 @@ class SetUserPasswordForm(SetPasswordForm):
                 ),
                 hqcrispy.FormActions(
                     crispy.ButtonHolder(
-                        Submit('submit',
-                               _('Reset Password'),
-                               data_bind="enable: passwordSufficient()")
+                        Submit('submit', _('Reset Password'))
                     )
                 ),
                 css_class="check-password",

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -426,6 +426,7 @@ class SetUserPasswordForm(SetPasswordForm):
     new_password1 = forms.CharField(
         label=ugettext_noop("New password"),
         widget=forms.PasswordInput(),
+        help_text='<span data-bind="text: passwordHelp, css: color">',
     )
 
     def __init__(self, project, user_id, **kwargs):
@@ -465,7 +466,9 @@ class SetUserPasswordForm(SetPasswordForm):
                 ),
                 hqcrispy.FormActions(
                     crispy.ButtonHolder(
-                        Submit('submit', _('Reset Password'))
+                        Submit('submit',
+                               _('Reset Password'),
+                               data_bind="enable: passwordSufficient()")
                     )
                 ),
                 css_class="check-password",


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Wherever a user can manually reset a password now disables the 'Submit' button (or equivalent) until the input password is strong enough. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket
](https://dimagi-dev.atlassian.net/browse/SAAS-12805)

This change was applied to 3 places: 

- 'Change My Password' in Account Settings: The `Change Password` button is now grayed out until a strong enough password is given. Even when re-enabled through inspect element, it will now do nothing when clicked/submitted.  
- Reset Password via the 'Forgot Password' page: Functions the same as above. 
- 'Reset Password for Mobile Worker' in 'Mobile Workers' under 'Users': When advanced privacy settings are on, this form will function like the two others above. A small UI change was also made where the help text that informs the user they've been given a suggested password (which it does automatically does when the form first loads) is replaced by password strength indicator text when you delete the suggested password from the 'New Password' input bar. (Previously it never went away)

Other places that already block weak passwords (disables buttons and/or gives an error if you submit anyway) that didn't need work (just listed here for completeness). 
- New web user sign up page
- New web user sign up through invitation

With advanced privacy settings turned on
- Create Mobile Worker modal
- Bulk mobile workers upload

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested locally and on staging. 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
