### PR TITLE
Move form accessors into XFormInstance.objects - phase 2

### DIFF
--- a/corehq/apps/api/models.py
+++ b/corehq/apps/api/models.py
@@ -14,10 +14,8 @@ from couchforms import const
 from corehq.apps.api.resources import DictObject
 from corehq.form_processor.models import CommCareCaseIndex
 from corehq.form_processor.models.abstract import CaseToXMLMixin, get_index_map
-from corehq.form_processor.interfaces.dbaccessors import (
-    CaseAccessors,
-    FormAccessors,
-)
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import XFormInstance
 
 PERMISSION_POST_SMS = "POST_SMS"
 PERMISSION_POST_WISEPILL = "POST_WISEPILL"
@@ -229,7 +227,7 @@ class ESCase(DictObject, CaseToXMLMixin):
 
     def get_forms(self):
         from corehq.apps.api.util import form_to_es_form
-        forms = FormAccessors(self.domain).get_forms(self.xform_ids)
+        forms = XFormInstance.objects.get_forms(self.xform_ids, self.domain)
         return list(filter(None, [form_to_es_form(form) for form in forms]))
 
     @property

--- a/corehq/apps/api/object_fetch_api.py
+++ b/corehq/apps/api/object_fetch_api.py
@@ -1,3 +1,4 @@
+import urllib.parse
 from wsgiref.util import FileWrapper
 
 from django.http import (
@@ -9,10 +10,6 @@ from django.http import (
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.generic import View
-
-import six.moves.urllib.error
-import six.moves.urllib.parse
-import six.moves.urllib.request
 
 from dimagi.utils.django.cached_object import (
     IMAGE_SIZE_ORDERING,
@@ -96,17 +93,14 @@ class CaseAttachmentAPI(View):
                         r.write('Resolution: %d x %d<br>' % (meta['width'], meta['height']))
                         r.write('Filesize: %d<br>' % meta['content_length'])
 
-                        url_params = six.moves.urllib.parse.urlencode({
+                        url_params = urllib.parse.urlencode({
                             "img": '1',
                             "size": fsize,
                             "max_size": max_filesize,
                             "max_image_width": max_width,
                             "max_image_height": max_height
                         })
-                        r.write('<img src="%(attach_url)s?%(params)s">' % {
-                                "attach_url": url_base,
-                                "params": url_params
-                        })
+                        r.write(f'<img src="{url_base}?{url_params}">')
                     else:
                         r.write('Not available')
                     r.write('</li>')
@@ -158,7 +152,8 @@ class FormAttachmentAPI(View):
         )
 
 
-def fetch_case_image(domain, case_id, attachment_id, filesize_limit=0, width_limit=0, height_limit=0, fixed_size=None):
+def fetch_case_image(domain, case_id, attachment_id, filesize_limit=0,
+                     width_limit=0, height_limit=0, fixed_size=None):
     """
     Return (metadata, stream) information of best matching image attachment.
 

--- a/corehq/apps/commtrack/tests/test_sms_reporting.py
+++ b/corehq/apps/commtrack/tests/test_sms_reporting.py
@@ -10,7 +10,7 @@ from corehq.apps.reminders.util import get_two_way_number_for_recipient
 from corehq.apps.sms.tests.util import setup_default_sms_test_backend
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.form_processor.exceptions import LedgerValueNotFound
-from corehq.form_processor.backends.sql.dbaccessors import FormAccessorSQL, LedgerAccessorSQL
+from corehq.form_processor.backends.sql.dbaccessors import LedgerAccessorSQL
 from corehq.form_processor.models import XFormInstance
 
 
@@ -218,8 +218,9 @@ class SMSTests(TestCase):
 
 
 def iter_commtrack_forms(domain_name):
-    for form_id in FormAccessorSQL.iter_form_ids_by_xmlns(domain_name, COMMTRACK_REPORT_XMLNS):
-        yield XFormInstance.objects.get_form(form_id)
+    db = XFormInstance.objects
+    for form_id in db.iter_form_ids_by_xmlns(domain_name, COMMTRACK_REPORT_XMLNS):
+        yield db.get_form(form_id)
 
 
 def _get_location_from_form(form):

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -78,7 +78,7 @@ from corehq.apps.reports.v2.reports.explore_case_data import (
 from corehq.apps.sms.views import BaseMessagingSectionView
 from corehq.apps.users.permissions import can_download_data_files
 from corehq.const import SERVER_DATETIME_FORMAT
-from corehq.form_processor.interfaces.dbaccessors import FormAccessors
+from corehq.form_processor.models import XFormInstance
 from corehq.messaging.util import MessagingRuleProgressHelper
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_user
@@ -509,7 +509,7 @@ class XFormManagementView(DataInterfaceSection):
         )
 
     def inaccessible_forms_accessed(self, xform_ids, domain, couch_user):
-        xforms = FormAccessors(domain).get_forms(xform_ids)
+        xforms = XFormInstance.objects.get_forms(xform_ids, domain)
         xforms_user_ids = set([xform.user_id for xform in xforms])
         accessible_user_ids = set(user_ids_at_accessible_locations(domain, couch_user))
         return xforms_user_ids - accessible_user_ids

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -492,7 +492,7 @@ class XFormManagementView(DataInterfaceSection):
                     "Inaccessible forms accessed. Id(s): %s " % ','.join(inaccessible_forms_accessed))
 
         mode = self.request.POST.get('mode')
-        task_ref = expose_cached_download(payload=None, expiry=1*60*60, file_extension=None)
+        task_ref = expose_cached_download(payload=None, expiry=1 * 60 * 60, file_extension=None)
         task = bulk_form_management_async.delay(
             mode,
             self.domain,
@@ -518,14 +518,11 @@ class XFormManagementView(DataInterfaceSection):
         if 'select_all' in self.request.POST:
             # Altough evaluating form_ids and sending to task would be cleaner,
             # heavier calls should be in an async task instead
-            import six.moves.urllib.error
-            import six.moves.urllib.parse
-            import six.moves.urllib.request
-            form_query_string = six.moves.urllib.parse.unquote(self.request.POST.get('select_all'))
+            from urllib.parse import unquote
             from django.http import HttpRequest, QueryDict
-
             from django_otp.middleware import OTPMiddleware
 
+            form_query_string = unquote(self.request.POST.get('select_all'))
             _request = HttpRequest()
             _request.couch_user = request.couch_user
             _request.user = request.couch_user.get_django_user()
@@ -665,9 +662,10 @@ class AutomaticUpdateRuleListView(DataInterfaceSection, CRUDPaginatedViewMixin):
     def page_context(self):
         context = self.pagination_context
         domain_obj = Domain.get_by_name(self.domain)
+        hour = domain_obj.auto_case_update_hour
         context.update({
             'help_site_url': 'https://confluence.dimagi.com/display/commcarepublic/Automatically+Close+Cases',
-            'time': f"{domain_obj.auto_case_update_hour}:00" if domain_obj.auto_case_update_hour else _('midnight'),
+            'time': f"{hour}:00" if hour else _('midnight'),
         })
         return context
 
@@ -794,10 +792,9 @@ class AddCaseRuleView(DataInterfaceSection):
     @memoized
     def read_only_mode(self):
         return (
-            not self.is_system_admin and
-            (
-                self.criteria_form.requires_system_admin_to_edit or
-                self.actions_form.requires_system_admin_to_edit
+            not self.is_system_admin and (
+                self.criteria_form.requires_system_admin_to_edit
+                or self.actions_form.requires_system_admin_to_edit
             )
         )
 
@@ -849,8 +846,8 @@ class AddCaseRuleView(DataInterfaceSection):
 
         if rule_form_valid and criteria_form_valid and actions_form_valid:
             if not self.is_system_admin and (
-                self.criteria_form.requires_system_admin_to_save or
-                self.actions_form.requires_system_admin_to_save
+                self.criteria_form.requires_system_admin_to_save
+                or self.actions_form.requires_system_admin_to_save
             ):
                 # Don't allow adding custom criteria/actions to rules
                 # unless the user has permission to

--- a/corehq/apps/es/management/commands/resave_failed_forms_and_cases.py
+++ b/corehq/apps/es/management/commands/resave_failed_forms_and_cases.py
@@ -8,10 +8,8 @@ from corehq.apps.data_pipeline_audit.management.commands.compare_doc_ids import 
     compare_xforms,
 )
 from corehq.apps.hqcase.utils import resave_case
-from corehq.form_processor.interfaces.dbaccessors import (
-    CaseAccessors,
-    FormAccessors,
-)
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import XFormInstance
 from corehq.form_processor.utils.xform import resave_form
 from corehq.util.log import with_progress_bar
 
@@ -55,9 +53,9 @@ def perform_resave_on_xforms(domain, start_date, end_date, no_input):
         if ok != "ok":
             print("No changes made")
             return
-    form_accessor = FormAccessors(domain)
+    get_forms = XFormInstance.objects.get_forms
     for xform_ids in chunked(with_progress_bar(xform_ids_missing_in_es), 100):
-        xforms = form_accessor.get_forms(list(xform_ids))
+        xforms = get_forms(list(xform_ids), domain)
         found_xform_ids = set()
 
         for xform in xforms:

--- a/corehq/apps/hqcase/management/commands/reindex_sql_forms_in_domain.py
+++ b/corehq/apps/hqcase/management/commands/reindex_sql_forms_in_domain.py
@@ -16,7 +16,7 @@ def reindex_sql_forms_in_domain(domain):
             print('Reindexing doc_ids: {}'.format(','.join(doc_ids)))
             reindexer.doc_processor.process_bulk_docs([
                 reindexer.reindex_accessor.doc_to_json(form)
-                for form in FormAccessorSQL.get_forms(list(doc_ids))
+                for form in XFormInstance.objects.get_forms(list(doc_ids))
             ])
 
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -137,7 +137,6 @@ from corehq.blobs import CODES, NotFound, get_blob_db, models
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
-    FormAccessors,
     LedgerAccessors,
 )
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
@@ -1275,7 +1274,7 @@ def case_forms(request, domain, case_id):
         return HttpResponseBadRequest()
 
     slice = list(reversed(case.xform_ids))[start_range:end_range]
-    forms = FormAccessors(domain).get_forms(slice, ordered=True)
+    forms = XFormInstance.objects.get_forms(slice, domain, ordered=True)
     timezone = get_timezone_for_user(request.couch_user, domain)
     return json_response([
         form_to_json(domain, form, timezone) for form in forms

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -25,7 +25,8 @@ from corehq.apps.userreports.expressions.specs import (
 from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.exceptions import CaseNotFound
-from corehq.form_processor.interfaces.dbaccessors import FormAccessors, CaseAccessors
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import XFormInstance
 from corehq.util.test_utils import (
     create_and_save_a_case,
     create_and_save_a_form,
@@ -1132,7 +1133,7 @@ class TestFormsExpressionSpec(TestCase):
         cls.domain = uuid.uuid4().hex
         factory = CaseFactory(domain=cls.domain)
         [cls.case] = factory.create_or_update_case(CaseStructure(attrs={'create': True}))
-        cls.forms = [f.to_json() for f in FormAccessors(cls.domain).get_forms(cls.case.xform_ids)]
+        cls.forms = [f.to_json() for f in XFormInstance.objects.get_forms(cls.case.xform_ids, cls.domain)]
         #  redundant case to create extra forms that shouldn't be in the results for cls.case
         [cls.case_b] = factory.create_or_update_case(CaseStructure(attrs={'create': True}))
 

--- a/corehq/apps/users/management/commands/archive_forms_submitted_by_user.py
+++ b/corehq/apps/users/management/commands/archive_forms_submitted_by_user.py
@@ -3,6 +3,7 @@ from django.core.management.base import BaseCommand
 from dimagi.utils.chunked import chunked
 
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
+from corehq.form_processor.models import XFormInstance
 from corehq.util.log import with_progress_bar
 
 
@@ -12,14 +13,14 @@ class Command(BaseCommand):
         parser.add_argument('user_id')
 
     def handle(self, domain, user_id, **options):
-        form_accessor = FormAccessors(domain)
-        form_ids = form_accessor.get_form_ids_for_user(user_id)
+        get_forms = XFormInstance.objects.get_forms
+        form_ids = FormAccessors(domain).get_form_ids_for_user(user_id)
         print("Found %s forms for user" % len(form_ids))
         response = input("Are you sure you want to archive them? (yes to proceed)")
         if response == 'yes':
             with open("archived_forms_for_user_%s.txt" % user_id, 'wb') as log:
                 for ids in chunked(with_progress_bar(form_ids), 100):
                     ids = list([f for f in ids if f])
-                    for form in form_accessor.get_forms(ids):
+                    for form in get_forms(ids, domain):
                         log.write(form.form_id + '\n')
                         form.archive()

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -14,7 +14,7 @@ from casexml.apps.case.exceptions import PhoneDateValueError
 from casexml.apps.phone.models import delete_synclogs
 from casexml.apps.phone.xml import get_case_element
 from corehq.util.soft_assert import soft_assert
-from corehq.form_processor.interfaces.dbaccessors import FormAccessors
+from corehq.form_processor.models import XFormInstance
 
 
 def validate_phone_datetime(datetime_string, none_ok=False, form_id=None):
@@ -214,7 +214,7 @@ def get_case_history(case):
     from corehq.apps.reports.display import xmlns_to_name
 
     changes = defaultdict(dict)
-    for form in FormAccessors(case.domain).get_forms(case.xform_ids):
+    for form in XFormInstance.objects.get_forms(case.xform_ids, case.domain):
         case_blocks = extract_case_blocks(form)
         for block in case_blocks:
             if block.get('@case_id') == case.case_id:

--- a/corehq/ex-submodules/pillowtop/reindexer/change_providers/form.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/change_providers/form.py
@@ -1,5 +1,6 @@
 from corehq.form_processor.backends.sql.dbaccessors import FormAccessorSQL, doc_type_to_state
 from corehq.form_processor.change_publishers import change_meta_from_sql_form
+from corehq.form_processor.models import XFormInstance
 from corehq.util.pagination import paginate_function, ArgsListProvider
 from pillowtop.feed.interface import Change
 from pillowtop.reindexer.change_providers.interface import ChangeProvider
@@ -16,7 +17,7 @@ class SqlDomainXFormChangeProvider(ChangeProvider):
             return
 
         for form_id_chunk in self._iter_form_id_chunks():
-            for form in FormAccessorSQL.get_forms(form_id_chunk):
+            for form in XFormInstance.objects.get_forms(form_id_chunk):
                 yield Change(
                     id=form.form_id,
                     sequence_id=None,

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -392,15 +392,8 @@ class FormAccessorSQL:
 
     @staticmethod
     def iter_form_ids_by_xmlns(domain, xmlns=None):
-        from corehq.sql_db.util import paginate_query_across_partitioned_databases
-
-        q_expr = Q(domain=domain) & Q(state=XFormInstance.NORMAL)
-        if xmlns:
-            q_expr &= Q(xmlns=xmlns)
-
-        for form_id in paginate_query_across_partitioned_databases(
-                XFormInstance, q_expr, values=['form_id'], load_source='formids_by_xmlns'):
-            yield form_id[0]
+        """DEPRECATED"""
+        return XFormInstance.objects.iter_form_ids_by_xmlns(domain, xmlns)
 
     @staticmethod
     def get_with_attachments(form_id):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -397,14 +397,8 @@ class FormAccessorSQL:
 
     @staticmethod
     def get_with_attachments(form_id):
-        """
-        It's necessary to store these on the form rather than use a memoized property
-        since the form_id can change (in the case of a deprecated form) which breaks
-        the memoize hash.
-        """
-        form = XFormInstance.objects.get_form(form_id)
-        form.attachments_list = FormAccessorSQL.get_attachments(form_id)
-        return form
+        """DEPRECATED"""
+        return XFormInstance.objects.get_with_attachments(form_id)
 
     @staticmethod
     def get_attachment_by_name(form_id, attachment_name):

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -119,7 +119,7 @@ class FormProcessorSQL(object):
                 if processed_forms.deprecated:
                     FormAccessorSQL.update_form(processed_forms.deprecated, publish_changes=False)
 
-                FormAccessorSQL.save_new_form(processed_forms.submitted)
+                XFormInstance.objects.save_new_form(processed_forms.submitted)
                 if cases:
                     for case in cases:
                         CaseAccessorSQL.save_case(case)

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -274,7 +274,7 @@ class FormProcessorSQL(object):
 
     @staticmethod
     def hard_rebuild_case(domain, case_id, detail, lock=True, save=True):
-        assert save or not lock, f"refusing to lock when not saving"
+        assert save or not lock, "refusing to lock when not saving"
         if lock:
             # only record metric if locking since otherwise it has been
             # (most likley) recorded elsewhere

--- a/corehq/form_processor/document_stores.py
+++ b/corehq/form_processor/document_stores.py
@@ -49,7 +49,7 @@ class FormDocumentStore(DocumentStore):
             return form.to_json()
 
     def iter_document_ids(self):
-        return iter(self.form_accessors.iter_form_ids_by_xmlns(self.xmlns))
+        return iter(XFormInstance.objects.iter_form_ids_by_xmlns(self.domain, self.xmlns))
 
     def iter_documents(self, ids):
         for wrapped_form in self.form_accessors.iter_forms(ids):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -66,12 +66,6 @@ class FormAccessors:
     def get_forms_by_type(self, type_, limit, recent_first=False):
         return self.db_accessor.get_forms_by_type(self.domain, type_, limit, recent_first)
 
-    def iter_forms_by_last_modified(self, start_datetime, end_datetime):
-        return self.db_accessor.iter_forms_by_last_modified(
-            start_datetime,
-            end_datetime,
-        )
-
     def iter_form_ids_by_xmlns(self, xmlns=None):
         return self.db_accessor.iter_form_ids_by_xmlns(self.domain, xmlns)
 

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -79,6 +79,7 @@ class FormAccessors:
         return self.db_accessor.get_with_attachments(form_id)
 
     def save_new_form(self, form):
+        """DEPRECATED use XFormInstance.objects"""
         self.db_accessor.save_new_form(form)
 
     def update_form_problem_and_state(self, form):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -48,11 +48,7 @@ class FormAccessors:
         return XFormInstance.objects.get_form(form_id, self.domain)
 
     def get_forms(self, form_ids, ordered=False):
-        """
-        :param form_ids: list of form_ids to fetch
-        :type ordered:   True if the list of returned forms should have the same order
-                         as the list of form_ids passed in
-        """
+        """DEPRECATED use XFormInstance.objects"""
         return self.db_accessor.get_forms(form_ids, ordered=ordered)
 
     def iter_forms(self, form_ids):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -67,6 +67,7 @@ class FormAccessors:
         return self.db_accessor.get_forms_by_type(self.domain, type_, limit, recent_first)
 
     def iter_form_ids_by_xmlns(self, xmlns=None):
+        """DEPRECATED use XFormInstance.objects"""
         return self.db_accessor.iter_form_ids_by_xmlns(self.domain, xmlns)
 
     def get_with_attachments(self, form_id):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -71,6 +71,7 @@ class FormAccessors:
         return self.db_accessor.iter_form_ids_by_xmlns(self.domain, xmlns)
 
     def get_with_attachments(self, form_id):
+        """DEPRECATED use XFormInstance.objects"""
         return self.db_accessor.get_with_attachments(form_id)
 
     def save_new_form(self, form):

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -13,6 +13,7 @@ from corehq.form_processor.exceptions import (
     XFormQuestionValueNotFound,
 )
 from memoized import memoized
+from ..models import XFormInstance
 from ..system_action import system_action
 
 
@@ -47,7 +48,6 @@ class FormProcessorInterface(object):
     @property
     @memoized
     def xform_model(self):
-        from corehq.form_processor.models import XFormInstance
         return XFormInstance
 
     @property
@@ -123,7 +123,6 @@ class FormProcessorInterface(object):
         Update a set of question responses. Returns a list of any
         questions that were not found in the xform.
         """
-        from corehq.form_processor.interfaces.dbaccessors import FormAccessors
         from corehq.form_processor.utils.xform import update_response
 
         errors = []
@@ -134,7 +133,7 @@ class FormProcessorInterface(object):
             except XFormQuestionValueNotFound:
                 errors.append(question)
 
-        existing_form = FormAccessors(xform.domain).get_with_attachments(xform.get_id)
+        existing_form = XFormInstance.objects.get_with_attachments(xform.get_id, xform.domain)
         existing_form, new_form = self.processor.new_form_from_old(existing_form, xml,
                                                                    value_responses_map, user_id)
         self.save_processed_models([new_form, existing_form])

--- a/corehq/form_processor/management/commands/archive_all_forms_for_user_in_domain.py
+++ b/corehq/form_processor/management/commands/archive_all_forms_for_user_in_domain.py
@@ -5,7 +5,7 @@ from casexml.apps.case.xform import get_case_updates
 from corehq.apps.users.models import CouchUser
 from corehq.form_processor.backends.sql.dbaccessors import LedgerAccessorSQL
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
-from corehq.form_processor.models import RebuildWithReason
+from corehq.form_processor.models import RebuildWithReason, XFormInstance
 from corehq.util.log import with_progress_bar
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.parsers.ledgers.form import get_case_ids_from_stock_transactions
@@ -30,9 +30,9 @@ class Command(BaseCommand):
 
     def _get_forms_to_archive(self):
         # ordered with latest form's id on top
-        form_accessor = FormAccessors(self.domain)
-        form_ids = form_accessor.get_form_ids_for_user(self.user_id)
-        return [f for f in form_accessor.get_forms(form_ids) if f.is_normal]
+        get_forms = XFormInstance.objects.get_forms
+        form_ids = FormAccessors(self.domain).get_form_ids_for_user(self.user_id)
+        return [f for f in get_forms(form_ids, self.domain) if f.is_normal]
 
     def _fetch_case_ids_to_rebuild(self):
         case_ids_to_rebuild = set()

--- a/corehq/form_processor/management/commands/delete_form_attachments.py
+++ b/corehq/form_processor/management/commands/delete_form_attachments.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand
 
 from corehq.blobs import get_blob_db
-from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.models import XFormInstance
 
 
@@ -16,14 +15,13 @@ class Command(BaseCommand):
         parser.add_argument('--dry-run', action='store_true')
 
     def handle(self, domain, xmlns, app_id, dry_run, xform_ids, **options):
-        accessor = FormAccessors(domain)
         if xform_ids:
             form_ids = xform_ids.split(',')
         else:
             form_ids = XFormInstance.objects.iter_form_ids_by_xmlns(domain, xmlns)
         attachments_to_delete = []
         for form_id in form_ids:
-            form = accessor.get_with_attachments(form_id)
+            form = XFormInstance.objects.get_with_attachments(form_id, domain)
             if form.domain != domain or form.xmlns != xmlns or form.app_id != app_id:
                 continue
             print(f'{form_id}\t{",".join(form.attachments) or "No attachments to delete"}')

--- a/corehq/form_processor/management/commands/delete_form_attachments.py
+++ b/corehq/form_processor/management/commands/delete_form_attachments.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand
 
 from corehq.blobs import get_blob_db
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
+from corehq.form_processor.models import XFormInstance
 
 
 class Command(BaseCommand):
@@ -19,7 +20,7 @@ class Command(BaseCommand):
         if xform_ids:
             form_ids = xform_ids.split(',')
         else:
-            form_ids = accessor.iter_form_ids_by_xmlns(xmlns)
+            form_ids = XFormInstance.objects.iter_form_ids_by_xmlns(domain, xmlns)
         attachments_to_delete = []
         for form_id in form_ids:
             form = accessor.get_with_attachments(form_id)

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -70,6 +70,16 @@ class XFormInstanceManager(RequireDBManager):
     def get_attachments(form_id):
         return get_blob_db().metadb.get_for_parent(form_id)
 
+    def get_with_attachments(self, form_id, domain=None):
+        """
+        It's necessary to store these on the form rather than use a memoized property
+        since the form_id can change (in the case of a deprecated form) which breaks
+        the memoize hash.
+        """
+        form = self.get_form(form_id, domain)
+        form.attachments_list = self.get_attachments(form_id)
+        return form
+
     def iter_form_ids_by_xmlns(self, domain, xmlns=None):
         q_expr = Q(domain=domain) & Q(state=self.model.NORMAL)
         if xmlns:

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -39,10 +39,11 @@ class XFormInstanceManager(RequireDBManager):
         except self.model.DoesNotExist:
             raise XFormNotFound(form_id)
 
-    def get_forms(self, form_ids, ordered=False):
+    def get_forms(self, form_ids, domain=None, ordered=False):
         """
         :param form_ids: list of form_ids to fetch
-        :type ordered:   True if the list of returned forms should have the
+        :param domain: Currently unused, may be enforced in the future.
+        :param ordered:  True if the list of returned forms should have the
                          same order as the list of form_ids passed in
         """
         assert isinstance(form_ids, list)

--- a/corehq/form_processor/models/util.py
+++ b/corehq/form_processor/models/util.py
@@ -1,0 +1,16 @@
+
+
+def sort_with_id_list(object_list, id_list, id_property):
+    """Sort object list in the same order as given list of ids
+
+    SQL does not necessarily return the rows in any particular order so
+    we need to order them ourselves.
+
+    NOTE: this does not return the sorted list. It sorts `object_list`
+    in place using Python's built-in `list.sort`.
+    """
+    def key(obj):
+        return index_map[getattr(obj, id_property)]
+
+    index_map = {id_: index for index, id_ in enumerate(id_list)}
+    object_list.sort(key=key)

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -7,9 +7,8 @@ from ddtrace import tracer
 from django.conf import settings
 
 from corehq.form_processor.exceptions import MissingFormXml
-from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.models import Attachment
+from corehq.form_processor.models import Attachment, XFormInstance
 from corehq.form_processor.utils import convert_xform_to_json, adjust_datetimes
 from corehq.util.soft_assert.api import soft_assert
 from couchforms import XMLSyntaxError
@@ -171,7 +170,7 @@ def _handle_duplicate(new_doc):
     """
     interface = FormProcessorInterface(new_doc.domain)
     conflict_id = new_doc.form_id
-    existing_doc = FormAccessors(new_doc.domain).get_with_attachments(conflict_id)
+    existing_doc = XFormInstance.objects.get_with_attachments(conflict_id, new_doc.domain)
 
     is_icds = settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS
     try:

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 from contextlib import contextmanager
 
-from couchdbkit import ResourceNotFound
 from ddtrace import tracer
 from django.conf import settings
 
@@ -108,7 +107,10 @@ def _create_new_xform(domain, instance_xml, attachments=None, auth_context=None)
     xform.auth_context = auth_context
 
     # Maps all attachments to uniform format and adds form.xml to list before storing
-    attachments = [Attachment(name=a[0], raw_content=a[1], content_type=a[1].content_type) for a in attachments.items()]
+    attachments = [
+        Attachment(name=a[0], raw_content=a[1], content_type=a[1].content_type)
+        for a in attachments.items()
+    ]
     attachments.append(Attachment(name='form.xml', raw_content=instance_xml, content_type='text/xml'))
     interface.store_attachments(xform, attachments)
 

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -28,8 +28,8 @@ from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
 from corehq.apps.users.models import CouchUser
 from corehq.apps.users.permissions import has_permission_to_view_report
 from corehq.form_processor.exceptions import PostSaveError, XFormSaveError
-from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
+from corehq.form_processor.models import XFormInstance
 from corehq.form_processor.parsers.form import process_xform_xml
 from corehq.form_processor.system_action import SYSTEM_ACTION_XMLNS, handle_system_action
 from corehq.form_processor.utils.metadata import scrub_meta
@@ -87,7 +87,6 @@ class SubmissionPost(object):
         self.auth_context = auth_context or DefaultAuthContext()
         self.path = path
         self.interface = FormProcessorInterface(domain)
-        self.formdb = FormAccessors(domain)
         self.partial_submission = partial_submission
         # always None except in the case where a system form is being processed as part of another submission
         # e.g. for closing extension cases
@@ -229,7 +228,7 @@ class SubmissionPost(object):
 
             if submitted_form.is_submission_error_log:
                 logging.info('Processing form %s as a submission error', submitted_form.form_id)
-                self.formdb.save_new_form(submitted_form)
+                XFormInstance.objects.save_new_form(submitted_form)
 
                 response = None
                 try:
@@ -586,11 +585,11 @@ def handle_unexpected_error(interface, instance, exception):
     notify_submission_error(instance, instance.problem, sys.exc_info())
 
     try:
-        FormAccessors(interface.domain).save_new_form(instance)
+        XFormInstance.objects.save_new_form(instance)
     except IntegrityError:
         # handle edge case where saving duplicate form fails
         instance = interface.xformerror_from_xform_instance(instance, instance.problem, with_new_id=True)
-        FormAccessors(interface.domain).save_new_form(instance)
+        XFormInstance.objects.save_new_form(instance)
     except XFormSaveError:
         # try a simple save
         instance.save()

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -88,32 +88,6 @@ class FormAccessorTestsSQL(TestCase):
         self.assertEqual(form1.form_id, forms[0].form_id)
         self.assertEqual(form2.form_id, forms[1].form_id)
 
-    def test_get_forms_by_last_modified(self):
-        start = datetime(2016, 1, 1)
-        end = datetime(2018, 1, 1)
-
-        form1 = create_form_for_test(DOMAIN, received_on=datetime(2017, 1, 1))
-        create_form_for_test(DOMAIN, received_on=datetime(2015, 1, 1))
-        # Test that it gets all states
-        form2 = create_form_for_test(
-            DOMAIN,
-            state=XFormInstance.ARCHIVED,
-            received_on=datetime(2017, 1, 1)
-        )
-        # Test that other date fields are properly fetched
-        form3 = create_form_for_test(
-            DOMAIN,
-            received_on=datetime(2015, 1, 1),
-            edited_on=datetime(2017, 1, 1),
-        )
-
-        forms = list(FormAccessorSQL.iter_forms_by_last_modified(start, end))
-        self.assertEqual(3, len(forms))
-        self.assertEqual(
-            {form1.form_id, form2.form_id, form3.form_id},
-            {form.form_id for form in forms},
-        )
-
     def test_get_with_attachments(self):
         form = create_form_for_test(DOMAIN)
         form = FormAccessorSQL.get_form(form.form_id)  # refetch to clear cached attachments

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -43,6 +43,19 @@ class XFormInstanceManagerTest(TestCase):
         with self.assertRaises(XFormNotFound):
             XFormInstance.objects.get_form('missing_form')
 
+    def test_get_forms(self):
+        form1 = create_form_for_test(DOMAIN)
+        form2 = create_form_for_test(DOMAIN)
+
+        forms = XFormInstance.objects.get_forms(['missing_form'])
+        self.assertEqual(forms, [])
+
+        forms = XFormInstance.objects.get_forms([form1.form_id])
+        self.assertEqual([f.form_id for f in forms], [form1.form_id])
+
+        forms = XFormInstance.objects.get_forms([form1.form_id, form2.form_id], ordered=True)
+        self.assertEqual([f.form_id for f in forms], [form1.form_id, form2.form_id])
+
     def _check_simple_form(self, form):
         self.assertIsInstance(form, XFormInstance)
         self.assertIsNotNone(form)

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -59,6 +59,23 @@ class XFormInstanceManagerTest(TestCase):
         forms = XFormInstance.objects.get_forms([form1.form_id, form2.form_id], ordered=True)
         self.assertEqual([f.form_id for f in forms], [form1.form_id, form2.form_id])
 
+    def test_iter_form_ids_by_xmlns(self):
+        OTHER_XMLNS = "http://openrosa.org/other"
+        form1 = create_form_for_test(DOMAIN)
+        form2 = create_form_for_test(DOMAIN, xmlns=OTHER_XMLNS)
+
+        ids = XFormInstance.objects.iter_form_ids_by_xmlns("nonexistent")
+        self.assertFalse(list(ids))
+
+        ids = XFormInstance.objects.iter_form_ids_by_xmlns(DOMAIN, "unknown-xmlns")
+        self.assertFalse(list(ids))
+
+        ids = XFormInstance.objects.iter_form_ids_by_xmlns(DOMAIN, OTHER_XMLNS)
+        self.assertEqual(list(ids), [form2.form_id])
+
+        ids = XFormInstance.objects.iter_form_ids_by_xmlns(DOMAIN)
+        self.assertEqual(list(ids), [form1.form_id, form2.form_id])
+
     def test_save_new_form_and_get_attachments(self):
         unsaved_form = create_form_for_test(DOMAIN, save=False)
         XFormInstance.objects.save_new_form(unsaved_form)

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -96,7 +96,7 @@ class XFormInstanceManagerTest(TestCase):
         self.assertEqual(list(ids), [form2.form_id])
 
         ids = XFormInstance.objects.iter_form_ids_by_xmlns(DOMAIN)
-        self.assertEqual(list(ids), [form1.form_id, form2.form_id])
+        self.assertEqual(set(ids), {form1.form_id, form2.form_id})
 
     def test_save_new_form_and_get_attachments(self):
         unsaved_form = create_form_for_test(DOMAIN, save=False)

--- a/corehq/motech/management/commands/create_repeat_records.py
+++ b/corehq/motech/management/commands/create_repeat_records.py
@@ -4,10 +4,7 @@ import re
 from django.core.management import CommandError
 from django.core.management.base import BaseCommand
 
-from corehq.form_processor.backends.sql.dbaccessors import (
-    CaseAccessorSQL,
-    FormAccessorSQL,
-)
+from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.models import XFormInstance
 from corehq.motech.repeaters.management.commands.find_missing_repeat_records import (
     get_repeaters_for_type_in_domain,
@@ -80,7 +77,7 @@ class Command(BaseCommand):
                         logger.exception(f"Unable to fetch doc '{doc_id}'")
 
         forms = XFormInstance.objects
-        bulk_accessor = FormAccessorSQL.get_forms if options['doc_type'] == 'form' else CaseAccessorSQL.get_cases
+        bulk_accessor = forms.get_forms if options['doc_type'] == 'form' else CaseAccessorSQL.get_cases
         single_accessor = forms.get_form if options['doc_type'] == 'form' else CaseAccessorSQL.get_case
         for doc_ids in chunked(with_progress_bar(doc_ids), 100):
             for doc in doc_iterator(list(doc_ids)):

--- a/corehq/motech/repeaters/management/commands/find_missing_repeat_records.py
+++ b/corehq/motech/repeaters/management/commands/find_missing_repeat_records.py
@@ -10,7 +10,8 @@ from corehq.apps.app_manager.models import Application
 from corehq.apps.es import CaseES, FormES, UserES, AppES
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import XFormInstance
 from corehq.motech.dhis2.repeaters import Dhis2EntityRepeater
 from corehq.motech.openmrs.repeaters import OpenmrsRepeater
 from corehq.motech.repeaters.dbaccessors import (
@@ -90,7 +91,7 @@ def find_missing_form_repeat_records_for_domain(domain, startdate, enddate, shou
     total_missing_count = total_count = 0
     form_repeaters_in_domain = get_form_repeaters_in_domain(domain)
     form_ids = [f['_id'] for f in get_form_ids_in_domain_between_dates(domain, startdate, enddate)]
-    forms = FormAccessors(domain).get_forms(form_ids)
+    forms = XFormInstance.objects.get_forms(form_ids, domain)
     for form in forms:
         missing_count, successful_count = find_missing_form_repeat_records_for_form(
             form, domain, form_repeaters_in_domain, enddate, should_create

--- a/custom/apps/crs_reports/views.py
+++ b/custom/apps/crs_reports/views.py
@@ -54,7 +54,7 @@ def get_questions_with_answers(forms, domain, report_slug):
         for question in section['questions']:
 
             if 'answers' not in question:
-                    question['answers'] = []
+                question['answers'] = []
             if len(question['answers']) < count:
                 for i in range(len(question['answers']), count):
                     question['answers'].append('')

--- a/custom/apps/crs_reports/views.py
+++ b/custom/apps/crs_reports/views.py
@@ -5,7 +5,8 @@ from corehq.apps.reports.dispatcher import QuestionTemplateDispatcher
 from corehq.apps.reports.views import require_case_view_permission
 from casexml.apps.case.templatetags.case_tags import case_inline_display
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL, FormAccessorSQL
+from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
+from corehq.form_processor.models import XFormInstance
 from django.template.loader import get_template
 from django.http import HttpResponse, Http404
 from custom.apps.crs_reports import MOTHER_POSTPARTUM_VISIT_FORM_XMLNS, BABY_POSTPARTUM_VISIT_FORM_XMLNS
@@ -95,4 +96,4 @@ def get_dict_to_report(domain, case_id, report_slug):
 
 def get_forms(case):
     txx = case.get_form_transactions()
-    return FormAccessorSQL.get_forms([t.form_id for t in txx])
+    return XFormInstance.objects.get_forms([t.form_id for t in txx])

--- a/custom/eqa/expressions.py
+++ b/custom/eqa/expressions.py
@@ -1,6 +1,7 @@
 from corehq.apps.app_manager.models import Application
 from corehq.apps.userreports.specs import TypeProperty
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import XFormInstance
 from corehq.util.quickcache import quickcache
 from dimagi.ext.jsonobject import JsonObject, StringProperty
 
@@ -40,7 +41,7 @@ def get_yes_no(val):
 @quickcache(['item', 'xmlns'])
 def get_two_last_forms(item, xmlns):
     xforms_ids = CaseAccessors(item['domain']).get_case_xform_ids(item['_id'])
-    forms = FormAccessors(item['domain']).get_forms(xforms_ids)
+    forms = XFormInstance.objects.get_forms(xforms_ids, item['domain'])
     f_forms = [f for f in forms if f.xmlns == xmlns]
     s_forms = sorted(f_forms, key=lambda x: x.received_on)
 
@@ -88,7 +89,7 @@ class EQAActionItemSpec(JsonObject):
 
     def __call__(self, item, context=None):
         xforms_ids = CaseAccessors(item['domain']).get_case_xform_ids(item['_id'])
-        forms = FormAccessors(item['domain']).get_forms(xforms_ids)
+        forms = XFormInstance.objects.get_forms(xforms_ids, item['domain'])
         f_forms = [f for f in forms if f.xmlns == self.xmlns]
         s_forms = sorted(f_forms, key=lambda x: x.received_on)
 

--- a/docs/forms_and_cases.rst
+++ b/docs/forms_and_cases.rst
@@ -89,7 +89,7 @@ name in order to know which DB needs to be queried.
 - XFormInstance.objects.get_form(form_id, domain)
 - XFormInstance.objects.get_forms(form_ids, domain)
 - FormAccessors(domain).iter_forms(form_ids)
-- FormAccessors(domain).save_new_form(form)
+- XFormInstance.objects.save_new_form(form)
 
   - only for new forms
 

--- a/docs/forms_and_cases.rst
+++ b/docs/forms_and_cases.rst
@@ -93,7 +93,7 @@ name in order to know which DB needs to be queried.
 
   - only for new forms
 
-- FormAccessors(domain).get_with_attachments(form)
+- XFormInstance.objects.get_with_attachments(form, domain)
 
   - Preload attachments to avoid having to the the DB again
 

--- a/docs/forms_and_cases.rst
+++ b/docs/forms_and_cases.rst
@@ -87,7 +87,7 @@ name in order to know which DB needs to be queried.
 **Forms**
 
 - XFormInstance.objects.get_form(form_id, domain)
-- FormAccessors(domain).get_forms(form_ids)
+- XFormInstance.objects.get_forms(form_ids, domain)
 - FormAccessors(domain).iter_forms(form_ids)
 - FormAccessors(domain).save_new_form(form)
 


### PR DESCRIPTION
Continuation of https://github.com/dimagi/commcare-hq/pull/31013

Phase 2:
- Move `FormAccessorSQL.get_forms` to `XFormInstance.objects.get_forms`
- Continue moving other form accessor functions to `XFormInstance.objects`

:blowfish: Review by commit.

## Safety Assurance

### Safety story

In addition to preserving all of the old tests and adapting the old methods that are being phased out to call the new method, new tests (copies of the old tests adapted to the new structure) are being added for the new model manager.

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
