### PR TITLE
Catch Atom feed XML syntax errors

### DIFF
--- a/corehq/motech/openmrs/exceptions.py
+++ b/corehq/motech/openmrs/exceptions.py
@@ -19,6 +19,10 @@ class OpenmrsFeedDoesNotExist(OpenmrsException):
     pass
 
 
+class OpenmrsFeedSyntaxError(OpenmrsException):
+    pass
+
+
 class OpenmrsHtmlUiChanged(OpenmrsException):
     """
     OpenMRS HTML UI is no longer what we expect.

--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -321,25 +321,18 @@ def poll_openmrs_atom_feeds(domain_name):
     for repeater in OpenmrsRepeater.by_domain(domain_name):
         errors = []
         if repeater.atom_feed_enabled and not repeater.paused:
-            try:
-                patient_uuids = get_feed_updates(repeater, ATOM_FEED_NAME_PATIENT)
-                for patient_uuid in patient_uuids:
-                    try:
-                        update_patient(repeater, patient_uuid)
-                    except (ConfigurationError, OpenmrsException) as err:
-                        errors.append(str(err))
-            except OpenmrsException as err:
-                errors.append(str(err))
-
-            try:
-                encounter_uuids = get_feed_updates(repeater, ATOM_FEED_NAME_ENCOUNTER)
-                for encounter_uuid in encounter_uuids:
-                    try:
-                        import_encounter(repeater, encounter_uuid)
-                    except (ConfigurationError, OpenmrsException) as err:
-                        errors.append(str(err))
-            except OpenmrsException as err:
-                errors.append(str(err))
+            patient_uuids = get_feed_updates(repeater, ATOM_FEED_NAME_PATIENT)
+            encounter_uuids = get_feed_updates(repeater, ATOM_FEED_NAME_ENCOUNTER)
+            for patient_uuid in patient_uuids:
+                try:
+                    update_patient(repeater, patient_uuid)
+                except (ConfigurationError, OpenmrsException) as err:
+                    errors.append(str(err))
+            for encounter_uuid in encounter_uuids:
+                try:
+                    import_encounter(repeater, encounter_uuid)
+                except (ConfigurationError, OpenmrsException) as err:
+                    errors.append(str(err))
 
         if errors:
             repeater.requests.notify_error(


### PR DESCRIPTION
## Technical Summary

Adds error handling for bad XML from an OpenMRS Atom feed.

Context: [Sentry](https://sentry.io/organizations/dimagi/issues/1218041676/?%5B%E2%80%A6%5Dery=is%3Aunresolved+%21message%3A%22Cloudcare%22&environment=production&project=136860&statsPeriod=14d)

An OpenMRS server has started returning invalid XML in its Atom feed. This change is to handle that more gracefully. (I will be following up with the Delivery team to address the root cause.)

fyi @mjriley 

## Feature Flag
"OpenMRS Integration"

## Safety Assurance

### Safety story

* This code is used by a small number of projects.
* This change is to handle a bug that appears to only be happening in a _test_ project space. It seems unlikely that any other projects will encounter this.

### Automated test coverage

Change includes tests.

### QA Plan

No QA required.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
