### PR TITLE
Move case accessors into CommCareCase.objects - part 6

### DIFF
--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -21,9 +21,7 @@ from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.models import BlobMeta
 from corehq.elastic import ESError
 from corehq.form_processor.backends.sql.dbaccessors import doc_type_to_state
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import XFormInstance
-from corehq.form_processor.models.cases import CommCareCase
+from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 from corehq.util.log import with_progress_bar
 from dimagi.utils.chunked import chunked
@@ -168,10 +166,9 @@ def _terminate_subscriptions(domain_name):
 
 def _delete_all_cases(domain_name):
     logger.info('Deleting cases...')
-    case_accessor = CaseAccessors(domain_name)
     case_ids = CommCareCase.objects.get_case_ids_in_domain(domain_name)
     for case_id_chunk in chunked(with_progress_bar(case_ids, stream=silence_during_tests()), 500):
-        case_accessor.soft_delete_cases(list(case_id_chunk))
+        CommCareCase.objects.soft_delete_cases(domain_name, list(case_id_chunk))
     logger.info('Deleting cases complete.')
 
 

--- a/corehq/apps/hqadmin/management/commands/delete_related_cases.py
+++ b/corehq/apps/hqadmin/management/commands/delete_related_cases.py
@@ -6,7 +6,6 @@ import csv
 
 from corehq.apps.receiverwrapper.util import get_app_version_info
 from corehq.apps.users.util import cached_owner_id_to_display
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase, XFormInstance
 
 
@@ -19,7 +18,6 @@ class Command(BaseCommand):
         parser.add_argument('--filename', dest='filename', default='case-delete-info.csv')
 
     def handle(self, domain, case_id, **options):
-        case_accessor = CaseAccessors(domain=domain)
         case = CommCareCase.objects.get_case(case_id, domain)
         if not case.is_deleted and input('\n'.join([
             'Case {} is not already deleted. Are you sure you want to delete it? (y/N)'.format(case_id)
@@ -64,7 +62,7 @@ class Command(BaseCommand):
         if cases_to_delete and input('\n'.join([
             'Delete these {} cases? (y/N)'.format(len(cases_to_delete)),
         ])).lower() == 'y':
-            case_accessor.soft_delete_cases([c.case_id for c in cases_to_delete])
+            CommCareCase.objects.soft_delete_cases(domain, [c.case_id for c in cases_to_delete])
             print('deleted {} cases'.format(len(cases_to_delete)))
 
         if cases_to_delete:

--- a/corehq/apps/hqcase/tasks.py
+++ b/corehq/apps/hqcase/tasks.py
@@ -16,7 +16,6 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.ota.utils import get_restore_user
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.backends.sql.dbaccessors import LedgerAccessorSQL
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase, XFormInstance
 
 
@@ -123,7 +122,6 @@ def delete_exploded_cases(domain, explosion_id, task=None):
     if task:
         DownloadBase.set_progress(delete_exploded_case_task, 0, len(case_ids))
 
-    case_accessor = CaseAccessors(domain)
     ledger_accessor = LedgerAccessorSQL
     deleted_form_ids = set()
     num_deleted_ledger_entries = 0
@@ -140,7 +138,7 @@ def delete_exploded_cases(domain, explosion_id, task=None):
 
     completed = 0
     for ids in chunked(case_ids, 100):
-        case_accessor.soft_delete_cases(list(ids))
+        CommCareCase.objects.soft_delete_cases(domain, list(ids))
         if task:
             completed += len(ids)
             DownloadBase.set_progress(delete_exploded_case_task, completed, len(case_ids))

--- a/corehq/apps/sms/tests/util.py
+++ b/corehq/apps/sms/tests/util.py
@@ -252,8 +252,11 @@ class TouchformsTestCase(LiveServerTestCase, DomainSubscriptionMixin):
         return site
 
     def get_case(self, external_id):
-        return CommCareCase.objects.get_case_by_external_id(
+        case = CommCareCase.objects.get_case_by_external_id(
             self.domain, external_id, raise_multiple=True)
+        if case is None:
+            raise CommCareCase.DoesNotExist
+        return case
 
     def assertCasePropertyEquals(self, case, prop, value):
         self.assertEqual(case.get_case_property(prop), value)

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -42,7 +42,6 @@ from corehq.apps.userreports.tests.utils import (
     skip_domain_filter_patch,
 )
 from corehq.apps.userreports.util import get_indicator_adapter
-from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.models import CommCareCase
 from corehq.pillows.case import get_case_pillow
 from corehq.util.context_managers import drop_connected_signals
@@ -510,7 +509,7 @@ class IndicatorPillowTest(TestCase):
 
         # delete the case and verify it's removed
         since = self.pillow.get_change_feed().get_latest_offsets()
-        CaseAccessorSQL.soft_delete_cases(case.domain, [case.case_id])
+        CommCareCase.objects.soft_delete_cases(case.domain, [case.case_id])
         self.pillow.process_changes(since=since, forever=False)
         self.assertEqual(0, self.adapter.get_query_object().count())
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -79,7 +79,6 @@ from corehq.apps.users.util import (
     username_to_user_id,
 )
 from corehq.form_processor.exceptions import CaseNotFound
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.interfaces.supply import SupplyInterface
 from corehq.form_processor.models import CommCareCase
 from corehq.util.dates import get_timestamp
@@ -1834,7 +1833,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         XFormInstance.objects.soft_undelete_forms(self.domain, deleted_form_ids)
 
         deleted_case_ids = self._get_deleted_case_ids()
-        CaseAccessors(self.domain).soft_undelete_cases(deleted_case_ids)
+        CommCareCase.objects.soft_undelete_cases(self.domain, deleted_case_ids)
 
         undelete_system_forms.delay(self.domain, set(deleted_form_ids), set(deleted_case_ids))
         self.save()

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -27,7 +27,6 @@ from soil import DownloadBase
 from corehq import toggles
 from corehq.apps.domain.models import Domain
 from corehq.form_processor.exceptions import CaseNotFound
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase, CommCareCaseIndex, UserArchivedRebuild, XFormInstance
 from corehq.util.celery_utils import deserialize_run_every_setting, run_periodic_task_again
 
@@ -88,7 +87,7 @@ def tag_cases_as_deleted_and_remove_indices(domain, case_ids, deletion_id, delet
     from corehq.apps.data_interfaces.tasks import delete_duplicates_for_cases
     from corehq.apps.sms.tasks import delete_phone_numbers_for_owners
     from corehq.messaging.scheduling.tasks import delete_schedule_instances_for_cases
-    CaseAccessors(domain).soft_delete_cases(list(case_ids), deletion_date, deletion_id)
+    CommCareCase.objects.soft_delete_cases(domain, list(case_ids), deletion_date, deletion_id)
     _remove_indices_from_deleted_cases_task.delay(domain, case_ids)
     delete_phone_numbers_for_owners.delay(case_ids)
     delete_schedule_instances_for_cases.delay(domain, case_ids)

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -20,7 +20,6 @@ from corehq.apps.users.model_log import UserModelAction
 from corehq.apps.users.models import CommCareUser, UserHistory
 from corehq.apps.users.tasks import remove_indices_from_deleted_cases
 from corehq.apps.users.util import SYSTEM_USER_ID
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase, UserArchivedRebuild, XFormInstance
 
 
@@ -194,7 +193,7 @@ class RetireUserTestCase(TestCase):
         self.assertEqual(1, len(child.xform_ids))
 
         # simulate parent deletion
-        CaseAccessors(self.domain).soft_delete_cases([parent_id])
+        CommCareCase.objects.soft_delete_cases(self.domain, [parent_id])
 
         # call the remove index task
         remove_indices_from_deleted_cases(self.domain, [parent_id])

--- a/corehq/ex-submodules/casexml/apps/case/mock/mock.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/mock.py
@@ -65,6 +65,10 @@ class CaseFactory(object):
 
     The API is a wrapper around the CaseBlock utility and is designed to be
     easier to work with to setup parent/child structures or default properties.
+
+    Use corehq.form_processor.tests.utils.create_case() instead if possible.
+    This submits a form to create the case. The form_procssor version
+    creates and saves the case directly, which is faster.
     """
 
     def __init__(self, domain=None, case_defaults=None, form_extras=None):
@@ -109,6 +113,10 @@ class CaseFactory(object):
     def create_case(self, **kwargs):
         """
         Shortcut to create a simple case without needing to make a structure for it.
+
+        Use corehq.form_processor.tests.utils.create_case() instead if possible.
+        This submits a form to create the case. The form_procssor version
+        creates and saves the case directly, which is faster.
         """
         kwargs['create'] = True
         case_id = uuid.uuid4().hex
@@ -117,6 +125,10 @@ class CaseFactory(object):
     def update_case(self, case_id, **kwargs):
         """
         Shortcut to update a simple case given its id without needing to make a structure for it.
+
+        Use corehq.form_processor.tests.utils.create_case() instead if possible.
+        This submits a form to create the case. The form_procssor version
+        creates and saves the case directly, which is faster.
         """
         kwargs['create'] = False
         return self.create_or_update_case(CaseStructure(case_id=case_id, attrs=kwargs))[0]
@@ -124,6 +136,10 @@ class CaseFactory(object):
     def close_case(self, case_id):
         """
         Shortcut to close a case (and do nothing else)
+
+        Use corehq.form_processor.tests.utils.create_case() instead if possible.
+        This submits a form to create the case. The form_procssor version
+        creates and saves the case directly, which is faster.
         """
         return self.create_or_update_case(CaseStructure(case_id=case_id, attrs={'close': True}))[0]
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -9,7 +9,6 @@ from casexml.apps.case.util import post_case_blocks
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.exceptions import CaseNotFound
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
@@ -139,8 +138,7 @@ class CaseBugTest(TestCase, TestFileMixin):
             CaseBlock.deprecated_init(create=True, case_id=case_id, user_id='whatever',
                 update={'foo': 'bar'}).as_xml()
         ], domain="test-domain")
-        cases = CaseAccessors("test-domain")
-        cases.soft_delete_cases([case_id])
+        CommCareCase.objects.soft_delete_cases("test-domain", [case_id])
 
         case = CommCareCase.objects.get_case(case_id, "test-domain")
         self.assertEqual('bar', case.dynamic_case_properties()['foo'])

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -8,7 +8,6 @@ from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests.util import delete_all_cases
 from casexml.apps.case.util import post_case_blocks, primary_actions
 from corehq.apps.change_feed import topics
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase, RebuildWithReason, XFormInstance
 from corehq.form_processor.tests.utils import sharded
 from testapps.test_pillowtop.utils import capture_kafka_changes_context
@@ -237,7 +236,7 @@ class CaseRebuildTest(TestCase):
                   form_extras={'received_on': now + timedelta(seconds=2)})
 
         case = CommCareCase.objects.get_case(case_id, REBUILD_TEST_DOMAIN)
-        CaseAccessors(REBUILD_TEST_DOMAIN).soft_delete_cases([case_id])
+        CommCareCase.objects.soft_delete_cases(REBUILD_TEST_DOMAIN, [case_id])
 
         [f1, f2, f3] = case.xform_ids
         f2_doc = XFormInstance.objects.get_form(f2, REBUILD_TEST_DOMAIN)

--- a/corehq/ex-submodules/casexml/apps/case/tests/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/util.py
@@ -67,6 +67,11 @@ def bootstrap_case_from_xml(test_class, filename, case_id_override=None, domain=
 
 @contextmanager
 def create_case(domain, case_type, **kwargs):
+    """Use corehq.form_processor.tests.utils.create_case() instead if possible
+
+    This submits a form to create the case. The form_procssor version
+    creates and saves the case directly, which is faster.
+    """
     case = CaseFactory(domain).create_case(case_type=case_type, **kwargs)
     try:
         yield case

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -17,8 +17,7 @@ from corehq.apps.groups.models import Group
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.blobs import get_blob_db
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.models import CommCareCaseIndex
+from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
 from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
     sharded,
@@ -788,7 +787,7 @@ class SyncDeletedCasesTest(BaseSyncTest):
     def test_deleted_case_doesnt_sync(self):
         case_id = uuid.uuid4().hex
         self.device.post_changes(case_id=case_id, create=True)
-        CaseAccessors(self.project.name).soft_delete_cases([case_id])
+        CommCareCase.objects.soft_delete_cases(self.project.name, [case_id])
         self.assertNotIn(case_id, self.device.sync().cases)
 
     def test_deleted_parent_doesnt_sync(self):
@@ -806,7 +805,7 @@ class SyncDeletedCasesTest(BaseSyncTest):
                 )],
             )
         )
-        CaseAccessors(self.project.name).soft_delete_cases([parent_id])
+        CommCareCase.objects.soft_delete_cases(self.project.name, [parent_id])
         self.assertEqual(set(self.device.sync().cases), {child_id})
         # todo: in the future we may also want to purge the child
 

--- a/corehq/ex-submodules/couchforms/management/commands/purge_forms_and_cases.py
+++ b/corehq/ex-submodules/couchforms/management/commands/purge_forms_and_cases.py
@@ -5,7 +5,6 @@ from django.http import Http404
 
 from corehq.apps.app_manager.models import Application
 from casexml.apps.case.xform import get_case_ids_from_form
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.apps.app_manager.dbaccessors import get_app
 from dimagi.utils.django.management import are_you_sure
@@ -39,7 +38,6 @@ though deletion would be re-confirmed so dont panic
         self.case_ids = set()
         self.filtered_xform_ids, self.xform_ids = [], []
         self.xform_writer, self.case_writer = None, None
-        self.case_accessors = None
         self.domain, self.app_id, self.version_number, self.test_run = None, None, None, None
         self.version_mapping = dict()
 
@@ -48,7 +46,6 @@ though deletion would be re-confirmed so dont panic
         self.xform_writer.writerow(XFORM_HEADER)
         self.case_writer = csv.writer(open(CASE_FILE_NAME, 'w+b'))
         self.case_writer.writerow(CASE_HEADER)
-        self.case_accessors = CaseAccessors(self.domain)
 
     def ensure_prerequisites(self, domain, app_id, version_number, test_run):
         self.domain = domain
@@ -119,7 +116,7 @@ though deletion would be re-confirmed so dont panic
     def delete_forms_and_cases(self):
         print('Proceeding with deleting forms and cases')
         XFormInstance.objects.soft_delete_forms(self.domain, self.filtered_xform_ids)
-        self.case_accessors.soft_delete_cases(list(self.case_ids))
+        CommCareCase.objects.soft_delete_cases(self.domain, list(self.case_ids))
 
 
 def _print_form_details(xform, file_writer, app_version_built_with):

--- a/corehq/ex-submodules/pillowtop/tests/test_utils.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_utils.py
@@ -5,7 +5,6 @@ from django.test import TestCase
 
 from corehq.form_processor.document_stores import CaseDocumentStore
 from corehq.form_processor.models import CommCareCase
-from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from pillowtop.dao.exceptions import DocumentNotFoundError
 from pillowtop.feed.interface import Change
 from pillowtop.utils import ensure_document_exists
@@ -39,7 +38,7 @@ class TestEnsureDocumentExists(TestCase):
         Should not raise an error when the doc has been deleted
         '''
         change, case = self._create_change()
-        CaseAccessorSQL.soft_delete_cases(self.domain, [case.case_id])
+        CommCareCase.objects.soft_delete_cases(self.domain, [case.case_id])
         ensure_document_exists(change)
 
     def test_handle_missing_doc(self):

--- a/corehq/form_processor/backends/sql/casedb.py
+++ b/corehq/form_processor/backends/sql/casedb.py
@@ -1,5 +1,4 @@
 from casexml.apps.case.exceptions import IllegalCaseId
-from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.backends.sql.update_strategy import SqlCaseUpdateStrategy
 from corehq.form_processor.casedb_base import AbstractCaseDbCache
 from corehq.form_processor.models import CommCareCase
@@ -28,7 +27,7 @@ class CaseDbCacheSQL(AbstractCaseDbCache):
         cases = self.get_changed()
 
         saved_case_ids = [case.case_id for case in cases if case.is_saved()]
-        cases_modified_on = CaseAccessorSQL.get_last_modified_dates(self.domain, saved_case_ids)
+        cases_modified_on = CommCareCase.objects.get_last_modified_dates(self.domain, saved_case_ids)
         for case in cases:
             if case.is_saved():
                 modified_on = cases_modified_on.get(case.case_id, None)

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -1,6 +1,5 @@
 import functools
 import itertools
-import logging
 import operator
 import struct
 from abc import ABCMeta, abstractmethod, abstractproperty
@@ -16,7 +15,6 @@ from django.db.models.functions import Concat
 
 import csiphash
 
-from casexml.apps.case.xform import get_case_updates
 from dimagi.utils.chunked import chunked
 
 from corehq.form_processor.exceptions import (
@@ -43,7 +41,6 @@ from corehq.sql_db.util import (
     get_db_aliases_for_partitioned_query,
     split_list_by_db_partition,
 )
-from corehq.util.metrics.load_counters import form_load_counter
 
 doc_type_to_state = XFormInstance.DOC_TYPE_TO_STATE
 
@@ -608,55 +605,9 @@ class CaseAccessorSQL:
 
     @staticmethod
     def fetch_case_transaction_forms(case, transactions, updated_xforms=None):
-        """
-        Fetches the forms for a list of transactions, caching them onto each transaction
-
-        :param transactions: list of ``CaseTransaction`` objects:
-        :param updated_xforms: list of forms that have been changed.
-        """
-
-        form_ids = {tx.form_id for tx in transactions if tx.form_id}
-        updated_xforms_map = {
-            xform.form_id: xform for xform in updated_xforms if not xform.is_deprecated
-        } if updated_xforms else {}
-
-        updated_xform_ids = set(updated_xforms_map)
-        form_ids_to_fetch = list(form_ids - updated_xform_ids)
-        form_load_counter("rebuild_case", case.domain)(len(form_ids_to_fetch))
-        xform_map = {
-            form.form_id: form
-            for form in XFormInstance.objects.get_forms_with_attachments_meta(form_ids_to_fetch)
-        }
-
-        forms_missing_transactions = list(updated_xform_ids - form_ids)
-        for form_id in forms_missing_transactions:
-            # Add in any transactions that aren't already present
-            form = updated_xforms_map[form_id]
-            case_updates = [update for update in get_case_updates(form) if update.id == case.case_id]
-            types = [
-                CaseTransaction.type_from_action_type_slug(a.action_type_slug)
-                for case_update in case_updates
-                for a in case_update.actions
-            ]
-            modified_on = case_updates[0].guess_modified_on()
-            new_transaction = CaseTransaction.form_transaction(case, form, modified_on, types)
-            transactions.append(new_transaction)
-
-        def get_form(form_id):
-            if form_id in updated_xforms_map:
-                return updated_xforms_map[form_id]
-
-            try:
-                return xform_map[form_id]
-            except KeyError:
-                raise XFormNotFound(form_id)
-
-        for case_transaction in transactions:
-            if case_transaction.form_id:
-                try:
-                    case_transaction.cached_form = get_form(case_transaction.form_id)
-                except XFormNotFound:
-                    logging.error('Form not found during rebuild: %s', case_transaction.form_id)
+        warn("DEPRECATED", DeprecationWarning)
+        from .update_strategy import SqlCaseUpdateStrategy
+        SqlCaseUpdateStrategy(case).fetch_case_transaction_forms(transactions, updated_xforms)
 
 
 class LedgerReindexAccessor(ReindexAccessor):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -5,7 +5,6 @@ import operator
 import struct
 from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import namedtuple
-from datetime import datetime
 from uuid import UUID
 from warnings import warn
 
@@ -607,23 +606,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def soft_delete_cases(domain, case_ids, deletion_date=None, deletion_id=None):
-        from corehq.form_processor.change_publishers import publish_case_deleted
-
-        assert isinstance(case_ids, list)
-        utcnow = datetime.utcnow()
-        deletion_date = deletion_date or utcnow
-        with CommCareCase.get_plproxy_cursor() as cursor:
-            cursor.execute(
-                'SELECT soft_delete_cases(%s, %s, %s, %s, %s) as affected_count',
-                [domain, case_ids, utcnow, deletion_date, deletion_id]
-            )
-            results = fetchall_as_namedtuple(cursor)
-            affected_count = sum([result.affected_count for result in results])
-
-        for case_id in case_ids:
-            publish_case_deleted(domain, case_id)
-
-        return affected_count
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCase.objects.soft_delete_cases(domain, case_ids, deletion_date, deletion_id)
 
     @staticmethod
     def get_case_owner_ids(domain):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -553,19 +553,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_last_modified_dates(domain, case_ids):
-        """
-        Given a list of case IDs, return a dict where the ids are keys and the
-        values are the last server modified date of that case.
-        """
-        if not case_ids:
-            return []
-        with CommCareCase.get_plproxy_cursor(readonly=True) as cursor:
-            cursor.execute(
-                'SELECT case_id, server_modified_on FROM get_case_last_modified_dates(%s, %s)',
-                [domain, case_ids]
-            )
-            results = fetchall_as_namedtuple(cursor)
-            return {result.case_id: result.server_modified_on for result in results}
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCase.objects.get_last_modified_dates(domain, case_ids)
 
     @staticmethod
     def get_cases_by_external_id(domain, external_id, case_type=None):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -587,21 +587,9 @@ class CaseAccessorSQL:
 
     @staticmethod
     def get_case_transactions_by_case_id(case, updated_xforms=None):
-        """
-        This fetches all the transactions required to rebuild the case along
-        with all the forms for those transactions.
-
-        For any forms that have been updated it replaces the old form
-        with the new one.
-
-        :param case_id: ID of case to rebuild
-        :param updated_xforms: list of forms that have been changed.
-        :return: list of ``CaseTransaction`` objects with their associated forms attached.
-        """
-
-        transactions = CaseAccessorSQL.get_transactions_for_case_rebuild(case.case_id)
-        CaseAccessorSQL.fetch_case_transaction_forms(case, transactions, updated_xforms)
-        return transactions
+        warn("DEPRECATED", DeprecationWarning)
+        from .update_strategy import SqlCaseUpdateStrategy
+        return SqlCaseUpdateStrategy(case).get_transactions_for_rebuild(updated_xforms)
 
     @staticmethod
     def fetch_case_transaction_forms(case, transactions, updated_xforms=None):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -580,24 +580,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def soft_undelete_cases(domain, case_ids):
-        from corehq.form_processor.change_publishers import publish_case_saved
-
-        assert isinstance(case_ids, list)
-
-        with CommCareCase.get_plproxy_cursor() as cursor:
-            cursor.execute(
-                'SELECT soft_undelete_cases(%s, %s) as affected_count',
-                [domain, case_ids]
-            )
-            results = fetchall_as_namedtuple(cursor)
-            return_value = sum([result.affected_count for result in results])
-
-        for case_ids_chunk in chunked(case_ids, 500):
-            cases = CaseAccessorSQL.get_cases(list(case_ids_chunk))
-            for case in cases:
-                publish_case_saved(case)
-
-        return return_value
+        warn("DEPRECATED", DeprecationWarning)
+        return CommCareCase.objects.soft_undelete_cases(domain, case_ids)
 
     @staticmethod
     def get_deleted_case_ids_by_owner(domain, owner_id):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -591,12 +591,6 @@ class CaseAccessorSQL:
         from .update_strategy import SqlCaseUpdateStrategy
         return SqlCaseUpdateStrategy(case).get_transactions_for_rebuild(updated_xforms)
 
-    @staticmethod
-    def fetch_case_transaction_forms(case, transactions, updated_xforms=None):
-        warn("DEPRECATED", DeprecationWarning)
-        from .update_strategy import SqlCaseUpdateStrategy
-        SqlCaseUpdateStrategy(case).fetch_case_transaction_forms(transactions, updated_xforms)
-
 
 class LedgerReindexAccessor(ReindexAccessor):
 

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -580,10 +580,8 @@ class CaseAccessorSQL:
 
     @staticmethod
     def form_has_case_transactions(form_id):
-        for db_name in get_db_aliases_for_partitioned_query():
-            if CaseTransaction.objects.using(db_name).filter(form_id=form_id).exists():
-                return True
-        return False
+        warn("DEPRECATED", DeprecationWarning)
+        return CaseTransaction.objects.exists_for_form(form_id)
 
     @staticmethod
     def get_case_transactions_by_case_id(case, updated_xforms=None):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -44,7 +44,6 @@ from corehq.sql_db.util import (
     split_list_by_db_partition,
 )
 from corehq.util.metrics.load_counters import form_load_counter
-from corehq.util.queries import fast_distinct_in_domain
 
 doc_type_to_state = XFormInstance.DOC_TYPE_TO_STATE
 
@@ -581,16 +580,6 @@ class CaseAccessorSQL:
     def soft_delete_cases(domain, case_ids, deletion_date=None, deletion_id=None):
         warn("DEPRECATED", DeprecationWarning)
         return CommCareCase.objects.soft_delete_cases(domain, case_ids, deletion_date, deletion_id)
-
-    @staticmethod
-    def get_case_owner_ids(domain):
-        from corehq.sql_db.util import get_db_aliases_for_partitioned_query
-        db_aliases = get_db_aliases_for_partitioned_query()
-        owner_ids = set()
-        for db_alias in db_aliases:
-            owner_ids.update(fast_distinct_in_domain(CommCareCase, 'owner_id', domain, using=db_alias))
-
-        return owner_ids
 
     @staticmethod
     def form_has_case_transactions(form_id):

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -11,10 +11,7 @@ from lxml import etree
 from casexml.apps.case import const
 from casexml.apps.case.xform import get_case_updates
 from corehq.form_processor.backends.sql.update_strategy import SqlCaseUpdateStrategy
-from corehq.form_processor.backends.sql.dbaccessors import (
-    CaseAccessorSQL,
-    LedgerAccessorSQL,
-)
+from corehq.form_processor.backends.sql.dbaccessors import LedgerAccessorSQL
 from corehq.form_processor.change_publishers import (
     publish_form_saved, publish_case_saved, publish_ledger_v2_saved)
 from corehq.form_processor.exceptions import CaseNotFound, KafkaPublishingError
@@ -326,7 +323,7 @@ class FormProcessorSQL(object):
 
     @staticmethod
     def form_has_case_transactions(form_id):
-        return CaseAccessorSQL.form_has_case_transactions(form_id)
+        return CaseTransaction.objects.exists_for_form(form_id)
 
     @staticmethod
     def get_case_with_lock(case_id, lock=False, wrap=False):

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -304,10 +304,8 @@ class FormProcessorSQL(object):
 
     @staticmethod
     def _rebuild_case_from_transactions(case, detail, updated_xforms=None):
-        transactions = CaseAccessorSQL.get_case_transactions_by_case_id(
-            case,
-            updated_xforms=updated_xforms)
         strategy = SqlCaseUpdateStrategy(case)
+        transactions = strategy.get_transactions_for_rebuild(updated_xforms)
 
         rebuild_transaction = CaseTransaction.rebuild_transaction(case, detail)
         if updated_xforms:

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -354,6 +354,21 @@ class SqlCaseUpdateStrategy(UpdateStrategy):
             for case_update in filtered_updates:
                 self._apply_case_update(case_update, form)
 
+    def get_transactions_for_rebuild(self, updated_xforms=None):
+        """
+        Fetch all the transactions required to rebuild the case along
+        with all the forms for those transactions.
+
+        For any forms that have been updated it replaces the old form
+        with the new one.
+
+        :param updated_xforms: optional list of forms that have been changed.
+        :return: list of ``CaseTransaction`` objects with their associated forms attached.
+        """
+        transactions = CaseTransaction.objects.get_transactions_for_case_rebuild(self.case.case_id)
+        self.fetch_case_transaction_forms(transactions, updated_xforms)
+        return transactions
+
     def fetch_case_transaction_forms(self, transactions, updated_xforms=None):
         """
         Fetch the forms for a list of transactions, caching them on each transaction

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -333,7 +333,7 @@ class SqlCaseUpdateStrategy(UpdateStrategy):
                     error.format(self.case.case_id, sorted_transactions[0])
                 )
 
-        self.fetch_case_transaction_forms(sorted_transactions)
+        self._fetch_case_transaction_forms(sorted_transactions)
         rebuild_detail = RebuildWithReason(reason="client_date_reconciliation")
         rebuild_transaction = CaseTransaction.rebuild_transaction(self.case, rebuild_detail)
         self.rebuild_from_transactions(sorted_transactions, rebuild_transaction)
@@ -366,10 +366,10 @@ class SqlCaseUpdateStrategy(UpdateStrategy):
         :return: list of ``CaseTransaction`` objects with their associated forms attached.
         """
         transactions = CaseTransaction.objects.get_transactions_for_case_rebuild(self.case.case_id)
-        self.fetch_case_transaction_forms(transactions, updated_xforms)
+        self._fetch_case_transaction_forms(transactions, updated_xforms)
         return transactions
 
-    def fetch_case_transaction_forms(self, transactions, updated_xforms=None):
+    def _fetch_case_transaction_forms(self, transactions, updated_xforms=None):
         """
         Fetch the forms for a list of transactions, caching them on each transaction
 

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -21,7 +21,6 @@ from casexml.apps.case.xml import V2
 from casexml.apps.case.xml.parser import KNOWN_PROPERTIES
 
 from corehq import toggles
-from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.exceptions import StockProcessingError
 from corehq.form_processor.models import (
     CaseAttachment,
@@ -31,9 +30,11 @@ from corehq.form_processor.models import (
     RebuildWithReason,
     STANDARD_CHARFIELD_LENGTH,
 )
+from corehq.form_processor.models.forms import XFormInstance, XFormNotFound
 from corehq.form_processor.update_strategy_base import UpdateStrategy
 from corehq.util import cmp
 from corehq.util.metrics import metrics_counter
+from corehq.util.metrics.load_counters import form_load_counter
 from corehq.util.soft_assert import soft_assert
 
 reconciliation_soft_assert = soft_assert('@'.join(['dmiller', 'dimagi.com']))
@@ -332,7 +333,7 @@ class SqlCaseUpdateStrategy(UpdateStrategy):
                     error.format(self.case.case_id, sorted_transactions[0])
                 )
 
-        CaseAccessorSQL.fetch_case_transaction_forms(self.case, sorted_transactions)
+        self.fetch_case_transaction_forms(sorted_transactions)
         rebuild_detail = RebuildWithReason(reason="client_date_reconciliation")
         rebuild_transaction = CaseTransaction.rebuild_transaction(self.case, rebuild_detail)
         self.rebuild_from_transactions(sorted_transactions, rebuild_transaction)
@@ -352,6 +353,56 @@ class SqlCaseUpdateStrategy(UpdateStrategy):
             filtered_updates = [u for u in case_updates if u.id == self.case.case_id]
             for case_update in filtered_updates:
                 self._apply_case_update(case_update, form)
+
+    def fetch_case_transaction_forms(self, transactions, updated_xforms=None):
+        """
+        Fetch the forms for a list of transactions, caching them on each transaction
+
+        :param transactions: list of ``CaseTransaction`` objects:
+        :param updated_xforms: optional list of forms that have been changed.
+        """
+        form_ids = {tx.form_id for tx in transactions if tx.form_id}
+        updated_xforms_map = {
+            xform.form_id: xform for xform in updated_xforms if not xform.is_deprecated
+        } if updated_xforms else {}
+
+        updated_xform_ids = set(updated_xforms_map)
+        form_ids_to_fetch = list(form_ids - updated_xform_ids)
+        form_load_counter("rebuild_case", self.case.domain)(len(form_ids_to_fetch))
+        xform_map = {
+            form.form_id: form
+            for form in XFormInstance.objects.get_forms_with_attachments_meta(form_ids_to_fetch)
+        }
+
+        forms_missing_transactions = list(updated_xform_ids - form_ids)
+        for form_id in forms_missing_transactions:
+            # Add in any transactions that aren't already present
+            form = updated_xforms_map[form_id]
+            case_updates = [update for update in get_case_updates(form) if update.id == self.case.case_id]
+            types = [
+                CaseTransaction.type_from_action_type_slug(a.action_type_slug)
+                for case_update in case_updates
+                for a in case_update.actions
+            ]
+            modified_on = case_updates[0].guess_modified_on()
+            new_transaction = CaseTransaction.form_transaction(self.case, form, modified_on, types)
+            transactions.append(new_transaction)
+
+        def get_form(form_id):
+            if form_id in updated_xforms_map:
+                return updated_xforms_map[form_id]
+
+            try:
+                return xform_map[form_id]
+            except KeyError:
+                raise XFormNotFound(form_id)
+
+        for case_transaction in transactions:
+            if case_transaction.form_id:
+                try:
+                    case_transaction.cached_form = get_form(case_transaction.form_id)
+                except XFormNotFound:
+                    logging.error('Form not found during rebuild: %s', case_transaction.form_id)
 
 
 def _transaction_sort_key_function(case):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -116,9 +116,6 @@ class CaseAccessors(object):
         return CommCareCaseIndex.objects.get_extension_chain(
             self.domain, case_ids, include_closed, exclude_for_case_type)
 
-    def get_case_owner_ids(self):
-        return self.db_accessor.get_case_owner_ids(self.domain)
-
 
 class AbstractLedgerAccessor(metaclass=ABCMeta):
 

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -76,6 +76,7 @@ class CaseAccessors(object):
             self.domain, case_ids, exclude_for_case_type=exclude_for_case_type)
 
     def get_last_modified_dates(self, case_ids):
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.get_last_modified_dates(self.domain, case_ids)
 
     def get_all_reverse_indices_info(self, case_ids):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -103,6 +103,7 @@ class CaseAccessors(object):
         return self.db_accessor.soft_delete_cases(self.domain, case_ids, deletion_date, deletion_id)
 
     def soft_undelete_cases(self, case_ids):
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.soft_undelete_cases(self.domain, case_ids)
 
     def get_deleted_case_ids_by_owner(self, owner_id):

--- a/corehq/form_processor/interfaces/dbaccessors.py
+++ b/corehq/form_processor/interfaces/dbaccessors.py
@@ -99,6 +99,7 @@ class CaseAccessors(object):
         return self.db_accessor.get_cases_by_external_id(self.domain, external_id, case_type)
 
     def soft_delete_cases(self, case_ids, deletion_date=None, deletion_id=None):
+        warn("DEPRECATED use CommCareCase.objects", DeprecationWarning)
         return self.db_accessor.soft_delete_cases(self.domain, case_ids, deletion_date, deletion_id)
 
     def soft_undelete_cases(self, case_ids):

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -186,6 +186,20 @@ class CommCareCaseManager(RequireDBManager):
             )
             return [row[0] for row in cursor]
 
+    def get_last_modified_dates(self, domain, case_ids):
+        """
+        Given a list of case IDs, return a dict where the ids are keys and the
+        values are the last server modified date of that case.
+        """
+        if not case_ids:
+            return []
+        with self.model.get_plproxy_cursor(readonly=True) as cursor:
+            cursor.execute(
+                'SELECT case_id, server_modified_on FROM get_case_last_modified_dates(%s, %s)',
+                [domain, case_ids]
+            )
+            return dict(cursor)
+
     def get_case_xform_ids(self, case_id):
         with self.model.get_plproxy_cursor(readonly=True) as cursor:
             cursor.execute(

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -1179,6 +1179,12 @@ class CaseTransactionManager(RequireDBManager):
                 [case_id, model.case_rebuild_types() | model.TYPE_CASE_CREATE])
             return cursor.fetchone()[0]
 
+    def exists_for_form(self, form_id):
+        for db_name in get_db_aliases_for_partitioned_query():
+            if self.using(db_name).filter(form_id=form_id).exists():
+                return True
+        return False
+
 
 class CaseTransaction(PartitionedModel, SaveStateMixin, models.Model):
     partition_attr = 'case_id'

--- a/corehq/form_processor/reprocess.py
+++ b/corehq/form_processor/reprocess.py
@@ -6,11 +6,11 @@ from casexml.apps.case.exceptions import IllegalCaseId, InvalidCaseIndex, CaseVa
 from casexml.apps.case.exceptions import UsesReferrals
 from corehq.apps.commtrack.exceptions import MissingProductId
 from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
-from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL, LedgerAccessorSQL
+from corehq.form_processor.backends.sql.dbaccessors import LedgerAccessorSQL
 from corehq.form_processor.backends.sql.processor import FormProcessorSQL
 from corehq.form_processor.exceptions import XFormNotFound, PostSaveError
 from corehq.form_processor.interfaces.processor import FormProcessorInterface, ProcessedForms
-from corehq.form_processor.models import XFormInstance, FormReprocessRebuild
+from corehq.form_processor.models import CommCareCase, XFormInstance, FormReprocessRebuild
 from corehq.form_processor.submission_post import SubmissionPost
 from corehq.util.metrics.load_counters import form_load_counter
 from dimagi.utils.couch import LockManager
@@ -191,7 +191,7 @@ def _get_case_ids_needing_rebuild(form, cases):
 
     # exclude any cases that didn't already exist
     case_ids = [case.case_id for case in cases if case.is_saved()]
-    modified_dates = CaseAccessorSQL.get_last_modified_dates(form.domain, case_ids)
+    modified_dates = CommCareCase.objects.get_last_modified_dates(form.domain, case_ids)
     return {
         case_id for case_id in case_ids
         if modified_dates.get(case_id, datetime.max) > form.received_on

--- a/corehq/form_processor/tests/test_case_dbaccessor.py
+++ b/corehq/form_processor/tests/test_case_dbaccessor.py
@@ -641,20 +641,6 @@ class CaseAccessorTestsSQL(TestCase):
         case_ids = CaseAccessorSQL.get_deleted_case_ids_by_owner(DOMAIN, user_id)
         self.assertEqual(set(case_ids), {case1.case_id, case2.case_id})
 
-    def test_get_case_owner_ids(self):
-        _create_case(user_id='user1', case_id='123')  # get's sharded to p1
-        _create_case(user_id='user2', case_id='125')  # get's sharded to p2
-        _create_case(user_id='user1')
-        _create_case(domain='other_domain', user_id='user3')
-        if settings.USE_PARTITIONED_DATABASE:
-            self.addCleanup(lambda: FormProcessorTestUtils.delete_all_cases('other_domain'))
-
-        owners = CaseAccessorSQL.get_case_owner_ids('other_domain')
-        self.assertEqual({'user3'}, owners)
-
-        owners = CaseAccessorSQL.get_case_owner_ids(DOMAIN)
-        self.assertEqual({'user1', 'user2'}, owners)
-
 
 @sharded
 class CaseAccessorsTests(TestCase):

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -634,11 +634,11 @@ class TestCaseTransactionManager(BaseCaseManagerTest):
 
 
 def _create_case(domain=DOMAIN, **kw):
-    return create_case(domain, **kw)
+    return create_case(domain, save=True, **kw)
 
 
 def _create_case_with_index(*args, **kw):
-    return create_case_with_index(DOMAIN, *args, **kw)
+    return create_case_with_index(DOMAIN, save=True, *args, **kw)
 
 
 def _create_case_transactions(case, all_forms=False):

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -672,6 +672,13 @@ class TestCaseTransactionManager(BaseCaseManagerTest):
         self.assertFalse(CaseTransaction.objects.case_has_transactions_since_sync(
             case1.case_id, "foo", datetime.utcnow()))
 
+    def test_exists_for_form(self):
+        self.assertFalse(CaseTransaction.objects.exists_for_form('missing-form'))
+
+        case = _create_case()
+        for form_id in _create_case_transactions(case):
+            self.assertTrue(CaseTransaction.objects.exists_for_form(form_id))
+
 
 def _create_case(domain=DOMAIN, **kw):
     return create_case(domain, save=True, **kw)

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -131,6 +131,18 @@ class TestCommCareCaseManager(BaseCaseManagerTest):
         )
         self.assertItemsEqual(case_ids, [case1.case_id, case2.case_id])
 
+    def test_get_last_modified_dates(self):
+        date1 = datetime(1992, 1, 30, 12, 0)
+        date2 = datetime(2015, 12, 28, 5, 48)
+        case1 = _create_case(server_modified_on=date1)
+        case2 = _create_case(server_modified_on=date2)
+        _create_case()
+
+        self.assertEqual(
+            CommCareCase.objects.get_last_modified_dates(DOMAIN, [case1.case_id, case2.case_id]),
+            {case1.case_id: date1, case2.case_id: date2}
+        )
+
     def test_get_case_xform_ids(self):
         form_id = uuid.uuid4().hex
         case = _create_case(form_id=form_id)

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -331,7 +331,7 @@ class TestCommCareCaseManager(BaseCaseManagerTest):
         with self.assertRaises(CaseSaveError):
             case.save(with_tracked_models=True)
 
-    def test_soft_delete(self):
+    def test_soft_delete_and_undelete(self):
         _create_case(case_id='c1')
         _create_case(case_id='c2')
         _create_case(case_id='c3')
@@ -347,6 +347,19 @@ class TestCommCareCaseManager(BaseCaseManagerTest):
 
         case = CommCareCase.objects.get_case('c3')
         self.assertFalse(case.is_deleted)
+
+        # undelete
+        num = CommCareCase.objects.soft_undelete_cases(DOMAIN, ['c2'])
+        self.assertEqual(num, 1)
+
+        case = CommCareCase.objects.get_case('c1')
+        self.assertTrue(case.is_deleted)
+        self.assertEqual(case.deletion_id, '123')
+
+        for case_id in ['c2', 'c3']:
+            case = CommCareCase.objects.get_case(case_id)
+            self.assertFalse(case.is_deleted, case_id)
+            self.assertIsNone(case.deletion_id, case_id)
 
     def test_hard_delete_cases(self):
         case1 = _create_case()

--- a/corehq/form_processor/tests/test_kafka.py
+++ b/corehq/form_processor/tests/test_kafka.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
 from corehq.util.test_utils import create_and_save_a_case, create_and_save_a_form
 from pillowtop.pillow.interface import ConstructedPillow
@@ -78,7 +78,7 @@ class KafkaPublishingTest(TestCase):
     def test_case_deletions(self):
         case = create_and_save_a_case(self.domain, case_id=uuid.uuid4().hex, case_name='test case')
         with self.process_case_changes:
-            CaseAccessors(self.domain).soft_delete_cases([case.case_id])
+            CommCareCase.objects.soft_delete_cases(self.domain, [case.case_id])
 
         self.assertEqual(1, len(self.processor.changes_seen))
         change_meta = self.processor.changes_seen[0].metadata

--- a/corehq/form_processor/tests/test_usercase_dbaccessor.py
+++ b/corehq/form_processor/tests/test_usercase_dbaccessor.py
@@ -26,6 +26,7 @@ class UsercaseAccessorsTests(TestCase):
             user_id=self.user._id,
             name="bar",
             external_id=self.user._id,
+            save=True,
         )
 
     def test_get_usercase(self):

--- a/corehq/form_processor/tests/test_usercase_dbaccessor.py
+++ b/corehq/form_processor/tests/test_usercase_dbaccessor.py
@@ -5,7 +5,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.models import CommCareCase
 
-from .test_cases import _create_case as create_case
+from .utils import create_case
 
 
 class UsercaseAccessorsTests(TestCase):

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -311,7 +311,7 @@ def create_case(
     *,
     form_id=None,
     case_id=None,
-    case_type=None,
+    case_type='',
     user_id='user1',
     save=False,
     **case_args,
@@ -324,22 +324,22 @@ def create_case(
     form_id = form_id or uuid4().hex
     case_id = case_id or uuid4().hex
     utcnow = datetime.utcnow()
+    case_args.setdefault("owner_id", user_id)
+    case_args.setdefault("opened_on", utcnow)
+    case_args.setdefault("modified_on", utcnow)
+    case_args.setdefault("modified_by", user_id)
+    received_on = case_args.setdefault("server_modified_on", utcnow)
     form = XFormInstance(
         form_id=form_id,
         xmlns='http://openrosa.org/formdesigner/form-processor',
-        received_on=utcnow,
+        received_on=received_on,
         user_id=user_id,
         domain=domain
     )
     case = CommCareCase(
         case_id=case_id,
         domain=domain,
-        type=case_type or '',
-        owner_id=user_id,
-        opened_on=utcnow,
-        modified_on=utcnow,
-        modified_by=user_id,
-        server_modified_on=utcnow,
+        type=case_type,
         **case_args
     )
     case.track_create(CaseTransaction.form_transaction(case, form, utcnow))

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -312,10 +312,12 @@ def create_case(
     case_id=None,
     case_type=None,
     user_id='user1',
+    save=False,
     **case_args,
 ):
     """Create case and related models directly (not via form processor)
 
+    :param save: Save case if true. The default is false.
     :return: CommCareCase
     """
     form_id = form_id or uuid4().hex
@@ -340,7 +342,8 @@ def create_case(
         **case_args
     )
     case.track_create(CaseTransaction.form_transaction(case, form, utcnow))
-    FormProcessorSQL.save_processed_models(ProcessedForms(form, None), [case])
+    if save:
+        FormProcessorSQL.save_processed_models(ProcessedForms(form, None), [case])
     return case
 
 
@@ -351,7 +354,9 @@ def create_case_with_index(
     referenced_type='mother',
     relationship_id=CommCareCaseIndex.CHILD,
     case_is_deleted=False,
-    case_type='child'
+    case_type='child',
+    *,
+    save=False,
 ):
     case = create_case(domain, case_type=case_type)
     case.deleted = case_is_deleted
@@ -363,7 +368,8 @@ def create_case_with_index(
         relationship_id=relationship_id
     )
     case.track_create(index)
-    case.save(with_tracked_models=True)
+    if save:
+        case.save(with_tracked_models=True)
     return case, index
 
 

--- a/corehq/motech/fhir/tests/test_fhir_views.py
+++ b/corehq/motech/fhir/tests/test_fhir_views.py
@@ -10,7 +10,6 @@ from casexml.apps.case.tests.util import delete_all_cases
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.users.models import WebUser
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
 from corehq.motech.fhir.tests.utils import (
     add_case_property_with_resource_property_path,
@@ -196,9 +195,8 @@ def _setup_cases(owner_id):
         _get_caseblock(TEST_CASE_ID, 'test', owner_id).as_text(),
     ], DOMAIN)
 
-    case_accessor = CaseAccessors(DOMAIN)
-    case_accessor.soft_delete_cases(
-        [DELETED_CASE_ID], datetime.utcnow(), 'test-deletion-with-cases'
+    CommCareCase.objects.soft_delete_cases(
+        DOMAIN, [DELETED_CASE_ID], datetime.utcnow(), 'test-deletion-with-cases'
     )
 
     test_case = CommCareCase.objects.get_case(TEST_CASE_ID, DOMAIN)

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -574,6 +574,11 @@ def create_and_save_a_form(domain):
 
 
 def _create_case(domain, **kwargs):
+    """Use corehq.form_processor.tests.utils.create_case() instead if possible
+
+    This submits a form to create the case. The form_procssor version
+    creates and saves the case directly, which is faster.
+    """
     from casexml.apps.case.mock import CaseBlock
     from corehq.apps.hqcase.utils import submit_case_blocks
     return submit_case_blocks(
@@ -583,6 +588,11 @@ def _create_case(domain, **kwargs):
 
 def create_and_save_a_case(domain, case_id, case_name, case_properties=None, case_type=None,
         drop_signals=True, owner_id=None, user_id=None, index=None):
+    """Use corehq.form_processor.tests.utils.create_case() instead if possible
+
+    This submits a form to create the case. The form_procssor version
+    creates and saves the case directly, which is faster.
+    """
     from corehq.form_processor.signals import sql_case_post_save
 
     kwargs = {
@@ -615,6 +625,11 @@ def create_and_save_a_case(domain, case_id, case_name, case_properties=None, cas
 @contextmanager
 def create_test_case(domain, case_type, case_name, case_properties=None, drop_signals=True,
         case_id=None, owner_id=None, user_id=None):
+    """Use corehq.form_processor.tests.utils.create_case() instead if possible
+
+    This submits a form to create the case. The form_procssor version
+    creates and saves the case directly, which is faster.
+    """
     from corehq.apps.sms.tasks import delete_phone_numbers_for_owners
     from corehq.form_processor.models import CommCareCase
     from corehq.messaging.scheduling.scheduling_partitioned.dbaccessors import delete_schedule_instances_by_case_id

--- a/testapps/test_pillowtop/tests/test_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_pillow.py
@@ -9,7 +9,7 @@ from pillowtop.es_utils import initialize_index_and_mapping
 from corehq.apps.es import CaseES, CaseSearchES
 from corehq.apps.es.tests.utils import es_test
 from corehq.elastic import get_es_new
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
@@ -85,7 +85,7 @@ class CasePillowTest(TestCase):
 
         # soft delete the case
         with self.process_case_changes:
-            CaseAccessors(self.domain).soft_delete_cases([case_id])
+            CommCareCase.objects.soft_delete_cases(self.domain, [case_id])
         self.elasticsearch.indices.refresh(CASE_INDEX_INFO.index)
 
         # ensure not there anymore


### PR DESCRIPTION
Continuation of https://github.com/dimagi/commcare-hq/pull/31051, https://github.com/dimagi/commcare-hq/pull/31060, https://github.com/dimagi/commcare-hq/pull/31065, https://github.com/dimagi/commcare-hq/pull/31083, and https://github.com/dimagi/commcare-hq/pull/31092

Case accessor methods are moving into `CommCareCase.objects` (which is `CommCareCaseManager`) or the relevant model manager that makes the most sense. `CaseAccessor(s|SQL)` will eventually be removed.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

In addition to preserving all of the old tests and adapting the old methods that are being phased out to call the new method, new tests (copies of the old tests adapted to the new structure) are being added for the new model manager.

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
