### PR TITLE
removed replaceAll in favor of a backwards compatible solution

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
@@ -89,7 +89,7 @@
                     else {
                         paperclip = '';
                     }
-                    return paperclip + DOMPurify.sanitize(m).replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+                    return paperclip + DOMPurify.sanitize(m).replace(/</g, '&lt;').replace(/>/g, '&gt;');
                 },
                 data: _valueToSelect2Data(optionObjects),
                 width: '100%',


### PR DESCRIPTION
## Technical Summary
This fix is in response to [this ticket](https://dimagi-dev.atlassian.net/browse/SAAS-12969). While the affected user is likely going to upgrade the browser, I think we want to avoid using relatively recent features, so this removes our dependency on `replaceAll()`

## Safety Assurance

### Safety story
Local testing to ensure that the two replace methods are equivalent. Also following: https://www.designcise.com/web/tutorial/how-to-fix-replaceall-is-not-a-function-javascript-error

### Automated test coverage

No tests

### QA Plan

No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
