### PR TITLE
Fix ptop_preindex now that couch cases are gone

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_preindex.py
+++ b/corehq/apps/hqcase/management/commands/ptop_preindex.py
@@ -38,7 +38,7 @@ def get_reindex_commands(hq_index_name):
     # that should be used to rebuild the index from scratch
     pillow_command_map = {
         DOMAIN_HQ_INDEX_NAME: ['domain'],
-        CASE_HQ_INDEX_NAME: ['case', 'sql-case'],
+        CASE_HQ_INDEX_NAME: ['sql-case'],
         XFORM_HQ_INDEX_NAME: ['sql-form'],
         # groupstousers indexing must happen after all users are indexed
         USER_HQ_INDEX_NAME: [

--- a/corehq/apps/hqcase/management/commands/ptop_preindex.py
+++ b/corehq/apps/hqcase/management/commands/ptop_preindex.py
@@ -9,7 +9,17 @@ import gevent
 from gevent import monkey
 
 from corehq.apps.hqcase.management.commands.ptop_reindexer_v2 import (
-    FACTORIES_BY_SLUG,
+    DomainReindexerFactory,
+    UserReindexerFactory,
+    GroupReindexerFactory,
+    GroupToUserReindexerFactory,
+    SqlCaseReindexerFactory,
+    SqlFormReindexerFactory,
+    CaseSearchReindexerFactory,
+    SmsReindexerFactory,
+    ReportCaseReindexerFactory,
+    ReportFormReindexerFactory,
+    AppReindexerFactory,
 )
 from corehq.elastic import get_es_new
 from corehq.pillows.user import add_demo_user_to_user_index
@@ -33,25 +43,26 @@ monkey.patch_all()
 
 
 def get_reindex_commands(hq_index_name):
-    # pillow_command_map is a mapping from es pillows
-    # to lists of management commands or functions
-    # that should be used to rebuild the index from scratch
+    """Return a list of ``ReindexerFactory`` classes or functions that are used
+    to rebuild the index from scratch.
+
+    :param hq_index_name: ``str`` name of the Elastic index alias"""
     pillow_command_map = {
-        DOMAIN_HQ_INDEX_NAME: ['domain'],
-        CASE_HQ_INDEX_NAME: ['sql-case'],
-        XFORM_HQ_INDEX_NAME: ['sql-form'],
+        DOMAIN_HQ_INDEX_NAME: [DomainReindexerFactory],
+        CASE_HQ_INDEX_NAME: [SqlCaseReindexerFactory],
+        XFORM_HQ_INDEX_NAME: [SqlFormReindexerFactory],
         # groupstousers indexing must happen after all users are indexed
         USER_HQ_INDEX_NAME: [
-            'user',
+            UserReindexerFactory,
             add_demo_user_to_user_index,
-            'groups-to-user',
+            GroupToUserReindexerFactory,
         ],
-        APP_HQ_INDEX_NAME: ['app'],
-        GROUP_HQ_INDEX_NAME: ['group'],
-        REPORT_XFORM_HQ_INDEX_NAME: ['report-xform'],
-        REPORT_CASE_HQ_INDEX_NAME: ['report-case'],
-        CASE_SEARCH_HQ_INDEX_NAME: ['case-search'],
-        SMS_HQ_INDEX_NAME: ['sms'],
+        APP_HQ_INDEX_NAME: [AppReindexerFactory],
+        GROUP_HQ_INDEX_NAME: [GroupReindexerFactory],
+        REPORT_XFORM_HQ_INDEX_NAME: [ReportFormReindexerFactory],
+        REPORT_CASE_HQ_INDEX_NAME: [ReportCaseReindexerFactory],
+        CASE_SEARCH_HQ_INDEX_NAME: [CaseSearchReindexerFactory],
+        SMS_HQ_INDEX_NAME: [SmsReindexerFactory],
     }
     return pillow_command_map.get(hq_index_name, [])
 
@@ -59,16 +70,22 @@ def get_reindex_commands(hq_index_name):
 def do_reindex(hq_index_name, reset):
     print("Starting pillow preindex %s" % hq_index_name)
     reindex_commands = get_reindex_commands(hq_index_name)
-    for reindex_command in reindex_commands:
-        if isinstance(reindex_command, str):
-            kwargs = {}
-            factory = FACTORIES_BY_SLUG[reindex_command]
-            reindex_args = ReindexerFactory.resumable_reindexer_args
-            if reset and factory.arg_contributors and reindex_args in factory.arg_contributors:
-                kwargs["reset"] = True
-            factory(**kwargs).build().reindex()
+    for factory_or_func in reindex_commands:
+        try:
+            is_factory = issubclass(factory_or_func, ReindexerFactory)
+        except TypeError:  # TypeError: issubclass() arg 1 must be a class
+            factory_or_func()
         else:
-            reindex_command()
+            if is_factory:
+                kwargs = {}
+                reindex_args = ReindexerFactory.resumable_reindexer_args
+                if reset \
+                        and factory_or_func.arg_contributors \
+                        and reindex_args in factory_or_func.arg_contributors:
+                    kwargs["reset"] = True
+                factory_or_func(**kwargs).build().reindex()
+            else:
+                raise ValueError(f"expected ReindexerFactory, got: {factory_or_func!r}")
     print("Pillow preindex finished %s" % hq_index_name)
 
 
@@ -120,8 +137,8 @@ class Command(BaseCommand):
         for index_info in indices_needing_reindex:
             # loop through pillows once before running greenlets
             # to fail hard on misconfigured pillows
-            reindex_command = get_reindex_commands(index_info.hq_index_name)
-            if not reindex_command:
+            reindex_commands = get_reindex_commands(index_info.hq_index_name)
+            if not reindex_commands:
                 raise Exception(
                     "Error, pillow [%s] is not configured "
                     "with its own management command reindex command "

--- a/corehq/apps/hqcase/management/commands/ptop_preindex.py
+++ b/corehq/apps/hqcase/management/commands/ptop_preindex.py
@@ -71,21 +71,18 @@ def do_reindex(hq_index_name, reset):
     print("Starting pillow preindex %s" % hq_index_name)
     reindex_commands = get_reindex_commands(hq_index_name)
     for factory_or_func in reindex_commands:
-        try:
-            is_factory = issubclass(factory_or_func, ReindexerFactory)
-        except TypeError:  # TypeError: issubclass() arg 1 must be a class
-            factory_or_func()
-        else:
-            if is_factory:
-                kwargs = {}
-                reindex_args = ReindexerFactory.resumable_reindexer_args
-                if reset \
-                        and factory_or_func.arg_contributors \
-                        and reindex_args in factory_or_func.arg_contributors:
-                    kwargs["reset"] = True
-                factory_or_func(**kwargs).build().reindex()
-            else:
+        if isinstance(factory_or_func, type):
+            if not issubclass(factory_or_func, ReindexerFactory):
                 raise ValueError(f"expected ReindexerFactory, got: {factory_or_func!r}")
+            kwargs = {}
+            reindex_args = ReindexerFactory.resumable_reindexer_args
+            if reset \
+                    and factory_or_func.arg_contributors \
+                    and reindex_args in factory_or_func.arg_contributors:
+                kwargs["reset"] = True
+            factory_or_func(**kwargs).build().reindex()
+        else:
+            factory_or_func()
     print("Pillow preindex finished %s" % hq_index_name)
 
 


### PR DESCRIPTION
## Technical Summary
Same issue as #30671, but for cases.

The `ptop_preindex` command fails due to its static-string reference to a part of code it doesn't control.

This PR replaces the fragile static strings with the actual classes they were "proxying" in order to prevent future bugs of this nature.

## Safety Assurance

### Safety story

The `ptop_preindex` management command was run locally to build all Elastic indices from scratch to ensure that all index factories are present.

### Automated test coverage

This part of the codebase is not tested.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
