### PR TITLE
properly set Access-Control-Allow-Methods in CORS headers

### DIFF
--- a/corehq/apps/api/cors.py
+++ b/corehq/apps/api/cors.py
@@ -3,9 +3,12 @@
 ACCESS_CONTROL_ALLOW = 'Allow'
 ACCESS_CONTROL_ALLOW_HEADERS = 'Access-Control-Allow-Headers'
 ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin'
+ACCESS_CONTROL_ALLOW_METHODS = 'Access-Control-Allow-Methods'
 
 
-def add_cors_headers_to_response(response):
+def add_cors_headers_to_response(response, allow_methods=None):
     response[ACCESS_CONTROL_ALLOW_ORIGIN] = '*'
     response[ACCESS_CONTROL_ALLOW_HEADERS] = 'Content-Type, Authorization'
+    if allow_methods:
+        response[ACCESS_CONTROL_ALLOW_METHODS] = allow_methods
     return response

--- a/corehq/apps/api/cors.py
+++ b/corehq/apps/api/cors.py
@@ -6,7 +6,7 @@ ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin'
 ACCESS_CONTROL_ALLOW_METHODS = 'Access-Control-Allow-Methods'
 
 
-def add_cors_headers_to_response(response, allow_methods=None):
+def add_cors_headers_to_response(response, allow_methods: str = ''):
     response[ACCESS_CONTROL_ALLOW_ORIGIN] = '*'
     response[ACCESS_CONTROL_ALLOW_HEADERS] = 'Content-Type, Authorization'
     if allow_methods:

--- a/corehq/apps/api/decorators.py
+++ b/corehq/apps/api/decorators.py
@@ -35,8 +35,9 @@ def allow_cors(allowed_methods):
         def wrapped_view(request, *args, **kwargs):
             if request.method == "OPTIONS":
                 response = HttpResponse()
-                response[ACCESS_CONTROL_ALLOW] = ', '.join(allowed_methods)
-                return add_cors_headers_to_response(response)
+                allowed_methods_header_value = ', '.join(allowed_methods)
+                response[ACCESS_CONTROL_ALLOW] = allowed_methods_header_value
+                return add_cors_headers_to_response(response, allowed_methods_header_value)
             response = view_func(request, *args, **kwargs)
             if request.method in allowed_methods:
                 add_cors_headers_to_response(response)

--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -72,11 +72,10 @@ class CorsResourceMixin(object):
             allowed = []
 
         request_method = request.method.lower()
-        allows = ','.join([x.upper() for x in allowed if x])
-
+        allows = ', '.join([x.upper() for x in allowed if x])
         if request_method == 'options':
             response = HttpResponse(allows)
-            add_cors_headers_to_response(response)
+            add_cors_headers_to_response(response, allows)
             response['Allow'] = allows
             raise ImmediateHttpResponse(response=response)
 

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -5,7 +5,8 @@ from django.http import HttpResponseForbidden, HttpResponse
 from django.test import SimpleTestCase, TestCase, RequestFactory
 from unittest.mock import patch
 
-from corehq.apps.api.cors import ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_ALLOW, ACCESS_CONTROL_ALLOW_HEADERS
+from corehq.apps.api.cors import ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_ALLOW, ACCESS_CONTROL_ALLOW_HEADERS, \
+    ACCESS_CONTROL_ALLOW_METHODS
 from corehq.apps.api.decorators import allow_cors
 from corehq.apps.domain.decorators import _login_or_challenge, api_auth
 from corehq.apps.domain.shortcuts import create_domain
@@ -270,4 +271,5 @@ class AllowCORSDecoratorTest(TestCase):
     def test_options(self):
         response = allow_cors(['POST'])(sample_view_with_response)(RequestFactory().options('/foobar/'))
         self._assert_cors(response)
+        self.assertEqual(response[ACCESS_CONTROL_ALLOW_METHODS], 'POST, OPTIONS')
         self.assertEqual(response[ACCESS_CONTROL_ALLOW], 'POST, OPTIONS')


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Allows APIs that support non-"simple" methods (anything that isn't a GET HEAD or POST) to be used with CORS.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

I believe this should have always been in place. We set the `Allow` header already, just not the CORS-specific one. [Allow is not relevant to CORS](https://fetch.spec.whatwg.org/#http-responses)

I came across this trying to get a cross-origin PUT request to work and seeing it rejected. This fixes it.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

I tested with cross-origin GET and PUT requests locally and verified this fixed the problem. I'm a bit confused how this hasn't come up already (perhaps no one has tried to use cross-origin for anything other than simple GET and POST?).

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

I'm uncertain if there is coverage for this. I did not add any.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

I'm comfortable going without QA once I have completed local testing.

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
