### PR TITLE
Move case accessors into CommCareCase.objects - part 2

### DIFF
--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -55,8 +55,7 @@ from corehq.apps.app_manager.models import Application, RemoteApp, LinkedApplica
 from corehq.apps.groups.models import Group
 from corehq.apps.users.models import CouchUser, Permissions
 from corehq.apps.users.util import format_username
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.motech.repeaters.models import Repeater, get_all_repeater_types
+from corehq.motech.repeaters.models import CommCareCase, Repeater, get_all_repeater_types
 from corehq.util.view_utils import absolute_reverse
 from no_exceptions.exceptions import Http400
 
@@ -184,7 +183,7 @@ def _cases_referenced_by_xform(esxform):
     """
     assert esxform.domain, esxform.form_id
     case_ids = set(cu.id for cu in get_case_updates(esxform))
-    return CaseAccessors(esxform.domain).get_cases(list(case_ids))
+    return CommCareCase.objects.get_cases(list(case_ids), esxform.domain)
 
 
 class RepeaterResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourceMixin):

--- a/corehq/apps/callcenter/utils.py
+++ b/corehq/apps/callcenter/utils.py
@@ -11,6 +11,7 @@ from corehq.apps.es import filters
 from corehq.apps.es.domains import DomainES
 from corehq.elastic import ESError
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 from corehq.util.quickcache import quickcache
 from corehq.util.timezones.conversions import ServerTime, UserTime
 
@@ -110,7 +111,7 @@ def get_call_center_cases(domain_name, case_type, user=None):
     else:
         case_ids = case_accessor.get_open_case_ids_in_domain_by_type(case_type=case_type)
 
-    for case in case_accessor.iter_cases(case_ids):
+    for case in CommCareCase.objects.iter_cases(case_ids, domain_name):
         cc_case = CallCenterCase.from_case(case)
         if cc_case:
             all_cases.append(cc_case)

--- a/corehq/apps/callcenter/utils.py
+++ b/corehq/apps/callcenter/utils.py
@@ -1,15 +1,12 @@
 from collections import namedtuple
 from datetime import datetime, timedelta
 
-from django.conf import settings
-
 import attr
 import pytz
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.es import filters
 from corehq.apps.es.domains import DomainES
-from corehq.elastic import ESError
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.util.quickcache import quickcache

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -121,7 +121,7 @@ class ImporterTest(TestCase):
         self.assertFalse(res['errors'])
         self.assertEqual(1, res['num_chunks'])
         case_ids = self.accessor.get_case_ids_in_domain()
-        cases = list(self.accessor.get_cases(case_ids))
+        cases = CommCareCase.objects.get_cases(case_ids, self.domain)
         self.assertEqual(5, len(cases))
         properties_seen = set()
         for case in cases:
@@ -147,7 +147,7 @@ class ImporterTest(TestCase):
         self.assertFalse(res['errors'])
         case_ids = self.accessor.get_case_ids_in_domain()
         self.assertItemsEqual(
-            [case.external_id for case in self.accessor.get_cases(case_ids)],
+            [case.external_id for case in CommCareCase.objects.get_cases(case_ids, self.domain)],
             ['external_id-0', 'external_id-0', 'external_id-1']
         )
 
@@ -203,7 +203,7 @@ class ImporterTest(TestCase):
         # shouldn't create any more cases, just the one
         case_ids = self.accessor.get_case_ids_in_domain()
         self.assertEqual(1, len(case_ids))
-        [case] = self.accessor.get_cases(case_ids)
+        [case] = CommCareCase.objects.get_cases(case_ids, self.domain)
         for prop in ['age', 'sex', 'location']:
             self.assertTrue(prop in case.get_case_property(prop))
 
@@ -367,7 +367,7 @@ class ImporterTest(TestCase):
         # should just create the one case
         case_ids = self.accessor.get_case_ids_in_domain()
         self.assertEqual(1, len(case_ids))
-        [case] = self.accessor.get_cases(case_ids)
+        [case] = CommCareCase.objects.get_cases(case_ids, self.domain)
         self.assertEqual(external_id, case.external_id)
         for prop in ['age', 'sex', 'location']:
             self.assertTrue(prop in case.get_case_property(prop))
@@ -426,7 +426,7 @@ class ImporterTest(TestCase):
         # Of the 3, 2 should be extension cases
         extension_case_ids = self.accessor.get_extension_case_ids([parent_case.case_id])
         self.assertEqual(len(extension_case_ids), 2)
-        extension_cases = self.accessor.get_cases(extension_case_ids)
+        extension_cases = CommCareCase.objects.get_cases(extension_case_ids, self.domain)
         # Check that identifier is set correctly
         self.assertEqual(
             {'host', 'mother'},
@@ -457,7 +457,7 @@ class ImporterTest(TestCase):
 
         # Asserting current domain
         cur_case_ids = self.accessor.get_case_ids_in_domain()
-        cur_cases = list(self.accessor.get_cases(cur_case_ids))
+        cur_cases = CommCareCase.objects.get_cases(cur_case_ids, self.domain)
         self.assertEqual(3, len(cur_cases))
         #Asserting current domain case property
         cases = {c.name: c for c in cur_cases}
@@ -465,7 +465,7 @@ class ImporterTest(TestCase):
 
         # Asserting subdomain 1
         s1_case_ids = CaseAccessors(self.subdomain1.name).get_case_ids_in_domain()
-        s1_cases = list(self.accessor.get_cases(s1_case_ids))
+        s1_cases = CommCareCase.objects.get_cases(s1_case_ids, self.domain)
         self.assertEqual(1, len(s1_cases))
         # Asserting subdomain 1 case property
         s1_cases_pro = {c.name: c for c in s1_cases}
@@ -473,7 +473,7 @@ class ImporterTest(TestCase):
 
         # Asserting subdomain 2
         s2_case_ids = CaseAccessors(self.subdomain2.name).get_case_ids_in_domain()
-        s2_cases = list(self.accessor.get_cases(s2_case_ids))
+        s2_cases = CommCareCase.objects.get_cases(s2_case_ids, self.domain)
         self.assertEqual(1, len(s2_cases))
         # Asserting subdomain 2 case property
         s2_cases_pro = {c.name: c for c in s2_cases}
@@ -498,7 +498,7 @@ class ImporterTest(TestCase):
         self.assertEqual(0, res['failed_count'])
         case_ids = self.accessor.get_case_ids_in_domain()
         # Asserting current domain
-        cur_cases = list(self.accessor.get_cases(case_ids))
+        cur_cases = CommCareCase.objects.get_cases(case_ids, self.domain)
         self.assertEqual(6, len(cur_cases))
         #Asserting domain case property
         cases = {c.name: c for c in cur_cases}
@@ -532,7 +532,7 @@ class ImporterTest(TestCase):
             ['', 'non-case-owning-name', '', improper_loc.name],
         ])
         case_ids = self.accessor.get_case_ids_in_domain()
-        cases = {c.name: c for c in list(self.accessor.get_cases(case_ids))}
+        cases = {c.name: c for c in CommCareCase.objects.get_cases(case_ids, self.domain)}
 
         self.assertEqual(cases['location-owner-id'].owner_id, location.location_id)
         self.assertEqual(cases['location-owner-code'].owner_id, location.location_id)
@@ -629,7 +629,7 @@ class ImporterTest(TestCase):
             ])
             self.assertEqual(res['errors'], {})
             case_ids = self.accessor.get_case_ids_in_domain()
-            cases = {c.name: c for c in list(self.accessor.get_cases(case_ids))}
+            cases = {c.name: c for c in CommCareCase.objects.get_cases(case_ids, self.domain)}
             self.assertEqual(cases['Jeff'].owner_id, case_owner._id)
             self.assertEqual(cases['Jeff'].get_case_property('favorite_color'), 'blue')
             self.assertEqual(cases['Caroline'].owner_id, case_owner._id)
@@ -646,7 +646,7 @@ class ImporterTest(TestCase):
             ])
 
         case_ids = self.accessor.get_case_ids_in_domain()
-        cases = {c.name: c for c in list(self.accessor.get_cases(case_ids))}
+        cases = {c.name: c for c in CommCareCase.objects.get_cases(case_ids, self.domain)}
         self.assertEqual(cases['Quinton Fortune'].owner_id, dsa.location_id)
         self.assertTrue(res['errors'])
         error_message = exceptions.InvalidLocation.title
@@ -668,7 +668,7 @@ class ImporterTest(TestCase):
             ])
 
         case_ids = self.accessor.get_case_ids_in_domain()
-        cases = {c.name: c for c in list(self.accessor.get_cases(case_ids))}
+        cases = {c.name: c for c in CommCareCase.objects.get_cases(case_ids, self.domain)}
         self.assertEqual(cases['Quinton Fortune'].owner_id, dsa_owner._id)
         self.assertTrue(res['errors'])
         error_message = exceptions.InvalidLocation.title

--- a/corehq/apps/case_importer/tracking/tests/test_dbaccessors.py
+++ b/corehq/apps/case_importer/tracking/tests/test_dbaccessors.py
@@ -21,7 +21,7 @@ from corehq.apps.case_importer.tracking.models import CaseUploadFileMeta, CaseUp
 from corehq.apps.case_importer.util import ImporterConfig
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CouchUser, WebUser
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 
 
 class DbaccessorsTest(TestCase):
@@ -156,7 +156,7 @@ class FormAndCaseIdsTest(TestCase):
         ]
         case_upload_record = self._import_rows(data)
         case_ids = list(get_case_ids_for_case_upload(case_upload_record))
-        cases = CaseAccessors(self.domain).get_cases(case_ids, ordered=True)
+        cases = CommCareCase.objects.get_cases(case_ids, self.domain, ordered=True)
         self.assertEqual(case_ids, [case.case_id for case in cases])
         should_match_original_data_order = [['name']] + [[case.name] for case in cases]
         self.assertEqual(should_match_original_data_order, data)

--- a/corehq/apps/casegroups/models.py
+++ b/corehq/apps/casegroups/models.py
@@ -1,7 +1,7 @@
 from dimagi.ext.couchdbkit import ListProperty, StringProperty
 from dimagi.utils.couch.undo import DeleteDocRecord, UndoableDocument
 
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 
 
 class CommCareCaseGroup(UndoableDocument):
@@ -24,7 +24,7 @@ class CommCareCaseGroup(UndoableDocument):
             case_ids = case_ids[skip:]
         if limit is not None:
             case_ids = case_ids[:limit]
-        for case in CaseAccessors(self.domain).iter_cases(case_ids):
+        for case in CommCareCase.objects.iter_cases(case_ids, self.domain):
             if not case.is_deleted:
                 yield case
 
@@ -36,7 +36,7 @@ class CommCareCaseGroup(UndoableDocument):
     def clean_cases(self):
         cleaned_list = []
         changed = False
-        for case in CaseAccessors(self.domain).iter_cases(self.cases):
+        for case in CommCareCase.objects.iter_cases(self.cases, self.domain):
             if not case.is_deleted:
                 cleaned_list.append(case.case_id)
             else:

--- a/corehq/apps/casegroups/models.py
+++ b/corehq/apps/casegroups/models.py
@@ -14,7 +14,8 @@ class CommCareCaseGroup(UndoableDocument):
     timezone = StringProperty()
 
     def get_time_zone(self):
-        # Necessary for the CommCareCaseGroup to interact with CommConnect, as if using the CommCareMobileContactMixin
+        # Necessary for the CommCareCaseGroup to interact with
+        # CommConnect, as if using the CommCareMobileContactMixin.
         # However, the entire mixin is not necessary.
         return self.timezone
 

--- a/corehq/apps/cleanup/management/commands/delete_case_indices.py
+++ b/corehq/apps/cleanup/management/commands/delete_case_indices.py
@@ -7,7 +7,7 @@ from django.core.management.base import BaseCommand
 
 from casexml.apps.case.mock import CaseBlock
 from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 
 logger = logging.getLogger("delete_case_indices")
 
@@ -56,7 +56,7 @@ class Command(BaseCommand):
         for domain, case_ids in case_ids_by_domain.items():
             logger.info(f"Processing {len(case_ids)} for domain '{domain}'")
             case_blocks_and_meta = []
-            cases = CaseAccessors(domain).get_cases(case_ids)
+            cases = CommCareCase.objects.get_cases(case_ids, domain)
             for case in cases:
                 meta = case_metas[case.case_id]
                 index = get_index_by_ref_id(case, meta)

--- a/corehq/apps/cleanup/management/commands/undo_uuid_clash.py
+++ b/corehq/apps/cleanup/management/commands/undo_uuid_clash.py
@@ -9,10 +9,7 @@ from dimagi.utils.chunked import chunked
 from corehq.apps.commtrack.processing import process_stock
 from corehq.apps.domain.dbaccessors import iter_domains
 from corehq.form_processor.backends.sql.casedb import CaseDbCacheSQL
-from corehq.form_processor.backends.sql.dbaccessors import (
-    CaseAccessorSQL,
-    LedgerAccessorSQL,
-)
+from corehq.form_processor.backends.sql.dbaccessors import LedgerAccessorSQL
 from corehq.form_processor.backends.sql.ledger import LedgerProcessorSQL
 from corehq.form_processor.backends.sql.processor import FormProcessorSQL
 from corehq.form_processor.backends.sql.update_strategy import (
@@ -20,6 +17,7 @@ from corehq.form_processor.backends.sql.update_strategy import (
 )
 from corehq.form_processor.models import (
     CaseTransaction,
+    CommCareCase,
     LedgerTransaction,
     RebuildWithReason,
     XFormInstance,
@@ -188,7 +186,7 @@ class Command(BaseCommand):
 
         if case_ids:
             form_ids = set()
-            for case in CaseAccessorSQL.get_cases(case_ids):
+            for case in CommCareCase.objects.get_cases(case_ids):
                 assert not domain or case.domain == domain, 'Case "%s" not in domain "%s"' % (case.case_id, domain)
                 form_ids.update(case.xform_ids)
 

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -1036,7 +1036,7 @@ class CaseDeduplicationActionDefinition(BaseUpdateCaseDefinition):
     def _update_cases(self, domain, rule, duplicate_case_ids):
         """Updates all the duplicate cases according to the rule
         """
-        duplicate_cases = CaseAccessors(domain).get_cases(list(duplicate_case_ids))
+        duplicate_cases = CommCareCase.objects.get_cases(list(duplicate_case_ids), domain)
         case_updates = self._get_case_updates(duplicate_cases)
         for case_update_batch in chunked(case_updates, 100):
             result = bulk_update_cases(

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -39,7 +39,6 @@ from corehq.apps.hqcase.utils import bulk_update_cases, update_case
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.form_processor.models import DEFAULT_PARENT_IDENTIFIER
 from corehq.form_processor.exceptions import CaseNotFound
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCaseIndex, CommCareCase, XFormInstance
 from corehq.messaging.scheduling.const import (
     VISIT_WINDOW_DUE_DATE,
@@ -236,7 +235,7 @@ class AutomaticUpdateRule(models.Model):
     @classmethod
     def _iter_cases_from_es(cls, domain, case_type, boundary_date=None):
         case_ids = list(cls._get_case_ids_from_es(domain, case_type, boundary_date))
-        return CaseAccessors(domain).iter_cases(case_ids)
+        return CommCareCase.objects.iter_cases(case_ids, domain)
 
     @classmethod
     def _get_case_ids_from_es(cls, domain, case_type, boundary_date=None):

--- a/corehq/apps/es/management/commands/resave_failed_forms_and_cases.py
+++ b/corehq/apps/es/management/commands/resave_failed_forms_and_cases.py
@@ -8,8 +8,7 @@ from corehq.apps.data_pipeline_audit.management.commands.compare_doc_ids import 
     compare_xforms,
 )
 from corehq.apps.hqcase.utils import resave_case
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.form_processor.utils.xform import resave_form
 from corehq.util.log import with_progress_bar
 
@@ -76,9 +75,8 @@ def perform_resave_on_cases(domain, start_date, end_date, no_input):
         if ok != "ok":
             print("No changes made")
             return
-    case_accessor = CaseAccessors(domain)
-    for case_ids in chunked(with_progress_bar(case_ids_missing_in_es), 100):
-        cases = case_accessor.get_cases(list(case_ids))
+    for case_ids in chunked(with_progress_bar(case_ids_missing_in_es), 100, list):
+        cases = CommCareCase.objects.get_cases(case_ids, domain)
         found_case_ids = set()
 
         for case in cases:

--- a/corehq/apps/hqadmin/management/commands/delete_related_cases.py
+++ b/corehq/apps/hqadmin/management/commands/delete_related_cases.py
@@ -27,7 +27,9 @@ class Command(BaseCommand):
             sys.exit(0)
         dependent_case_ids = get_entire_case_network(domain, [case_id])
 
-        cases_to_delete = [case for case in case_accessor.get_cases(dependent_case_ids) if not case.is_deleted]
+        cases_to_delete = [case
+            for case in CommCareCase.objects.get_cases(dependent_case_ids, domain)
+            if not case.is_deleted]
         if cases_to_delete:
             with open(options['filename'], 'w') as csvfile:
                 writer = csv.writer(csvfile)

--- a/corehq/apps/hqcase/tests/test_explode_cases.py
+++ b/corehq/apps/hqcase/tests/test_explode_cases.py
@@ -257,7 +257,8 @@ class ExplodeLedgersTest(BaseSyncTest):
         case_ids = self.case_accessor.get_case_ids_in_domain()
         cases = CommCareCase.objects.iter_cases(case_ids, self.project.name)
         for case in cases:
-            ledger_values = {l.entry_id: l for l in self.ledger_accessor.get_ledger_values_for_case(case.case_id)}
+            ledger_values = {v.entry_id: v
+                for v in self.ledger_accessor.get_ledger_values_for_case(case.case_id)}
 
             if case.case_id == 'case2' or case.get_case_property('cc_exploded_from') == 'case2':
                 self.assertEqual(len(ledger_values), 0)

--- a/corehq/apps/hqcase/tests/test_explode_cases.py
+++ b/corehq/apps/hqcase/tests/test_explode_cases.py
@@ -20,6 +20,7 @@ from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
     LedgerAccessors,
 )
+from corehq.form_processor.models import CommCareCase
 from corehq.util.test_utils import flag_enabled
 
 
@@ -62,7 +63,7 @@ class ExplodeCasesDbTest(TestCase):
         explode_cases(self.domain.name, self.user_id, 10)
 
         case_ids = self.accessor.get_case_ids_in_domain()
-        cases_back = list(self.accessor.iter_cases(case_ids))
+        cases_back = list(CommCareCase.objects.iter_cases(case_ids, self.domain.name))
         self.assertEqual(10, len(cases_back))
         for case in cases_back:
             self.assertEqual(self.user_id, case.owner_id)
@@ -80,7 +81,7 @@ class ExplodeCasesDbTest(TestCase):
         explode_cases(self.domain.name, self.user_id, 10)
 
         case_ids = self.accessor.get_case_ids_in_domain()
-        cases_back = list(self.accessor.iter_cases(case_ids))
+        cases_back = list(CommCareCase.objects.iter_cases(case_ids, self.domain.name))
         self.assertEqual(1, len(cases_back))
         for case in cases_back:
             self.assertEqual(self.user_id, case.owner_id)
@@ -111,7 +112,7 @@ class ExplodeCasesDbTest(TestCase):
 
         explode_cases(self.domain.name, self.user_id, 5)
         case_ids = self.accessor.get_case_ids_in_domain()
-        cases_back = list(self.accessor.iter_cases(case_ids))
+        cases_back = list(CommCareCase.objects.iter_cases(case_ids, self.domain.name))
         self.assertEqual(10, len(cases_back))
         parent_cases = {p.case_id: p for p in [case for case in cases_back if case.type == parent_type]}
         self.assertEqual(5, len(parent_cases))
@@ -253,7 +254,8 @@ class ExplodeLedgersTest(BaseSyncTest):
 
     def test_explode_ledgers(self):
         explode_cases(self.project.name, self.user_id, 5)
-        cases = self.case_accessor.iter_cases(self.case_accessor.get_case_ids_in_domain())
+        case_ids = self.case_accessor.get_case_ids_in_domain()
+        cases = CommCareCase.objects.iter_cases(case_ids, self.project.name)
         for case in cases:
             ledger_values = {l.entry_id: l for l in self.ledger_accessor.get_ledger_values_for_case(case.case_id)}
 

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -428,7 +428,7 @@ class CaseClaimEndpointTests(TestCase):
         self.assertEqual(len(claim_ids), 2)
 
         # The most recent one should be the extension owned by the other user
-        claim_cases = CaseAccessors(DOMAIN).get_cases(claim_ids)
+        claim_cases = CommCareCase.objects.get_cases(claim_ids, DOMAIN)
         self.assertIn(another_user._id, [case.owner_id for case in claim_cases])
 
     def test_search_endpoint(self):

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -80,7 +80,7 @@ def _process_form(request, domain, app_id, user_id, authenticated,
             instance = request.FILES[MAGIC_PROPERTY].read()
             xform = convert_xform_to_json(instance)
             meta = xform.get("meta", {})
-        except:
+        except Exception:
             meta = {}
 
         metrics_counter('commcare.corrupt_multimedia_submissions', tags={

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -48,7 +48,7 @@ from corehq.apps.receiverwrapper.util import (
     should_ignore_submission,
 )
 from corehq.form_processor.exceptions import XFormLockError
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.submission_post import SubmissionPost
 from corehq.form_processor.utils import convert_xform_to_json
 from corehq.util.metrics import metrics_counter, metrics_histogram
@@ -295,7 +295,7 @@ def _noauth_post(request, domain, app_id=None):
 
         # todo: consider whether we want to remove this call, and/or pass the result
         # through to the next function so we don't have to get the cases again later
-        cases = CaseAccessors(domain).get_cases(list(case_ids))
+        cases = CommCareCase.objects.get_cases(list(case_ids), domain)
         for case in cases:
             if case.domain != domain:
                 return False

--- a/corehq/apps/registry/helper.py
+++ b/corehq/apps/registry/helper.py
@@ -4,7 +4,6 @@ from operator import attrgetter
 from corehq.apps.registry.exceptions import RegistryNotFound, RegistryAccessException
 from corehq.apps.registry.models import DataRegistry
 from corehq.apps.registry.utils import RegistryPermissionCheck
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.util.timer import TimingContext
 
@@ -84,7 +83,7 @@ class DataRegistryHelper:
         # using livequery to get related cases matches the semantics of case claim
         all_case_ids, indices = get_live_case_ids_and_indices(domain, case_ids, TimingContext())
         new_case_ids = list(all_case_ids - case_ids)
-        new_cases = PrefetchIndexCaseAccessor(CaseAccessors(domain), indices).get_cases(new_case_ids)
+        new_cases = PrefetchIndexCaseAccessor(domain, indices).get_cases(new_case_ids)
 
         return cases + new_cases
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -137,10 +137,7 @@ from corehq.apps.users.permissions import (
 )
 from corehq.blobs import CODES, NotFound, get_blob_db, models
 from corehq.form_processor.exceptions import AttachmentNotFound, CaseNotFound
-from corehq.form_processor.interfaces.dbaccessors import (
-    CaseAccessors,
-    LedgerAccessors,
-)
+from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import CommCareCase, UserRequestedRebuild, XFormInstance
 from corehq.form_processor.utils.general import use_sqlite_backend
@@ -2134,7 +2131,7 @@ def _get_cases_with_other_forms(domain, xform):
     :returns: Dict of Case ID -> Case"""
     cases_created = {u.id for u in get_case_updates(xform) if u.creates_case()}
     cases = {}
-    for case in CaseAccessors(domain).iter_cases(list(cases_created)):
+    for case in CommCareCase.objects.iter_cases(cases_created, domain):
         if not case.is_deleted and case.xform_ids != [xform.form_id]:
             # case has other forms that need to be archived before this one
             cases[case.case_id] = case.name

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -123,7 +123,7 @@ from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import CommCareUser, CouchUser, Permissions
 from corehq.apps.users.views.mobile.users import EditCommCareUserView
 from corehq.const import SERVER_DATE_FORMAT, SERVER_DATETIME_FORMAT
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.utils import is_commcarecase
 from corehq.messaging.scheduling.async_handlers import SMSSettingsAsyncHandler
 from corehq.messaging.smsbackends.telerivet.models import SQLTelerivetBackend
@@ -587,7 +587,7 @@ class ChatOverSMSView(BaseMessagingSectionView):
 
 def get_case_contact_info(domain_obj, case_ids):
     data = {}
-    for case in CaseAccessors(domain_obj.name).iter_cases(case_ids):
+    for case in CommCareCase.objects.iter_cases(case_ids, domain_obj.name):
         if domain_obj.custom_case_username:
             name = case.get_case_property(domain_obj.custom_case_username)
         else:

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import base64
 import io
 import json
 import re
@@ -122,7 +121,6 @@ from corehq.apps.users import models as user_models
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import CommCareUser, CouchUser, Permissions
 from corehq.apps.users.views.mobile.users import EditCommCareUserView
-from corehq.const import SERVER_DATE_FORMAT, SERVER_DATETIME_FORMAT
 from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.utils import is_commcarecase
 from corehq.messaging.scheduling.async_handlers import SMSSettingsAsyncHandler
@@ -262,11 +260,11 @@ def send_to_recipients(request, domain):
             elif (not send_to_all_checked) and recipient.endswith(GROUP):
                 name = recipient[:-len(GROUP)].strip()
                 group_names.append(name)
-            elif re.match(r'^\+\d+$', recipient): # here we expect it to have a plus sign
+            elif re.match(r'^\+\d+$', recipient):  # here we expect it to have a plus sign
                 def wrap_user_by_type(u):
                     return getattr(user_models, u['doc']['doc_type']).wrap(u['doc'])
 
-                phone_users = CouchUser.view("users/by_default_phone", # search both with and w/o the plus
+                phone_users = CouchUser.view("users/by_default_phone",  # search both with and w/o the plus
                     keys=[recipient, recipient[1:]], include_docs=True,
                     wrapper=wrap_user_by_type).all()
 
@@ -342,11 +340,14 @@ def send_to_recipients(request, domain):
                 messages.error(request, _("The following groups don't exist: ") + (', '.join(empty_groups)))
                 comma_reminder()
             if no_numbers:
-                messages.error(request, _("The following users don't have phone numbers: ") + (', '.join(no_numbers)))
+                messages.error(request,
+                    _("The following users don't have phone numbers: ") + (', '.join(no_numbers)))
             if failed_numbers:
-                messages.error(request, _("Couldn't send to the following number(s): ") + (', '.join(failed_numbers)))
+                messages.error(request,
+                    _("Couldn't send to the following number(s): ") + (', '.join(failed_numbers)))
             if unknown_usernames:
-                messages.error(request, _("Couldn't find the following user(s): ") + (', '.join(unknown_usernames)))
+                messages.error(request,
+                    _("Couldn't find the following user(s): ") + (', '.join(unknown_usernames)))
                 comma_reminder()
             if sent:
                 messages.success(request, _("Successfully sent: ") + (', '.join(sent)))
@@ -356,8 +357,8 @@ def send_to_recipients(request, domain):
             messages.success(request, _("Message sent"))
 
     return HttpResponseRedirect(
-        request.META.get('HTTP_REFERER') or
-        reverse(ComposeMessageView.urlname, args=[domain])
+        request.META.get('HTTP_REFERER')
+        or reverse(ComposeMessageView.urlname, args=[domain])
     )
 
 
@@ -659,7 +660,7 @@ def get_contact_info(domain):
         try:
             client.set(cache_key, json.dumps(data))
             client.expire(cache_key, cache_expiration)
-        except:
+        except Exception:
             pass
 
     return data
@@ -801,7 +802,7 @@ class ChatMessageHistory(View, DomainViewMixin):
         try:
             user = CouchUser.get_by_user_id(user_id)
             return user.first_name or user.raw_username
-        except:
+        except Exception:
             return _("Unknown")
 
     @property
@@ -840,8 +841,8 @@ class ChatMessageHistory(View, DomainViewMixin):
 
         if self.domain_object.show_invalid_survey_responses_in_chat:
             return queryset.exclude(
-                Q(xforms_session_couch_id__isnull=False) &
-                ~Q(direction=INCOMING, invalid_survey_response=True)
+                Q(xforms_session_couch_id__isnull=False)
+                & ~Q(direction=INCOMING, invalid_survey_response=True)
             )
         else:
             return queryset.exclude(
@@ -901,7 +902,7 @@ class ChatMessageHistory(View, DomainViewMixin):
         if last_sms:
             try:
                 self.update_last_read_message(request.couch_user.get_id, last_sms)
-            except:
+            except Exception:
                 notify_exception(request, "Error updating last read message for %s" % last_sms.pk)
 
         return HttpResponse(json.dumps(data))
@@ -1264,10 +1265,10 @@ class EditDomainGatewayView(AddDomainGatewayView):
         except ResourceNotFound:
             raise Http404()
         if (
-            backend.is_global or
-            backend.domain != self.domain or
-            backend.hq_api_id != self.backend_class.get_api_id() or
-            backend.deleted
+            backend.is_global
+            or backend.domain != self.domain
+            or backend.hq_api_id != self.backend_class.get_api_id()
+            or backend.deleted
         ):
             raise Http404()
         return backend
@@ -1495,9 +1496,9 @@ class EditGlobalGatewayView(AddGlobalGatewayView):
         except ResourceNotFound:
             raise Http404()
         if (
-            not backend.is_global or
-            backend.deleted or
-            backend.hq_api_id != self.backend_class.get_api_id()
+            not backend.is_global
+            or backend.deleted
+            or backend.hq_api_id != self.backend_class.get_api_id()
         ):
             raise Http404()
         return backend
@@ -1729,8 +1730,8 @@ class SMSSettingsView(BaseMessagingSectionView, AsyncHandlerMixin):
 
     def get_welcome_message_recipient(self, domain_obj):
         if (
-            domain_obj.enable_registration_welcome_sms_for_case and
-            domain_obj.enable_registration_welcome_sms_for_mobile_worker
+            domain_obj.enable_registration_welcome_sms_for_case
+            and domain_obj.enable_registration_welcome_sms_for_mobile_worker
         ):
             return WELCOME_RECIPIENT_ALL
         elif domain_obj.enable_registration_welcome_sms_for_case:
@@ -1751,8 +1752,8 @@ class SMSSettingsView(BaseMessagingSectionView, AsyncHandlerMixin):
             )
         else:
             domain_obj = Domain.get_by_name(self.domain, strict=True)
-            enabled_disabled = lambda b: (ENABLED if b else DISABLED)
-            default_custom = lambda b: (CUSTOM if b else DEFAULT)
+            enabled_disabled = lambda b: (ENABLED if b else DISABLED)  # noqa: E731
+            default_custom = lambda b: (CUSTOM if b else DEFAULT)  # noqa: E731
             initial = {
                 "use_default_sms_response":
                     enabled_disabled(domain_obj.use_default_sms_response),

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -142,7 +142,7 @@ def _get_forms_to_modify(domain, modified_forms, modified_cases, is_deletion):
 
         case_ids = get_case_ids_from_form(form)
         # all cases touched by the form and not already modified
-        for case in CaseAccessors(domain).iter_cases(case_ids - modified_cases):
+        for case in CommCareCase.objects.iter_cases(case_ids - modified_cases):
             if case.is_deleted != is_deletion:
                 # we can't delete/undelete this form - this would change the state of `case`
                 return False

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -96,7 +96,7 @@ class RetireUserTestCase(TestCase):
         xform = submit_case_blocks(caseblocks, self.domain, user_id=owner_id)[0]
 
         self.commcare_user.retire(self.domain, deleted_by=None)
-        cases = CaseAccessors(self.domain).get_cases(case_ids)
+        cases = CommCareCase.objects.get_cases(case_ids, self.domain)
         self.assertTrue(all([c.is_deleted for c in cases]))
         self.assertEqual(len(cases), 3)
         form = XFormInstance.objects.get_form(xform.form_id, self.domain)
@@ -121,7 +121,7 @@ class RetireUserTestCase(TestCase):
         self.assertEqual(user_history.changed_by, self.other_user.get_id)
         self.assertEqual(user_history.changed_via, "Test")
 
-        cases = CaseAccessors(self.domain).get_cases(case_ids)
+        cases = CommCareCase.objects.get_cases(case_ids, self.domain)
         self.assertFalse(all([c.is_deleted for c in cases]))
         self.assertEqual(len(cases), 3)
         form = XFormInstance.objects.get_form(xform.form_id, self.domain)

--- a/corehq/ex-submodules/casexml/apps/case/mock/mock.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/mock.py
@@ -131,7 +131,7 @@ class CaseFactory(object):
         return self.create_or_update_cases([case_structure], form_extras, user_id=user_id)
 
     def create_or_update_cases(self, case_structures, form_extras=None, user_id=None, device_id=None):
-        from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+        from corehq.form_processor.models import CommCareCase
         self.post_case_blocks(
             self.get_case_blocks(case_structures),
             form_extras,
@@ -140,4 +140,4 @@ class CaseFactory(object):
         )
 
         case_ids = [id for structure in case_structures for id in structure.walk_ids()]
-        return list(CaseAccessors(self.domain).get_cases(case_ids, ordered=True))
+        return list(CommCareCase.objects.get_cases(case_ids, self.domain, ordered=True))

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -3,6 +3,7 @@ import uuid
 from django.test import TestCase
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 from casexml.apps.case.xform import (
     get_all_extensions_to_close, get_extensions_to_close, get_ush_extension_cases_to_close)
 from casexml.apps.phone.tests.utils import create_restore_user
@@ -227,7 +228,7 @@ class AutoCloseExtensionsTest(TestCase):
     def test_close_cases_host(self):
         """Closing a host should close all the extensions"""
         self._create_extension_chain()
-        cases = CaseAccessors(self.domain).get_cases(self.extension_ids)
+        cases = CommCareCase.objects.get_cases(self.extension_ids, self.domain)
         self.assertFalse(cases[0].closed)
         self.assertFalse(cases[1].closed)
         self.assertFalse(cases[2].closed)
@@ -238,7 +239,7 @@ class AutoCloseExtensionsTest(TestCase):
         ))
         cases = {
             case.case_id: case.closed
-            for case in CaseAccessors(self.domain).get_cases([self.host_id] + self.extension_ids)
+            for case in CommCareCase.objects.get_cases([self.host_id] + self.extension_ids, self.domain)
         }
         self.assertFalse(cases[self.host_id])
         self.assertFalse(cases[self.extension_ids[0]])
@@ -251,7 +252,7 @@ class AutoCloseExtensionsTest(TestCase):
         ))
         cases = {
             case.case_id: case
-            for case in CaseAccessors(self.domain).get_cases([self.host_id] + self.extension_ids)
+            for case in CommCareCase.objects.get_cases([self.host_id] + self.extension_ids, self.domain)
         }
         self.assertTrue(cases[self.host_id].closed)
         self.assertTrue(cases[self.extension_ids[0]].closed)
@@ -269,7 +270,7 @@ class AutoCloseExtensionsTest(TestCase):
         self._create_host_is_subcase_chain()
         cases = {
             case.case_id: case.closed
-            for case in CaseAccessors(self.domain).get_cases([self.host_id] + self.extension_ids)
+            for case in CommCareCase.objects.get_cases([self.host_id] + self.extension_ids, self.domain)
         }
         self.assertFalse(cases[self.host_id])
         self.assertFalse(cases[self.extension_ids[0]])
@@ -281,7 +282,8 @@ class AutoCloseExtensionsTest(TestCase):
         ))
         cases = {
             case.case_id: case
-            for case in CaseAccessors(self.domain).get_cases([self.parent_id, self.host_id] + self.extension_ids)
+            for case in CommCareCase.objects.get_cases(
+                [self.parent_id, self.host_id] + self.extension_ids, self.domain)
         }
         self.assertFalse(cases[self.parent_id].closed)
         self.assertTrue(cases[self.host_id].closed)

--- a/corehq/ex-submodules/couchforms/management/commands/purge_forms_and_cases.py
+++ b/corehq/ex-submodules/couchforms/management/commands/purge_forms_and_cases.py
@@ -6,7 +6,7 @@ from django.http import Http404
 from corehq.apps.app_manager.models import Application
 from casexml.apps.case.xform import get_case_ids_from_form
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.apps.app_manager.dbaccessors import get_app
 from dimagi.utils.django.management import are_you_sure
 from datetime import datetime
@@ -107,7 +107,7 @@ though deletion would be re-confirmed so dont panic
             _raise_xform_domain_mismatch(xform)
 
     def print_case_details(self):
-        for case in self.case_accessors.iter_cases(self.case_ids):
+        for case in CommCareCase.objects.iter_cases(self.case_ids, self.domain):
             _print_case_details(case, self.case_writer)
 
     def delete_permitted(self):

--- a/corehq/form_processor/backends/sql/casedb.py
+++ b/corehq/form_processor/backends/sql/casedb.py
@@ -22,7 +22,7 @@ class CaseDbCacheSQL(AbstractCaseDbCache):
                 raise IllegalCaseId("Case [%s] is deleted " % case.case_id)
 
     def _iter_cases(self, case_ids):
-        return iter(CaseAccessorSQL.get_cases(case_ids))
+        return iter(CommCareCase.objects.get_cases(case_ids))
 
     def get_cases_for_saving(self, now):
         cases = self.get_changed()

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -6,7 +6,6 @@ import struct
 from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import namedtuple
 from datetime import datetime
-from itertools import groupby
 from uuid import UUID
 
 from django.conf import settings
@@ -30,7 +29,7 @@ from corehq.form_processor.exceptions import (
     MissingFormXml,
     XFormNotFound,
 )
-from corehq.form_processor.models.util import sort_with_id_list as _sort_with_id_list
+from corehq.form_processor.models.util import attach_prefetch_models as _attach_prefetch_models
 from corehq.form_processor.interfaces.dbaccessors import (
     AbstractLedgerAccessor,
     CaseIndexInfo,
@@ -413,28 +412,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_cases(case_ids, ordered=False, prefetched_indices=None):
-        """
-        :param case_ids: List of case IDs to fetch
-        :param ordered: Return cases in the same order as ``case_ids``
-        :param prefetched_indices: If not None this must be a dict containing ALL the indices for ALL the
-                                    cases being fetched. If the list does not contain indices for a case
-                                    then an empty list will be attached to the case preventing further DB lookup.
-        :return: List of cases
-        """
-        assert isinstance(case_ids, list)
-        if not case_ids:
-            return []
-        cases = list(CommCareCase.objects.plproxy_raw('SELECT * from get_cases_by_id(%s)', [case_ids]))
-
-        if ordered:
-            _sort_with_id_list(cases, case_ids, 'case_id')
-
-        if prefetched_indices is not None:
-            cases_by_id = {case.case_id: case for case in cases}
-            _attach_prefetch_models(
-                cases_by_id, prefetched_indices, 'case_id', 'cached_indices')
-
-        return cases
+        """DEPRECATED"""
+        return CommCareCase.objects.get_cases(case_ids, ordered, prefetched_indices)
 
     @staticmethod
     def case_exists(case_id):
@@ -1123,17 +1102,3 @@ class LedgerAccessorSQL(AbstractLedgerAccessor):
             )
             for trans in resultset:
                 yield trans
-
-
-def _attach_prefetch_models(objects_by_id, prefetched_models, link_field_name, cached_attrib_name):
-    prefetched_groups = groupby(prefetched_models, lambda x: getattr(x, link_field_name))
-    seen = set()
-    for obj_id, group in prefetched_groups:
-        seen.add(obj_id)
-        obj = objects_by_id[obj_id]
-        setattr(obj, cached_attrib_name, list(group))
-
-    unseen = set(objects_by_id) - seen
-    for obj_id in unseen:
-        obj = objects_by_id[obj_id]
-        setattr(obj, cached_attrib_name, [])

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -7,6 +7,7 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import namedtuple
 from datetime import datetime
 from uuid import UUID
+from warnings import warn
 
 from django.conf import settings
 from django.db import InternalError, transaction, router, DatabaseError
@@ -407,12 +408,12 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_case(case_id):
-        """DEPRECATED"""
+        warn("DEPRECATED", DeprecationWarning)
         return CommCareCase.objects.get_case(case_id)
 
     @staticmethod
     def get_cases(case_ids, ordered=False, prefetched_indices=None):
-        """DEPRECATED"""
+        warn("DEPRECATED", DeprecationWarning)
         return CommCareCase.objects.get_cases(case_ids, ordered, prefetched_indices)
 
     @staticmethod

--- a/corehq/form_processor/backends/sql/supply.py
+++ b/corehq/form_processor/backends/sql/supply.py
@@ -34,4 +34,4 @@ class SupplyPointSQL:
 
     @staticmethod
     def get_supply_points(supply_point_ids):
-        return list(CaseAccessorSQL.get_cases(supply_point_ids))
+        return list(CommCareCase.objects.get_cases(supply_point_ids))

--- a/corehq/form_processor/document_stores.py
+++ b/corehq/form_processor/document_stores.py
@@ -16,7 +16,6 @@ from corehq.form_processor.exceptions import (
     MissingFormXml,
     XFormNotFound,
 )
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase, XFormInstance
 
 
@@ -59,7 +58,6 @@ class CaseDocumentStore(DocumentStore):
 
     def __init__(self, domain, case_type=None):
         self.domain = domain
-        self.case_accessors = CaseAccessors(domain=domain)
         self.case_type = case_type
 
     def get_document(self, doc_id):
@@ -73,7 +71,7 @@ class CaseDocumentStore(DocumentStore):
         return iter_all_ids(accessor)
 
     def iter_documents(self, ids):
-        for wrapped_case in self.case_accessors.iter_cases(ids):
+        for wrapped_case in CommCareCase.objects.iter_cases(ids, self.domain):
             yield wrapped_case.to_json()
 
 

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from collections import namedtuple
 from io import BytesIO
+from warnings import warn
 
 from memoized import memoized
 from corehq.form_processor.models import CommCareCase
@@ -26,16 +27,16 @@ class CaseAccessors(object):
         return CaseAccessorSQL
 
     def get_case(self, case_id):
-        """DEPRECATED use CommCareCase.objects"""
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return CommCareCase.objects.get_case(case_id, self.domain)
 
     def get_cases(self, case_ids, ordered=False, prefetched_indices=None):
-        """DEPRECATED use CommCareCase.objects"""
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.get_cases(
             case_ids, ordered=ordered, prefetched_indices=prefetched_indices)
 
     def iter_cases(self, case_ids):
-        """DEPRECATED use CommCareCase.objects"""
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         yield from CommCareCase.objects.iter_cases(case_ids)
 
     def get_case_ids_that_exist(self, case_ids):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -5,8 +5,6 @@ from io import BytesIO
 from memoized import memoized
 from corehq.form_processor.models import CommCareCase
 
-from dimagi.utils.chunked import chunked
-
 
 CaseIndexInfo = namedtuple(
     'CaseIndexInfo', ['case_id', 'identifier', 'referenced_id', 'referenced_type', 'relationship']
@@ -37,10 +35,8 @@ class CaseAccessors(object):
             case_ids, ordered=ordered, prefetched_indices=prefetched_indices)
 
     def iter_cases(self, case_ids):
-        for chunk in chunked(case_ids, 100):
-            chunk = list([_f for _f in chunk if _f])
-            for case in self.get_cases(chunk):
-                yield case
+        """DEPRECATED use CommCareCase.objects"""
+        yield from CommCareCase.objects.iter_cases(case_ids)
 
     def get_case_ids_that_exist(self, case_ids):
         return self.db_accessor.get_case_ids_that_exist(self.domain, case_ids)

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -32,6 +32,7 @@ class CaseAccessors(object):
         return CommCareCase.objects.get_case(case_id, self.domain)
 
     def get_cases(self, case_ids, ordered=False, prefetched_indices=None):
+        """DEPRECATED use CommCareCase.objects"""
         return self.db_accessor.get_cases(
             case_ids, ordered=ordered, prefetched_indices=prefetched_indices)
 

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -225,12 +225,11 @@ class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
 
     @memoized
     def get_subcases(self, index_identifier=None):
-        from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
         subcase_ids = [
             ix.referenced_id for ix in self.reverse_indices
             if (index_identifier is None or ix.identifier == index_identifier)
         ]
-        return list(CaseAccessorSQL.get_cases(subcase_ids))
+        return type(self).objects.get_cases(subcase_ids, self.domain)
 
     def get_reverse_index_map(self):
         return self.get_index_map(True)

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -13,6 +13,7 @@ from jsonobject import JsonObject, StringProperty
 from jsonobject.properties import BooleanProperty
 from memoized import memoized
 
+from dimagi.utils.chunked import chunked
 from dimagi.utils.couch import RedisLockableMixIn
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 
@@ -74,6 +75,14 @@ class CommCareCaseManager(RequireDBManager):
                 cases_by_id, prefetched_indices, 'case_id', 'cached_indices')
 
         return cases
+
+    def iter_cases(self, case_ids, domain=None):
+        """
+        :param case_ids: case ids iterable.
+        :param domain: See the same parameter of `get_cases`.
+        """
+        for chunk in chunked((x for x in case_ids if x), 100, list):
+            yield from self.get_cases(chunk, domain)
 
 
 class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -66,6 +66,14 @@ class CaseAccessorTestsSQL(TestCase):
         self.assertEqual(case1.case_id, cases[0].case_id)
         self.assertEqual(case2.case_id, cases[1].case_id)
 
+    def test_iter_cases(self):
+        case1 = _create_case()
+        case2 = _create_case()
+        case_ids = {'missing_case', case1.case_id, case2.case_id, '', None}
+
+        result = CommCareCase.objects.iter_cases(case_ids, DOMAIN)
+        self.assertEqual({r.case_id for r in result}, {case1.case_id, case2.case_id})
+
 
 def _create_case(domain=DOMAIN, form_id=None, case_type=None, user_id='user1', closed=False, case_id=None):
     """Create case and related models directly (not via form processor)

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -50,6 +50,22 @@ class CaseAccessorTestsSQL(TestCase):
         with self.assertRaises(CaseNotFound):
             CommCareCase.objects.get_case('missing_case')
 
+    def test_get_cases(self):
+        case1 = _create_case()
+        case2 = _create_case()
+
+        cases = CommCareCase.objects.get_cases(['missing_case'])
+        self.assertEqual(0, len(cases))
+
+        cases = CommCareCase.objects.get_cases([case1.case_id])
+        self.assertEqual(1, len(cases))
+        self.assertEqual(case1.case_id, cases[0].case_id)
+
+        cases = CommCareCase.objects.get_cases([case1.case_id, case2.case_id], ordered=True)
+        self.assertEqual(2, len(cases))
+        self.assertEqual(case1.case_id, cases[0].case_id)
+        self.assertEqual(case2.case_id, cases[1].case_id)
+
 
 def _create_case(domain=DOMAIN, form_id=None, case_type=None, user_id='user1', closed=False, case_id=None):
     """Create case and related models directly (not via form processor)

--- a/corehq/form_processor/tests/test_reindex_accessors.py
+++ b/corehq/form_processor/tests/test_reindex_accessors.py
@@ -138,7 +138,7 @@ class UnshardedCaseReindexAccessorTests(BaseReindexAccessorTest, TestCase):
     def _create_docs(cls, domain, count):
         case_ids = [uuid.uuid4().hex for i in range(count)]
         [create_form_for_test(domain, case_id=case_id) for case_id in case_ids]
-        return CaseAccessorSQL.get_cases(case_ids, ordered=True)
+        return CommCareCase.objects.get_cases(case_ids, ordered=True)
 
     @classmethod
     def _get_doc_ids(cls, docs):

--- a/corehq/form_processor/utils/sql.py
+++ b/corehq/form_processor/utils/sql.py
@@ -7,7 +7,7 @@ import json
 from jsonfield.fields import JSONEncoder
 from psycopg2.extensions import adapt
 
-from corehq.form_processor.models import (
+from ..models import (
     CaseAttachment,
     CommCareCase,
     CommCareCaseIndex,

--- a/corehq/messaging/management/commands/run_rule.py
+++ b/corehq/messaging/management/commands/run_rule.py
@@ -1,5 +1,6 @@
 from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 from corehq.messaging.scheduling.util import utcnow
 from corehq.messaging.tasks import get_sync_key
 from corehq.util.log import with_progress_bar
@@ -39,5 +40,5 @@ class Command(BaseCommand):
         for case_id_chunk in with_progress_bar(case_id_chunks):
             case_id_chunk = list(case_id_chunk)
             with CriticalSection([get_sync_key(case_id) for case_id in case_id_chunk], timeout=5 * 60):
-                for case in CaseAccessors(rule.domain).get_cases(case_id_chunk):
+                for case in CommCareCase.objects.get_cases(case_id_chunk, rule.domain):
                     rule.run_rule(case, utcnow())

--- a/corehq/motech/fhir/repeaters.py
+++ b/corehq/motech/fhir/repeaters.py
@@ -10,8 +10,7 @@ from dimagi.ext.couchdbkit import BooleanProperty, StringProperty
 
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.form_processor.exceptions import CaseNotFound
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.motech.repeater_helpers import RepeaterResponse
 from corehq.motech.repeaters.models import CaseRepeater
 from corehq.motech.repeaters.repeater_generators import (
@@ -144,7 +143,7 @@ class FHIRRepeater(CaseRepeater):
 
 def _get_cases_by_id(domain, case_blocks):
     case_ids = [case_block['@case_id'] for case_block in case_blocks]
-    cases = CaseAccessors(domain).get_cases(case_ids, ordered=True)
+    cases = CommCareCase.objects.get_cases(case_ids, domain, ordered=True)
     return {c.case_id: c for c in cases}
 
 

--- a/corehq/motech/management/commands/create_repeat_records.py
+++ b/corehq/motech/management/commands/create_repeat_records.py
@@ -4,7 +4,6 @@ import re
 from django.core.management import CommandError
 from django.core.management.base import BaseCommand
 
-from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.motech.repeaters.management.commands.find_missing_repeat_records import (
     get_repeaters_for_type_in_domain,
@@ -78,7 +77,7 @@ class Command(BaseCommand):
 
         forms = XFormInstance.objects
         cases = CommCareCase.objects
-        bulk_accessor = forms.get_forms if options['doc_type'] == 'form' else CaseAccessorSQL.get_cases
+        bulk_accessor = forms.get_forms if options['doc_type'] == 'form' else cases.get_cases
         single_accessor = forms.get_form if options['doc_type'] == 'form' else cases.get_case
         for doc_ids in chunked(with_progress_bar(doc_ids), 100):
             for doc in doc_iterator(list(doc_ids)):

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -22,8 +22,7 @@ from dimagi.ext.couchdbkit import (
 )
 
 from corehq.apps.locations.dbaccessors import get_one_commcare_user_at_location
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.motech.openmrs.const import ATOM_FEED_NAME_PATIENT, XMLNS_OPENMRS
 from corehq.motech.openmrs.openmrs_config import OpenmrsConfig
 from corehq.motech.openmrs.repeater_helpers import (
@@ -170,7 +169,7 @@ class OpenmrsRepeater(CaseRepeater):
 
         case_blocks = extract_case_blocks(payload)
         case_ids = [case_block['@case_id'] for case_block in case_blocks]
-        cases = CaseAccessors(payload.domain).get_cases(case_ids, ordered=True)
+        cases = CommCareCase.objects.get_cases(case_ids, payload.domain, ordered=True)
         if not any(CaseRepeater.allowed_to_forward(self, case) for case in cases):
             # If none of the case updates in the payload are allowed to
             # be forwarded, drop it.

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -17,7 +17,6 @@ from corehq.apps.case_importer.const import LookupErrors
 from corehq.apps.locations.tests.util import LocationHierarchyTestCase
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.motech.const import DIRECTION_EXPORT, DIRECTION_IMPORT
 from corehq.motech.openmrs.atom_feed import get_observation_mappings
@@ -141,7 +140,7 @@ CASE_CONFIG = {
 }
 
 
-@mock.patch.object(CaseAccessors, 'get_cases', lambda self, case_ids, ordered=False: [{
+@mock.patch.object(CommCareCase.objects, 'get_cases', lambda case_ids, domain=None, ordered=False: [{
     '65e55473-e83b-4d78-9dde-eaf949758997': CommCareCase(
         case_id='65e55473-e83b-4d78-9dde-eaf949758997',
         type='paciente',

--- a/corehq/motech/repeater_helpers.py
+++ b/corehq/motech/repeater_helpers.py
@@ -4,7 +4,7 @@ import attr
 
 from casexml.apps.case.xform import extract_case_blocks
 
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 from corehq.motech.value_source import CaseTriggerInfo
 
 
@@ -30,7 +30,7 @@ def get_relevant_case_updates_from_form_json(
     result = []
     case_blocks = extract_case_blocks(form_json)
     case_ids = [case_block['@case_id'] for case_block in case_blocks]
-    cases = CaseAccessors(domain).get_cases(case_ids, ordered=True)
+    cases = CommCareCase.objects.get_cases(case_ids, domain, ordered=True)
     db_case_dict = {case.case_id: case for case in cases}
 
     for case_block in case_blocks:

--- a/corehq/motech/repeaters/management/commands/find_missing_repeat_records.py
+++ b/corehq/motech/repeaters/management/commands/find_missing_repeat_records.py
@@ -10,8 +10,7 @@ from corehq.apps.app_manager.models import Application
 from corehq.apps.es import CaseES, FormES, UserES, AppES
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.motech.dhis2.repeaters import Dhis2EntityRepeater
 from corehq.motech.openmrs.repeaters import OpenmrsRepeater
 from corehq.motech.repeaters.dbaccessors import (
@@ -175,7 +174,7 @@ def find_missing_case_repeat_records_for_domain(domain, startdate, enddate, shou
     # get all cases in domain
     case_repeaters_in_domain = get_case_repeaters_in_domain(domain)
     case_ids = [c['_id'] for c in get_case_ids_in_domain_since_date(domain, startdate)]
-    cases = CaseAccessors(domain).get_cases(case_ids)
+    cases = CommCareCase.objects.get_cases(case_ids, domain)
 
     missing_case_counts = defaultdict(int)
     for case in cases:

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -19,7 +19,6 @@ from corehq.apps.registry.helper import DataRegistryHelper
 from corehq.apps.users.models import CouchUser
 from corehq.const import OPENROSA_VERSION_3
 from corehq.form_processor.exceptions import CaseNotFound
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.middleware import OPENROSA_VERSION_HEADER
 from corehq.motech.repeaters.exceptions import ReferralError, DataRegistryCaseUpdateError
@@ -250,7 +249,7 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
         else:
             case_ids_to_forward = [cid for cid in case_ids_to_forward.split(' ') if cid]
         new_owner = payload_doc.get_case_property('new_owner')
-        cases_to_forward = CaseAccessors(payload_doc.domain).get_cases(case_ids_to_forward)
+        cases_to_forward = CommCareCase.objects.get_cases(case_ids_to_forward, payload_doc.domain)
         case_ids_to_forward = set(case_ids_to_forward)
         included_case_types = payload_doc.get_case_property('case_types').split(' ')
         case_type_configs = {}

--- a/corehq/motech/repeaters/tests/test_refer_case_repeater.py
+++ b/corehq/motech/repeaters/tests/test_refer_case_repeater.py
@@ -6,7 +6,6 @@ from testil import eq
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.xml import V2_NAMESPACE
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.motech.repeaters.models import ReferCaseRepeater
 from corehq.motech.repeaters.repeater_generators import ReferCasePayloadGenerator
@@ -62,7 +61,7 @@ def _test_refer_case_payload_generator(initial_case_properties, expected_referra
         type="patient",
         case_json=properties
     )
-    with patch.object(CaseAccessors, "get_cases", return_value=[target_case]):
+    with patch.object(CommCareCase.objects, "get_cases", return_value=[target_case]):
         form = generator.get_payload(None, transfer_case)
         formxml = ElementTree.fromstring(form)
         case = CaseBlock.from_xml(formxml.find("{%s}case" % V2_NAMESPACE))

--- a/corehq/motech/tests/test_repeater_helpers.py
+++ b/corehq/motech/tests/test_repeater_helpers.py
@@ -1,8 +1,9 @@
-from django.test.testcases import TestCase
-from unittest.mock import patch
-from corehq.form_processor.models import CommCareCase
 from datetime import datetime
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from unittest.mock import patch
+
+from django.test.testcases import TestCase
+
+from corehq.form_processor.models import CommCareCase
 from corehq.motech.repeater_helpers import get_relevant_case_updates_from_form_json
 
 
@@ -37,7 +38,7 @@ class TestRepeaterHelpers(TestCase):
         self.case_1.delete()
         self.case_2.delete()
 
-    @patch.object(CaseAccessors, 'get_cases')
+    @patch.object(CommCareCase.objects, 'get_cases')
     def test__get_relevant_case_updates_from_form_json_with_case_types(self, get_cases):
         get_cases.return_value = [self.case_1, self.case_2]
 
@@ -49,7 +50,7 @@ class TestRepeaterHelpers(TestCase):
         )
         self.assertEqual(len(result), 2)
 
-    @patch.object(CaseAccessors, 'get_cases')
+    @patch.object(CommCareCase.objects, 'get_cases')
     def test__get_relevant_case_updates_from_form_json_without_case_types(self, get_cases):
         get_cases.return_value = [self.case_1, self.case_2]
 

--- a/custom/covid/casesync.py
+++ b/custom/covid/casesync.py
@@ -1,4 +1,5 @@
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 
 
 def get_ush_extension_cases_to_close(domain, cases):
@@ -16,7 +17,7 @@ def get_ush_extension_cases_to_close(domain, cases):
     )
     valid_extensions = {
         case.case_id
-        for case in CaseAccessors(domain).get_cases(list(patient_extensions))
+        for case in CommCareCase.objects.get_cases(list(patient_extensions), domain)
         # exclude CONTACT_CASE_TYPE extensions of the PATIENT_CASE_TYPE
         if case.type != CONTACT_CASE_TYPE
     }

--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -57,7 +57,7 @@ class Command(CaseUpdateCommand):
         case_blocks = []
         errors = []
         skip_count = 0
-        for case in accessor.iter_cases(case_ids):
+        for case in CommCareCase.objects.iter_cases(case_ids, domain):
             if case.get_case_property('current_status') == 'closed':
                 skip_count += 1
             elif needs_update(case):

--- a/custom/covid/management/commands/add_hq_user_id_to_case.py
+++ b/custom/covid/management/commands/add_hq_user_id_to_case.py
@@ -7,7 +7,7 @@ from dimagi.utils.chunked import chunked
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.users.util import normalize_username
 from corehq.apps.users.util import username_to_user_id
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 from custom.covid.management.commands.update_cases import CaseUpdateCommand
 
 BATCH_SIZE = 100
@@ -26,11 +26,10 @@ class Command(CaseUpdateCommand):
 
     def update_cases(self, domain, case_type, user_id):
         case_ids = self.find_case_ids_by_type(domain, case_type)
-        accessor = CaseAccessors(domain)
         case_blocks = []
         errors = []
         skip_count = 0
-        for case in accessor.iter_cases(case_ids):
+        for case in CommCareCase.objects.iter_cases(case_ids, domain):
             username_of_associated_mobile_workers = case.get_case_property('username')
             try:
                 normalized_username = normalize_username(username_of_associated_mobile_workers, domain)

--- a/custom/covid/management/commands/add_hq_user_id_to_case.py
+++ b/custom/covid/management/commands/add_hq_user_id_to_case.py
@@ -43,7 +43,8 @@ class Command(CaseUpdateCommand):
                 case_blocks.append(self.case_block(case, user_id_of_mobile_worker))
             else:
                 skip_count += 1
-        print(f"{len(case_blocks)} to update in {domain}, {skip_count} cases have skipped due to unknown username.")
+        print(f"{len(case_blocks)} to update in {domain}, {skip_count} "
+              "cases have skipped due to unknown username.")
 
         total = 0
         for chunk in chunked(case_blocks, BATCH_SIZE):

--- a/custom/covid/management/commands/clear_owner_ids.py
+++ b/custom/covid/management/commands/clear_owner_ids.py
@@ -3,7 +3,7 @@ from xml.etree import cElementTree as ElementTree
 from casexml.apps.case.mock import CaseBlock
 
 from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 from custom.covid.management.commands.update_cases import CaseUpdateCommand
 
 BATCH_SIZE = 100
@@ -23,14 +23,13 @@ class Command(CaseUpdateCommand):
 
     def update_cases(self, domain, case_type, user_id):
         case_ids = self.find_case_ids_by_type(domain, case_type)
-        accessor = CaseAccessors(domain)
         case_blocks = []
 
         print(f"Found {len(case_ids)} {case_type} cases in {domain}. Proceeding...")
 
         total_cases_updated = 0
         count_already_blank = 0
-        for case in accessor.iter_cases(case_ids):
+        for case in CommCareCase.objects.iter_cases(case_ids, domain):
             if case.get_case_property('owner_id') != '-':
                 case_blocks.append(self.case_block(case))
             else:

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -7,6 +7,7 @@ from dimagi.utils.chunked import chunked
 
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 
 '''This command has an optional argument '--location' that will exclude all cases with that location. If the
 case_type is lab_result, the owner_id of that extension case is set to '-'. '''
@@ -61,7 +62,7 @@ class Command(CaseUpdateCommand):
 
         case_blocks = []
         skip_count = 0
-        for case in accessor.iter_cases(case_ids):
+        for case in CommCareCase.objects.iter_cases(case_ids, domain):
             if should_skip(case, traveler_location_id, inactive_location):
                 skip_count += 1
             elif needs_update(case):

--- a/custom/covid/management/commands/update_owner_ids.py
+++ b/custom/covid/management/commands/update_owner_ids.py
@@ -4,7 +4,7 @@ from casexml.apps.case.mock import CaseBlock
 from dimagi.utils.chunked import chunked
 
 from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 from corehq.apps.locations.models import SQLLocation
 from custom.covid.management.commands.update_cases import CaseUpdateCommand
 
@@ -26,13 +26,12 @@ class Command(CaseUpdateCommand):
 
     def update_cases(self, domain, case_type, user_id):
         case_ids = self.find_case_ids_by_type(domain, case_type)
-        accessor = CaseAccessors(domain)
 
         locations_objects = {}
         case_blocks = []
         errors = []
         skip_count = 0
-        for case in accessor.iter_cases(case_ids):
+        for case in CommCareCase.objects.iter_cases(case_ids, domain):
             owner_id = case.get_case_property('owner_id')
             if owner_id in locations_objects:
                 location_obj = locations_objects[owner_id]

--- a/custom/inddex/example_data/data.py
+++ b/custom/inddex/example_data/data.py
@@ -17,6 +17,7 @@ from corehq.apps.userreports.tasks import rebuild_indicators
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import format_username
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 from corehq.toggles import BULK_UPLOAD_DATE_OPENED, NAMESPACE_DOMAIN
 from corehq.util.couch import IterDB
 from corehq.util.workbook_reading import make_worksheet
@@ -60,10 +61,8 @@ def _import_case_type(domain, case_type, csv_filename, user):
 
 def _update_case_id_properties(domain, user):
     """Some case properties store the ID of related cases.  This updates those IDs"""
-
-    accessor = CaseAccessors(domain)
-    case_ids = accessor.get_case_ids_in_domain()
-    cases = list(accessor.get_cases(case_ids))
+    case_ids = CaseAccessors(domain).get_case_ids_in_domain()
+    cases = CommCareCase.objects.get_cases(case_ids, domain)
     case_ids_by_external_id = {c.external_id: c.case_id for c in cases}
 
     case_blocks = []

--- a/custom/inddex/tests/test_master_report.py
+++ b/custom/inddex/tests/test_master_report.py
@@ -14,11 +14,9 @@ from dimagi.utils.dates import DateSpan
 import custom.inddex.reports.r4_nutrient_stats
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.fixtures.dbaccessors import (
-    count_fixture_items,
-    get_fixture_data_types,
-)
+from corehq.apps.fixtures.dbaccessors import get_fixture_data_types
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 from corehq.util.test_utils import require_db_context
 
 from ..example_data.data import (
@@ -53,9 +51,9 @@ def get_expected_report(filename):
 
 def _overwrite_report(filename, actual_report):
     """For use when making changes - force overwrites test data"""
-    accessor = CaseAccessors(DOMAIN)
-    case_ids = accessor.get_case_ids_in_domain()
-    external_ids_by_case_id = {c.case_id: c.external_id for c in accessor.get_cases(case_ids)}
+    case_ids = CaseAccessors(DOMAIN).get_case_ids_in_domain()
+    external_ids_by_case_id = {c.case_id: c.external_id
+        for c in CommCareCase.objects.get_cases(case_ids)}
     rows = [[
         external_ids_by_case_id[val] if val in external_ids_by_case_id else val
         for val in row
@@ -65,7 +63,6 @@ def _overwrite_report(filename, actual_report):
         writer = csv.writer(f)
         writer.writerow(actual_report.headers)
         writer.writerows(rows)
-
 
 
 @require_db_context
@@ -94,9 +91,8 @@ def get_food_data(*args, **kwargs):
 
 @memoized
 def _get_case_ids_by_external_id():
-    accessor = CaseAccessors(DOMAIN)
-    case_ids = accessor.get_case_ids_in_domain()
-    return {c.external_id: c.case_id for c in accessor.get_cases(case_ids)}
+    case_ids = CaseAccessors(DOMAIN).get_case_ids_in_domain()
+    return {c.external_id: c.case_id for c in CommCareCase.objects.get_cases(case_ids)}
 
 
 def sort_rows(rows):
@@ -110,9 +106,8 @@ def food_names(rows):
 
 class TestSetupUtils(TestCase):
     def test_cases_created(self):
-        accessor = CaseAccessors(DOMAIN)
-        case_ids = accessor.get_case_ids_in_domain()
-        cases = list(accessor.get_cases(case_ids))
+        case_ids = CaseAccessors(DOMAIN).get_case_ids_in_domain()
+        cases = CommCareCase.objects.get_cases(case_ids)
 
         self.assertEqual(len(cases), 18)
         self.assertTrue(all(

--- a/docs/databases.rst
+++ b/docs/databases.rst
@@ -213,7 +213,7 @@ In order to maintain the SQL function naming the new plproxy cluster must be in 
 
     # this will call the `get_cases_by_id` function on the 'standby' proxy which in turn
     # will query the shard standby nodes
-    cases = CaseAccessor(domain).get_cases(case_ids)
+    cases = CommCareCase.objects.get_cases(case_ids, domain)
 
 These examples assume the standby routing is active as described in the `Routing queries to standbys`_
 section below.

--- a/docs/forms_and_cases.rst
+++ b/docs/forms_and_cases.rst
@@ -100,7 +100,7 @@ name in order to know which DB needs to be queried.
 **Cases**
 
 - CommCareCase.objects.get_case(case_id, domain)
-- CaseAccessors(domain).get_cases(case_ids)
+- CommCareCase.objects.get_cases(case_ids, domain)
 - CaseAccessors(domain).iter_cases(case_ids)
 - CaseAccessors(domain).get_case_ids_in_domain(type='dog')
 

--- a/docs/forms_and_cases.rst
+++ b/docs/forms_and_cases.rst
@@ -101,7 +101,7 @@ name in order to know which DB needs to be queried.
 
 - CommCareCase.objects.get_case(case_id, domain)
 - CommCareCase.objects.get_cases(case_ids, domain)
-- CaseAccessors(domain).iter_cases(case_ids)
+- CommCareCase.objects.iter_cases(case_ids, domain)
 - CaseAccessors(domain).get_case_ids_in_domain(type='dog')
 
 **Ledgers**


### PR DESCRIPTION
Continuation of https://github.com/dimagi/commcare-hq/pull/31051

Case accessor methods are moving into `CommCareCase.objects` (which is `CommCareCaseManager`) or the relevant model manager that makes the most sense. `CaseAccessor(s|SQL)` will eventually be removed.

Thanks to @kaapstorm for the [suggestion to use real deprecation warnings](https://github.com/dimagi/commcare-hq/pull/31051#discussion_r799385424).

Methods moved in this PR:
- `get_cases`
- `iter_cases`

:blowfish: Review by commit.

## Safety Assurance

### Safety story

In addition to preserving all of the old tests and adapting the old methods that are being phased out to call the new method, new tests (copies of the old tests adapted to the new structure) are being added for the new model manager.

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
