### PR TITLE
Remove pickling from motech module

### DIFF
--- a/corehq/motech/dhis2/management/commands/send_datasets.py
+++ b/corehq/motech/dhis2/management/commands/send_datasets.py
@@ -14,10 +14,5 @@ class Command(BaseCommand):
         parser.add_argument('--send_date', help="YYYY-MM-DD")
 
     def handle(self, domain_name, **options):
-        if options.get('send_date'):
-            send_date = datetime.strptime(options['send_date'], '%Y-%m-%d')
-        else:
-            send_date = None
-        send_datasets.apply(args=[domain_name], kwargs={
-            'send_now': True, 'send_date': send_date,
-        })
+        send_date = options.get('send_date', None)
+        send_datasets.apply(args=[domain_name], kwargs={'send_now': True, 'date_to_send': send_date})

--- a/corehq/motech/dhis2/tasks.py
+++ b/corehq/motech/dhis2/tasks.py
@@ -30,13 +30,15 @@ def send_datasets_for_all_domains():
             send_datasets.delay(domain)
 
 
-@task(serializer='pickle', queue='background_queue')
+@task(queue='background_queue')
 def send_datasets(domain_name, send_now=False, send_date=None):
-    if not send_date:
-        send_date = datetime.utcnow().date()
+    """
+    send_date is a string formatted as YYYY-MM-DD
+    """
+    date_to_send = datetime.strptime(send_date, '%Y-%m-%d') if send_date else datetime.utcnow().date()
     for dataset_map in SQLDataSetMap.objects.filter(domain=domain_name).all():
-        if send_now or should_send_on_date(dataset_map, send_date):
-            send_dataset(dataset_map, send_date)
+        if send_now or should_send_on_date(dataset_map, date_to_send):
+            send_dataset(dataset_map, date_to_send)
 
 
 def send_dataset(

--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -234,7 +234,7 @@ def import_patients_to_domain(domain_name, force=False):
             import_patients_with_importer.delay(importer.to_json())
 
 
-@task(serializer='pickle', queue='background_queue')
+@task(queue='background_queue')
 def import_patients_with_importer(importer_json):
     importer = OpenmrsImporter.wrap(importer_json)
     password = b64_aes_decrypt(importer.password)

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1344,7 +1344,7 @@ def attempt_forward_now(repeater: SQLRepeater):
         return
     if not repeater.is_ready:
         return
-    process_repeater.delay(repeater)
+    process_repeater.delay(repeater.id)
 
 
 def get_payload(repeater: Repeater, repeat_record: SQLRepeatRecord) -> str:

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1157,9 +1157,9 @@ class RepeatRecord(Document):
         task = retry_process_repeat_record if is_retry else process_repeat_record
 
         if fire_synchronously:
-            task(self)
+            task(self._id)
         else:
-            task.delay(self)
+            task.delay(self._id)
 
     def requeue(self):
         self.cancelled = False

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -35,6 +35,7 @@ from .dbaccessors import (
     iterate_repeat_records_for_ids,
 )
 from .models import (
+    RepeatRecord,
     SQLRepeater,
     domain_can_forward,
     get_payload,
@@ -143,13 +144,15 @@ def check_repeaters_in_partition(partition):
         check_repeater_lock.release()
 
 
-@task(serializer='pickle', queue=settings.CELERY_REPEAT_RECORD_QUEUE)
-def process_repeat_record(repeat_record):
+@task(queue=settings.CELERY_REPEAT_RECORD_QUEUE)
+def process_repeat_record(repeat_record_id):
+    repeat_record = RepeatRecord.get(repeat_record_id)
     _process_repeat_record(repeat_record)
 
 
-@task(serializer='pickle', queue=settings.CELERY_REPEAT_RECORD_QUEUE)
-def retry_process_repeat_record(repeat_record):
+@task(queue=settings.CELERY_REPEAT_RECORD_QUEUE)
+def retry_process_repeat_record(repeat_record_id):
+    repeat_record = RepeatRecord.get(repeat_record_id)
     _process_repeat_record(repeat_record)
 
 

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -211,7 +211,7 @@ repeaters_overdue = metrics_gauge_task(
 
 
 @task(queue=settings.CELERY_REPEAT_RECORD_QUEUE)
-def process_repeater(repeater_id):
+def process_repeater(repeater_id: int):
     """
     Worker task to send SQLRepeatRecords in chronological order.
 

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -201,14 +201,15 @@ repeaters_overdue = metrics_gauge_task(
 )
 
 
-@task(serializer='pickle', queue=settings.CELERY_REPEAT_RECORD_QUEUE)
-def process_repeater(repeater: SQLRepeater):
+@task(queue=settings.CELERY_REPEAT_RECORD_QUEUE)
+def process_repeater(repeater_id):
     """
     Worker task to send SQLRepeatRecords in chronological order.
 
     This function assumes that ``repeater`` checks have already
     been performed. Call via ``models.attempt_forward_now()``.
     """
+    repeater = SQLRepeater.objects.get(id=repeater_id)
     with CriticalSection(
         [f'process-repeater-{repeater.repeater_id}'],
         fail_hard=False, block=False, timeout=5 * 60 * 60,

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -146,12 +146,18 @@ def check_repeaters_in_partition(partition):
 
 @task(queue=settings.CELERY_REPEAT_RECORD_QUEUE)
 def process_repeat_record(repeat_record_id):
+    """
+    NOTE: Keep separate from retry_process_repeat_record for monitoring purposes
+    """
     repeat_record = RepeatRecord.get(repeat_record_id)
     _process_repeat_record(repeat_record)
 
 
 @task(queue=settings.CELERY_REPEAT_RECORD_QUEUE)
 def retry_process_repeat_record(repeat_record_id):
+    """
+    NOTE: Keep separate from process_repeat_record for monitoring purposes
+    """
     repeat_record = RepeatRecord.get(repeat_record_id)
     _process_repeat_record(repeat_record)
 

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -350,7 +350,10 @@ class RepeaterTest(BaseRepeaterTest):
             self.assertEqual(mock_process.delay.call_count, 2)
 
     def test_automatic_cancel_repeat_record(self):
-        repeat_record = self.case_repeater.register(CommCareCase.objects.get_case(CASE_ID, self.domain))
+        case = CommCareCase.objects.get_case(CASE_ID, self.domain)
+        rr = self.case_repeater.register(case)
+        # Fetch the revision that was updated:
+        repeat_record = RepeatRecord.get(rr.record_id)
         self.assertEqual(1, repeat_record.overall_tries)
         with patch('corehq.motech.repeaters.models.simple_request', side_effect=Exception('Boom!')):
             for __ in range(repeat_record.max_possible_tries - repeat_record.overall_tries):

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -845,12 +845,14 @@ class TestRepeaterFormat(BaseRepeaterTest):
             RegisterGenerator.get_collection(CaseRepeater).add_new_format(NewCaseGenerator, is_default=True)
 
     def test_new_format_payload(self):
-        repeat_record = self.repeater.register(CommCareCase.objects.get_case(CASE_ID, self.domain))
+        case = CommCareCase.objects.get_case(CASE_ID, self.domain)
         with patch('corehq.motech.repeaters.models.simple_request') as mock_request, \
                 patch.object(ConnectionSettings, 'get_auth_manager') as mock_manager:
             mock_request.return_value.status_code = 200
             mock_manager.return_value = 'MockAuthManager'
-            repeat_record.fire()
+            rr = self.repeater.register(case)
+
+            repeat_record = RepeatRecord.get(rr.record_id)
             headers = self.repeater.get_headers(repeat_record)
             mock_request.assert_called_with(
                 self.domain,

--- a/corehq/motech/repeaters/tests/test_tasks.py
+++ b/corehq/motech/repeaters/tests/test_tasks.py
@@ -120,7 +120,7 @@ class TestProcessRepeater(TestCase):
         # payload
         with patch('corehq.motech.repeaters.models.log_repeater_error_in_datadog'), \
                 patch('corehq.motech.repeaters.tasks.metrics_counter'):
-            process_repeater(self.sql_repeater)
+            process_repeater(self.sql_repeater.id)
 
         # All records were tried and cancelled
         records = list(self.sql_repeater.repeat_records.all())
@@ -138,7 +138,7 @@ class TestProcessRepeater(TestCase):
                 patch('corehq.motech.repeaters.tasks.metrics_counter'), \
                 form_context(PAYLOAD_IDS):
             post_mock.return_value = Mock(status_code=400, reason='Bad request')
-            process_repeater(self.sql_repeater)
+            process_repeater(self.sql_repeater.id)
 
         # Only the first record was attempted, the rest are still pending
         states = [r.state for r in self.sql_repeater.repeat_records.all()]


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This is part of an effort to replace pickling with json serialization for all celery tasks which will allow us to safely upgrade celery. This was a fairly straightforward module, with a few instances just needing to use an id instead of the db object that could then be refetched, an arg that was already in converted to json, and a date that could be parsed from a string representation just as easily within the task.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-3944

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
