### PR TITLE
remove legacy search params

### DIFF
--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -23,14 +23,11 @@ CONFIG_KEYS_MAPPING = {
     CASE_SEARCH_REGISTRY_ID_KEY: "data_registry",
     CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY: "custom_related_case_property"
 }
-LEGACY_CONFIG_KEYS = {
-    CASE_SEARCH_REGISTRY_ID_KEY: "commcare_registry"
-}
 UNSEARCHABLE_KEYS = (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
     'owner_id',
     'include_closed',   # backwards compatibility for deprecated functionality to include closed cases
-) + tuple(CONFIG_KEYS_MAPPING.values()) + tuple(LEGACY_CONFIG_KEYS.values())
+) + tuple(CONFIG_KEYS_MAPPING.values())
 
 
 def _flatten_singleton_list(value):
@@ -64,17 +61,8 @@ class CaseSearchRequestConfig:
 def extract_search_request_config(request_dict):
     params = dict(request_dict.lists())
 
-    def _get_value(key):
-        val = None
-        try:
-            val = params.pop(key)
-        except KeyError:
-            if key in LEGACY_CONFIG_KEYS:
-                val = params.pop(LEGACY_CONFIG_KEYS[key], None)
-        return val
-
     kwargs_from_params = {
-        config_name: _get_value(param_name)
+        config_name: params.pop(param_name, None)
         for param_name, config_name in CONFIG_KEYS_MAPPING.items()
     }
     return CaseSearchRequestConfig(criteria=params, **kwargs_from_params)

--- a/corehq/apps/case_search/tests/test_models.py
+++ b/corehq/apps/case_search/tests/test_models.py
@@ -70,14 +70,6 @@ def test_extract_criteria_config(self, case_type, data_registry, custom_related_
         ))
 
 
-def test_extract_criteria_config_legacy():
-    config = extract_search_request_config(_make_request_dict({
-        CASE_SEARCH_CASE_TYPE_KEY: "type",
-        "commcare_registry": "reg1",
-    }))
-    eq(config, CaseSearchRequestConfig(criteria={}, case_types=["type"], data_registry="reg1"))
-
-
 def _make_request_dict(params):
     """All values must be a list to match what we get from Django during a request.
     """

--- a/corehq/apps/ota/tests/test_registry_case_details.py
+++ b/corehq/apps/ota/tests/test_registry_case_details.py
@@ -124,16 +124,6 @@ class RegistryCaseDetailsTests(TestCase):
         expected_cases = {case.case_id: case for case in self.cases}
         self.assertEqual(set(actual_cases), set(expected_cases))
 
-    def test_get_case_details_post_request_legacy_param(self):
-        response_content = self._make_request({
-            "commcare_registry": self.registry.slug,
-            "case_id": self.parent_case_id,
-            "case_type": "parent",
-        }, 200, method="post")
-        actual_cases = self._get_cases_in_response(response_content)
-        expected_cases = {case.case_id: case for case in self.cases}
-        self.assertEqual(set(actual_cases), set(expected_cases))
-
 
     def test_get_case_details_missing_case(self):
         self._make_request({

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -418,9 +418,6 @@ def registry_case(request, domain, app_id):
     case_ids = request_dict.getlist("case_id")
     case_types = request_dict.getlist("case_type")
     registry = request_dict.get(CASE_SEARCH_REGISTRY_ID_KEY)
-    if not registry:
-        # legacy name
-        registry = request_dict.get("commcare_registry")
 
     missing = [
         name


### PR DESCRIPTION
## Technical Summary
Removes support for the 'commcare_registry' case search parameter. This was renamed to `x_commcare_data_registry` in https://github.com/dimagi/commcare-hq/pull/30838.

Since the rename happened before any apps were using the feature in production there is no need for a lengthy deprecation time.

## Feature Flag
DATA_REGISTRY

## Safety Assurance

### Safety story
All live apps use the new param name.

### Automated test coverage
Updated

### QA Plan
None


### Migrations
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
