### PR TITLE
Add nose support for TestCase.addClassCleanup

### DIFF
--- a/corehq/tests/noseplugins/classcleanup.py
+++ b/corehq/tests/noseplugins/classcleanup.py
@@ -1,0 +1,29 @@
+"""Call TestCase.doClassCleanups after each test"""
+from nose.plugins import Plugin
+
+
+class ClassCleanupPlugin(Plugin):
+    """Call TestCase.doClassCleanups after running tests on a test class
+
+    Nose overrides the part of the default Python test suite runner
+    that normally calls TestCase.doClassCleanups(). This plugin ensures
+    that it gets called.
+    """
+
+    name = "classcleanup"
+    enabled = True
+
+    def options(self, parser, env):
+        """Do not call super (always enabled)"""
+
+    def handleError(self, test, err):
+        if getattr(test, "error_context", None) in {"setup", "teardown"}:
+            self._do_class_cleanups(test.context)
+
+    def stopContext(self, context):
+        self._do_class_cleanups(context)
+
+    def _do_class_cleanups(self, context):
+        cleanup = getattr(context, "doClassCleanups", None)
+        if cleanup is not None:
+            cleanup()

--- a/corehq/tests/test_classcleanup.py
+++ b/corehq/tests/test_classcleanup.py
@@ -1,0 +1,142 @@
+from functools import wraps
+from unittest import TestCase
+
+from nose.plugins import PluginTester
+from testil import eq
+
+from .noseplugins import classcleanup as mod
+
+
+class TestClassCleanupPlugin(PluginTester, TestCase):
+    activate = ''  # Activate option not needed. Plugin is always enabled.
+    plugins = [mod.ClassCleanupPlugin()]
+
+    def setUp(self):
+        pass  # super().setUp() is called by self.run_with_errors(...)
+
+    def makeSuite(self):
+        class Test(TestCase):
+            @classmethod
+            @maybe_error(self)
+            def setUpClass(cls):
+                cls.addClassCleanup(lambda: self.result.append("cleanup"))
+
+            @maybe_error(self)
+            def setUp(self):
+                pass
+
+            @maybe_error(self)
+            def runTest(self):
+                pass
+
+            @maybe_error(self)
+            def tearDown(self):
+                pass
+
+            @classmethod
+            @maybe_error(self)
+            def tearDownClass(cls):
+                pass
+
+        return [Test()]
+
+    def run_with_errors(self, *errors, error_class=Exception):
+        self.errors = errors
+        self.result = []
+        self.error_class = error_class
+        super().setUp()
+
+    def test_cleanup_in_happy_path(self):
+        self.run_with_errors()
+        eq(self.result, [
+            "setUpClass",
+            "setUp",
+            "runTest",
+            "tearDown",
+            "tearDownClass",
+            "cleanup",
+        ])
+
+    def test_cleanup_on_error_in_set_up_class(self):
+        self.run_with_errors("setUpClass")
+        eq(self.result, [
+            "setUpClass Exception",
+            "cleanup"
+        ])
+
+    def test_cleanup_on_error_in_set_up(self):
+        self.run_with_errors("setUp")
+        eq(self.result, [
+            "setUpClass",
+            "setUp Exception",
+            "tearDownClass",
+            "cleanup",
+        ])
+
+    def test_cleanup_on_error_in_test(self):
+        self.run_with_errors("runTest")
+        eq(self.result, [
+            "setUpClass",
+            "setUp",
+            "runTest Exception",
+            "tearDown",
+            "tearDownClass",
+            "cleanup",
+        ])
+
+    def test_cleanup_on_test_fail(self):
+        self.run_with_errors("runTest", error_class=AssertionError)
+        eq(self.result, [
+            "setUpClass",
+            "setUp",
+            "runTest AssertionError",
+            "tearDown",
+            "tearDownClass",
+            "cleanup",
+        ])
+
+    def test_cleanup_on_error_in_tearDown(self):
+        self.run_with_errors("tearDown")
+        eq(self.result, [
+            "setUpClass",
+            "setUp",
+            "runTest",
+            "tearDown Exception",
+            "tearDownClass",
+            "cleanup",
+        ])
+
+    def test_cleanup_on_error_in_tearDownClass(self):
+        self.run_with_errors("tearDownClass")
+        eq(self.result, [
+            "setUpClass",
+            "setUp",
+            "runTest",
+            "tearDown",
+            "tearDownClass Exception",
+            "cleanup",
+        ])
+
+    def test_cleanup_on_error_in_tearDown_and_tearDownClass(self):
+        self.run_with_errors("tearDown", "tearDownClass")
+        eq(self.result, [
+            "setUpClass",
+            "setUp",
+            "runTest",
+            "tearDown Exception",
+            "tearDownClass Exception",
+            "cleanup",
+        ])
+
+
+def maybe_error(test):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(self):
+            func(self)
+            test.result.append(func.__name__)
+            if func.__name__ in test.errors:
+                test.result[-1] += f" {test.error_class.__name__}"
+                raise test.error_class
+        return wrapper
+    return decorator

--- a/corehq/tests/test_classcleanup.py
+++ b/corehq/tests/test_classcleanup.py
@@ -30,7 +30,7 @@ class TestClassCleanupPlugin(PluginTester, TestCase):
             @classmethod
             @log_call_and_maybe_error
             def setUpClass(cls):
-                cls.addClassCleanup(self.call_log.append, "cleanup")
+                cls.addClassCleanup(self.call_log.append, "classCleanup")
 
             @log_call_and_maybe_error
             def setUp(self):
@@ -65,14 +65,14 @@ class TestClassCleanupPlugin(PluginTester, TestCase):
             "runTest",
             "tearDown",
             "tearDownClass",
-            "cleanup",
+            "classCleanup",
         ])
 
     def test_cleanup_on_error_in_set_up_class(self):
         self.run_with_errors("setUpClass")
         eq(self.call_log, [
             "setUpClass Exception",
-            "cleanup"
+            "classCleanup"
         ])
 
     def test_cleanup_on_error_in_set_up(self):
@@ -81,7 +81,7 @@ class TestClassCleanupPlugin(PluginTester, TestCase):
             "setUpClass",
             "setUp Exception",
             "tearDownClass",
-            "cleanup",
+            "classCleanup",
         ])
 
     def test_cleanup_on_error_in_test(self):
@@ -92,7 +92,7 @@ class TestClassCleanupPlugin(PluginTester, TestCase):
             "runTest Exception",
             "tearDown",
             "tearDownClass",
-            "cleanup",
+            "classCleanup",
         ])
 
     def test_cleanup_on_test_fail(self):
@@ -103,7 +103,7 @@ class TestClassCleanupPlugin(PluginTester, TestCase):
             "runTest AssertionError",
             "tearDown",
             "tearDownClass",
-            "cleanup",
+            "classCleanup",
         ])
 
     def test_cleanup_on_error_in_tearDown(self):
@@ -114,7 +114,7 @@ class TestClassCleanupPlugin(PluginTester, TestCase):
             "runTest",
             "tearDown Exception",
             "tearDownClass",
-            "cleanup",
+            "classCleanup",
         ])
 
     def test_cleanup_on_error_in_tearDownClass(self):
@@ -125,7 +125,7 @@ class TestClassCleanupPlugin(PluginTester, TestCase):
             "runTest",
             "tearDown",
             "tearDownClass Exception",
-            "cleanup",
+            "classCleanup",
         ])
 
     def test_cleanup_on_error_in_tearDown_and_tearDownClass(self):
@@ -136,5 +136,5 @@ class TestClassCleanupPlugin(PluginTester, TestCase):
             "runTest",
             "tearDown Exception",
             "tearDownClass Exception",
-            "cleanup",
+            "classCleanup",
         ])

--- a/testsettings.py
+++ b/testsettings.py
@@ -23,6 +23,7 @@ NOSE_ARGS = [
 ]
 NOSE_PLUGINS = [
     'corehq.tests.nose.HqTestFinderPlugin',
+    'corehq.tests.noseplugins.classcleanup.ClassCleanupPlugin',
     'corehq.tests.noseplugins.dividedwerun.DividedWeRunPlugin',
     'corehq.tests.noseplugins.djangomigrations.DjangoMigrationsPlugin',
     'corehq.tests.noseplugins.cmdline_params.CmdLineParametersPlugin',


### PR DESCRIPTION
Since Python 3.8, `TestCase` has a new [`addClassCleanup(...)` method](https://docs.python.org/3.9/library/unittest.html#unittest.TestCase.addClassCleanup), which can be used in `setUpClass` to register cleanup functions. Unfortunately nosetests overrides the part of Python's test suite runner that normally calls `TestCase.doClassCleanups()`. This adds a plugin that calls it at the proper times.

FYI @dimagi/team-commcare-hq 

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

Tests that use `addClassCleanup` should be updated to not use that since it will not be called if this is reverted.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
