### PR TITLE
Fix failing test on master

### DIFF
--- a/corehq/apps/saved_reports/tests/test_models.py
+++ b/corehq/apps/saved_reports/tests/test_models.py
@@ -19,7 +19,7 @@ class TestReportConfig(TestCase):
             domain=domain,
         )
         self.config.save()
-        self.assertFalse(self.config.is_shared_on_domain)
+        self.assertFalse(self.config.is_shared_on_domain())
 
 
 class TestReportNotification(SimpleTestCase):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Failing test on master. @Charl1996 it looks like you committed directly to master [here](https://github.com/dimagi/commcare-hq/commit/e2ea944a040e082437fb0d5008eda038759422dd), was that intentional or an accident? The only time we commit to master is when updating staging.yml, otherwise everything should go through the PR process.
```
    self.assertFalse(self.config.is_shared_on_domain)
AssertionError: <bound method ReportConfig.is_shared_on_domain of ReportConfig(_attachments=None, _id='3789e90ccfee34b898c1b5e10002fe08', _rev='1-736778daa7dc0d48615c41658e218800', date_range=None, datespan_slug=None, days=None, description=None, doc_type='ReportConfig', domain='test_domain', end_date=None, filters={}, name=None, owner_id=None, report_slug=None, report_type=None, start_date=None, subreport_slug=None)> is not false
```
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
