### PR TITLE
add non blocking case rate limits

### DIFF
--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -67,6 +67,45 @@ global_submission_rate_limiter = RateLimiter(
 )
 
 
+global_case_rate_limiter = RateLimiter(
+    feature_key='global_case_updates',
+    get_rate_limits=lambda: get_dynamic_rate_definition(
+        'global_case_updates',
+        default=RateDefinition(
+            per_hour=170000,
+            per_minute=4000,
+            per_second=300,
+        )
+    ).get_rate_limits(),
+    scope_length=0,
+)
+
+
+def _get_per_user_case_rate_definition(domain):
+    return PerUserRateDefinition(
+        per_user_rate_definition=get_dynamic_rate_definition(
+            'case_updates_per_user',
+            default=get_standard_ratio_rate_definition(events_per_day=460),
+        ),
+        constant_rate_definition=get_dynamic_rate_definition(
+            'baseline_case_updates_per_project',
+            default=RateDefinition(
+                per_week=1000,
+                per_day=500,
+                per_hour=300,
+                per_minute=100,
+                per_second=10,
+            ),
+        ),
+    ).get_rate_limits(domain)
+
+
+domain_case_rate_limiter = RateLimiter(
+    feature_key='domain_case_updates',
+    get_rate_limits=lambda domain: _get_per_user_case_rate_definition(domain)
+)
+
+
 SHOULD_RATE_LIMIT_SUBMISSIONS = settings.RATE_LIMIT_SUBMISSIONS and not settings.UNIT_TESTING
 
 
@@ -76,11 +115,15 @@ SHOULD_RATE_LIMIT_SUBMISSIONS = settings.RATE_LIMIT_SUBMISSIONS and not settings
 def rate_limit_submission(domain, delay_rather_than_reject=False, max_wait=15):
     if TEST_FORM_SUBMISSION_RATE_LIMIT_RESPONSE.enabled(domain):
         return True
-    should_allow_usage = (
+    allow_form_usage = (
         global_submission_rate_limiter.allow_usage()
         or submission_rate_limiter.allow_usage(domain))
 
-    if should_allow_usage:
+    allow_case_usage = (
+        global_case_rate_limiter.allow_usage()
+        or case_rate_limiter.allow_usage(domain))
+
+    if allow_form_usage:
         allow_usage = True
     elif DO_NOT_RATE_LIMIT_SUBMISSIONS.enabled(domain):
         # If we're disabling rate limiting on a domain then allow it
@@ -94,6 +137,10 @@ def rate_limit_submission(domain, delay_rather_than_reject=False, max_wait=15):
             domain, max_wait=max_wait, delay_rather_than_reject=delay_rather_than_reject,
             datadog_metric='commcare.xform_submissions.rate_limited')
 
+    if allow_form_usage and not allow_case_usage:
+        _delay_and_report_rate_limit_submission(
+            domain, max_wait=max_wait, delay_rather_than_reject=delay_rather_than_reject,
+            datadog_metric='commcare.case_updates.rate_limited.test')
     return not allow_usage
 
 
@@ -104,6 +151,11 @@ def report_submission_usage(domain):
     submission_rate_limiter.report_usage(domain)
     global_submission_rate_limiter.report_usage()
     _report_current_global_submission_thresholds()
+
+
+def report_case_usage(domain, num_cases):
+    global_case_rate_limiter.report_usage(delta=num_cases)
+    domain_case_rate_limiter.report_usage(scope=domain, delta=num_cases)
 
 
 def _delay_and_report_rate_limit_submission(domain, max_wait, delay_rather_than_reject, datadog_metric):

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -18,7 +18,7 @@ from casexml.apps.phone.restore_caching import AsyncRestoreTaskIdCache, RestoreP
 import couchforms
 from casexml.apps.case.exceptions import PhoneDateValueError, IllegalCaseId, UsesReferrals, InvalidCaseIndex, \
     CaseValueError
-from corehq.apps.receiverwrapper.rate_limiter import report_submission_usage
+from corehq.apps.receiverwrapper.rate_limiter import report_case_usage, report_submission_usage
 from corehq.const import OPENROSA_VERSION_3
 from corehq.middleware import OPENROSA_VERSION_HEADER
 from corehq.toggles import ASYNC_RESTORE, SUMOLOGIC_LOGS, NAMESPACE_OTHER
@@ -328,7 +328,7 @@ class SubmissionPost(object):
                             openrosa_kwargs['error_nature'] = ResponseNature.POST_PROCESSING_FAILURE
                         cases = case_stock_result.case_models
                         ledgers = case_stock_result.stock_result.models_to_save
-
+                        report_case_usage(domain, len(cases))
                         openrosa_kwargs['success_message'] = self._get_success_message(instance, cases=cases)
                 elif instance.is_error:
                     submission_type = 'error'

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -328,7 +328,7 @@ class SubmissionPost(object):
                             openrosa_kwargs['error_nature'] = ResponseNature.POST_PROCESSING_FAILURE
                         cases = case_stock_result.case_models
                         ledgers = case_stock_result.stock_result.models_to_save
-                        report_case_usage(domain, len(cases))
+                        report_case_usage(self.domain, len(cases))
                         openrosa_kwargs['success_message'] = self._get_success_message(instance, cases=cases)
                 elif instance.is_error:
                     submission_type = 'error'


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This adds basic rate limiting for case transactions (as triggered by forms). I set the limits to 10x the form ones, which I think are probably way too high (if form limits aren't being hit, it would be shocking if these case limits are), but I wanted to open this now for review on the approach itself. It is heavily coupled to the existing form limits, being part of the same check. It functions similarly to the limits in place for system forms and exempted domains, in that it will not block submission, just potentially delay it, and most importantly send info to datadog when that occurs.

I will add tests before we merge, but didn't want review to have to wait on them.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This has no user facing effects (just sends a metric when the limit is hit), with a one line modification to form processing code, which itself is heavily tested.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
