### PR TITLE
Upgrade Django to 2.2.27

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -40,7 +40,7 @@ django-transfer
 django-two-factor-auth
 django-user-agents
 django-websocket-redis
-django<3.0  # we are not ready to move to django 3.0
+django>=2.2.27,<3.0  # we are not ready to move to django 3.0
 djangorestframework
 dnspython
 dropbox

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -657,9 +657,9 @@ xmlsec==1.3.11
     # via python3-saml
 yapf==0.31.0
     # via -r dev-requirements.in
-zope-event==4.5.0
+zope.event==4.5.0
     # via gevent
-zope-interface==5.4.0
+zope.interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -676,5 +676,5 @@ setuptools==50.3.0
     #   protobuf
     #   python-termstyle
     #   sphinx
-    #   zope-event
-    #   zope-interface
+    #   zope.event
+    #   zope.interface

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -95,7 +95,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==2.2.25
+django==2.2.27
     # via
     #   -r base-requirements.in
     #   django-angular
@@ -657,9 +657,9 @@ xmlsec==1.3.11
     # via python3-saml
 yapf==0.31.0
     # via -r dev-requirements.in
-zope.event==4.5.0
+zope-event==4.5.0
     # via gevent
-zope.interface==5.4.0
+zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -676,5 +676,5 @@ setuptools==50.3.0
     #   protobuf
     #   python-termstyle
     #   sphinx
-    #   zope.event
-    #   zope.interface
+    #   zope-event
+    #   zope-interface

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -72,7 +72,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==2.2.25
+django==2.2.27
     # via
     #   -r base-requirements.in
     #   django-angular
@@ -503,9 +503,9 @@ xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
-zope.event==4.5.0
+zope-event==4.5.0
     # via gevent
-zope.interface==5.4.0
+zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -517,5 +517,5 @@ setuptools==53.0.0
     #   jsonschema
     #   protobuf
     #   sphinx
-    #   zope.event
-    #   zope.interface
+    #   zope-event
+    #   zope-interface

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -503,9 +503,9 @@ xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
-zope-event==4.5.0
+zope.event==4.5.0
     # via gevent
-zope-interface==5.4.0
+zope.interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -517,5 +517,5 @@ setuptools==53.0.0
     #   jsonschema
     #   protobuf
     #   sphinx
-    #   zope-event
-    #   zope-interface
+    #   zope.event
+    #   zope.interface

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -531,9 +531,9 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.11
     # via python3-saml
-zope-event==4.5.0
+zope.event==4.5.0
     # via gevent
-zope-interface==5.4.0
+zope.interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -547,5 +547,5 @@ setuptools==50.3.0
     #   ipython
     #   jsonschema
     #   protobuf
-    #   zope-event
-    #   zope-interface
+    #   zope.event
+    #   zope.interface

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -83,7 +83,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==2.2.25
+django==2.2.27
     # via
     #   -r base-requirements.in
     #   django-angular
@@ -531,9 +531,9 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.11
     # via python3-saml
-zope.event==4.5.0
+zope-event==4.5.0
     # via gevent
-zope.interface==5.4.0
+zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -547,5 +547,5 @@ setuptools==50.3.0
     #   ipython
     #   jsonschema
     #   protobuf
-    #   zope.event
-    #   zope.interface
+    #   zope-event
+    #   zope-interface

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -69,7 +69,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==2.2.25
+django==2.2.27
     # via
     #   -r base-requirements.in
     #   django-angular
@@ -457,9 +457,9 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.11
     # via python3-saml
-zope.event==4.5.0
+zope-event==4.5.0
     # via gevent
-zope.interface==5.4.0
+zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -470,5 +470,5 @@ setuptools==50.3.0
     #   gunicorn
     #   jsonschema
     #   protobuf
-    #   zope.event
-    #   zope.interface
+    #   zope-event
+    #   zope-interface

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -457,9 +457,9 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.11
     # via python3-saml
-zope-event==4.5.0
+zope.event==4.5.0
     # via gevent
-zope-interface==5.4.0
+zope.interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -470,5 +470,5 @@ setuptools==50.3.0
     #   gunicorn
     #   jsonschema
     #   protobuf
-    #   zope-event
-    #   zope-interface
+    #   zope.event
+    #   zope.interface

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -77,7 +77,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==2.2.25
+django==2.2.27
     # via
     #   -r base-requirements.in
     #   django-angular
@@ -510,9 +510,9 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.11
     # via python3-saml
-zope.event==4.5.0
+zope-event==4.5.0
     # via gevent
-zope.interface==5.4.0
+zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -526,5 +526,5 @@ setuptools==50.3.0
     #   jsonschema
     #   pip-tools
     #   protobuf
-    #   zope.event
-    #   zope.interface
+    #   zope-event
+    #   zope-interface

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -510,9 +510,9 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.11
     # via python3-saml
-zope-event==4.5.0
+zope.event==4.5.0
     # via gevent
-zope-interface==5.4.0
+zope.interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -526,5 +526,5 @@ setuptools==50.3.0
     #   jsonschema
     #   pip-tools
     #   protobuf
-    #   zope-event
-    #   zope-interface
+    #   zope.event
+    #   zope.interface


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-13165

## Safety Assurance

### Safety story

Reviewed [changes since 2.2.25](https://github.com/django/django/compare/2.2.25...2.2.27).

### Automated test coverage

No new tests added.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

Rollback may introduce security vulnerabilities.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
