### PR TITLE
add attempt number to scheduled messages report

### DIFF
--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -1357,6 +1357,7 @@ class ScheduleInstanceReport(ProjectReport, ProjectReportParametersMixin, Generi
             DataTablesColumn(_("Scheduling Configuration")),
             DataTablesColumn(_("Recipient")),
             DataTablesColumn(_("Triggering Case")),
+            DataTablesColumn(_("Attempt Number"))
         )
 
     @property
@@ -1558,6 +1559,7 @@ class ScheduleInstanceReport(ProjectReport, ProjectReportParametersMixin, Generi
                 self.get_broadcast_display(schedule_instance),
                 self.get_recipient_display(schedule_instance.recipient),
                 '-',
+                schedule_instance.attempts + 1
             ]
         elif isinstance(schedule_instance, (CaseAlertScheduleInstance, CaseTimedScheduleInstance)):
             return [
@@ -1565,6 +1567,7 @@ class ScheduleInstanceReport(ProjectReport, ProjectReportParametersMixin, Generi
                 self.get_rule_display(schedule_instance.rule_id),
                 self.get_recipient_display(schedule_instance.recipient),
                 self.get_case_display(schedule_instance.case) if schedule_instance.case else '-',
+                schedule_instance.attempts + 1
             ]
         else:
             raise TypeError("Unexpected type: %s" % type(schedule_instance))


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A new column added to the "Scheduled Messaging Events" report that says what number attempt this will be. This is a response to confusion about whether future events represent a retry or the original attempt from a series of slack messages

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Attempts are already tracked in the table since the retry code went live, so adding them to this report was easy. (PR where that was added https://github.com/dimagi/commcare-hq/pull/30758)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally and the column appeared

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
