### PR TITLE
Move case accessors into CommCareCase.objects - part 3

### DIFF
--- a/corehq/apps/api/models.py
+++ b/corehq/apps/api/models.py
@@ -12,10 +12,8 @@ from django.http import HttpResponse
 from couchforms import const
 
 from corehq.apps.api.resources import DictObject
-from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
+from corehq.form_processor.models import CommCareCase, CommCareCaseIndex, XFormInstance
 from corehq.form_processor.models.cases import CaseToXMLMixin, get_index_map
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import XFormInstance
 
 PERMISSION_POST_SMS = "POST_SMS"
 PERMISSION_POST_WISEPILL = "POST_WISEPILL"
@@ -223,7 +221,7 @@ class ESCase(DictObject, CaseToXMLMixin):
 
     @property
     def _reverse_indices(self):
-        return CaseAccessors(self.domain).get_all_reverse_indices_info([self._id])
+        return CommCareCaseIndex.objects.get_all_reverse_indices_info(self.domain, [self._id])
 
     def get_forms(self):
         from corehq.apps.api.util import form_to_es_form

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -390,7 +390,8 @@ class ImporterTest(TestCase):
         res = do_import(file, config, self.domain)
         self.assertEqual(rows, res['created_count'])
         # Should create child cases
-        self.assertEqual(len(self.accessor.get_reverse_indexed_cases([parent_case.case_id])), 3)
+        cases = CommCareCase.objects.get_reverse_indexed_cases(self.domain, [parent_case.case_id])
+        self.assertEqual(len(cases), 3)
         self.assertEqual(self.accessor.get_extension_case_ids([parent_case.case_id]), [])
 
         file_missing = make_worksheet_wrapper(

--- a/corehq/apps/change_feed/tests/test_data_sources.py
+++ b/corehq/apps/change_feed/tests/test_data_sources.py
@@ -15,17 +15,14 @@ from corehq.apps.change_feed.data_sources import get_document_store
 from corehq.apps.change_feed.exceptions import UnknownDocumentStore
 from corehq.apps.locations.document_store import LocationDocumentStore
 from corehq.apps.sms.document_stores import SMSDocumentStore
-from corehq.form_processor.backends.sql.dbaccessors import (
-    CaseAccessorSQL,
-    LedgerAccessorSQL,
-)
+from corehq.form_processor.backends.sql.dbaccessors import LedgerAccessorSQL
 from corehq.form_processor.document_stores import (
     CaseDocumentStore,
     DocStoreLoadTracker,
     FormDocumentStore,
     LedgerV2DocumentStore,
 )
-from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.form_processor.tests.utils import sharded
 from corehq.util.exceptions import DatabaseNotFound
 from corehq.util.test_utils import generate_cases
@@ -103,7 +100,7 @@ def case_form_data():
         yield form_ids, case_ids
     finally:
         XFormInstance.objects.hard_delete_forms('domain', form_ids)
-        CaseAccessorSQL.hard_delete_cases('domain', case_ids)
+        CommCareCase.objects.hard_delete_cases('domain', case_ids)
 
 
 @contextmanager

--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -43,7 +43,7 @@ def _with_case(domain, case_type, last_modified, **kwargs):
     try:
         yield case
     finally:
-        CaseAccessorSQL.hard_delete_cases(domain, [case.case_id])
+        CommCareCase.objects.hard_delete_cases(domain, [case.case_id])
 
 
 def _save_case(domain, case):

--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -24,7 +24,6 @@ from corehq.apps.data_interfaces.models import (
 )
 from corehq.apps.data_interfaces.tasks import run_case_update_rules_for_domain
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.form_processor.signals import sql_case_post_save
 from corehq.toggles import NAMESPACE_DOMAIN, RUN_AUTO_CASE_UPDATES_ON_SAVE
@@ -47,7 +46,7 @@ def _with_case(domain, case_type, last_modified, **kwargs):
 
 
 def _save_case(domain, case):
-    CaseAccessorSQL.save_case(case)
+    case.save(with_tracked_models=True)
 
 
 def _update_case(domain, case_id, server_modified_on, last_visit_date=None):

--- a/corehq/apps/domain/management/commands/hard_delete_forms_and_cases_in_domain.py
+++ b/corehq/apps/domain/management/commands/hard_delete_forms_and_cases_in_domain.py
@@ -6,7 +6,7 @@ from dimagi.utils.chunked import chunked
 
 from corehq.apps.domain.utils import silence_during_tests
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
-from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.util.log import with_progress_bar
 
 logger = logging.getLogger(__name__)
@@ -46,6 +46,6 @@ class Command(BaseCommand):
         logger.info('Hard deleting cases...')
         deleted_sql_case_ids = CaseAccessorSQL.get_deleted_case_ids_in_domain(domain)
         for case_id_chunk in chunked(with_progress_bar(deleted_sql_case_ids, stream=silence_during_tests()), 500):
-            CaseAccessorSQL.hard_delete_cases(domain, list(case_id_chunk))
+            CommCareCase.objects.hard_delete_cases(domain, list(case_id_chunk))
 
         logger.info('Done.')

--- a/corehq/apps/hqadmin/management/commands/delete_related_cases.py
+++ b/corehq/apps/hqadmin/management/commands/delete_related_cases.py
@@ -80,11 +80,11 @@ def get_entire_case_network(domain, case_ids):
     This includes all cases that index into the passed in cases (extensions or children)
     as well as all cases that index into those, recursively.
     """
-    case_accessor = CaseAccessors(domain=domain)
     all_ids = set(case_ids)
     remaining_ids = set(case_ids)
     while remaining_ids:
-        this_round_ids = set(c.case_id for c in case_accessor.get_reverse_indexed_cases(list(remaining_ids)))
+        cases = CommCareCase.objects.get_reverse_indexed_cases(domain, list(remaining_ids))
+        this_round_ids = {c.case_id for c in cases}
         remaining_ids = this_round_ids - all_ids
         all_ids = all_ids | this_round_ids
     return all_ids

--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -7,7 +7,7 @@ from memoized import memoized
 from casexml.apps.case.mock import CaseBlock, IndexAttrs
 
 from corehq.apps.hqcase.utils import CASEBLOCK_CHUNKSIZE, submit_case_blocks
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 
 from .core import SubmissionError, UserError
 
@@ -152,7 +152,7 @@ def _get_bulk_updates(domain, all_data, user):
 
 
 def _missing_cases(domain, case_ids):
-    real_case_ids = CaseAccessors(domain).get_case_ids_that_exist(case_ids)
+    real_case_ids = CommCareCase.objects.get_case_ids_that_exist(domain, case_ids)
     return set(case_ids) - set(real_case_ids)
 
 

--- a/corehq/apps/hqcase/tasks.py
+++ b/corehq/apps/hqcase/tasks.py
@@ -17,7 +17,7 @@ from corehq.apps.ota.utils import get_restore_user
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.backends.sql.dbaccessors import LedgerAccessorSQL
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models import CommCareCase, XFormInstance
 
 
 @task
@@ -134,7 +134,7 @@ def delete_exploded_cases(domain, explosion_id, task=None):
             ledger_accessor.delete_ledger_transactions_for_form([id], form_id)
         num_deleted_ledger_entries += ledger_accessor.delete_ledger_values(id)
 
-        new_form_ids = set(case_accessor.get_case_xform_ids(id)) - deleted_form_ids
+        new_form_ids = set(CommCareCase.objects.get_case_xform_ids(id)) - deleted_form_ids
         XFormInstance.objects.soft_delete_forms(domain, list(new_form_ids))
         deleted_form_ids |= new_form_ids
 

--- a/corehq/apps/ota/tests/test_registry_case_details.py
+++ b/corehq/apps/ota/tests/test_registry_case_details.py
@@ -15,7 +15,7 @@ from corehq.apps.registry.models import RegistryAuditLog
 from corehq.apps.registry.tests.utils import create_registry_for_test
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
-from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.util.test_utils import generate_cases, flag_enabled
 
 
@@ -73,7 +73,7 @@ class RegistryCaseDetailsTests(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.user.delete(deleted_by_domain=None, deleted_by=None)
-        xform_ids = CaseAccessorSQL.get_case_xform_ids(cls.parent_case_id)
+        xform_ids = CommCareCase.objects.get_case_xform_ids(cls.parent_case_id)
         CaseAccessorSQL.hard_delete_cases(cls.domain, [case.case_id for case in cls.cases])
         XFormInstance.objects.hard_delete_forms(cls.domain, xform_ids)
         cls.app.delete()

--- a/corehq/apps/ota/tests/test_registry_case_details.py
+++ b/corehq/apps/ota/tests/test_registry_case_details.py
@@ -14,7 +14,6 @@ from corehq.apps.registry.helper import DataRegistryHelper
 from corehq.apps.registry.models import RegistryAuditLog
 from corehq.apps.registry.tests.utils import create_registry_for_test
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.util.test_utils import generate_cases, flag_enabled
 
@@ -74,7 +73,7 @@ class RegistryCaseDetailsTests(TestCase):
     def tearDownClass(cls):
         cls.user.delete(deleted_by_domain=None, deleted_by=None)
         xform_ids = CommCareCase.objects.get_case_xform_ids(cls.parent_case_id)
-        CaseAccessorSQL.hard_delete_cases(cls.domain, [case.case_id for case in cls.cases])
+        CommCareCase.objects.hard_delete_cases(cls.domain, [case.case_id for case in cls.cases])
         XFormInstance.objects.hard_delete_forms(cls.domain, xform_ids)
         cls.app.delete()
         Domain.get_db().delete_doc(cls.domain_object)  # no need to run the full domain delete

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -29,7 +29,6 @@ from corehq.apps.userreports.mixins import NoPropertyTypeCoercionMixIn
 from corehq.apps.userreports.specs import EvaluationContext, TypeProperty
 from corehq.apps.userreports.util import add_tabbed_text
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.util.couch import get_db_by_doc_type
@@ -794,7 +793,7 @@ class SubcasesExpressionSpec(JsonObject):
     @ucr_context_cache(vary_on=('case_id',))
     def _get_subcases(self, case_id, context):
         domain = context.root_doc['domain']
-        return [c.to_json() for c in CaseAccessors(domain).get_reverse_indexed_cases([case_id])]
+        return [c.to_json() for c in CommCareCase.objects.get_reverse_indexed_cases(domain, [case_id])]
 
     def __str__(self):
         return "get subcases for {}".format(str(self._case_id_expression))

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -43,6 +43,7 @@ from corehq.apps.userreports.tests.utils import (
 )
 from corehq.apps.userreports.util import get_indicator_adapter
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
+from corehq.form_processor.models import CommCareCase
 from corehq.pillows.case import get_case_pillow
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.test_utils import softer_assert, flaky_slow
@@ -482,7 +483,7 @@ class IndicatorPillowTest(TestCase):
         self.pillow.process_changes(since=since, forever=False)
         self._check_sample_doc_state(expected_indicators)
 
-        CaseAccessorSQL.hard_delete_cases(case.domain, [case.case_id])
+        CommCareCase.objects.hard_delete_cases(case.domain, [case.case_id])
 
     @mock.patch('corehq.apps.userreports.specs.datetime')
     def test_process_deleted_doc_from_sql_chunked(self, datetime_mock):
@@ -513,7 +514,7 @@ class IndicatorPillowTest(TestCase):
         self.pillow.process_changes(since=since, forever=False)
         self.assertEqual(0, self.adapter.get_query_object().count())
 
-        CaseAccessorSQL.hard_delete_cases(case.domain, [case.case_id])
+        CommCareCase.objects.hard_delete_cases(case.domain, [case.case_id])
 
     @mock.patch('corehq.apps.userreports.specs.datetime')
     def test_process_filter_no_longer_pass(self, datetime_mock):

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -28,7 +28,7 @@ from corehq import toggles
 from corehq.apps.domain.models import Domain
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import CommCareCase, UserArchivedRebuild, XFormInstance
+from corehq.form_processor.models import CommCareCase, CommCareCaseIndex, UserArchivedRebuild, XFormInstance
 from corehq.util.celery_utils import deserialize_run_every_setting, run_periodic_task_again
 
 logger = get_task_logger(__name__)
@@ -188,7 +188,8 @@ def _remove_indices_from_deleted_cases_task(domain, case_ids):
 def remove_indices_from_deleted_cases(domain, case_ids):
     from corehq.apps.hqcase.utils import submit_case_blocks
     deleted_ids = set(case_ids)
-    indexes_referencing_deleted_cases = CaseAccessors(domain).get_all_reverse_indices_info(list(case_ids))
+    indexes_referencing_deleted_cases = \
+        CommCareCaseIndex.objects.get_all_reverse_indices_info(domain, list(case_ids))
     case_updates = [
         CaseBlock.deprecated_init(
             case_id=index_info.case_id,

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_db_accessors.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_db_accessors.py
@@ -148,35 +148,3 @@ class TestExtensionCaseIds(TestCase):
         )
         returned_cases = CaseAccessors(self.domain).get_extension_case_ids([host_id, host_2_id])
         self.assertItemsEqual(returned_cases, [extension_id, extension_2_id])
-
-
-@sharded
-class TestIndexedCaseIds(TestCase):
-
-    def setUp(self):
-        super(TestIndexedCaseIds, self).setUp()
-        self.domain = 'domain'
-        self.factory = CaseFactory(self.domain)
-
-    def tearDown(self):
-        FormProcessorTestUtils.delete_all_cases()
-        FormProcessorTestUtils.delete_all_xforms()
-        super(TestIndexedCaseIds, self).tearDown()
-
-    def test_indexed_case_ids_returns_extensions(self):
-        """ When getting indices, also return extensions """
-        host_id = uuid.uuid4().hex
-        extension_id = uuid.uuid4().hex
-        host = CaseStructure(case_id=host_id, attrs={'create': True})
-
-        self.factory.create_or_update_case(
-            CaseStructure(
-                case_id=extension_id,
-                indices=[
-                    CaseIndex(host, relationship=CASE_INDEX_EXTENSION)
-                ],
-                attrs={'create': True}
-            )
-        )
-        returned_cases = CaseAccessors(self.domain).get_indexed_case_ids([extension_id])
-        self.assertItemsEqual(returned_cases, [host_id])

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multi_case_submits.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multi_case_submits.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 import os
 from casexml.apps.case.tests.util import delete_all_xforms, delete_all_cases
 from corehq.apps.receiverwrapper.util import submit_form_locally
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 
 
 class MultiCaseTest(TestCase):
@@ -40,6 +40,6 @@ class MultiCaseTest(TestCase):
 
     def _check_ids(self, form, cases):
         for case in cases:
-            ids = CaseAccessors(case.domain).get_case_xform_ids(case.case_id)
+            ids = CommCareCase.objects.get_case_xform_ids(case.case_id)
             self.assertEqual(1, len(ids))
             self.assertEqual(form.form_id, ids[0])

--- a/corehq/ex-submodules/casexml/apps/case/tests/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/util.py
@@ -11,7 +11,7 @@ from casexml.apps.case.xml import NS_VERSION_MAP, V1, V2
 from casexml.apps.phone.restore import RestoreConfig, RestoreParams
 from casexml.apps.phone.restore_caching import RestorePayloadPathCache
 from corehq.apps.receiverwrapper.util import submit_form_locally
-from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
+from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.tests.util.xml import assert_xml_equal
 from corehq.util.test_utils import unit_testing_only
@@ -71,7 +71,7 @@ def create_case(domain, case_type, **kwargs):
     try:
         yield case
     finally:
-        CaseAccessorSQL.hard_delete_cases(domain, [case.case_id])
+        CommCareCase.objects.hard_delete_cases(domain, [case.case_id])
 
 
 def _replace_ids_in_xform_xml(xml_data, case_id_override=None):

--- a/corehq/form_processor/backends/sql/casedb.py
+++ b/corehq/form_processor/backends/sql/casedb.py
@@ -40,8 +40,8 @@ class CaseDbCacheSQL(AbstractCaseDbCache):
         return cases
 
     def get_reverse_indexed_cases(self, case_ids, case_types=None, is_closed=None):
-        return CaseAccessorSQL.get_reverse_indexed_cases(self.domain, case_ids,
-                                                         case_types=case_types, is_closed=is_closed)
+        return CommCareCase.objects.get_reverse_indexed_cases(
+            self.domain, case_ids, case_types=case_types, is_closed=is_closed)
 
     def filter_closed_extensions(self, extensions_to_close):
         # noop for SQL since the filtering already happened when we fetched the IDs

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -31,10 +31,7 @@ from corehq.form_processor.exceptions import (
     XFormNotFound,
 )
 from corehq.form_processor.models.util import attach_prefetch_models as _attach_prefetch_models
-from corehq.form_processor.interfaces.dbaccessors import (
-    AbstractLedgerAccessor,
-    CaseIndexInfo,
-)
+from corehq.form_processor.interfaces.dbaccessors import AbstractLedgerAccessor
 from corehq.form_processor.models import (
     AttachmentContent,
     CaseAttachment,
@@ -438,23 +435,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_all_reverse_indices_info(domain, case_ids):
-        assert isinstance(case_ids, list)
-        if not case_ids:
-            return []
-
-        indexes = CommCareCaseIndex.objects.plproxy_raw(
-            'SELECT * FROM get_all_reverse_indices(%s, %s)',
-            [domain, case_ids]
-        )
-        return [
-            CaseIndexInfo(
-                case_id=index.case_id,
-                identifier=index.identifier,
-                referenced_id=index.referenced_id,
-                referenced_type=index.referenced_type,
-                relationship=index.relationship_id
-            ) for index in indexes
-        ]
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCaseIndex.objects.get_all_reverse_indices_info(domain, case_ids)
 
     @staticmethod
     def get_indexed_case_ids(domain, case_ids):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -448,11 +448,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def hard_delete_cases(domain, case_ids):
-        assert isinstance(case_ids, list)
-        with CommCareCase.get_plproxy_cursor() as cursor:
-            cursor.execute('SELECT hard_delete_cases(%s, %s) as deleted_count', [domain, case_ids])
-            results = fetchall_as_namedtuple(cursor)
-            return sum([result.deleted_count for result in results])
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCase.objects.hard_delete_cases(domain, case_ids)
 
     @staticmethod
     def get_attachment_by_name(case_id, attachment_name):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -439,22 +439,6 @@ class CaseAccessorSQL:
         return CommCareCaseIndex.objects.get_all_reverse_indices_info(domain, case_ids)
 
     @staticmethod
-    def get_indexed_case_ids(domain, case_ids):
-        """
-        Given a base list of case ids, gets all ids of cases they reference (parent and host cases)
-        """
-        if not case_ids:
-            return []
-
-        with CommCareCaseIndex.get_plproxy_cursor(readonly=True) as cursor:
-            cursor.execute(
-                'SELECT referenced_id FROM get_multiple_cases_indices(%s, %s)',
-                [domain, list(case_ids)]
-            )
-            results = fetchall_as_namedtuple(cursor)
-            return [result.referenced_id for result in results]
-
-    @staticmethod
     def get_reverse_indexed_cases(domain, case_ids, case_types=None, is_closed=None):
         assert isinstance(case_ids, list)
         assert case_types is None or isinstance(case_types, list)

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -417,10 +417,6 @@ class CaseAccessorSQL:
         return CommCareCase.objects.get_cases(case_ids, ordered, prefetched_indices)
 
     @staticmethod
-    def case_exists(case_id):
-        return CommCareCase.objects.partitioned_query(case_id).filter(case_id=case_id).exists()
-
-    @staticmethod
     def get_case_ids_that_exist(domain, case_ids):
         result = []
         for db_name, case_ids_chunk in split_list_by_db_partition(case_ids):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -21,7 +21,6 @@ from casexml.apps.case.xform import get_case_updates
 from dimagi.utils.chunked import chunked
 
 from corehq.form_processor.exceptions import (
-    AttachmentNotFound,
     CaseNotFound,
     LedgerSaveError,
     LedgerValueNotFound,
@@ -452,13 +451,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_attachment_by_name(case_id, attachment_name):
-        try:
-            return CaseAttachment.objects.plproxy_raw(
-                'select * from get_case_attachment_by_name(%s, %s)',
-                [case_id, attachment_name]
-            )[0]
-        except IndexError:
-            raise AttachmentNotFound(case_id, attachment_name)
+        warn("DEPRECATED", DeprecationWarning)
+        return CaseAttachment.objects.get_attachment_by_name(case_id, attachment_name)
 
     @staticmethod
     def get_attachment_content(case_id, attachment_name):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -418,13 +418,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_case_ids_that_exist(domain, case_ids):
-        result = []
-        for db_name, case_ids_chunk in split_list_by_db_partition(case_ids):
-            result.extend(CommCareCase.objects
-                          .using(db_name)
-                          .filter(domain=domain, case_id__in=case_ids_chunk)
-                          .values_list('case_id', flat=True))
-        return result
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCase.objects.get_case_ids_that_exist(domain, case_ids)
 
     @staticmethod
     def get_case_xform_ids(case_id):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -30,7 +30,6 @@ from corehq.form_processor.exceptions import (
     MissingFormXml,
     XFormNotFound,
 )
-from corehq.form_processor.models.util import attach_prefetch_models as _attach_prefetch_models
 from corehq.form_processor.interfaces.dbaccessors import AbstractLedgerAccessor
 from corehq.form_processor.models import (
     AttachmentContent,
@@ -440,23 +439,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_reverse_indexed_cases(domain, case_ids, case_types=None, is_closed=None):
-        assert isinstance(case_ids, list)
-        assert case_types is None or isinstance(case_types, list)
-        if not case_ids:
-            return []
-
-        cases = list(CommCareCase.objects.plproxy_raw(
-            'SELECT * FROM get_reverse_indexed_cases_3(%s, %s, %s, %s)',
-            [domain, case_ids, case_types, is_closed])
-        )
-        cases_by_id = {case.case_id: case for case in cases}
-        if cases_by_id:
-            indices = list(CommCareCaseIndex.objects.plproxy_raw(
-                'SELECT * FROM get_multiple_cases_indices(%s, %s)',
-                [domain, list(cases_by_id)])
-            )
-            _attach_prefetch_models(cases_by_id, indices, 'case_id', 'cached_indices')
-        return cases
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCase.objects.get_reverse_indexed_cases(domain, case_ids, case_types, is_closed)
 
     @staticmethod
     @tracer.wrap("form_processor.sql.check_transaction_order_for_case")

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -460,7 +460,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_attachments(case_id):
-        return list(CaseAttachment.objects.partitioned_query(case_id).filter(case_id=case_id))
+        warn("DEPRECATED", DeprecationWarning)
+        return CaseAttachment.objects.get_attachments(case_id)
 
     @staticmethod
     def get_transactions(case_id):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -29,7 +29,6 @@ from corehq.form_processor.exceptions import (
 )
 from corehq.form_processor.interfaces.dbaccessors import AbstractLedgerAccessor
 from corehq.form_processor.models import (
-    AttachmentContent,
     CaseAttachment,
     CaseTransaction,
     CommCareCaseIndex,
@@ -456,8 +455,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_attachment_content(case_id, attachment_name):
-        meta = CaseAccessorSQL.get_attachment_by_name(case_id, attachment_name)
-        return AttachmentContent(meta.content_type, meta.open())
+        warn("DEPRECATED", DeprecationWarning)
+        return CaseAttachment.get_content(case_id, attachment_name)
 
     @staticmethod
     def get_attachments(case_id):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -16,7 +16,6 @@ from django.db.models.expressions import Value
 from django.db.models.functions import Concat
 
 import csiphash
-from ddtrace import tracer
 
 from casexml.apps.case.xform import get_case_updates
 from dimagi.utils.chunked import chunked
@@ -443,21 +442,9 @@ class CaseAccessorSQL:
         return CommCareCase.objects.get_reverse_indexed_cases(domain, case_ids, case_types, is_closed)
 
     @staticmethod
-    @tracer.wrap("form_processor.sql.check_transaction_order_for_case")
     def check_transaction_order_for_case(case_id):
-        """ Returns whether the order of transactions needs to be reconciled by client_date
-
-        True if the order is fine, False if the order is bad
-        """
-        if not case_id:
-            return False
-
-        with CaseTransaction.get_cursor_for_partition_value(case_id) as cursor:
-            cursor.execute(
-                'SELECT compare_server_client_case_transaction_order(%s, %s)',
-                [case_id, CaseTransaction.case_rebuild_types() | CaseTransaction.TYPE_CASE_CREATE])
-            result = cursor.fetchone()[0]
-            return result
+        warn("DEPRECATED", DeprecationWarning)
+        return CaseTransaction.objects.check_order_for_case(case_id)
 
     @staticmethod
     def hard_delete_cases(domain, case_ids):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -423,13 +423,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_case_xform_ids(case_id):
-        with CommCareCase.get_plproxy_cursor(readonly=True) as cursor:
-            cursor.execute(
-                'SELECT form_id FROM get_case_transactions_by_type(%s, %s)',
-                [case_id, CaseTransaction.TYPE_FORM]
-            )
-            results = fetchall_as_namedtuple(cursor)
-            return [result.form_id for result in results]
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCase.objects.get_case_xform_ids(case_id)
 
     @staticmethod
     def get_indices(domain, case_id):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -433,16 +433,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_reverse_indices(domain, case_id):
-        indices = list(CommCareCaseIndex.objects.plproxy_raw(
-            'SELECT * FROM get_case_indices_reverse(%s, %s)', [domain, case_id]
-        ))
-
-        def _set_referenced_id(index):
-            # see corehq/couchapps/case_indices/views/related/map.js
-            index.referenced_id = index.case_id
-            return index
-
-        return [_set_referenced_id(index) for index in indices]
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCaseIndex.objects.get_reverse_indices(domain, case_id)
 
     @staticmethod
     def get_all_reverse_indices_info(domain, case_ids):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -428,8 +428,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_indices(domain, case_id):
-        query = CommCareCaseIndex.objects.partitioned_query(case_id)
-        return list(query.filter(case_id=case_id, domain=domain))
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCaseIndex.objects.get_indices(domain, case_id)
 
     @staticmethod
     def get_reverse_indices(domain, case_id):

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -66,7 +66,7 @@ class FormProcessorSQL(object):
     def hard_delete_case_and_forms(cls, domain, case, xforms):
         form_ids = [xform.form_id for xform in xforms]
         XFormInstance.objects.hard_delete_forms(domain, form_ids)
-        CaseAccessorSQL.hard_delete_cases(domain, [case.case_id])
+        CommCareCase.objects.hard_delete_cases(domain, [case.case_id])
         for form in xforms:
             form.state |= XFormInstance.DELETED
             publish_form_saved(form)

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -344,7 +344,3 @@ class FormProcessorSQL(object):
             return None, None
 
         return case, None
-
-    @staticmethod
-    def case_exists(case_id):
-        return CaseAccessorSQL.case_exists(case_id)

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -323,7 +323,7 @@ class FormProcessorSQL(object):
 
     @staticmethod
     def get_case_forms(case_id):
-        xform_ids = CaseAccessorSQL.get_case_xform_ids(case_id)
+        xform_ids = CommCareCase.objects.get_case_xform_ids(case_id)
         return XFormInstance.objects.get_forms_with_attachments_meta(xform_ids)
 
     @staticmethod

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -123,7 +123,7 @@ class FormProcessorSQL(object):
                 XFormInstance.objects.save_new_form(processed_forms.submitted)
                 if cases:
                     for case in cases:
-                        CaseAccessorSQL.save_case(case)
+                        case.save(with_tracked_models=True)
 
                 if stock_result:
                     ledgers_to_save = stock_result.models_to_save
@@ -135,7 +135,7 @@ class FormProcessorSQL(object):
                 if sort_submissions:
                     for case in cases:
                         if SqlCaseUpdateStrategy(case).reconcile_transactions_if_necessary():
-                            CaseAccessorSQL.save_case(case)
+                            case.save(with_tracked_models=True)
         except DatabaseError:
             for model in all_models:
                 setattr(model, model._meta.pk.attname, None)
@@ -296,7 +296,7 @@ class FormProcessorSQL(object):
 
             case.server_modified_on = rebuild_transaction.server_date
             if save:
-                CaseAccessorSQL.save_case(case)
+                case.save(with_tracked_models=True)
                 publish_case_saved(case)
             return case
         finally:

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -96,9 +96,6 @@ class CaseAccessors(object):
         return self.db_accessor.get_extension_case_ids(
             self.domain, case_ids, exclude_for_case_type=exclude_for_case_type)
 
-    def get_indexed_case_ids(self, case_ids):
-        return self.db_accessor.get_indexed_case_ids(self.domain, case_ids)
-
     def get_last_modified_dates(self, case_ids):
         return self.db_accessor.get_last_modified_dates(self.domain, case_ids)
 

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -107,6 +107,7 @@ class CaseAccessors(object):
         return self.db_accessor.get_all_reverse_indices_info(self.domain, case_ids)
 
     def get_reverse_indexed_cases(self, case_ids, case_types=None, is_closed=None):
+        warn("DEPRECATED use CommCareCaseIndex.objects", DeprecationWarning)
         return self.db_accessor.get_reverse_indexed_cases(self.domain, case_ids, case_types, is_closed)
 
     def get_attachment_content(self, case_id, attachment_id):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -44,6 +44,7 @@ class CaseAccessors(object):
         return self.db_accessor.get_case_ids_that_exist(self.domain, case_ids)
 
     def get_case_xform_ids(self, case_id):
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.get_case_xform_ids(case_id)
 
     def get_case_ids_in_domain(self, type=None):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -40,6 +40,7 @@ class CaseAccessors(object):
         yield from CommCareCase.objects.iter_cases(case_ids)
 
     def get_case_ids_that_exist(self, case_ids):
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.get_case_ids_that_exist(self.domain, case_ids)
 
     def get_case_xform_ids(self, case_id):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -106,6 +106,7 @@ class CaseAccessors(object):
         return self.db_accessor.get_closed_case_ids_for_owner(self.domain, owner_id)
 
     def get_all_reverse_indices_info(self, case_ids):
+        warn("DEPRECATED use CommCareCaseIndex.objects", DeprecationWarning)
         return self.db_accessor.get_all_reverse_indices_info(self.domain, case_ids)
 
     def get_reverse_indexed_cases(self, case_ids, case_types=None, is_closed=None):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -1,6 +1,5 @@
 from abc import ABCMeta, abstractmethod
 from collections import namedtuple
-from io import BytesIO
 from warnings import warn
 
 from memoized import memoized
@@ -111,6 +110,7 @@ class CaseAccessors(object):
         return self.db_accessor.get_reverse_indexed_cases(self.domain, case_ids, case_types, is_closed)
 
     def get_attachment_content(self, case_id, attachment_id):
+        warn("DEPRECATED use CaseAttachment.get_content", DeprecationWarning)
         return self.db_accessor.get_attachment_content(case_id, attachment_id)
 
     def get_case_by_domain_hq_user_id(self, user_id, case_type):
@@ -146,23 +146,6 @@ class CaseAccessors(object):
 
     def get_case_owner_ids(self):
         return self.db_accessor.get_case_owner_ids(self.domain)
-
-
-def get_cached_case_attachment(domain, case_id, attachment_id, is_image=False):
-    attachment_cache_key = "%(case_id)s_%(attachment)s" % {
-        "case_id": case_id,
-        "attachment": attachment_id
-    }
-
-    from dimagi.utils.django.cached_object import CachedObject, CachedImage
-    cobject = CachedImage(attachment_cache_key) if is_image else CachedObject(attachment_cache_key)
-    if not cobject.is_cached():
-        content = CaseAccessors(domain).get_attachment_content(case_id, attachment_id)
-        stream = BytesIO(content.content_body)
-        metadata = {'content_type': content.content_type}
-        cobject.cache_put(stream, metadata)
-
-    return cobject
 
 
 class AbstractLedgerAccessor(metaclass=ABCMeta):

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -94,6 +94,14 @@ class CommCareCaseManager(RequireDBManager):
                           .values_list('case_id', flat=True))
         return result
 
+    def get_case_xform_ids(self, case_id):
+        with self.model.get_plproxy_cursor(readonly=True) as cursor:
+            cursor.execute(
+                'SELECT form_id FROM get_case_transactions_by_type(%s, %s)',
+                [case_id, CaseTransaction.TYPE_FORM]
+            )
+            return [row[0] for row in cursor]
+
 
 class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
                    AttachmentMixin, CaseToXMLMixin, TrackRelatedChanges,

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -710,6 +710,30 @@ class CommCareCaseIndexManager(RequireDBManager):
 
         return [_set_referenced_id(index) for index in indices]
 
+    def get_all_reverse_indices_info(self, domain, case_ids):
+        assert isinstance(case_ids, list), type(case_ids)
+        if not case_ids:
+            return []
+
+        indexes = self.plproxy_raw(
+            'SELECT * FROM get_all_reverse_indices(%s, %s)',
+            [domain, case_ids]
+        )
+        return [
+            CaseIndexInfo(
+                case_id=index.case_id,
+                identifier=index.identifier,
+                referenced_id=index.referenced_id,
+                referenced_type=index.referenced_type,
+                relationship=index.relationship_id
+            ) for index in indexes
+        ]
+
+
+CaseIndexInfo = namedtuple(
+    'CaseIndexInfo', ['case_id', 'identifier', 'referenced_id', 'referenced_type', 'relationship']
+)
+
 
 class CommCareCaseIndex(PartitionedModel, models.Model, SaveStateMixin):
     partition_attr = 'case_id'

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -28,7 +28,7 @@ from corehq.util.json import CommCareJSONEncoder
 
 from ..exceptions import AttachmentNotFound, CaseNotFound, CaseSaveError, UnknownActionType
 from ..track_related import TrackRelatedChanges
-from .attachment import AttachmentMixin
+from .attachment import AttachmentContent, AttachmentMixin
 from .forms import XFormInstance
 from .mixin import CaseToXMLMixin, IsImageMixin, SaveStateMixin
 from .util import attach_prefetch_models, sort_with_id_list
@@ -746,6 +746,11 @@ class CaseAttachment(PartitionedModel, models.Model, SaveStateMixin, IsImageMixi
     @classmethod
     def new(cls, name):
         return cls(name=name, attachment_id=uuid.uuid4())
+
+    @classmethod
+    def get_content(cls, case_id, name):
+        att = cls.objects.get_attachment_by_name(case_id, name)
+        return AttachmentContent(att.content_type, att.open())
 
     def __str__(self):
         return str(

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -122,6 +122,16 @@ class CommCareCaseManager(RequireDBManager):
             attach_prefetch_models(cases_by_id, indices, 'case_id', 'cached_indices')
         return cases
 
+    def hard_delete_cases(self, domain, case_ids):
+        """Permanently delete cases in domain
+
+        :returns: Number of deleted cases.
+        """
+        assert isinstance(case_ids, list), type(case_ids)
+        with self.model.get_plproxy_cursor() as cursor:
+            cursor.execute('SELECT hard_delete_cases(%s, %s)', [domain, case_ids])
+            return sum(row[0] for row in cursor)
+
 
 class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
                    AttachmentMixin, CaseToXMLMixin, TrackRelatedChanges,

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -346,8 +346,7 @@ class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
         return CaseAttachment.objects.get_attachment_by_name(self.case_id, name)
 
     def _get_attachments_from_db(self):
-        from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
-        return CaseAccessorSQL.get_attachments(self.case_id)
+        return CaseAttachment.objects.get_attachments(self.case_id)
 
     @property
     @memoized
@@ -658,6 +657,9 @@ def get_index_map(indices):
 
 
 class CaseAttachmentManager(RequireDBManager):
+
+    def get_attachments(self, case_id):
+        return list(self.partitioned_query(case_id).filter(case_id=case_id))
 
     def get_attachment_by_name(self, case_id, name):
         try:

--- a/corehq/form_processor/reprocess.py
+++ b/corehq/form_processor/reprocess.py
@@ -150,7 +150,7 @@ def reprocess_form(form, save=True, lock_form=True):
 
             if save:
                 for case in cases:
-                    CaseAccessorSQL.save_case(case)
+                    case.save(with_tracked_models=True)
                 LedgerAccessorSQL.save_ledger_values(ledgers)
                 XFormInstance.objects.update_form_problem_and_state(form)
                 FormProcessorSQL.publish_changes_to_kafka(ProcessedForms(form, None), cases, stock_result)

--- a/corehq/form_processor/tests/test_case_dbaccessor.py
+++ b/corehq/form_processor/tests/test_case_dbaccessor.py
@@ -514,44 +514,6 @@ class CaseAccessorTestsSQL(TestCase):
             [case.case_id]
         )
 
-    def test_get_indexed_case_ids(self):
-        # Create case and indexes
-        case = _create_case()
-        extension_index = CommCareCaseIndex(
-            case=case,
-            identifier="task",
-            referenced_type="task",
-            referenced_id=uuid.uuid4().hex,
-            relationship_id=CommCareCaseIndex.EXTENSION
-        )
-        case.track_create(extension_index)
-        child_index = CommCareCaseIndex(
-            case=case,
-            identifier='parent',
-            referenced_type='mother',
-            referenced_id=uuid.uuid4().hex,
-            relationship_id=CommCareCaseIndex.CHILD
-        )
-        case.track_create(child_index)
-        CaseAccessorSQL.save_case(case)
-
-        # Create irrelevant case
-        other_case = _create_case()
-        other_child_index = CommCareCaseIndex(
-            case=other_case,
-            identifier='parent',
-            referenced_type='mother',
-            referenced_id=case.case_id,
-            relationship_id=CommCareCaseIndex.CHILD
-        )
-        other_case.track_create(other_child_index)
-        CaseAccessorSQL.save_case(other_case)
-
-        self.assertEqual(
-            set(CaseAccessorSQL.get_indexed_case_ids(DOMAIN, [case.case_id])),
-            set([extension_index.referenced_id, child_index.referenced_id])
-        )
-
     def test_get_last_modified_dates(self):
         case1 = _create_case()
         date1 = datetime(1992, 1, 30, 12, 0)

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -74,6 +74,16 @@ class CaseAccessorTestsSQL(TestCase):
         result = CommCareCase.objects.iter_cases(case_ids, DOMAIN)
         self.assertEqual({r.case_id for r in result}, {case1.case_id, case2.case_id})
 
+    def test_get_case_ids_that_exist(self):
+        case1 = _create_case()
+        case2 = _create_case()
+
+        case_ids = CommCareCase.objects.get_case_ids_that_exist(
+            DOMAIN,
+            ['missing_case', case1.case_id, case2.case_id]
+        )
+        self.assertItemsEqual(case_ids, [case1.case_id, case2.case_id])
+
 
 def _create_case(domain=DOMAIN, form_id=None, case_type=None, user_id='user1', closed=False, case_id=None):
     """Create case and related models directly (not via form processor)

--- a/corehq/form_processor/tests/test_reindex_accessors.py
+++ b/corehq/form_processor/tests/test_reindex_accessors.py
@@ -199,7 +199,7 @@ def _create_ledger(domain, entry_id, balance, case_id=None, section_id='stock'):
         server_modified_on=utcnow,
     )
 
-    CaseAccessorSQL.save_case(case)
+    case.save(with_tracked_models=True)
 
     ledger = LedgerValue(
         domain=domain,

--- a/corehq/form_processor/tests/test_reprocess_errors.py
+++ b/corehq/form_processor/tests/test_reprocess_errors.py
@@ -479,10 +479,8 @@ class TestTransactionErrors(TransactionTestCase):
         form_id = uuid.uuid4().hex
         case_id = uuid.uuid4().hex
 
-        with patch(
-            'corehq.form_processor.backends.sql.dbaccessors.CaseAccessorSQL.save_case',
-            side_effect=IntegrityError
-        ), self.assertRaises(IntegrityError):
+        error_on_save = patch.object(CommCareCase, 'save', side_effect=IntegrityError)
+        with error_on_save, self.assertRaises(IntegrityError):
             submit_case_blocks(
                 [CaseBlock.deprecated_init(case_id=case_id, update={'a': "2"}).as_text()],
                 self.domain,
@@ -502,10 +500,8 @@ class TestTransactionErrors(TransactionTestCase):
             form_id=form_id
         )
 
-        with patch(
-            'corehq.form_processor.backends.sql.dbaccessors.CaseAccessorSQL.save_case',
-            side_effect=IntegrityError
-        ), self.assertRaises(IntegrityError):
+        error_on_save = patch.object(CommCareCase, 'save', side_effect=IntegrityError)
+        with error_on_save, self.assertRaises(IntegrityError):
             submit_case_blocks(
                 [CaseBlock.deprecated_init(case_id=case_id, update={'a': "2"}).as_text()],
                 self.domain,

--- a/corehq/form_processor/tests/test_sql_update_strategy.py
+++ b/corehq/form_processor/tests/test_sql_update_strategy.py
@@ -59,7 +59,7 @@ class SqlUpdateStrategyTest(TestCase):
         self.assertTrue(update_strategy.reconcile_transactions_if_necessary())
         self._check_for_reconciliation_error_soft_assert(soft_assert_mock)
 
-        CaseAccessorSQL.save_case(case)
+        case.save(with_tracked_models=True)
 
         case = CommCareCase.objects.get_case(case.case_id)
         update_strategy = SqlCaseUpdateStrategy(case)
@@ -140,7 +140,7 @@ class SqlUpdateStrategyTest(TestCase):
         self.assertTrue(update_strategy.reconcile_transactions_if_necessary())
         self._check_for_reconciliation_error_soft_assert(soft_assert_mock)
 
-        CaseAccessorSQL.save_case(case)
+        case.save(with_tracked_models=True)
 
         case = CommCareCase.objects.get_case(case.case_id)
         update_strategy = SqlCaseUpdateStrategy(case)

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -326,7 +326,7 @@ def create_case_with_index(case, index) -> CommCareCase:
     case = create_case(case)
     index.case = case
     case.track_create(index)
-    CaseAccessorSQL.save_case(case)
+    case.save(with_tracked_models=True)
     return case
 
 

--- a/corehq/motech/fhir/tests/test_fhir_views.py
+++ b/corehq/motech/fhir/tests/test_fhir_views.py
@@ -209,7 +209,7 @@ def _setup_cases(owner_id):
         referenced_id=PERSON_CASE_ID,
         relationship_id=CommCareCaseIndex.CHILD
     ))
-    case_accessor.db_accessor.save_case(test_case)
+    test_case.save(with_tracked_models=True)
 
 
 def _get_caseblock(case_id, case_type, owner_id, updates=None):

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -9,7 +9,6 @@ from corehq.apps.domain.decorators import (
     require_superuser,
 )
 from corehq.form_processor.exceptions import CaseNotFound
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.motech.exceptions import ConfigurationError
 from corehq.motech.repeaters.views import AddRepeaterView, EditRepeaterView
@@ -101,8 +100,8 @@ def search_view(request, domain, fhir_version_name, resource_type):
         return JsonResponse(status=400,
                             data={'message': f"Resource type {resource_type} not available on {domain}"})
 
-    cases = CaseAccessors(domain).get_reverse_indexed_cases(
-        [patient_case_id], case_types=case_types_for_resource_type, is_closed=False)
+    cases = CommCareCase.objects.get_reverse_indexed_cases(
+        domain, [patient_case_id], case_types=case_types_for_resource_type, is_closed=False)
     response = {
         'resourceType': "Bundle",
         "type": "searchset",

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -10,7 +10,6 @@ from couchforms.const import TAG_FORM, TAG_META
 
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.cases import get_owner_id, get_wrapped_owner
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.motech.const import (  # noqa: F401
     COMMCARE_DATA_TYPE_DECIMAL,
@@ -552,7 +551,8 @@ class SubcaseValueSource(ValueSource):
             value_source.set_external_value(external_data, subcase_info)
 
     def _iter_subcase_info(self, info: CaseTriggerInfo):
-        subcases = CaseAccessors(info.domain).get_reverse_indexed_cases(
+        subcases = CommCareCase.objects.get_reverse_indexed_cases(
+            info.domain,
             [info.case_id],
             self.case_types,
             self.is_closed,

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -616,7 +616,7 @@ def create_and_save_a_case(domain, case_id, case_name, case_properties=None, cas
 def create_test_case(domain, case_type, case_name, case_properties=None, drop_signals=True,
         case_id=None, owner_id=None, user_id=None):
     from corehq.apps.sms.tasks import delete_phone_numbers_for_owners
-    from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
+    from corehq.form_processor.models import CommCareCase
     from corehq.messaging.scheduling.scheduling_partitioned.dbaccessors import delete_schedule_instances_by_case_id
 
     case = create_and_save_a_case(domain, case_id or uuid.uuid4().hex, case_name,
@@ -627,7 +627,7 @@ def create_test_case(domain, case_type, case_name, case_properties=None, drop_si
     finally:
         delete_phone_numbers_for_owners([case.case_id])
         delete_schedule_instances_by_case_id(domain, case.case_id)
-        CaseAccessorSQL.hard_delete_cases(domain, [case.case_id])
+        CommCareCase.objects.hard_delete_cases(domain, [case.case_id])
 
 
 create_test_case.__test__ = False

--- a/custom/eqa/expressions.py
+++ b/custom/eqa/expressions.py
@@ -1,7 +1,6 @@
 from corehq.apps.app_manager.models import Application
 from corehq.apps.userreports.specs import TypeProperty
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.util.quickcache import quickcache
 from dimagi.ext.jsonobject import JsonObject, StringProperty
 
@@ -40,7 +39,7 @@ def get_yes_no(val):
 
 @quickcache(['item', 'xmlns'])
 def get_two_last_forms(item, xmlns):
-    xforms_ids = CaseAccessors(item['domain']).get_case_xform_ids(item['_id'])
+    xforms_ids = CommCareCase.objects.get_case_xform_ids(item['_id'])
     forms = XFormInstance.objects.get_forms(xforms_ids, item['domain'])
     f_forms = [f for f in forms if f.xmlns == xmlns]
     s_forms = sorted(f_forms, key=lambda x: x.received_on)
@@ -88,7 +87,7 @@ class EQAActionItemSpec(JsonObject):
     question_id = StringProperty()
 
     def __call__(self, item, context=None):
-        xforms_ids = CaseAccessors(item['domain']).get_case_xform_ids(item['_id'])
+        xforms_ids = CommCareCase.objects.get_case_xform_ids(item['_id'])
         forms = XFormInstance.objects.get_forms(xforms_ids, item['domain'])
         f_forms = [f for f in forms if f.xmlns == self.xmlns]
         s_forms = sorted(f_forms, key=lambda x: x.received_on)


### PR DESCRIPTION
Continuation of https://github.com/dimagi/commcare-hq/pull/31051 and https://github.com/dimagi/commcare-hq/pull/31060

Case accessor methods are moving into `CommCareCase.objects` (which is `CommCareCaseManager`) or the relevant model manager that makes the most sense. `CaseAccessor(s|SQL)` will eventually be removed.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

In addition to preserving all of the old tests and adapting the old methods that are being phased out to call the new method, new tests (copies of the old tests adapted to the new structure) are being added for the new model manager.

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
