### PR TITLE
add null check for domain membership

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1505,7 +1505,7 @@ class UserFilterForm(forms.Form):
             # 1) reflect all locations user is assigned to ('All' option)
             # 2) restrict user access
             domain_membership = self.couch_user.get_domain_membership(self.domain)
-            if domain_membership.assigned_location_ids:
+            if domain_membership and domain_membership.assigned_location_ids:
                 data['web_user_assigned_location_ids'] = list(domain_membership.assigned_location_ids)
 
         return data


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
https://dimagi-dev.atlassian.net/browse/SAAS-13140
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
While downloading the users, [this](https://sentry.io/organizations/dimagi/issues/2974383828/?environment=production&project=136860&query=is%3Aunresolved) error was thrown which was happening because `get_domain_membership` was returning `None` for `admin` users.
Added a check in the if condition which would avoid this condition.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->





### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
