### PR TITLE
subcase search support for case search

### DIFF
--- a/corehq/apps/case_search/exceptions.py
+++ b/corehq/apps/case_search/exceptions.py
@@ -8,3 +8,18 @@ class CaseSearchNotEnabledException(CaseSearchException):
 
 class CaseSearchUserError(CaseSearchException):
     pass
+
+
+class CaseFilterError(Exception):
+
+    def __init__(self, message, filter_part):
+        self.filter_part = filter_part
+        super(CaseFilterError, self).__init__(message)
+
+
+class TooManyRelatedCasesError(CaseFilterError):
+    pass
+
+
+class XPathFunctionException(CaseFilterError):
+    pass

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -8,7 +8,7 @@ from eulxml.xpath import parse as parse_xpath
 from eulxml.xpath.ast import FunctionCall, Step, UnaryExpression, BinaryExpression, serialize
 
 from corehq.apps.case_search.xpath_functions import (
-    XPATH_FUNCTIONS,
+    XPATH_VALUE_FUNCTIONS,
     XPathFunctionException,
 )
 from corehq.apps.es import filters, queries
@@ -219,12 +219,12 @@ def build_filter_from_ast(domain, node, fuzzy=False):
         if not isinstance(node, FunctionCall):
             return node
         try:
-            return XPATH_FUNCTIONS[node.name](node)
+            return XPATH_VALUE_FUNCTIONS[node.name](node)
         except KeyError:
             raise CaseFilterError(
                 _("We don't know what to do with the function \"{}\". Accepted functions are: {}").format(
                     node.name,
-                    ", ".join(list(XPATH_FUNCTIONS.keys())),
+                    ", ".join(list(XPATH_VALUE_FUNCTIONS.keys())),
                 ),
                 serialize(node)
             )

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -230,7 +230,6 @@ def build_filter_from_ast(domain, node, fuzzy=False):
                 )
 
         if not hasattr(node, 'op'):
-            # TODO: adjust this for subcase queries
             raise CaseFilterError(
                 _("Your search query is required to have at least one boolean operator ({boolean_ops})").format(
                     boolean_ops=", ".join(list(COMPARISON_MAPPING.keys()) + [EQ, NEQ]),

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -267,6 +267,8 @@ def build_filter_from_ast(domain, node, fuzzy=False):
 
 
 def build_filter_from_xpath(domain, xpath, fuzzy=False):
+    """Given an xpath expression this function will generate an Elasticsearch
+    filter"""
     error_message = _(
         "We didn't understand what you were trying to do with {}. "
         "Please try reformatting your query. "

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -78,7 +78,7 @@ def build_filter_from_ast(domain, node, fuzzy=False):
     If fuzzy is true, all equality operations will be treated as fuzzy.
     """
 
-    def _walk_related_cases(node):
+    def _walk_ancestor_cases(node):
         """Return a query that will fulfill the filter on the related case.
 
         :param node: a node returned from eulxml.xpath.parse of the form `parent/grandparent/property = 'value'`
@@ -96,7 +96,7 @@ def build_filter_from_ast(domain, node, fuzzy=False):
 
         # get the related case path we need to walk, i.e. `parent/grandparent/property`
         n = node.left
-        while _is_related_case_lookup(n):
+        while _is_ancestor_case_lookup(n):
             # This walks down the tree and finds case ids that match each identifier
             # This is basically performing multiple "joins" to find related cases since ES
             # doesn't have a way to relate models together
@@ -137,8 +137,8 @@ def build_filter_from_ast(domain, node, fuzzy=False):
         """
         return CaseSearchES().domain(domain).get_child_cases(case_ids, identifier).scroll_ids()
 
-    def _is_related_case_lookup(node):
-        """Returns whether a particular AST node is a related case lookup
+    def _is_ancestor_case_lookup(node):
+        """Returns whether a particular AST node is an ancestory case lookup
 
         e.g. `parent/host/thing = 'foo'`
         """
@@ -221,9 +221,9 @@ def build_filter_from_ast(domain, node, fuzzy=False):
                 serialize(node)
             )
 
-        if _is_related_case_lookup(node):
+        if _is_ancestor_case_lookup(node):
             # this node represents a filter on a property for a related case
-            return _walk_related_cases(node)
+            return _walk_ancestor_cases(node)
 
         if node.op in [EQ, NEQ]:
             # This node is a leaf

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -56,7 +56,6 @@ MAX_RELATED_CASES = 500000  # Limit each related case lookup to return 500,000 c
 
 OPERATOR_MAPPING = {
     'and': filters.AND,
-    'not': filters.NOT,
     'or': filters.OR,
 }
 COMPARISON_MAPPING = {

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -340,7 +340,9 @@ def _parse_normalize_subcase_query(node):
     current_node = node
     invert_condition = False
 
-    if not isinstance(current_node, (FunctionCall, BinaryExpression, Step)):
+    try:
+        assert isinstance(current_node, (FunctionCall, BinaryExpression, Step))
+    except AssertionError:
         raise TypeError("Xpath incorrectly formatted.")  # TODO: clearer error text
 
     # If xpath is a NOT(query), set invert_condition and get first arg
@@ -360,7 +362,8 @@ def _parse_normalize_subcase_query(node):
         assert str(current_node.node_test) in ["subcase_exists", "subcase_count"]
     except AssertionError:
         raise ValueError(
-            f"Xpath incorrectly formatted. Expected: subcase_exists or subcase_count. Received: {current_node.node_test}"
+            "Xpath incorrectly formatted."
+            f"Expected: subcase_exists or subcase_count. Received: {current_node.node_test}"
         )
 
     if str(current_node.node_test) == "subcase_exists":

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -3,12 +3,22 @@ import re
 from django.utils.translation import ugettext as _
 
 from eulxml.xpath import parse as parse_xpath
-from eulxml.xpath.ast import FunctionCall, Step, UnaryExpression, serialize, BinaryExpression
+from eulxml.xpath.ast import (
+    BinaryExpression,
+    FunctionCall,
+    Step,
+    UnaryExpression,
+    serialize,
+)
 
-from corehq.apps.case_search.xpath_functions import (
-    XPATH_VALUE_FUNCTIONS,
-    XPATH_QUERY_FUNCTIONS,
+from corehq.apps.case_search.exceptions import (
+    CaseFilterError,
+    TooManyRelatedCasesError,
     XPathFunctionException,
+)
+from corehq.apps.case_search.xpath_functions import (
+    XPATH_QUERY_FUNCTIONS,
+    XPATH_VALUE_FUNCTIONS,
 )
 from corehq.apps.es import filters
 from corehq.apps.es.case_search import (
@@ -17,17 +27,6 @@ from corehq.apps.es.case_search import (
     case_property_range_query,
     reverse_index_case_query,
 )
-
-
-class CaseFilterError(Exception):
-
-    def __init__(self, message, filter_part):
-        self.filter_part = filter_part
-        super(CaseFilterError, self).__init__(message)
-
-
-class TooManyRelatedCasesError(CaseFilterError):
-    pass
 
 
 def print_ast(node):

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -146,13 +146,13 @@ def build_filter_from_ast(domain, node, fuzzy=False):
         return hasattr(node, 'left') and hasattr(node.left, 'op') and node.left.op == '/'
 
     def _subcase_filter(node):
-        index_identifier, subcase_predicate, case_count_gt, invert_condition = _parse_normalize_subcase_query(node)
-        ids = _get_parent_case_ids_matching_subcase_query(index_identifier, subcase_predicate, case_count_gt)
+        index_identifier, subcase_predicate, count_op, case_count, invert_condition = _parse_normalize_subcase_query(node)
+        ids = _get_parent_case_ids_matching_subcase_query(index_identifier, subcase_predicate, count_op, case_count)
         if invert_condition:
             return filters.NOT(filters.doc_id(ids))
         return filters.doc_id(ids)
 
-    def _get_parent_case_ids_matching_subcase_query(index_identifier, subcase_predicates, case_count_gt):
+    def _get_parent_case_ids_matching_subcase_query(index_identifier, subcase_predicates, count_op, case_count):
         """Get a list of case IDs for cases that have a subcase with the given index identifier
         and matching the subcase predicate filter.
 
@@ -190,11 +190,12 @@ def build_filter_from_ast(domain, node, fuzzy=False):
             if indices:
                 parent_case_id_counter.update([indices[0]['referenced_id']])
 
-        if case_count_gt <= 0:
+        # TODO: support '=' as well as '>' for the comparison operator: 'count_op'
+        if case_count <= 0:
             return list(parent_case_id_counter)
 
         return [
-            case_id for case_id, count in parent_case_id_counter.items() if count > case_count_gt
+            case_id for case_id, count in parent_case_id_counter.items() if count > case_count
         ]
 
     def _is_subcase_lookup(node):

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -343,11 +343,11 @@ def _parse_normalize_subcase_query(node):
     #             str(right.left + right.op + right.right)
     #         ]
 
-        # NOTES:
-        #  - instead of returning a tuple we could create a dataclass to make it easier to work with and
-        #    could encapsulate some functionality:
-        #       subcase_query.include_parent(subcase_count)
-        #       subcase_query.create_parent_filter(matching_parent_ids)
+    # NOTES:
+    #  - instead of returning a tuple we could create a dataclass to make it easier to work with and
+    #    could encapsulate some functionality:
+    #       subcase_query.include_parent(subcase_count)
+    #       subcase_query.create_parent_filter(matching_parent_ids)
 
     current_node = parse_xpath(node)
     invert_condition = False

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -198,13 +198,32 @@ def build_filter_from_ast(domain, node, fuzzy=False):
         ]
 
     def _parse_subcase_query(node):
-        """Parse the subcase query and normalize it to the form 'subcase_count > N'
+        """Parse the subcase query and normalize it to the form 'subcase_count > N' or 'subcase_count = N'
 
-        :returns: tuple(index_identifier, subcase search predicate, case_count_gt, invert_condition)"""
-        return "", None, 0  # TODO
+        Supports the following syntax:
+        - subcase_exists[identifier='X'][ {subcase filter} ]
+        - subcase_count[identifier='X'][ {subcase_filter} ] {one of =, >, <, >=, <= } {integer value}
+
+        :returns: tuple(index_identifier, subcase search predicates, count_op, case_count, invert_condition)
+         - index_identifier: the name of the index identifier to match on
+         - subcase search predicates: list of predicates used to filter the subcase query
+         - count_op: One of ['>', '=']
+         - case_count: Integer value used in conjunction with count_op to filter parent cases
+         - invert_condition: True if the initial expression is one of ['<', '<=']
+        """
+
+        # NOTES:
+        #  - it would be useful to have this accessible in tests so that we can test it
+        #    independently of the rest
+        #  - instead of returning a tuple we could create a dataclass to make it easier to work with and
+        #    could encapsulate some functionality:
+        #       subcase_query.include_parent(subcase_count)
+        #       subcase_query.create_parent_filter(matching_parent_ids)
+
+        return "", [], "", 0, False  # TODO
 
     def _is_subcase_lookup(node):
-        """Returns whether a particular AST node is a subcase lookup"""
+        """Returns whether a particular AST node is a subcase lookup."""
         return False  # TODO
 
     def _raise_step_RHS(node):

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -245,7 +245,7 @@ def build_filter_from_ast(domain, node, fuzzy=False):
             return _walk_ancestor_cases(node)
 
         if _is_subcase_count(node):
-            return XPATH_QUERY_FUNCTIONS['subcase_count'](domain, node, fuzzy)
+            return XPATH_QUERY_FUNCTIONS['subcase-count'](domain, node, fuzzy)
 
         if node.op in [EQ, NEQ]:
             # This node is a leaf

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -1,17 +1,16 @@
 import re
-from collections import Counter
-from dataclasses import dataclass
 
 from django.utils.translation import ugettext as _
 
 from eulxml.xpath import parse as parse_xpath
-from eulxml.xpath.ast import FunctionCall, Step, UnaryExpression, BinaryExpression, serialize
+from eulxml.xpath.ast import FunctionCall, Step, UnaryExpression, serialize
 
 from corehq.apps.case_search.xpath_functions import (
     XPATH_VALUE_FUNCTIONS,
+    XPATH_QUERY_FUNCTIONS,
     XPathFunctionException,
 )
-from corehq.apps.es import filters, queries
+from corehq.apps.es import filters
 from corehq.apps.es.case_search import (
     CaseSearchES,
     case_property_query,
@@ -146,59 +145,6 @@ def build_filter_from_ast(domain, node, fuzzy=False):
         """
         return hasattr(node, 'left') and hasattr(node.left, 'op') and node.left.op == '/'
 
-    def _subcase_filter(node):
-        index_identifier, subcase_predicate, count_op, case_count, invert_condition = _parse_normalize_subcase_query(node)
-        ids = _get_parent_case_ids_matching_subcase_query(index_identifier, subcase_predicate, count_op, case_count)
-        if invert_condition:
-            return filters.NOT(filters.doc_id(ids))
-        return filters.doc_id(ids)
-
-    def _get_parent_case_ids_matching_subcase_query(index_identifier, subcase_predicates, count_op, case_count):
-        """Get a list of case IDs for cases that have a subcase with the given index identifier
-        and matching the subcase predicate filter.
-
-        Only cases with `> case_count_gt` subcases will be returned.
-        """
-        # TODO: validate that the subcase filter doesn't contain any ancestor filtering
-        subcase_filter = build_filter_from_ast(domain, subcase_predicates, fuzzy=fuzzy)
-
-        index_query = queries.nested(
-            'indices',
-            queries.filtered(
-                queries.match_all(),
-                filters.AND(
-                    filters.term('indices.identifier', index_identifier),
-                    filters.NOT(filters.term('indices.referenced_id', ''))  # exclude deleted indices
-                )
-            )
-        )
-        subcase_query = (
-            CaseSearchES().domain(domain)
-                .filter(index_query)
-                .filter(subcase_filter)
-                .source('indices')
-        )
-
-        if subcase_query.count() > MAX_RELATED_CASES:
-            raise TooManyRelatedCasesError(
-                _("The related case lookup you are trying to perform would return too many cases"),
-                ' and '.join([serialize(predicate) for predicate in subcase_predicates])
-            )
-
-        parent_case_id_counter = Counter()
-        for subcase in subcase_query.run().hits:
-            indices = [index for index in subcase['indices'] if index['identifier'] == index_identifier]
-            if indices:
-                parent_case_id_counter.update([indices[0]['referenced_id']])
-
-        # TODO: support '=' as well as '>' for the comparison operator: 'count_op'
-        if case_count <= 0:
-            return list(parent_case_id_counter)
-
-        return [
-            case_id for case_id, count in parent_case_id_counter.items() if count > case_count
-        ]
-
     def _is_subcase_lookup(node):
         """Returns whether a particular AST node is a subcase lookup."""
         return False  # TODO
@@ -272,6 +218,15 @@ def build_filter_from_ast(domain, node, fuzzy=False):
             )
 
     def visit(node):
+        if isinstance(node, FunctionCall):
+            try:
+                return XPATH_QUERY_FUNCTIONS[node.name](domain, node, fuzzy)
+            except KeyError:
+                raise CaseFilterError(
+                    _("Unsupported function '{name}')").format(name=node.name),
+                    serialize(node)
+                )
+
         if not hasattr(node, 'op'):
             # TODO: adjust this for subcase queries
             raise CaseFilterError(
@@ -306,111 +261,6 @@ def build_filter_from_ast(domain, node, fuzzy=False):
         )
 
     return visit(node)
-
-
-@dataclass
-class SubCaseQuery:
-    index_identifier: str
-    subcase_filter: object
-    count_op: str
-    count: int
-    invert: bool
-
-    def as_tuple(self):
-        return (
-            self.index_identifier, serialize(self.subcase_filter), self.count_op, self.count, self.invert
-        )
-
-
-def _parse_normalize_subcase_query(node):
-    """Parse the subcase query and normalize it to the form 'subcase_count > N' or 'subcase_count = N'
-
-    Supports the following syntax:
-    - subcase_exists[identifier='X'][ {subcase filter} ]
-    - subcase_count[identifier='X'][ {subcase_filter} ] {one of =, !=, >, <, >=, <= } {integer value}
-    - not( subcase query )
-
-    :returns: tuple(index_identifier, subcase search predicates, count_op, case_count, invert_condition)
-    - index_identifier: the name of the index identifier to match on
-    - subcase search predicates: list of predicates used to filter the subcase query
-    - count_op: One of ['>', '=']
-    - case_count: Integer value used in conjunction with count_op to filter parent cases
-    - invert_condition: True if the initial expression is one of ['<', '<=']
-    """
-    def parse_predicates(node):
-        if node.op in ['and', 'or']:
-            return [node.left, node.right]
-        return [node]
-
-    # NOTES:
-    #  - instead of returning a tuple we could create a dataclass to make it easier to work with and
-    #    could encapsulate some functionality:
-    #       subcase_query.include_parent(subcase_count)
-    #       subcase_query.create_parent_filter(matching_parent_ids)
-
-    current_node = node
-    invert_condition = False
-
-    try:
-        assert isinstance(current_node, (FunctionCall, BinaryExpression, Step))
-    except AssertionError:
-        raise TypeError("Xpath incorrectly formatted. Check your subcase function syntax.")
-
-    # If xpath is a NOT(query), set invert_condition and get first arg
-    if isinstance(current_node, FunctionCall):
-        if current_node.name.lower() == "not":
-            invert_condition = not invert_condition
-            current_node = current_node.args[0]
-
-    # If subcase query is a count comparison:
-    # Set current_op and case_count, and traverse to left node
-    if isinstance(current_node, BinaryExpression):
-        count_op = current_node.op
-        case_count = current_node.right
-        current_node = current_node.left
-
-    print(current_node)
-    try:
-        assert str(current_node.name) in ["subcase_exists", "subcase_count"]
-    except AssertionError:
-        raise ValueError(
-            "Xpath incorrectly formatted."
-            f"Expected: subcase_exists or subcase_count. Received: {current_node.name}"
-        )
-
-    if str(current_node.name) == "subcase_exists":
-        case_count = 0
-        count_op = ">"
-
-    try:
-        assert count_op in [">", "<", "<=", ">=", "=", "!="]
-    except AssertionError:
-        raise TypeError(f"Xpath incorrectly formatted. Check comparison operator. Received: {count_op}")
-
-    if count_op in ["<", "<="]:
-        invert_condition = not invert_condition
-
-    if count_op in [">=", "<"]:
-        case_count -= 1
-
-    if count_op == "!=":
-        count_op = '='
-        invert_condition = not invert_condition
-
-    if count_op != "=":
-        count_op = ">"
-
-    if count_op == "=" and case_count == 0:
-        count_op = ">"
-        invert_condition = not invert_condition
-
-    index_indetifier = current_node.args[0]
-    # subcase_predicates = parse_predicates(current_node.args[1])
-    subcase_predicates = current_node.args[1]
-
-    print(index_indetifier, subcase_predicates, count_op, case_count, invert_condition)
-
-    return SubCaseQuery(index_indetifier, subcase_predicates, count_op, case_count, invert_condition)
 
 
 def build_filter_from_xpath(domain, xpath, fuzzy=False):

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -608,10 +608,6 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_subcase_count_no_match(self):
-        # TODO: can we 'exit early' if there are no matching subcases? Seems silly to continue
-        # with the parent query if we know there aren't going to be any results. We probably have
-        # to raise an exception and handle it in the calling code.
-
         parsed = parse_xpath("subcase-count('father', house='Tyrell') > 2")
 
         expected_filter = {"terms": {"_id": []}}

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -569,9 +569,33 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         built_filter = build_filter_from_ast(self.domain, parsed)
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
+    def test_subcase_exists__filter_no_match(self):
+        parsed = parse_xpath("subcase-exists('father', name='Mace')")
+        expected_filter = {"terms": {"_id": []}}
+        built_filter = build_filter_from_ast(self.domain, parsed)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
+
+    def test_subcase_exists__no_subase_filter(self):
+        parsed = parse_xpath("subcase-exists('father')")
+        expected_filter = {"terms": {"_id": [self.parent_case_id]}}
+        built_filter = build_filter_from_ast(self.domain, parsed)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
+
     def test_subcase_exists_inverted(self):
         parsed = parse_xpath("not(subcase-exists('father', name='Margaery'))")
         expected_filter = {"bool": {"must_not": {"terms": {"_id": [self.parent_case_id]}}}}
+        built_filter = build_filter_from_ast(self.domain, parsed)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
+
+    def test_subcase_count__no_subcase_filter(self):
+        parsed = parse_xpath("subcase-count('father') > 1")
+        expected_filter = {"terms": {"_id": [self.parent_case_id]}}
+        built_filter = build_filter_from_ast(self.domain, parsed)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
+
+    def test_subcase_count__filter_no_match(self):
+        parsed = parse_xpath("subcase-count('father', house='Martel') > 0")
+        expected_filter = {"terms": {"_id": []}}
         built_filter = build_filter_from_ast(self.domain, parsed)
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -1,15 +1,16 @@
 from django.test import SimpleTestCase, TestCase
 from testil import eq
 
+from corehq.apps.case_search.xpath_functions.subcase_functions import _parse_normalize_subcase_query
 from corehq.util.es.elasticsearch import ConnectionError
-from eulxml.xpath import parse as parse_xpath, serialize as serialize_xpath
+from eulxml.xpath import parse as parse_xpath
 
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from pillowtop.es_utils import initialize_index_and_mapping
 
 from corehq.apps.case_search.filter_dsl import (
     CaseFilterError,
-    build_filter_from_ast, _parse_normalize_subcase_query,
+    build_filter_from_ast,
 )
 from corehq.apps.es import CaseSearchES
 from corehq.apps.es.tests.utils import ElasticTestMixin, es_test

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -9,9 +9,9 @@ from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from pillowtop.es_utils import initialize_index_and_mapping
 
 from corehq.apps.case_search.filter_dsl import (
-    CaseFilterError,
     build_filter_from_ast,
 )
+from corehq.apps.case_search.exceptions import CaseFilterError
 from corehq.apps.es import CaseSearchES
 from corehq.apps.es.tests.utils import ElasticTestMixin, es_test
 from corehq.elastic import get_es_new, send_to_elasticsearch

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -59,7 +59,7 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
             }
         }
         built_filter = build_filter_from_ast("domain", parsed)
-        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_not_filter(self):
         parsed = parse_xpath("not(name = 'farid')")
@@ -99,7 +99,7 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
             }
         }
         built_filter = build_filter_from_ast("domain", parsed)
-        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_date_comparison(self):
         parsed = parse_xpath("dob >= '2017-02-12'")
@@ -215,7 +215,7 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
             }
         }
         built_filter = build_filter_from_ast("domain", parsed)
-        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_case_property_existence(self):
         parsed = parse_xpath("property != ''")
@@ -384,7 +384,7 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         }
 
         built_filter = build_filter_from_ast("domain", parsed)
-        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_self_reference(self):
         with self.assertRaises(CaseFilterError):
@@ -520,7 +520,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
             }
         }
         built_filter = build_filter_from_ast(self.domain, parsed)
-        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
         self.assertEqual([self.child_case1_id, self.child_case2_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
 
     def test_nested_parent_lookups(self):
@@ -557,7 +557,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
             }
         }
         built_filter = build_filter_from_ast(self.domain, parsed)
-        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
         self.assertEqual([self.child_case1_id, self.child_case2_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
 
     def test_subcase_exists(self):
@@ -565,7 +565,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
 
         expected_filter = {"terms": {"_id": [self.parent_case_id]}}
         built_filter = build_filter_from_ast(self.domain, parsed)
-        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
         self.assertEqual([self.parent_case_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
 
     def test_subcase_exists_inverted(self):
@@ -573,7 +573,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
 
         expected_filter = {"bool": {"must_not": {"terms": {"_id": [self.parent_case_id]}}}}
         built_filter = build_filter_from_ast(self.domain, parsed)
-        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
         self.assertEqual(
             [self.child_case1_id, self.child_case2_id, self.grandparent_case_id],
             CaseSearchES().filter(built_filter).values_list('_id', flat=True)
@@ -584,7 +584,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
 
         expected_filter = {"terms": {"_id": [self.parent_case_id]}}
         built_filter = build_filter_from_ast(self.domain, parsed)
-        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
         self.assertEqual([self.parent_case_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
 
     def test_subcase_count_lt(self):
@@ -592,7 +592,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
 
         expected_filter = {"bool": {"must_not": {"terms": {"_id": [self.parent_case_id]}}}}
         built_filter = build_filter_from_ast(self.domain, parsed)
-        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
         self.assertEqual(
             {self.grandparent_case_id, self.child_case1_id, self.child_case2_id},
             set(CaseSearchES().filter(built_filter).values_list('_id', flat=True))
@@ -605,7 +605,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
 
         expected_filter = {"match_all": {}}
         built_filter = build_filter_from_ast(self.domain, parsed)
-        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_subcase_count_no_match(self):
         # TODO: can we 'exit early' if there are no matching subcases? Seems silly to continue
@@ -616,7 +616,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
 
         expected_filter = {"terms": {"_id": []}}
         built_filter = build_filter_from_ast(self.domain, parsed)
-        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
         self.assertEqual([], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
 
     def test_subcase_count_eq(self):

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -619,6 +619,17 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         self.checkQuery(expected_filter, built_filter, is_raw_query=True)
         self.assertEqual([], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
 
+    def test_subcase_count_eq(self):
+        parsed = parse_xpath("subcase-count('father', house='Tyrell') = 2")
+
+        expected_filter = {"terms": {"_id": [self.parent_case_id]}}
+        built_filter = build_filter_from_ast(self.domain, parsed)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
+        self.assertEqual(
+            {self.parent_case_id},
+            set(CaseSearchES().filter(built_filter).values_list('_id', flat=True))
+        )
+
 
 def test_subcase_query_parsing():
     def _check(query, expected):

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -586,62 +586,62 @@ def test_subcase_query_parsing():
     yield from [
         (
             _check,
-            "subcase_exists[identifier='parent'][@case_type='bob']",
+            "subcase_exists('parent', @case_type='bob')",
             ("parent", ["@case_type='bob'"], ">", 0, False)
         ),
         (
             _check,
-            "subcase_exists[identifier='p'][@case_type='bob'][prop='value']",
+            "subcase_exists('p', (@case_type='bob' and prop='value'))",
             ("p", ["@case_type='bob'", "prop='value'"], ">", 0, False)
         ),
         (
             _check,
-            "not(subcase_exists[identifier='p'][prop=1])",
+            "not(subcase_exists('p', prop=1))",
             ("p", ["prop=1"], ">", 0, True)
         ),
         (
             _check,
-            "subcase_count[identifier='p'][prop=1] > 3",
+            "subcase_count('p', prop=1) > 3",
             ("p", ["prop=1"], ">", 3, False)
         ),
         (
             _check,
-            "subcase_count[identifier='p'][prop=1] >= 3",
+            "subcase_count('p', prop=1) >= 3",
             ("p", ["prop=1"], ">", 2, False)
         ),
         (
             _check,
-            "subcase_count[identifier='p'][prop=1] < 3",
+            "subcase_count('p', prop=1) < 3",
             ("p", ["prop=1"], ">", 2, True)
         ),
         (
             _check,
-            "subcase_count[identifier='p'][prop=1] <= 3",
+            "subcase_count('p', prop=1) <= 3",
             ("p", ["prop=1"], ">", 3, True)
         ),
         (
             _check,
-            "subcase_count[identifier='p'][prop=1] = 3",
+            "subcase_count('p', prop=1) = 3",
             ("p", ["prop=1"], "=", 3, False)
         ),
         (
             _check,
-            "subcase_count[identifier='p'][prop=1] = 0",
+            "subcase_count('p', prop=1) = 0",
             ("p", ["prop=1"], ">", 0, True)
         ),
         (
             _check,
-            "subcase_count[identifier='p'][prop=1] != 2",
+            "subcase_count('p', prop=1) != 2",
             ("p", ["prop=1"], "=", 2, True)
         ),
         (
             _check,
-            "not(subcase_count[identifier='p'][prop=1] = 2)",
-            ("p", ["prop=1"], "!=", 2, True)
+            "not(subcase_count('p', prop=1) = 2)",
+            ("p", ["prop=1"], "=", 2, True)
         ),
         (  # double inversion: not, <
             _check,
-            "not(subcase_count[identifier='p'][prop=1] < 3)",
+            "not(subcase_count('p', prop=1) < 3)",
             ("p", ["prop=1"], ">", 2, False)
         ),
     ]

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -521,7 +521,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         self.assertEqual([self.child_case1_id, self.child_case2_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
 
     def test_subase_exists(self):
-        parsed = parse_xpath("subcase_exists[identifier='father'][name='Margaery']")
+        parsed = parse_xpath("subcase-exists[identifier='father'][name='Margaery']")
 
         expected_filter = {"terms": {"_id": [self.parent_case_id]}}
         built_filter = build_filter_from_ast(self.domain, parsed)
@@ -529,7 +529,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         self.assertEqual([self.parent_case_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
 
     def test_subase_exists_inverted(self):
-        parsed = parse_xpath("not(subcase_exists[identifier='father'][name='Margaery'])")
+        parsed = parse_xpath("not(subcase-exists[identifier='father'][name='Margaery'])")
 
         expected_filter = {"bool": {"must_not": {"terms": {"_id": [self.parent_case_id]}}}}
         built_filter = build_filter_from_ast(self.domain, parsed)
@@ -537,7 +537,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         self.assertEqual([self.parent_case_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
 
     def test_subase_count_gt(self):
-        parsed = parse_xpath("subcase_count[identifier='father'][house='Tyrell'] > 1")
+        parsed = parse_xpath("subcase-count[identifier='father'][house='Tyrell'] > 1")
 
         expected_filter = {"terms": {"_id": [self.parent_case_id]}}
         built_filter = build_filter_from_ast(self.domain, parsed)
@@ -545,7 +545,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         self.assertEqual([self.parent_case_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
 
     def test_subase_count_lt(self):
-        parsed = parse_xpath("subcase_count[identifier='father'][house='Tyrell'] < 1")
+        parsed = parse_xpath("subcase-count[identifier='father'][house='Tyrell'] < 1")
 
         expected_filter = {"bool": {"must_not": {"terms": {"_id": [self.parent_case_id]}}}}
         built_filter = build_filter_from_ast(self.domain, parsed)
@@ -558,7 +558,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
     def test_subase_count_lt_no_match(self):
         """Subcase filter matches no cases and since it's an 'inverted' filter (lt)
         we don't need to apply any filtering to the parent query"""
-        parsed = parse_xpath("subcase_count[identifier='father'][house='Reyne'] < 1")
+        parsed = parse_xpath("subcase-count[identifier='father'][house='Reyne'] < 1")
 
         expected_filter = None
         built_filter = build_filter_from_ast(self.domain, parsed)
@@ -569,7 +569,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         # with the parent query if we know there aren't going to be any results. We probably have
         # to raise an exception and handle it in the calling code.
 
-        parsed = parse_xpath("subcase_count[identifier='father'][house='Tyrell'] > 2")
+        parsed = parse_xpath("subcase-count[identifier='father'][house='Tyrell'] > 2")
 
         expected_filter = {"terms": {"_id": []}}
         built_filter = build_filter_from_ast(self.domain, parsed)
@@ -586,62 +586,62 @@ def test_subcase_query_parsing():
     yield from [
         (
             _check,
-            "subcase_exists('parent', @case_type='bob')",
+            "subcase-exists('parent', @case_type='bob')",
             ("parent", "@case_type='bob'", ">", 0, False)
         ),
         (
             _check,
-            "subcase_exists('p', @case_type='bob' and prop='value')",
+            "subcase-exists('p', @case_type='bob' and prop='value')",
             ("p", "@case_type='bob' and prop='value'", ">", 0, False)
         ),
         (
             _check,
-            "not(subcase_exists('p', prop=1))",
+            "not(subcase-exists('p', prop=1))",
             ("p", "prop=1", ">", 0, True)
         ),
         (
             _check,
-            "subcase_count('p', prop=1) > 3",
+            "subcase-count('p', prop=1) > 3",
             ("p", "prop=1", ">", 3, False)
         ),
         (
             _check,
-            "subcase_count('p', prop=1) >= 3",
+            "subcase-count('p', prop=1) >= 3",
             ("p", "prop=1", ">", 2, False)
         ),
         (
             _check,
-            "subcase_count('p', prop=1) < 3",
+            "subcase-count('p', prop=1) < 3",
             ("p", "prop=1", ">", 2, True)
         ),
         (
             _check,
-            "subcase_count('p', prop=1) <= 3",
+            "subcase-count('p', prop=1) <= 3",
             ("p", "prop=1", ">", 3, True)
         ),
         (
             _check,
-            "subcase_count('p', prop=1) = 3",
+            "subcase-count('p', prop=1) = 3",
             ("p", "prop=1", "=", 3, False)
         ),
         (
             _check,
-            "subcase_count('p', prop=1) = 0",
+            "subcase-count('p', prop=1) = 0",
             ("p", "prop=1", ">", 0, True)
         ),
         (
             _check,
-            "subcase_count('p', prop=1) != 2",
+            "subcase-count('p', prop=1) != 2",
             ("p", "prop=1", "=", 2, True)
         ),
         (
             _check,
-            "not(subcase_count('p', prop=1) = 2)",
+            "not(subcase-count('p', prop=1) = 2)",
             ("p", "prop=1", "=", 2, True)
         ),
         (  # double inversion: not, <
             _check,
-            "not(subcase_count('p', prop=1) < 3)",
+            "not(subcase-count('p', prop=1) < 3)",
             ("p", "prop=1", ">", 2, False)
         ),
     ]

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -578,19 +578,20 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
 
 def test_subcase_query_parsing():
     def _check(query, expected):
-        result = _parse_normalize_subcase_query(query)
-        eq(result, expected)
+        node = parse_xpath(query)
+        result = _parse_normalize_subcase_query(node)
+        assert(result == expected)
 
     yield from [
         (
             _check,
             "subcase_exists[identifier='parent'][@case_type='bob']",
-            ("parent", ["@case_type='bob'"], ">", 0, False)
+            ("parent", [parse_xpath("@case_type='bob'")], ">", 0, False)
         ),
         (
             _check,
             "subcase_exists[identifier='p'][@case_type='bob'][prop='value']",
-            ("p", ["@case_type='bob'", "prop=value"], ">", 0, False)
+            ("p", ["@case_type='bob'", "prop='value'"], ">", 0, False)
         ),
         (
             _check,

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -596,52 +596,52 @@ def test_subcase_query_parsing():
         ),
         (
             _check,
-            "NOT(subcase_exists[identifier='p'][prop=1]",
+            "not(subcase_exists[identifier='p'][prop=1])",
             ("p", ["prop=1"], ">", 0, True)
         ),
         (
             _check,
-            "subcase_count[identifier='p'][prop=1'] > 3",
+            "subcase_count[identifier='p'][prop=1] > 3",
             ("p", ["prop=1"], ">", 3, False)
         ),
         (
             _check,
-            "subcase_count[identifier='p'][prop=1'] >= 3",
+            "subcase_count[identifier='p'][prop=1] >= 3",
             ("p", ["prop=1"], ">", 2, False)
         ),
         (
             _check,
-            "subcase_count[identifier='p'][prop=1'] < 3",
+            "subcase_count[identifier='p'][prop=1] < 3",
             ("p", ["prop=1"], ">", 2, True)
         ),
         (
             _check,
-            "subcase_count[identifier='p'][prop=1'] <= 3",
+            "subcase_count[identifier='p'][prop=1] <= 3",
             ("p", ["prop=1"], ">", 3, True)
         ),
         (
             _check,
-            "subcase_count[identifier='p'][prop=1'] = 3",
+            "subcase_count[identifier='p'][prop=1] = 3",
             ("p", ["prop=1"], "=", 3, False)
         ),
         (
             _check,
-            "subcase_count[identifier='p'][prop=1'] = 0",
+            "subcase_count[identifier='p'][prop=1] = 0",
             ("p", ["prop=1"], ">", 0, True)
         ),
         (
             _check,
-            "subcase_count[identifier='p'][prop=1'] != 2",
+            "subcase_count[identifier='p'][prop=1] != 2",
             ("p", ["prop=1"], "=", 2, True)
         ),
         (
             _check,
-            "not(subcase_count[identifier='p'][prop=1'] = 2",
-            ("p", ["prop=1"], "=", 2, True)
+            "not(subcase_count[identifier='p'][prop=1] = 2)",
+            ("p", ["prop=1"], "!=", 2, True)
         ),
         (  # double inversion: not, <
             _check,
-            "not(subcase_count[identifier='p'][prop=1'] < 3)",
+            "not(subcase_count[identifier='p'][prop=1] < 3)",
             ("p", ["prop=1"], ">", 2, False)
         ),
     ]

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -639,11 +639,6 @@ def test_subcase_query_parsing():
         ),
         (
             _check,
-            "not(subcase-exists('p', prop=1))",
-            ("p", "prop=1", ">", 0, True)
-        ),
-        (
-            _check,
             "subcase-count('p', prop=1) > 3",
             ("p", "prop=1", ">", 3, False)
         ),
@@ -676,15 +671,5 @@ def test_subcase_query_parsing():
             _check,
             "subcase-count('p', prop=1) != 2",
             ("p", "prop=1", "=", 2, True)
-        ),
-        (
-            _check,
-            "not(subcase-count('p', prop=1) = 2)",
-            ("p", "prop=1", "=", 2, True)
-        ),
-        (  # double inversion: not, <
-            _check,
-            "not(subcase-count('p', prop=1) < 3)",
-            ("p", "prop=1", ">", 2, False)
         ),
     ]

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -2,7 +2,7 @@ from django.test import SimpleTestCase, TestCase
 from testil import eq
 
 from corehq.util.es.elasticsearch import ConnectionError
-from eulxml.xpath import parse as parse_xpath
+from eulxml.xpath import parse as parse_xpath, serialize as serialize_xpath
 
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from pillowtop.es_utils import initialize_index_and_mapping
@@ -580,13 +580,14 @@ def test_subcase_query_parsing():
     def _check(query, expected):
         node = parse_xpath(query)
         result = _parse_normalize_subcase_query(node)
-        assert(result == expected)
+        result = result[0:1] + ([serialize_xpath(v) for v in result[1]],) + result[2:]
+        eq(result, expected)
 
     yield from [
         (
             _check,
             "subcase_exists[identifier='parent'][@case_type='bob']",
-            ("parent", [parse_xpath("@case_type='bob'")], ">", 0, False)
+            ("parent", ["@case_type='bob'"], ">", 0, False)
         ),
         (
             _check,

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -521,7 +521,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         self.assertEqual([self.child_case1_id, self.child_case2_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
 
     def test_subase_exists(self):
-        parsed = parse_xpath("subcase-exists[identifier='father'][name='Margaery']")
+        parsed = parse_xpath("subcase-exists('father', name='Margaery')")
 
         expected_filter = {"terms": {"_id": [self.parent_case_id]}}
         built_filter = build_filter_from_ast(self.domain, parsed)
@@ -529,7 +529,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         self.assertEqual([self.parent_case_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
 
     def test_subase_exists_inverted(self):
-        parsed = parse_xpath("not(subcase-exists[identifier='father'][name='Margaery'])")
+        parsed = parse_xpath("not(subcase-exists('father', name='Margaery'))")
 
         expected_filter = {"bool": {"must_not": {"terms": {"_id": [self.parent_case_id]}}}}
         built_filter = build_filter_from_ast(self.domain, parsed)
@@ -537,7 +537,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         self.assertEqual([self.parent_case_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
 
     def test_subase_count_gt(self):
-        parsed = parse_xpath("subcase-count[identifier='father'][house='Tyrell'] > 1")
+        parsed = parse_xpath("subcase-count('father', house='Tyrell') > 1")
 
         expected_filter = {"terms": {"_id": [self.parent_case_id]}}
         built_filter = build_filter_from_ast(self.domain, parsed)
@@ -545,7 +545,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         self.assertEqual([self.parent_case_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
 
     def test_subase_count_lt(self):
-        parsed = parse_xpath("subcase-count[identifier='father'][house='Tyrell'] < 1")
+        parsed = parse_xpath("subcase-count('father', house='Tyrell') < 1")
 
         expected_filter = {"bool": {"must_not": {"terms": {"_id": [self.parent_case_id]}}}}
         built_filter = build_filter_from_ast(self.domain, parsed)
@@ -558,7 +558,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
     def test_subase_count_lt_no_match(self):
         """Subcase filter matches no cases and since it's an 'inverted' filter (lt)
         we don't need to apply any filtering to the parent query"""
-        parsed = parse_xpath("subcase-count[identifier='father'][house='Reyne'] < 1")
+        parsed = parse_xpath("subcase-count('father', house='Reyne') < 1")
 
         expected_filter = None
         built_filter = build_filter_from_ast(self.domain, parsed)
@@ -569,7 +569,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         # with the parent query if we know there aren't going to be any results. We probably have
         # to raise an exception and handle it in the calling code.
 
-        parsed = parse_xpath("subcase-count[identifier='father'][house='Tyrell'] > 2")
+        parsed = parse_xpath("subcase-count('father', house='Tyrell') > 2")
 
         expected_filter = {"terms": {"_id": []}}
         built_filter = build_filter_from_ast(self.domain, parsed)

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -580,68 +580,67 @@ def test_subcase_query_parsing():
     def _check(query, expected):
         node = parse_xpath(query)
         result = _parse_normalize_subcase_query(node)
-        result = result[0:1] + ([serialize_xpath(v) for v in result[1]],) + result[2:]
-        eq(result, expected)
+        eq(result.as_tuple(), expected)
 
     yield from [
         (
             _check,
             "subcase_exists('parent', @case_type='bob')",
-            ("parent", ["@case_type='bob'"], ">", 0, False)
+            ("parent", "@case_type='bob'", ">", 0, False)
         ),
         (
             _check,
-            "subcase_exists('p', (@case_type='bob' and prop='value'))",
-            ("p", ["@case_type='bob'", "prop='value'"], ">", 0, False)
+            "subcase_exists('p', @case_type='bob' and prop='value')",
+            ("p", "@case_type='bob' and prop='value'", ">", 0, False)
         ),
         (
             _check,
             "not(subcase_exists('p', prop=1))",
-            ("p", ["prop=1"], ">", 0, True)
+            ("p", "prop=1", ">", 0, True)
         ),
         (
             _check,
             "subcase_count('p', prop=1) > 3",
-            ("p", ["prop=1"], ">", 3, False)
+            ("p", "prop=1", ">", 3, False)
         ),
         (
             _check,
             "subcase_count('p', prop=1) >= 3",
-            ("p", ["prop=1"], ">", 2, False)
+            ("p", "prop=1", ">", 2, False)
         ),
         (
             _check,
             "subcase_count('p', prop=1) < 3",
-            ("p", ["prop=1"], ">", 2, True)
+            ("p", "prop=1", ">", 2, True)
         ),
         (
             _check,
             "subcase_count('p', prop=1) <= 3",
-            ("p", ["prop=1"], ">", 3, True)
+            ("p", "prop=1", ">", 3, True)
         ),
         (
             _check,
             "subcase_count('p', prop=1) = 3",
-            ("p", ["prop=1"], "=", 3, False)
+            ("p", "prop=1", "=", 3, False)
         ),
         (
             _check,
             "subcase_count('p', prop=1) = 0",
-            ("p", ["prop=1"], ">", 0, True)
+            ("p", "prop=1", ">", 0, True)
         ),
         (
             _check,
             "subcase_count('p', prop=1) != 2",
-            ("p", ["prop=1"], "=", 2, True)
+            ("p", "prop=1", "=", 2, True)
         ),
         (
             _check,
             "not(subcase_count('p', prop=1) = 2)",
-            ("p", ["prop=1"], "=", 2, True)
+            ("p", "prop=1", "=", 2, True)
         ),
         (  # double inversion: not, <
             _check,
             "not(subcase_count('p', prop=1) < 3)",
-            ("p", ["prop=1"], ">", 2, False)
+            ("p", "prop=1", ">", 2, False)
         ),
     ]

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -589,7 +589,7 @@ def test_subcase_query_parsing():
         ),
         (
             _check,
-            "subcase_exists[identifier='p'][@case_type='bob'][prop=value]",
+            "subcase_exists[identifier='p'][@case_type='bob'][prop='value']",
             ("p", ["@case_type='bob'", "prop=value"], ">", 0, False)
         ),
         (

--- a/corehq/apps/case_search/tests/test_subcase_query_parser.py
+++ b/corehq/apps/case_search/tests/test_subcase_query_parser.py
@@ -1,0 +1,59 @@
+from eulxml.xpath import parse as parse_xpath
+from testil import eq
+
+from corehq.apps.case_search.xpath_functions.subcase_functions import _parse_normalize_subcase_query
+
+
+def test_subcase_query_parsing():
+    def _check(query, expected):
+        node = parse_xpath(query)
+        result = _parse_normalize_subcase_query(node)
+        eq(result.as_tuple(), expected)
+
+    yield from [
+        (
+            _check,
+            "subcase-exists('parent', @case_type='bob')",
+            ("parent", "@case_type='bob'", ">", 0, False)
+        ),
+        (
+            _check,
+            "subcase-exists('p', @case_type='bob' and prop='value')",
+            ("p", "@case_type='bob' and prop='value'", ">", 0, False)
+        ),
+        (
+            _check,
+            "subcase-count('p', prop=1) > 3",
+            ("p", "prop=1", ">", 3, False)
+        ),
+        (
+            _check,
+            "subcase-count('p', prop=1) >= 3",
+            ("p", "prop=1", ">", 2, False)
+        ),
+        (
+            _check,
+            "subcase-count('p', prop=1) < 3",
+            ("p", "prop=1", ">", 2, True)
+        ),
+        (
+            _check,
+            "subcase-count('p', prop=1) <= 3",
+            ("p", "prop=1", ">", 3, True)
+        ),
+        (
+            _check,
+            "subcase-count('p', prop=1) = 3",
+            ("p", "prop=1", "=", 3, False)
+        ),
+        (
+            _check,
+            "subcase-count('p', prop=1) = 0",
+            ("p", "prop=1", ">", 0, True)
+        ),
+        (
+            _check,
+            "subcase-count('p', prop=1) != 2",
+            ("p", "prop=1", "=", 2, True)
+        ),
+    ]

--- a/corehq/apps/case_search/tests/test_subcase_query_parser.py
+++ b/corehq/apps/case_search/tests/test_subcase_query_parser.py
@@ -112,4 +112,14 @@ def test_subcase_query_parsing_validations():
             "subcase-count('p', name = 'bob') > date('2020-01-01')",
             "'subcase-count' must be compared to a positive integer"
         ),
+        (
+            _check,
+            "subcase-count(parent) = 1",
+            "'subcase-count' error. Index identifier must be a string"
+        ),
+        (
+            _check,
+            "subcase-exists(3)",
+            "'subcase-exists' error. Index identifier must be a string"
+        ),
     ]

--- a/corehq/apps/case_search/tests/test_subcase_query_parser.py
+++ b/corehq/apps/case_search/tests/test_subcase_query_parser.py
@@ -102,4 +102,14 @@ def test_subcase_query_parsing_validations():
             "subcase-count('p', name = 'bob') + 1",
             "Unsupported operator for use with 'subcase-count': +"
         ),
+        (
+            _check,
+            "subcase-count('p', name = 'bob') > 'bob'",
+            "'subcase-count' must be compared to a positive integer"
+        ),
+        (
+            _check,
+            "subcase-count('p', name = 'bob') > date('2020-01-01')",
+            "'subcase-count' must be compared to a positive integer"
+        ),
     ]

--- a/corehq/apps/case_search/tests/test_subcase_query_parser.py
+++ b/corehq/apps/case_search/tests/test_subcase_query_parser.py
@@ -57,6 +57,16 @@ def test_subcase_query_parsing():
             "subcase-count('p', prop=1) != 2",
             ("p", "prop=1", "=", 2, True)
         ),
+        (
+            _check,
+            "subcase-count('p') = 2",
+            ("p", None, "=", 2, False)
+        ),
+        (
+            _check,
+            "subcase-exists('p')",
+            ("p", None, ">", 0, False)
+        ),
     ]
 
 
@@ -70,12 +80,12 @@ def test_subcase_query_parsing_validations():
         (
             _check,
             "subcase-exists()",
-            "'subcase-exists' expects two arguments"
+            "'subcase-exists' expects one or two arguments"
         ),
         (
             _check,
             "subcase-count() > 1",
-            "'subcase-count' expects two arguments"
+            "'subcase-count' expects one or two arguments"
         ),
         (
             _check,

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -12,10 +12,8 @@ from corehq.apps.case_search.const import (
     CASE_SEARCH_MAX_RESULTS,
     COMMCARE_PROJECT,
 )
-from corehq.apps.case_search.exceptions import CaseSearchUserError
+from corehq.apps.case_search.exceptions import CaseSearchUserError, CaseFilterError, TooManyRelatedCasesError
 from corehq.apps.case_search.filter_dsl import (
-    CaseFilterError,
-    TooManyRelatedCasesError,
     build_filter_from_xpath,
 )
 from corehq.apps.case_search.models import (

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -1,4 +1,4 @@
-from .query_functions import _not
+from .query_functions import not_
 from .subcase_functions import subcase
 from .value_functions import date  # noqa: F401
 
@@ -9,7 +9,7 @@ XPATH_VALUE_FUNCTIONS = {
 
 
 XPATH_QUERY_FUNCTIONS = {
-    'not': _not,
+    'not': not_,
     'subcase-exists': subcase,
     'subcase-count': subcase,
 }

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -1,5 +1,6 @@
+from .query_functions import _not
 from .subcase_functions import subcase
-from .value_functions import date, XPathFunctionException  # noqa: F401
+from .value_functions import XPathFunctionException, date  # noqa: F401
 
 # functions that transform a value
 XPATH_VALUE_FUNCTIONS = {
@@ -8,6 +9,7 @@ XPATH_VALUE_FUNCTIONS = {
 
 
 XPATH_QUERY_FUNCTIONS = {
+    'not': _not,
     'subcase-exists': subcase,
     'subcase-count': subcase,
 }

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -1,6 +1,12 @@
+from .subcase_functions import subcase
 from .value_functions import date, XPathFunctionException  # noqa: F401
 
 # functions that transform a value
 XPATH_VALUE_FUNCTIONS = {
     'date': date,
+}
+
+
+XPATH_QUERY_FUNCTIONS = {
+    'subcase-exists': subcase,
 }

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -1,0 +1,6 @@
+from .value_functions import date, XPathFunctionException  # noqa: F401
+
+# functions that transform a value
+XPATH_VALUE_FUNCTIONS = {
+    'date': date,
+}

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -1,6 +1,6 @@
 from .query_functions import _not
 from .subcase_functions import subcase
-from .value_functions import XPathFunctionException, date  # noqa: F401
+from .value_functions import date  # noqa: F401
 
 # functions that transform a value
 XPATH_VALUE_FUNCTIONS = {

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -8,6 +8,6 @@ XPATH_VALUE_FUNCTIONS = {
 
 
 XPATH_QUERY_FUNCTIONS = {
-    'subcase_exists': subcase,
-    'subcase_count': subcase,
+    'subcase-exists': subcase,
+    'subcase-count': subcase,
 }

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -8,5 +8,6 @@ XPATH_VALUE_FUNCTIONS = {
 
 
 XPATH_QUERY_FUNCTIONS = {
-    'subcase-exists': subcase,
+    'subcase_exists': subcase,
+    'subcase_count': subcase,
 }

--- a/corehq/apps/case_search/xpath_functions/exceptions.py
+++ b/corehq/apps/case_search/xpath_functions/exceptions.py
@@ -1,0 +1,2 @@
+class XPathFunctionException(Exception):
+    pass

--- a/corehq/apps/case_search/xpath_functions/exceptions.py
+++ b/corehq/apps/case_search/xpath_functions/exceptions.py
@@ -1,2 +1,0 @@
-class XPathFunctionException(Exception):
-    pass

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -1,8 +1,7 @@
 from django.utils.translation import ugettext as _
 
+from corehq.apps.case_search.exceptions import XPathFunctionException
 from corehq.apps.es import filters
-
-from .exceptions import XPathFunctionException
 
 
 def _not(domain, node, fuzzy):

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -1,0 +1,13 @@
+from django.utils.translation import ugettext as _
+
+from corehq.apps.es import filters
+
+from .exceptions import XPathFunctionException
+
+
+def _not(domain, node, fuzzy):
+    from corehq.apps.case_search.filter_dsl import build_filter_from_ast
+
+    if len(node.args) != 1:
+        raise XPathFunctionException(_("The \"not\" function only accepts a single argument"))
+    return filters.NOT(build_filter_from_ast(domain, node.args[0], fuzzy))

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -4,7 +4,7 @@ from corehq.apps.case_search.exceptions import XPathFunctionException
 from corehq.apps.es import filters
 
 
-def _not(domain, node, fuzzy):
+def not_(domain, node, fuzzy):
     from corehq.apps.case_search.filter_dsl import build_filter_from_ast
 
     if len(node.args) != 1:

--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -84,11 +84,11 @@ def _get_parent_case_ids_matching_subcase_query(domain, subcase_query, fuzzy=Fal
 
 
 def _parse_normalize_subcase_query(node):
-    """Parse the subcase query and normalize it to the form 'subcase_count > N' or 'subcase_count = N'
+    """Parse the subcase query and normalize it to the form 'subcase-count > N' or 'subcase-count = N'
 
     Supports the following syntax:
-    - subcase_exists[identifier='X'][ {subcase filter} ]
-    - subcase_count[identifier='X'][ {subcase_filter} ] {one of =, !=, >, <, >=, <= } {integer value}
+    - subcase-exists[identifier='X'][ {subcase filter} ]
+    - subcase-count[identifier='X'][ {subcase_filter} ] {one of =, !=, >, <, >=, <= } {integer value}
     - not( subcase query )
 
     :returns: tuple(index_identifier, subcase search predicates, count_op, case_count, invert_condition)
@@ -106,7 +106,7 @@ def _parse_normalize_subcase_query(node):
     # NOTES:
     #  - instead of returning a tuple we could create a dataclass to make it easier to work with and
     #    could encapsulate some functionality:
-    #       subcase_query.include_parent(subcase_count)
+    #       subcase_query.include_parent(subcase-count)
     #       subcase_query.create_parent_filter(matching_parent_ids)
 
     current_node = node
@@ -132,14 +132,14 @@ def _parse_normalize_subcase_query(node):
 
     print(current_node)
     try:
-        assert str(current_node.name) in ["subcase_exists", "subcase_count"]
+        assert str(current_node.name) in ["subcase-exists", "subcase-count"]
     except AssertionError:
         raise ValueError(
             "Xpath incorrectly formatted."
-            f"Expected: subcase_exists or subcase_count. Received: {current_node.name}"
+            f"Expected: subcase-exists or subcase-count. Received: {current_node.name}"
         )
 
-    if str(current_node.name) == "subcase_exists":
+    if str(current_node.name) == "subcase-exists":
         case_count = 0
         count_op = ">"
 

--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -110,17 +110,6 @@ def _parse_normalize_subcase_query(node) -> SubCaseQuery:
     current_node = node
     invert_condition = False
 
-    try:
-        assert isinstance(current_node, (FunctionCall, BinaryExpression, Step))
-    except AssertionError:
-        raise XPathFunctionException("Xpath incorrectly formatted. Check your subcase function syntax.")
-
-    # If xpath is a NOT(query), set invert_condition and get first arg
-    if isinstance(current_node, FunctionCall):
-        if current_node.name.lower() == "not":
-            invert_condition = not invert_condition
-            current_node = current_node.args[0]
-
     # If subcase query is a count comparison:
     # Set current_op and case_count, and traverse to left node
     if isinstance(current_node, BinaryExpression):

--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -1,0 +1,171 @@
+from collections import Counter
+from dataclasses import dataclass
+
+from django.utils.translation import ugettext as _
+
+from eulxml.xpath.ast import BinaryExpression, FunctionCall, Step, serialize
+
+from corehq.apps.es import CaseSearchES, filters, queries
+
+
+@dataclass
+class SubCaseQuery:
+    index_identifier: str
+    subcase_filter: object
+    count_op: str
+    count: int
+    invert: bool
+
+    def as_tuple(self):
+        return (
+            self.index_identifier, serialize(self.subcase_filter), self.count_op, self.count, self.invert
+        )
+
+
+def subcase(domain, node, fuzzy=False):
+    subcase_query = _parse_normalize_subcase_query(node)
+    ids = _get_parent_case_ids_matching_subcase_query(domain, subcase_query, fuzzy)
+    if subcase_query.invert:
+        return filters.NOT(filters.doc_id(ids))
+    return filters.doc_id(ids)
+
+
+def _get_parent_case_ids_matching_subcase_query(domain, subcase_query, fuzzy=False):
+    """Get a list of case IDs for cases that have a subcase with the given index identifier
+    and matching the subcase predicate filter.
+
+    Only cases with `> case_count_gt` subcases will be returned.
+    """
+    # TODO: validate that the subcase filter doesn't contain any ancestor filtering
+    from corehq.apps.case_search.filter_dsl import (
+        MAX_RELATED_CASES,
+        TooManyRelatedCasesError,
+        build_filter_from_ast,
+    )
+
+    subcase_filter = build_filter_from_ast(domain, subcase_query.subcase_filter, fuzzy=fuzzy)
+
+    index_query = queries.nested(
+        'indices',
+        queries.filtered(
+            queries.match_all(),
+            filters.AND(
+                filters.term('indices.identifier', subcase_query.index_identifier),
+                filters.NOT(filters.term('indices.referenced_id', ''))  # exclude deleted indices
+            )
+        )
+    )
+    subcase_query = (
+        CaseSearchES().domain(domain)
+        .filter(index_query)
+        .filter(subcase_filter)
+        .source('indices')
+    )
+
+    if subcase_query.count() > MAX_RELATED_CASES:
+        raise TooManyRelatedCasesError(
+            _("The related case lookup you are trying to perform would return too many cases"),
+            serialize(subcase_query.subcase_filter)
+        )
+
+    parent_case_id_counter = Counter()
+    for subcase in subcase_query.run().hits:
+        indices = [index for index in subcase['indices'] if index['identifier'] == subcase_query.index_identifier]
+        if indices:
+            parent_case_id_counter.update([indices[0]['referenced_id']])
+
+    # TODO: support '=' as well as '>' for the comparison operator: 'count_op'
+    if subcase_query.count <= 0:
+        return list(parent_case_id_counter)
+
+    return [
+        case_id for case_id, count in parent_case_id_counter.items() if count > subcase_query.count
+    ]
+
+
+def _parse_normalize_subcase_query(node):
+    """Parse the subcase query and normalize it to the form 'subcase_count > N' or 'subcase_count = N'
+
+    Supports the following syntax:
+    - subcase_exists[identifier='X'][ {subcase filter} ]
+    - subcase_count[identifier='X'][ {subcase_filter} ] {one of =, !=, >, <, >=, <= } {integer value}
+    - not( subcase query )
+
+    :returns: tuple(index_identifier, subcase search predicates, count_op, case_count, invert_condition)
+    - index_identifier: the name of the index identifier to match on
+    - subcase search predicates: list of predicates used to filter the subcase query
+    - count_op: One of ['>', '=']
+    - case_count: Integer value used in conjunction with count_op to filter parent cases
+    - invert_condition: True if the initial expression is one of ['<', '<=']
+    """
+    def parse_predicates(node):
+        if node.op in ['and', 'or']:
+            return [node.left, node.right]
+        return [node]
+
+    # NOTES:
+    #  - instead of returning a tuple we could create a dataclass to make it easier to work with and
+    #    could encapsulate some functionality:
+    #       subcase_query.include_parent(subcase_count)
+    #       subcase_query.create_parent_filter(matching_parent_ids)
+
+    current_node = node
+    invert_condition = False
+
+    try:
+        assert isinstance(current_node, (FunctionCall, BinaryExpression, Step))
+    except AssertionError:
+        raise TypeError("Xpath incorrectly formatted. Check your subcase function syntax.")
+
+    # If xpath is a NOT(query), set invert_condition and get first arg
+    if isinstance(current_node, FunctionCall):
+        if current_node.name.lower() == "not":
+            invert_condition = not invert_condition
+            current_node = current_node.args[0]
+
+    # If subcase query is a count comparison:
+    # Set current_op and case_count, and traverse to left node
+    if isinstance(current_node, BinaryExpression):
+        count_op = current_node.op
+        case_count = current_node.right
+        current_node = current_node.left
+
+    print(current_node)
+    try:
+        assert str(current_node.name) in ["subcase_exists", "subcase_count"]
+    except AssertionError:
+        raise ValueError(
+            "Xpath incorrectly formatted."
+            f"Expected: subcase_exists or subcase_count. Received: {current_node.name}"
+        )
+
+    if str(current_node.name) == "subcase_exists":
+        case_count = 0
+        count_op = ">"
+
+    try:
+        assert count_op in [">", "<", "<=", ">=", "=", "!="]
+    except AssertionError:
+        raise TypeError(f"Xpath incorrectly formatted. Check comparison operator. Received: {count_op}")
+
+    if count_op in ["<", "<="]:
+        invert_condition = not invert_condition
+
+    if count_op in [">=", "<"]:
+        case_count -= 1
+
+    if count_op == "!=":
+        count_op = '='
+        invert_condition = not invert_condition
+
+    if count_op != "=":
+        count_op = ">"
+
+    if count_op == "=" and case_count == 0:
+        count_op = ">"
+        invert_condition = not invert_condition
+
+    index_indetifier = current_node.args[0]
+    subcase_predicates = current_node.args[1]
+
+    return SubCaseQuery(index_indetifier, subcase_predicates, count_op, case_count, invert_condition)

--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -55,21 +55,21 @@ def _get_parent_case_ids_matching_subcase_query(domain, subcase_query, fuzzy=Fal
             )
         )
     )
-    subcase_query = (
+    es_query = (
         CaseSearchES().domain(domain)
         .filter(index_query)
         .filter(subcase_filter)
         .source('indices')
     )
 
-    if subcase_query.count() > MAX_RELATED_CASES:
+    if es_query.count() > MAX_RELATED_CASES:
         raise TooManyRelatedCasesError(
             _("The related case lookup you are trying to perform would return too many cases"),
             serialize(subcase_query.subcase_filter)
         )
 
     parent_case_id_counter = Counter()
-    for subcase in subcase_query.run().hits:
+    for subcase in es_query.run().hits:
         indices = [index for index in subcase['indices'] if index['identifier'] == subcase_query.index_identifier]
         if indices:
             parent_case_id_counter.update([indices[0]['referenced_id']])

--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -213,4 +213,10 @@ def _extract_subcase_query_parts(node):
     index_identifier = args[0]
     subcase_filter = args[1] if len(args) == 2 else None
 
+    if not isinstance(index_identifier, str):
+        raise XPathFunctionException(
+            _("'{name}' error. Index identifier must be a string").format(name=current_node.name),
+            serialize(node)
+        )
+
     return index_identifier, subcase_filter, count_op, case_count

--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -182,7 +182,7 @@ def _extract_subcase_query_parts(node):
 
         try:
             case_count = int(case_count)
-        except ValueError:
+        except (ValueError, TypeError):
             raise XPathFunctionException(
                 _("'subcase-count' must be compared to a positive integer"),
                 serialize(node)

--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -26,6 +26,8 @@ def subcase(domain, node, fuzzy=False):
     subcase_query = _parse_normalize_subcase_query(node)
     ids = _get_parent_case_ids_matching_subcase_query(domain, subcase_query, fuzzy)
     if subcase_query.invert:
+        if not ids:
+            return filters.match_all()
         return filters.NOT(filters.doc_id(ids))
     return filters.doc_id(ids)
 

--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -54,7 +54,10 @@ def subcase(domain, node, fuzzy=False):
         if not ids:
             return filters.match_all()
         return filters.NOT(filters.doc_id(ids))
-    return filters.doc_id(ids)  # TODO handle empty ids
+    # uncomment once we are on ES > 2.4
+    # if not ids:
+    #     return filters.match_none()
+    return filters.doc_id(ids)
 
 
 def _get_parent_case_ids_matching_subcase_query(domain, subcase_query, fuzzy=False):

--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -74,8 +74,7 @@ def _get_parent_case_ids_matching_subcase_query(domain, subcase_query, fuzzy=Fal
         if indices:
             parent_case_id_counter.update([indices[0]['referenced_id']])
 
-    # TODO: support '=' as well as '>' for the comparison operator: 'count_op'
-    if subcase_query.count <= 0:
+    if subcase_query.count_op == '>' and subcase_query.count <= 0:
         return list(parent_case_id_counter)
 
     return [

--- a/corehq/apps/case_search/xpath_functions/value_functions.py
+++ b/corehq/apps/case_search/xpath_functions/value_functions.py
@@ -33,8 +33,3 @@ def date(node):
     raise XPathFunctionException(
         "The \"date\" function only accepts integers or strings of the format \"YYYY-mm-dd\""
     )
-
-
-XPATH_FUNCTIONS = {
-    'date': date,
-}

--- a/corehq/apps/case_search/xpath_functions/value_functions.py
+++ b/corehq/apps/case_search/xpath_functions/value_functions.py
@@ -3,7 +3,7 @@ import datetime
 from django.utils.dateparse import parse_date
 from django.utils.translation import ugettext as _
 
-from .exceptions import XPathFunctionException
+from corehq.apps.case_search.exceptions import XPathFunctionException
 
 
 def date(node):

--- a/corehq/apps/case_search/xpath_functions/value_functions.py
+++ b/corehq/apps/case_search/xpath_functions/value_functions.py
@@ -3,9 +3,7 @@ import datetime
 from django.utils.dateparse import parse_date
 from django.utils.translation import ugettext as _
 
-
-class XPathFunctionException(Exception):
-    pass
+from .exceptions import XPathFunctionException
 
 
 def date(node):

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -5,9 +5,9 @@ from django.utils.http import urlencode
 
 from corehq.apps.api.util import make_date_filter
 from corehq.apps.case_search.filter_dsl import (
-    CaseFilterError,
     build_filter_from_xpath,
 )
+from corehq.apps.case_search.exceptions import CaseFilterError
 from corehq.apps.es import case_search, filters
 from corehq.apps.es import cases as case_es
 from dimagi.utils.parsing import FALSE_STRINGS

--- a/corehq/apps/reports/standard/cases/case_list_explorer.py
+++ b/corehq/apps/reports/standard/cases/case_list_explorer.py
@@ -8,7 +8,7 @@ from corehq.apps.case_search.const import (
     CASE_COMPUTED_METADATA,
     SPECIAL_CASE_PROPERTIES_MAP,
 )
-from corehq.apps.case_search.filter_dsl import CaseFilterError
+from corehq.apps.case_search.exceptions import CaseFilterError
 from corehq.apps.es.case_search import CaseSearchES, flatten_result
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader


### PR DESCRIPTION
## Product Description
Support for doing subcase queries in Case Search and CLE via the 'XPath' queries.

There are two variations on the query which allow doing 'exists' queries as well as 'count' queries:
```
subcase-exists('parent', sex = 'm')
subcase-count('host', status='active') > 2
```

Spec: https://docs.google.com/document/d/1yqS-DqPRDHAf2Dy64J053vnu83vS2DY4eYTC1kTitwo/edit#

## Technical Summary
This includes some small refactoring of the 'xpath -> ES' code. In addition to adding support for the above expressions this PR also adds support for the `not` function: 7fd573ebac47b0bad82455cf23de076911083b0c

Best reviewed as a whole 🏠 

## Feature Flag
Case Search

## Safety Assurance

### Safety story
The code changes are well covered by tests. These changes also only impact CLE and the '_xpath_query' case search filter.

### Automated test coverage
Added

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
