### PR TITLE
raise custom exception for deleted report configs

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -39,6 +39,7 @@ from dimagi.ext.jsonobject import JsonObject
 from dimagi.utils.couch import CriticalSection
 from dimagi.utils.couch.bulk import get_docs
 from dimagi.utils.couch.database import iter_docs
+from dimagi.utils.couch.undo import DELETED_SUFFIX
 from dimagi.utils.dates import DateSpan
 from dimagi.utils.modules import to_function
 
@@ -255,6 +256,10 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
 
     def __str__(self):
         return '{} - {}'.format(self.domain, self.display_name)
+
+    @property
+    def is_deleted(self):
+        return DELETED_SUFFIX in self.doc_type
 
     def save(self, **params):
         self.last_modified = datetime.utcnow()

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -92,7 +92,7 @@ from corehq.toggles import (
     SHOW_IDS_IN_REPORT_BUILDER,
     DATA_REGISTRY
 )
-
+from dimagi.utils.couch.undo import DELETED_SUFFIX
 
 STATIC_CASE_PROPS = [
     "closed",
@@ -1340,7 +1340,10 @@ class ConfigureNewReportBase(forms.Form):
         if not self.ds_builder.uses_managed_data_source:
             return
 
-        data_source_config = get_ucr_datasource_config_by_id(data_source_config_id)
+        data_source_config = get_ucr_datasource_config_by_id(data_source_config_id, allow_deleted=True)
+        if data_source_config.is_deleted:
+            # undelete the temp data source
+            data_source_config.doc_type = data_source_config.doc_type.replace(DELETED_SUFFIX, '')
 
         filters = self.cleaned_data['user_filters'] + self.cleaned_data['default_filters']
         # The data source needs indicators for all possible calculations, not just the ones currently in use

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -43,9 +43,7 @@ from corehq.apps.userreports.const import (
     UCR_CELERY_QUEUE,
     UCR_INDICATOR_CELERY_QUEUE,
 )
-from corehq.apps.userreports.exceptions import (
-    StaticDataSourceConfigurationNotFoundError,
-)
+from corehq.apps.userreports.exceptions import DataSourceConfigurationNotFoundError
 from corehq.apps.userreports.models import (
     AsyncIndicator,
     get_report_config,
@@ -470,7 +468,7 @@ def build_async_indicators(indicator_doc_ids):
                         config_ids.add(config_id)
                         try:
                             config = _get_config(config_id)
-                        except (ResourceNotFound, StaticDataSourceConfigurationNotFoundError):
+                        except (ResourceNotFound, DataSourceConfigurationNotFoundError):
                             celery_task_logger.info("{} no longer exists, skipping".format(config_id))
                             # remove because the config no longer exists
                             _mark_config_to_remove(config_id, [indicator.pk])


### PR DESCRIPTION
## Technical Summary
Instead of raising a `KeyError` raise a `ReportConfigurationNotFoundError` or `DataSourceConfigurationNotFoundError`

There is one place where deleted data source are OK for which I've added a specific flag to permit it.


## Safety Assurance

### Safety story
Prior to this change deleted data sources would not error at all. There is now the potential that we will see more errors from deleted data sources. Most of these should be isolated to celery tasks.

### Automated test coverage
Not covered by tests

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
