### PR TITLE
Increased sync window for USH nightly restore priming

### DIFF
--- a/custom/covid/tasks.py
+++ b/custom/covid/tasks.py
@@ -20,8 +20,8 @@ from django.conf import settings
 
 RATE_LIMIT = getattr(settings, 'USH_PRIME_RESTORE_RATE_LIMIT', 100)
 
-# Include users that have synced in the last 48 hours
-SYNC_WINDOW_HOURS = 48
+# Include users that have synced in the last 72 hours
+SYNC_WINDOW_HOURS = 72
 
 # Exclude users that have synced in the last 8 hours
 SYNC_CUTOFF_HOURS = 8


### PR DESCRIPTION
## Technical Summary
Came out of conversation on https://dimagi-dev.atlassian.net/browse/USH-1494

As discussed in #ush-devs. Increase this window so we don't miss people on Mondays who haven't synced since Friday.

## Safety Assurance

### Safety story
Parameter change to custom code. Priming only takes about an hour. This shouldn't add significant load.

### Automated test coverage

None

### QA Plan

None

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
