### PR TITLE
Force keyword arguments

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1127,7 +1127,7 @@ class RepeatRecord(Document):
         self.next_check = None
         self.cancelled = True
 
-    def attempt_forward_now(self, is_retry=False, fire_synchronously=False):
+    def attempt_forward_now(self, *, is_retry=False, fire_synchronously=False):
         from corehq.motech.repeaters.tasks import process_repeat_record, retry_process_repeat_record
 
         def is_ready():

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -7,7 +7,7 @@ from django.db.models.deletion import ProtectedError
 from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
 
-from nose.tools import assert_in
+from nose.tools import assert_in, assert_raises
 
 from corehq.motech.const import ALGO_AES, BASIC_AUTH
 from corehq.motech.models import ConnectionSettings
@@ -24,6 +24,7 @@ from ..const import (
 )
 from ..models import (
     FormRepeater,
+    RepeatRecord,
     SQLRepeater,
     are_repeat_records_migrated,
     format_response,
@@ -447,3 +448,9 @@ class TestSQLRepeaterConnectionSettings(RepeaterTestCase):
     def test_used_connection_setting_cannot_be_deleted(self):
         with self.assertRaises(ProtectedError):
             self.sql_repeater.connection_settings.delete()
+
+
+def test_attempt_forward_now_kwargs():
+    rr = RepeatRecord()
+    with assert_raises(TypeError):
+        rr.attempt_forward_now(True)


### PR DESCRIPTION
## Technical Summary

Tiny. Figured it might be useful.

## Safety Assurance

### Safety story

Checked usage. All calls use kwargs already.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
