### PR TITLE
Update transifex client config files for cli v1.0.0

### DIFF
--- a/.transifexrc.example
+++ b/.transifexrc.example
@@ -1,5 +1,5 @@
 [https://www.transifex.com]
-username = dimagi_dev
-token =
-password = TRANSIFEX_PASSWORD_FROM_HQ_KEEPASS
+api_hostname = https://api.transifex.com
 hostname = https://www.transifex.com
+rest_hostname = https://rest.api.transifex.com
+token = 

--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[commcare-hq.djangopo]
+[o:dimagi:p:commcare-hq:r:djangopo]
 file_filter = locale/<lang>/LC_MESSAGES/django.po
 source_file = locale/en/LC_MESSAGES/django.po
 source_lang = en
@@ -12,7 +12,7 @@ trans.pt = locale/por/LC_MESSAGES/django.po
 trans.sw = locale/sw/LC_MESSAGES/django.po
 type = PO
 
-[commcare-hq.djangojspo]
+[o:dimagi:p:commcare-hq:r:djangojspo]
 file_filter = locale/<lang>/LC_MESSAGES/djangojs.po
 source_file = locale/en/LC_MESSAGES/djangojs.po
 source_lang = en

--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -6,7 +6,6 @@ psutil>5.1.3  # for memory profiling
 django-extensions
 ipython  # for nicer django shell experience
 wheel
-transifex-client
 gnureadline
 git-build-branch
 

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -230,10 +230,6 @@ ghdiff==0.4
     # via -r base-requirements.in
 git-build-branch==0.1.13
     # via -r dev-requirements.in
-gitdb==4.0.7
-    # via gitpython
-gitpython==3.1.14
-    # via transifex-client
 gnureadline==8.0.0
     # via -r dev-requirements.in
 greenlet==1.1.2
@@ -431,8 +427,6 @@ python-magic==0.4.22
     # via -r base-requirements.in
 python-mimeparse==1.6.0
     # via django-tastypie
-python-slugify==4.0.1
-    # via transifex-client
 python-termstyle==0.1.10
     # via sniffer
 python3-saml==1.12.0
@@ -481,7 +475,6 @@ requests==2.25.1
     #   sphinx
     #   stripe
     #   tinys3
-    #   transifex-client
     #   twilio
 requests-mock==1.9.3
     # via -r test-requirements.in
@@ -510,7 +503,6 @@ simplejson==3.17.2
 six==1.15.0
     # via
     #   -r base-requirements.in
-    #   asttokens
     #   django-braces
     #   django-compressor
     #   django-oauth-toolkit
@@ -539,10 +531,7 @@ six==1.15.0
     #   requests-mock
     #   sqlalchemy-postgres-copy
     #   tenacity
-    #   transifex-client
     #   twilio
-smmap==4.0.0
-    # via gitdb
 sniffer==0.4.1
     # via -r dev-requirements.in
 snowballstemmer==2.0.0
@@ -599,7 +588,6 @@ text-unidecode==1.3
     # via
     #   -r base-requirements.in
     #   faker
-    #   python-slugify
 tinys3==0.1.12
     # via -r base-requirements.in
 toml==0.10.2
@@ -612,8 +600,6 @@ traitlets==5.1.1
     # via
     #   ipython
     #   matplotlib-inline
-transifex-client==0.14.3
-    # via -r dev-requirements.in
 tropo-webapi-python==0.1.3
     # via -r base-requirements.in
 turn-python==0.0.1
@@ -634,7 +620,6 @@ urllib3==1.26.5
     #   py-kissmetrics
     #   requests
     #   sentry-sdk
-    #   transifex-client
 user-agents==2.2.0
     # via django-user-agents
 vine==1.3.0


### PR DESCRIPTION
The [transifex-client](https://github.com/transifex/transifex-client) library has been deprecated since January 2022, and a [new version of the client](https://github.com/transifex/cli/) is now the supported way to update translations.

This removes the old library from requirements files. [Transifex setup instructions](https://confluence.dimagi.com/display/saas/Internationalization+and+Localization+-+Transifex+Translations#InternationalizationandLocalization-TransifexTranslations-0.SetupTransifex) on confluence have been updated for the new process.

:blowfish: Review by commit.

### Updating the client:

- [Install the new client](https://github.com/transifex/cli/#installation).
- Change your `~/.transifexrc` to use a transifex API token rather than username/password.

## Safety Assurance

### Safety story
transifex-client was a dev dependency.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
