### PR TITLE
Don't use `rstrip()` in `undo_delete()`

### DIFF
--- a/corehq/ex-submodules/dimagi/utils/couch/undo.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/undo.py
@@ -61,9 +61,13 @@ def get_deleted_doc_type(document_class_or_instance):
     return '{}{}'.format(base_name, DELETED_SUFFIX)
 
 
+def get_undeleted_doc_type(instance: Document) -> str:
+    return removesuffix(instance.doc_type, DELETED_SUFFIX)
+
+
 def undo_delete(document):
     if is_deleted(document):
-        document.doc_type = removesuffix(document.doc_type, DELETED_SUFFIX)
+        document.doc_type = get_undeleted_doc_type(document)
         document.save()
 
 

--- a/corehq/ex-submodules/dimagi/utils/couch/undo.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/undo.py
@@ -62,5 +62,30 @@ def get_deleted_doc_type(document_class_or_instance):
 
 
 def undo_delete(document):
-    document.doc_type = document.doc_type.rstrip(DELETED_SUFFIX)
-    document.save()
+    if is_deleted(document):
+        document.doc_type = removesuffix(document.doc_type, DELETED_SUFFIX)
+        document.save()
+
+
+def removesuffix(string: str, suffix: str) -> str:
+    """
+    If ``string`` ends with ``suffix``, returns ``string[:-len(suffix)]``,
+    otherwise, returns ``string``.
+
+    >>> 'Completed-Deleted'.rstrip(DELETED_SUFFIX)
+    'Comp'
+    >>> removesuffix('Completed-Deleted', DELETED_SUFFIX)
+    'Completed'
+
+    >>> 'I-Get-Deleted-But-I-Get-Undeleted-Again'.replace(DELETED_SUFFIX, '')
+    'I-Get-But-I-Get-Undeleted-Again'
+    >>> removesuffix('I-Get-Deleted-But-I-Get-Undeleted-Again', DELETED_SUFFIX)
+    'I-Get-Deleted-But-I-Get-Undeleted-Again'
+
+    """
+    try:
+        return string.removesuffix(suffix)  # Python 3.9+
+    except AttributeError:
+        if suffix and string.endswith(suffix):
+            return string[:-len(suffix)]
+        return string

--- a/corehq/ex-submodules/dimagi/utils/tests/test_undo.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/test_undo.py
@@ -1,10 +1,18 @@
+import doctest
+
 from django.test import SimpleTestCase
+
 from dimagi.ext.couchdbkit import Document
-from dimagi.utils.couch.undo import get_deleted_doc_type
+from dimagi.utils.couch.undo import (
+    get_deleted_doc_type,
+    soft_delete,
+    undo_delete,
+)
 
 
 class TestDocument(Document):
-    pass
+    def save(self):
+        pass
 
 
 class TestSubDocument(TestDocument):
@@ -27,3 +35,20 @@ class TestDeletedDocType(SimpleTestCase):
 
     def test_format_subclass_instance(self):
         self.assertEqual('TestSubDocument-Deleted', get_deleted_doc_type(TestSubDocument()))
+
+
+class TestUndoDelete(SimpleTestCase):
+
+    def test_undo_delete(self):
+        document = TestDocument(doc_type='Completed')
+        soft_delete(document)
+        self.assertEqual(document.doc_type, 'Completed-Deleted')
+        undo_delete(document)
+        self.assertEqual(document.doc_type, 'Completed')
+
+
+def test_doctests():
+    import dimagi.utils.couch.undo
+
+    results = doctest.testmod(dimagi.utils.couch.undo)
+    assert results.failed == 0

--- a/corehq/ex-submodules/dimagi/utils/tests/test_undo.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/test_undo.py
@@ -5,6 +5,7 @@ from django.test import SimpleTestCase
 from dimagi.ext.couchdbkit import Document
 from dimagi.utils.couch.undo import (
     get_deleted_doc_type,
+    get_undeleted_doc_type,
     soft_delete,
     undo_delete,
 )
@@ -45,6 +46,12 @@ class TestUndoDelete(SimpleTestCase):
         self.assertEqual(document.doc_type, 'Completed-Deleted')
         undo_delete(document)
         self.assertEqual(document.doc_type, 'Completed')
+
+    def test_get_undeleted_doc_type(self):
+        document = TestDocument(doc_type='Completed')
+        self.assertEqual('Completed', get_undeleted_doc_type(document))
+        soft_delete(document)
+        self.assertEqual('Completed', get_undeleted_doc_type(document))
 
 
 def test_doctests():


### PR DESCRIPTION
## Technical Summary

I spotted different ways of getting an undeleted doc_type of Couch documents, and figured I'd address that quickly.

This PR uses `removesuffix()` instead of `rstrip()` to get the undeleted doc_type. In other areas of the codebase we sometimes use `doc_type.replace(DELETED_SUFFIX, '')`. This change offers `get_undeleted_doc_type()` as a single, safer way to do that.

## Safety Assurance

### Safety story

Couch is still widely used. Any bugs in this small change should be immediately obvious from our existing test suite.

### Automated test coverage

PR includes test coverage.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
