### PR TITLE
USH: Make new version of case migration script

### DIFF
--- a/corehq/apps/hqcase/bulk.py
+++ b/corehq/apps/hqcase/bulk.py
@@ -16,16 +16,21 @@ class SystemFormMeta:
     xmlns: str = SYSTEM_FORM_XMLNS
 
     @classmethod
-    def for_script(cls, name, username):
-        user_id = username_to_user_id(username)
-        if not user_id:
-            raise Exception(f"User '{username}' not found")
+    def for_script(cls, name, username=None):
+        user_kwargs = {}
+        if username:
+            user_id = username_to_user_id(username)
+            if not user_id:
+                raise Exception(f"User '{username}' not found")
+            user_kwargs = {
+                'user_id': user_id,
+                'username': username,
+            }
 
         return cls(
-            user_id=user_id,
-            username=username,
             device_id=name,
             xmlns=f"http://commcarehq.org/script/{name.split('.')[-1]}",
+            **user_kwargs,
         )
 
 

--- a/corehq/apps/hqcase/bulk.py
+++ b/corehq/apps/hqcase/bulk.py
@@ -1,9 +1,32 @@
 import time
+from dataclasses import dataclass
 from xml.etree import cElementTree as ElementTree
 
+from corehq.apps.users.util import SYSTEM_USER_ID, username_to_user_id
 from corehq.form_processor.models import CommCareCase
 
-from .utils import CASEBLOCK_CHUNKSIZE, submit_case_blocks
+from .utils import CASEBLOCK_CHUNKSIZE, SYSTEM_FORM_XMLNS, submit_case_blocks
+
+
+@dataclass(frozen=True)
+class SystemFormMeta:
+    user_id: str = SYSTEM_USER_ID
+    username: str = SYSTEM_USER_ID
+    device_id: str = SYSTEM_USER_ID
+    xmlns: str = SYSTEM_FORM_XMLNS
+
+    @classmethod
+    def for_script(cls, name, username):
+        user_id = username_to_user_id(username)
+        if not user_id:
+            raise Exception(f"User '{username}' not found")
+
+        return cls(
+            user_id=user_id,
+            username=username,
+            device_id=name,
+            xmlns=f"http://commcarehq.org/script/{name.split('.')[-1]}",
+        )
 
 
 class CaseBulkDB:
@@ -13,10 +36,9 @@ class CaseBulkDB:
     Can optionally wait between each chunk to throttle the form submission rate.
     """
 
-    def __init__(self, domain, user_id, device_id, throttle_secs=None):
+    def __init__(self, domain, form_meta: SystemFormMeta = None, throttle_secs=None):
         self.domain = domain
-        self.user_id = user_id
-        self.device_id = device_id
+        self.form_meta = form_meta or SystemFormMeta()
         self.throttle_secs = throttle_secs or 0
 
     def __enter__(self):
@@ -39,18 +61,25 @@ class CaseBulkDB:
                 ElementTree.tostring(case_block.as_xml(), encoding='utf-8').decode('utf-8')
                 for case_block in self.to_save
             ]
-            submit_case_blocks(case_blocks, self.domain, device_id=self.device_id, user_id=self.user_id)
+            submit_case_blocks(
+                case_blocks,
+                self.domain,
+                device_id=self.form_meta.device_id,
+                xmlns=self.form_meta.xmlns,
+                user_id=self.form_meta.user_id,
+                username=self.form_meta.username,
+            )
             self.to_save = []
 
 
-def update_cases(domain, update_fn, case_ids, user_id, device_id, throttle_secs=None):
+def update_cases(domain, update_fn, case_ids, form_meta: SystemFormMeta = None, throttle_secs=None):
     """
     Perform a large number of case updates in chunks
 
     update_fn should be a function which accepts a case and returns a CaseBlock
     if an update is to be performed, or None to skip the case.
     """
-    with CaseBulkDB(domain, user_id, device_id, throttle_secs) as bulk_db:
+    with CaseBulkDB(domain, form_meta, throttle_secs) as bulk_db:
         for case in CommCareCase.objects.iter_cases(case_ids):
             case_block = update_fn(case)
             if case_block:

--- a/corehq/apps/hqcase/tests/test_bulk.py
+++ b/corehq/apps/hqcase/tests/test_bulk.py
@@ -22,7 +22,7 @@ class TestUpdateCases(TestCase):
     def test(self):
         case_ids = [str(uuid.uuid4()) for i in range(1, 18)]
 
-        with CaseBulkDB(self.domain, 'my_user_id', 'my_device_id') as bulk_db:
+        with CaseBulkDB(self.domain) as bulk_db:
             for i, case_id in enumerate(case_ids):
                 bulk_db.save(CaseBlock(
                     create=True,
@@ -38,7 +38,7 @@ class TestUpdateCases(TestCase):
         self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.domain)), 4)
         self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain)), len(case_ids))
 
-        update_cases(self.domain, _set_phase_2, case_ids, 'my_user_id', 'my_device_id')
+        update_cases(self.domain, _set_phase_2, case_ids)
 
         for case in CommCareCase.objects.get_cases(case_ids):
             correct_phase = '2' if case.get_case_property('to_update') == 'yes' else '1'

--- a/custom/covid/management/commands/update_all_activity_complete_date.py
+++ b/custom/covid/management/commands/update_all_activity_complete_date.py
@@ -122,7 +122,7 @@ def _get_new_contact_date_value(case):
 
 def _get_new_date_value(case, plain_date_props, adjust_date_props):
     def _is_date(value):
-        return value and re_date.match(value)
+        return value and (isinstance(value, datetime.date) or re_date.match(value))
 
     found_prop, found_value = None, None
     for prop in plain_date_props + adjust_date_props:

--- a/custom/covid/management/commands/update_all_activity_complete_date.py
+++ b/custom/covid/management/commands/update_all_activity_complete_date.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('domain')
         parser.add_argument('case_type', choices=['patient', 'contact'])
-        parser.add_argument('--username', type=str, required=True)
+        parser.add_argument('--username', type=str)
         parser.add_argument('--and-linked', action='store_true', default=False)
         parser.add_argument('--throttle-secs', type=float, default=0)
 
@@ -56,7 +56,7 @@ class Command(BaseCommand):
                 domain=domain,
                 update_fn=_correct_bad_property,
                 case_ids=with_progress_bar(bad_case_ids, oneline=False),
-                form_meta=SystemFormMeta.for_script(__name__, options['username']),
+                form_meta=SystemFormMeta.for_script(__name__, options.get('username')),
                 throttle_secs=options['throttle_secs'],
             )
 

--- a/custom/covid/management/commands/update_all_activity_complete_date.py
+++ b/custom/covid/management/commands/update_all_activity_complete_date.py
@@ -67,13 +67,13 @@ def _get_bad_case_ids(domain, case_type):
              .filter(exact_case_property_text_query('current_status', 'closed'))
              .filter(case_property_missing("all_activity_complete_date"))
              .case_type(case_type)
-             .owner(INACTIVE_LOCATION_IDS)
-             .modified_range(gte=datetime.date(2022, 2, 2)))
+             .owner(INACTIVE_LOCATION_IDS))
 
     if case_type == 'contact':
-        query = query.NOT(
-            exact_case_property_text_query('final_disposition', 'converted_to_pui')
-        )
+        query = (query.modified_range(gte=datetime.date(2022, 2, 2))
+            .NOT(
+                exact_case_property_text_query('final_disposition', 'converted_to_pui')
+        ))
 
     return list(query.scroll_ids())
 

--- a/custom/covid/management/commands/update_all_activity_complete_date.py
+++ b/custom/covid/management/commands/update_all_activity_complete_date.py
@@ -56,7 +56,7 @@ class Command(BaseCommand):
                 domain=domain,
                 update_fn=_correct_bad_property,
                 case_ids=with_progress_bar(bad_case_ids, oneline=False),
-                form_meta=SystemFormMeta.for_script(__name__, options.get('username')),
+                form_meta=SystemFormMeta.for_script(__name__, options['username']),
                 throttle_secs=options['throttle_secs'],
             )
 

--- a/custom/covid/management/commands/update_all_activity_complete_date.py
+++ b/custom/covid/management/commands/update_all_activity_complete_date.py
@@ -72,7 +72,7 @@ def _get_bad_case_ids(domain, case_type):
 
     if case_type == 'contact':
         query = query.NOT(
-            exact_case_property_text_query('finale_disposition', 'converted_to_pui')
+            exact_case_property_text_query('final_disposition', 'converted_to_pui')
         )
 
     return list(query.scroll_ids())
@@ -84,7 +84,7 @@ def _correct_bad_property(case):
             case.get_case_property('all_activity_complete_date')
             or case.get_case_property('current_status') != 'closed'
             or (case.type == 'contact'
-                and case.get_case_property('finale_disposition') == 'converted_to_pui')
+                and case.get_case_property('final_disposition') == 'converted_to_pui')
             or case.owner_id not in INACTIVE_LOCATION_IDS
     ):
         return None

--- a/custom/covid/management/commands/update_all_activity_complete_date.py
+++ b/custom/covid/management/commands/update_all_activity_complete_date.py
@@ -6,19 +6,17 @@ from django.core.management.base import BaseCommand
 from jsonobject.api import re_date
 
 from casexml.apps.case.mock import CaseBlock
+from dimagi.utils.parsing import json_format_date
 
 from corehq.apps.es.case_search import (
     CaseSearchES,
     case_property_missing,
     exact_case_property_text_query,
 )
-from corehq.apps.hqcase.bulk import update_cases
+from corehq.apps.hqcase.bulk import SystemFormMeta, update_cases
 from corehq.apps.linked_domain.dbaccessors import get_linked_domains
-from corehq.apps.users.util import SYSTEM_USER_ID, username_to_user_id
 from corehq.util.dates import iso_string_to_date
 from corehq.util.log import with_progress_bar
-
-from dimagi.utils.parsing import json_format_date
 
 DEVICE_ID = __name__
 
@@ -36,7 +34,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('domain')
         parser.add_argument('case_type', choices=['patient', 'contact'])
-        parser.add_argument('--username', type=str, default=None)
+        parser.add_argument('--username', type=str, required=True)
         parser.add_argument('--and-linked', action='store_true', default=False)
         parser.add_argument('--output-file', type=str, default=None)
         parser.add_argument('--throttle-secs', type=float, default=0)
@@ -47,13 +45,6 @@ class Command(BaseCommand):
             domains = domains | {link.linked_domain for link in get_linked_domains(domain)}
             print(f"Running against {len(domains)} total domains")
 
-        if options["username"]:
-            user_id = username_to_user_id(options["username"])
-            if not user_id:
-                raise Exception("The username you entered is invalid")
-        else:
-            user_id = SYSTEM_USER_ID
-
         for i, domain in enumerate(sorted(domains), start=1):
             bad_case_ids = _get_bad_case_ids(domain, options['case_type'])
             print(f"Updating {len(bad_case_ids)} cases on {domain} ({i}/{len(domains)})")
@@ -61,8 +52,7 @@ class Command(BaseCommand):
                 domain=domain,
                 update_fn=_correct_bad_property,
                 case_ids=with_progress_bar(bad_case_ids, oneline=False),
-                user_id=user_id,
-                device_id=DEVICE_ID,
+                form_meta=SystemFormMeta.for_script(__name__, options['username']),
                 throttle_secs=options['throttle_secs'],
             )
 

--- a/custom/covid/management/commands/update_all_activity_complete_date.py
+++ b/custom/covid/management/commands/update_all_activity_complete_date.py
@@ -108,7 +108,7 @@ def _get_new_patient_date_value(case):
     return _get_new_date_value(
         case,
         ['closed_date', 'isolation_end_date', 'quarantine_end_date'],
-        ['new_lab_result_specimen_collection_date', 'symptom_onset_date', 'opened_on']
+        ['symptom_onset_date', 'new_lab_result_specimen_collection_date', 'specimen_collection_date', 'opened_on']
     )
 
 

--- a/custom/covid/management/commands/update_all_activity_complete_date.py
+++ b/custom/covid/management/commands/update_all_activity_complete_date.py
@@ -1,10 +1,15 @@
 import datetime
+import textwrap
 
 from django.core.management.base import BaseCommand
 
 from casexml.apps.case.mock import CaseBlock
 
-from corehq.apps.es import CaseSearchES
+from corehq.apps.es.case_search import (
+    CaseSearchES,
+    case_property_missing,
+    exact_case_property_text_query,
+)
 from corehq.apps.hqcase.bulk import update_cases
 from corehq.apps.linked_domain.dbaccessors import get_linked_domains
 from corehq.apps.users.util import SYSTEM_USER_ID, username_to_user_id
@@ -14,12 +19,18 @@ DEVICE_ID = __name__
 
 
 class Command(BaseCommand):
-    help = ("One-off script created 2022-02-03. A bunch of cases had the "
-            "property all_activity_complete_date inadvertently set to the string "
-            "'date(today())' rather than a date. This blanks that out.")
+    help = textwrap.dedent("""
+        Twice-off script created 2022-02-03, updated 2022-02-11. A bunch of
+        cases had the property all_activity_complete_date inadvertently set to
+        the string 'date(today())' rather than a date. This blanked that out.
+        Later, it was determined an integration doesn't handle blank values
+        well, so this now finds those cases that were blanked out and sets them
+        to an actual date.
+    """)
 
     def add_arguments(self, parser):
         parser.add_argument('domain')
+        parser.add_argument('case_type', choices=['patient', 'contact'])
         parser.add_argument('--username', type=str, default=None)
         parser.add_argument('--and-linked', action='store_true', default=False)
         parser.add_argument('--output-file', type=str, default=None)
@@ -39,7 +50,7 @@ class Command(BaseCommand):
             user_id = SYSTEM_USER_ID
 
         for i, domain in enumerate(sorted(domains), start=1):
-            bad_case_ids = _get_bad_case_ids(domain)
+            bad_case_ids = _get_bad_case_ids(domain, options['case_type'])
             print(f"Updating {len(bad_case_ids)} cases on {domain} ({i}/{len(domains)})")
             update_cases(
                 domain=domain,
@@ -51,19 +62,107 @@ class Command(BaseCommand):
             )
 
 
-def _get_bad_case_ids(domain):
-    return list(CaseSearchES()
-                .domain(domain)
-                .case_property_query("all_activity_complete_date", "date(today())")
-                .modified_range(gte=datetime.date(2022, 2, 2))
-                .case_type(["patient", "contact"])
-                .scroll_ids())
+def _get_bad_case_ids(domain, case_type):
+    query = (CaseSearchES()
+             .domain(domain)
+             .filter(exact_case_property_text_query('current_status', 'closed'))
+             .filter(case_property_missing("all_activity_complete_date"))
+             .case_type(case_type)
+             .owner(INACTIVE_LOCATION_IDS)
+             .modified_range(gte=datetime.date(2022, 2, 2)))
+
+    if case_type == 'contact':
+        query = query.NOT(
+            exact_case_property_text_query('finale_disposition', 'converted_to_pui')
+        )
+
+    return list(query.scroll_ids())
 
 
 def _correct_bad_property(case):
-    if case.get_case_property('all_activity_complete_date') == 'date(today())':
-        return CaseBlock(
-            create=False,
-            case_id=case.case_id,
-            update={"all_activity_complete_date": ""},
-        )
+    if (
+            # Double check filters in case ES data is stale
+            case.get_case_property('all_activity_complete_date')
+            or case.get_case_property('current_status') != 'closed'
+            or (case.type == 'contact'
+                and case.get_case_property('finale_disposition') == 'converted_to_pui')
+            or case.owner_id not in INACTIVE_LOCATION_IDS
+    ):
+        return None
+
+    fallback_property = 'quarantine_end_date' if case.type == 'contact' else 'isolation_end_date'
+    new_value = case.get_case_property(fallback_property) or '2022-02-02'
+    return CaseBlock(
+        create=False,
+        case_id=case.case_id,
+        update={"all_activity_complete_date": new_value},
+    )
+
+
+INACTIVE_LOCATION_IDS = [
+    '9074edfe555043fd8f16825a6236a313',
+    '62c7aa16b77140b98ed1e4d09ae0b756',
+    'de98c400ca394099be014e632d3e342e',
+    '21a9e05ff2ee4e468d7d69b66f537d06',
+    '38eec5e54108404d86779e4d5735f42e',
+    '6840086194254414b89854125f5c84d1',
+    '0ff93180c3a44e8f860213f9f15c46a1',
+    'f36d29ae1c29442988f27cdb87e6cb9f',
+    '35bb743c0af14ed797054a633aaac4a7',
+    'db0ebafbf7e24b2387eb12a1f5b116ba',
+    '009b98aac229405688be47bd60569465',
+    'ab883ee22aed4962bfdab2032e55ef4f',
+    '0184901e04054c45b86be7210952dc5f',
+    'b02aed10be34410f9fb27247ec0bbf88',
+    'c7a5639716aa4b3eaceb6c26300ac636',
+    'd32cbde5383c40ea8570222a58df1f57',
+    '7880d1a174c0442189395a38d5aa3eed',
+    '6e9e6280776e44fb82b6844c5e543254',
+    'cee3dc5061b34f048f2057fa1dde9520',
+    'a899f294bdab47b9911bc95fa407d641',
+    '4956529fb3534f9a8b1296d2d64f173f',
+    '5a6409666eec4d3dadb59864e82314af',
+    'cee8594870e045d5acbbc5baacbce677',
+    '1984b807bd8246968a1c9c1aaf852a8f',
+    '69f546be9f26429cb17cd6f008279dc9',
+    '12958635046d4e4eae3d1236217a7cb8',
+    '48b07d59372745edb62d1fd2ace63856',
+    'd440460e27404d35b385b3b7de174349',
+    '986d1724ec0c4e6791e18efada2c4876',
+    '6a732bd91abf4640a5a43e00705bea75',
+    'd407b7af31bc4284b22f43ca30537faf',
+    'e90b03868bdb472987a04e1e3854d9ba',
+    'fccebb04f82c4ed3b6e96ed2b70791c2',
+    'c794ee8e2ac14b029e317e6d229bf82b',
+    'd1885ac098424d94a3cae6f4a5ea5fac',
+    'be411ad04eb94e51be51d47d741c3e59',
+    '10f8038c7d904391837a861f523b945f',
+    '41a7a599ddb44636946a57847d373820',
+    '94eaa48f839243cf85b953a181d016a3',
+    '92747c2446024381a2acd7a3912c824f',
+    'e24875dc72ef4b9995d4d272fe17ca35',
+    '092a985d390a4b8fa114daacb4a61117',
+    'f423aedcdb8c4bdaaf5a95165b70481f',
+    '7a8116e2ab164821ab45bf2c0968d644',
+    '3537604285a14f3c98b867671c988b1d',
+    'a83b9f69af6544d9bdbb0e7e1bea0a15',
+    '7ecc4d6a8c544d42862701b572d75cbd',
+    '6ac85f598f3343a2aa730e742bf1c2e1',
+    'e73f8fd2626e48a3a5369e9b177beb81',
+    '74660120f439484c8c6918522d83e0c2',
+    '240ae98bd84e4d95b7f50a3d89567937',
+    '2954a873a4094ba0af8b16822caf1656',
+    'db33040a54e543eb8c340fb192d74fa3',
+    'a29f7fbb8df745f48f2f2cd5c7bdb245',
+    'b63fa6c57aaa4e6cba16b919e7c2f408',
+    'ce18fd8ddac14be686e7ffb8755377be',
+    '4546387a1819439196edf4a52e5d121a',
+    'e07d0bbaccbb4bde8f37a77fc9926359',
+    '99560c995f9d44b08873de78e7b92b74',
+    'c5395b938b044c92957dc0a1c457c6ab',
+    '02d287bb6685455eab691d770c6bafbc',
+    '569b53a60c9b4fd5aadeb878a715a60e',
+    '0466344625eb4223a8f7bc93516d9de5',
+    'ced235a967064d4b8da251759abc9791',
+    '9c70aa3d87694ec3b82c278501ba489b',
+]

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -4,8 +4,11 @@ from datetime import timedelta
 from django.core.management import call_command
 from django.test import TestCase
 
+from unittest.mock import patch
+
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.util import post_case_blocks
+from dimagi.utils.parsing import json_format_date
 
 from corehq.apps.app_manager.util import enable_usercase
 from corehq.apps.domain.shortcuts import create_domain
@@ -20,7 +23,6 @@ from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import normalize_username
 from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
-from dimagi.utils.parsing import json_format_date
 
 
 class CaseCommandsTest(TestCase):
@@ -418,9 +420,10 @@ class TestUpdateAllActivityCompleteDate(TestCase):
         case_search_es_teardown()
         super().tearDownClass()
 
+    @patch('corehq.apps.hqcase.bulk.username_to_user_id', new=lambda _: 'my_username')
     def test(self):
-        call_command('update_all_activity_complete_date', self.domain, 'patient')
-        call_command('update_all_activity_complete_date', self.domain, 'contact')
+        call_command('update_all_activity_complete_date', self.domain, 'patient', username='test@example.com')
+        call_command('update_all_activity_complete_date', self.domain, 'contact', username='test@example.com')
 
         cases = {
             label: (CommCareCase.objects.get_case(case_block.case_id), case_block)

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -406,7 +406,7 @@ class TestUpdateAllActivityCompleteDate(TestCase):
             'not_status_closed': cls._make_case('patient', {"current_status": "open"}),
             'in_active_location': cls._make_case(
                 'patient', {"isolation_end_date": "2022-01-04"}, inactive_owner=False),
-            'contact_to_ignore': cls._make_case('contact', {'finale_disposition': 'converted_to_pui'}),
+            'contact_to_ignore': cls._make_case('contact', {'final_disposition': 'converted_to_pui'}),
             'patient_to_update': cls._make_case('patient', {"isolation_end_date": "2022-01-04"}),
             'patient_to_update_adjust': cls._make_case('patient', {"symptom_onset_date": "2022-01-05"}),
             'contact_to_update': cls._make_case('contact', {"quarantine_end_date": "2022-01-07"}),

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -1,10 +1,10 @@
+import logging
 import uuid
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.core.management import call_command
 from django.test import TestCase
-
-from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.util import post_case_blocks
@@ -422,6 +422,7 @@ class TestUpdateAllActivityCompleteDate(TestCase):
 
     @patch('corehq.apps.hqcase.bulk.username_to_user_id', new=lambda _: 'my_username')
     def test(self):
+        logging.getLogger('custom.covid.management.commands.update_all_activity_complete_date').disabled = True
         call_command('update_all_activity_complete_date', self.domain, 'patient', username='test@example.com')
         call_command('update_all_activity_complete_date', self.domain, 'contact', username='test@example.com')
 


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-1593
https://docs.google.com/document/d/1BJ9X4mzy4qDb_GdWPX4U0zxTv7yHaqceP3aFD2Xw68U/edit#bookmark=id.7x5miopaxp31
We'd previously corrected a case property on a few million cases, setting it to `''`.  Turns out that breaks an integration, so now we need to do it again, via a different means.  A description of the logic changes is described in the docs above. 

Another change here is that patients are far more urgent to migrate than contacts, so I've made case_type parameterizable, so we can run the whole script first on the one, _then_ the other.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
We'll pilot this in a test space next week.

### Automated test coverage
tests included
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
