### PR TITLE
Upgrade pip tools

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -350,7 +350,7 @@ pillow==9.0.0
     # via
     #   -r base-requirements.in
     #   reportlab
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r test-requirements.in
 platformdirs==2.4.1
     # via black

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -642,9 +642,9 @@ xmlsec==1.3.11
     # via python3-saml
 yapf==0.31.0
     # via -r dev-requirements.in
-zope.event==4.5.0
+zope-event==4.5.0
     # via gevent
-zope.interface==5.4.0
+zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -660,5 +660,5 @@ setuptools==50.3.0
     #   pip-tools
     #   python-termstyle
     #   sphinx
-    #   zope.event
-    #   zope.interface
+    #   zope-event
+    #   zope-interface

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -503,9 +503,9 @@ xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
-zope.event==4.5.0
+zope-event==4.5.0
     # via gevent
-zope.interface==5.4.0
+zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -516,5 +516,5 @@ setuptools==53.0.0
     #   gunicorn
     #   jsonschema
     #   sphinx
-    #   zope.event
-    #   zope.interface
+    #   zope-event
+    #   zope-interface

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -307,7 +307,7 @@ prometheus-client==0.7.1
     # via -r base-requirements.in
 prompt-toolkit==3.0.26
     # via ipython
-protobuf==3.15.0
+protobuf==3.13.0
     # via ddtrace
 psycogreen==1.0.2
     # via -r base-requirements.in
@@ -531,9 +531,9 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.11
     # via python3-saml
-zope.event==4.5.0
+zope-event==4.5.0
     # via gevent
-zope.interface==5.4.0
+zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -546,5 +546,6 @@ setuptools==50.3.0
     #   gunicorn
     #   ipython
     #   jsonschema
-    #   zope.event
-    #   zope.interface
+    #   protobuf
+    #   zope-event
+    #   zope-interface

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -266,7 +266,7 @@ polib==1.1.0
     # via -r base-requirements.in
 prometheus-client==0.7.1
     # via -r base-requirements.in
-protobuf==3.15.0
+protobuf==3.13.0
     # via ddtrace
 psycogreen==1.0.2
     # via -r base-requirements.in
@@ -457,9 +457,9 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.11
     # via python3-saml
-zope.event==4.5.0
+zope-event==4.5.0
     # via gevent
-zope.interface==5.4.0
+zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -469,5 +469,6 @@ setuptools==50.3.0
     #   gevent
     #   gunicorn
     #   jsonschema
-    #   zope.event
-    #   zope.interface
+    #   protobuf
+    #   zope-event
+    #   zope-interface

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -5,7 +5,7 @@ django-nose @ https://github.com/dimagi/django-nose/raw/fast-first-1.4.6.1/relea
 fakecouch
 nose
 nose-exclude
-pip-tools
+pip-tools>6.4.0
 testil
 requests-mock
 sqlalchemy-postgres-copy

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -287,7 +287,7 @@ pillow==9.0.0
     # via
     #   -r base-requirements.in
     #   reportlab
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r test-requirements.in
 ply==3.11
     # via

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -297,7 +297,7 @@ polib==1.1.0
     # via -r base-requirements.in
 prometheus-client==0.7.1
     # via -r base-requirements.in
-protobuf==3.15.0
+protobuf==3.13.0
     # via ddtrace
 psycogreen==1.0.2
     # via -r base-requirements.in
@@ -510,9 +510,9 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.11
     # via python3-saml
-zope.event==4.5.0
+zope-event==4.5.0
     # via gevent
-zope.interface==5.4.0
+zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -525,5 +525,6 @@ setuptools==50.3.0
     #   gunicorn
     #   jsonschema
     #   pip-tools
-    #   zope.event
-    #   zope.interface
+    #   protobuf
+    #   zope-event
+    #   zope-interface


### PR DESCRIPTION
pip-tools 6.5.1 generates slightly different requirements.txt files, which means that pull requests generated by @dependabot were causing test failures because `make requirements` was using pip-tools 6.4.0 in tests.

## Safety Assurance

### Safety story

Does not affect production code directly.

### Rollback instructions

@dependabot will update requirements files in a way that will cause test failures if this PR is reverted.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
