### PR TITLE
Removed MOBILE_UCR_LINKED_DOMAIN

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -125,14 +125,9 @@
       {% endif %}
       {% if show_report_modules %}
         <div class="pull-left">
-          <button type="button" class="popover-additem-option new-module" data-type="report" {% if disable_report_modules %} disabled {% endif %}>
-            <i class="fa {% if disable_report_modules %}fa-ban{% else %}fa-bar-chart{% endif %}"></i>
-            {% trans "Report Menu" %}
-            {% if disable_report_modules %}
-              <p>{% blocktrans %}Mobile reports are disabled because this is a linked domain.{% endblocktrans %}</p>
-            {% else %}
-              <p>{% blocktrans %}Worker performance.{% endblocktrans %}</p>
-            {% endif %}
+          <button type="button" class="popover-additem-option new-module" data-type="report">
+            <i class="fa fa-bar-chart"></i> {% trans "Report Menu" %}
+            <p>{% blocktrans %}Worker performance.{% endblocktrans %}</p>
           </button>
         </div>
       {% endif %}

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -397,11 +397,6 @@ def get_apps_base_context(request, domain, app):
             and app.is_biometric_enabled
         )
 
-        disable_report_modules = (
-            is_active_upstream_domain(domain)
-            and not toggles.MOBILE_UCR_LINKED_DOMAIN.enabled(domain)
-        )
-
         # ideally this should be loaded on demand
         practice_users = []
         if app.enable_practice_users:
@@ -418,7 +413,6 @@ def get_apps_base_context(request, domain, app):
             'show_advanced': show_advanced,
             'show_biometric': show_biometric,
             'show_report_modules': toggles.MOBILE_UCR.enabled(domain),
-            'disable_report_modules': disable_report_modules,
             'show_shadow_modules': toggles.APP_BUILDER_SHADOW_MODULES.enabled(domain),
             'show_shadow_module_v1': toggles.V1_SHADOW_MODULES.enabled(domain),
             'show_shadow_forms': show_advanced,

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1071,15 +1071,6 @@ MOBILE_UCR = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-MOBILE_UCR_LINKED_DOMAIN = StaticToggle(
-    'mobile_ucr_linked_domain',
-    'Mobile UCR: Configure viewing user configurable reports on the mobile when using linked domains.',
-    TAG_CUSTOM,
-    namespaces=[NAMESPACE_DOMAIN],
-    description='Mobile UCR: Configure viewing user configurable reports on the mobile when using linked domains. '
-                'NOTE: This won\'t work without developer intervention'
-)
-
 API_THROTTLE_WHITELIST = StaticToggle(
     'api_throttle_whitelist',
     ('API throttle whitelist'),


### PR DESCRIPTION
## Product Description
This flag is no longer necessarily. We've had linked project space support for mobile UCR for a little while.

Marking don't merge until I verify that docs are up to date.

## Feature Flag
Mobile UCR: Configure viewing user configurable reports on the mobile when using linked domains.

## Safety Assurance

### Safety story

The code change is pretty trivial - all the flag is gating is the ability to add a new report menu to an app.

### Automated test coverage

Nothing at the UI level.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
