### PR TITLE
use delete / undo utils instead of re-implementing them + fix them

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -39,7 +39,7 @@ from dimagi.ext.jsonobject import JsonObject
 from dimagi.utils.couch import CriticalSection
 from dimagi.utils.couch.bulk import get_docs
 from dimagi.utils.couch.database import iter_docs
-from dimagi.utils.couch.undo import DELETED_SUFFIX
+from dimagi.utils.couch.undo import is_deleted
 from dimagi.utils.dates import DateSpan
 from dimagi.utils.modules import to_function
 
@@ -259,7 +259,7 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
 
     @property
     def is_deleted(self):
-        return DELETED_SUFFIX in self.doc_type
+        return is_deleted(self)
 
     def save(self, **params):
         self.last_modified = datetime.utcnow()

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -92,7 +92,7 @@ from corehq.toggles import (
     SHOW_IDS_IN_REPORT_BUILDER,
     DATA_REGISTRY
 )
-from dimagi.utils.couch.undo import DELETED_SUFFIX
+from dimagi.utils.couch.undo import undo_delete
 
 STATIC_CASE_PROPS = [
     "closed",
@@ -1343,7 +1343,7 @@ class ConfigureNewReportBase(forms.Form):
         data_source_config = get_ucr_datasource_config_by_id(data_source_config_id, allow_deleted=True)
         if data_source_config.is_deleted:
             # undelete the temp data source
-            data_source_config.doc_type = data_source_config.doc_type.replace(DELETED_SUFFIX, '')
+            undo_delete(data_source_config)
 
         filters = self.cleaned_data['user_filters'] + self.cleaned_data['default_filters']
         # The data source needs indicators for all possible calculations, not just the ones currently in use

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1343,7 +1343,7 @@ class ConfigureNewReportBase(forms.Form):
         data_source_config = get_ucr_datasource_config_by_id(data_source_config_id, allow_deleted=True)
         if data_source_config.is_deleted:
             # undelete the temp data source
-            undo_delete(data_source_config)
+            undo_delete(data_source_config, save=False)
 
         filters = self.cleaned_data['user_filters'] + self.cleaned_data['default_filters']
         # The data source needs indicators for all possible calculations, not just the ones currently in use

--- a/corehq/apps/userreports/tests/test_utils.py
+++ b/corehq/apps/userreports/tests/test_utils.py
@@ -93,4 +93,5 @@ def test_remove_deleted_doc_type_suffix():
     yield from [
         (_check, 'DataSource', 'DataSource'),
         (_check, 'DataSource-Deleted', 'DataSource'),
+        (_check, 'DataSource-Deleted-Deleted', 'DataSource'),
     ]

--- a/corehq/apps/userreports/tests/test_utils.py
+++ b/corehq/apps/userreports/tests/test_utils.py
@@ -1,4 +1,5 @@
 from django.test import SimpleTestCase
+from testil import eq
 
 from corehq.apps.userreports.sql import get_column_name
 from corehq.apps.userreports.util import (
@@ -6,6 +7,7 @@ from corehq.apps.userreports.util import (
     get_table_name,
     truncate_value,
 )
+from dimagi.utils.couch.undo import remove_deleted_doc_type_suffix
 
 
 class UtilitiesTestCase(SimpleTestCase):
@@ -82,3 +84,13 @@ class UtilitiesTestCase(SimpleTestCase):
             column_name,
             '_be_a_bunch_longer_than_sixty_three_characters_6174b354_decimal',
         )
+
+
+def test_remove_deleted_doc_type_suffix():
+    def _check(doc_type, expected):
+        eq(expected, remove_deleted_doc_type_suffix(doc_type))
+
+    yield from [
+        (_check, 'DataSource', 'DataSource'),
+        (_check, 'DataSource-Deleted', 'DataSource'),
+    ]

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -16,7 +16,7 @@ from corehq.toggles import ENABLE_UCR_MIRRORS
 from corehq.util import reverse
 from corehq.util.couch import DocumentNotFound
 from corehq.util.metrics.load_counters import ucr_load_counter
-from dimagi.utils.couch.undo import DELETED_SUFFIX
+from dimagi.utils.couch.undo import is_deleted
 
 UCR_TABLE_PREFIX = 'ucr_'
 LEGACY_UCR_TABLE_PREFIX = 'config_report_'
@@ -309,8 +309,9 @@ def _wrap_data_source_by_doc_type(doc, allow_deleted=False):
         DataSourceConfiguration,
         RegistryDataSourceConfiguration,
     )
-    if DELETED_SUFFIX in doc["doc_type"] and not allow_deleted:
+    if is_deleted(doc) and not allow_deleted:
         raise DataSourceConfigurationNotFoundError()
+
     doc_type = doc["doc_type"].replace(DELETED_SUFFIX, '')
     return {
         "DataSourceConfiguration": DataSourceConfiguration,

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -16,7 +16,7 @@ from corehq.toggles import ENABLE_UCR_MIRRORS
 from corehq.util import reverse
 from corehq.util.couch import DocumentNotFound
 from corehq.util.metrics.load_counters import ucr_load_counter
-from dimagi.utils.couch.undo import is_deleted
+from dimagi.utils.couch.undo import is_deleted, remove_deleted_doc_type_suffix
 
 UCR_TABLE_PREFIX = 'ucr_'
 LEGACY_UCR_TABLE_PREFIX = 'config_report_'
@@ -312,7 +312,7 @@ def _wrap_data_source_by_doc_type(doc, allow_deleted=False):
     if is_deleted(doc) and not allow_deleted:
         raise DataSourceConfigurationNotFoundError()
 
-    doc_type = doc["doc_type"].replace(DELETED_SUFFIX, '')
+    doc_type = remove_deleted_doc_type_suffix(doc["doc_type"])
     return {
         "DataSourceConfiguration": DataSourceConfiguration,
         "RegistryDataSourceConfiguration": RegistryDataSourceConfiguration,

--- a/corehq/ex-submodules/dimagi/utils/couch/undo.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/undo.py
@@ -72,4 +72,4 @@ def undo_delete(document, save=True):
 
 
 def remove_deleted_doc_type_suffix(doc_type):
-    return doc_type.rstrip(DELETED_SUFFIX)
+    return doc_type.removesuffix(DELETED_SUFFIX)

--- a/corehq/ex-submodules/dimagi/utils/couch/undo.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/undo.py
@@ -72,4 +72,6 @@ def undo_delete(document, save=True):
 
 
 def remove_deleted_doc_type_suffix(doc_type):
-    return doc_type.removesuffix(DELETED_SUFFIX)
+    while _is_doc_type_deleted(doc_type):
+        doc_type = doc_type.removesuffix(DELETED_SUFFIX)
+    return doc_type

--- a/corehq/ex-submodules/dimagi/utils/couch/undo.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/undo.py
@@ -43,9 +43,13 @@ def is_deleted(doc):
     Returns False otherwise.
     """
     try:
-        return doc and doc['doc_type'].endswith(DELETED_SUFFIX)
+        return doc and _is_doc_type_deleted(doc['doc_type'])
     except KeyError:
         return False
+
+
+def _is_doc_type_deleted(doc_type):
+    return doc_type.endswith(DELETED_SUFFIX)
 
 
 def soft_delete(document):
@@ -61,6 +65,11 @@ def get_deleted_doc_type(document_class_or_instance):
     return '{}{}'.format(base_name, DELETED_SUFFIX)
 
 
-def undo_delete(document):
-    document.doc_type = document.doc_type.rstrip(DELETED_SUFFIX)
-    document.save()
+def undo_delete(document, save=True):
+    document.doc_type = remove_deleted_doc_type_suffix(document['doc_type'])
+    if save:
+        document.save()
+
+
+def remove_deleted_doc_type_suffix(doc_type):
+    return doc_type.rstrip(DELETED_SUFFIX)


### PR DESCRIPTION
## Technical Summary
Instead of manually undoing a doc delete use the existing utils.

This also includes a fix for those to prevent generating bad doc types by checking if the doc is deleted first, replacing `rstrip` with `removesuffix` (and doing it repeatedly).

`rstrip` removes all combinations of the characters:
```python
>>> 'ExportInstance-Deleted'.rstrip('-Deleted')
'ExportInstanc'
>>> 'ExportInstance-Deleted'.removesuffix('-Deleted')
'ExportInstance'
```

As best I can tell (by looking at the usages of `undo_delete`) we haven't hit this bug yet.

## Safety Assurance

### Safety story
Improves on existing functionality + covered by tests

### Automated test coverage
Added tests.

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
