### PR TITLE
case property comparison query script command

### DIFF
--- a/corehq/apps/case_search/management/commands/compare_case_properties.py
+++ b/corehq/apps/case_search/management/commands/compare_case_properties.py
@@ -1,9 +1,47 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from corehq.apps.es.case_search import CaseSearchES
 import timeit
+import heapq
+import json
 
 
-def define_query(domain, props, operator, case_type=None):
+# Returns min, max, average of test suite results list
+def get_stats(results_list):
+    n = len(results_list)
+    min = heapq.heappop(heapq.heapify(results_list))
+    max = heapq.heappop(heapq._heapify_max(results_list))
+    avg = sum(min) / n
+    return min, max, avg
+
+
+def run_baseline_query(query_obj):
+    print("Running baseline query...")
+    result = query_obj.run().total
+    print("Done!")
+    return result
+
+
+def run_test_queries(query_obj, repeats):
+    results = []
+    print("Running test queries...")
+    for _ in range(repeats):
+        results.append(results=timeit.timeit(query_obj.run))
+    print("Done!")
+    return results
+
+
+def define_baseline_query(domain, case_type=None):
+    if case_type is None:
+        query_obj = (CaseSearchES()
+            .domain(domain))
+    else:
+        query_obj = (CaseSearchES()
+            .domain(domain)
+            .case_type(case_type))
+    return query_obj
+
+
+def append_baseline_query(query_obj, props, operator):
     script = {
         "bool": {
             "must": [
@@ -18,15 +56,7 @@ def define_query(domain, props, operator, case_type=None):
             ]
         }
     }
-    if case_type is None:
-        query_obj = (CaseSearchES()
-            .domain(domain)
-            .set_query(script))
-    else:
-        query_obj = (CaseSearchES()
-            .domain(domain)
-            .case_type(case_type)
-            .set_query(script))
+    query_obj.set_query(script)
     return query_obj
 
 
@@ -35,23 +65,27 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('domain')
-        parser.add_argument('-ct', '--type', dest='type', type=str)
-        parser.add_argument('-cp', '--properties', dest='props', nargs='+', type=str)
+        parser.add_argument('-ct', '--type', dest='type')
+        parser.add_argument('-cp', '--properties', dest='props', nargs=2)
+        parser.add_argument('-n', dest='n', default=1)
 
         # operator arguments, only one of these is permitted
         parser.add_argument('-eq', dest='equals', action='store_true')
         parser.add_argument('-neq', dest='not_equals', action='store_true')
         parser.add_argument('-gt', dest='greater_than', action='store_true')
         parser.add_argument('-lt', dest='less_than', action='store_true')
-        parser.add_argument('-gteq', dest='greater_equal', action='store_true')
-        parser.add_argument('-lteq', dest='less_equal', action='store_true')
+        parser.add_argument('-gte', dest='greater_equal', action='store_true')
+        parser.add_argument('-lte', dest='less_equal', action='store_true')
 
         parser.add_argument('--verbose', dest="verbose", action='store_true')
+        parser.add_argument('--analyze', dest="analyze", action='store_true')
+        parser.add_argument('--profile', dest="profile", action='store_true')
 
     def handle(self, *args, **kwargs):
         domain = kwargs['domain']
         case_type = kwargs['type'] if kwargs['type'] else None
         props = kwargs['props']
+        repeats = kwargs['n']
         operators = {
             "==": kwargs['equals'],
             "!=": kwargs['not_equals'],
@@ -64,22 +98,37 @@ class Command(BaseCommand):
         operator_keylist = list(operators.keys())
 
         if operator_valuelist.count(True) != 1:
-            raise Exception('Exception: only one operator flag may be invoked (-eq, -neq, -gt, -lt, -gteq, -lteq)')
+            raise CommandError('Only one operator flag may be invoked (-eq, -neq, -gt, -lt, -gte, -lte)')
         if len(props) != 2:
-            raise ValueError('Value Error exception thown: 2 arguments required for properties flag')
+            raise CommandError("'properties' flag requires exactly 2 arguments")
 
         operator = operator_keylist[operator_valuelist.index(True)]
-        query_obj = define_query(domain, props, operator, case_type)
+
+        # Need need to get baseline amount of cases that are being against for context
+        # Define and run query with only domain and case_type specified
+        query_obj = define_baseline_query(domain, case_type)
+        baseline_amt = run_baseline_query(query_obj)
+
+        # Define, run, and analyze the test query
+        query_obj = append_baseline_query(query_obj, props, operator)
+        test_results = run_test_queries(query_obj, repeats=repeats)
+        min, max, avg = get_stats(test_results)
+
         type_str = f"{case_type}s in" if case_type else "All cases in"
         query_str = query_obj.get_query() if kwargs['verbose'] else (
             f"QUERY: {type_str} {domain} where {props[0]} {operator} {props[1]}"
         )
 
+        # if 'profile' flag is invoked, print out profiled results
+        if kwargs['profile']:
+            query_obj.enable_profiling()
+            profiled_hits = query_obj.run().raw
+            print("=" * 8 + "PROFILED QUERY RESULTS " + "=" * 8)
+            print(json.dumps(profiled_hits.get('profile', {}), indent=2))
+
+        # print out results
         print("=" * 8 + " SCRIPT QUERY TEST " + "=" * 8)
         print(query_str)
-        results = timeit.timeit(
-            lambda: print("HITS: " + str(query_obj.run().total)),
-            number=1
-        )
-        print(f"RUNTIME: {results}")
+        print(f"BASELINE: {baseline_amt} cases")
+        print(f"MIN RUNTIME: {min} | MAX RUNTIME: {max} | AVG RUNTIME: {avg}")
         return None

--- a/corehq/apps/case_search/management/commands/compare_case_properties.py
+++ b/corehq/apps/case_search/management/commands/compare_case_properties.py
@@ -37,12 +37,16 @@ class Command(BaseCommand):
         parser.add_argument('domain')
         parser.add_argument('-ct', '--type', dest='type', type=str)
         parser.add_argument('-cp', '--properties', dest='props', nargs='+', type=str)
+
+        # operator arguments, only one of these is permitted
         parser.add_argument('-eq', dest='equals', action='store_true')
         parser.add_argument('-neq', dest='not_equals', action='store_true')
         parser.add_argument('-gt', dest='greater_than', action='store_true')
         parser.add_argument('-lt', dest='less_than', action='store_true')
         parser.add_argument('-gteq', dest='greater_equal', action='store_true')
         parser.add_argument('-lteq', dest='less_equal', action='store_true')
+
+        parser.add_argument('--verbose', dest="verbose", action='store_true')
 
     def handle(self, *args, **kwargs):
         domain = kwargs['domain']
@@ -67,9 +71,12 @@ class Command(BaseCommand):
         operator = operator_keylist[operator_valuelist.index(True)]
         query_obj = define_query(domain, props, operator, case_type)
         type_str = f"{case_type}s in" if case_type else "All cases in"
+        query_str = query_obj.get_query() if kwargs['verbose'] else (
+            f"QUERY: {type_str} {domain} where {props[0]} {operator} {props[1]}"
+        )
 
         print("=" * 8 + " SCRIPT QUERY TEST " + "=" * 8)
-        print(f"QUERY: {type_str} {domain} where {props[0]} {operator} {props[1]}")
+        print(query_str)
         results = timeit.timeit(
             lambda: print("HITS: " + str(query_obj.run().total)),
             number=1

--- a/corehq/apps/case_search/management/commands/compare_case_properties.py
+++ b/corehq/apps/case_search/management/commands/compare_case_properties.py
@@ -18,7 +18,7 @@ def define_query(domain, props, operator, case_type=None):
             ]
         }
     }
-    if case_type:
+    if case_type is None:
         query_obj = (CaseSearchES()
             .domain(domain)
             .set_query(script))

--- a/corehq/apps/case_search/management/commands/compare_case_properties.py
+++ b/corehq/apps/case_search/management/commands/compare_case_properties.py
@@ -1,0 +1,61 @@
+from django.core.management.base import BaseCommand
+from corehq.apps.es.case_search import CaseSearchES
+import timeit
+
+
+def define_query(domain, props, operator, case_type=None):
+    script = {
+        "bool": {
+            "must": [
+                {
+                    "script": {
+                        "script": "def val = _source['case_properties'].find{ it -> it.key == '%s' }?.value;"
+                        "_source['case_properties'].find{ it -> it.key == '%s' }?.value %s val;"
+                        % (props[0], props[1], operator),
+                        "lang": "groovy"
+                    }
+                }
+            ]
+        }
+    }
+    if case_type:
+        query_obj = (CaseSearchES()
+            .domain(domain)
+            .set_query(script))
+    else:
+        query_obj = (CaseSearchES()
+            .domain(domain)
+            .case_type(case_type)
+            .set_query(script))
+    return query_obj
+
+
+class Command(BaseCommand):
+    help = "Run test queries for perfomance benchmarks for comparison script queries."
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+        parser.add_argument('-ct', '--type', dest='type', type=str)
+        parser.add_argument('-cp', '--properties', dest='props', nargs='+', type=str)
+        parser.add_argument('-op', '--operator', dest='operator', type=str)
+
+    def handle(self, *args, **kwargs):
+        domain = kwargs['domain']
+        case_type = kwargs['type'] if kwargs['type'] else None
+        props = kwargs['props']
+        operator = kwargs['operator']
+
+        if len(props) != 2:
+            raise ValueError('Value Error exception thown: 2 arguments are needed for properties flag')
+
+        query_obj = define_query(domain, props, operator, case_type)
+        type_str = f"{case_type}s in" if case_type else "All cases in"
+
+        print("=" * 8 + " SCRIPT QUERY TEST " + "=" * 8)
+        print(f"QUERY: {type_str} {domain} where {props[0]} {operator} {props[1]}")
+        results = timeit.timeit(
+            lambda: print("HITS: " + str(query_obj.run().total)),
+            number=1
+        )
+        print(f"RUNTIME: {results}")
+        return None

--- a/corehq/apps/case_search/management/commands/compare_case_properties.py
+++ b/corehq/apps/case_search/management/commands/compare_case_properties.py
@@ -146,5 +146,8 @@ class Command(BaseCommand):
         print(f"BASELINE: {baseline_amt} cases")
         print(f"MATCHED: {hits} cases")
         print(f"MIN TOOK: {min_took} ms | MAX TOOK: {max_took} ms | AVG TOOK: {avg_took} ms")
-        print(f"MIN RUNTIME: {(min_value * 1000):.4g} ms | MAX RUNTIME: {(max_value * 1000):.4g} ms | AVG RUNTIME: {(avg_value * 1000):.4g} ms")
+        print(
+            f"MIN RUNTIME: {(min_value * 1000):.4g} ms | MAX RUNTIME: {(max_value * 1000):.4g} ms | "
+            + f"AVG RUNTIME: {(avg_value * 1000):.4g} ms"
+        )
         return None

--- a/corehq/apps/case_search/management/commands/compare_case_properties.py
+++ b/corehq/apps/case_search/management/commands/compare_case_properties.py
@@ -37,17 +37,34 @@ class Command(BaseCommand):
         parser.add_argument('domain')
         parser.add_argument('-ct', '--type', dest='type', type=str)
         parser.add_argument('-cp', '--properties', dest='props', nargs='+', type=str)
-        parser.add_argument('-op', '--operator', dest='operator', type=str)
+        parser.add_argument('-eq', dest='equals', action='store_true')
+        parser.add_argument('-neq', dest='not_equals', action='store_true')
+        parser.add_argument('-gt', dest='greater_than', action='store_true')
+        parser.add_argument('-lt', dest='less_than', action='store_true')
+        parser.add_argument('-gteq', dest='greater_equal', action='store_true')
+        parser.add_argument('-lteq', dest='less_equal', action='store_true')
 
     def handle(self, *args, **kwargs):
         domain = kwargs['domain']
         case_type = kwargs['type'] if kwargs['type'] else None
         props = kwargs['props']
-        operator = kwargs['operator']
+        operators = {
+            "==": kwargs['equals'],
+            "!=": kwargs['not_equals'],
+            ">": kwargs['greater_than'],
+            "<": kwargs['less_than'],
+            ">=": kwargs['greater_equal'],
+            "<=": kwargs['less_equal']
+        }
+        operator_valuelist = list(operators.values())
+        operator_keylist = list(operators.keys())
 
+        if operator_valuelist.count(True) != 1:
+            raise Exception('Exception: only one operator flag may be invoked (-eq, -neq, -gt, -lt, -gteq, -lteq)')
         if len(props) != 2:
-            raise ValueError('Value Error exception thown: 2 arguments are needed for properties flag')
+            raise ValueError('Value Error exception thown: 2 arguments required for properties flag')
 
+        operator = operator_keylist[operator_valuelist.index(True)]
         query_obj = define_query(domain, props, operator, case_type)
         type_str = f"{case_type}s in" if case_type else "All cases in"
 

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -100,7 +100,7 @@ services:
       - ./files/elasticsearch_2.yml:/usr/share/elasticsearch/config/elasticsearch.yml:rw
 
   elasticsearch5:
-    image: arm64v8/elasticsearch:7.14.1
+    image: elasticsearch:5.6.16
     environment:
       ES_JAVA_OPTS: "-Xms750m -Xmx750m -Des.script.engine.groovy.inline.aggs=true -Des.script.engine.groovy.inline.search=true"
     expose:

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -100,7 +100,7 @@ services:
       - ./files/elasticsearch_2.yml:/usr/share/elasticsearch/config/elasticsearch.yml:rw
 
   elasticsearch5:
-    image: elasticsearch:5.6.16
+    image: arm64v8/elasticsearch:7.14.1
     environment:
       ES_JAVA_OPTS: "-Xms750m -Xmx750m -Des.script.engine.groovy.inline.aggs=true -Des.script.engine.groovy.inline.search=true"
     expose:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This PR adds the `compare_case_properties` management command for elasticsearch script query testing. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Jira](https://dimagi-dev.atlassian.net/browse/USH-1331?atlOrigin=eyJpIjoiNGYxYTQwYjZmMjU1NDA5YWE3ZGY5NzQwNDllODMzZWQiLCJwIjoiaiJ9)

The management command is designed to able to customize case property comparison queries from the console for performance testing purposes. 

There are a number of flags than can be invoked to define the query:
| Command | Description | Required |
| --- | --- | --- |
| domain | String value of domain to query against | Yes |
| -ct / --type | String value of case types to query against | No | 
| -cp / --properties | String values of case properties to compare | Yes (requires 2 args) |
| -eq | Sets comparison operator to `==` | Yes * | 
| -neq  | Sets comparison operator to `!=` | Yes * | 
| -gt | Sets comparison operator to `>` | Yes * | 
| -lt | Sets comparison operator to `<` | Yes * | 
| -gteq  | Sets comparison operator to `>=` | Yes * | 
| -lteq  | Sets comparison operator to `<=` | Yes * | 
| --verbose | Prints raw query to console | No |
| --profile | Prints out query profile | No |

* : only one operator flag may be called 

### Example: 
The following console command:
```console
(hq) user commcare-hq % ./manage.py compare_case_properties dev -ct commcare_user -cp  name email -neq
```
Produces this elasticsearch query:
```yaml
{'bool': 
 {'must': [{'script': 
  {'script': "def val = _source['case_properties'].find{ it -> it.key == 'name' }?.value;
    _source['case_properties'].find{ it -> it.key == 'email' }?.value != val;", 
   'lang': 'groovy'}}]}}
```
Then prints out these results in the console:
```console
======== SCRIPT QUERY TEST ========
QUERY: commcare_users in dev where name != email
HITS: 24 cases
MATCHED: 24 cases
TOOK: 2
MIN RUNTIME: 0.000705041999999878 | MAX RUNTIME: 0.015776333999999892 | AVG RUNTIME: 0.00112907021599998
```


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
user_cases

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This PR doesn't change any existing code and only adds a management command to the case-search app. 
Because this script is meant to test performance on potentially large datasets on staging, running this script should be a coordinated effort with other teams. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
