### PR TITLE
Fix broken tabclass tests after MRM changes

### DIFF
--- a/corehq/tabs/tests.py
+++ b/corehq/tabs/tests.py
@@ -1,8 +1,12 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from django.test import SimpleTestCase
 
-from corehq.tabs.tabclasses import _get_release_management_items, _get_feature_flag_items
+from corehq.privileges import LITE_RELEASE_MANAGEMENT, RELEASE_MANAGEMENT
+from corehq.tabs.tabclasses import (
+    _get_feature_flag_items,
+    _get_release_management_items,
+)
 from corehq.tabs.utils import path_starts_with_url
 
 __test__ = {
@@ -44,43 +48,48 @@ class TestAccessToLinkedProjects(SimpleTestCase):
         self.assertFalse(items)
 
 
-@patch('corehq.apps.users.models.CouchUser')
 class TestAccessToReleaseManagementTab(SimpleTestCase):
 
-    def test_get_release_management_items_returns_none(self, mock_user):
-        mock_user.is_domain_admin.return_value = False
+    def setUp(self):
+        super().setUp()
 
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
-            items = _get_release_management_items(mock_user, "domain")
+        access_patcher = patch('corehq.tabs.tabclasses.can_user_access_release_management')
+        self.mock_can_access = access_patcher.start()
+        self.addCleanup(access_patcher.stop)
 
+        privilege_patcher = patch('corehq.tabs.tabclasses.domain_has_privilege')
+        self.mock_domain_has_privilege = privilege_patcher.start()
+        self.addCleanup(privilege_patcher.stop)
+
+        reverse_patcher = patch('corehq.tabs.tabclasses.reverse')
+        self.mock_reverse = reverse_patcher.start()
+        self.mock_reverse.return_value = 'dummy_url'
+        self.addCleanup(reverse_patcher.stop)
+
+    def test_returns_none_if_cannot_user_access_release_management(self):
+        self.mock_can_access.return_value = False
+
+        title, items = _get_release_management_items(ANY, "domain")
+
+        self.assertFalse(title)
         self.assertFalse(items)
 
-    def test_get_release_management_items_returns_none_with_admin(self, mock_user):
-        mock_user.is_domain_admin.return_value = True
+    def test_returns_erm_if_can_access_full_release_management(self):
+        self.mock_can_access.return_value = True
+        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
 
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
-            items = _get_release_management_items(mock_user, "domain")
+        title, items = _get_release_management_items(ANY, "domain")
 
-        self.assertFalse(items)
+        self.assertEqual(title, 'Enterprise Release Management')
+        self.assertEqual(items[0]['title'], 'Linked Project Spaces')
+        self.assertEqual(items[1]['title'], 'Linked Project Space History')
 
-    def test_get_release_management_items_returns_none_with_domain_privilege(self, mock_user):
-        mock_user.is_domain_admin.return_value = False
+    def test_returns_mrm_if_has_privilege_but_not_admin(self):
+        self.mock_can_access.return_value = True
+        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == LITE_RELEASE_MANAGEMENT
 
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = True
-            items = _get_release_management_items(mock_user, "domain")
+        title, items = _get_release_management_items(ANY, "domain")
 
-        self.assertFalse(items)
-
-    def test_get_release_management_items_returns_some(self, mock_user):
-        mock_user.is_domain_admin.return_value = True
-
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege, \
-             patch('corehq.tabs.tabclasses.reverse') as mock_reverse:
-            mock_domain_has_privilege.return_value = True
-            mock_reverse.return_value = 'dummy_url'
-            items = _get_release_management_items(mock_user, "domain")
-
-        self.assertTrue(items)
+        self.assertEqual(title, 'Multi-Environment Release Management')
+        self.assertEqual(items[0]['title'], 'Linked Project Spaces')
+        self.assertEqual(items[1]['title'], 'Linked Project Space History')

--- a/corehq/tabs/tests.py
+++ b/corehq/tabs/tests.py
@@ -1,7 +1,8 @@
-from unittest.mock import ANY, patch
+from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
+from corehq.apps.users.models import WebUser
 from corehq.privileges import LITE_RELEASE_MANAGEMENT, RELEASE_MANAGEMENT
 from corehq.tabs.tabclasses import (
     _get_feature_flag_items,
@@ -70,6 +71,11 @@ class TestAccessToLinkedProjects(SimpleTestCase):
 
 class TestAccessToReleaseManagementTab(SimpleTestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = WebUser(username='test-username')
+
     def setUp(self):
         super().setUp()
 
@@ -89,7 +95,7 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
     def test_returns_none_if_cannot_user_access_release_management(self):
         self.mock_can_access.return_value = False
 
-        title, items = _get_release_management_items(ANY, "domain")
+        title, items = _get_release_management_items(self.user, "domain")
 
         self.assertFalse(title)
         self.assertFalse(items)
@@ -98,7 +104,7 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
         self.mock_can_access.return_value = True
         self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
 
-        title, items = _get_release_management_items(ANY, "domain")
+        title, items = _get_release_management_items(self.user, "domain")
 
         self.assertEqual(title, 'Enterprise Release Management')
         self.assertEqual(items[0]['title'], 'Linked Project Spaces')
@@ -108,7 +114,7 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
         self.mock_can_access.return_value = True
         self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == LITE_RELEASE_MANAGEMENT
 
-        title, items = _get_release_management_items(ANY, "domain")
+        title, items = _get_release_management_items(self.user, "domain")
 
         self.assertEqual(title, 'Multi-Environment Release Management')
         self.assertEqual(items[0]['title'], 'Linked Project Spaces')

--- a/corehq/tabs/tests.py
+++ b/corehq/tabs/tests.py
@@ -19,33 +19,53 @@ from corehq.util.test_utils import flag_enabled
 @patch('corehq.apps.users.models.CouchUser')
 class TestAccessToLinkedProjects(SimpleTestCase):
 
-    def test_get_feature_flag_items_returns_none(self, mock_user):
+    def setUp(self):
+        super().setUp()
+
+        access_patcher = patch('corehq.tabs.tabclasses.can_domain_access_release_management')
+        self.mock_can_access = access_patcher.start()
+        self.addCleanup(access_patcher.stop)
+
+        privilege_patcher = patch('corehq.tabs.tabclasses.domain_has_privilege')
+        self.mock_domain_has_privilege = privilege_patcher.start()
+        self.addCleanup(privilege_patcher.stop)
+
+    def test_returns_empty_if_no_release_management_access_and_is_admin_but_no_toggle(self, mock_user):
         mock_user.is_domain_admin.return_value = True
-        with patch('corehq.tabs.tabclasses.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
-            items = _get_feature_flag_items("domain", mock_user)
+        self.mock_can_access.return_value = False
+
+        items = _get_feature_flag_items("domain", mock_user)
 
         self.assertFalse(items)
 
     @flag_enabled('LINKED_DOMAINS')
-    def test_get_feature_flag_items_returns_some(self, mock_user):
-        mock_user.is_domain_admin.return_value = True
-        with patch('corehq.tabs.tabclasses.domain_has_privilege') as mock_domain_has_privilege, \
-             patch('corehq.tabs.tabclasses.reverse') as mock_reverse:
-            mock_domain_has_privilege.return_value = False
-            mock_reverse.return_value = 'dummy_url'
-            items = _get_feature_flag_items("domain", mock_user)
+    def test_returns_empty_if_no_release_management_access_and_toggle_but_not_admin(self, mock_user):
+        mock_user.is_domain_admin.return_value = False
+        self.mock_can_access.return_value = False
 
-        self.assertTrue(items)
-
-    @flag_enabled('LINKED_DOMAINS')
-    def test_get_feature_flag_items_returns_none_if_domain_has_release_management_privilege(self, mock_user):
-        mock_user.is_domain_admin.return_value = True
-        with patch('corehq.tabs.tabclasses.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = True
-            items = _get_feature_flag_items("domain", mock_user)
+        items = _get_feature_flag_items("domain", mock_user)
 
         self.assertFalse(items)
+
+    @flag_enabled('LINKED_DOMAINS')
+    def test_returns_empty_if_is_admin_and_has_toggle_but_can_access_release_management_privilege(self, mock_user):
+        mock_user.is_domain_admin.return_value = True
+        self.mock_can_access.return_value = True
+
+        items = _get_feature_flag_items("domain", mock_user)
+
+        self.assertFalse(items)
+
+    @flag_enabled('LINKED_DOMAINS')
+    def test_returns_items_if_toggle_enabled_with_no_release_management_access_and_is_admin(self, mock_user):
+        mock_user.is_domain_admin.return_value = True
+        self.mock_can_access.return_value = False
+
+        with patch('corehq.tabs.tabclasses.reverse', return_value='dummy_url'):
+            items = _get_feature_flag_items("domain", mock_user)
+
+        self.assertEqual(items[0]['title'], 'Linked Project Spaces')
+        self.assertEqual(items[1]['title'], 'Linked Project Space History')
 
 
 class TestAccessToReleaseManagementTab(SimpleTestCase):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Discovered on [this PR](https://github.com/dimagi/commcare-hq/pull/31047), there are some tests I failed to update after making changes to this logic, and didn't see the failing tests until the github action build. 

This only addresses some of the failures on the parent PR, because the other failing test will require implementation changes as well. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
