### PR TITLE
deduplicate cases in 'registry_case' results

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -1,4 +1,3 @@
-import itertools
 import os
 from datetime import datetime
 from distutils.version import LooseVersion
@@ -456,10 +455,7 @@ def registry_case(request, domain, app_id):
         if case.type not in case_types:
             return HttpResponseNotFound(f"Case '{case.case_id}' not found")
 
-    all_cases = list(itertools.chain.from_iterable(
-        helper.get_case_hierarchy(request.couch_user, case)
-        for case in cases
-    ))
+    all_cases = helper.get_multi_domain_case_hierarchy(request.couch_user, cases)
     for case in all_cases:
         case.case_json[COMMCARE_PROJECT] = case.domain
     return HttpResponse(CaseDBFixture(all_cases).fixture, content_type="text/xml; charset=utf-8")

--- a/corehq/apps/registry/helper.py
+++ b/corehq/apps/registry/helper.py
@@ -1,3 +1,6 @@
+import itertools
+from operator import attrgetter
+
 from corehq.apps.registry.exceptions import RegistryNotFound, RegistryAccessException
 from corehq.apps.registry.models import DataRegistry
 from corehq.apps.registry.utils import RegistryPermissionCheck
@@ -59,20 +62,32 @@ class DataRegistryHelper:
         })
         return case
 
-    def get_case_hierarchy(self, couch_user, case):
+    def get_multi_domain_case_hierarchy(self, couch_user, cases):
+        """Get the combined case hierarchy for a list of cases that spans multiple domains"""
+        all_cases = list(itertools.chain.from_iterable(
+            self.get_case_hierarchy(domain, couch_user, list(domain_cases))
+            for domain, domain_cases in itertools.groupby(cases, key=attrgetter("domain"))
+        ))
+        return all_cases
+
+    def get_case_hierarchy(self, domain, couch_user, cases):
+        """Get the combined case hierarchy for the input cases"""
         from casexml.apps.phone.data_providers.case.livequery import (
             get_live_case_ids_and_indices, PrefetchIndexCaseAccessor
         )
+        domains = {case.domain for case in cases}
+        assert domains == {domain}, "All cases must belong to the same domain"
 
-        self.check_data_access(couch_user, [case.type], case.domain)
+        self.check_data_access(couch_user, [case.type for case in cases], domain)
+
+        case_ids = {case.case_id for case in cases}
 
         # using livequery to get related cases matches the semantics of case claim
-        case_ids, indices = get_live_case_ids_and_indices(case.domain, [case.case_id], TimingContext())
-        accessor = PrefetchIndexCaseAccessor(CaseAccessors(case.domain), indices)
-        case_ids.remove(case.case_id)
-        cases = accessor.get_cases(list(case_ids))
+        all_case_ids, indices = get_live_case_ids_and_indices(domain, case_ids, TimingContext())
+        new_case_ids = list(all_case_ids - case_ids)
+        new_cases = PrefetchIndexCaseAccessor(CaseAccessors(domain), indices).get_cases(new_case_ids)
 
-        return [case] + cases
+        return cases + new_cases
 
     def check_data_access(self, couch_user, case_types, case_domain=None):
         """Perform all checks for data access.
@@ -86,7 +101,7 @@ class DataRegistryHelper:
 
     def _check_user_has_access(self, couch_user, case_domain=None):
         if case_domain and self.current_domain == case_domain:
-            # always allow to access data in the current domain
+            # always allow access data in the current domain
             return
 
         checker = RegistryPermissionCheck(self.current_domain, couch_user)


### PR DESCRIPTION
## Product Description
Prevent duplicate cases from being returned in the `registry_case` results

## Technical Summary
If there is an overlap in the case hierarchies for the cases requested by the view then duplicates can appear in the results. 

To prevent this the code has been updated to generate the hierarchy for all requested cases at once instead of generating each case hierarchy individually and then combining them.

Jira: https://dimagi-dev.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/issue/SUPPORT-12400

## Feature Flag
DATA_REGISTRY

## Safety Assurance

### Safety story
Only impacts the FF and no production usages yet.

### Automated test coverage
Unit tests added to existing suite.

### QA Plan
Will be QA'd by USH delivery team

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
