### PR TITLE
fixes link arg name

### DIFF
--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -320,7 +320,7 @@
               {% if not forloop.first %}<br>{% endif %}
               <dt>{{ key }}</dt>
               {% if attachment.is_image %}
-                <dd><img src="{% url "form_attachment_view" domain=domain form_id=instance.form_id attachment_id=key %}"></dd>
+                <dd><img src="{% url "form_attachment_view" domain=domain instance_id=instance.form_id attachment_id=key %}"></dd>
               {% else %}
                 <dd><a href="{% url "form_attachment_view" domain instance.form_id key %}" download="{{ key }}">{% trans "Download" %}</a></dd>
               {% endif %}


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Fixes bug introduced in https://github.com/dimagi/commcare-hq/pull/30801 when creating the link to view form attachment if its an image

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Sentry](https://sentry.io/organizations/dimagi/issues/2984546966/events/?environment=production&project=136860&statsPeriod=14d)

A view was replaced but I missed changing the argument name in https://github.com/dimagi/commcare-hq/pull/30801/commits/5c7bd0efefcf80f82159fd98ad9a6220de5616a1#diff-40e8d0436757f1becabbd6bb605334fe71c196a698b74feb6f83a95af724d59fR323

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
