### PR TITLE
Fix queueing of broadcast messages

### DIFF
--- a/corehq/messaging/scheduling/tasks.py
+++ b/corehq/messaging/scheduling/tasks.py
@@ -299,7 +299,7 @@ def refresh_alert_schedule_instances(schedule_id, recipients):
     :param recipients: a list of (recipient_type, recipient_id) tuples; the
     recipient type should be one of the values checked in ScheduleInstance.recipient
     """
-    with CriticalSection(['refresh-alert-schedule-instances-for-%s' % schedule_id.hex], timeout=5 * 60):
+    with CriticalSection(['refresh-alert-schedule-instances-for-%s' % schedule_id], timeout=5 * 60):
         schedule = AlertSchedule.objects.get(schedule_id=schedule_id)
         AlertScheduleInstanceRefresher(
             schedule,

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -493,10 +493,10 @@ class CreateScheduleView(BaseMessagingSectionView, AsyncHandlerMixin):
 
             broadcast, schedule = self.schedule_form.save_broadcast_and_schedule()
             if isinstance(schedule, AlertSchedule):
-                refresh_alert_schedule_instances.delay(schedule.schedule_id, broadcast.recipients)
+                refresh_alert_schedule_instances.delay(schedule.schedule_id.hex, broadcast.recipients)
             elif isinstance(schedule, TimedSchedule):
                 refresh_timed_schedule_instances.delay(
-                    schedule.schedule_id,
+                    schedule.schedule_id.hex,
                     broadcast.recipients,
                     start_date=json_format_date(broadcast.start_date)
                 )


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
A previous change to how tasks were enqueued (removing pickling) caused UUIDs to be passed as plain string objects. This makes passing them as strings explicit, so we don't attempt to access UUID fields within the task.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Tested this via local testing. This seems like a strange defect to write tests for, as the issue was caused by changing the serialization process (and running the task with ALWAYS_EAGER still succeeded). I think the best we can do is verify this works as intended on staging.

### Automated test coverage

Noted above, I don't see a good test to write for this.

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
