### PR TITLE
Handling OpenMRS Atom Feed 500 errors

### DIFF
--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -42,7 +42,7 @@ from corehq.motech.openmrs.const import (
 from corehq.motech.openmrs.exceptions import (
     DuplicateCaseMatch,
     OpenmrsException,
-    OpenmrsFeedDoesNotExist,
+    OpenmrsFeedRuntimeException,
     OpenmrsFeedSyntaxError,
 )
 from corehq.motech.openmrs.openmrs_config import (
@@ -68,15 +68,16 @@ class CaseAttrs(NamedTuple):
     owner_id: str
 
 
-def get_feed_xml(requests, feed_name, page):
+def get_feed_xml(requests, feed_name, page: str):
     assert feed_name in ATOM_FEED_NAMES
     feed_url = f'/ws/atomfeed/{feed_name}/{page}'
     resp = requests.get(feed_url)
+
     if resp.status_code == 500:
         if 'AtomFeedRuntimeException: feed does not exist' in resp.text:
-            exception = OpenmrsFeedDoesNotExist(
+            exception = OpenmrsFeedRuntimeException(
                 f'Domain "{requests.domain_name}": Page does not exist in Atom '
-                f'feed "{resp.url}". Resetting atom feed status.'
+                f'feed "{resp.url}". Resetting Atom feed status.'
             )
             requests.notify_exception(
                 str(exception),
@@ -87,6 +88,33 @@ def get_feed_xml(requests, feed_name, page):
                   "patients that can no longer be found.")
             )
             raise exception
+        if ('AtomFeedRuntimeException: feedId must not be null and must be '
+                'greater than 0') in resp.text:
+            exception = OpenmrsFeedRuntimeException(
+                f'Domain "{requests.domain_name}": Page "{page}" is not valid '
+                f'in Atom feed "{resp.url}". Resetting Atom feed status.'
+            )
+            requests.notify_exception(
+                str(exception),
+                _('It is unclear how Atom feed pagination can lead to page '
+                  '"{}". Follow up with OpenMRS system '
+                  'administrator.').format(page)
+            )
+            raise exception
+
+        # Use OpenmrsException instead of OpenmrsFeedRuntimeException so
+        # that we don't reset the Atom feed if we don't know what the
+        # problem is.
+        exception = OpenmrsException(
+            f'Domain "{requests.domain_name}": Unrecognized error in Atom '
+            f'feed "{resp.url}".'
+        )
+        requests.notify_exception(
+            str(exception),
+            _('Response text: \n{}').format(resp.text)
+        )
+        raise exception
+
     try:
         root = etree.fromstring(resp.content)
     except etree.XMLSyntaxError as err:
@@ -218,15 +246,15 @@ def get_feed_updates(repeater, feed_name):
                     href = this_page[0].get('href')
                     page = href.split('/')[-1]
                 break
-    except (OpenmrsFeedSyntaxError, RequestException, HTTPError):
-        # Don't update repeater if OpenMRS is offline, or XML cannot be
-        # parsed.
-        return
-    except OpenmrsFeedDoesNotExist:
+    except OpenmrsFeedRuntimeException:
         # Reset feed status so that polling will start at the beginning
         # of the feed.
         repeater.atom_feed_status[feed_name] = AtomFeedStatus()
         repeater.save()
+    except (OpenmrsException, RequestException, HTTPError):
+        # Don't update repeater if OpenMRS is offline, or XML cannot be
+        # parsed.
+        return
     else:
         repeater.atom_feed_status[feed_name] = AtomFeedStatus(
             last_polled_at=datetime.utcnow(),

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -69,11 +69,6 @@ class CaseAttrs(NamedTuple):
 
 
 def get_feed_xml(requests, feed_name, page):
-    if not page:
-        # If this is the first time the patient feed is polled, just get
-        # the most recent changes. This shows updating patients
-        # successfully, but does not replay all OpenMRS changes.
-        page = 'recent'
     assert feed_name in ATOM_FEED_NAMES
     feed_url = '/'.join(('/ws/atomfeed', feed_name, page))
     resp = requests.get(feed_url)

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -70,25 +70,23 @@ class CaseAttrs(NamedTuple):
 
 def get_feed_xml(requests, feed_name, page):
     assert feed_name in ATOM_FEED_NAMES
-    feed_url = '/'.join(('/ws/atomfeed', feed_name, page))
+    feed_url = f'/ws/atomfeed/{feed_name}/{page}'
     resp = requests.get(feed_url)
-    if (
-        resp.status_code == 500
-        and 'AtomFeedRuntimeException: feed does not exist' in resp.text
-    ):
-        exception = OpenmrsFeedDoesNotExist(
-            f'Domain "{requests.domain_name}": Page does not exist in atom '
-            f'feed "{resp.url}". Resetting atom feed status.'
-        )
-        requests.notify_exception(
-            str(exception),
-            _("This can happen if the IP address of a Repeater is changed to "
-              "point to a different server, or if a server has been rebuilt. "
-              "It can signal more severe consequences, like attempts to "
-              "synchronize CommCare cases with OpenMRS patients that can no "
-              "longer be found.")
-        )
-        raise exception
+    if resp.status_code == 500:
+        if 'AtomFeedRuntimeException: feed does not exist' in resp.text:
+            exception = OpenmrsFeedDoesNotExist(
+                f'Domain "{requests.domain_name}": Page does not exist in Atom '
+                f'feed "{resp.url}". Resetting atom feed status.'
+            )
+            requests.notify_exception(
+                str(exception),
+                _("This can happen if the IP address of a Repeater is changed "
+                  "to point to a different server, or if a server has been "
+                  "rebuilt. It can signal more severe consequences, like "
+                  "attempts to synchronize CommCare cases with OpenMRS "
+                  "patients that can no longer be found.")
+            )
+            raise exception
     try:
         root = etree.fromstring(resp.content)
     except etree.XMLSyntaxError as err:

--- a/corehq/motech/openmrs/exceptions.py
+++ b/corehq/motech/openmrs/exceptions.py
@@ -15,7 +15,7 @@ class OpenmrsConfigurationError(OpenmrsException):
     pass
 
 
-class OpenmrsFeedDoesNotExist(OpenmrsException):
+class OpenmrsFeedRuntimeException(OpenmrsException):
     pass
 
 

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -61,7 +61,10 @@ from corehq.toggles import OPENMRS_INTEGRATION
 
 class AtomFeedStatus(DocumentSchema):
     last_polled_at = DateTimeProperty(default=None)
-    last_page = StringProperty(default=None)
+
+    # The first time the feed is polled, don't replay all the changes
+    # since OpenMRS was installed. Start from the most recent changes.
+    last_page = StringProperty(default='recent')
 
 
 class OpenmrsRepeater(CaseRepeater):

--- a/corehq/motech/openmrs/tests/test_atom_feed.py
+++ b/corehq/motech/openmrs/tests/test_atom_feed.py
@@ -11,7 +11,7 @@ from django.test import SimpleTestCase, TestCase
 import attr
 from dateutil.tz import tzoffset, tzutc
 from lxml import etree
-from nose.tools import assert_raises
+from nose.tools import assert_equal, assert_is_none, assert_raises
 
 import corehq.motech.openmrs.atom_feed
 from corehq.motech.openmrs.atom_feed import (
@@ -28,7 +28,7 @@ from corehq.motech.openmrs.atom_feed import (
 )
 from corehq.motech.openmrs.const import ATOM_FEED_NAME_PATIENT
 from corehq.motech.openmrs.exceptions import OpenmrsFeedSyntaxError
-from corehq.motech.openmrs.repeaters import OpenmrsRepeater
+from corehq.motech.openmrs.repeaters import AtomFeedStatus, OpenmrsRepeater
 from corehq.motech.requests import Requests
 from corehq.util.test_utils import TestFileMixin
 
@@ -491,6 +491,12 @@ def test_get_feed_updates():
 
         # Assert returns without raising
         get_feed_updates(repeater, ATOM_FEED_NAME_PATIENT)
+
+
+def test_status_defaults():
+    status = AtomFeedStatus()
+    assert_is_none(status.last_polled_at)
+    assert_equal(status.last_page, 'recent')
 
 
 def test_doctests():


### PR DESCRIPTION
## Technical Summary

Follows up from PR  #30991

The real problem is not an XML parsing issue. It is that HQ is requesting an invalid page number from the OpenMRS Atom feed. It is unclear how Atom feed pagination can lead to an invalid page number. (I am following up with the OpenMRS administrator.) 

Regardless, we do need to reset the pagination. This PR is to achieve that.

:blowfish: :fish: :tropical_fish: 

fyi @mjriley 

## Feature Flag
OpenMRS integration

## Safety Assurance

### Safety story

* Only affects a test project space

### Automated test coverage

Includes tests

### QA Plan

No QA required.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
