### PR TITLE
Retry upgrading Openpyxl to 3.0.9

### DIFF
--- a/corehq/ex-submodules/couchexport/tests/test_excel_format_value.py
+++ b/corehq/ex-submodules/couchexport/tests/test_excel_format_value.py
@@ -1,13 +1,12 @@
 import datetime
 from decimal import Decimal
 
+from openpyxl.styles import numbers
 from testil import eq
 
-from dateutil.tz import tzoffset, tzlocal
-from openpyxl.styles import numbers
-
-from corehq.apps.export.const import MISSING_VALUE, EMPTY_VALUE
 from couchexport.util import get_excel_format_value
+
+from corehq.apps.export.const import EMPTY_VALUE, MISSING_VALUE
 
 
 def check(input, output, format, output_type):

--- a/corehq/ex-submodules/couchexport/tests/test_excel_format_value.py
+++ b/corehq/ex-submodules/couchexport/tests/test_excel_format_value.py
@@ -107,18 +107,16 @@ def test_datetime():
         datetime.datetime(2020, 1, 20, 13, 33, 22), \
         numbers.FORMAT_DATE_DATETIME, datetime.datetime
     yield check, '2020-01-20 09:33:22.890000-6:00', \
-        datetime.datetime(2020, 1, 20, 9, 33, 22, 890000,
-                          tzinfo=tzoffset(None, -21600)), \
+        datetime.datetime(2020, 1, 20, 9, 33, 22, 890000), \
         numbers.FORMAT_DATE_DATETIME, datetime.datetime
     yield check, '2020-01-20 09:33:22.890000-6', \
-        datetime.datetime(2020, 1, 20, 9, 33, 22, 890000,
-                          tzinfo=tzoffset(None, -21600)), \
+        datetime.datetime(2020, 1, 20, 9, 33, 22, 890000), \
         numbers.FORMAT_DATE_DATETIME, datetime.datetime
     yield check, datetime.datetime(2020, 1, 20, 11, 11), \
         datetime.datetime(2020, 1, 20, 11, 11), \
         numbers.FORMAT_DATE_DATETIME, datetime.datetime
     yield check, '2020-01-17T15:45:37.268000Z', \
-        datetime.datetime(2020, 1, 17, 15, 45, 37, 268000, tzinfo=tzlocal()), \
+        datetime.datetime(2020, 1, 17, 15, 45, 37, 268000), \
         numbers.FORMAT_DATE_DATETIME, datetime.datetime
 
 

--- a/corehq/ex-submodules/couchexport/util.py
+++ b/corehq/ex-submodules/couchexport/util.py
@@ -5,11 +5,12 @@ from decimal import Decimal
 import dateutil
 from openpyxl.styles import numbers
 
-from corehq.apps.export.const import MISSING_VALUE, EMPTY_VALUE
+from corehq.apps.export.const import EMPTY_VALUE, MISSING_VALUE
 
 _dirty_chars = re.compile(
     '[\x00-\x08\x0b-\x1f\x7f-\x84\x86-\x9f\ud800-\udfff\ufdd0-\ufddf\ufffe-\uffff]'
 )
+
 
 def get_excel_format_value(value):
     from corehq.apps.export.models.new import ExcelFormatValue

--- a/corehq/util/workbook_reading/adapters/xlsx.py
+++ b/corehq/util/workbook_reading/adapters/xlsx.py
@@ -45,15 +45,8 @@ class _XLSXWorksheetAdaptor(object):
         self._worksheet = openpyxl_worksheet
 
     def _make_cell_value(self, cell):
-        if isinstance(cell.value, datetime):
-            if cell._value == 0 and from_excel(0) == datetime(1899, 12, 30, 0, 0):
-                # openpyxl has a bug that treats '12:00:00 AM'
-                # as 0 seconds from the 'Windows Epoch' of 1899-12-30
-                return time(0, 0)
-            elif cell.value.time() == time(0, 0):
-                return cell.value.date()
-            else:
-                return cell.value
+        if isinstance(cell.value, datetime) and cell.value.time() == time(0, 0):
+            return cell.value.date()
         return cell.value
 
     @property

--- a/corehq/util/workbook_reading/tests/test_spreadsheets.py
+++ b/corehq/util/workbook_reading/tests/test_spreadsheets.py
@@ -48,7 +48,7 @@ def test_xlsx_types(self, open_workbook, ext):
                         ['Date', date(1988, 7, 7)],
                         ['Date Time', datetime(2016, 1, 1, 12, 0)],
                         ['Time', time(12, 0)],
-                        ['Midnight', date(1899, 12, 30) if ext == 'xlsx' else time(0, 0)],
+                        ['Midnight', time(0, 0)],
                         ['Int', 28],
                         ['Int.0', 5],
                         ['Float', 5.1],

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -278,8 +278,6 @@ iso8601==0.1.13
     # via -r base-requirements.in
 isodate==0.6.1
     # via python3-saml
-jdcal==1.4.1
-    # via openpyxl
 jedi==0.18.1
     # via ipython
 jinja2==2.11.3
@@ -349,7 +347,7 @@ oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-openpyxl==3.0.6
+openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -231,8 +231,6 @@ intervaltree==3.1.0
     # via ddtrace
 iso8601==0.1.13
     # via -r base-requirements.in
-jdcal==1.4.1
-    # via openpyxl
 jinja2==2.11.3
     # via
     #   -r base-requirements.in
@@ -290,7 +288,7 @@ oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-openpyxl==3.0.6
+openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -236,8 +236,6 @@ iso8601==0.1.13
     # via -r base-requirements.in
 isodate==0.6.1
     # via python3-saml
-jdcal==1.4.1
-    # via openpyxl
 jedi==0.18.1
     # via ipython
 jinja2==2.11.3
@@ -292,7 +290,7 @@ oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-openpyxl==3.0.6
+openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -219,8 +219,6 @@ iso8601==0.1.13
     # via -r base-requirements.in
 isodate==0.6.1
     # via python3-saml
-jdcal==1.4.1
-    # via openpyxl
 jinja2==2.11.3
     # via -r base-requirements.in
 jmespath==0.10.0
@@ -269,7 +267,7 @@ oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-openpyxl==3.0.6
+openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -237,8 +237,6 @@ iso8601==0.1.13
     # via -r base-requirements.in
 isodate==0.6.1
     # via python3-saml
-jdcal==1.4.1
-    # via openpyxl
 jinja2==2.11.3
     # via -r base-requirements.in
 jmespath==0.10.0
@@ -296,7 +294,7 @@ oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-openpyxl==3.0.6
+openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker


### PR DESCRIPTION
Reverts dimagi/commcare-hq#31042

See https://github.com/dimagi/commcare-hq/pull/30559#issuecomment-1016603483 for context on 3485e80956ef2afd11ec3d5c67d8012341d9d4ae (the first commit) which has already been reviewed.

See https://dimagi-dev.atlassian.net/browse/SAAS-13134 for context on the uncaught issue that resulted from this upgrade related to timezones, which will provide context for 149ebce49f8003bf94375ca603ed51b4cad06d47 (the second commit).

My understanding is that it is expected that datetimes in exports are always in UTC, so stripping timezone info prior to sending to openpyxl should not be an issue.

QA Ticket: https://dimagi-dev.atlassian.net/browse/QA-4067