### PR TITLE
hide case search config options until case search is active

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -430,7 +430,8 @@ hqDefine("app_manager/js/details/case_claim", function () {
         };
 
         self.isEnabled = ko.computed(() => {
-            return self._getProperties().length > 0;
+            // match logic in corehq.apps.app_manager.util.module_offers_search
+            return self._getProperties().length > 0 || self._getDefaultProperties().length > 0;
         });
 
         self.serialize = function () {

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -429,6 +429,10 @@ hqDefine("app_manager/js/details/case_claim", function () {
             return self.commonProperties().indexOf(prop) !== -1;
         };
 
+        self.isEnabled = ko.computed(() => {
+            return self._getProperties().length > 0;
+        });
+
         self.serialize = function () {
             return _.extend({
                 properties: self._getProperties(),

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -7,6 +7,9 @@
 </legend>
 
 <div data-bind="with: search">
+  <div class="alert alert-info" data-bind="hidden: isEnabled">
+    {% trans "Add at least one search property to active case search for this case list" %}
+  </div>
   <form>
     <div class="panel panel-appmanager">
       <div class="panel-heading">
@@ -39,7 +42,7 @@
         </p>
       </div>
     </div>
-    <div class="panel panel-appmanager">
+    <div class="panel panel-appmanager" data-bind="visible: isEnabled">
       <div class="panel-heading">
         <h4 class="panel-title panel-title-nolink">{% trans "Default Search Filters" %}</h4>
       </div>
@@ -86,7 +89,7 @@
         </p>
       </div>
     </div>
-    <div class="panel panel-appmanager">
+    <div class="panel panel-appmanager" data-bind="visible: isEnabled">
       <div class="panel-heading">
         <h4 class="panel-title panel-title-nolink">{% trans "Search and Claim Options" %}</h4>
       </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -42,7 +42,7 @@
         </p>
       </div>
     </div>
-    <div class="panel panel-appmanager" data-bind="visible: isEnabled">
+    <div class="panel panel-appmanager">
       <div class="panel-heading">
         <h4 class="panel-title panel-title-nolink">{% trans "Default Search Filters" %}</h4>
       </div>


### PR DESCRIPTION
## Product Description
In order for case search to be enabled there needs to be at least one valid search property. Currently the UI does not make this clear since it displays all the config options regardless of whether it is enabled or not.

This change hides all the config options until at least one property is present. It also adds a small hint info:

![Peek 2022-02-01 13-36](https://user-images.githubusercontent.com/249606/151961819-f1de1d7a-7a61-4ea6-81fa-08594c734cf5.gif)



## Feature Flag
Case search and claim

## Safety Assurance

### Safety story
UI & JS change only - tested locally

### Automated test coverage
None

### QA Plan
None

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
