### PR TITLE
Register renamed models for celery tasks

### DIFF
--- a/corehq/form_processor/app_config.py
+++ b/corehq/form_processor/app_config.py
@@ -43,7 +43,16 @@ class FormProcessorAppConfig(AppConfig):
 
     def register_renamed_model(self, new_name, old_name):
         registry_name = old_name.lower()
+        assert registry_name not in self.models, (registry_name, self.models)
         model = self.get_model(new_name)
-        models = self.apps.all_models[self.label]
-        assert registry_name not in models, (registry_name, models)
-        models[registry_name] = model
+        self.models[registry_name] = model
+        assert self.apps.all_models[self.label][registry_name] is model, \
+            (self.apps.all_models[self.label][registry_name], model)
+
+    def get_models(self, *args, **kw):
+        seen = set()
+        for model in super().get_models(*args, **kw):
+            if model in seen:
+                continue
+            seen.add(model)
+            yield model

--- a/corehq/form_processor/app_config.py
+++ b/corehq/form_processor/app_config.py
@@ -31,3 +31,19 @@ class FormProcessorAppConfig(AppConfig):
         LedgerTransaction = self.get_model('LedgerTransaction')
         register_adapter(LedgerValue, ledger_value_adapter)
         register_adapter(LedgerTransaction, ledger_transaction_adapter)
+
+        for name in [
+            "XFormInstance",
+            "XFormOperation",
+            "CommCareCase",
+            "CommCareCaseIndex",
+            "CaseAttachment",
+        ]:
+            self.register_renamed_model(name, name + "SQL")
+
+    def register_renamed_model(self, new_name, old_name):
+        registry_name = old_name.lower()
+        model = self.get_model(new_name)
+        models = self.apps.all_models[self.label]
+        assert registry_name not in models, (registry_name, models)
+        models[registry_name] = model


### PR DESCRIPTION
Pickled model classes will be loaded using the old model name if the pickle was created before the model was renamed.

https://dimagi-dev.atlassian.net/browse/SAAS-12959

## Safety Assurance

### Safety story

Tested locally in shell.

```py
In [1]: from django.apps.registry import apps

In [2]: config = apps.get_app_config("form_processor")

In [3]: config.get_model("CommCareCaseSQL", require_ready=True)
Out[3]: corehq.form_processor.models.CommCareCase
```

### Automated test coverage

Not yet. This is a high priority fix.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
