### PR TITLE
Upgrade transifex-client to fix dependabot

### DIFF
--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -6,7 +6,7 @@ psutil>5.1.3  # for memory profiling
 django-extensions
 ipython  # for nicer django shell experience
 wheel
-transifex-client
+transifex-client>=0.14.4
 gnureadline
 git-build-branch
 

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -612,7 +612,7 @@ traitlets==5.1.1
     # via
     #   ipython
     #   matplotlib-inline
-transifex-client==0.14.3
+transifex-client==0.14.4
     # via -r dev-requirements.in
 tropo-webapi-python==0.1.3
     # via -r base-requirements.in


### PR DESCRIPTION
Dependabot builds were failing with "DistributionNotFound: No matching distribution found for transifex-client==0.14.3"

## Safety Assurance

### Safety story
This is a dev dependency, and a point release upgrade at that.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
