### PR TITLE
Support domains that are legacied into RELEASE_MANAGEMENT but not enterprise accounts

### DIFF
--- a/corehq/apps/accounting/utils/account.py
+++ b/corehq/apps/accounting/utils/account.py
@@ -2,7 +2,7 @@ from django.http import Http404
 from django_prbac.utils import has_privilege
 
 from corehq import privileges
-from corehq.apps.accounting.models import BillingAccount
+from corehq.apps.accounting.models import BillingAccount, Subscription, SoftwarePlanEdition
 
 
 def get_account_or_404(domain):
@@ -15,3 +15,11 @@ def get_account_or_404(domain):
 def request_has_permissions_for_enterprise_admin(request, account):
     return (account.has_enterprise_admin(request.couch_user.username)
             or has_privilege(request, privileges.ACCOUNTING_ADMIN))
+
+
+def domain_is_enterprise(domain):
+    subscription = Subscription.get_active_subscription_by_domain(domain)
+    try:
+        return subscription.plan_version.plan.edition == SoftwarePlanEdition.ENTERPRISE
+    except AttributeError:
+        return False

--- a/corehq/apps/linked_domain/tests/test_dbaccessors.py
+++ b/corehq/apps/linked_domain/tests/test_dbaccessors.py
@@ -6,114 +6,151 @@ from corehq.apps.linked_domain.dbaccessors import (
     get_available_domains_to_link,
     get_available_upstream_domains,
 )
-from corehq.privileges import LITE_RELEASE_MANAGEMENT
+from corehq.privileges import LITE_RELEASE_MANAGEMENT, RELEASE_MANAGEMENT
 from corehq.util.test_utils import flag_enabled
 
 
+@patch('corehq.apps.users.models.CouchUser')
 class TestGetAvailableUpstreamDomains(SimpleTestCase):
 
-    @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.accounting.models.BillingAccount')
-    def test_no_privilege_or_feature_flag_returns_none(self, mock_user, mock_account):
-        mock_account.get_domains.return_value = ['upstream', 'downstream-1', 'downstream-2']
-        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
-            upstream_domains = get_available_upstream_domains('downstream-1', mock_user, mock_account)
+    def setUp(self):
+        super().setUp()
+        self.expected_domains = ['upstream-1', 'upstream-2']
+
+        privilege_patcher = patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege')
+        self.mock_domain_has_privilege = privilege_patcher.start()
+        self.addCleanup(privilege_patcher.stop)
+
+        account_patcher = patch(
+            'corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_enterprise'
+        )
+        self.mock_available_account_domains = account_patcher.start()
+        self.addCleanup(account_patcher.stop)
+
+        user_patcher = patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_user')
+        self.mock_available_user_domains = user_patcher.start()
+        self.addCleanup(user_patcher.stop)
+
+        enterprise_patcher = patch('corehq.apps.linked_domain.dbaccessors.domain_is_enterprise')
+        self.mock_is_enterprise = enterprise_patcher.start()
+        self.mock_is_enterprise.return_value = False
+        self.addCleanup(enterprise_patcher.stop)
+
+    def test_returns_empty_if_no_privilege_or_feature_flag(self, mock_user):
+        self.mock_domain_has_privilege.return_value = False
+
+        upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
 
         self.assertFalse(upstream_domains)
 
-    @flag_enabled("LINKED_DOMAINS")
-    @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.accounting.models.BillingAccount')
-    def test_release_management_privilege_returns_domains_for_account(self, mock_user, mock_account):
-        """NOTE: this also tests that the release_management privilege overrides the linked domains flag"""
-        mock_account.get_domains.return_value = ['upstream', 'downstream-1', 'downstream-2']
-        expected_upstream_domains = ['upstream']
-        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_account') \
-             as mock_account_domains:
-            mock_domain_has_privilege.return_value = True
-            mock_account_domains.return_value = expected_upstream_domains
-            upstream_domains = get_available_upstream_domains('downstream-1', mock_user, mock_account)
+    def test_returns_domains_for_account_if_enterprise_and_release_management_privilege(self, mock_user):
+        self.mock_is_enterprise.return_value = True
+        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
+        self.mock_available_account_domains.return_value = self.expected_domains
 
-        self.assertEqual(expected_upstream_domains, upstream_domains)
+        upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
 
-    @flag_enabled("LINKED_DOMAINS")
-    @patch('corehq.apps.users.models.CouchUser')
-    def test_lite_release_management_privilege_returns_admin_domains_for_users(self, mock_user):
-        def mock_handler(domain, privilege):
-            return privilege == LITE_RELEASE_MANAGEMENT
+        self.assertEqual(upstream_domains, self.expected_domains)
 
-        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_user') \
-             as mock_user_domains:
-            mock_domain_has_privilege.side_effect = mock_handler
-            get_available_upstream_domains('downstream-1', mock_user, None)
-        mock_user_domains.assert_called_with('downstream-1', mock_user, True)
+    def test_returns_domains_for_user_if_not_enterprise_and_release_management_privilege(self, mock_user):
+        self.mock_is_enterprise.return_value = False
+        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
+        self.mock_available_user_domains.return_value = self.expected_domains
+
+        upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
+
+        self.assertEqual(upstream_domains, self.expected_domains)
+
+    def test_returns_admin_domains_for_user_if_lite_release_management_privilege(self, mock_user):
+        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == LITE_RELEASE_MANAGEMENT
+        self.mock_available_user_domains.return_value = self.expected_domains
+
+        upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
+
+        self.mock_available_user_domains.assert_called_with('downstream-1', mock_user, should_enforce_admin=True)
+        self.assertEqual(upstream_domains, self.expected_domains)
 
     @flag_enabled("LINKED_DOMAINS")
-    @patch('corehq.apps.users.models.CouchUser')
-    def test_linked_domains_flag_returns_domains_for_user(self, mock_user):
-        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_user') \
-             as mock_user_domains:
-            mock_domain_has_privilege.return_value = False
-            get_available_upstream_domains('downstream-1', mock_user)
+    def test_returns_domains_for_user_if_linked_domains_flag(self, mock_user):
+        self.mock_domain_has_privilege.return_value = False
+        self.mock_available_user_domains.return_value = self.expected_domains
 
-        mock_user_domains.assert_called_with('downstream-1', mock_user, False)
+        upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
+
+        self.mock_available_user_domains.assert_called_with('downstream-1', mock_user, should_enforce_admin=False)
+        self.assertEqual(upstream_domains, self.expected_domains)
 
 
+@patch('corehq.apps.users.models.CouchUser')
 class TestGetAvailableDomainsToLink(SimpleTestCase):
 
-    @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.accounting.models.BillingAccount')
-    def test_no_privilege_or_feature_flag_returns_none(self, mock_user, mock_account):
-        mock_account.get_domains.return_value = ['upstream', 'downstream-1', 'downstream-2']
-        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
-            domains = get_available_domains_to_link('upstream', mock_user, mock_account)
+    def setUp(self):
+        super().setUp()
+        self.expected_domains = ['downstream-1', 'downstream-2']
 
-        self.assertEqual([], domains)
+        privilege_patcher = patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege')
+        self.mock_domain_has_privilege = privilege_patcher.start()
+        self.addCleanup(privilege_patcher.stop)
+
+        account_patcher = patch(
+            'corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_enterprise'
+        )
+        self.mock_available_account_domains = account_patcher.start()
+        self.addCleanup(account_patcher.stop)
+
+        user_patcher = patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_user')
+        self.mock_available_user_domains = user_patcher.start()
+        self.addCleanup(user_patcher.stop)
+
+        enterprise_patcher = patch('corehq.apps.linked_domain.dbaccessors.domain_is_enterprise')
+        self.mock_is_enterprise = enterprise_patcher.start()
+        self.mock_is_enterprise.return_value = False
+        self.addCleanup(enterprise_patcher.stop)
+
+    def test_returns_empty_if_no_privilege_or_feature_flag(self, mock_user):
+        self.mock_domain_has_privilege.return_value = False
+
+        domains = get_available_domains_to_link('upstream', mock_user)
+
+        self.assertFalse(domains)
+
+    def test_returns_domains_for_account_if_enterprise_and_release_management_privilege(self, mock_user):
+        self.mock_is_enterprise.return_value = True
+        self.mock_domain_has_privilege.return_value = True
+        self.mock_available_account_domains.return_value = self.expected_domains
+        self.mock_available_user_domains.return_value = ['wrong']
+
+        domains = get_available_domains_to_link('upstream', mock_user)
+
+        self.assertEqual(domains, self.expected_domains)
+
+    def test_returns_domains_for_user_if_not_enterprise_and_release_management_privilege(self, mock_user):
+        self.mock_is_enterprise.return_value = False
+        self.mock_domain_has_privilege.return_value = True
+        self.mock_available_user_domains.return_value = self.expected_domains
+        self.mock_available_account_domains.return_value = ['wrong']
+
+        domains = get_available_domains_to_link('upstream', mock_user)
+
+        self.assertEqual(domains, self.expected_domains)
+
+    def test_returns_admin_domains_for_users_if_lite_release_management_privilege(self, mock_user):
+        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == LITE_RELEASE_MANAGEMENT
+        self.mock_available_user_domains.return_value = self.expected_domains
+        self.mock_available_account_domains.return_value = ['wrong']
+
+        domains = get_available_domains_to_link('upstream', mock_user)
+
+        self.mock_available_user_domains.assert_called_with('upstream', mock_user, should_enforce_admin=True)
+        self.assertEqual(domains, self.expected_domains)
 
     @flag_enabled("LINKED_DOMAINS")
-    @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.accounting.models.BillingAccount')
-    def test_release_management_privilege_returns_domains_for_account(self, mock_user, mock_account):
-        """NOTE: this also tests that the release_management privilege overrides the linked domains flag"""
-        expected_domains = ['downstream-1', 'downstream-2']
-        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_account') \
-             as mock_account_domains,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_user') \
-             as mock_user_domains:
-            mock_domain_has_privilege.return_value = True
-            mock_account_domains.return_value = expected_domains
-            mock_user_domains.return_value = ['wrong']
-            domains = get_available_domains_to_link('upstream', mock_user, mock_account)
+    def test_returns_domains_for_user_for_linked_domains_flag(self, mock_user):
+        self.mock_domain_has_privilege.return_value = False
+        self.mock_available_user_domains.return_value = self.expected_domains
+        self.mock_available_account_domains.return_value = ['wrong']
 
-        self.assertEqual(expected_domains, domains)
+        domains = get_available_domains_to_link('upstream', mock_user)
 
-    @flag_enabled("LINKED_DOMAINS")
-    @patch('corehq.apps.users.models.CouchUser')
-    def test_lite_release_management_privilege_returns_admin_domains_for_users(self, mock_user):
-        def mock_handler(domain, privilege):
-            return privilege == LITE_RELEASE_MANAGEMENT
-
-        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_user') \
-             as mock_user_domains:
-            mock_domain_has_privilege.side_effect = mock_handler
-            get_available_domains_to_link('upstream', mock_user)
-
-        mock_user_domains.assert_called_with('upstream', mock_user, True)
-
-    @flag_enabled("LINKED_DOMAINS")
-    @patch('corehq.apps.users.models.CouchUser')
-    def test_linked_domains_flag_returns_domains_for_user(self, mock_user):
-        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_user') \
-             as mock_user_domains:
-            mock_domain_has_privilege.return_value = False
-            get_available_domains_to_link('upstream', mock_user)
-
-        mock_user_domains.assert_called_with('upstream', mock_user, False)
+        self.mock_available_user_domains.assert_called_with('upstream', mock_user, should_enforce_admin=False)
+        self.assertEqual(domains, self.expected_domains)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
When initially designed, the plan was for only enterprise level accounts to be on `RELEASE_MANAGEMENT`, but the plan now is to legacy domains with the feature flag currently enabled to the `RELEASE_MANAGEMENT` privilege, meaning it would not apply to only enterprise accounts. I added a helper to determine if a domain is within an enterprise account, updated the methods that retrieve available domains to link or available upstream domains, and updated tests to reflect these changes.

Test failures on [this PR](https://github.com/dimagi/commcare-hq/pull/31047) originally brought this to my attention, and it is those tests that have been updated.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Updated tests to reflect changes made here.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will QA on base branch.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
