### PR TITLE
Move and optimize fetchall_as_namedtuple

### DIFF
--- a/corehq/apps/cleanup/management/commands/dedupe_case_indices.py
+++ b/corehq/apps/cleanup/management/commands/dedupe_case_indices.py
@@ -10,10 +10,7 @@ from django.core.management.base import BaseCommand
 from dimagi.utils.chunked import chunked
 
 from corehq.form_processor.models import CommCareCaseIndex
-from corehq.form_processor.utils.sql import (
-    fetchall_as_namedtuple,
-    fetchone_as_namedtuple,
-)
+from corehq.form_processor.utils.sql import fetchall_as_namedtuple
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 
 IDENTIFIER_INDEX_NAME = 'form_processor_commcarecaseindexsql_identifier'
@@ -96,7 +93,7 @@ def _index_exists(db, index_name):
         sql = "SELECT to_regclass('{}') IS NOT NULL as index_exists".format(index_name)
         log_sql(sql)
         cursor.execute(sql)
-        return fetchone_as_namedtuple(cursor).index_exists
+        return cursor.fetchone()[0]
 
 
 def _drop_index(db, index_name):

--- a/corehq/apps/cleanup/management/commands/dedupe_case_indices.py
+++ b/corehq/apps/cleanup/management/commands/dedupe_case_indices.py
@@ -90,9 +90,9 @@ def _add_temp_index(db):
 
 def _index_exists(db, index_name):
     with CommCareCaseIndex.get_cursor_for_partition_db(db).cursor() as cursor:
-        sql = "SELECT to_regclass('{}') IS NOT NULL as index_exists".format(index_name)
-        log_sql(sql)
-        cursor.execute(sql)
+        sql = "SELECT to_regclass(%s) IS NOT NULL as index_exists"
+        log_sql(sql % repr(index_name))
+        cursor.execute(sql, [index_name])
         return cursor.fetchone()[0]
 
 
@@ -145,16 +145,15 @@ def _delete_duplicate_indices(case_ids, db):
         SELECT id FROM (
           SELECT id, case_id, row_number() OVER (PARTITION BY case_id, identifier, referenced_id, relationship_id)
           FROM {case_index_table}
-          JOIN (SELECT UNNEST(ARRAY['{{case_ids}}']) AS case_id) AS cx USING (case_id)) as indices
+          JOIN (SELECT UNNEST(%s) AS case_id) AS cx USING (case_id)) as indices
         WHERE row_number > 1
         )
     """.format(case_index_table=CommCareCaseIndex._meta.db_table)
 
-    for chunk in chunked(case_ids, 100):
+    for chunk in chunked(case_ids, 100, list):
         with CommCareCaseIndex.get_cursor_for_partition_db(db) as cursor:
-            delete_sql = delete_dupes_sql.format(case_ids="','".join(chunk))
-            log_sql(delete_sql)
-            cursor.execute(delete_sql)
+            log_sql(delete_dupes_sql % repr(chunk))
+            cursor.execute(delete_dupes_sql, [chunk])
 
 
 def _get_case_ids_with_dupe_indices(db):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -46,10 +46,7 @@ from corehq.form_processor.models import (
     LedgerValue,
     XFormInstance,
 )
-from corehq.form_processor.utils.sql import (
-    fetchall_as_namedtuple,
-    fetchone_as_namedtuple,
-)
+from corehq.form_processor.utils.sql import fetchall_as_namedtuple
 from corehq.sql_db.config import plproxy_config
 from corehq.sql_db.util import (
     estimate_row_count,
@@ -128,7 +125,7 @@ class ShardAccessor(object):
         with XFormInstance.get_plproxy_cursor() as cursor:
             doc_uuid_before_cast = '\\x%s' % doc_uuid.hex
             cursor.execute(query, [doc_uuid_before_cast])
-            return fetchone_as_namedtuple(cursor).hash
+            return cursor.fetchone()[0]
 
     @staticmethod
     def hash_doc_ids_python(doc_ids):

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -42,7 +42,7 @@ from ..system_action import system_action
 from ..track_related import TrackRelatedChanges
 from .attachment import AttachmentContent, AttachmentMixin
 from .mixin import SaveStateMixin
-from .util import attach_prefetch_models, sort_with_id_list
+from .util import attach_prefetch_models, fetchall_as_namedtuple, sort_with_id_list
 
 log = logging.getLogger(__name__)
 
@@ -174,7 +174,6 @@ class XFormInstanceManager(RequireDBManager):
         return self.get_form_ids_in_domain_by_state(domain, state)
 
     def get_form_ids_in_domain_by_state(self, domain, state):
-        from ..utils.sql import fetchall_as_namedtuple
         with self.model.get_plproxy_cursor(readonly=True) as cursor:
             cursor.execute(
                 'SELECT form_id from get_form_ids_in_domain_by_type(%s, %s)',
@@ -209,7 +208,6 @@ class XFormInstanceManager(RequireDBManager):
         return self._get_form_ids_for_user(domain, user_id, is_deleted=True)
 
     def _get_form_ids_for_user(self, domain, user_id, is_deleted):
-        from ..utils.sql import fetchall_as_namedtuple
         with self.model.get_plproxy_cursor(readonly=True) as cursor:
             cursor.execute(
                 'SELECT form_id FROM get_form_ids_for_user(%s, %s, %s)',
@@ -340,7 +338,6 @@ class XFormInstanceManager(RequireDBManager):
 
     def soft_delete_forms(self, domain, form_ids, deletion_date=None, deletion_id=None):
         from ..change_publishers import publish_form_deleted
-        from ..utils.sql import fetchall_as_namedtuple
         assert isinstance(form_ids, list)
         deletion_date = deletion_date or datetime.utcnow()
         with self.model.get_plproxy_cursor() as cursor:
@@ -358,7 +355,6 @@ class XFormInstanceManager(RequireDBManager):
 
     def soft_undelete_forms(self, domain, form_ids):
         from ..change_publishers import publish_form_saved
-        from ..utils.sql import fetchall_as_namedtuple
         assert isinstance(form_ids, list)
         problem = 'Restored on {}'.format(datetime.utcnow())
         with self.model.get_plproxy_cursor() as cursor:

--- a/corehq/form_processor/models/util.py
+++ b/corehq/form_processor/models/util.py
@@ -1,4 +1,16 @@
+from collections import namedtuple
 from itertools import groupby
+
+
+def fetchall_as_namedtuple(cursor):
+    "Return all rows from a cursor as a namedtuple generator"
+    Result = _namedtuple_from_cursor(cursor)
+    return (Result(*row) for row in cursor)
+
+
+def _namedtuple_from_cursor(cursor):
+    desc = cursor.description
+    return namedtuple('Result', [col[0] for col in desc])
 
 
 def sort_with_id_list(object_list, id_list, id_property):

--- a/corehq/form_processor/utils/sql.py
+++ b/corehq/form_processor/utils/sql.py
@@ -3,29 +3,18 @@ Note that the adapters must return the fields in the same order as they appear
 in the table DSL
 """
 import json
-from collections import namedtuple
 
 from jsonfield.fields import JSONEncoder
 from psycopg2.extensions import adapt
 
-from corehq.form_processor.models import (
+from ..models import (
     CommCareCase_DB_TABLE, CaseAttachment_DB_TABLE,
     CommCareCaseIndex_DB_TABLE, CaseTransaction_DB_TABLE,
     XFormInstance,
     LedgerValue_DB_TABLE, LedgerTransaction_DB_TABLE,
     XFormOperation,
 )
-
-
-def fetchall_as_namedtuple(cursor):
-    "Return all rows from a cursor as a namedtuple generator"
-    Result = _namedtuple_from_cursor(cursor)
-    return (Result(*row) for row in cursor)
-
-
-def _namedtuple_from_cursor(cursor):
-    desc = cursor.description
-    return namedtuple('Result', [col[0] for col in desc])
+from ..models.util import fetchall_as_namedtuple  # noqa: F401
 
 
 def form_adapter(form):

--- a/corehq/form_processor/utils/sql.py
+++ b/corehq/form_processor/utils/sql.py
@@ -23,13 +23,6 @@ def fetchall_as_namedtuple(cursor):
     return (Result(*row) for row in cursor)
 
 
-def fetchone_as_namedtuple(cursor):
-    "Return one row from a cursor as a namedtuple"
-    Result = _namedtuple_from_cursor(cursor)
-    row = cursor.fetchone()
-    return Result(*row)
-
-
 def _namedtuple_from_cursor(cursor):
     desc = cursor.description
     return namedtuple('Result', [col[0] for col in desc])


### PR DESCRIPTION
The most interesting part of this is the [final commit](https://github.com/dimagi/commcare-hq/commit/18f043a1151516a96178c91855f3d1fb47e13dd1), which caches recently used query result namedtuples rather than constructing a new `namedtuple` for every query. The cache uses the default `lru_cache` `maxsize` of 128, which should be plenty. Currently `fetchall_as_namedtuple` is used in less than 20 places, and some of those occurrences use the same column names, meaning there are even fewer cached namedtuples. The cache size can be customized by changing the decorator to `@lru_cache(maxsize=...)` if necessary in the future.

Ref https://rhye.org/post/python-cassandra-namedtuple-performance/

:blowfish: Review by commit.

## Safety Assurance

### Safety story

I expect issues to be surfaced by tests since many tests indirectly call `fetchall_as_namedtuple`.

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
