### PR TITLE
Added metrics to export creation

### DIFF
--- a/corehq/apps/export/static/export/js/export_list_main.js
+++ b/corehq/apps/export/static/export/js/export_list_main.js
@@ -34,18 +34,15 @@ hqDefine("export/js/export_list_main", [
             $('#createExportOptionsModal').on('show.bs.modal', function () {
                 kissmetricsAnalytics.track.event("Clicked New Export");
 
-                let modelType = initialPageData.get('model_type', true);
-                if (modelType) {
-                    modelType = utils.capitalize(modelType);
-                    const metricsMessage = `${modelType} Export - Clicked Add Export Button`;
-                    kissmetricsAnalytics.track.event(metricsMessage, {
-                        domain: initialPageData.get('domain'),
-                    });
-                }
-
                 if (isOData) {
                     kissmetricsAnalytics.track.event("[BI Integration] Clicked + Add Odata Feed button");
                 }
+
+                const exportAction = getExportAction();
+                const metricsMessage = `${exportAction} Export - Clicked Add Export Button`;
+                kissmetricsAnalytics.track.event(metricsMessage, {
+                    domain: initialPageData.get('domain'),
+                });
             });
         }
 
@@ -93,4 +90,23 @@ hqDefine("export/js/export_list_main", [
             kissmetricsAnalytics.track.event("Dismissed alert bubble - Deep links in exports");
         });
     });
+
+    function getExportAction() {
+        const modelType = initialPageData.get('model_type', true);
+        if (modelType) {
+            return utils.capitalize(modelType);
+        }
+
+        const isDailySavedExport = initialPageData.get('is_daily_saved_export', true);
+        const isExcelExport = initialPageData.get('is_feed', true);
+        const isOData = initialPageData.get('is_odata', true);
+
+        if (isDailySavedExport) {
+            // NOTE: Currently, excel exports are considered daily exports,
+            // but if this was not intentional, this code should be separated
+            return (isExcelExport ? 'Excel Dashboard' : 'Daily Saved');
+        } else if (isOData) {
+            return 'PowerBI';
+        }
+    }
 });

--- a/corehq/apps/export/static/export/js/export_list_main.js
+++ b/corehq/apps/export/static/export/js/export_list_main.js
@@ -2,6 +2,7 @@ hqDefine("export/js/export_list_main", [
     'jquery',
     'hqwebapp/js/initial_page_data',
     'analytix/js/kissmetrix',
+    'hqwebapp/js/main',
     'export/js/create_export',
     'export/js/export_list',
     'hqwebapp/js/select_2_ajax_widget',  // for case owner & user filters in DashboardFeedFilterForm
@@ -9,6 +10,7 @@ hqDefine("export/js/export_list_main", [
     $,
     initialPageData,
     kissmetricsAnalytics,
+    utils,
     createModels,
     listModels
 ) {
@@ -31,6 +33,14 @@ hqDefine("export/js/export_list_main", [
             }));
             $('#createExportOptionsModal').on('show.bs.modal', function () {
                 kissmetricsAnalytics.track.event("Clicked New Export");
+
+                const modelType = utils.capitalize(initialPageData.get('model_type', 'unknown'));
+                const metricsMessage = `${modelType} Export - Clicked Add Export Button`;
+                kissmetricsAnalytics.track.event(metricsMessage, {
+                    username: initialPageData.get('user'),
+                    domain: initialPageData.get('domain'),
+                });
+
                 if (isOData) {
                     kissmetricsAnalytics.track.event("[BI Integration] Clicked + Add Odata Feed button");
                 }

--- a/corehq/apps/export/static/export/js/export_list_main.js
+++ b/corehq/apps/export/static/export/js/export_list_main.js
@@ -37,7 +37,6 @@ hqDefine("export/js/export_list_main", [
                 const modelType = utils.capitalize(initialPageData.get('model_type', 'unknown'));
                 const metricsMessage = `${modelType} Export - Clicked Add Export Button`;
                 kissmetricsAnalytics.track.event(metricsMessage, {
-                    username: initialPageData.get('user'),
                     domain: initialPageData.get('domain'),
                 });
 

--- a/corehq/apps/export/static/export/js/export_list_main.js
+++ b/corehq/apps/export/static/export/js/export_list_main.js
@@ -34,11 +34,14 @@ hqDefine("export/js/export_list_main", [
             $('#createExportOptionsModal').on('show.bs.modal', function () {
                 kissmetricsAnalytics.track.event("Clicked New Export");
 
-                const modelType = utils.capitalize(initialPageData.get('model_type', 'unknown'));
-                const metricsMessage = `${modelType} Export - Clicked Add Export Button`;
-                kissmetricsAnalytics.track.event(metricsMessage, {
-                    domain: initialPageData.get('domain'),
-                });
+                let modelType = initialPageData.get('model_type', true);
+                if (modelType) {
+                    modelType = utils.capitalize(modelType);
+                    const metricsMessage = `${modelType} Export - Clicked Add Export Button`;
+                    kissmetricsAnalytics.track.event(metricsMessage, {
+                        domain: initialPageData.get('domain'),
+                    });
+                }
 
                 if (isOData) {
                     kissmetricsAnalytics.track.event("[BI Integration] Clicked + Add Odata Feed button");

--- a/corehq/apps/export/templates/export/export_list.html
+++ b/corehq/apps/export/templates/export/export_list.html
@@ -19,7 +19,6 @@
   {% initial_page_data 'shared_export_type' shared_export_type %}
   {% initial_page_data 'static_model_type' static_model_type %}
   {% initial_page_data 'domain' domain %}
-  {% initial_page_data 'user' user %}
   {% registerurl 'commit_filters' domain %}
   {% registerurl 'get_app_data_drilldown_values' domain %}
   {% registerurl 'get_exports_page' domain %}

--- a/corehq/apps/export/templates/export/export_list.html
+++ b/corehq/apps/export/templates/export/export_list.html
@@ -18,6 +18,8 @@
   {% initial_page_data 'my_export_type' my_export_type %}
   {% initial_page_data 'shared_export_type' shared_export_type %}
   {% initial_page_data 'static_model_type' static_model_type %}
+  {% initial_page_data 'domain' domain %}
+  {% initial_page_data 'user' user %}
   {% registerurl 'commit_filters' domain %}
   {% registerurl 'get_app_data_drilldown_values' domain %}
   {% registerurl 'get_exports_page' domain %}

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -527,7 +527,6 @@ class BaseExportListView(BaseProjectDataView):
                 ) if self.include_saved_filters else None
             ),
             'create_url': '#createExportOptionsModal',
-            'user': self.request.user.username
         }
 
 

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -527,6 +527,7 @@ class BaseExportListView(BaseProjectDataView):
                 ) if self.include_saved_filters else None
             ),
             'create_url': '#createExportOptionsModal',
+            'user': self.request.user.username
         }
 
 

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -353,9 +353,11 @@ class CreateODataCaseFeedView(ODataFeedMixin, CreateNewCustomCaseExportView):
     urlname = 'new_odata_case_feed'
     page_title = ugettext_lazy("Create OData Case Feed")
 
-    def create_new_export_instance(self, schema, export_settings=None):
+    def create_new_export_instance(self, schema, username, domain, export_settings=None):
         export_instance = super(CreateODataCaseFeedView, self).create_new_export_instance(
             schema,
+            username,
+            domain,
             export_settings=export_settings
         )
         clean_odata_columns(export_instance)
@@ -367,9 +369,11 @@ class CreateODataFormFeedView(ODataFeedMixin, CreateNewCustomFormExportView):
     urlname = 'new_odata_form_feed'
     page_title = ugettext_lazy("Create OData Form Feed")
 
-    def create_new_export_instance(self, schema, export_settings=None):
+    def create_new_export_instance(self, schema, username, domain, export_settings=None):
         export_instance = super(CreateODataFormFeedView, self).create_new_export_instance(
             schema,
+            username,
+            domain,
             export_settings=export_settings
         )
         # odata settings only apply to form exports

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -266,9 +266,12 @@ class CreateNewCustomFormExportView(BaseExportView):
 
     def create_new_export_instance(self, schema, username, domain, export_settings=None):
         export = self.export_instance_cls.generate_instance_from_schema(schema, export_settings=export_settings)
-        track_workflow(username, 'Form Export - Clicked Add Export Popup', properties={
-            'domain': domain
-        })
+
+        from corehq.apps.export.views.list import FormExportListView
+        if self.report_class == FormExportListView:
+            track_workflow(username, 'Form Export - Clicked Add Export Popup', properties={
+                'domain': domain
+            })
         return export
 
     def get(self, request, *args, **kwargs):
@@ -299,10 +302,14 @@ class CreateNewCustomCaseExportView(BaseExportView):
         return CaseExportListView
 
     def create_new_export_instance(self, schema, username, domain, export_settings=None):
+
         export = self.export_instance_cls.generate_instance_from_schema(schema, export_settings=export_settings)
-        track_workflow(username, 'Case Export - Clicked Add Export Popup', properties={
-            'domain': domain
-        })
+
+        from corehq.apps.export.views.list import CaseExportListView
+        if self.report_class == CaseExportListView:
+            track_workflow(username, 'Case Export - Clicked Add Export Popup', properties={
+                'domain': domain
+            })
         return export
 
     def get(self, request, *args, **kwargs):

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -145,12 +145,22 @@ class BaseExportView(BaseProjectDataView):
 
     def commit(self, request):
         export = self.export_instance_cls.wrap(json.loads(request.body.decode('utf-8')))
+
         if (self.domain != export.domain
                 or (export.export_format == "html" and not domain_has_privilege(self.domain, EXCEL_DASHBOARD))
                 or (export.is_daily_saved_export and not domain_has_privilege(self.domain, DAILY_SAVED_EXPORT))):
             raise BadExportConfiguration()
 
         if not export._rev:
+            # This is a new export
+            export_type = export.type.capitalize()
+
+            track_workflow(
+                request.user.username,
+                f'{export_type} Export - Created Export',
+                properties={'domain': self.domain}
+            )
+
             if toggles.EXPORT_OWNERSHIP.enabled(request.domain):
                 export.owner_id = request.couch_user.user_id
             if getattr(settings, "ENTERPRISE_MODE"):
@@ -254,8 +264,12 @@ class CreateNewCustomFormExportView(BaseExportView):
         from corehq.apps.export.views.list import FormExportListView
         return FormExportListView
 
-    def create_new_export_instance(self, schema, export_settings=None):
-        return self.export_instance_cls.generate_instance_from_schema(schema, export_settings=export_settings)
+    def create_new_export_instance(self, schema, username, domain, export_settings=None):
+        export = self.export_instance_cls.generate_instance_from_schema(schema, export_settings=export_settings)
+        track_workflow(username, 'Form Export - Clicked Add Export Popup', properties={
+            'domain': domain
+        })
+        return export
 
     def get(self, request, *args, **kwargs):
         app_id = request.GET.get('app_id')
@@ -263,7 +277,11 @@ class CreateNewCustomFormExportView(BaseExportView):
 
         export_settings = get_default_export_settings_if_available(self.domain)
         schema = self.get_export_schema(self.domain, app_id, xmlns)
-        self.export_instance = self.create_new_export_instance(schema, export_settings=export_settings)
+        self.export_instance = self.create_new_export_instance(
+            schema,
+            request.user.username,
+            self.domain,
+            export_settings=export_settings)
 
         return super(CreateNewCustomFormExportView, self).get(request, *args, **kwargs)
 
@@ -280,15 +298,23 @@ class CreateNewCustomCaseExportView(BaseExportView):
         from corehq.apps.export.views.list import CaseExportListView
         return CaseExportListView
 
-    def create_new_export_instance(self, schema, export_settings=None):
-        return self.export_instance_cls.generate_instance_from_schema(schema, export_settings=export_settings)
+    def create_new_export_instance(self, schema, username, domain, export_settings=None):
+        export = self.export_instance_cls.generate_instance_from_schema(schema, export_settings=export_settings)
+        track_workflow(username, 'Case Export - Clicked Add Export Popup', properties={
+            'domain': domain
+        })
+        return export
 
     def get(self, request, *args, **kwargs):
         case_type = request.GET.get('export_tag').strip('"')
 
         export_settings = get_default_export_settings_if_available(self.domain)
         schema = self.get_export_schema(self.domain, None, case_type)
-        self.export_instance = self.create_new_export_instance(schema, export_settings=export_settings)
+        self.export_instance = self.create_new_export_instance(
+            schema,
+            request.user.username,
+            self.domain,
+            export_settings=export_settings)
 
         return super(CreateNewCustomCaseExportView, self).get(request, *args, **kwargs)
 

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -265,11 +265,11 @@ class CreateNewCustomFormExportView(BaseExportView):
         from corehq.apps.export.views.list import FormExportListView
         return FormExportListView
 
-    def create_new_export_instance(self, schema, username, domain, export_settings=None):
+    def create_new_export_instance(self, schema, username, export_settings=None):
         export = self.export_instance_cls.generate_instance_from_schema(schema, export_settings=export_settings)
 
         track_workflow(username, f'{self.metric_name} - Clicked Add Export Popup', properties={
-            'domain': domain
+            'domain': self.domain
         })
 
         return export
@@ -283,7 +283,6 @@ class CreateNewCustomFormExportView(BaseExportView):
         self.export_instance = self.create_new_export_instance(
             schema,
             request.user.username,
-            self.domain,
             export_settings=export_settings)
 
         return super(CreateNewCustomFormExportView, self).get(request, *args, **kwargs)
@@ -302,12 +301,12 @@ class CreateNewCustomCaseExportView(BaseExportView):
         from corehq.apps.export.views.list import CaseExportListView
         return CaseExportListView
 
-    def create_new_export_instance(self, schema, username, domain, export_settings=None):
+    def create_new_export_instance(self, schema, username, export_settings=None):
 
         export = self.export_instance_cls.generate_instance_from_schema(schema, export_settings=export_settings)
 
         track_workflow(username, f'{self.metric_name} - Clicked Add Export Popup', properties={
-            'domain': domain
+            'domain': self.domain
         })
 
         return export
@@ -320,7 +319,6 @@ class CreateNewCustomCaseExportView(BaseExportView):
         self.export_instance = self.create_new_export_instance(
             schema,
             request.user.username,
-            self.domain,
             export_settings=export_settings)
 
         return super(CreateNewCustomCaseExportView, self).get(request, *args, **kwargs)
@@ -358,11 +356,10 @@ class CreateODataCaseFeedView(ODataFeedMixin, CreateNewCustomCaseExportView):
     page_title = ugettext_lazy("Create OData Case Feed")
     metric_name = 'PowerBI Case Export'
 
-    def create_new_export_instance(self, schema, username, domain, export_settings=None):
+    def create_new_export_instance(self, schema, username, export_settings=None):
         export_instance = super().create_new_export_instance(
             schema,
             username,
-            domain,
             export_settings=export_settings
         )
         clean_odata_columns(export_instance)
@@ -375,11 +372,10 @@ class CreateODataFormFeedView(ODataFeedMixin, CreateNewCustomFormExportView):
     page_title = ugettext_lazy("Create OData Form Feed")
     metric_name = 'PowerBI Form Export'
 
-    def create_new_export_instance(self, schema, username, domain, export_settings=None):
+    def create_new_export_instance(self, schema, username, export_settings=None):
         export_instance = super().create_new_export_instance(
             schema,
             username,
-            domain,
             export_settings=export_settings
         )
         # odata settings only apply to form exports

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -354,7 +354,7 @@ class CreateODataCaseFeedView(ODataFeedMixin, CreateNewCustomCaseExportView):
     page_title = ugettext_lazy("Create OData Case Feed")
 
     def create_new_export_instance(self, schema, username, domain, export_settings=None):
-        export_instance = super(CreateODataCaseFeedView, self).create_new_export_instance(
+        export_instance = super().create_new_export_instance(
             schema,
             username,
             domain,
@@ -370,7 +370,7 @@ class CreateODataFormFeedView(ODataFeedMixin, CreateNewCustomFormExportView):
     page_title = ugettext_lazy("Create OData Form Feed")
 
     def create_new_export_instance(self, schema, username, domain, export_settings=None):
-        export_instance = super(CreateODataFormFeedView, self).create_new_export_instance(
+        export_instance = super().create_new_export_instance(
             schema,
             username,
             domain,

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -149,9 +149,11 @@ class DailySavedExportMixin(object):
         self._priv_check()
         return super(DailySavedExportMixin, self).dispatch(*args, **kwargs)
 
-    def create_new_export_instance(self, schema, export_settings=None):
+    def create_new_export_instance(self, schema, username, domain, export_settings=None):
         instance = super(DailySavedExportMixin, self).create_new_export_instance(
             schema,
+            username,
+            domain,
             export_settings=export_settings
         )
         instance.is_daily_saved_export = True
@@ -184,9 +186,11 @@ class DashboardFeedMixin(DailySavedExportMixin):
         if not domain_has_privilege(self.domain, EXCEL_DASHBOARD):
             raise Http404
 
-    def create_new_export_instance(self, schema, export_settings=None):
+    def create_new_export_instance(self, schema, username, domain, export_settings=None):
         instance = super(DashboardFeedMixin, self).create_new_export_instance(
             schema,
+            username,
+            domain,
             export_settings=export_settings
         )
         instance.export_format = "html"

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -149,11 +149,10 @@ class DailySavedExportMixin(object):
         self._priv_check()
         return super().dispatch(*args, **kwargs)
 
-    def create_new_export_instance(self, schema, username, domain, export_settings=None):
+    def create_new_export_instance(self, schema, username, export_settings=None):
         instance = super().create_new_export_instance(
             schema,
             username,
-            domain,
             export_settings=export_settings
         )
         instance.is_daily_saved_export = True
@@ -186,11 +185,10 @@ class DashboardFeedMixin(DailySavedExportMixin):
         if not domain_has_privilege(self.domain, EXCEL_DASHBOARD):
             raise Http404
 
-    def create_new_export_instance(self, schema, username, domain, export_settings=None):
+    def create_new_export_instance(self, schema, username, export_settings=None):
         instance = super().create_new_export_instance(
             schema,
             username,
-            domain,
             export_settings=export_settings
         )
         instance.export_format = "html"
@@ -227,11 +225,10 @@ class ODataFeedMixin(object):
             """),
         }
 
-    def create_new_export_instance(self, schema, username, domain, export_settings=None):
+    def create_new_export_instance(self, schema, username, export_settings=None):
         instance = super().create_new_export_instance(
             schema,
             username,
-            domain,
             export_settings=export_settings)
         instance.is_odata_config = True
         instance.transform_dates = False

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -147,10 +147,10 @@ class DailySavedExportMixin(object):
 
     def dispatch(self, *args, **kwargs):
         self._priv_check()
-        return super(DailySavedExportMixin, self).dispatch(*args, **kwargs)
+        return super().dispatch(*args, **kwargs)
 
     def create_new_export_instance(self, schema, username, domain, export_settings=None):
-        instance = super(DailySavedExportMixin, self).create_new_export_instance(
+        instance = super().create_new_export_instance(
             schema,
             username,
             domain,
@@ -187,7 +187,7 @@ class DashboardFeedMixin(DailySavedExportMixin):
             raise Http404
 
     def create_new_export_instance(self, schema, username, domain, export_settings=None):
-        instance = super(DashboardFeedMixin, self).create_new_export_instance(
+        instance = super().create_new_export_instance(
             schema,
             username,
             domain,
@@ -198,7 +198,7 @@ class DashboardFeedMixin(DailySavedExportMixin):
 
     @property
     def page_context(self):
-        context = super(DashboardFeedMixin, self).page_context
+        context = super().page_context
         context['format_options'] = ["html"]
         return context
 
@@ -212,7 +212,7 @@ class ODataFeedMixin(object):
 
     @method_decorator(requires_privilege_with_fallback(privileges.ODATA_FEED))
     def dispatch(self, *args, **kwargs):
-        return super(ODataFeedMixin, self).dispatch(*args, **kwargs)
+        return super().dispatch(*args, **kwargs)
 
     @property
     def terminology(self):
@@ -228,7 +228,7 @@ class ODataFeedMixin(object):
         }
 
     def create_new_export_instance(self, schema, username, domain, export_settings=None):
-        instance = super(ODataFeedMixin, self).create_new_export_instance(
+        instance = super().create_new_export_instance(
             schema,
             username,
             domain,
@@ -239,7 +239,7 @@ class ODataFeedMixin(object):
 
     @property
     def page_context(self):
-        context = super(ODataFeedMixin, self).page_context
+        context = super().page_context
         context['format_options'] = ["odata"]
         return context
 
@@ -257,7 +257,7 @@ class ODataFeedMixin(object):
         return ODataFeedListView
 
     def get_export_instance(self, schema, original_export_instance):
-        export_instance = super(ODataFeedMixin, self).get_export_instance(schema, original_export_instance)
+        export_instance = super().get_export_instance(schema, original_export_instance)
         clean_odata_columns(export_instance)
         export_instance.is_odata_config = True
         export_instance.transform_dates = False

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -227,8 +227,12 @@ class ODataFeedMixin(object):
             """),
         }
 
-    def create_new_export_instance(self, schema, export_settings=None):
-        instance = super(ODataFeedMixin, self).create_new_export_instance(schema, export_settings=export_settings)
+    def create_new_export_instance(self, schema, username, domain, export_settings=None):
+        instance = super(ODataFeedMixin, self).create_new_export_instance(
+            schema,
+            username,
+            domain,
+            export_settings=export_settings)
         instance.is_odata_config = True
         instance.transform_dates = False
         return instance


### PR DESCRIPTION
## Technical Summary
[Associated Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-13064). Add metrics to the export creation process.  I could use extra attention paid to the javascript metrics. The server-side generation explicitly asks for a username, whereas the JS code does not. So, the JS code attaches it arbitrarily, but I get the feeling it may be set up earlier, and so is redundant here?

## Safety Assurance

### Safety story
Verified everything still is working with local testing. Would like to verify on staging that the metrics behave as expected.

### Automated test coverage

I'm on the fence whether we should have tests that explicitly verify that metrics were generated, as metrics tend to change fairly frequently. If this is going to be a critical workflow, I should probably add them in, however.

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
