### PR TITLE
Ignore missing scheduled reports in queue

### DIFF
--- a/corehq/apps/saved_reports/exceptions.py
+++ b/corehq/apps/saved_reports/exceptions.py
@@ -12,3 +12,7 @@ class UnsupportedScheduledReportError(Exception):
     For unknown (discontinued/legacy) scheduled-reports
     """
     pass
+
+
+class ReportNotFound(Exception):
+    pass

--- a/corehq/apps/saved_reports/tests/test_tasks.py
+++ b/corehq/apps/saved_reports/tests/test_tasks.py
@@ -2,8 +2,8 @@ from unittest.mock import patch
 from django.test import SimpleTestCase, TestCase
 from freezegun import freeze_time
 import datetime
-from couchdbkit import ResourceNotFound
 
+from ..exceptions import ReportNotFound
 from ..models import ScheduledReportLog
 from ..tasks import purge_old_scheduled_report_logs, queue_scheduled_reports
 from .. import tasks
@@ -47,7 +47,7 @@ class QueueScheduledReportsTests(SimpleTestCase):
     @patch.object(tasks, 'create_records_for_scheduled_reports')
     def test_resource_not_found_does_not_stop_sending(self, mock_get_ids, mock_send):
         mock_get_ids.return_value = ['a', 'b', 'c']  # Expect to send these 3 reports
-        mock_send.side_effect = ResourceNotFound  # ...and have all of them throw ResourceNotFound
+        mock_send.side_effect = ReportNotFound  # ...and have all of them throw ReportNotFound
 
         queue_scheduled_reports()
 

--- a/corehq/apps/saved_reports/tests/test_tasks.py
+++ b/corehq/apps/saved_reports/tests/test_tasks.py
@@ -1,9 +1,12 @@
-from django.test import TestCase
+from unittest.mock import patch
+from django.test import SimpleTestCase, TestCase
 from freezegun import freeze_time
 import datetime
+from couchdbkit import ResourceNotFound
 
 from ..models import ScheduledReportLog
-from ..tasks import purge_old_scheduled_report_logs
+from ..tasks import purge_old_scheduled_report_logs, queue_scheduled_reports
+from .. import tasks
 
 
 CURRENT_DATE = datetime.date(2020, 1, 2)
@@ -37,3 +40,18 @@ class PurgeOldScheduledReportLogsTests(TestCase):
             size=10,
             timestamp=date
         )
+
+
+class QueueScheduledReportsTests(SimpleTestCase):
+    @patch.object(tasks, 'send_delayed_report')
+    @patch.object(tasks, 'create_records_for_scheduled_reports')
+    def test_resource_not_found_does_not_stop_sending(self, mock_get_ids, mock_send):
+        mock_get_ids.return_value = ['a', 'b', 'c']  # Expect to send these 3 reports
+        mock_send.side_effect = ResourceNotFound  # ...and have all of them throw ResourceNotFound
+
+        queue_scheduled_reports()
+
+        # Verify that the 3 expected reports were attempted
+        ARG_INDEX = 0
+        calls = set(call[ARG_INDEX][0] for call in mock_send.call_args_list)
+        self.assertSetEqual(calls, {'a', 'b', 'c'})


### PR DESCRIPTION
## Technical Summary
Fixes this [sentry error](https://sentry.io/organizations/dimagi/issues/2406217376/events/1c300651a90f453db22adca424da1331/?environment=production&project=136860&query=is%3Aunresolved+%21message%3A%22Cloudcare%22&statsPeriod=14d). I'm guessing on rare occasions, we generate a list of reports to email out, but by the time it comes to actually spawn the tasks, the report has been deleted.  This fix just makes sure that that situation no longer throws an exception.

## Safety Assurance

### Safety story


### Automated test coverage

New test created in _test_tasks.py_.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
