### PR TITLE
Revert "Merge pull request #30559 from dimagi/dependabot/pip/requirem…

### DIFF
--- a/corehq/util/workbook_reading/adapters/xlsx.py
+++ b/corehq/util/workbook_reading/adapters/xlsx.py
@@ -45,8 +45,15 @@ class _XLSXWorksheetAdaptor(object):
         self._worksheet = openpyxl_worksheet
 
     def _make_cell_value(self, cell):
-        if isinstance(cell.value, datetime) and cell.value.time() == time(0, 0):
-            return cell.value.date()
+        if isinstance(cell.value, datetime):
+            if cell._value == 0 and from_excel(0) == datetime(1899, 12, 30, 0, 0):
+                # openpyxl has a bug that treats '12:00:00 AM'
+                # as 0 seconds from the 'Windows Epoch' of 1899-12-30
+                return time(0, 0)
+            elif cell.value.time() == time(0, 0):
+                return cell.value.date()
+            else:
+                return cell.value
         return cell.value
 
     @property

--- a/corehq/util/workbook_reading/tests/test_spreadsheets.py
+++ b/corehq/util/workbook_reading/tests/test_spreadsheets.py
@@ -48,7 +48,7 @@ def test_xlsx_types(self, open_workbook, ext):
                         ['Date', date(1988, 7, 7)],
                         ['Date Time', datetime(2016, 1, 1, 12, 0)],
                         ['Time', time(12, 0)],
-                        ['Midnight', time(0, 0)],
+                        ['Midnight', date(1899, 12, 30) if ext == 'xlsx' else time(0, 0)],
                         ['Int', 28],
                         ['Int.0', 5],
                         ['Float', 5.1],

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -261,6 +261,8 @@ iso8601==0.1.13
     # via -r base-requirements.in
 isodate==0.6.0
     # via python3-saml
+jdcal==1.4.1
+    # via openpyxl
 jedi==0.18.1
     # via ipython
 jinja2==2.11.3
@@ -328,7 +330,7 @@ oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-openpyxl==3.0.9
+openpyxl==3.0.6
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -210,6 +210,8 @@ intervaltree==3.1.0
     # via ddtrace
 iso8601==0.1.13
     # via -r base-requirements.in
+jdcal==1.4.1
+    # via openpyxl
 jinja2==2.11.3
     # via
     #   -r base-requirements.in
@@ -265,7 +267,7 @@ oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-openpyxl==3.0.9
+openpyxl==3.0.6
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -219,6 +219,8 @@ iso8601==0.1.13
     # via -r base-requirements.in
 isodate==0.6.0
     # via python3-saml
+jdcal==1.4.1
+    # via openpyxl
 jedi==0.18.1
     # via ipython
 jinja2==2.11.3
@@ -273,7 +275,7 @@ oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-openpyxl==3.0.9
+openpyxl==3.0.6
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -198,6 +198,8 @@ iso8601==0.1.13
     # via -r base-requirements.in
 isodate==0.6.0
     # via python3-saml
+jdcal==1.4.1
+    # via openpyxl
 jinja2==2.11.3
     # via -r base-requirements.in
 jmespath==0.10.0
@@ -244,7 +246,7 @@ oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-openpyxl==3.0.9
+openpyxl==3.0.6
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -216,6 +216,8 @@ iso8601==0.1.13
     # via -r base-requirements.in
 isodate==0.6.0
     # via python3-saml
+jdcal==1.4.1
+    # via openpyxl
 jinja2==2.11.3
     # via -r base-requirements.in
 jmespath==0.10.0
@@ -271,7 +273,7 @@ oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-openpyxl==3.0.9
+openpyxl==3.0.6
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker


### PR DESCRIPTION
…ents/openpyxl-3.0.9"

This reverts commit ddfdc07463daf4489c4e01fd94bcbc1d5cf10757, reversing
changes made to 2026a74c6aa9acd8a996de77b7cc231a4fd3095a.

Reverting [this PR](https://github.com/dimagi/commcare-hq/pull/30559)

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13134

Introduced a bug into downloading exports that I should have caught. I'm looking into stripping timezone info entirely from the couch date before sending to openpyxl, but due to local env issues is taking longer than I hoped. Reverting this PR for now to fix the bug.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
