### PR TITLE
Remove doc type when creating commcare indices

### DIFF
--- a/corehq/apps/api/tests/test_models.py
+++ b/corehq/apps/api/tests/test_models.py
@@ -1,0 +1,20 @@
+from django.test import SimpleTestCase
+
+from ..models import ESCase
+
+
+class ESCaseTests(SimpleTestCase):
+    def test_handles_no_indices(self):
+        case = ESCase({'indices': []})
+        self.assertEqual(case.indices, [])
+
+    def test_handles_index_with_doc_type(self):
+        case = ESCase(
+            {
+                'indices': [{
+                    'doc_type': 'CommCareCaseIndex',
+                    'referenced_id': 'some_id'
+                }]
+            })
+        index = case.indices[0]
+        self.assertEqual(index.referenced_id, 'some_id')

--- a/corehq/form_processor/tests/test_models.py
+++ b/corehq/form_processor/tests/test_models.py
@@ -9,7 +9,7 @@ from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import Attachment, CommCareCase
+from corehq.form_processor.models import Attachment, CommCareCase, CommCareCaseIndex
 
 DOMAIN = 'test-domain'
 
@@ -33,6 +33,60 @@ class AttachmentHasSizeTests(SimpleTestCase):
     @staticmethod
     def create_attachment_with_content(content):
         return Attachment(name='test_attachment', raw_content=content, content_type='text')
+
+
+class CommCareCaseTests(SimpleTestCase):
+    def test_sets_index(self):
+        data = {
+            'indices': [{
+                'referenced_id': 'some_id'
+            }]
+        }
+        case = CommCareCase(**data)
+        index = case.indices[0]
+        self.assertEqual(index.referenced_id, 'some_id')
+
+    def test_sets_index_with_doc_type(self):
+        data = {
+            'indices': [{
+                'doc_type': 'CommCareCaseIndex',
+                'referenced_id': 'some_id'
+            }]
+        }
+        case = CommCareCase(**data)
+        index = case.indices[0]
+        self.assertEqual(index.referenced_id, 'some_id')
+
+
+class CommCareCaseIndexTests(SimpleTestCase):
+    def test_fields(self):
+        data = {
+            'identifier': 'my_parent',
+            'relationship': 'child',
+            'referenced_type': 'some_type',
+            'referenced_id': 'some_id'
+        }
+        index = CommCareCaseIndex(**data)
+
+        self.assertEqual(index.identifier, 'my_parent')
+        self.assertEqual(index.relationship, 'child')
+        self.assertEqual(index.referenced_type, 'some_type')
+        self.assertEqual(index.referenced_id, 'some_id')
+
+    def test_relationship_id_is_set_by_relationship(self):
+        index = CommCareCaseIndex(relationship='extension')
+        self.assertEqual(index.relationship_id, 2)
+
+    def test_constructor_ignores_doc_type(self):
+        # Just ensure it doesn't raise an exception
+        data = {
+            'doc_type': 'CommCareCaseIndex',
+            'identifier': 'my_parent',
+            'relationship': 'child',
+            'referenced_type': 'comunidad',
+            'referenced_id': 'ed285193-3795-4b39-b08b-ac9ad941527f'
+        }
+        CommCareCaseIndex(**data)
 
 
 class TestIndices(TestCase):


### PR DESCRIPTION
## Technical Summary
[Associated Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-12965). For case search data that contain indices, a 500 error is generated, because the `CommCareCaseIndex` constructor does not recognize the `doc_type` field passed to it. This fix removes `doc_type` within the constructor so the index is created successfully.

## Safety Assurance

### Safety story
Multiple test suites were created. Synced with @millerdev to ensure that we're covering the affected code paths.

### Automated test coverage

Tests in _form_processor/tests/test_models_ and _api/tests/test_models_

### QA Plan

No QA.


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
