### PR TITLE
Remove redundant aggregation on username

### DIFF
--- a/corehq/apps/data_analytics/esaccessors.py
+++ b/corehq/apps/data_analytics/esaccessors.py
@@ -20,7 +20,6 @@ def get_app_submission_breakdown_es(domain_name, monthspan, user_ids=None):
         AggregationTerm('app_id', 'app_id'),
         AggregationTerm('device_id', 'form.meta.deviceID'),
         AggregationTerm('user_id', 'form.meta.userID'),
-        AggregationTerm('username', 'form.meta.username'),
     ]
     query = FormES(es_instance_alias=ES_EXPORT_INSTANCE).domain(domain_name).submitted(
         gte=monthspan.startdate,

--- a/corehq/apps/data_analytics/malt_generator.py
+++ b/corehq/apps/data_analytics/malt_generator.py
@@ -45,9 +45,8 @@ class MALTTableGenerator(object):
                 if not domain:
                     continue
 
-            logger.info("Building MALT for {}".format(domain.name))
-
             for monthspan in self.monthspan_list:
+                logger.info(f"Building MALT for {domain.name} for {monthspan}")
                 all_users = get_all_user_rows(domain.name, include_inactive=False, include_docs=True)
                 for users in chunked(all_users, 1000):
                     users_by_id = {user['id']: CouchUser.wrap_correctly(user['doc']) for user in users}

--- a/corehq/apps/data_analytics/malt_generator.py
+++ b/corehq/apps/data_analytics/malt_generator.py
@@ -32,21 +32,16 @@ def generate_malt(monthspans, domains=None):
     """
     Populates MALTRow SQL table with app submission data for a given list of months
     :param monthspans: list of DateSpan objects
-    :param domains: list of domain ids
+    :param domains: list of domain names
     """
-    domains = domains or Domain.get_all()
-    for domain in domains:
-        if isinstance(domain, str):
-            domain = Domain.get_by_name(domain)
-            if not domain:
-                continue
-
+    domain_names = domains or Domain.get_all_names()
+    for domain_name in domain_names:
         for monthspan in monthspans:
-            logger.info(f"Building MALT for {domain.name} for {monthspan}")
-            all_users = get_all_user_rows(domain.name, include_inactive=False, include_docs=True)
+            logger.info(f"Building MALT for {domain_name} for {monthspan}")
+            all_users = get_all_user_rows(domain_name, include_inactive=False, include_docs=True)
             for users in chunked(all_users, 1000):
                 users_by_id = {user['id']: CouchUser.wrap_correctly(user['doc']) for user in users}
-                malt_row_dicts = _get_malt_row_dicts(domain.name, monthspan, users_by_id)
+                malt_row_dicts = _get_malt_row_dicts(domain_name, monthspan, users_by_id)
                 if malt_row_dicts:
                     _save_malt_row_dicts_to_db(malt_row_dicts)
 

--- a/corehq/apps/data_analytics/malt_generator.py
+++ b/corehq/apps/data_analytics/malt_generator.py
@@ -97,13 +97,13 @@ def _get_malt_row_dicts(domain_name, monthspan, users_by_id):
     :param users_by_id: list of dictionaries [{user_id: user_obj}, ...]
     """
     malt_row_dicts = []
-    if get_last_form_submission_received(domain_name) < monthspan.startdate:
-        return malt_row_dicts
-    app_rows = get_app_submission_breakdown_es(domain_name, monthspan, list(users_by_id))
-    for app_row in app_rows:
-        user = users_by_id[app_row.user_id]
-        malt_row_dict = _build_malt_row_dict(app_row, domain_name, user, monthspan)
-        malt_row_dicts.append(malt_row_dict)
+    last_submission_date = get_last_form_submission_received(domain_name)
+    if last_submission_date and last_submission_date >= monthspan.startdate:
+        app_rows = get_app_submission_breakdown_es(domain_name, monthspan, list(users_by_id))
+        for app_row in app_rows:
+            user = users_by_id[app_row.user_id]
+            malt_row_dict = _build_malt_row_dict(app_row, domain_name, user, monthspan)
+            malt_row_dicts.append(malt_row_dict)
 
     return malt_row_dicts
 

--- a/corehq/apps/data_analytics/management/commands/update_malt_table.py
+++ b/corehq/apps/data_analytics/management/commands/update_malt_table.py
@@ -4,7 +4,7 @@ import dateutil
 
 from dimagi.utils.dates import DateSpan
 
-from corehq.apps.data_analytics.malt_generator import MALTTableGenerator
+from corehq.apps.data_analytics.malt_generator import generate_malt
 
 
 class Command(BaseCommand):
@@ -26,7 +26,6 @@ class Command(BaseCommand):
         for arg in month_years:
             month_year = dateutil.parser.parse(arg)
             datespan_list.append(DateSpan.from_month(month_year.month, month_year.year))
-        generator = MALTTableGenerator(datespan_list)
         print("Building Malt table... for time range {}".format(datespan_list))
-        generator.build_table()
+        generate_malt(datespan_list)
         print("Finished!")

--- a/corehq/apps/data_analytics/tasks.py
+++ b/corehq/apps/data_analytics/tasks.py
@@ -10,7 +10,7 @@ from dimagi.utils.chunked import chunked
 from dimagi.utils.dates import DateSpan
 
 from corehq.apps.data_analytics.gir_generator import GIRTableGenerator
-from corehq.apps.data_analytics.malt_generator import MALTTableGenerator
+from corehq.apps.data_analytics.malt_generator import generate_malt
 from corehq.apps.domain.models import Domain
 from corehq.util.log import send_HTML_email
 from corehq.util.soft_assert import soft_assert
@@ -71,7 +71,7 @@ def build_last_month_GIR():
 @task(queue='malt_generation_queue')
 def update_current_MALT_for_domains(month_dict, domains):
     month = DateSpan.from_month(month_dict['month'], month_dict['year'])
-    MALTTableGenerator([month]).build_table(domains=domains)
+    generate_malt([month], domains=domains)
 
 
 def send_MALT_complete_email(month_dict):

--- a/corehq/apps/data_analytics/tests/test_esaccessors.py
+++ b/corehq/apps/data_analytics/tests/test_esaccessors.py
@@ -32,24 +32,19 @@ class MaltAnalyticsTest(SimpleTestCase):
 
 @generate_cases([
     ([
-         # differentiate by username
-         ('app', 'device', 'userid', 'username0', 1),
-         ('app', 'device', 'userid', 'username1', 2),
-     ],),
-    ([
          # differentiate by userid
-         ('app', 'device', 'userid0', 'username', 1),
-         ('app', 'device', 'userid1', 'username', 2),
+         ('app', 'device', 'userid0', 1),
+         ('app', 'device', 'userid1', 2),
      ],),
     ([
          # differentiate by device
-         ('app', 'device0', 'userid', 'username', 1),
-         ('app', 'device1', 'userid', 'username', 2),
+         ('app', 'device0', 'userid', 1),
+         ('app', 'device1', 'userid', 2),
      ],),
     ([
          # differentiate by app
-         ('app0', 'device', 'userid', 'username', 1),
-         ('app1', 'device', 'userid', 'username', 2),
+         ('app0', 'device', 'userid', 1),
+         ('app1', 'device', 'userid', 2),
      ],),
 ], MaltAnalyticsTest)
 def test_app_submission_breakdown(self, combination_count_list):
@@ -59,9 +54,9 @@ def test_app_submission_breakdown(self, combination_count_list):
     domain = 'test-data-analytics'
     received = datetime(2016, 3, 24)
     month = DateSpan.from_month(3, 2016)
-    for app, device, userid, username, count in combination_count_list:
+    for app, device, userid, count in combination_count_list:
         for i in range(count):
-            save_to_es_analytics_db(domain, received, app, device, userid, username)
+            save_to_es_analytics_db(domain, received, app, device, userid, 'test-user')
 
     self.es.indices.refresh(XFORM_INDEX_INFO.index)
     data_back = get_app_submission_breakdown_es(domain, month)

--- a/corehq/apps/data_analytics/tests/test_esaccessors.py
+++ b/corehq/apps/data_analytics/tests/test_esaccessors.py
@@ -49,7 +49,7 @@ class MaltAnalyticsTest(SimpleTestCase):
 ], MaltAnalyticsTest)
 def test_app_submission_breakdown(self, combination_count_list):
     """
-    The breakdown of this report is (app, device, userid, username): count
+    The breakdown of this report is (app, device, userid): count
     """
     domain = 'test-data-analytics'
     received = datetime(2016, 3, 24)

--- a/corehq/apps/data_analytics/tests/test_malt_generator.py
+++ b/corehq/apps/data_analytics/tests/test_malt_generator.py
@@ -245,17 +245,31 @@ class TestGetMaltAppData(SimpleTestCase):
         self.assertEqual(actual_app_data, self.default_app_data)
 
     def test_returns_expected_app_data(self):
-        mock_app = Mock()
-        mock_app.amplifies_workers = True
-        mock_app.amplifies_project = False
-        mock_app.minimum_use_threshold = 1
-        mock_app.experienced_threshold = 10
-        mock_app.is_deleted.return_value = False
+        app = Application(
+            amplifies_workers='yes',
+            amplifies_project='no',
+            minimum_use_threshold='1',
+            experienced_threshold='10',
+        )
 
-        with patch('corehq.apps.data_analytics.malt_generator.get_app', return_value=mock_app):
+        with patch('corehq.apps.data_analytics.malt_generator.get_app', return_value=app):
             actual_app_data = _get_malt_app_data('domain', 'app_id')
 
-        self.assertEqual(actual_app_data, MaltAppData(True, False, 1, 10, False))
+        self.assertEqual(actual_app_data, MaltAppData('yes', 'no', '1', '10', False))
+
+    def test_returns_expected_app_data_if_deleted(self):
+        app = Application(
+            amplifies_workers='yes',
+            amplifies_project='no',
+            minimum_use_threshold='1',
+            experienced_threshold='10',
+        )
+        app.doc_type = 'Application-Deleted'
+
+        with patch('corehq.apps.data_analytics.malt_generator.get_app', return_value=app):
+            actual_app_data = _get_malt_app_data('domain', 'app_id')
+
+        self.assertEqual(actual_app_data, MaltAppData('yes', 'no', '1', '10', True))
 
 
 class TestBuildMaltRowDict(SimpleTestCase):

--- a/corehq/apps/data_analytics/tests/test_malt_generator.py
+++ b/corehq/apps/data_analytics/tests/test_malt_generator.py
@@ -384,7 +384,7 @@ class TestGetMaltRowDicts(SimpleTestCase):
         self.assertEqual(user1_malt_row_dict['num_of_forms'], 50)
         self.assertEqual(user2_malt_row_dict['num_of_forms'], 25)
 
-    def test_skips_if_no_submission_since_startdate(self):
+    def test_returns_empty_if_no_submission_since_startdate(self):
         self.monthspan = DateSpan.from_month(3, 2020)
         self.mock_get_last_form_submission.return_value = datetime.datetime(2020, 2, 25, 0, 0)
 
@@ -392,13 +392,21 @@ class TestGetMaltRowDicts(SimpleTestCase):
 
         self.assertFalse(malt_row_dicts)
 
-    def test_runs_if_last_submission_on_startdate(self):
+    def test_returns_results_if_last_submission_on_startdate(self):
         self.monthspan = DateSpan.from_month(3, 2020)
         self.mock_get_last_form_submission.return_value = datetime.datetime(2020, 3, 1, 0, 0)
 
         malt_row_dicts = _get_malt_row_dicts(self.domain, self.monthspan, self.users_by_id)
 
         self.assertTrue(malt_row_dicts)
+
+    def test_returns_empty_if_last_submission_returns_none(self):
+        self.monthspan = DateSpan.from_month(3, 2020)
+        self.mock_get_last_form_submission.return_value = None
+
+        malt_row_dicts = _get_malt_row_dicts(self.domain, self.monthspan, self.users_by_id)
+
+        self.assertFalse(malt_row_dicts)
 
 
 def create_malt_app_data(wam=AMPLIFIES_NOT_SET,

--- a/corehq/apps/data_analytics/tests/test_malt_generator.py
+++ b/corehq/apps/data_analytics/tests/test_malt_generator.py
@@ -7,11 +7,22 @@ from django.test import SimpleTestCase, TestCase
 from dimagi.utils.dates import DateSpan
 from pillowtop.es_utils import initialize_index_and_mapping
 
-from corehq.apps.app_manager.const import AMPLIFIES_YES, AMPLIFIES_NOT_SET, AMPLIFIES_NO
+from corehq.apps.app_manager.const import (
+    AMPLIFIES_NO,
+    AMPLIFIES_NOT_SET,
+    AMPLIFIES_YES,
+)
 from corehq.apps.app_manager.models import Application
 from corehq.apps.data_analytics.const import NOT_SET, YES
-from corehq.apps.data_analytics.malt_generator import MALTTableGenerator, _get_malt_app_data, MaltAppData, \
-    DEFAULT_MINIMUM_USE_THRESHOLD, DEFAULT_EXPERIENCED_THRESHOLD, _build_malt_row_dict, _get_malt_row_dicts
+from corehq.apps.data_analytics.malt_generator import (
+    DEFAULT_EXPERIENCED_THRESHOLD,
+    DEFAULT_MINIMUM_USE_THRESHOLD,
+    MaltAppData,
+    MALTTableGenerator,
+    _build_malt_row_dict,
+    _get_malt_app_data,
+    _get_malt_row_dicts,
+)
 from corehq.apps.data_analytics.models import MALTRow
 from corehq.apps.data_analytics.tests.utils import save_to_es_analytics_db
 from corehq.apps.domain.models import Domain

--- a/corehq/apps/data_analytics/tests/test_malt_generator.py
+++ b/corehq/apps/data_analytics/tests/test_malt_generator.py
@@ -52,7 +52,7 @@ class MaltGeneratorTest(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(MaltGeneratorTest, cls).setUpClass()
+        super().setUpClass()
         cls.es = get_es_new()
         ensure_index_deleted(XFORM_INDEX_INFO.index)
         initialize_index_and_mapping(cls.es, XFORM_INDEX_INFO)
@@ -67,7 +67,7 @@ class MaltGeneratorTest(TestCase):
         cls.domain.delete()
         MALTRow.objects.all().delete()
         ensure_index_deleted(XFORM_INDEX_INFO.index)
-        super(MaltGeneratorTest, cls).tearDownClass()
+        super().tearDownClass()
 
     @classmethod
     def _setup_domain_user(cls):
@@ -225,7 +225,7 @@ class TestGetMaltAppData(SimpleTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestGetMaltAppData, cls).setUpClass()
+        super().setUpClass()
         cls.default_app_data = MaltAppData(
             AMPLIFIES_NOT_SET,
             AMPLIFIES_NOT_SET,
@@ -276,7 +276,7 @@ class TestBuildMaltRowDict(SimpleTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestBuildMaltRowDict, cls).setUpClass()
+        super().setUpClass()
         cls.domain = 'domain'
         cls.monthspan = DateSpan.from_month(1, 2022)
         cls.app_row = create_mock_app_row_for_malt_tests()
@@ -352,7 +352,7 @@ class TestGetMaltRowDicts(SimpleTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestGetMaltRowDicts, cls).setUpClass()
+        super().setUpClass()
         cls.domain = 'domain'
         cls.monthspan = DateSpan.from_month(1, 2022)
         cls.mock_user1 = create_mock_user_for_malt_tests('user_id_1', 'user1')

--- a/corehq/apps/data_analytics/tests/test_malt_generator.py
+++ b/corehq/apps/data_analytics/tests/test_malt_generator.py
@@ -17,8 +17,8 @@ from corehq.apps.data_analytics.const import NOT_SET, YES
 from corehq.apps.data_analytics.malt_generator import (
     DEFAULT_EXPERIENCED_THRESHOLD,
     DEFAULT_MINIMUM_USE_THRESHOLD,
+    generate_malt,
     MaltAppData,
-    MALTTableGenerator,
     _build_malt_row_dict,
     _get_malt_app_data,
     _get_malt_row_dicts,
@@ -123,8 +123,7 @@ class MaltGeneratorTest(TestCase):
 
     @classmethod
     def run_malt_generation(cls):
-        generator = MALTTableGenerator([cls.malt_month])
-        generator.build_table()
+        generate_malt([cls.malt_month])
 
     def _assert_malt_row_exists(self, query_filters):
         rows = MALTRow.objects.filter(username=self.USERNAME, **query_filters)

--- a/corehq/apps/data_analytics/tests/test_malt_generator.py
+++ b/corehq/apps/data_analytics/tests/test_malt_generator.py
@@ -288,10 +288,12 @@ class TestBuildMaltRowDict(SimpleTestCase):
         )
 
     def test_returns_expected_value_for_month(self):
-        with patch('corehq.apps.data_analytics.malt_generator._get_malt_app_data', return_value=self.app_data):
-            actual_malt_row_dict = _build_malt_row_dict(self.app_row, self.domain, self.user, self.monthspan)
+        monthspan = DateSpan.from_month(3, 2020)
 
-        self.assertEqual(actual_malt_row_dict['month'], datetime.datetime(2022, 1, 1, 0, 0))
+        with patch('corehq.apps.data_analytics.malt_generator._get_malt_app_data', return_value=self.app_data):
+            actual_malt_row_dict = _build_malt_row_dict(self.app_row, self.domain, self.user, monthspan)
+
+        self.assertEqual(actual_malt_row_dict['month'], datetime.datetime(2020, 3, 1, 0, 0))
 
     def test_app_id_set_to_missing_if_none(self):
         custom_app_row = create_mock_app_row_for_malt_tests()

--- a/corehq/apps/data_analytics/tests/test_malt_generator.py
+++ b/corehq/apps/data_analytics/tests/test_malt_generator.py
@@ -222,13 +222,10 @@ class TestBuildMaltRowDict(SimpleTestCase):
         self.user = create_user_for_malt_tests(is_web_user=True)
         self.app_data = create_malt_app_data()
 
-        self.patcher = patch('corehq.apps.data_analytics.malt_generator._get_malt_app_data')
-        self.mock_get_malt_app_data = self.patcher.start()
+        app_data_patcher = patch('corehq.apps.data_analytics.malt_generator._get_malt_app_data')
+        self.mock_get_malt_app_data = app_data_patcher.start()
         self.mock_get_malt_app_data.return_value = self.app_data
-
-    def tearDown(self):
-        self.patcher.stop()
-        super().tearDown()
+        self.addCleanup(app_data_patcher.stop)
 
     def test_returns_expected_value_for_month(self):
         monthspan = DateSpan.from_month(3, 2020)
@@ -295,26 +292,23 @@ class TestGetMaltRowDicts(SimpleTestCase):
         self.app_data = create_malt_app_data()
         self.users_by_id = {'user_id_1': self.web_user, 'user_id_2': self.mobile_user}
 
-        self.patcher = patch('corehq.apps.data_analytics.malt_generator._get_malt_app_data')
-        self.mock_get_malt_app_data = self.patcher.start()
+        app_data_patcher = patch('corehq.apps.data_analytics.malt_generator._get_malt_app_data')
+        self.mock_get_malt_app_data = app_data_patcher.start()
         self.mock_get_malt_app_data.return_value = self.app_data
+        self.addCleanup(app_data_patcher.stop)
 
-        self.patcher2 = patch('corehq.apps.data_analytics.malt_generator.get_last_form_submission_received')
-        self.mock_get_last_form_submission = self.patcher2.start()
+        last_form_patcher = patch('corehq.apps.data_analytics.malt_generator.get_last_form_submission_received')
+        self.mock_get_last_form_submission = last_form_patcher.start()
         self.mock_get_last_form_submission.return_value = datetime.datetime(2022, 1, 10, 0, 0)
+        self.addCleanup(last_form_patcher.stop)
 
-        self.patcher3 = patch('corehq.apps.data_analytics.malt_generator.get_app_submission_breakdown_es')
-        self.mock_app_submission_breakdown = self.patcher3.start()
+        breakdown_es_patcher = patch('corehq.apps.data_analytics.malt_generator.get_app_submission_breakdown_es')
+        self.mock_app_submission_breakdown = breakdown_es_patcher.start()
         self.mock_app_submission_breakdown.return_value = [
             create_mock_nested_query_row(user_id='user_id_1'),
             create_mock_nested_query_row(user_id='user_id_2'),
         ]
-
-    def tearDown(self):
-        self.patcher.stop()
-        self.patcher2.stop()
-        self.patcher3.stop()
-        super().tearDown()
+        self.addCleanup(breakdown_es_patcher.stop)
 
     def test_num_of_forms(self):
         self.mock_app_submission_breakdown.return_value = [

--- a/corehq/apps/data_analytics/tests/test_malt_generator.py
+++ b/corehq/apps/data_analytics/tests/test_malt_generator.py
@@ -271,7 +271,7 @@ class TestBuildMaltRowDict(SimpleTestCase):
         super().setUp()
         self.domain = 'domain'
         self.monthspan = DateSpan.from_month(1, 2022)
-        self.app_row = create_mock_app_row_for_malt_tests()
+        self.app_row = create_mock_nested_query_row()
         self.user = create_user_for_malt_tests(is_web_user=True)
         self.app_data = create_malt_app_data()
 
@@ -291,10 +291,9 @@ class TestBuildMaltRowDict(SimpleTestCase):
         self.assertEqual(actual_malt_row_dict['month'], datetime.datetime(2020, 3, 1, 0, 0))
 
     def test_app_id_set_to_missing_if_none(self):
-        custom_app_row = create_mock_app_row_for_malt_tests()
-        custom_app_row.app_id = None
+        self.app_row.app_id = None
 
-        actual_malt_row_dict = _build_malt_row_dict(custom_app_row, self.domain, self.user, self.monthspan)
+        actual_malt_row_dict = _build_malt_row_dict(self.app_row, self.domain, self.user, self.monthspan)
 
         self.assertEqual(actual_malt_row_dict['app_id'], '_MISSING_APP_ID')
 
@@ -360,8 +359,8 @@ class TestGetMaltRowDicts(SimpleTestCase):
         users_by_id = {'user_id_1': self.web_user, 'user_id_2': self.mobile_user}
         with patch('corehq.apps.data_analytics.malt_generator.get_app_submission_breakdown_es') as mock_esquery:
             mock_esquery.return_value = [
-                create_mock_nested_query_row('user_id_1', doc_count=50),
-                create_mock_nested_query_row('user_id_2', doc_count=25),
+                create_mock_nested_query_row(user_id='user_id_1', doc_count=50),
+                create_mock_nested_query_row(user_id='user_id_2', doc_count=25),
             ]
             malt_row_dicts = _get_malt_row_dicts(self.domain, self.monthspan, users_by_id)
 
@@ -387,15 +386,8 @@ def create_user_for_malt_tests(is_web_user=True, user_id='user_id', username='us
     return user
 
 
-def create_mock_app_row_for_malt_tests(app_id='app_id', device_id='device_id', doc_count=10):
-    mock_app_row = Mock()
-    mock_app_row.app_id = app_id
-    mock_app_row.device_id = device_id
-    mock_app_row.doc_count = doc_count
-    return mock_app_row
-
-
-def create_mock_nested_query_row(user_id, app_id='abc123', device_id='web', doc_count=10):
+def create_mock_nested_query_row(user_id='user_id', app_id='abc123', device_id='web', doc_count=10):
+    # NestedQueryRow is the ElasticSearch class this is mocking
     mock_nested_query_row = Mock()
     mock_nested_query_row.app_id = app_id
     mock_nested_query_row.device_id = device_id

--- a/corehq/apps/data_analytics/tests/test_malt_generator.py
+++ b/corehq/apps/data_analytics/tests/test_malt_generator.py
@@ -223,10 +223,9 @@ class TestUpdateOrCreateMaltRow(TestCase):
 @disable_quickcache
 class TestGetMaltAppData(SimpleTestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.default_app_data = MaltAppData(
+    def setUp(self) -> None:
+        super().setUp()
+        self.default_app_data = MaltAppData(
             AMPLIFIES_NOT_SET,
             AMPLIFIES_NOT_SET,
             DEFAULT_MINIMUM_USE_THRESHOLD,
@@ -274,14 +273,13 @@ class TestGetMaltAppData(SimpleTestCase):
 
 class TestBuildMaltRowDict(SimpleTestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.domain = 'domain'
-        cls.monthspan = DateSpan.from_month(1, 2022)
-        cls.app_row = create_mock_app_row_for_malt_tests()
-        cls.user = create_mock_user_for_malt_tests()
-        cls.app_data = MaltAppData(
+    def setUp(self):
+        super().setUp()
+        self.domain = 'domain'
+        self.monthspan = DateSpan.from_month(1, 2022)
+        self.app_row = create_mock_app_row_for_malt_tests()
+        self.user = create_mock_user_for_malt_tests()
+        self.app_data = MaltAppData(
             AMPLIFIES_NOT_SET,
             AMPLIFIES_NOT_SET,
             DEFAULT_MINIMUM_USE_THRESHOLD,
@@ -350,14 +348,13 @@ class TestBuildMaltRowDict(SimpleTestCase):
 
 class TestGetMaltRowDicts(SimpleTestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.domain = 'domain'
-        cls.monthspan = DateSpan.from_month(1, 2022)
-        cls.mock_user1 = create_mock_user_for_malt_tests('user_id_1', 'user1')
-        cls.mock_user2 = create_mock_user_for_malt_tests('user_id_2', 'user2')
-        cls.app_data = MaltAppData(
+    def setUp(self) -> None:
+        super().setUp()
+        self.domain = 'domain'
+        self.monthspan = DateSpan.from_month(1, 2022)
+        self.mock_user1 = create_mock_user_for_malt_tests('user_id_1', 'user1')
+        self.mock_user2 = create_mock_user_for_malt_tests('user_id_2', 'user2')
+        self.app_data = MaltAppData(
             AMPLIFIES_NOT_SET,
             AMPLIFIES_NOT_SET,
             DEFAULT_MINIMUM_USE_THRESHOLD,

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -25,7 +25,6 @@ from corehq.util.quickcache import quickcache
 # SYSTEM_USER_ID is used when submitting xml to make system-generated case updates
 SYSTEM_USER_ID = 'system'
 DEMO_USER_ID = 'demo_user'
-JAVA_ADMIN_USERNAME = 'admin'
 WEIRD_USER_IDS = [
     'commtrack-system',    # internal HQ/commtrack system forms
     DEMO_USER_ID,           # demo mode


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12878

The `get_app_submission_breakdown_es` query takes too long. Seeing as aggregating on both user_id and username _should_ be redundant, I removed the username aggregation. We can still grab the username from the couch user and set it on the `MALTRow` object to not disrupt the MALT. I tested this in a shell and saw solid timing improvements, though this would still qualify as a slow query and is subject to change based on current load on ES. 

I removed the `_user_data` logic because after doing some investigation, I saw that:
- the most recent user_type of "AdminUser" was from November 2016
- the most recent user_type of "DemoUser" was from August 2017
- the most recent user_type of "UnknownUser" was also from August 2017

The only two user_types found in the MALT since September 2017 are "CommCareUser" and "WebUser" which come from the user doc_type field. Just in case, I added a `notify_exception` if we run into a situation where the user_id fetched is not part of the list of user_ids specified.

More concerning than removing those special user types, and the focus of this PR, is removing the username aggregation and potential risks involved with that. I sampled a random date (June 1st, 2021), and of the 99,226 records for that date, there wasn't a single case where the user fetched with the user_id had a different username than the username saved on the MALTRow. Even if we factor in that there is a possibility of deleting mobile workers and recycled usernames, that is still a reason to aggregate only on user_id and not username. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Malt generation is currently turned off on production, so this wouldn't have any immediate impacts.

Ideally, I'd initially create a limited release to do timing comparisons on production size domains.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Updated tests for the `get_app_submission_breakdown_es` query.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
