### PR TITLE
rename CommCareCaseSQL to CommCareCase

### DIFF
--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -92,7 +92,7 @@ def create_location_repeat_records(sender, raw=False, **kwargs):
     create_repeat_records(LocationRepeater, kwargs['instance'])
 
 
-@receiver(sql_case_post_save, sender=CommCareCaseSQL, dispatch_uid="fire_synchronous_repeaters")
+@receiver(sql_case_post_save, sender=CommCareCase, dispatch_uid="fire_synchronous_repeaters")
 def fire_synchronous_case_repeaters(sender, case, **kwargs):
     """These repeaters need to fire synchronously since the changes they make to cases
     must reflect by the end of form submission processing


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
While deploying to Prod we figure out out that there was one reference of `CommcareCaseSQL` was left in the code. The PR replaces it with `CommcareCase`
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Looked out for more references of that in master and did not find any and tested on local and was working fine.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
