### PR TITLE
Fix redundant global admin URL pattern resolvers

### DIFF
--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -172,15 +172,17 @@ NON_GLOBAL_USER_API_LIST = (
 USER_API_LIST = GLOBAL_USER_API_LIST + NON_GLOBAL_USER_API_LIST
 
 
-def get_global_api_url_patterns(resources):
+def _get_global_api_url_patterns(resources):
     api = CommCareHqApi(api_name='global')
     for resource in resources:
         api.register(resource())
-        yield url(r'^', include(api.urls))
+    return url(r'^', include(api.urls))
 
 
-admin_urlpatterns = list(get_global_api_url_patterns(ADMIN_API_LIST)) + \
-                    list(get_global_api_url_patterns(GLOBAL_USER_API_LIST))
+admin_urlpatterns = [
+    _get_global_api_url_patterns(ADMIN_API_LIST),
+    _get_global_api_url_patterns(GLOBAL_USER_API_LIST),
+]
 
 
 VERSIONED_USER_API_LIST = (


### PR DESCRIPTION
Only noticed this because of a lint error.

It was adding a new `url(...)` item with one extra resource for each resource in `ADMIN_API_LIST` and `GLOBAL_USER_API_LIST`. Not a big deal for `GLOBAL_USER_API_LIST` since it only has one item, but it was especially bad for `ADMIN_API_LIST`, which contains 25 resources, resulting in a total of 25 redundant URL patterns and 1 + 2 + 3 ... + 25 = 325 redundant resolvers:

```
<URLPattern '^(?P<api_name>global)/$' [name='api_global_top_level']>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>

<URLPattern '^(?P<api_name>global)/$' [name='api_global_top_level']>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>

<URLPattern '^(?P<api_name>global)/$' [name='api_global_top_level']>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>

...

<URLPattern '^(?P<api_name>global)/$' [name='api_global_top_level']>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
<URLResolver <URLPattern list> (None:None) '^(?P<api_name>global)/'>
```

## Safety Assurance

### Safety story

Tested URL pattern construction in a shell.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None added.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
