### PR TITLE
moves auth decorators first

### DIFF
--- a/corehq/apps/api/object_fetch_api.py
+++ b/corehq/apps/api/object_fetch_api.py
@@ -126,9 +126,9 @@ class CaseAttachmentAPI(View):
                                      content_type=mime_type)
 
 
+@api_auth
 @require_form_view_permission
 @location_safe
-@api_auth
 def view_form_attachment(request, domain, instance_id, attachment_id):
     return get_form_attachment_response(request, domain, instance_id, attachment_id)
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1860,9 +1860,9 @@ class FormDataView(BaseProjectReportSectionView):
         return page_context
 
 
+@login_and_domain_required
 @require_form_view_permission
 @location_safe
-@login_and_domain_required
 def view_form_attachment(request, domain, instance_id, attachment_id):
     # Open form attachment in browser
     return get_form_attachment_response(request, domain, instance_id, attachment_id)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
In a change made in https://github.com/dimagi/commcare-hq/pull/30801/files we flipped the order of function calls to login the user and check for permission to view form. 
This changed the behavior of the api url (`/a/<domain>/api/form/attachment/<form_id>/<attachment_id>`) to access form attachment to use normal default login instead of api type login where you could pass the username and password in the header itself.
If anyone access that url now in browser, they are redirected to the login page instead of seeing the prompt from the browser to enter credentials.
In case they access that url with headers like for API, they get a response to visit the normal login page instead thus breaking that workflow.
This PR fixes that order.

~~It's not clear if that URL is used often or at all and there has not been any issues raised till now. So does not look like this cased any issues~~
This URL is used in exports and API. There were two issues reported where it broke integration implemented by user.
https://dimagi-dev.atlassian.net/browse/SUPPORT-12563
https://dimagi-dev.atlassian.net/browse/SUPPORT-12589

This PR fixes that order to support api type authorization for the api url.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/INDIV-28?focusedCommentId=189963
In addition to the product summary above, the wrong order lead to user to being redirected to domain less login in case no login, which defeated the purpose of the linked PR to use `login_and_domain_required` in the [html view](https://github.com/dimagi/commcare-hq/pull/30801/files#diff-3ee284c76d901bb74bc51d844c455d014f9a2675460fa35fb4fde2febe057942R1852) to support mobile workers to enter just their username and not the full username with domain name (`<username>@<domain_name>.commcarehq.org`).
Its not fully clear why the users were redirected to the domain less accounts login instead of domain aware login, even if it was internally using the same auth decorator since `login_and_domain_required` is the default login in `require_form_view_permission`, but tested that the correct order fixes that behavior now.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally that api auth works now on the api url.
And that on the html view, user is redirected to domain aware login instead of default login.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
