### PR TITLE
Updated web apps combobox fuzzy search logic

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -640,8 +640,8 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         } else if (matchType === Const.COMBOBOX_FUZZY) {
             var isFuzzyMatch = function (haystack, query, distanceThreshold) {
                 return (
-                    (window.Levenshtein.get(haystack, query) <= distanceThreshold && query.length > 3) ||
-                    haystack === query
+                    haystack === query ||
+                    (query.length > 3 && window.Levenshtein.get(haystack, query) <= distanceThreshold)
                 );
             };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -643,7 +643,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
                     (window.Levenshtein.get(haystack, query) <= distanceThreshold && query.length > 3) ||
                     haystack === query
                 );
-            }
+            };
 
             // First handle prefixes, which will fail fuzzy match if they're too short
             var distanceThreshold = 2;

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -625,24 +625,45 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         query = query.toLowerCase();
         var haystack = option.text.toLowerCase();
 
-        var match;
+        var match,
+            wordsInQuery = query.split(/\s+/),
+            wordsInChoice = haystack.split(/\s+/);
         if (matchType === Const.COMBOBOX_MULTIWORD) {
             // Multiword filter, matches any choice that contains all of the words in the query
             //
             // Assumption is both query and choice will not be very long. Runtime is O(nm)
             // where n is number of words in the query, and m is number of words in the choice
-            var wordsInQuery = query.split(' ');
-            var wordsInChoice = haystack.split(' ');
 
             match = _.all(wordsInQuery, function (word) {
                 return _.include(wordsInChoice, word);
             });
         } else if (matchType === Const.COMBOBOX_FUZZY) {
+            function isFuzzyMatch(haystack, query, distanceThreshold) {
+                return (
+                    (window.Levenshtein.get(haystack, query) <= distanceThreshold && query.length > 3) ||
+                    haystack === query
+                );
+            }
+
+            // First handle prefixes, which will fail fuzzy match if they're too short
+            var distanceThreshold = 2;
+            if (haystack.length > query.length + distanceThreshold) {
+                haystack = haystack.substring(0, query.length + distanceThreshold);
+            }
+
             // Fuzzy filter, matches if query is "close" to answer
-            match = (
-                (window.Levenshtein.get(haystack, query) <= 2 && query.length > 3) ||
-                haystack === query
-            );
+            match = isFuzzyMatch(haystack, query, distanceThreshold);
+
+            // For multiword strings, return true if any word in the query fuzzy matches any word in the target
+            if (!match) {
+                if (wordsInChoice.length > 1 || wordsInQuery.length > 1) {
+                    _.each(wordsInChoice, function (choiceWord) {
+                        _.each(wordsInQuery, function (queryWord) {
+                            match = match || isFuzzyMatch(choiceWord, queryWord, distanceThreshold);
+                        });
+                    });
+                }
+            }
         }
 
         // If we've already matched, return true

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -638,7 +638,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
                 return _.include(wordsInChoice, word);
             });
         } else if (matchType === Const.COMBOBOX_FUZZY) {
-            function isFuzzyMatch(haystack, query, distanceThreshold) {
+            var isFuzzyMatch = function (haystack, query, distanceThreshold) {
                 return (
                     (window.Levenshtein.get(haystack, query) <= distanceThreshold && query.length > 3) ||
                     haystack === query

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
@@ -179,9 +179,15 @@ describe('Entries', function () {
             Controls.ComboboxEntry.filter('onet', { text: 'onetwo', id: 1 }, Const.COMBOBOX_FUZZY)
         );
         assert.isTrue(
-            Controls.ComboboxEntry.filter('OneT', { text: 'onetwo', id: 1 }, Const.COMBOBOX_FUZZY)
+            Controls.ComboboxEntry.filter('onet', { text: 'onetwothree', id: 1 }, Const.COMBOBOX_FUZZY)
         );
         assert.isFalse(
+            Controls.ComboboxEntry.filter('onwt', { text: 'onetwo', id: 1 }, Const.COMBOBOX_FUZZY)
+        );
+        assert.isTrue(
+            Controls.ComboboxEntry.filter('OneT', { text: 'onetwo', id: 1 }, Const.COMBOBOX_FUZZY)
+        );
+        assert.isTrue(
             Controls.ComboboxEntry.filter('one tt', { text: 'one', id: 1 }, Const.COMBOBOX_FUZZY)
         );
         assert.isTrue(
@@ -189,6 +195,15 @@ describe('Entries', function () {
         );
         assert.isTrue(
             Controls.ComboboxEntry.filter('on', { text: 'on', id: 1 }, Const.COMBOBOX_FUZZY)
+        );
+        assert.isTrue(
+            Controls.ComboboxEntry.filter('three', { text: 'one two three', id: 1 }, Const.COMBOBOX_FUZZY)
+        );
+        assert.isTrue(
+            Controls.ComboboxEntry.filter('tree', { text: 'one two three', id: 1 }, Const.COMBOBOX_FUZZY)
+        );
+        assert.isFalse(
+            Controls.ComboboxEntry.filter('thirty', { text: 'one two three', id: 1 }, Const.COMBOBOX_FUZZY)
         );
     });
 


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-11497

I started looking at this after hearing a report that fuzzy search in web apps was broken. It ended up being a difference between the web and mobile algorithms. This PR basically makes the web apps algorithm more "forgiving", more often matching when dealing with multi-word strings, using logic more similar to mobile's. I don't think web apps and mobile need to use the exact same logic, but I do think the mobile algorithm is generally better - it's gotten more tech attention over the years and has been used by more clients.

Mobile's fuzzy match utility is [here](https://github.com/dimagi/commcare-core/blob/670ff633bf303978f96d8f2e03de205918c34941/src/main/java/org/commcare/cases/util/StringUtils.java#L76-L94). It has an adjustment to handle exact prefixes, which fail the fuzzy match test if they're more than 2 characters shorter than the target string.

The mobile combobox logic is [here](https://github.com/dimagi/commcare-core/blob/670ff633bf303978f96d8f2e03de205918c34941/src/main/java/org/javarosa/core/model/FuzzyMatchFilterRule.java#L20-L34). It's much more forgiving for multi word strings, matching if there's a fuzzy match between any single word in the query and any single word in the target.

## Safety Assurance

### Automated test coverage

The matching logic has decent test coverage. The code that isn't covered is minimal.

### QA Plan

I'm requesting QA for the sake of sticking to the "all user-facing web apps changes get QA" best practice.

https://dimagi-dev.atlassian.net/browse/QA-3858

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
