### PR TITLE
Add an API for UCR data sources

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -769,6 +769,26 @@ class DataSourceConfigurationResource(CouchResourceMixin, HqBaseResource, Domain
         domain = kwargs['domain']
         return get_datasources_for_domain(domain)
 
+    def obj_update(self, bundle, **kwargs):
+        domain = kwargs['domain']
+        pk = kwargs['pk']
+        try:
+            data_source = get_document_or_404(DataSourceConfiguration, domain, pk)
+        except Http404 as e:
+            raise NotFound(str(e))
+        allowed_update_fields = [
+            'display_name',
+            'configured_filter',
+            'configured_indicators',
+        ]
+        for key, value in bundle.data.items():
+            if key in allowed_update_fields:
+                print(f'setting {key} to {value}')
+                data_source[key] = value
+        data_source.save()
+        bundle.obj = data_source
+        return bundle
+
     def detail_uri_kwargs(self, bundle_or_obj):
         return {
             'domain': get_obj(bundle_or_obj).domain,
@@ -777,8 +797,9 @@ class DataSourceConfigurationResource(CouchResourceMixin, HqBaseResource, Domain
 
     class Meta(CustomResourceMeta):
         resource_name = 'ucr_data_source'
-        list_allowed_methods = ["get"]
-        detail_allowed_methods = ["get"]
+        list_allowed_methods = ['get']
+        detail_allowed_methods = ['get', 'put']
+        always_return_data = True
         paginator_class = DoesNothingPaginator
 
 

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -801,6 +801,7 @@ class DataSourceConfigurationResource(CouchResourceMixin, HqBaseResource, Domain
         detail_allowed_methods = ['get', 'put']
         always_return_data = True
         paginator_class = DoesNothingPaginator
+        authentication = RequirePermissionAuthentication(Permissions.edit_ucrs)
 
 
 UserDomain = namedtuple('UserDomain', 'domain_name project_name')

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -23,6 +23,7 @@ from phonelog.models import DeviceReportEntry
 
 from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.apps.api.cors import add_cors_headers_to_response
 from corehq.apps.api.odata.serializers import (
     ODataCaseSerializer,
     ODataFormSerializer,
@@ -103,7 +104,6 @@ from . import (
     v0_4,
 )
 from .pagination import DoesNothingPaginator, NoCountingPaginator
-
 
 MOCK_BULK_USER_ES = None
 
@@ -760,10 +760,14 @@ class DataSourceConfigurationResource(CouchResourceMixin, HqBaseResource, Domain
 
     def _ensure_toggle_enabled(self, request):
         if not toggles.USER_CONFIGURABLE_REPORTS.enabled_for_request(request):
-            raise ImmediateHttpResponse(HttpResponse(
-                json.dumps({"error": _("You don't have permission to access this API")}),
-                content_type="application/json",
-                status=401)
+            raise ImmediateHttpResponse(
+                add_cors_headers_to_response(
+                    HttpResponse(
+                        json.dumps({"error": _("You don't have permission to access this API")}),
+                        content_type="application/json",
+                        status=401,
+                    )
+                )
             )
 
     def obj_get(self, bundle, **kwargs):
@@ -801,10 +805,15 @@ class DataSourceConfigurationResource(CouchResourceMixin, HqBaseResource, Domain
             data_source.validate()
             data_source.save()
         except BadSpecError as e:
-            raise ImmediateHttpResponse(HttpResponse(
-                json.dumps({"error": _("Invalid data source! Details: {details}").format(details=str(e))}),
-                content_type="application/json",
-                status=500))
+            raise ImmediateHttpResponse(
+                add_cors_headers_to_response(
+                    HttpResponse(
+                        json.dumps({"error": _("Invalid data source! Details: {details}").format(details=str(e))}),
+                        content_type="application/json",
+                        status=500,
+                    )
+                )
+            )
         bundle.obj = data_source
         return bundle
 

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -752,9 +752,9 @@ class DataSourceConfigurationResource(CouchResourceMixin, HqBaseResource, Domain
     API resource for DataSourceConfigurations (UCR data sources)
     """
     id = fields.CharField(attribute='get_id', readonly=True, unique=True)
-    display_name = fields.CharField(attribute="display_name", readonly=True, null=True)
-    configured_filter = fields.DictField(attribute="configured_filter", readonly=True, use_in='detail')
-    configured_indicators = fields.ListField(attribute="configured_indicators", readonly=True, use_in='detail')
+    display_name = fields.CharField(attribute="display_name", null=True)
+    configured_filter = fields.DictField(attribute="configured_filter", use_in='detail')
+    configured_indicators = fields.ListField(attribute="configured_indicators", use_in='detail')
 
     def obj_get(self, bundle, **kwargs):
         domain = kwargs['domain']

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -73,6 +73,7 @@ API_LIST = (
         locations.v0_5.LocationTypeResource,
         v0_5.SimpleReportConfigurationResource,
         v0_5.ConfigurableReportDataResource,
+        v0_5.DataSourceConfigurationResource,
         DomainForms,
         DomainCases,
         DomainUsernames,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Adds a new API that exposes UCR data source data (the JSON configurations, not the data itself). Including the ability to write back certain fields from the API.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Related to work that will be described better in https://github.com/dimagi/dashboard-oauth-poc/pull/1/

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

UCR.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

It's a new API and it only exposes configuration objects, so it seems relatively safe, though the ability to modify UCR data sources does expose a fair number of possible risks (e.g. bypassing our existing validation). I haven't thought hard about how or whether these should be mitigated and plan to look a little closer to convince myself that the API does at a minimum the same thing the UI does.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

There aren't any tests. I can add them if it feels important, though it's not obviously high-value since at the moment the API is a pretty standard tastypie implementation.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not proposing any manual QA.

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
