### PR TITLE
Removed the safe filter from userreports templates

### DIFF
--- a/corehq/apps/hqwebapp/tests/utils/test_html.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_html.py
@@ -1,0 +1,43 @@
+from django.test import SimpleTestCase
+
+from django.utils.safestring import SafeString
+from django.utils.html import format_html
+
+from ...utils.html import safe_replace
+
+
+class SafeReplaceTests(SimpleTestCase):
+    def test_replacement_is_html_safe(self):
+        def replace_fun(token):
+            return 'replaced'
+
+        result = safe_replace(r'Hello', replace_fun, 'Hello World')
+        self.assertIsInstance(result, SafeString)
+
+    def test_no_matches_returns_full_string(self):
+        def noop(match):
+            return match.group()
+
+        result = safe_replace(r'gibberishPattern', noop, 'Hello World')
+        self.assertEqual(result, 'Hello World')
+
+    def test_replacement_is_escaped(self):
+        def replace_fun(match):
+            return f'<{match.group()}>'
+
+        result = safe_replace(r'Hello', replace_fun, 'Hello World')
+        self.assertEqual(result, '&lt;Hello&gt; World')
+
+    def test_sanitized_replacement_is_left_alone(self):
+        def replace_fun(match):
+            return format_html('<{}>', match.group())
+
+        result = safe_replace(r'Hello', replace_fun, 'Hello World')
+        self.assertEqual(result, '<Hello> World')
+
+    def test_replacement_is_applied_globally(self):
+        def replace_fun(match):
+            return 'replaced'
+
+        result = safe_replace(r'Hello', replace_fun, 'Hello 1 Hello 2 Hello 3 Hello')
+        self.assertEqual(result, 'replaced 1 replaced 2 replaced 3 replaced')

--- a/corehq/apps/hqwebapp/utils/html.py
+++ b/corehq/apps/hqwebapp/utils/html.py
@@ -1,0 +1,23 @@
+import re
+from django.utils.html import format_html_join
+
+
+def safe_replace(pattern, replace_fun, raw_string):
+    """
+    Runs all matches found in raw_string through replace_fun, ensuring that all parts of this
+    new string are sanitized for HTML display
+    """
+    current_index = 0
+    tokens = []
+    for match in re.finditer(pattern, raw_string):
+        previous_chars = raw_string[current_index:match.start()]
+        if previous_chars:
+            tokens.append(previous_chars)
+        tokens.append(replace_fun(match))
+        current_index = match.end()
+
+    remainder = raw_string[current_index:]
+    if remainder:
+        tokens.append(remainder)
+
+    return format_html_join('', '{}', ((token,) for token in tokens))

--- a/corehq/apps/userreports/templates/userreports/report_error.html
+++ b/corehq/apps/userreports/templates/userreports/report_error.html
@@ -3,14 +3,14 @@
 {% load i18n %}
 {% load compress %}
 
-{% block title %}{{ report.title|default:"Project Reports"|safe }}{% endblock %}
+{% block title %}{{ report.title|default:"Project Reports" }}{% endblock %}
 
 {% block page_title %}{% endblock %}
 
 {% block page_content %}
   {% block report_alerts %}
     <div id="report-error" class="alert alert-danger">
-      <p>{{ error_message|safe }}</p>
+      <p>{{ error_message }}</p>
       {% if details %}
         <p>{% trans "Technical Details:" %}</p>
         {{ details }}

--- a/corehq/apps/userreports/templates/userreports/summary_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/summary_data_source.html
@@ -32,7 +32,7 @@
       <tr>
         <td>{{ indicator.column_id }}</td>
         <td>{{ indicator.comment }}</td>
-        <td><pre>{{ indicator.readable_output|safe }}</pre></td>
+        <td><pre>{{ indicator.readable_output }}</pre></td>
       </tr>
     {% endfor %}
   </table>
@@ -52,7 +52,7 @@
       <tr>
         <td id="{{ named_expression_prefix }}:{{ expression.name }}">{{ expression.name }}</td>
         <td>{{ expression.comment }}</td>
-        <td><pre>{{ expression.readable_output|safe }}</pre></td>
+        <td><pre>{{ expression.readable_output }}</pre></td>
       </tr>
     {% endfor %}
   </table>

--- a/corehq/apps/userreports/templates/userreports/summary_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/summary_data_source.html
@@ -72,7 +72,7 @@
       <tr>
         <td id="{{ named_filter_prefix }}:{{ filter.name }}">{{ filter.name }}</td>
         <td>{{ filter.comment }}</td>
-        <td><pre>{{ filter.readable_output|safe }}</pre></td>
+        <td><pre>{{ filter.readable_output }}</pre></td>
       </tr>
     {% endfor %}
   </table>

--- a/corehq/apps/userreports/tests/test_views.py
+++ b/corehq/apps/userreports/tests/test_views.py
@@ -1,0 +1,17 @@
+from django.test import SimpleTestCase
+from django.utils.safestring import SafeString
+
+from ..views import NamedExpressionHighlighter
+
+
+class NamedExpressionHighlighterTests(SimpleTestCase):
+    def test_normal_text_has_no_changes(self):
+        self.assertEqual(NamedExpressionHighlighter.highlight_links('normalText'), 'normalText')
+
+    def test_named_filter_is_highlighted(self):
+        highlighted = NamedExpressionHighlighter.highlight_links('NamedFilter:abc')
+        self.assertHTMLEqual(highlighted, '<a href="#NamedFilter:abc">NamedFilter:abc</a>')
+
+    def test_result_is_html_safe(self):
+        highlighted = NamedExpressionHighlighter.highlight_links('NamedFilter:abc')
+        self.assertIsInstance(highlighted, SafeString)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -16,6 +16,7 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from django.views.decorators.http import require_POST
 from django.views.generic import View
+from django.utils.html import format_html
 
 import six.moves.urllib.error
 import six.moves.urllib.parse
@@ -65,6 +66,7 @@ from corehq.apps.hqwebapp.decorators import (
 )
 from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
+from corehq.apps.hqwebapp.utils.html import safe_replace
 from corehq.apps.linked_domain.models import DomainLink, ReportLinkDetail
 from corehq.apps.linked_domain.ucr import create_linked_ucr, linked_downstream_reports_by_domain
 from corehq.apps.linked_domain.util import is_linked_report
@@ -1521,9 +1523,9 @@ class DataSourceSummaryView(BaseUserConfigReportsView):
         return {
             'datasource_display_name': self.config.display_name,
             'filter_summary': self.configured_filter_summary(),
-            'indicator_summary': self._add_links_to_output(self.indicator_summary()),
-            'named_expression_summary': self._add_links_to_output(self.named_expression_summary()),
-            'named_filter_summary': self._add_links_to_output(self.named_filter_summary()),
+            'indicator_summary': self.indicator_summary(),
+            'named_expression_summary': self.named_expression_summary(),
+            'named_filter_summary': self.named_filter_summary(),
             'named_filter_prefix': NAMED_FILTER_PREFIX,
             'named_expression_prefix': NAMED_EXPRESSION_PREFIX,
         }
@@ -1538,7 +1540,7 @@ class DataSourceSummaryView(BaseUserConfigReportsView):
             {
                 "column_id": wrapped.column_id,
                 "comment": wrapped.comment,
-                "readable_output": wrapped.readable_output(context)
+                "readable_output": NamedExpressionHighlighter.highlight_links(wrapped.readable_output(context))
             }
             for wrapped in wrapped_specs if wrapped
         ]
@@ -1548,7 +1550,7 @@ class DataSourceSummaryView(BaseUserConfigReportsView):
             {
                 "name": name,
                 "comment": self.config.named_expressions[name].get('comment'),
-                "readable_output": str(exp)
+                "readable_output": NamedExpressionHighlighter.highlight_links(str(exp))
             }
             for name, exp in self.config.named_expression_objects.items()
         ]
@@ -1558,7 +1560,7 @@ class DataSourceSummaryView(BaseUserConfigReportsView):
             {
                 "name": name,
                 "comment": self.config.named_filters[name].get('comment'),
-                "readable_output": str(filter)
+                "readable_output": NamedExpressionHighlighter.highlight_links(str(filter))
             }
             for name, filter in self.config.named_filter_objects.items()
         ]
@@ -1567,21 +1569,23 @@ class DataSourceSummaryView(BaseUserConfigReportsView):
         return str(FilterFactory.from_spec(self.config.configured_filter,
                                            context=self.config.get_factory_context()))
 
-    def _add_links_to_output(self, items):
-        def make_link(match):
-            value = match.group()
-            return '<a href="#{value}">{value}</a>'.format(value=value)
 
-        def add_links(content):
-            content = re.sub(r"{}:[A-Za-z0-9_-]+".format(NAMED_FILTER_PREFIX), make_link, content)
-            content = re.sub(r"{}:[A-Za-z0-9_-]+".format(NAMED_EXPRESSION_PREFIX), make_link, content)
-            return content
+class NamedExpressionHighlighter:
+    # NOTE: This might be worth looking into the intent on the name after the prefix
+    # this looks like it could be simplified as [\w-], but that allows other word characters for non-ASCII
+    # inputs that might change existing behavior
+    NAMED_FILTER_PATTERN = f'{NAMED_FILTER_PREFIX}:[A-Za-z0-9_-]+'
+    NAMED_EXPRESSION_PATTERN = f'{NAMED_EXPRESSION_PREFIX}:[A-Za-z0-9_-]+'
 
-        list = []
-        for i in items:
-            i['readable_output'] = add_links(i.get('readable_output'))
-            list.append(i)
-        return list
+    @classmethod
+    def highlight_links(cls, content):
+        pattern = f'{cls.NAMED_FILTER_PATTERN}|{cls.NAMED_EXPRESSION_PATTERN}'
+        return safe_replace(pattern, cls._make_link, content)
+
+    @classmethod
+    def _make_link(cls, match):
+        value = match.group()
+        return format_html('<a href="#{value}">{value}</a>', value=value)
 
 
 @domain_admin_required


### PR DESCRIPTION
## Technical Summary
Part of [the 'safe' filter removal](https://dimagi-dev.atlassian.net/browse/SAAS-12098). I split this one out, as it's a bit more involved -- we were replacing all instances of a given pattern with links, which necessitated some variant of `safe` so that the links displayed correctly. To restrict the scope of that safety, I wrote a few utilities so that the replacement could be handled as before, and only the link markup would be considered safe.

## Safety Assurance

### Safety story
Confirmed this was safe by doing local and unit testing

### Automated test coverage

Test suite for the new replacement utility in `test_html`. Test suite for how this integrates into the existing userreports output in `test_views`

### QA Plan
No QA necessary.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
