### PR TITLE
Move case accessors into CommCareCase.objects - part 4

### DIFF
--- a/corehq/apps/callcenter/utils.py
+++ b/corehq/apps/callcenter/utils.py
@@ -7,7 +7,6 @@ import pytz
 from corehq.apps.domain.models import Domain
 from corehq.apps.es import filters
 from corehq.apps.es.domains import DomainES
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.util.quickcache import quickcache
 from corehq.util.timezones.conversions import ServerTime, UserTime
@@ -97,16 +96,12 @@ def get_call_center_domains():
 def get_call_center_cases(domain_name, case_type, user=None):
     all_cases = []
 
-    case_accessor = CaseAccessors(domain_name)
-
     if user:
-        case_ids = [
-            case_id for case_id in case_accessor.get_open_case_ids_in_domain_by_type(
-                case_type=case_type, owner_ids=user.get_owner_ids()
-            )
-        ]
+        case_ids = CommCareCase.objects.get_open_case_ids_in_domain_by_type(
+            domain_name, case_type=case_type, owner_ids=user.get_owner_ids())
     else:
-        case_ids = case_accessor.get_open_case_ids_in_domain_by_type(case_type=case_type)
+        case_ids = CommCareCase.objects.get_open_case_ids_in_domain_by_type(
+            domain_name, case_type=case_type)
 
     for case in CommCareCase.objects.iter_cases(case_ids, domain_name):
         cc_case = CallCenterCase.from_case(case)

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -103,7 +103,7 @@ class ImporterTest(TestCase):
         update_state.assert_called_with(
             state=states.FAILURE,
             meta=get_interned_exception('Sorry, your session has expired. Please start over and try again.'))
-        self.assertEqual(0, len(self.accessor.get_case_ids_in_domain()))
+        self.assertEqual(0, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
 
     def testImportBasic(self):
         config = self._config(['case_id', 'age', 'sex', 'location'])
@@ -120,7 +120,7 @@ class ImporterTest(TestCase):
         self.assertEqual(0, res['match_count'])
         self.assertFalse(res['errors'])
         self.assertEqual(1, res['num_chunks'])
-        case_ids = self.accessor.get_case_ids_in_domain()
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(self.domain)
         cases = CommCareCase.objects.get_cases(case_ids, self.domain)
         self.assertEqual(5, len(cases))
         properties_seen = set()
@@ -145,7 +145,7 @@ class ImporterTest(TestCase):
         self.assertEqual(3, res['created_count'])
         self.assertEqual(0, res['match_count'])
         self.assertFalse(res['errors'])
-        case_ids = self.accessor.get_case_ids_in_domain()
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(self.domain)
         self.assertItemsEqual(
             [case.external_id for case in CommCareCase.objects.get_cases(case_ids, self.domain)],
             ['external_id-0', 'external_id-0', 'external_id-1']
@@ -163,7 +163,7 @@ class ImporterTest(TestCase):
         res = do_import(file, config, self.domain)
 
         self.assertEqual(4, res['created_count'])
-        self.assertEqual(4, len(self.accessor.get_case_ids_in_domain()))
+        self.assertEqual(4, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
 
     def testImportTrailingWhitespace(self):
         cols = ['case_id', 'age', 'sex\xa0', 'location']
@@ -175,7 +175,7 @@ class ImporterTest(TestCase):
         res = do_import(file, config, self.domain)
 
         self.assertEqual(1, res['created_count'])
-        case_ids = self.accessor.get_case_ids_in_domain()
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(self.domain)
         self.assertEqual(1, len(case_ids))
         case = CommCareCase.objects.get_case(case_ids[0], self.domain)
         self.assertTrue(bool(case.get_case_property('sex')))  # make sure the value also got properly set
@@ -186,7 +186,7 @@ class ImporterTest(TestCase):
             'create': True,
             'update': {'importer_test_prop': 'foo'},
         }))
-        self.assertEqual(1, len(self.accessor.get_case_ids_in_domain()))
+        self.assertEqual(1, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
 
         config = self._config(['case_id', 'age', 'sex', 'location'])
         file = make_worksheet_wrapper(
@@ -201,7 +201,7 @@ class ImporterTest(TestCase):
         self.assertFalse(res['errors'])
 
         # shouldn't create any more cases, just the one
-        case_ids = self.accessor.get_case_ids_in_domain()
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(self.domain)
         self.assertEqual(1, len(case_ids))
         [case] = CommCareCase.objects.get_cases(case_ids, self.domain)
         for prop in ['age', 'sex', 'location']:
@@ -215,7 +215,7 @@ class ImporterTest(TestCase):
             'create': True,
             'case_type': 'nonmatch-type',
         }))
-        self.assertEqual(1, len(self.accessor.get_case_ids_in_domain()))
+        self.assertEqual(1, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
         config = self._config(['case_id', 'age', 'sex', 'location'])
         file = make_worksheet_wrapper(
             ['case_id', 'age', 'sex', 'location'],
@@ -227,14 +227,14 @@ class ImporterTest(TestCase):
         # because the type is wrong these shouldn't match
         self.assertEqual(3, res['created_count'])
         self.assertEqual(0, res['match_count'])
-        self.assertEqual(4, len(self.accessor.get_case_ids_in_domain()))
+        self.assertEqual(4, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
 
     def testCaseLookupDomainCheck(self):
         self.factory.domain = 'wrong-domain'
         [case] = self.factory.create_or_update_case(CaseStructure(attrs={
             'create': True,
         }))
-        self.assertEqual(0, len(self.accessor.get_case_ids_in_domain()))
+        self.assertEqual(0, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
         config = self._config(['case_id', 'age', 'sex', 'location'])
         file = make_worksheet_wrapper(
             ['case_id', 'age', 'sex', 'location'],
@@ -247,7 +247,7 @@ class ImporterTest(TestCase):
         # because the domain is wrong these shouldn't match
         self.assertEqual(3, res['created_count'])
         self.assertEqual(0, res['match_count'])
-        self.assertEqual(3, len(self.accessor.get_case_ids_in_domain()))
+        self.assertEqual(3, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
 
     def testExternalIdMatching(self):
         # bootstrap a stub case
@@ -258,7 +258,7 @@ class ImporterTest(TestCase):
                 'external_id': external_id,
             }
         ))
-        self.assertEqual(1, len(self.accessor.get_case_ids_in_domain()))
+        self.assertEqual(1, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
 
         headers = ['external_id', 'age', 'sex', 'location']
         config = self._config(headers, search_field='external_id')
@@ -274,7 +274,7 @@ class ImporterTest(TestCase):
         self.assertFalse(res['errors'])
 
         # shouldn't create any more cases, just the one
-        self.assertEqual(1, len(self.accessor.get_case_ids_in_domain()))
+        self.assertEqual(1, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
 
     def test_external_id_matching_on_create_with_custom_column_name(self):
         headers = ['id_column', 'age', 'sex', 'location']
@@ -290,7 +290,7 @@ class ImporterTest(TestCase):
         self.assertFalse(res['errors'])
         self.assertEqual(1, res['created_count'])
         self.assertEqual(1, res['match_count'])
-        case_ids = self.accessor.get_case_ids_in_domain()
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(self.domain)
         self.assertEqual(1, len(case_ids))
         case = CommCareCase.objects.get_case(case_ids[0], self.domain)
         self.assertEqual(external_id, case.external_id)
@@ -310,7 +310,7 @@ class ImporterTest(TestCase):
         # no matching and no create new set - should do nothing
         self.assertEqual(0, res['created_count'])
         self.assertEqual(0, res['match_count'])
-        self.assertEqual(0, len(self.accessor.get_case_ids_in_domain()))
+        self.assertEqual(0, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
 
     def testBlankRows(self):
         # don't create new cases for rows left blank
@@ -325,7 +325,7 @@ class ImporterTest(TestCase):
         # no matching and no create new set - should do nothing
         self.assertEqual(0, res['created_count'])
         self.assertEqual(0, res['match_count'])
-        self.assertEqual(0, len(self.accessor.get_case_ids_in_domain()))
+        self.assertEqual(0, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
 
     @patch('corehq.apps.case_importer.do_import.CASEBLOCK_CHUNKSIZE', 2)
     def testBasicChunking(self):
@@ -342,7 +342,7 @@ class ImporterTest(TestCase):
         # 5 cases in chunks of 2 = 3 chunks
         self.assertEqual(3, res['num_chunks'])
         self.assertEqual(5, res['created_count'])
-        self.assertEqual(5, len(self.accessor.get_case_ids_in_domain()))
+        self.assertEqual(5, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
 
     def testExternalIdChunking(self):
         # bootstrap a stub case
@@ -365,7 +365,7 @@ class ImporterTest(TestCase):
         self.assertEqual(2, res['num_chunks'])  # the lookup causes an extra chunk
 
         # should just create the one case
-        case_ids = self.accessor.get_case_ids_in_domain()
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(self.domain)
         self.assertEqual(1, len(case_ids))
         [case] = CommCareCase.objects.get_cases(case_ids, self.domain)
         self.assertEqual(external_id, case.external_id)
@@ -377,7 +377,7 @@ class ImporterTest(TestCase):
         config = self._config(headers, create_new_cases=True, search_column='case_id')
         rows = 3
         [parent_case] = self.factory.create_or_update_case(CaseStructure(attrs={'create': True}))
-        self.assertEqual(1, len(self.accessor.get_case_ids_in_domain()))
+        self.assertEqual(1, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
 
         file = make_worksheet_wrapper(
             ['parent_id', 'name', 'case_id'],
@@ -412,7 +412,7 @@ class ImporterTest(TestCase):
         headers = ['parent_id', 'name', 'case_id', 'parent_relationship_type', 'parent_identifier']
         config = self._config(headers, create_new_cases=True, search_column='case_id')
         [parent_case] = self.factory.create_or_update_case(CaseStructure(attrs={'create': True}))
-        self.assertEqual(1, len(self.accessor.get_case_ids_in_domain()))
+        self.assertEqual(1, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
 
         file = make_worksheet_wrapper(
             headers,
@@ -457,7 +457,7 @@ class ImporterTest(TestCase):
         self.assertEqual(2, res['failed_count'])
 
         # Asserting current domain
-        cur_case_ids = self.accessor.get_case_ids_in_domain()
+        cur_case_ids = CommCareCase.objects.get_case_ids_in_domain(self.domain)
         cur_cases = CommCareCase.objects.get_cases(cur_case_ids, self.domain)
         self.assertEqual(3, len(cur_cases))
         #Asserting current domain case property
@@ -465,7 +465,7 @@ class ImporterTest(TestCase):
         self.assertEqual(cases['name-0'].get_case_property('artist'), 'artist-0')
 
         # Asserting subdomain 1
-        s1_case_ids = CaseAccessors(self.subdomain1.name).get_case_ids_in_domain()
+        s1_case_ids = CommCareCase.objects.get_case_ids_in_domain(self.subdomain1.name)
         s1_cases = CommCareCase.objects.get_cases(s1_case_ids, self.domain)
         self.assertEqual(1, len(s1_cases))
         # Asserting subdomain 1 case property
@@ -473,7 +473,7 @@ class ImporterTest(TestCase):
         self.assertEqual(s1_cases_pro['name-1'].get_case_property('artist'), 'artist-1')
 
         # Asserting subdomain 2
-        s2_case_ids = CaseAccessors(self.subdomain2.name).get_case_ids_in_domain()
+        s2_case_ids = CommCareCase.objects.get_case_ids_in_domain(self.subdomain2.name)
         s2_cases = CommCareCase.objects.get_cases(s2_case_ids, self.domain)
         self.assertEqual(1, len(s2_cases))
         # Asserting subdomain 2 case property
@@ -497,7 +497,7 @@ class ImporterTest(TestCase):
         self.assertEqual(6, res['created_count'])
         self.assertEqual(0, res['match_count'])
         self.assertEqual(0, res['failed_count'])
-        case_ids = self.accessor.get_case_ids_in_domain()
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(self.domain)
         # Asserting current domain
         cur_cases = CommCareCase.objects.get_cases(case_ids, self.domain)
         self.assertEqual(6, len(cur_cases))
@@ -532,7 +532,7 @@ class ImporterTest(TestCase):
             ['', 'duplicate-location-name', '', duplicate_loc.name],
             ['', 'non-case-owning-name', '', improper_loc.name],
         ])
-        case_ids = self.accessor.get_case_ids_in_domain()
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(self.domain)
         cases = {c.name: c for c in CommCareCase.objects.get_cases(case_ids, self.domain)}
 
         self.assertEqual(cases['location-owner-id'].owner_id, location.location_id)
@@ -629,7 +629,7 @@ class ImporterTest(TestCase):
                 ['', 'Caroline', '', 'yellow', case_owner._id],
             ])
             self.assertEqual(res['errors'], {})
-            case_ids = self.accessor.get_case_ids_in_domain()
+            case_ids = CommCareCase.objects.get_case_ids_in_domain(self.domain)
             cases = {c.name: c for c in CommCareCase.objects.get_cases(case_ids, self.domain)}
             self.assertEqual(cases['Jeff'].owner_id, case_owner._id)
             self.assertEqual(cases['Jeff'].get_case_property('favorite_color'), 'blue')
@@ -646,7 +646,7 @@ class ImporterTest(TestCase):
                 ['', 'Quinton Fortune', dsa.location_id],
             ])
 
-        case_ids = self.accessor.get_case_ids_in_domain()
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(self.domain)
         cases = {c.name: c for c in CommCareCase.objects.get_cases(case_ids, self.domain)}
         self.assertEqual(cases['Quinton Fortune'].owner_id, dsa.location_id)
         self.assertTrue(res['errors'])
@@ -668,7 +668,7 @@ class ImporterTest(TestCase):
                 ['', 'Quinton Fortune', dsa_owner._id],
             ])
 
-        case_ids = self.accessor.get_case_ids_in_domain()
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(self.domain)
         cases = {c.name: c for c in CommCareCase.objects.get_cases(case_ids, self.domain)}
         self.assertEqual(cases['Quinton Fortune'].owner_id, dsa_owner._id)
         self.assertTrue(res['errors'])

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -23,6 +23,7 @@ from corehq.elastic import ESError
 from corehq.form_processor.backends.sql.dbaccessors import doc_type_to_state
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models.cases import CommCareCase
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 from corehq.util.log import with_progress_bar
 from dimagi.utils.chunked import chunked
@@ -168,7 +169,7 @@ def _terminate_subscriptions(domain_name):
 def _delete_all_cases(domain_name):
     logger.info('Deleting cases...')
     case_accessor = CaseAccessors(domain_name)
-    case_ids = case_accessor.get_case_ids_in_domain()
+    case_ids = CommCareCase.objects.get_case_ids_in_domain(domain_name)
     for case_id_chunk in chunked(with_progress_bar(case_ids, stream=silence_during_tests()), 500):
         case_accessor.soft_delete_cases(list(case_id_chunk))
     logger.info('Deleting cases complete.')

--- a/corehq/apps/domain/management/commands/hard_delete_forms_and_cases_in_domain.py
+++ b/corehq/apps/domain/management/commands/hard_delete_forms_and_cases_in_domain.py
@@ -5,7 +5,6 @@ from django.core.management import BaseCommand
 from dimagi.utils.chunked import chunked
 
 from corehq.apps.domain.utils import silence_during_tests
-from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.util.log import with_progress_bar
 
@@ -44,7 +43,7 @@ class Command(BaseCommand):
             XFormInstance.objects.hard_delete_forms(domain, list(form_id_chunk), delete_attachments=True)
 
         logger.info('Hard deleting cases...')
-        deleted_sql_case_ids = CaseAccessorSQL.get_deleted_case_ids_in_domain(domain)
+        deleted_sql_case_ids = CommCareCase.objects.get_deleted_case_ids_in_domain(domain)
         for case_id_chunk in chunked(with_progress_bar(deleted_sql_case_ids, stream=silence_during_tests()), 500):
             CommCareCase.objects.hard_delete_cases(domain, list(case_id_chunk))
 

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -116,8 +116,7 @@ from corehq.form_processor.backends.sql.dbaccessors import (
     CaseAccessorSQL,
     doc_type_to_state,
 )
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.form_processor.tests.utils import create_form_for_test
 from corehq.motech.models import ConnectionSettings, RequestLog
 from corehq.motech.repeaters.const import RECORD_SUCCESS_STATE
@@ -294,12 +293,12 @@ class TestDeleteDomain(TestCase):
     def _test_case_deletion(self):
         for domain_name in [self.domain.name, self.domain2.name]:
             CaseFactory(domain_name).create_case()
-            self.assertEqual(len(CaseAccessors(domain_name).get_case_ids_in_domain()), 1)
+            self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(domain_name)), 1)
 
         self.domain.delete()
 
-        self.assertEqual(len(CaseAccessors(self.domain.name).get_case_ids_in_domain()), 0)
-        self.assertEqual(len(CaseAccessors(self.domain2.name).get_case_ids_in_domain()), 1)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain.name)), 0)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain2.name)), 1)
 
     def test_case_deletion_sql(self):
         self._test_case_deletion()
@@ -1063,20 +1062,20 @@ class TestHardDeleteSQLFormsAndCases(TestCase):
     def test_hard_delete_cases(self):
         for domain_name in [self.domain.name, self.domain2.name]:
             CaseFactory(domain_name).create_case()
-            self.assertEqual(len(CaseAccessors(domain_name).get_case_ids_in_domain()), 1)
+            self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(domain_name)), 1)
 
         self.domain.delete()
 
-        self.assertEqual(len(CaseAccessors(self.domain.name).get_case_ids_in_domain()), 0)
-        self.assertEqual(len(CaseAccessors(self.domain2.name).get_case_ids_in_domain()), 1)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain.name)), 0)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain2.name)), 1)
 
         self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain.name)), 1)
         self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain2.name)), 0)
 
         call_command('hard_delete_forms_and_cases_in_domain', self.domain.name, noinput=True)
 
-        self.assertEqual(len(CaseAccessors(self.domain.name).get_case_ids_in_domain()), 0)
-        self.assertEqual(len(CaseAccessors(self.domain2.name).get_case_ids_in_domain()), 1)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain.name)), 0)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain2.name)), 1)
 
         self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain.name)), 0)
         self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain2.name)), 0)
@@ -1084,20 +1083,20 @@ class TestHardDeleteSQLFormsAndCases(TestCase):
     def test_hard_delete_cases_none_to_delete(self):
         for domain_name in [self.domain.name, self.domain2.name]:
             CaseFactory(domain_name).create_case()
-            self.assertEqual(len(CaseAccessors(domain_name).get_case_ids_in_domain()), 1)
+            self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(domain_name)), 1)
 
         self.domain.delete()
 
-        self.assertEqual(len(CaseAccessors(self.domain.name).get_case_ids_in_domain()), 0)
-        self.assertEqual(len(CaseAccessors(self.domain2.name).get_case_ids_in_domain()), 1)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain.name)), 0)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain2.name)), 1)
 
         self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain.name)), 1)
         self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain2.name)), 0)
 
         call_command('hard_delete_forms_and_cases_in_domain', self.domain2.name, noinput=True)
 
-        self.assertEqual(len(CaseAccessors(self.domain.name).get_case_ids_in_domain()), 0)
-        self.assertEqual(len(CaseAccessors(self.domain2.name).get_case_ids_in_domain()), 1)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain.name)), 0)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain2.name)), 1)
 
         self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain.name)), 1)
         self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain2.name)), 0)

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -112,10 +112,7 @@ from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.apps.zapier.consts import EventTypes
 from corehq.apps.zapier.models import ZapierSubscription
 from corehq.blobs import CODES, NotFound, get_blob_db
-from corehq.form_processor.backends.sql.dbaccessors import (
-    CaseAccessorSQL,
-    doc_type_to_state,
-)
+from corehq.form_processor.backends.sql.dbaccessors import doc_type_to_state
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.form_processor.tests.utils import create_form_for_test
 from corehq.motech.models import ConnectionSettings, RequestLog
@@ -1069,16 +1066,16 @@ class TestHardDeleteSQLFormsAndCases(TestCase):
         self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain.name)), 0)
         self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain2.name)), 1)
 
-        self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain.name)), 1)
-        self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain2.name)), 0)
+        self.assertEqual(len(CommCareCase.objects.get_deleted_case_ids_in_domain(self.domain.name)), 1)
+        self.assertEqual(len(CommCareCase.objects.get_deleted_case_ids_in_domain(self.domain2.name)), 0)
 
         call_command('hard_delete_forms_and_cases_in_domain', self.domain.name, noinput=True)
 
         self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain.name)), 0)
         self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain2.name)), 1)
 
-        self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain.name)), 0)
-        self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain2.name)), 0)
+        self.assertEqual(len(CommCareCase.objects.get_deleted_case_ids_in_domain(self.domain.name)), 0)
+        self.assertEqual(len(CommCareCase.objects.get_deleted_case_ids_in_domain(self.domain2.name)), 0)
 
     def test_hard_delete_cases_none_to_delete(self):
         for domain_name in [self.domain.name, self.domain2.name]:
@@ -1090,16 +1087,16 @@ class TestHardDeleteSQLFormsAndCases(TestCase):
         self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain.name)), 0)
         self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain2.name)), 1)
 
-        self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain.name)), 1)
-        self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain2.name)), 0)
+        self.assertEqual(len(CommCareCase.objects.get_deleted_case_ids_in_domain(self.domain.name)), 1)
+        self.assertEqual(len(CommCareCase.objects.get_deleted_case_ids_in_domain(self.domain2.name)), 0)
 
         call_command('hard_delete_forms_and_cases_in_domain', self.domain2.name, noinput=True)
 
         self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain.name)), 0)
         self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain2.name)), 1)
 
-        self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain.name)), 1)
-        self.assertEqual(len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain2.name)), 0)
+        self.assertEqual(len(CommCareCase.objects.get_deleted_case_ids_in_domain(self.domain.name)), 1)
+        self.assertEqual(len(CommCareCase.objects.get_deleted_case_ids_in_domain(self.domain2.name)), 0)
 
 
 def ensure_deleted(domain):

--- a/corehq/apps/hqcase/tests/test_bulk.py
+++ b/corehq/apps/hqcase/tests/test_bulk.py
@@ -6,8 +6,7 @@ from django.test import TestCase
 from casexml.apps.case.mock import CaseBlock
 
 from corehq.apps.hqcase.bulk import CaseBulkDB, update_cases
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 
 
@@ -21,7 +20,6 @@ class TestUpdateCases(TestCase):
         super().tearDown()
 
     def test(self):
-        case_accessor = CaseAccessors(self.domain)
         case_ids = [str(uuid.uuid4()) for i in range(1, 18)]
 
         with CaseBulkDB(self.domain, 'my_user_id', 'my_device_id') as bulk_db:
@@ -38,11 +36,11 @@ class TestUpdateCases(TestCase):
                 ))
 
         self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.domain)), 4)
-        self.assertEqual(len(case_accessor.get_case_ids_in_domain()), len(case_ids))
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain)), len(case_ids))
 
         update_cases(self.domain, _set_phase_2, case_ids, 'my_user_id', 'my_device_id')
 
-        for case in case_accessor.get_cases(case_ids):
+        for case in CommCareCase.objects.get_cases(case_ids):
             correct_phase = '2' if case.get_case_property('to_update') == 'yes' else '1'
             self.assertEqual(case.get_case_property('phase'), correct_phase)
 

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -223,7 +223,7 @@ class TestCaseAPI(TestCase):
             },
         })
         self.assertEqual(res.json()['error'], "No case found with ID 'notarealcaseid'")
-        self.assertEqual(self.case_accessor.get_case_ids_in_domain(), [])
+        self.assertEqual(CommCareCase.objects.get_case_ids_in_domain(self.domain), [])
 
     def test_update_case_on_other_domain(self):
         case_id = str(uuid.uuid4())
@@ -239,7 +239,7 @@ class TestCaseAPI(TestCase):
             'owner_id': 'stealing_this_case',
         })
         self.assertEqual(res.json()['error'], f"No case found with ID '{case_id}'")
-        self.assertEqual(self.case_accessor.get_case_ids_in_domain(), [])
+        self.assertEqual(CommCareCase.objects.get_case_ids_in_domain(self.domain), [])
 
     def test_create_child_case(self):
         parent_case = self._make_case()
@@ -333,7 +333,7 @@ class TestCaseAPI(TestCase):
             },
         ])
         self.assertEqual(res.json()['error'], "The following case IDs were not found: notarealcaseid")
-        self.assertEqual(self.case_accessor.get_case_ids_in_domain(), [])
+        self.assertEqual(CommCareCase.objects.get_case_ids_in_domain(self.domain), [])
 
     def test_create_parent_and_child_together(self):
         res = self._bulk_update_cases([

--- a/corehq/apps/ota/tests/test_claim.py
+++ b/corehq/apps/ota/tests/test_claim.py
@@ -10,7 +10,6 @@ from corehq.apps.case_search.models import CLAIM_CASE_TYPE
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.ota.utils import get_restore_user
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCase
 
@@ -54,7 +53,7 @@ class CaseClaimTests(TestCase):
 
     def assert_claim(self, claim=None, claim_id=None):
         if claim is None:
-            claim_ids = CaseAccessors(DOMAIN).get_case_ids_in_domain(CLAIM_CASE_TYPE)
+            claim_ids = CommCareCase.objects.get_case_ids_in_domain(DOMAIN, CLAIM_CASE_TYPE)
             self.assertEqual(len(claim_ids), 1)
             claim = CommCareCase.objects.get_case(claim_ids[0], DOMAIN)
         if claim_id:

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -26,7 +26,6 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es.tests.utils import ElasticTestMixin, es_test
 from corehq.apps.users.models import CommCareUser
 from corehq.elastic import get_es_new
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.pillows.case_search import CaseSearchReindexerFactory, domains_needing_search_index
 from corehq.pillows.mappings.case_search_mapping import (
@@ -327,14 +326,14 @@ class CaseClaimEndpointTests(TestCase):
         """
         A claim case request should create an extension case
         """
-        self.assertEqual(len(CaseAccessors(DOMAIN).get_case_ids_in_domain(CLAIM_CASE_TYPE)), 0)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(DOMAIN, CLAIM_CASE_TYPE)), 0)
 
         client = Client()
         client.login(username=USERNAME, password=PASSWORD)
         url = reverse('claim_case', kwargs={'domain': DOMAIN})
         client.post(url, {'case_id': self.case_id})
 
-        claim_ids = CaseAccessors(DOMAIN).get_case_ids_in_domain(CLAIM_CASE_TYPE)
+        claim_ids = CommCareCase.objects.get_case_ids_in_domain(DOMAIN, CLAIM_CASE_TYPE)
         self.assertEqual(len(claim_ids), 1)
         claim = CommCareCase.objects.get_case(claim_ids[0], DOMAIN)
         self.assertEqual(claim.owner_id, self.user.get_id)
@@ -388,7 +387,7 @@ class CaseClaimEndpointTests(TestCase):
             'commcare_login_as': other_user_username
         })
 
-        claim_ids = CaseAccessors(DOMAIN).get_case_ids_in_domain(CLAIM_CASE_TYPE)
+        claim_ids = CommCareCase.objects.get_case_ids_in_domain(DOMAIN, CLAIM_CASE_TYPE)
         self.assertEqual(len(claim_ids), 1)
 
         claim_case = CommCareCase.objects.get_case(claim_ids[0], DOMAIN)
@@ -412,7 +411,7 @@ class CaseClaimEndpointTests(TestCase):
             'commcare_login_as': other_user_username
         })
 
-        claim_ids = CaseAccessors(DOMAIN).get_case_ids_in_domain(CLAIM_CASE_TYPE)
+        claim_ids = CommCareCase.objects.get_case_ids_in_domain(DOMAIN, CLAIM_CASE_TYPE)
         self.assertEqual(len(claim_ids), 1)
 
         claim_case = CommCareCase.objects.get_case(claim_ids[0], DOMAIN)
@@ -424,7 +423,7 @@ class CaseClaimEndpointTests(TestCase):
         })
 
         # We've now created two claims
-        claim_ids = CaseAccessors(DOMAIN).get_case_ids_in_domain(CLAIM_CASE_TYPE)
+        claim_ids = CommCareCase.objects.get_case_ids_in_domain(DOMAIN, CLAIM_CASE_TYPE)
         self.assertEqual(len(claim_ids), 2)
 
         # The most recent one should be the extension owned by the other user

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1804,7 +1804,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         return XFormInstance.objects.get_deleted_form_ids_for_user(self.domain, self.user_id)
 
     def _get_deleted_case_ids(self):
-        return CaseAccessors(self.domain).get_deleted_case_ids_by_owner(self.user_id)
+        return CommCareCase.objects.get_deleted_case_ids_by_owner(self.domain, self.user_id)
 
     def get_owner_ids(self, domain=None):
         owner_ids = [self.user_id]

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1798,7 +1798,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         return XFormInstance.objects.get_form_ids_for_user(self.domain, self.user_id)
 
     def _get_case_ids(self):
-        return CaseAccessors(self.domain).get_case_ids_by_owners([self.user_id])
+        return CommCareCase.objects.get_case_ids_in_domain_by_owners(self.domain, [self.user_id])
 
     def _get_deleted_form_ids(self):
         return XFormInstance.objects.get_deleted_form_ids_for_user(self.domain, self.user_id)

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -313,7 +313,8 @@ class RetireUserTestCase(TestCase):
         )
         submit_case_blocks(caseblock.as_text(), self.domain, user_id=self.other_user._id)
 
-        case_ids = CaseAccessors(self.domain).get_case_ids_by_owners([self.commcare_user._id])
+        case_ids = CommCareCase.objects.get_case_ids_in_domain_by_owners(
+            self.domain, [self.commcare_user._id])
         self.assertEqual(1, len(case_ids))
 
         form_ids = XFormInstance.objects.get_form_ids_for_user(self.domain, self.commcare_user._id)

--- a/corehq/apps/zapier/tests/test_create_update_cases_from_zapier.py
+++ b/corehq/apps/zapier/tests/test_create_update_cases_from_zapier.py
@@ -12,7 +12,6 @@ from corehq.apps.accounting.models import (
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import HQApiKey, WebUser
 from corehq.apps.zapier.views import ZapierCreateCase, ZapierUpdateCase
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 
@@ -34,7 +33,6 @@ class TestZapierCreateCaseAction(TestCase):
         subscription.save()
         cls.query_string = "?domain=fruit&case_type=watermelon&owner_id=test_user&user=test"
         cls.data = {'case_name': 'test1', 'price': '11'}
-        cls.accessor = CaseAccessors(cls.domain)
         cls.user = WebUser.create(cls.domain, 'test', '******', None, None)
         api_key_object, _ = HQApiKey.objects.get_or_create(user=cls.user.get_django_user())
         cls.api_key = api_key_object.key
@@ -55,7 +53,7 @@ class TestZapierCreateCaseAction(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
-        case_id = self.accessor.get_case_ids_in_domain()
+        case_id = CommCareCase.objects.get_case_ids_in_domain(self.domain)
         case = CommCareCase.objects.get_case(case_id[0], self.domain)
         self.assertEqual('test1', case.get_case_property('name'))
         self.assertEqual('11', case.get_case_property('price'))
@@ -69,7 +67,7 @@ class TestZapierCreateCaseAction(TestCase):
                                HTTP_AUTHORIZATION='ApiKey test:{}'.format(self.api_key))
 
         self.assertEqual(response.status_code, 200)
-        case_id = self.accessor.get_case_ids_in_domain()
+        case_id = CommCareCase.objects.get_case_ids_in_domain(self.domain)
         case = CommCareCase.objects.get_case(case_id[0], self.domain)
         self.assertEqual('11', case.get_case_property('price'))
 
@@ -102,7 +100,7 @@ class TestZapierCreateCaseAction(TestCase):
                                HTTP_AUTHORIZATION='ApiKey test:{}'.format(self.api_key))
 
         self.assertEqual(response.status_code, 200)
-        case_id = self.accessor.get_case_ids_in_domain()
+        case_id = CommCareCase.objects.get_case_ids_in_domain(self.domain)
 
         data = {'case_name': 'test1', 'price': '15', 'case_id': case_id[0]}
         query_string = "?domain=me&case_type=watermelon&user_id=test_user&user=test"
@@ -122,7 +120,7 @@ class TestZapierCreateCaseAction(TestCase):
                                HTTP_AUTHORIZATION='ApiKey test:{}'.format(self.api_key))
 
         self.assertEqual(response.status_code, 200)
-        case_id = self.accessor.get_case_ids_in_domain()
+        case_id = CommCareCase.objects.get_case_ids_in_domain(self.domain)
 
         data = {'case_name': 'test1', 'price': '15', 'case_id': case_id[0]}
         query_string = "?domain=fruit&case_type=orange&user_id=test_user&user=test"

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 import os
 from casexml.apps.case.tests.util import delete_all_cases
 from corehq.apps.receiverwrapper.util import submit_form_locally
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.tests.utils import sharded
 
 TEST_DOMAIN = 'test-domain'
@@ -27,7 +27,7 @@ class CaseExclusionTest(TestCase):
             xml_data = f.read()
 
         submit_form_locally(xml_data, TEST_DOMAIN)
-        self.assertEqual(0, len(CaseAccessors(TEST_DOMAIN).get_case_ids_in_domain()))
+        self.assertEqual(0, len(CommCareCase.objects.get_case_ids_in_domain(TEST_DOMAIN)))
 
     def testNestedExclusion(self):
         """
@@ -37,5 +37,5 @@ class CaseExclusionTest(TestCase):
         with open(file_path, "rb") as f:
             xml_data = f.read()
         result = submit_form_locally(xml_data, TEST_DOMAIN)
-        self.assertEqual(['case_in_form'], CaseAccessors(TEST_DOMAIN).get_case_ids_in_domain())
+        self.assertEqual(['case_in_form'], CommCareCase.objects.get_case_ids_in_domain(TEST_DOMAIN))
         self.assertEqual("form case", result.case.name)

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -70,7 +70,8 @@ def do_livequery(timing_context, restore_state, response, async_task=None):
     debug("sync %s for %r", restore_state.current_sync_log._id, owner_ids)
     with timing_context("livequery"):
         with timing_context("get_case_ids_by_owners"):
-            owned_ids = accessor.get_case_ids_by_owners(owner_ids, closed=False)
+            owned_ids = CommCareCase.objects.get_case_ids_in_domain_by_owners(
+                restore_state.domain, owner_ids, closed=False)
             debug("owned: %r", owned_ids)
 
         live_ids, indices = get_live_case_ids_and_indices(restore_state.domain, owned_ids, timing_context)

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -465,12 +465,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_transactions(case_id):
-        return list(
-            CaseTransaction.objects
-            .partitioned_query(case_id)
-            .filter(case_id=case_id)
-            .order_by('server_date')
-        )
+        warn("DEPRECATED", DeprecationWarning)
+        return CaseTransaction.objects.get_transactions(case_id)
 
     @staticmethod
     def get_transaction_by_form_id(case_id, form_id):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -480,14 +480,13 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_transactions_by_type(case_id, transaction_type):
-        return list(CaseTransaction.objects.plproxy_raw(
-            'SELECT * from get_case_transactions_by_type(%s, %s)',
-            [case_id, transaction_type])
-        )
+        warn("DEPRECATED", DeprecationWarning)
+        return CaseTransaction.objects.get_transactions_by_type(case_id, transaction_type)
 
     @staticmethod
     def get_transactions_for_case_rebuild(case_id):
-        return CaseAccessorSQL.get_transactions_by_type(case_id, CaseTransaction.TYPE_FORM)
+        warn("DEPRECATED", DeprecationWarning)
+        return CaseTransaction.objects.get_transactions_for_case_rebuild(case_id)
 
     @staticmethod
     def case_has_transactions_since_sync(case_id, sync_log_id, sync_log_date):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -495,13 +495,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_case_by_location(domain, location_id):
-        try:
-            return CommCareCase.objects.plproxy_raw(
-                'SELECT * from get_case_by_location_id(%s, %s)',
-                [domain, location_id]
-            )[0]
-        except IndexError:
-            return None
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCase.objects.get_case_by_location(domain, location_id)
 
     @staticmethod
     def get_case_ids_in_domain(domain, type_=None):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -510,6 +510,7 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_case_ids_in_domain_by_owners(domain, owner_ids, closed=None, case_type=None):
+        warn("DEPRECATED", DeprecationWarning)
         return CaseAccessorSQL._get_case_ids_in_domain(domain, case_type=case_type,
                                                        owner_ids=owner_ids, is_closed=closed)
 

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -505,6 +505,7 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_deleted_case_ids_in_domain(domain):
+        warn("DEPRECATED", DeprecationWarning)
         return CaseAccessorSQL._get_case_ids_in_domain(domain, deleted=True)
 
     @staticmethod

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -520,10 +520,6 @@ class CaseAccessorSQL:
         return case.save(with_tracked_models=True)
 
     @staticmethod
-    def get_closed_case_ids_for_owner(domain, owner_id):
-        return CaseAccessorSQL._get_case_ids_in_domain(domain, owner_ids=[owner_id], is_closed=True)
-
-    @staticmethod
     def get_open_case_ids_in_domain_by_type(domain, case_type, owner_ids=None):
         warn("DEPRECATED", DeprecationWarning)
         return CaseAccessorSQL._get_case_ids_in_domain(

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -520,10 +520,6 @@ class CaseAccessorSQL:
         return case.save(with_tracked_models=True)
 
     @staticmethod
-    def get_open_case_ids_for_owner(domain, owner_id):
-        return CaseAccessorSQL._get_case_ids_in_domain(domain, owner_ids=[owner_id], is_closed=False)
-
-    @staticmethod
     def get_closed_case_ids_for_owner(domain, owner_id):
         return CaseAccessorSQL._get_case_ids_in_domain(domain, owner_ids=[owner_id], is_closed=True)
 

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -647,6 +647,7 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_deleted_case_ids_by_owner(domain, owner_id):
+        warn("DEPRECATED", DeprecationWarning)
         return CaseAccessorSQL._get_case_ids_in_domain(domain, owner_ids=[owner_id], deleted=True)
 
     @staticmethod

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -525,6 +525,7 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_open_case_ids_in_domain_by_type(domain, case_type, owner_ids=None):
+        warn("DEPRECATED", DeprecationWarning)
         return CaseAccessorSQL._get_case_ids_in_domain(
             domain, case_type=case_type, owner_ids=owner_ids, is_closed=False
         )

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -500,6 +500,7 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_case_ids_in_domain(domain, type_=None):
+        warn("DEPRECATED", DeprecationWarning)
         return CaseAccessorSQL._get_case_ids_in_domain(domain, case_type=type_)
 
     @staticmethod
@@ -532,14 +533,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def _get_case_ids_in_domain(domain, case_type=None, owner_ids=None, is_closed=None, deleted=False):
-        owner_ids = list(owner_ids) if owner_ids else None
-        with CommCareCase.get_plproxy_cursor(readonly=True) as cursor:
-            cursor.execute(
-                'SELECT case_id FROM get_case_ids_in_domain(%s, %s, %s, %s, %s)',
-                [domain, case_type, owner_ids, is_closed, deleted]
-            )
-            results = fetchall_as_namedtuple(cursor)
-            return [result.case_id for result in results]
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCase.objects._get_case_ids_in_domain(domain, case_type, owner_ids, is_closed, deleted)
 
     @staticmethod
     def get_related_indices(domain, case_ids, exclude_indices):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -475,9 +475,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_most_recent_form_transaction(case_id):
-        return CaseTransaction.objects.partitioned_query(case_id).filter(case_id=case_id, revoked=False).annotate(
-            type_filter=F('type').bitand(CaseTransaction.TYPE_FORM)
-        ).filter(type_filter=CaseTransaction.TYPE_FORM).order_by("-server_date").first()
+        warn("DEPRECATED", DeprecationWarning)
+        return CaseTransaction.objects.get_most_recent_form_transaction(case_id)
 
     @staticmethod
     def get_transactions_by_type(case_id, transaction_type):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -470,12 +470,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_transaction_by_form_id(case_id, form_id):
-        transactions = list(CaseTransaction.objects.plproxy_raw(
-            'SELECT * from get_case_transaction_by_form_id(%s, %s)',
-            [case_id, form_id])
-        )
-        assert len(transactions) <= 1
-        return transactions[0] if transactions else None
+        warn("DEPRECATED", DeprecationWarning)
+        return CaseTransaction.objects.get_transaction_by_form_id(case_id, form_id)
 
     @staticmethod
     def get_most_recent_form_transaction(case_id):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -490,12 +490,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def case_has_transactions_since_sync(case_id, sync_log_id, sync_log_date):
-        with CaseTransaction.get_plproxy_cursor(readonly=True) as cursor:
-            cursor.execute(
-                'SELECT case_has_transactions_since_sync(%s, %s, %s)', [case_id, sync_log_id, sync_log_date]
-            )
-            result = cursor.fetchone()[0]
-            return result
+        warn("DEPRECATED", DeprecationWarning)
+        return CaseTransaction.objects.case_has_transactions_since_sync(case_id, sync_log_id, sync_log_date)
 
     @staticmethod
     def get_case_by_location(domain, location_id):

--- a/corehq/form_processor/backends/sql/supply.py
+++ b/corehq/form_processor/backends/sql/supply.py
@@ -1,6 +1,5 @@
 from corehq.apps.commtrack.helpers import make_supply_point
 from corehq.apps.locations.models import SQLLocation
-from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.models import CommCareCase
 
 
@@ -19,7 +18,7 @@ class SupplyPointSQL:
 
     @staticmethod
     def get_closed_and_open_by_location_id_and_domain(domain, location_id):
-        return CaseAccessorSQL.get_case_by_location(domain, location_id)
+        return CommCareCase.objects.get_case_by_location(domain, location_id)
 
     @staticmethod
     def get_supply_point_ids_by_location(domain):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -51,16 +51,7 @@ class CaseAccessors(object):
         return self.db_accessor.get_case_ids_in_domain(self.domain, type)
 
     def get_case_ids_by_owners(self, owner_ids, closed=None):
-        """
-        get case_ids for open, closed, or all cases in a domain
-        that belong to a list of owner_ids
-
-        owner_ids: a list of owner ids to filter on.
-            A case matches if it belongs to any of them.
-        closed: True (only closed cases), False (only open cases), or None (all)
-
-        returns a list of case_ids
-        """
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.get_case_ids_in_domain_by_owners(self.domain, owner_ids, closed=closed)
 
     def get_open_case_ids_for_owner(self, owner_id):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -88,9 +88,6 @@ class CaseAccessors(object):
     def get_last_modified_dates(self, case_ids):
         return self.db_accessor.get_last_modified_dates(self.domain, case_ids)
 
-    def get_closed_case_ids_for_owner(self, owner_id):
-        return self.db_accessor.get_closed_case_ids_for_owner(self.domain, owner_id)
-
     def get_all_reverse_indices_info(self, case_ids):
         warn("DEPRECATED use CommCareCaseIndex.objects", DeprecationWarning)
         return self.db_accessor.get_all_reverse_indices_info(self.domain, case_ids)

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -47,6 +47,7 @@ class CaseAccessors(object):
         return self.db_accessor.get_case_xform_ids(case_id)
 
     def get_case_ids_in_domain(self, type=None):
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.get_case_ids_in_domain(self.domain, type)
 
     def get_case_ids_by_owners(self, owner_ids, closed=None):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -54,9 +54,6 @@ class CaseAccessors(object):
         warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.get_case_ids_in_domain_by_owners(self.domain, owner_ids, closed=closed)
 
-    def get_open_case_ids_for_owner(self, owner_id):
-        return self.db_accessor.get_open_case_ids_for_owner(self.domain, owner_id)
-
     def get_open_case_ids_in_domain_by_type(self, case_type, owner_ids=None):
         return self.db_accessor.get_open_case_ids_in_domain_by_type(self.domain, case_type, owner_ids)
 

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -118,6 +118,7 @@ class CaseAccessors(object):
         return self.db_accessor.soft_undelete_cases(self.domain, case_ids)
 
     def get_deleted_case_ids_by_owner(self, owner_id):
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.get_deleted_case_ids_by_owner(self.domain, owner_id)
 
     def get_extension_chain(self, case_ids, include_closed=True, exclude_for_case_type=None):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -55,6 +55,7 @@ class CaseAccessors(object):
         return self.db_accessor.get_case_ids_in_domain_by_owners(self.domain, owner_ids, closed=closed)
 
     def get_open_case_ids_in_domain_by_type(self, case_type, owner_ids=None):
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.get_open_case_ids_in_domain_by_type(self.domain, case_type, owner_ids)
 
     def get_related_indices(self, case_ids, exclude_indices):

--- a/corehq/form_processor/management/commands/list_data_by_shard.py
+++ b/corehq/form_processor/management/commands/list_data_by_shard.py
@@ -1,8 +1,7 @@
 from collections import Counter
 from django.core.management.base import BaseCommand
 from corehq.form_processor.backends.sql.dbaccessors import ShardAccessor
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models import CommCareCase, XFormInstance
 
 
 class Command(BaseCommand):
@@ -25,7 +24,7 @@ class Command(BaseCommand):
             print('{}\t{}\t{}'.format(form_id, shard_id, dbname))
         print('\n======================== cases ========================')
         print('id\t\t\t\t\tshard\tdatabase')
-        for case_id in sorted(CaseAccessors(domain=domain).get_case_ids_in_domain()):
+        for case_id in sorted(CommCareCase.objects.get_case_ids_in_domain(domain)):
             shard_id, dbname = ShardAccessor.get_shard_id_and_database_for_doc(case_id)
             cases_by_shard[shard_id] += 1
             cases_by_db[dbname] += 1

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -102,6 +102,9 @@ class CommCareCaseManager(RequireDBManager):
     def get_deleted_case_ids_in_domain(self, domain):
         return self._get_case_ids_in_domain(domain, deleted=True)
 
+    def get_deleted_case_ids_by_owner(self, domain, owner_id):
+        return self._get_case_ids_in_domain(domain, owner_ids=[owner_id], deleted=True)
+
     def get_case_ids_in_domain_by_owners(self, domain, owner_ids, closed=None, case_type=None):
         """
         get case_ids for open, closed, or all cases in a domain

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -102,6 +102,20 @@ class CommCareCaseManager(RequireDBManager):
     def get_deleted_case_ids_in_domain(self, domain):
         return self._get_case_ids_in_domain(domain, deleted=True)
 
+    def get_case_ids_in_domain_by_owners(self, domain, owner_ids, closed=None, case_type=None):
+        """
+        get case_ids for open, closed, or all cases in a domain
+        that belong to a list of owner_ids
+
+        owner_ids: a list of owner ids to filter on.
+            A case matches if it belongs to any of them.
+        closed: True (only closed cases), False (only open cases), or None (all)
+
+        returns a list of case_ids
+        """
+        return self._get_case_ids_in_domain(
+            domain, case_type=case_type, owner_ids=owner_ids, is_closed=closed)
+
     def _get_case_ids_in_domain(self, domain, case_type=None, owner_ids=None, is_closed=None, deleted=False):
         owner_ids = list(owner_ids) if owner_ids else None
         with self.model.get_plproxy_cursor(readonly=True) as cursor:

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -99,6 +99,9 @@ class CommCareCaseManager(RequireDBManager):
     def get_case_ids_in_domain(self, domain, type=None):
         return self._get_case_ids_in_domain(domain, case_type=type)
 
+    def get_deleted_case_ids_in_domain(self, domain):
+        return self._get_case_ids_in_domain(domain, deleted=True)
+
     def _get_case_ids_in_domain(self, domain, case_type=None, owner_ids=None, is_closed=None, deleted=False):
         owner_ids = list(owner_ids) if owner_ids else None
         with self.model.get_plproxy_cursor(readonly=True) as cursor:

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -123,6 +123,15 @@ class CommCareCaseManager(RequireDBManager):
             attach_prefetch_models(cases_by_id, indices, 'case_id', 'cached_indices')
         return cases
 
+    def get_case_by_location(self, domain, location_id):
+        try:
+            return self.plproxy_raw(
+                'SELECT * from get_case_by_location_id(%s, %s)',
+                [domain, location_id]
+            )[0]
+        except IndexError:
+            return None
+
     def hard_delete_cases(self, domain, case_ids):
         """Permanently delete cases in domain
 

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -99,6 +99,10 @@ class CommCareCaseManager(RequireDBManager):
     def get_case_ids_in_domain(self, domain, type=None):
         return self._get_case_ids_in_domain(domain, case_type=type)
 
+    def get_open_case_ids_in_domain_by_type(self, domain, case_type, owner_ids=None):
+        return self._get_case_ids_in_domain(
+            domain, case_type=case_type, owner_ids=owner_ids, is_closed=False)
+
     def get_deleted_case_ids_in_domain(self, domain):
         return self._get_case_ids_in_domain(domain, deleted=True)
 

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -96,6 +96,18 @@ class CommCareCaseManager(RequireDBManager):
                           .values_list('case_id', flat=True))
         return result
 
+    def get_case_ids_in_domain(self, domain, type=None):
+        return self._get_case_ids_in_domain(domain, case_type=type)
+
+    def _get_case_ids_in_domain(self, domain, case_type=None, owner_ids=None, is_closed=None, deleted=False):
+        owner_ids = list(owner_ids) if owner_ids else None
+        with self.model.get_plproxy_cursor(readonly=True) as cursor:
+            cursor.execute(
+                'SELECT case_id FROM get_case_ids_in_domain(%s, %s, %s, %s, %s)',
+                [domain, case_type, owner_ids, is_closed, deleted]
+            )
+            return [row[0] for row in cursor]
+
     def get_case_xform_ids(self, case_id):
         with self.model.get_plproxy_cursor(readonly=True) as cursor:
             cursor.execute(

--- a/corehq/form_processor/tests/test_case_dbaccessor.py
+++ b/corehq/form_processor/tests/test_case_dbaccessor.py
@@ -467,15 +467,6 @@ class CaseAccessorTestsSQL(TestCase):
         )
         self.assertEqual(set(case_ids), set([case1.case_id, case3.case_id]))
 
-    def test_get_closed_case_ids(self):
-        case1 = _create_case(user_id="user1")  # noqa: F841
-        case2 = _create_case(user_id="user1")
-        case3 = _create_case(user_id="user2")  # noqa: F841
-        case2.closed = True
-        CaseAccessorSQL.save_case(case2)
-
-        self.assertEqual(CaseAccessorSQL.get_closed_case_ids_for_owner(DOMAIN, "user1"), [case2.case_id])
-
     def test_get_open_case_ids_in_domain_by_type(self):
         case1 = _create_case(user_id="user1", case_type='t1')
         case2 = _create_case(user_id="user1", case_type='t1')

--- a/corehq/form_processor/tests/test_case_dbaccessor.py
+++ b/corehq/form_processor/tests/test_case_dbaccessor.py
@@ -467,19 +467,10 @@ class CaseAccessorTestsSQL(TestCase):
         )
         self.assertEqual(set(case_ids), set([case1.case_id, case3.case_id]))
 
-    def test_get_open_case_ids(self):
-        case1 = _create_case(user_id="user1")
-        case2 = _create_case(user_id="user1")
-        case3 = _create_case(user_id="user2")
-        case2.closed = True
-        CaseAccessorSQL.save_case(case2)
-
-        self.assertEqual(CaseAccessorSQL.get_open_case_ids_for_owner(DOMAIN, "user1"), [case1.case_id])
-
     def test_get_closed_case_ids(self):
-        case1 = _create_case(user_id="user1")
+        case1 = _create_case(user_id="user1")  # noqa: F841
         case2 = _create_case(user_id="user1")
-        case3 = _create_case(user_id="user2")
+        case3 = _create_case(user_id="user2")  # noqa: F841
         case2.closed = True
         CaseAccessorSQL.save_case(case2)
 

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -164,6 +164,18 @@ class TestCommCareCaseManager(BaseCaseManagerTest):
         deleted = CommCareCase.objects.get_deleted_case_ids_in_domain(DOMAIN)
         self.assertEqual(deleted, [case1.case_id])
 
+    def test_get_deleted_case_ids_by_owner(self):
+        from ..backends.sql.dbaccessors import CaseAccessorSQL
+        user_id = uuid.uuid4().hex
+        case1 = _create_case(user_id=user_id)
+        case2 = _create_case(user_id=user_id)
+        _create_case(user_id=user_id)
+
+        CaseAccessorSQL.soft_delete_cases(DOMAIN, [case1.case_id, case2.case_id])
+
+        case_ids = CommCareCase.objects.get_deleted_case_ids_by_owner(DOMAIN, user_id)
+        self.assertEqual(set(case_ids), {case1.case_id, case2.case_id})
+
     def test_get_case_ids_in_domain_by_owners(self):
         case1 = _create_case(user_id="user1")
         case2 = _create_case(user_id="user1")

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -152,6 +152,19 @@ class TestCommCareCaseManager(BaseCaseManagerTest):
         case_ids = CommCareCase.objects.get_case_ids_in_domain(DOMAIN)
         self.assertEqual({case1.case_id, case3.case_id}, set(case_ids))
 
+    def test_get_open_case_ids_in_domain_by_type(self):
+        case1 = _create_case(user_id="user1", case_type='t1')
+        case2 = _create_case(user_id="user1", case_type='t1')
+        _create_case(user_id="user1", case_type='t1', closed=True)
+        _create_case(user_id="user2", case_type='t1')
+        _create_case(user_id="user1", case_type='t2')
+
+        case_ids = CommCareCase.objects.get_open_case_ids_in_domain_by_type(DOMAIN, 't1', ["user1"])
+        self.assertEqual(
+            set(case_ids),
+            {case1.case_id, case2.case_id}
+        )
+
     def test_get_deleted_case_ids_in_domain(self):
         from ..backends.sql.dbaccessors import CaseAccessorSQL
         case1 = _create_case()

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -479,6 +479,14 @@ class TestCaseTransactionManager(BaseCaseManagerTest):
         self.assertEqual({t.form_id for t in transactions}, {form_id} | form_ids)
         self.assertEqual(4, len(transactions))
 
+    def test_case_has_transactions_since_sync(self):
+        case1 = _create_case()
+        _create_case_transactions(case1)
+        self.assertTrue(CaseTransaction.objects.case_has_transactions_since_sync(
+            case1.case_id, "foo", datetime(1992, 1, 30)))
+        self.assertFalse(CaseTransaction.objects.case_has_transactions_since_sync(
+            case1.case_id, "foo", datetime.utcnow()))
+
 
 def _create_case(domain=DOMAIN, form_id=None, case_type=None, user_id='user1', closed=False, case_id=None):
     """Create case and related models directly (not via form processor)

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.db import router
 from django.test import TestCase
 
+from corehq.apps.commtrack.const import SUPPLY_POINT_CASE_TYPE
 from corehq.form_processor.backends.sql.processor import FormProcessorSQL
 from corehq.form_processor.exceptions import AttachmentNotFound, CaseNotFound, CaseSaveError
 from corehq.form_processor.interfaces.processor import ProcessedForms
@@ -124,6 +125,15 @@ class TestCommCareCaseManager(BaseCaseManagerTest):
         bambi.save(with_tracked_models=True)
         cases = CommCareCase.objects.get_reverse_indexed_cases(DOMAIN, referenced_case_ids, is_closed=True)
         self.assertEqual([c.case_id for c in cases], [bambi.case_id])
+
+    def test_get_case_by_location(self):
+        case = _create_case(case_type=SUPPLY_POINT_CASE_TYPE)
+        location_id = uuid.uuid4().hex
+        case.location_id = location_id
+        case.save(with_tracked_models=True)
+
+        fetched_case = CommCareCase.objects.get_case_by_location(DOMAIN, location_id)
+        self.assertEqual(case.id, fetched_case.id)
 
     def test_save_case_update_index(self):
         case = _create_case()

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -470,6 +470,15 @@ class TestCaseTransactionManager(BaseCaseManagerTest):
         # still second_form_id since the newest one is revoked
         self.assertEqual(transaction.form_id, second_form_id)
 
+    def test_get_transactions_for_case_rebuild(self):
+        form_id = uuid.uuid4().hex
+        case = _create_case(form_id=form_id)
+        form_ids = _create_case_transactions(case)
+
+        transactions = CaseTransaction.objects.get_transactions_for_case_rebuild(case.case_id)
+        self.assertEqual({t.form_id for t in transactions}, {form_id} | form_ids)
+        self.assertEqual(4, len(transactions))
+
 
 def _create_case(domain=DOMAIN, form_id=None, case_type=None, user_id='user1', closed=False, case_id=None):
     """Create case and related models directly (not via form processor)

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -412,6 +412,17 @@ class TestCaseTransactionManager(BaseCaseManagerTest):
         self.assertEqual({t.form_id for t in transactions}, {form_id} | form_ids)
         self.assertEqual(len(transactions), 6)
 
+    def test_get_transaction_by_form_id(self):
+        form_id = uuid.uuid4().hex
+        case = _create_case(form_id=form_id)
+
+        transaction = CaseTransaction.objects.get_transaction_by_form_id(case.case_id, form_id)
+        self.assertEqual(form_id, transaction.form_id)
+        self.assertEqual(case.case_id, transaction.case_id)
+
+        transaction = CaseTransaction.objects.get_transaction_by_form_id(case.case_id, 'wrong')
+        self.assertIsNone(transaction)
+
 
 def _create_case(domain=DOMAIN, form_id=None, case_type=None, user_id='user1', closed=False, case_id=None):
     """Create case and related models directly (not via form processor)

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -164,6 +164,29 @@ class TestCommCareCaseManager(BaseCaseManagerTest):
         deleted = CommCareCase.objects.get_deleted_case_ids_in_domain(DOMAIN)
         self.assertEqual(deleted, [case1.case_id])
 
+    def test_get_case_ids_in_domain_by_owners(self):
+        case1 = _create_case(user_id="user1")
+        case2 = _create_case(user_id="user1")
+        _create_case(user_id="user2")
+        case4 = _create_case(user_id="user3")
+
+        case_ids = CommCareCase.objects.get_case_ids_in_domain_by_owners(DOMAIN, ["user1", "user3"])
+        self.assertEqual(set(case_ids), set([case1.case_id, case2.case_id, case4.case_id]))
+
+    def test_get_case_ids_in_domain_by_owners_closed(self):
+        case1 = _create_case(user_id="user1")
+        case2 = _create_case(user_id="user1", closed=True)
+        case3 = _create_case(user_id="user2")
+        case4 = _create_case(user_id="user3", closed=True)
+
+        case_ids = CommCareCase.objects.get_case_ids_in_domain_by_owners(
+            DOMAIN, ["user1", "user3"], closed=True)
+        self.assertEqual(set(case_ids), set([case2.case_id, case4.case_id]))
+
+        case_ids = CommCareCase.objects.get_case_ids_in_domain_by_owners(
+            DOMAIN, ["user1", "user2", "user3"], closed=False)
+        self.assertEqual(set(case_ids), set([case1.case_id, case3.case_id]))
+
     def test_save_case_update_index(self):
         case = _create_case()
 

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -152,6 +152,18 @@ class TestCommCareCaseManager(BaseCaseManagerTest):
         case_ids = CommCareCase.objects.get_case_ids_in_domain(DOMAIN)
         self.assertEqual({case1.case_id, case3.case_id}, set(case_ids))
 
+    def test_get_deleted_case_ids_in_domain(self):
+        from ..backends.sql.dbaccessors import CaseAccessorSQL
+        case1 = _create_case()
+        case2 = _create_case()
+        CaseAccessorSQL.soft_delete_cases(DOMAIN, [case1.case_id])
+
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(DOMAIN)
+        self.assertEqual(case_ids, [case2.case_id])
+
+        deleted = CommCareCase.objects.get_deleted_case_ids_in_domain(DOMAIN)
+        self.assertEqual(deleted, [case1.case_id])
+
     def test_save_case_update_index(self):
         case = _create_case()
 

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -135,6 +135,23 @@ class TestCommCareCaseManager(BaseCaseManagerTest):
         fetched_case = CommCareCase.objects.get_case_by_location(DOMAIN, location_id)
         self.assertEqual(case.id, fetched_case.id)
 
+    def test_get_case_ids_in_domain(self):
+        case1 = _create_case(case_type='t1')
+        case2 = _create_case(case_type='t1')
+        case3 = _create_case(case_type='t2')
+
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(DOMAIN)
+        self.assertEqual({case1.case_id, case2.case_id, case3.case_id}, set(case_ids))
+
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(DOMAIN, 't1')
+        self.assertEqual({case1.case_id, case2.case_id}, set(case_ids))
+
+        case2.domain = 'new_domain'
+        case2.save(with_tracked_models=True)
+
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(DOMAIN)
+        self.assertEqual({case1.case_id, case3.case_id}, set(case_ids))
+
     def test_save_case_update_index(self):
         case = _create_case()
 

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -12,10 +12,9 @@ from corehq.sql_db.util import get_db_alias_for_partitioned_doc
 from corehq.util.test_utils import trap_extra_setup
 
 from ..backends.sql.processor import FormProcessorSQL
-from ..backends.sql.dbaccessors import CaseAccessorSQL
 from ..exceptions import AttachmentNotFound, XFormNotFound
 from ..interfaces.processor import ProcessedForms
-from ..models import XFormInstance, XFormOperation
+from ..models import CaseTransaction, XFormInstance, XFormOperation
 from ..tests.utils import FormProcessorTestUtils, create_form_for_test, sharded
 from ..parsers.form import apply_deprecation
 from ..utils import get_simple_form_xml, get_simple_wrapped_form
@@ -220,7 +219,7 @@ class XFormInstanceManagerTest(TestCase):
         self.assertEqual(XFormInstance.NORMAL, form.state)
         self.assertEqual(0, len(form.history))
 
-        transactions = CaseAccessorSQL.get_transactions(case_id)
+        transactions = CaseTransaction.objects.get_transactions(case_id)
         self.assertEqual(1, len(transactions))
         self.assertFalse(transactions[0].revoked)
 
@@ -234,7 +233,7 @@ class XFormInstanceManagerTest(TestCase):
             self.assertEqual(form.form_id, operations[i].form_id)
             self.assertEqual('user1', operations[i].user_id)
 
-            transactions = CaseAccessorSQL.get_transactions(case_id)
+            transactions = CaseTransaction.objects.get_transactions(case_id)
             self.assertEqual(1, len(transactions), transactions)
             self.assertTrue(transactions[0].revoked)
 
@@ -248,7 +247,7 @@ class XFormInstanceManagerTest(TestCase):
             self.assertEqual(form.form_id, operations[i].form_id)
             self.assertEqual('user2', operations[i].user_id)
 
-            transactions = CaseAccessorSQL.get_transactions(case_id)
+            transactions = CaseTransaction.objects.get_transactions(case_id)
             self.assertEqual(1, len(transactions))
             self.assertFalse(transactions[0].revoked)
 

--- a/corehq/form_processor/tests/test_ledgers.py
+++ b/corehq/form_processor/tests/test_ledgers.py
@@ -6,9 +6,9 @@ from django.test import TestCase
 from casexml.apps.case.mock import CaseFactory, CaseBlock
 from corehq.apps.commtrack.helpers import make_product
 from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL, LedgerAccessorSQL
+from corehq.form_processor.backends.sql.dbaccessors import LedgerAccessorSQL
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.models import CommCareCase, LedgerTransaction
+from corehq.form_processor.models import CaseTransaction, CommCareCase, LedgerTransaction
 from corehq.form_processor.parsers.ledgers.helpers import UniqueLedgerReference
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
 
@@ -166,7 +166,7 @@ class LedgerTests(TestCase):
         self._assert_ledger_state(100)
         case = CommCareCase.objects.get_case(self.case.case_id, DOMAIN)
         self.assertEqual("1", case.dynamic_case_properties()['a'])
-        transactions = CaseAccessorSQL.get_transactions(self.case.case_id)
+        transactions = CaseTransaction.objects.get_transactions(self.case.case_id)
         self.assertEqual(2, len(transactions))
         self.assertTrue(transactions[0].is_form_transaction)
         # ordering not guaranteed since they have the same date
@@ -214,7 +214,7 @@ class LedgerTests(TestCase):
 
         self._assert_ledger_state(100)
 
-        transactions = CaseAccessorSQL.get_transactions(self.case.case_id)
+        transactions = CaseTransaction.objects.get_transactions(self.case.case_id)
         self.assertEqual(2, len(transactions))
         self.assertTrue(transactions[0].is_form_transaction)
         self.assertTrue(transactions[1].is_form_transaction)
@@ -228,7 +228,7 @@ class LedgerTests(TestCase):
 
         self._assert_ledger_state(0)
 
-        transactions = CaseAccessorSQL.get_transactions(self.case.case_id)
+        transactions = CaseTransaction.objects.get_transactions(self.case.case_id)
         self.assertEqual(3, len(transactions))
         self.assertTrue(transactions[0].is_form_transaction)
         # ordering not guaranteed since they have the same date
@@ -250,7 +250,7 @@ class LedgerTests(TestCase):
 
         self._assert_ledger_state(100)
 
-        transactions = CaseAccessorSQL.get_transactions(self.case.case_id)
+        transactions = CaseTransaction.objects.get_transactions(self.case.case_id)
         self.assertEqual(2, len(transactions))
         self.assertTrue(transactions[0].is_form_transaction)
         self.assertTrue(transactions[1].is_form_transaction)
@@ -264,7 +264,7 @@ class LedgerTests(TestCase):
 
         self._assert_ledger_state(50)
 
-        transactions = CaseAccessorSQL.get_transactions(self.case.case_id)
+        transactions = CaseTransaction.objects.get_transactions(self.case.case_id)
         self.assertEqual(2, len(transactions))
         self.assertTrue(transactions[0].is_form_transaction)
         self.assertTrue(transactions[1].is_form_transaction)

--- a/corehq/form_processor/tests/test_reprocess_errors.py
+++ b/corehq/form_processor/tests/test_reprocess_errors.py
@@ -11,10 +11,7 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.products.models import SQLProduct
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.exceptions import CaseNotFound, XFormNotFound
-from corehq.form_processor.interfaces.dbaccessors import (
-    CaseAccessors,
-    LedgerAccessors,
-)
+from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.form_processor.reprocess import (
     reprocess_form,
@@ -116,7 +113,6 @@ class ReprocessSubmissionStubTests(TestCase):
         super(ReprocessSubmissionStubTests, self).setUp()
         self.factory = CaseFactory(domain=self.domain)
         self.formdb = XFormInstance.objects
-        self.casedb = CaseAccessors(self.domain)
         self.ledgerdb = LedgerAccessors(self.domain)
 
     def tearDown(self):
@@ -146,12 +142,12 @@ class ReprocessSubmissionStubTests(TestCase):
         self.assertIsNone(error_forms[0].orig_id)
         self.assertEqual(error_forms[0].form_id, stubs[0].xform_id)
 
-        self.assertEqual(0, len(self.casedb.get_case_ids_in_domain()))
+        self.assertEqual(0, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
 
         result = reprocess_unfinished_stub(stubs[0])
         self.assertEqual(1, len(result.cases))
 
-        case_ids = self.casedb.get_case_ids_in_domain()
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(self.domain)
         self.assertEqual(1, len(case_ids))
         self.assertEqual(case_id, case_ids[0])
 
@@ -380,7 +376,6 @@ class TestReprocessDuringSubmission(TestCase):
         super(TestReprocessDuringSubmission, self).setUp()
         self.factory = CaseFactory(domain=self.domain)
         self.formdb = XFormInstance.objects
-        self.casedb = CaseAccessors(self.domain)
         self.ledgerdb = LedgerAccessors(self.domain)
 
     def tearDown(self):

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -14,8 +14,7 @@ from casexml.apps.phone.models import SyncLogSQL
 from corehq.blobs import CODES
 from corehq.blobs.models import BlobMeta
 from corehq.form_processor.backends.sql.dbaccessors import (
-    CaseAccessorSQL, LedgerAccessorSQL, LedgerReindexAccessor,
-    iter_all_rows)
+    LedgerAccessorSQL, LedgerReindexAccessor, iter_all_rows)
 from corehq.form_processor.backends.sql.processor import FormProcessorSQL
 from corehq.form_processor.interfaces.processor import ProcessedForms
 from corehq.form_processor.models import XFormInstance, CommCareCase, CaseTransaction, Attachment
@@ -60,7 +59,7 @@ class FormProcessorTestUtils(object):
             for ledger in iter_all_rows(LedgerReindexAccessor()):
                 _delete_ledgers_for_case(ledger.case_id)
         else:
-            for case_id in CaseAccessorSQL.get_case_ids_in_domain(domain):
+            for case_id in CommCareCase.objects.get_case_ids_in_domain(domain):
                 _delete_ledgers_for_case(case_id)
 
     @classmethod

--- a/corehq/messaging/management/commands/run_rule.py
+++ b/corehq/messaging/management/commands/run_rule.py
@@ -1,5 +1,4 @@
 from corehq.apps.data_interfaces.models import AutomaticUpdateRule
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.messaging.scheduling.util import utcnow
 from corehq.messaging.tasks import get_sync_key
@@ -34,7 +33,7 @@ class Command(BaseCommand):
         rule = self.get_rule(options['domain'], options['rule_id'])
 
         print("Fetching case ids...")
-        case_ids = CaseAccessors(rule.domain).get_case_ids_in_domain(rule.case_type)
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(rule.domain, rule.case_type)
         case_id_chunks = list(chunked(case_ids, 10))
 
         for case_id_chunk in with_progress_bar(case_id_chunks):

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -85,9 +85,8 @@ from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.cachehq.mixins import QuickCachedDocumentMixin
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.exceptions import XFormNotFound
-from corehq.form_processor.models import CommCareCase, XFormInstance
+from corehq.form_processor.models import CaseTransaction, CommCareCase, XFormInstance
 from corehq.motech.const import (
     ALGO_AES,
     BASIC_AUTH,
@@ -794,7 +793,7 @@ class DataRegistryCaseUpdateRepeater(CreateCaseRepeater):
         if host_index and host_index.referenced_type in self.white_listed_case_types:
             return False
 
-        transaction = CaseAccessorSQL.get_most_recent_form_transaction(payload.case_id)
+        transaction = CaseTransaction.objects.get_most_recent_form_transaction(payload.case_id)
         if transaction:
             # prevent chaining updates
             return transaction.xmlns != DataRegistryCaseUpdatePayloadGenerator.XMLNS

--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -8,7 +8,6 @@ from casexml.apps.case.mock import CaseBlock
 from dimagi.utils.chunked import chunked
 
 from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 
 
@@ -46,13 +45,13 @@ class Command(CaseUpdateCommand):
         ).as_xml()).decode('utf-8')
 
     def update_cases(self, domain, case_type, user_id):
-        accessor = CaseAccessors(domain)
         location_id = self.extra_options['location']
         if location_id is None:
             case_ids = []
             print("Warning: no active location was entered")
         else:
-            case_ids = accessor.get_open_case_ids_in_domain_by_type(case_type, owner_ids=[location_id])
+            case_ids = CommCareCase.objects.get_open_case_ids_in_domain_by_type(
+                domain, case_type, owner_ids=[location_id])
 
         case_blocks = []
         errors = []

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -6,7 +6,6 @@ from casexml.apps.case.mock import CaseBlock
 from dimagi.utils.chunked import chunked
 
 from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 
 '''This command has an optional argument '--location' that will exclude all cases with that location. If the
@@ -55,8 +54,7 @@ class Command(CaseUpdateCommand):
 
     def update_cases(self, domain, case_type, user_id):
         inactive_location = self.extra_options['inactive_location']
-        accessor = CaseAccessors(domain)
-        case_ids = accessor.get_case_ids_in_domain(case_type)
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(domain, case_type)
         print(f"Found {len(case_ids)} {case_type} cases in {domain}")
         traveler_location_id = self.extra_options['location']
 

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -3,7 +3,7 @@ from django.core.management.base import BaseCommand
 from corehq.apps.linked_domain.dbaccessors import get_linked_domains
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.apps.users.util import username_to_user_id
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 
 
 class CaseUpdateCommand(BaseCommand):
@@ -23,8 +23,7 @@ class CaseUpdateCommand(BaseCommand):
         raise NotImplementedError()
 
     def find_case_ids_by_type(self, domain, case_type):
-        accessor = CaseAccessors(domain)
-        case_ids = accessor.get_case_ids_in_domain(case_type)
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(domain, case_type)
         print(f"Found {len(case_ids)} {case_type} cases in {domain}")
         return case_ids
 

--- a/custom/covid/tests/test_custom_rules.py
+++ b/custom/covid/tests/test_custom_rules.py
@@ -12,7 +12,6 @@ from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import normalize_username
 from corehq.elastic import get_es_new, send_to_elasticsearch
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
@@ -44,8 +43,6 @@ class DeactivatedMobileWorkersTest(BaseCaseRuleTest):
         self.mobile_worker = CommCareUser.create(self.domain, username, "123", None, None)
         sync_usercases(self.mobile_worker, self.domain)
 
-        self.case_accessor = CaseAccessors(self.domain)
-
     def tearDown(self):
         FormProcessorTestUtils.delete_all_cases()
         delete_all_users()
@@ -66,7 +63,7 @@ class DeactivatedMobileWorkersTest(BaseCaseRuleTest):
         return checkin_case
 
     def close_all_usercases(self):
-        usercase_ids = self.case_accessor.get_case_ids_in_domain(type=USERCASE_TYPE)
+        usercase_ids = CommCareCase.objects.get_case_ids_in_domain(self.domain, USERCASE_TYPE)
         for usercase_id in usercase_ids:
             CaseFactory(self.domain).close_case(usercase_id)
             usercase = CommCareCase.objects.get_case(usercase_id, self.domain)

--- a/custom/inddex/example_data/data.py
+++ b/custom/inddex/example_data/data.py
@@ -16,7 +16,6 @@ from corehq.apps.userreports.models import StaticDataSourceConfiguration
 from corehq.apps.userreports.tasks import rebuild_indicators
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import format_username
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.toggles import BULK_UPLOAD_DATE_OPENED, NAMESPACE_DOMAIN
 from corehq.util.couch import IterDB
@@ -61,7 +60,7 @@ def _import_case_type(domain, case_type, csv_filename, user):
 
 def _update_case_id_properties(domain, user):
     """Some case properties store the ID of related cases.  This updates those IDs"""
-    case_ids = CaseAccessors(domain).get_case_ids_in_domain()
+    case_ids = CommCareCase.objects.get_case_ids_in_domain(domain)
     cases = CommCareCase.objects.get_cases(case_ids, domain)
     case_ids_by_external_id = {c.external_id: c.case_id for c in cases}
 

--- a/custom/inddex/tests/test_master_report.py
+++ b/custom/inddex/tests/test_master_report.py
@@ -15,7 +15,6 @@ import custom.inddex.reports.r4_nutrient_stats
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.fixtures.dbaccessors import get_fixture_data_types
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.util.test_utils import require_db_context
 
@@ -51,7 +50,7 @@ def get_expected_report(filename):
 
 def _overwrite_report(filename, actual_report):
     """For use when making changes - force overwrites test data"""
-    case_ids = CaseAccessors(DOMAIN).get_case_ids_in_domain()
+    case_ids = CommCareCase.objects.get_case_ids_in_domain(DOMAIN)
     external_ids_by_case_id = {c.case_id: c.external_id
         for c in CommCareCase.objects.get_cases(case_ids)}
     rows = [[
@@ -91,7 +90,7 @@ def get_food_data(*args, **kwargs):
 
 @memoized
 def _get_case_ids_by_external_id():
-    case_ids = CaseAccessors(DOMAIN).get_case_ids_in_domain()
+    case_ids = CommCareCase.objects.get_case_ids_in_domain(DOMAIN)
     return {c.external_id: c.case_id for c in CommCareCase.objects.get_cases(case_ids)}
 
 
@@ -106,7 +105,7 @@ def food_names(rows):
 
 class TestSetupUtils(TestCase):
     def test_cases_created(self):
-        case_ids = CaseAccessors(DOMAIN).get_case_ids_in_domain()
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(DOMAIN)
         cases = CommCareCase.objects.get_cases(case_ids)
 
         self.assertEqual(len(cases), 18)

--- a/custom/onse/tasks.py
+++ b/custom/onse/tasks.py
@@ -17,7 +17,6 @@ from dimagi.utils.chunked import chunked
 
 from corehq.apps.domain.dbaccessors import domain_exists
 from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.motech.models import ConnectionSettings
 from corehq.util.soft_assert import soft_assert
@@ -163,8 +162,7 @@ def get_dhis2_server(
 
 
 def get_clays() -> Iterable[CassiusMarcellus]:
-    case_accessors = CaseAccessors(DOMAIN)
-    for case_id in case_accessors.get_case_ids_in_domain(type=CASE_TYPE):
+    for case_id in CommCareCase.objects.get_case_ids_in_domain(DOMAIN, CASE_TYPE):
         case = CommCareCase.objects.get_case(case_id, DOMAIN)
         if not case.external_id:
             # This case is not mapped to a facility in DHIS2.

--- a/docs/forms_and_cases.rst
+++ b/docs/forms_and_cases.rst
@@ -102,7 +102,7 @@ name in order to know which DB needs to be queried.
 - CommCareCase.objects.get_case(case_id, domain)
 - CommCareCase.objects.get_cases(case_ids, domain)
 - CommCareCase.objects.iter_cases(case_ids, domain)
-- CaseAccessors(domain).get_case_ids_in_domain(type='dog')
+- CommCareCase.objects.get_case_ids_in_domain(domain, type='dog')
 
 **Ledgers**
 


### PR DESCRIPTION
Continuation of https://github.com/dimagi/commcare-hq/pull/31051, https://github.com/dimagi/commcare-hq/pull/31060, and https://github.com/dimagi/commcare-hq/pull/31065

Case accessor methods are moving into `CommCareCase.objects` (which is `CommCareCaseManager`) or the relevant model manager that makes the most sense. `CaseAccessor(s|SQL)` will eventually be removed.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

In addition to preserving all of the old tests and adapting the old methods that are being phased out to call the new method, new tests (copies of the old tests adapted to the new structure) are being added for the new model manager.

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
