### PR TITLE
Pick display format from style itself

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -180,7 +180,6 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var headers = detailObject.get('headers');
         var details = detailObject.get('details');
         var styles = detailObject.get('styles');
-        var templateForms = detailObject.get('templateForms') || [];
         var detailModel = [];
         // we need to map the details and headers JSON to a list for a Backbone Collection
         for (i = 0; i < headers.length; i++) {
@@ -188,9 +187,8 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
             obj.data = details[i];
             obj.header = headers[i];
             obj.style = styles[i];
-            obj.templateForm = templateForms[i];
             obj.id = i;
-            if (obj.templateForm === 'markdown') {
+            if (obj.style.displayFormat === 'Markdown') {
                 obj.html = DOMPurify.sanitize(md.render(details[i]));
             }
             detailModel.push(obj);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -180,6 +180,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var headers = detailObject.get('headers');
         var details = detailObject.get('details');
         var styles = detailObject.get('styles');
+        var templateForms = detailObject.get('templateForms') || [];
         var detailModel = [];
         // we need to map the details and headers JSON to a list for a Backbone Collection
         for (i = 0; i < headers.length; i++) {
@@ -187,7 +188,11 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
             obj.data = details[i];
             obj.header = headers[i];
             obj.style = styles[i];
+            obj.templateForm = templateForms[i];
             obj.id = i;
+            if (obj.templateForm === 'markdown') {
+                obj.html = DOMPurify.sanitize(md.render(details[i]));
+            }
             if (obj.style.displayFormat === 'Markdown') {
                 obj.html = DOMPurify.sanitize(md.render(details[i]));
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -180,6 +180,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var headers = detailObject.get('headers');
         var details = detailObject.get('details');
         var styles = detailObject.get('styles');
+        // ToDo: to be removed post displayFormat change for Markdown is deployed
         var templateForms = detailObject.get('templateForms') || [];
         var detailModel = [];
         // we need to map the details and headers JSON to a list for a Backbone Collection
@@ -188,14 +189,17 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
             obj.data = details[i];
             obj.header = headers[i];
             obj.style = styles[i];
-            obj.templateForm = templateForms[i];
             obj.id = i;
-            if (obj.templateForm === 'markdown') {
-                obj.html = DOMPurify.sanitize(md.render(details[i]));
-            }
             if (obj.style.displayFormat === 'Markdown') {
                 obj.html = DOMPurify.sanitize(md.render(details[i]));
             }
+            // ToDo: to be removed post displayFormat change for Markdown is deployed
+            else if (templateForms[i] === 'markdown') {
+                // populate displayFormat based on legacy property
+                obj.style.displayFormat = 'Markdown';
+                obj.html = DOMPurify.sanitize(md.render(details[i]));
+            }
+            // EndToDo
             detailModel.push(obj);
         }
         var detailCollection = new Backbone.Collection();

--- a/corehq/apps/cloudcare/templates/formplayer/case_detail.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_detail.html
@@ -14,6 +14,8 @@
   <td class="module-caselist-column"><img class="module-icon" src="<%- resolveUri(data) %>"/></td>
   <% } else if (style.displayFormat === 'Phone') { %>
   <td><a href="tel:<%- data %>"><%- data %></a></td>
+  <% } else if (templateForm === 'markdown' && html) { %>
+  <td><%= html %></td>
   <% } else if (style.displayFormat === 'Markdown' && html) { %>
   <td><%= html %></td>
   <% } else { %>

--- a/corehq/apps/cloudcare/templates/formplayer/case_detail.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_detail.html
@@ -14,8 +14,6 @@
   <td class="module-caselist-column"><img class="module-icon" src="<%- resolveUri(data) %>"/></td>
   <% } else if (style.displayFormat === 'Phone') { %>
   <td><a href="tel:<%- data %>"><%- data %></a></td>
-  <% } else if (templateForm === 'markdown' && html) { %>
-  <td><%= html %></td>
   <% } else if (style.displayFormat === 'Markdown' && html) { %>
   <td><%= html %></td>
   <% } else { %>

--- a/corehq/apps/cloudcare/templates/formplayer/case_detail.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_detail.html
@@ -14,7 +14,7 @@
   <td class="module-caselist-column"><img class="module-icon" src="<%- resolveUri(data) %>"/></td>
   <% } else if (style.displayFormat === 'Phone') { %>
   <td><a href="tel:<%- data %>"><%- data %></a></td>
-  <% } else if (templateForm === 'markdown' && html) { %>
+  <% } else if (style.displayFormat === 'Markdown' && html) { %>
   <td><%= html %></td>
   <% } else { %>
   <td><%- data %></td>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Fix markdown in case details modal.
Markdown was not working as expected at times. This was fixed at formplayer end.
This PR updates HQ implementation originally done in https://github.com/dimagi/commcare-hq/pull/29557/files to support markdown with the fix now done in formplayer (https://github.com/dimagi/commcare-core/pull/1066 and https://github.com/dimagi/formplayer/pull/1087)

The change is backward compatible to avoid formplayer deploy dependency.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/INDIV-29
The original implementation to support markdown from formplayer was buggy and was reverted in favor of an already present way of identifying markdown.
This PR just updates the corresponding HQ part.
To avoid deploy dependency with formplayer deploy we have kept things working with old implementation as well. 
So for the old response from formplayer, we simply populate `obj.style.displayFormat` at HQ, which is currently empty. This simply replicates what formplayer would [do now](https://github.com/dimagi/commcare-core/pull/1066/files).
For new response, `obj.style.displayFormat` would already be set for markdown.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Simple enough change. Tested on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
