### PR TITLE
Fixed intrusive progress screen

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/controller.js
@@ -12,6 +12,7 @@ hqDefine("cloudcare/js/formplayer/users/controller", function () {
                 query: query,
             });
 
+            FormplayerFrontend.trigger('clearProgress');
             FormplayerFrontend.regions.getRegion('main').show(restoreAsView);
         },
     };


### PR DESCRIPTION
## Technical Summary
Minor followup to https://github.com/dimagi/commcare-hq/pull/30847

Without this, when a smart link requires a user to Login As, the spinner keeps spinning over the Login As screen.

## Feature Flag
Data registries

## Safety Assurance

### Safety story
Low-risk change, feature not yet being used in production.

### Automated test coverage

None

### QA Plan

Not requesting QA. Loaded locally and tested a smart link that did go through Login As and then one that didn't.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
