### PR TITLE
Remote API Logs CSV export

### DIFF
--- a/corehq/motech/templates/motech/logs.html
+++ b/corehq/motech/templates/motech/logs.html
@@ -9,7 +9,8 @@
       <form method="GET">
         <span class="col-sm-2">
           <label for="filter_from_date">From date*</label>
-          <input class="form-control"
+          <input id="filter_from_date"
+                 class="form-control"
                  type="text"
                  name="filter_from_date"
                  value="{{ filter_from_date }}"
@@ -18,7 +19,8 @@
 
         <span class="col-sm-2">
           <label for="filter_to_date">To date</label>
-          <input class="form-control"
+          <input id="filter_to_date"
+                 class="form-control"
                  type="text"
                  name="filter_to_date"
                  value="{{ filter_to_date }}"
@@ -26,8 +28,9 @@
         </span>
 
         <span class="col-sm-2">
-          <label for="filter_to_date">Payload</label>
-          <input class="form-control"
+          <label for="filter_payload">Payload</label>
+          <input id="filter_payload"
+                 class="form-control"
                  type="text"
                  name="filter_payload"
                  value="{{ filter_payload }}" />
@@ -35,16 +38,18 @@
 
         <span class="col-sm-3">
           <label for="filter_url">URL starts with</label>
-          <input class="form-control"
+          <input id="filter_url"
+                 class="form-control"
                  type="text"
                  name="filter_url"
                  value="{{ filter_url }}"
                  placeholder="http..." />
         </span>
 
-        <span class="col-sm-2">
+        <span class="col-sm-1">
           <label for="filter_status">Status</label>
-          <input class="form-control"
+          <input id="filter_status"
+                 class="form-control"
                  type="text"
                  name="filter_status"
                  value="{{ filter_status }}"
@@ -52,11 +57,22 @@
         </span>
 
         <span class="col-sm-1">
-          <label for="submit">&nbsp;</label>
-          <input class="btn btn-default"
+          <label for="submit_button">&nbsp;</label>
+          <input id="submit_button"
+                 class="form-control btn btn-primary"
                  type="submit"
-                 name="submit"
+                 name="submit_button"
                  value="Filter"/>
+        </span>
+
+        <span class="col-sm-1">
+          <label for="export_button">&nbsp;</label>
+          <input id="export_button"
+                 class="form-control btn btn-default"
+                 type="submit"
+                 name="export_button"
+                 formaction="{% url 'motech_log_export_view' domain %}"
+                 value="Export"/>
         </span>
       </form>
     </div>

--- a/corehq/motech/urls.py
+++ b/corehq/motech/urls.py
@@ -14,6 +14,10 @@ from corehq.motech.openmrs.views import (
     EditOpenmrsRepeaterView,
     config_openmrs_repeater,
 )
+from corehq.motech.repeaters.expression.views import (
+    AddCaseExpressionRepeaterView,
+    EditCaseExpressionRepeaterView,
+)
 from corehq.motech.repeaters.views import (
     AddCaseRepeaterView,
     AddFormRepeaterView,
@@ -26,15 +30,12 @@ from corehq.motech.repeaters.views import (
     pause_repeater,
     resume_repeater,
 )
-from corehq.motech.repeaters.expression.views import (
-    AddCaseExpressionRepeaterView,
-    EditCaseExpressionRepeaterView,
-)
 from corehq.motech.views import (
     ConnectionSettingsDetailView,
     ConnectionSettingsListView,
     MotechLogDetailView,
     MotechLogListView,
+    motech_log_export_view,
     test_connection_settings,
 )
 
@@ -111,4 +112,6 @@ urlpatterns = [
 
     url(r'^logs/$', MotechLogListView.as_view(), name=MotechLogListView.urlname),
     url(r'^logs/(?P<pk>\d+)/$', MotechLogDetailView.as_view(), name=MotechLogDetailView.urlname),
+    url(r'^logs/remote_api_logs.csv$', motech_log_export_view,
+        name='motech_log_export_view'),
 ]

--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -96,57 +96,6 @@ def motech_log_export_view(request, domain):
     """
     Download ``RequestLog``s as CSV. Uses ``StreamingHttpResponse`` to
     support large file sizes.
-
-    CSV files can be imported into PostgreSQL using ::
-
-        COPY api_logs FROM 'remote_api_logs.csv' FORMAT csv HEADER;
-
-    Replace "api_logs" with your own table name.
-
-    To create a suitable PostgreSQL table, use the following statement,
-    with your own table name, of course::
-
-        CREATE TABLE public.api_logs (
-            "timestamp" timestamp NOT NULL,
-            payload_id varchar NULL,
-            request_method varchar NOT NULL,
-            request_url varchar NOT NULL,
-            request_body jsonb NULL,
-            request_error varchar NULL,
-            response_status int NULL,
-            response_headers jsonb NULL,
-            response_body jsonb NULL
-        );
-
-    This view supports API key authentication so that exports can be
-    scripted. For example, the following script exports the remote API
-    logs from the previous 24 hours, and appends them to a table in
-    Postgres::
-
-        #!/bin/bash
-
-        DOMAIN=demo
-        USERNAME=admin@example.com
-        API_KEY=abc123
-
-        DB_HOST=localhost
-        DB_PORT=5433
-        DB_USER=postgres
-        DB_DATABASE=postgres
-
-        yesterday=`date -d "yesterday" '+%Y-%m-%d'`
-        day_before=`date -d "2 days ago" '+%Y-%m-%d'`
-        url="https://commcarehq.org/a/$DOMAIN/motech/logs/remote_api_logs.csv"
-        curl -L \
-            -H "Authorization: ApiKey $USERNAME:$API_KEY" \
-            -o remote_api_logs.csv \
-            "${url}?filter_from_date=${day_before}&filter_to_date=${yesterday}"
-
-        psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_DATABASE \
-            -c "COPY api_logs FROM 'remote_api_logs.csv' csv HEADER; "
-
-        rm remote_api_logs.csv
-
     """
 
     def as_utc_timestamp(timestamp):

--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -121,7 +121,7 @@ def motech_log_export_view(request, domain):
     This view supports API key authentication so that exports can be
     scripted. For example, the following script exports the remote API
     logs from the previous 24 hours, and appends them to a table in
-    Postgres ::
+    Postgres::
 
         #!/bin/bash
 
@@ -140,7 +140,7 @@ def motech_log_export_view(request, domain):
         curl -L \
             -H "Authorization: ApiKey $USERNAME:$API_KEY" \
             -o remote_api_logs.csv \
-            "${url}?filter_from_date=${day_before}&filter_from_date=${yesterday}"
+            "${url}?filter_from_date=${day_before}&filter_to_date=${yesterday}"
 
         psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_DATABASE \
             -c "COPY api_logs FROM 'remote_api_logs.csv' csv HEADER; "
@@ -150,9 +150,13 @@ def motech_log_export_view(request, domain):
     """
 
     def as_utc_timestamp(timestamp):
+        """
+        Formats a datetime as a string that Postgres recognizes as a UTC
+        timestamp.
+        """
         return timestamp.isoformat(sep=' ', timespec='milliseconds') + '+00'
 
-    def dict_to_json(dict_):
+    def json_or_none(dict_):
         if not dict_:
             return None
         return json.dumps(dict_)
@@ -180,7 +184,7 @@ def motech_log_export_view(request, domain):
         ('request_body', _('Request Body'), string_or_none),
         ('request_error', _('Error'), string_or_none),
         ('response_status', _('Status Code'), int_or_none),
-        ('response_headers', _('Response Headers'), dict_to_json),
+        ('response_headers', _('Response Headers'), json_or_none),
         ('response_body', _('Response Body'), string_or_none),
     ]
 


### PR DESCRIPTION
## Product Description

Allows users to download Remote API Logs in CSV format. Supports filtering.

CSV format was chosen because
* it allows for larger downloads,
* and it can be imported into DBMSes like Postgres or MySQL easily, for teams that use tools like Superset.

Logs can be downloaded from the Remote API Logs list page, or from a command line using API key authentication. This allows admin users to script the export and import of data on a schedule.

#### Remote API Logs list page

![image](https://user-images.githubusercontent.com/708421/153074611-a5b79dbc-ebb2-47e9-a74d-c35a00f01980.png)

#### Command line or script

As an example, the following script exports the remote API logs from the previous 24 hours, and appends them to a table in Postgres:

        #!/bin/bash

        DOMAIN=demo
        USERNAME=admin@example.com
        API_KEY=abc123

        DB_HOST=localhost
        DB_PORT=5433
        DB_USER=postgres
        DB_DATABASE=postgres

        yesterday=`date -d "yesterday" '+%Y-%m-%d'`
        day_before=`date -d "2 days ago" '+%Y-%m-%d'`
        url="https://commcarehq.org/a/$DOMAIN/motech/logs/remote_api_logs.csv"
        curl -L \
            -H "Authorization: ApiKey $USERNAME:$API_KEY" \
            -o remote_api_logs.csv \
            "${url}?filter_from_date=${day_before}&filter_to_date=${yesterday}"

        psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_DATABASE \
            -c "COPY api_logs FROM 'remote_api_logs.csv' csv HEADER; "

        rm remote_api_logs.csv


## Technical Summary

Context: [SC-1981](https://dimagi-dev.atlassian.net/browse/SC-1981)

:blowfish: 

## Feature Flag

None, but requires Pro Plan or higher.

## Safety Assurance

### Safety story

* Tested on Staging
* Very small footprint


### Automated test coverage

Changes are limited to a Django view and a button in a template. They are not covered by tests.


### QA Plan

This feature will go through QA.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
