### PR TITLE
Registry Permissions: restrict domains for filtering report

### DIFF
--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -406,14 +406,14 @@ class DomainChoiceProvider(ChainableChoiceProvider):
     def _query_domains(self, domain, query_text, user):
         domains = {domain}
         if user is None:
-            return domains
+            return list(domains)
         if not RegistryPermissionCheck(domain, user).can_view_registry_data(
                 self.report.registry_helper.registry_slug):
-            return domains
+            return list(domains)
         try:
             domains.update(self.report.registry_helper.visible_domains)
         except RegistryNotFound:
-            return domains
+            return list(domains)
         if query_text:
             domains = {domain for domain in domains if re.search(query_text, domain)}
         return list(domains)

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -405,9 +405,7 @@ class DomainChoiceProvider(ChainableChoiceProvider):
     @memoized
     def _query_domains(self, domain, query_text, user):
         domains = {domain}
-        if user is None:
-            return list(domains)
-        if not RegistryPermissionCheck(domain, user).can_view_registry_data(
+        if user is None or not RegistryPermissionCheck(domain, user).can_view_registry_data(
                 self.report.registry_helper.registry_slug):
             return list(domains)
         try:

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -402,8 +402,11 @@ class GroupChoiceProvider(ChainableChoiceProvider):
 class DomainChoiceProvider(ChainableChoiceProvider):
 
     @memoized
-    def _query_domains(self, domain, query_text):
+    def _query_domains(self, domain, query_text, user=None):
         domains = {domain}
+        if user:
+            if not user.can_view_registry_data(self.report.registry_helper.registry_slug):
+                return domains
         try:
             domains.update(self.report.registry_helper.visible_domains)
         except RegistryNotFound:
@@ -413,17 +416,17 @@ class DomainChoiceProvider(ChainableChoiceProvider):
         return list(domains)
 
     def query(self, query_context):
-        domains = self._query_domains(self.domain, query_context.query)
+        domains = self._query_domains(self.domain, query_context.query, query_context.user)
         domains.sort()
         return self._domains_to_choices(
             domains[query_context.offset:query_context.offset + query_context.limit]
         )
 
-    def query_count(self, query):
-        return len(self._query_domains(self.domain, query))
+    def query_count(self, query, user=None):
+        return len(self._query_domains(self.domain, query, user))
 
     def get_choices_for_known_values(self, values, user):
-        domains = self._query_domains(self.domain, None)
+        domains = self._query_domains(self.domain, None, user=user)
         domain_options = [domain for domain in domains if domain in values]
         return self._domains_to_choices(domain_options)
 

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -534,7 +534,6 @@ class DomainChoiceProviderTest(TestCase, ChoiceProviderTestMixin):
         web_user.save()
         return web_user
 
-
     @classmethod
     def setUpClass(cls):
         super(DomainChoiceProviderTest, cls).setUpClass()
@@ -604,8 +603,9 @@ class DomainChoiceProviderTest(TestCase, ChoiceProviderTestMixin):
         self.assertEqual([Choice(value='A', display='A')],
                          self.choice_provider.query(ChoiceQueryContext(query='', offset=0,
                                                                        user=self.web_user_no_registry_access)))
-        self.assertEqual([], self.choice_provider.query(ChoiceQueryContext(query='D', offset=0,
-                                                                           user=self.web_user_no_registry_access)))
+        self.assertEqual([Choice(value='A', display='A')],
+                         self.choice_provider.query(ChoiceQueryContext(query='D', offset=0,
+                                                                       user=self.web_user_no_registry_access)))
 
     def test_query_count(self):
         self.assertEqual(1, self.choice_provider.query_count("A", user=self.web_user))

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -561,14 +561,14 @@ class DomainChoiceProviderTest(TestCase, ChoiceProviderTestMixin):
             name='Can View Registry Data',
             permissions=Permissions(view_data_registry_contents=True),
         )
-        cls.web_user.set_role(cls.domain_a, view_registry_role.get_qualified_id())
+        cls.web_user.set_role(cls.domain_a.name, view_registry_role.get_qualified_id())
         cls.web_user.save()
         restrit_registry_access_role = UserRole.create(
             domain=cls.domain_a,
             name='Cannot View Registry Data',
             permissions=Permissions(view_data_registry_contents=False),
         )
-        cls.web_user_no_registry_access.set_role(cls.domain_a, restrit_registry_access_role.get_qualified_id())
+        cls.web_user_no_registry_access.set_role(cls.domain_a.name, restrit_registry_access_role.get_qualified_id())
         cls.web_user_no_registry_access.save()
 
     @classmethod

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -81,6 +81,7 @@ class ChoiceProviderTestMixin(metaclass=ABCMeta):
     choice_provider = None
     static_choice_provider = None
     choice_query_context = ChoiceQueryContext
+    web_user = None
 
     def _test_query(self, query_context):
         self.assertEqual(
@@ -94,13 +95,13 @@ class ChoiceProviderTestMixin(metaclass=ABCMeta):
         )
 
     def test_query_no_search_all(self):
-        self._test_query(self.choice_query_context('', limit=20, page=0))
+        self._test_query(self.choice_query_context('', limit=20, page=0, user=self.web_user))
 
     def test_query_no_search_first_short_page(self):
-        self._test_query(self.choice_query_context('', 2, page=0))
+        self._test_query(self.choice_query_context('', 2, page=0, user=self.web_user))
 
     def test_query_no_search_second_short_page(self):
-        self._test_query(self.choice_query_context('', 2, page=1))
+        self._test_query(self.choice_query_context('', 2, page=1, user=self.web_user))
 
     @abstractmethod
     def test_query_search(self):

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -527,6 +527,8 @@ class DomainChoiceProviderTest(TestCase, ChoiceProviderTestMixin):
             domain.save()
         cls.user = create_user("admin", "123")
         cls.web_user = UserChoiceProviderTest.make_web_user('web-user@example.com', domain="A")
+        cls.web_user_no_registry_access = UserChoiceProviderTest.make_web_user('other-web-user@example.com',
+                                                                               domain="A")
 
         invitations = [Invitation('A'), Invitation('B'), Invitation('C')]
         # A, B, and C are in the registry A has access to B and C, B has access to C
@@ -554,13 +556,20 @@ class DomainChoiceProviderTest(TestCase, ChoiceProviderTestMixin):
         choices.sort(key=lambda choice: choice.display)
         cls.choice_provider = DomainChoiceProvider(cls.report, None)
         cls.static_choice_provider = StaticChoiceProvider(choices)
-        role = UserRole.create(
+        view_registry_role = UserRole.create(
             domain=cls.domain_a,
             name='Can View Registry Data',
             permissions=Permissions(view_data_registry_contents=True),
         )
-        cls.web_user.set_role(cls.domain_a, role.get_qualified_id())
+        cls.web_user.set_role(cls.domain_a, view_registry_role.get_qualified_id())
         cls.web_user.save()
+        restrit_registry_access_role = UserRole.create(
+            domain=cls.domain_a,
+            name='Cannot View Registry Data',
+            permissions=Permissions(view_data_registry_contents=False),
+        )
+        cls.web_user_no_registry_access.set_role(cls.domain_a, restrit_registry_access_role.get_qualified_id())
+        cls.web_user_no_registry_access.save()
 
     @classmethod
     def tearDownClass(cls):
@@ -571,35 +580,33 @@ class DomainChoiceProviderTest(TestCase, ChoiceProviderTestMixin):
         super(DomainChoiceProviderTest, cls).tearDownClass()
 
     def test_query_search(self):
-        self._test_query(ChoiceQueryContext("A", limit=1, page=0))
+        self._test_query(ChoiceQueryContext("A", limit=1, page=0, user=self.web_user))
 
     def test_query_full_registry_access(self):
         self.assertEqual([Choice(value='A', display='A')],
-                         self.choice_provider.query(ChoiceQueryContext(query='A', offset=0)))
+                         self.choice_provider.query(ChoiceQueryContext(query='A', offset=0, user=self.web_user)))
         self.assertEqual([Choice(value='A', display='A'),
                           Choice(value='B', display='B'),
                           Choice(value='C', display='C')],
-                         self.choice_provider.query(ChoiceQueryContext(query='', offset=0)))
-        self.assertEqual([], self.choice_provider.query(ChoiceQueryContext(query='D', offset=0)))
+                         self.choice_provider.query(ChoiceQueryContext(query='', offset=0, user=self.web_user)))
+        self.assertEqual([], self.choice_provider.query(ChoiceQueryContext(query='D', offset=0, user=self.web_user)))
 
     def test_query_no_registry_access(self):
-        role = UserRole.create(
-            domain=self.domain_a,
-            name='Cannot View Registry Data',
-            permissions=Permissions(view_data_registry_contents=False),
-        )
-        self.web_user.set_role(self.domain_a, role.get_qualified_id())
-        self.web_user.save()
         self.assertEqual([Choice(value='A', display='A')],
-                         self.choice_provider.query(ChoiceQueryContext(query='A', offset=0)))
+                         self.choice_provider.query(ChoiceQueryContext(query='A', offset=0,
+                                                                       user=self.web_user_no_registry_access)))
         self.assertEqual([Choice(value='A', display='A')],
-                         self.choice_provider.query(ChoiceQueryContext(query='', offset=0)))
-        self.assertEqual([], self.choice_provider.query(ChoiceQueryContext(query='D', offset=0)))
+                         self.choice_provider.query(ChoiceQueryContext(query='', offset=0,
+                                                                       user=self.web_user_no_registry_access)))
+        self.assertEqual([], self.choice_provider.query(ChoiceQueryContext(query='D', offset=0,
+                                                                           user=self.web_user_no_registry_access)))
 
     def test_query_count(self):
-        self.assertEqual(1, self.choice_provider.query_count("A"))
-        self.assertEqual(3, self.choice_provider.query_count(""))
-        self.assertEqual(0, self.choice_provider.query_count("D"))
+        self.assertEqual(1, self.choice_provider.query_count("A", user=self.web_user))
+        self.assertEqual(3, self.choice_provider.query_count("", user=self.web_user))
+        self.assertEqual(0, self.choice_provider.query_count("D", user=self.web_user))
+        self.assertEqual(1, self.choice_provider.query_count("A", user=self.web_user_no_registry_access))
+        self.assertEqual(1, self.choice_provider.query_count("", user=self.web_user_no_registry_access))
 
     def test_get_choices_for_values(self):
         self._test_get_choices_for_values(
@@ -615,8 +622,8 @@ class DomainChoiceProviderTest(TestCase, ChoiceProviderTestMixin):
         config.save()
         report = RegistryReportConfiguration(domain="B", config_id=config._id)
         self.choice_provider = DomainChoiceProvider(report, None)
-        self.assertEqual([Choice(value='B', display='B'), Choice(value='C', display='C')],
-                         self.choice_provider.query(ChoiceQueryContext(query='', offset=0)))
+        self.assertEqual([Choice(value='B', display='B'), Choice(value='C', display='C', )],
+                         self.choice_provider.query(ChoiceQueryContext(query='', offset=0, user=self.web_user)))
         config.delete()
 
     def test_domain_with_no_grants(self):
@@ -628,5 +635,5 @@ class DomainChoiceProviderTest(TestCase, ChoiceProviderTestMixin):
         report = RegistryReportConfiguration(domain="C", config_id=config._id)
         self.choice_provider = DomainChoiceProvider(report, None)
         self.assertEqual([Choice(value='C', display='C')],
-                         self.choice_provider.query(ChoiceQueryContext(query='', offset=0)))
+                         self.choice_provider.query(ChoiceQueryContext(query='', offset=0, user=self.web_user)))
         config.delete()


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Second part to this ticket https://dimagi-dev.atlassian.net/browse/USH-1571


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
When viewing a report, only users with access to that registry can select any other domains to select other than the current domain:
Example where user **does** have access. (Without access to the registry they would just have one domain to select)
<img width="816" alt="Screen Shot 2022-02-14 at 9 43 18 AM" src="https://user-images.githubusercontent.com/36681924/153886204-553b6f7d-c424-4a20-bf1a-a4b2e8aba597.png">


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
DATA_REGISTRIES

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I will have this get a quick sweep on QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
