### PR TITLE
Move case accessors into CommCareCase.objects - part 5

### DIFF
--- a/corehq/apps/callcenter/tests/test_location_owners.py
+++ b/corehq/apps/callcenter/tests/test_location_owners.py
@@ -8,7 +8,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.models import LocationType
 from corehq.apps.locations.tests.util import make_loc
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 
 TEST_DOMAIN = "cc-location-owner-test-domain"
 CASE_TYPE = "cc-case-type"
@@ -109,5 +109,5 @@ class CallCenterLocationOwnerTest(TestCase):
         self.domain.save()
 
     def assertCallCenterCaseOwner(self, owner_id):
-        case = CaseAccessors(TEST_DOMAIN).get_case_by_domain_hq_user_id(self.user._id, CASE_TYPE)
+        case = CommCareCase.objects.get_case_by_external_id(TEST_DOMAIN, self.user._id, CASE_TYPE)
         self.assertEqual(case.owner_id, owner_id)

--- a/corehq/apps/case_importer/tests/test_util.py
+++ b/corehq/apps/case_importer/tests/test_util.py
@@ -1,0 +1,73 @@
+from django.conf import settings
+from django.test import TestCase
+
+from corehq.form_processor.tests.test_cases import _create_case
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
+from corehq.sql_db.tests.utils import new_id_in_different_dbalias
+
+from .. import util
+from ..const import LookupErrors
+
+DOMAIN = 'test-case-importer-utils'
+
+
+class Unexpected(Exception):
+    pass
+
+
+@sharded
+class TestImporterUtils(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.case1 = _create_case(DOMAIN, case_id='c1', case_type='t1', external_id='123')
+        cls.case2 = _create_case('d2', case_id='c2', case_type='t2', external_id='123')
+        if settings.USE_PARTITIONED_DATABASE:
+            cls.addClassCleanup(cls.case1.delete)
+            cls.addClassCleanup(cls.case2.delete)
+
+    @classmethod
+    def tearDownClass(cls):
+        if settings.USE_PARTITIONED_DATABASE:
+            FormProcessorTestUtils.delete_all_sql_forms(DOMAIN)
+            FormProcessorTestUtils.delete_all_sql_forms('d2')
+        super().tearDownClass()
+
+    def test_lookup_case_with_case_id(self):
+        result = util.lookup_case("case_id", "c1", DOMAIN, "t1")
+        self.checkResult(result, self.case1, None)
+
+    def test_lookup_case_with_case_id_and_wrong_type(self):
+        result = util.lookup_case("case_id", "c1", DOMAIN, "t2")
+        self.checkResult(result, None, LookupErrors.NotFound)
+
+    def test_lookup_case_with_unknown_case_id(self):
+        result = util.lookup_case("case_id", "unknown", DOMAIN, "t2")
+        self.checkResult(result, None, LookupErrors.NotFound)
+
+    def test_lookup_case_with_external_id(self):
+        result = util.lookup_case(util.EXTERNAL_ID, "123", DOMAIN, "t1")
+        self.checkResult(result, self.case1, None)
+
+    def test_lookup_case_with_external_id_and_wrong_type(self):
+        result = util.lookup_case(util.EXTERNAL_ID, "123", DOMAIN, "t2")
+        self.checkResult(result, None, LookupErrors.NotFound)
+
+    def test_lookup_case_with_unknown_external_id(self):
+        result = util.lookup_case(util.EXTERNAL_ID, "unknown", DOMAIN, "t1")
+        self.checkResult(result, None, LookupErrors.NotFound)
+
+    def test_lookup_case_with_multiple_results(self):
+        case3_id = new_id_in_different_dbalias(self.case1.case_id)  # raises SkipTest on non-sharded db
+        case3 = _create_case(DOMAIN, case_id=case3_id, case_type='t1', external_id='123')
+        self.addCleanup(case3.delete)
+
+        result = util.lookup_case(util.EXTERNAL_ID, "123", DOMAIN, "t1")
+        self.checkResult(result, None, LookupErrors.MultipleResults)
+
+    def checkResult(self, result, case, code):
+        def get_case_id(case):
+            return None if case is None else case.case_id
+        rcase, rcode = result
+        self.assertEqual((get_case_id(rcase), rcode), (get_case_id(case), code))

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -17,7 +17,6 @@ from corehq.apps.case_importer.exceptions import (
     ImporterRefError,
 )
 from corehq.form_processor.exceptions import CaseNotFound
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.util.workbook_reading import (
     SpreadsheetFileEncrypted,
@@ -146,7 +145,6 @@ def lookup_case(search_field, search_id, domain, case_type):
     error code (if there was an error in lookup).
     """
     found = False
-    case_accessors = CaseAccessors(domain)
     if search_field == 'case_id':
         try:
             case = CommCareCase.objects.get_case(search_id, domain)
@@ -155,7 +153,8 @@ def lookup_case(search_field, search_id, domain, case_type):
         except CaseNotFound:
             pass
     elif search_field == EXTERNAL_ID:
-        cases_by_type = case_accessors.get_cases_by_external_id(search_id, case_type=case_type)
+        cases_by_type = CommCareCase.objects.get_cases_by_external_id(
+            domain, search_id, case_type=case_type)
         if not cases_by_type:
             return (None, LookupErrors.NotFound)
         elif len(cases_by_type) > 1:

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -10,7 +10,6 @@ from casexml.apps.case.mock import CaseBlock
 from corehq import privileges
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import Permissions, UserRole, WebUser
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
@@ -37,7 +36,6 @@ class TestCaseAPI(TestCase):
             cls.domain, 'edit-data', permissions=Permissions(edit_data=True, access_api=True)
         )
         cls.web_user = WebUser.create(cls.domain, 'netflix', 'password', None, None, role_id=role.get_id)
-        cls.case_accessor = CaseAccessors(cls.domain)
 
     def setUp(self):
         self.client.login(username='netflix', password='password')
@@ -302,7 +300,7 @@ class TestCaseAPI(TestCase):
         updated_case = CommCareCase.objects.get_case(existing_case.case_id, self.domain)
         self.assertEqual(updated_case.name, 'Beth Harmon')
 
-        new_case = self.case_accessor.get_cases_by_external_id('jolene')[0]
+        new_case = CommCareCase.objects.get_cases_by_external_id(self.domain, 'jolene')[0]
         self.assertEqual(new_case.name, 'Jolene')
 
     def test_bulk_update_too_big(self):
@@ -362,8 +360,8 @@ class TestCaseAPI(TestCase):
             },
         ])
         self.assertEqual(res.status_code, 200)
-        parent = self.case_accessor.get_cases_by_external_id('beth')[0]
-        child = self.case_accessor.get_cases_by_external_id('harmon-luchenko')[0]
+        parent = CommCareCase.objects.get_cases_by_external_id(self.domain, 'beth')[0]
+        child = CommCareCase.objects.get_cases_by_external_id(self.domain, 'harmon-luchenko')[0]
         self.assertEqual(parent.case_id, child.get_index('parent').referenced_id)
 
     def test_create_child_with_no_parent(self):

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -300,7 +300,7 @@ class TestCaseAPI(TestCase):
         updated_case = CommCareCase.objects.get_case(existing_case.case_id, self.domain)
         self.assertEqual(updated_case.name, 'Beth Harmon')
 
-        new_case = CommCareCase.objects.get_cases_by_external_id(self.domain, 'jolene')[0]
+        new_case = CommCareCase.objects.get_case_by_external_id(self.domain, 'jolene')
         self.assertEqual(new_case.name, 'Jolene')
 
     def test_bulk_update_too_big(self):
@@ -360,8 +360,8 @@ class TestCaseAPI(TestCase):
             },
         ])
         self.assertEqual(res.status_code, 200)
-        parent = CommCareCase.objects.get_cases_by_external_id(self.domain, 'beth')[0]
-        child = CommCareCase.objects.get_cases_by_external_id(self.domain, 'harmon-luchenko')[0]
+        parent = CommCareCase.objects.get_case_by_external_id(self.domain, 'beth')
+        child = CommCareCase.objects.get_case_by_external_id(self.domain, 'harmon-luchenko')
         self.assertEqual(parent.case_id, child.get_index('parent').referenced_id)
 
     def test_create_child_with_no_parent(self):

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -38,7 +38,6 @@ class TestCaseAPI(TestCase):
         )
         cls.web_user = WebUser.create(cls.domain, 'netflix', 'password', None, None, role_id=role.get_id)
         cls.case_accessor = CaseAccessors(cls.domain)
-        cls.form_accessor = XFormInstance.objects
 
     def setUp(self):
         self.client.login(username='netflix', password='password')
@@ -144,7 +143,7 @@ class TestCaseAPI(TestCase):
             'sport': 'chess',
         })
 
-        xform = self.form_accessor.get_form(res['form_id'])
+        xform = XFormInstance.objects.get_form(res['form_id'])
         self.assertEqual(xform.xmlns, 'http://commcarehq.org/case_api')
         self.assertEqual(xform.metadata.userID, self.web_user.user_id)
         self.assertEqual(xform.metadata.deviceID, 'user agent string')
@@ -436,7 +435,7 @@ class TestCaseAPI(TestCase):
         })
         self.assertEqual(res.status_code, 400)
         self.assertIn("InvalidCaseIndex", res.json()['error'])
-        form = self.form_accessor.get_form(res.json()['form_id'])
+        form = XFormInstance.objects.get_form(res.json()['form_id'])
         self.assertEqual(form.is_error, True)
 
     def test_unset_external_id(self):

--- a/corehq/apps/sms/handlers/keyword.py
+++ b/corehq/apps/sms/handlers/keyword.py
@@ -31,7 +31,7 @@ from corehq.apps.smsforms.models import SQLXFormsSession
 from corehq.apps.smsforms.util import critical_section_for_smsforms_sessions
 from corehq.apps.users.cases import get_owner_id, get_wrapped_owner
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.utils import is_commcarecase
 from corehq.messaging.scheduling.models import SMSContent, SMSSurveyContent
 from corehq.messaging.scheduling.scheduling_partitioned.models import (
@@ -495,7 +495,7 @@ def keyword_uses_form_that_requires_case(survey_keyword):
 
 
 def get_case_by_external_id(domain, external_id, user):
-    cases = CaseAccessors(domain).get_cases_by_external_id(external_id)
+    cases = CommCareCase.objects.get_cases_by_external_id(domain, external_id)
 
     def filter_fcn(case):
         return not case.closed and user_can_access_case(user, case)

--- a/corehq/apps/sms/handlers/keyword.py
+++ b/corehq/apps/sms/handlers/keyword.py
@@ -495,7 +495,11 @@ def keyword_uses_form_that_requires_case(survey_keyword):
 
 
 def get_case_by_external_id(domain, external_id, user):
-    cases = CommCareCase.objects.get_cases_by_external_id(domain, external_id)
+    try:
+        case = CommCareCase.objects.get_case_by_external_id(domain, external_id, raise_multiple=True)
+        cases = [case] if case is not None else []
+    except CommCareCase.MultipleObjectsReturned as err:
+        cases = err.cases
 
     def filter_fcn(case):
         return not case.closed and user_can_access_case(user, case)

--- a/corehq/apps/sms/tests/util.py
+++ b/corehq/apps/sms/tests/util.py
@@ -32,8 +32,7 @@ from corehq.apps.sms.models import (
 )
 from corehq.apps.smsforms.models import SQLXFormsSession
 from corehq.apps.users.models import CommCareUser, WebUser
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.messaging.smsbackends.test.models import SQLTestSMSBackend
 from corehq.util.test_utils import unit_testing_only
 
@@ -253,7 +252,7 @@ class TouchformsTestCase(LiveServerTestCase, DomainSubscriptionMixin):
         return site
 
     def get_case(self, external_id):
-        [case] = CaseAccessors(self.domain).get_cases_by_external_id(external_id)
+        [case] = CommCareCase.objects.get_cases_by_external_id(self.domain, external_id)
         return case
 
     def assertCasePropertyEquals(self, case, prop, value):

--- a/corehq/apps/sms/tests/util.py
+++ b/corehq/apps/sms/tests/util.py
@@ -252,8 +252,8 @@ class TouchformsTestCase(LiveServerTestCase, DomainSubscriptionMixin):
         return site
 
     def get_case(self, external_id):
-        [case] = CommCareCase.objects.get_cases_by_external_id(self.domain, external_id)
-        return case
+        return CommCareCase.objects.get_case_by_external_id(
+            self.domain, external_id, raise_multiple=True)
 
     def assertCasePropertyEquals(self, case, prop, value):
         self.assertEqual(case.get_case_property(prop), value)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2267,7 +2267,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         return self.get_usercase()
 
     def get_usercase(self):
-        return CaseAccessors(self.domain).get_case_by_domain_hq_user_id(self._id, USERCASE_TYPE)
+        return CommCareCase.objects.get_case_by_external_id(self.domain, self._id, USERCASE_TYPE)
 
     @quickcache(['self._id'], lambda _: settings.UNIT_TESTING)
     def get_usercase_id(self):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -1,16 +1,20 @@
 import uuid
 
+from django.conf import settings
 from django.test import TestCase
+
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from casexml.apps.case.xform import (
-    get_all_extensions_to_close, get_extensions_to_close, get_ush_extension_cases_to_close)
+    get_all_extensions_to_close,
+    get_extensions_to_close,
+    get_ush_extension_cases_to_close,
+)
 from casexml.apps.phone.tests.utils import create_restore_user
 from corehq.apps.domain.models import Domain
+from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
 from corehq.util.test_utils import flag_enabled
-from corehq.apps.users.dbaccessors import delete_all_users
 
 
 @sharded
@@ -29,8 +33,9 @@ class AutoCloseExtensionsTest(TestCase):
         cls.parent_id = 'parent-{}'.format(uuid.uuid4().hex)
 
     def tearDown(self):
-        FormProcessorTestUtils.delete_all_cases()
-        FormProcessorTestUtils.delete_all_xforms()
+        if settings.USE_PARTITIONED_DATABASE:
+            FormProcessorTestUtils.delete_all_cases()
+            FormProcessorTestUtils.delete_all_xforms()
 
     @classmethod
     def tearDownClass(cls):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -3,11 +3,11 @@ import uuid
 from django.test import TestCase
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import CommCareCase
 from casexml.apps.case.xform import (
     get_all_extensions_to_close, get_extensions_to_close, get_ush_extension_cases_to_close)
 from casexml.apps.phone.tests.utils import create_restore_user
 from corehq.apps.domain.models import Domain
+from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
 from corehq.util.test_utils import flag_enabled
 from corehq.apps.users.dbaccessors import delete_all_users
@@ -117,7 +117,7 @@ class AutoCloseExtensionsTest(TestCase):
         self.factory.create_or_update_cases([extension])
         self.assertEqual(
             set(self.extension_ids[0]),
-            CaseAccessors(self.domain).get_extension_chain([self.host_id])
+            CommCareCaseIndex.objects.get_extension_chain(self.domain, [self.host_id])
         )
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
@@ -171,7 +171,7 @@ class AutoCloseExtensionsTest(TestCase):
         created_cases = self._create_extension_chain()
         self.assertEqual(
             set(self.extension_ids),
-            CaseAccessors(self.domain).get_extension_chain([created_cases[-1].case_id])
+            CommCareCaseIndex.objects.get_extension_chain(self.domain, [created_cases[-1].case_id])
         )
 
     def test_get_extension_chain_circular_ref(self):
@@ -182,7 +182,7 @@ class AutoCloseExtensionsTest(TestCase):
 
         self.assertEqual(
             set([self.host_id] + self.extension_ids),
-            CaseAccessors(self.domain).get_extension_chain([self.extension_ids[2]])
+            CommCareCaseIndex.objects.get_extension_chain(self.domain, [self.extension_ids[2]])
         )
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -8,7 +8,7 @@ from casexml.apps.case.util import validate_phone_datetime, prune_previous_log
 from corehq import toggles
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCaseIndex
 from corehq.util.soft_assert import soft_assert
 from casexml.apps.case.exceptions import InvalidCaseIndex, IllegalCaseId
 
@@ -154,7 +154,7 @@ def get_all_extensions_to_close(domain, cases):
 
 def get_extensions_to_close(domain, cases):
     case_ids = [case.case_id for case in cases if case.closed]
-    return CaseAccessors(domain).get_extension_chain(case_ids, include_closed=False)
+    return CommCareCaseIndex.objects.get_extension_chain(domain, case_ids, include_closed=False)
 
 
 def is_device_report(doc):

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -235,7 +235,7 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
             if index.relationship == 'extension'
         }
         check_cases = list(set(case_ids) - open_cases)
-        rows = accessor.get_closed_and_deleted_ids(check_cases)
+        rows = CommCareCase.objects.get_closed_and_deleted_ids(domain, check_cases)
         for case_id, closed, deleted in rows:
             if deleted:
                 deleted_ids.add(case_id)
@@ -245,7 +245,6 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
 
     IGNORE = object()
     debug = logging.getLogger(__name__).debug
-    accessor = CaseAccessors(domain)
 
     # case graph data structures
     live_ids = set()

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -533,12 +533,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_related_indices(domain, case_ids, exclude_indices):
-        assert isinstance(case_ids, list), case_ids
-        if not case_ids:
-            return []
-        return list(CommCareCaseIndex.objects.plproxy_raw(
-            'SELECT * FROM get_related_indices(%s, %s, %s)',
-            [domain, case_ids, list(exclude_indices)]))
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCaseIndex.objects.get_related_indices(domain, case_ids, exclude_indices)
 
     @staticmethod
     def get_closed_and_deleted_ids(domain, case_ids):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -576,6 +576,7 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_case_by_domain_hq_user_id(domain, user_id, case_type):
+        warn("DEPRECATED", DeprecationWarning)
         return CommCareCase.objects.get_case_by_external_id(domain, user_id, case_type)
 
     @staticmethod

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -548,25 +548,9 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_extension_case_ids(domain, case_ids, include_closed=True, exclude_for_case_type=None):
-        """
-        Given a base list of case ids, get all ids of all extension cases that reference them
-        """
-        if not case_ids:
-            return []
-
-        extension_case_ids = set()
-        for db_name in get_db_aliases_for_partitioned_query():
-            query = CommCareCaseIndex.objects.using(db_name).filter(
-                domain=domain,
-                relationship_id=CommCareCaseIndex.EXTENSION,
-                case__deleted=False,
-                referenced_id__in=case_ids)
-            if not include_closed:
-                query = query.filter(case__closed=False)
-            if exclude_for_case_type:
-                query = query.exclude(referenced_type=exclude_for_case_type)
-            extension_case_ids.update(query.values_list('case_id', flat=True))
-        return list(extension_case_ids)
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCaseIndex.objects.get_extension_case_ids(
+            domain, case_ids, include_closed, exclude_for_case_type)
 
     @staticmethod
     def get_last_modified_dates(domain, case_ids):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -570,10 +570,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_cases_by_external_id(domain, external_id, case_type=None):
-        return list(CommCareCase.objects.plproxy_raw(
-            'SELECT * FROM get_case_by_external_id(%s, %s, %s)',
-            [domain, external_id, case_type]
-        ))
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCase.objects.get_cases_by_external_id(domain, external_id, case_type)
 
     @staticmethod
     def get_case_by_domain_hq_user_id(domain, user_id, case_type):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -571,14 +571,12 @@ class CaseAccessorSQL:
     @staticmethod
     def get_cases_by_external_id(domain, external_id, case_type=None):
         warn("DEPRECATED", DeprecationWarning)
-        return CommCareCase.objects.get_cases_by_external_id(domain, external_id, case_type)
+        case = CommCareCase.objects.get_case_by_external_id(domain, external_id, case_type)
+        return [case] if case is not None else []
 
     @staticmethod
     def get_case_by_domain_hq_user_id(domain, user_id, case_type):
-        try:
-            return CaseAccessorSQL.get_cases_by_external_id(domain, user_id, case_type)[0]
-        except IndexError:
-            return None
+        return CommCareCase.objects.get_case_by_external_id(domain, user_id, case_type)
 
     @staticmethod
     def soft_undelete_cases(domain, case_ids):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -543,16 +543,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_modified_case_ids(accessor, case_ids, sync_log):
-        assert isinstance(case_ids, list), case_ids
-        if not case_ids:
-            return []
-        with CommCareCase.get_plproxy_cursor(readonly=True) as cursor:
-            cursor.execute(
-                'SELECT case_id FROM get_modified_case_ids(%s, %s, %s, %s)',
-                [accessor.domain, case_ids, sync_log.date, sync_log._id]
-            )
-            results = fetchall_as_namedtuple(cursor)
-            return [result.case_id for result in results]
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCase.objects.get_modified_case_ids(accessor.domain, case_ids, sync_log)
 
     @staticmethod
     def get_extension_case_ids(domain, case_ids, include_closed=True, exclude_for_case_type=None):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -538,15 +538,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_closed_and_deleted_ids(domain, case_ids):
-        assert isinstance(case_ids, list), case_ids
-        if not case_ids:
-            return []
-        with CommCareCase.get_plproxy_cursor(readonly=True) as cursor:
-            cursor.execute(
-                'SELECT case_id, closed, deleted FROM get_closed_and_deleted_ids(%s, %s)',
-                [domain, case_ids]
-            )
-            return list(fetchall_as_namedtuple(cursor))
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCase.objects.get_closed_and_deleted_ids(domain, case_ids)
 
     @staticmethod
     def get_modified_case_ids(accessor, case_ids, sync_log):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -91,6 +91,7 @@ class CaseAccessors(object):
         return self.db_accessor.get_attachment_content(case_id, attachment_id)
 
     def get_case_by_domain_hq_user_id(self, user_id, case_type):
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.get_case_by_domain_hq_user_id(self.domain, user_id, case_type)
 
     def get_cases_by_external_id(self, external_id, case_type=None):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -59,13 +59,7 @@ class CaseAccessors(object):
         return self.db_accessor.get_open_case_ids_in_domain_by_type(self.domain, case_type, owner_ids)
 
     def get_related_indices(self, case_ids, exclude_indices):
-        """Get indices (forward and reverse) for the given set of case ids
-
-        :param case_ids: A list of case ids.
-        :param exclude_indices: A set or dict of index id strings with
-        the format ``'<index.case_id> <index.identifier>'``.
-        :returns: A list of CommCareCaseIndex-like objects.
-        """
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.get_related_indices(self.domain, case_ids, exclude_indices)
 
     def get_closed_and_deleted_ids(self, case_ids):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -67,9 +67,7 @@ class CaseAccessors(object):
         return self.db_accessor.get_closed_and_deleted_ids(self.domain, case_ids)
 
     def get_modified_case_ids(self, case_ids, sync_log):
-        """Get the subset of given list of case ids that have been modified
-        since sync date/log id
-        """
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.get_modified_case_ids(self, case_ids, sync_log)
 
     def get_extension_case_ids(self, case_ids, exclude_for_case_type=None):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from warnings import warn
 
 from memoized import memoized
-from corehq.form_processor.models import CommCareCase
+from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
 
 
 CaseIndexInfo = namedtuple(
@@ -107,20 +107,9 @@ class CaseAccessors(object):
         return self.db_accessor.get_deleted_case_ids_by_owner(self.domain, owner_id)
 
     def get_extension_chain(self, case_ids, include_closed=True, exclude_for_case_type=None):
-        assert isinstance(case_ids, list)
-        get_extension_case_ids = self.db_accessor.get_extension_case_ids
-
-        incoming_extensions = set(get_extension_case_ids(
-            self.domain, case_ids, include_closed, exclude_for_case_type))
-        all_extension_ids = set(incoming_extensions)
-        new_extensions = set(incoming_extensions)
-        while new_extensions:
-            extensions = get_extension_case_ids(
-                self.domain, list(new_extensions), include_closed, exclude_for_case_type
-            )
-            new_extensions = set(extensions) - all_extension_ids
-            all_extension_ids = all_extension_ids | new_extensions
-        return all_extension_ids
+        warn("DEPRECATED use CommCareCaseIndex.objects", DeprecationWarning)
+        return CommCareCaseIndex.objects.get_extension_chain(
+            self.domain, case_ids, include_closed, exclude_for_case_type)
 
     def get_case_owner_ids(self):
         return self.db_accessor.get_case_owner_ids(self.domain)

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -63,10 +63,7 @@ class CaseAccessors(object):
         return self.db_accessor.get_related_indices(self.domain, case_ids, exclude_indices)
 
     def get_closed_and_deleted_ids(self, case_ids):
-        """Get the subset of given list of case ids that are closed or deleted
-
-        :returns: List of three-tuples: `(case_id, closed, deleted)`
-        """
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.get_closed_and_deleted_ids(self.domain, case_ids)
 
     def get_modified_case_ids(self, case_ids, sync_log):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -94,6 +94,7 @@ class CaseAccessors(object):
         return self.db_accessor.get_case_by_domain_hq_user_id(self.domain, user_id, case_type)
 
     def get_cases_by_external_id(self, external_id, case_type=None):
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.get_cases_by_external_id(self.domain, external_id, case_type)
 
     def soft_delete_cases(self, case_ids, deletion_date=None, deletion_id=None):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -71,6 +71,7 @@ class CaseAccessors(object):
         return self.db_accessor.get_modified_case_ids(self, case_ids, sync_log)
 
     def get_extension_case_ids(self, case_ids, exclude_for_case_type=None):
+        warn("DEPRECATED use CommCareCaseIndex.objects", DeprecationWarning)
         return self.db_accessor.get_extension_case_ids(
             self.domain, case_ids, exclude_for_case_type=exclude_for_case_type)
 

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -87,6 +87,12 @@ class CommCareCaseManager(RequireDBManager):
         for chunk in chunked((x for x in case_ids if x), 100, list):
             yield from self.get_cases(chunk, domain)
 
+    def get_cases_by_external_id(self, domain, external_id, case_type=None):
+        return list(self.plproxy_raw(
+            'SELECT * FROM get_case_by_external_id(%s, %s, %s)',
+            [domain, external_id, case_type]
+        ))
+
     def get_case_ids_that_exist(self, domain, case_ids):
         result = []
         for db_name, case_ids_chunk in split_list_by_db_partition(case_ids):

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -835,6 +835,22 @@ class CommCareCaseIndexManager(RequireDBManager):
         query = self.partitioned_query(case_id)
         return list(query.filter(case_id=case_id, domain=domain))
 
+    def get_related_indices(self, domain, case_ids, exclude_indices):
+        """Get indices (forward and reverse) for the given set of case ids
+
+        :param case_ids: A list of case ids.
+        :param exclude_indices: A set or dict of index id strings with
+        the format ``'<index.case_id> <index.identifier>'``.
+        :returns: A list of CommCareCaseIndex-like objects.
+        """
+        assert isinstance(case_ids, list), case_ids
+        if not case_ids:
+            return []
+        return list(self.plproxy_raw(
+            'SELECT * FROM get_related_indices(%s, %s, %s)',
+            [domain, case_ids, list(exclude_indices)],
+        ))
+
     def get_reverse_indices(self, domain, case_id):
         indices = list(self.plproxy_raw(
             'SELECT * FROM get_case_indices_reverse(%s, %s)', [domain, case_id]

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -931,6 +931,19 @@ class CommCareCaseIndexManager(RequireDBManager):
             extension_case_ids.update(query.values_list('case_id', flat=True))
         return list(extension_case_ids)
 
+    def get_extension_chain(self, domain, case_ids, include_closed=True, exclude_for_case_type=None):
+        assert isinstance(case_ids, list)
+        incoming_extensions = set(self.get_extension_case_ids(
+            domain, case_ids, include_closed, exclude_for_case_type))
+        all_extension_ids = set(incoming_extensions)
+        new_extensions = set(incoming_extensions)
+        while new_extensions:
+            extensions = self.get_extension_case_ids(
+                domain, list(new_extensions), include_closed, exclude_for_case_type)
+            new_extensions = set(extensions) - all_extension_ids
+            all_extension_ids = all_extension_ids | new_extensions
+        return all_extension_ids
+
 
 CaseIndexInfo = namedtuple(
     'CaseIndexInfo', ['case_id', 'identifier', 'referenced_id', 'referenced_type', 'relationship']

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -147,6 +147,19 @@ class CommCareCaseManager(RequireDBManager):
             )
             return list(fetchall_as_namedtuple(cursor))
 
+    def get_modified_case_ids(self, domain, case_ids, sync_log):
+        """Get the subset of given list of case ids that have been modified
+        since sync date/log id
+        """
+        assert isinstance(case_ids, list), case_ids
+        if not case_ids:
+            return []
+        with self.model.get_plproxy_cursor(readonly=True) as cursor:
+            cursor.execute(
+                'SELECT case_id FROM get_modified_case_ids(%s, %s, %s, %s)',
+                [domain, case_ids, sync_log.date, sync_log._id]
+            )
+            return [row[0] for row in cursor]
 
     def get_case_xform_ids(self, case_id):
         with self.model.get_plproxy_cursor(readonly=True) as cursor:

--- a/corehq/form_processor/tests/test_case_dbaccessor.py
+++ b/corehq/form_processor/tests/test_case_dbaccessor.py
@@ -2,6 +2,7 @@ import uuid
 from collections import namedtuple
 from datetime import datetime
 
+from django.conf import settings
 from django.db import router
 from django.test import TestCase
 
@@ -645,6 +646,8 @@ class CaseAccessorTestsSQL(TestCase):
         _create_case(user_id='user2', case_id='125')  # get's sharded to p2
         _create_case(user_id='user1')
         _create_case(domain='other_domain', user_id='user3')
+        if settings.USE_PARTITIONED_DATABASE:
+            self.addCleanup(lambda: FormProcessorTestUtils.delete_all_cases('other_domain'))
 
         owners = CaseAccessorSQL.get_case_owner_ids('other_domain')
         self.assertEqual({'user3'}, owners)

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -483,6 +483,28 @@ class TestCommCareCaseIndexManager(BaseCaseManagerTest):
             }
         )
 
+    def test_get_extension_case_ids(self):
+        # There are similar tests for get_extension_case_ids in the
+        # `.test_extension_cases` module, but none that replicate this
+        # one precisely. This one may also be better because it creates
+        # models directly rather creating cases by constructing and
+        # processing form XML.
+
+        # Create case and index
+        referenced_id = uuid.uuid4().hex
+        case, _ = _create_case_with_index(referenced_id, identifier='task', referenced_type='task',
+                                relationship_id=CommCareCaseIndex.EXTENSION)
+
+        # Create irrelevant cases
+        _create_case_with_index(referenced_id)
+        _create_case_with_index(referenced_id, identifier='task', referenced_type='task',
+                                relationship_id=CommCareCaseIndex.EXTENSION, case_is_deleted=True)
+
+        self.assertEqual(
+            CommCareCaseIndex.objects.get_extension_case_ids(DOMAIN, [referenced_id]),
+            [case.case_id],
+        )
+
 
 class TestCaseTransactionManager(BaseCaseManagerTest):
 

--- a/corehq/form_processor/tests/test_usercase_dbaccessor.py
+++ b/corehq/form_processor/tests/test_usercase_dbaccessor.py
@@ -1,11 +1,11 @@
 from django.test import TestCase
 
-from casexml.apps.case.mock import CaseFactory
-
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
+
+from .test_cases import _create_case as create_case
 
 
 class UsercaseAccessorsTests(TestCase):
@@ -16,7 +16,6 @@ class UsercaseAccessorsTests(TestCase):
         cls.domain = Domain(name='foo')
         cls.domain.save()
         cls.user = CommCareUser.create(cls.domain.name, 'username', 's3cr3t', None, None)
-        cls.accessor = CaseAccessors(cls.domain.name)
 
     @classmethod
     def tearDownClass(cls):
@@ -25,11 +24,16 @@ class UsercaseAccessorsTests(TestCase):
         super(UsercaseAccessorsTests, cls).tearDownClass()
 
     def setUp(self):
-        factory = CaseFactory(domain='foo')
-        factory.create_case(case_type=USERCASE_TYPE, owner_id=self.user._id, case_name='bar',
-                            update={'hq_user_id': self.user._id})
+        create_case(
+            self.domain.name,
+            case_type=USERCASE_TYPE,
+            user_id=self.user._id,
+            name="bar",
+            external_id=self.user._id,
+        )
 
     def test_get_usercase(self):
-        usercase = self.accessor.get_case_by_domain_hq_user_id(self.user._id, USERCASE_TYPE)
+        usercase = CommCareCase.objects.get_case_by_external_id(
+            self.domain.name, self.user._id, USERCASE_TYPE)
         self.assertIsNotNone(usercase)
         self.assertEqual(usercase.name, 'bar')

--- a/corehq/form_processor/tests/test_usercase_dbaccessor.py
+++ b/corehq/form_processor/tests/test_usercase_dbaccessor.py
@@ -15,13 +15,9 @@ class UsercaseAccessorsTests(TestCase):
         super(UsercaseAccessorsTests, cls).setUpClass()
         cls.domain = Domain(name='foo')
         cls.domain.save()
+        cls.addClassCleanup(cls.domain.delete)
         cls.user = CommCareUser.create(cls.domain.name, 'username', 's3cr3t', None, None)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.user.delete(cls.domain.name, deleted_by=None)
-        cls.domain.delete()
-        super(UsercaseAccessorsTests, cls).tearDownClass()
+        cls.addClassCleanup(cls.user.delete, cls.domain.name, deleted_by=None)
 
     def setUp(self):
         create_case(

--- a/corehq/motech/fhir/tasks.py
+++ b/corehq/motech/fhir/tasks.py
@@ -12,7 +12,6 @@ from casexml.apps.case.mock import CaseBlock
 from corehq import toggles
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.form_processor.exceptions import CaseNotFound
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.motech.const import (
     IMPORT_FREQUENCY_DAILY,
@@ -257,9 +256,8 @@ def get_case_by_id(domain, case_id):
 
 
 def get_case_by_external_id(domain, external_id, case_type):
-    accessor = CaseAccessors(domain)
     try:
-        [case] = accessor.get_cases_by_external_id(external_id, case_type)
+        [case] = CommCareCase.objects.get_cases_by_external_id(domain, external_id, case_type)
     except ValueError:
         return None
     return case if not case.is_deleted else None

--- a/corehq/motech/fhir/tasks.py
+++ b/corehq/motech/fhir/tasks.py
@@ -257,8 +257,9 @@ def get_case_by_id(domain, case_id):
 
 def get_case_by_external_id(domain, external_id, case_type):
     try:
-        [case] = CommCareCase.objects.get_cases_by_external_id(domain, external_id, case_type)
-    except ValueError:
+        case = CommCareCase.objects.get_case_by_external_id(
+            domain, external_id, case_type, raise_multiple=True)
+    except CommCareCase.MultipleObjectsReturned:
         return None
     return case if not case.is_deleted else None
 

--- a/corehq/motech/fhir/tasks.py
+++ b/corehq/motech/fhir/tasks.py
@@ -261,7 +261,7 @@ def get_case_by_external_id(domain, external_id, case_type):
             domain, external_id, case_type, raise_multiple=True)
     except CommCareCase.MultipleObjectsReturned:
         return None
-    return case if not case.is_deleted else None
+    return case if case is not None and not case.is_deleted else None
 
 
 def get_caseblock_kwargs(resource_type, resource):

--- a/custom/covid/casesync.py
+++ b/custom/covid/casesync.py
@@ -1,5 +1,4 @@
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import CommCareCase
+from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
 
 
 def get_ush_extension_cases_to_close(domain, cases):
@@ -10,7 +9,8 @@ def get_ush_extension_cases_to_close(domain, cases):
     PATIENT_CASE_TYPE = 'patient'
     CONTACT_CASE_TYPE = 'contact'
     patient_case_ids = [case.case_id for case in cases if case.closed and case.type == PATIENT_CASE_TYPE]
-    patient_extensions = CaseAccessors(domain).get_extension_chain(
+    patient_extensions = CommCareCaseIndex.objects.get_extension_chain(
+        domain,
         patient_case_ids,
         include_closed=False,
         exclude_for_case_type=CONTACT_CASE_TYPE  # exclude extensions of CONTACT_CASE_TYPE from the chain
@@ -22,4 +22,5 @@ def get_ush_extension_cases_to_close(domain, cases):
         if case.type != CONTACT_CASE_TYPE
     }
     other_case_ids = [case.case_id for case in cases if case.closed and case.type != PATIENT_CASE_TYPE]
-    return valid_extensions.union(CaseAccessors(domain).get_extension_chain(other_case_ids, include_closed=False))
+    return valid_extensions.union(CommCareCaseIndex.objects.get_extension_chain(
+        domain, other_case_ids, include_closed=False))

--- a/dev_settings.py
+++ b/dev_settings.py
@@ -39,8 +39,7 @@ SHELL_PLUS_POST_IMPORTS = (
     ('corehq.apps.domain.models', 'Domain'),
     ('corehq.apps.groups.models', 'Group'),
     ('corehq.apps.users.models', ('CouchUser', 'WebUser', 'CommCareUser')),
-    ('corehq.form_processor.interfaces.dbaccessors', ('CaseAccessors',)),
-    ('corehq.form_processor.models', ('XFormInstance',)),
+    ('corehq.form_processor.models', ('CommCareCase', 'XFormInstance')),
 
     # Data querying utils
     ('dimagi.utils.couch.database', 'get_db'),


### PR DESCRIPTION
Continuation of https://github.com/dimagi/commcare-hq/pull/31051, https://github.com/dimagi/commcare-hq/pull/31060, https://github.com/dimagi/commcare-hq/pull/31065, and https://github.com/dimagi/commcare-hq/pull/31083

Case accessor methods are moving into `CommCareCase.objects` (which is `CommCareCaseManager`) or the relevant model manager that makes the most sense. `CaseAccessor(s|SQL)` will eventually be removed.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

In addition to preserving all of the old tests and adapting the old methods that are being phased out to call the new method, new tests (copies of the old tests adapted to the new structure) are being added for the new model manager.

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
