### PR TITLE
[Auto-Deactivate Mobile Workers] Add Feature Flag

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2051,6 +2051,14 @@ ERM_DEVELOPMENT = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
+AUTO_DEACTIVATE_MOBILE_WORKERS = StaticToggle(
+    'auto_deactivate_mobile_workers',
+    'Development flag for auto-deactivation of mobile workers. To be replaced '
+    'by a privilege.',
+    TAG_PRODUCT,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
 ADD_LIMITED_FIXTURES_TO_CASE_RESTORE = StaticToggle(
     'fixtures_in_case_restore',
     'Allow limited fixtures to be available in case restore for SMS workflows.',


### PR DESCRIPTION
## Technical Summary
adds the feature flag for Auto-Deactivate Mobile Workers
see: https://dimagi-dev.atlassian.net/browse/SAAS-13121

## Feature Flag
`AUTO_DEACTIVATE_MOBILE_WORKERS`

## Safety Assurance

### Safety story
Adds a feature flag

### Automated test coverage
Yes

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
