### PR TITLE
[bugfix] Data registry repeater use correct index attribute

### DIFF
--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -571,11 +571,11 @@ class CaseUpdateConfig:
         index = indices[0]
         if index.referenced_id != self.index_remove_case_id:
             raise DataRegistryCaseUpdateError("Index case ID does not match for index to remove")
-        if self.index_remove_relationship and self.index_remove_relationship != index.relationship_id:
+        if self.index_remove_relationship and self.index_remove_relationship != index.relationship:
             raise DataRegistryCaseUpdateError("Index relationship does not match for index to remove")
 
         return {
-            index.identifier: (index.referenced_type, "", index.relationship_id)
+            index.identifier: (index.referenced_type, "", index.relationship)
         }
 
     @staticmethod


### PR DESCRIPTION
## Technical Summary
Use `relationship` field instead of `relationsihp_id` which is the DB integer field.

Ultimately this bug was due to failure to mock the case index fields correctly in the tests. The mocks set `relationship_id` to the human readable. So although the tests passed the code was using the incorrect model field.

A good case study in the danger of mocks being out of sync with reality.

Jira: https://dimagi-dev.atlassian.net/browse/SUPPORT-12319

## Feature Flag
Data registry case update repeater

## Safety Assurance

### Safety story
Localised change to the repeater

### Automated test coverage
Updated tests to use the actual model classes instead of mocks to avoid any other similar issues.

### QA Plan
None

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
