### PR TITLE
Clear render_xform cache if necessary

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4874,9 +4874,6 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
     def default_language(self):
         return self.langs[0] if len(self.langs) > 0 else "en"
 
-    def fetch_xform(self, form, build_profile_id=None):
-        return form.validate_form().render_xform(build_profile_id)
-
     @time_method()
     def set_form_versions(self):
         """

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5153,9 +5153,6 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
                 form = form_stuff['form']
                 try:
                     files[filename] = form.render_xform(build_profile_id=build_profile_id)
-                except XFormValidationFailed:
-                    raise XFormException(_('Unable to validate the forms due to a server error. '
-                                           'Please try again later.'))
                 except XFormException as e:
                     raise XFormException(_('Error in form "{}": {}').format(trans(form.name), e))
         return files

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4906,11 +4906,12 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
 
                     # set form version to previous version, and only update if content has changed
                     current_form.version = previous_form.get_version()
-                    current_hash = _hash(self.fetch_xform(current_form))
+                    current_form = current_form.validate_form()
+                    rendered_form = current_form.render_xform()
+                    current_hash = _hash(rendered_form)
                     if previous_hash != current_hash:
                         current_form.version = None
-                        # fetch_xform calls render_xform which is memoized
-                        # clear cache since fetch_xform was called with a mutated form set to the previous version
+                        # clear cache since render_xform was called with a mutated form set to the previous version
                         current_form.render_xform.reset_cache(current_form)
             else:
                 current_form.version = None
@@ -5155,7 +5156,7 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
                 filename = prefix + self.get_form_filename(**form_stuff)
                 form = form_stuff['form']
                 try:
-                    files[filename] = self.fetch_xform(form, build_profile_id=build_profile_id)
+                    files[filename] = form.render_xform(build_profile_id=build_profile_id)
                 except XFormValidationFailed:
                     raise XFormException(_('Unable to validate the forms due to a server error. '
                                            'Please try again later.'))

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4907,8 +4907,7 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
                     # set form version to previous version, and only update if content has changed
                     current_form.version = previous_form.get_version()
                     current_form = current_form.validate_form()
-                    rendered_form = current_form.render_xform()
-                    current_hash = _hash(rendered_form)
+                    current_hash = _hash(current_form.render_xform())
                     if previous_hash != current_hash:
                         current_form.version = None
                         # clear cache since render_xform was called with a mutated form set to the previous version

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4892,30 +4892,28 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
         force_new_version = self.build_profiles != latest_build.build_profiles
         for form_stuff in self.get_forms(bare=False):
             filename = 'files/%s' % self.get_form_filename(**form_stuff)
-            form = form_stuff["form"]
+            current_form = form_stuff["form"]
             if not force_new_version:
                 try:
-                    previous_form = latest_build.get_form(form.unique_id)
+                    previous_form = latest_build.get_form(current_form.unique_id)
                     # take the previous version's compiled form as-is
                     # (generation code may have changed since last build)
                     previous_source = latest_build.fetch_attachment(filename)
                 except (ResourceNotFound, FormNotFoundException):
-                    form.version = None
+                    current_form.version = None
                 else:
                     previous_hash = _hash(previous_source)
 
-                    # hack - temporarily set my version to the previous version
-                    # so that that's not treated as the diff
-                    previous_form_version = previous_form.get_version()
-                    form.version = previous_form_version
-                    my_hash = _hash(self.fetch_xform(form))
-                    if previous_hash != my_hash:
-                        form.version = None
+                    # set form version to previous version, and only update if content has changed
+                    current_form.version = previous_form.get_version()
+                    current_hash = _hash(self.fetch_xform(current_form))
+                    if previous_hash != current_hash:
+                        current_form.version = None
                         # fetch_xform calls render_xform which is memoized
                         # clear cache since fetch_xform was called with a mutated form set to the previous version
-                        form.render_xform.reset_cache(form)
+                        current_form.render_xform.reset_cache(current_form)
             else:
-                form.version = None
+                current_form.version = None
 
     @time_method()
     def set_media_versions(self):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4911,6 +4911,9 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
                     my_hash = _hash(self.fetch_xform(form))
                     if previous_hash != my_hash:
                         form.version = None
+                        # fetch_xform calls render_xform which is memoized
+                        # clear cache since fetch_xform was called with a mutated form set to the previous version
+                        form.render_xform.reset_cache(form)
             else:
                 form.version = None
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1120,7 +1120,7 @@ class FormBase(DocumentSchema):
             form.strip_vellum_ns_attributes()
             try:
                 if form.xml is not None:
-                    validate_xform(self.get_app().domain, etree.tostring(form.xml, encoding='utf-8'))
+                    validate_xform(etree.tostring(form.xml, encoding='utf-8'))
             except XFormValidationError as e:
                 validation_dict = {
                     "fatal_error": e.fatal_error,

--- a/corehq/apps/app_manager/tests/test_xform.py
+++ b/corehq/apps/app_manager/tests/test_xform.py
@@ -1,7 +1,15 @@
+from unittest.mock import patch
+
 from django.test import SimpleTestCase
 
-from ..xform import parse_xml
-from ..exceptions import DangerousXmlException
+from ...formplayer_api.exceptions import FormplayerAPIException
+from ...formplayer_api.form_validation import FormValidationResult
+from ..exceptions import (
+    DangerousXmlException,
+    XFormValidationError,
+    XFormValidationFailed,
+)
+from ..xform import parse_xml, validate_xform
 
 
 class ParseXMLTests(SimpleTestCase):
@@ -38,3 +46,64 @@ class ParseXMLTests(SimpleTestCase):
 
         with self.assertRaises(DangerousXmlException):
             parse_xml(xml)
+
+
+@patch('corehq.apps.app_manager.xform.formplayer_api.validate_form')
+class ValidateXFormTests(SimpleTestCase):
+    """
+    Bare bones test since the actual validation logic lives in formplayer
+    """
+
+    def test_validation_failed_exception_raised(self, mock_validate_form):
+        xml = '''
+        <html>
+            <head>
+                <title>Survey</title>
+            </head>
+        </html>
+        '''.strip()
+
+        mock_validate_form.side_effect = FormplayerAPIException
+
+        # rendered_form = etree.tostring(xml, encoding='utf-8')
+        with self.assertRaises(XFormValidationFailed):
+            validate_xform(xml)
+
+    def test_validation_error_exception_raised(self, mock_validate_form):
+        xml = '''
+        <html>
+            <head>
+                <title>Survey</title>
+            </head>
+        </html>
+        '''.strip()
+
+        validation_result = FormValidationResult(
+            problems=[],
+            success=False,
+            fatal_error=None,
+        )
+        mock_validate_form.return_value = validation_result
+
+        with self.assertRaises(XFormValidationError):
+            validate_xform(xml)
+
+    def test_successful(self, mock_validate_form):
+        xml = '''
+        <html>
+            <head>
+                <title>Survey</title>
+            </head>
+        </html>
+        '''.strip()
+
+        validation_result = FormValidationResult(
+            problems=[],
+            success=True,
+            fatal_error=None,
+        )
+        mock_validate_form.return_value = validation_result
+        try:
+            validate_xform(xml)
+        except (XFormValidationFailed, FormValidationResult) as e:
+            self.fail(f"validate_xform raised {e} unexpectedly")

--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -126,7 +126,7 @@ def patch_get_xform_resource_overrides():
 
 
 def patch_validate_xform():
-    return mock.patch('corehq.apps.app_manager.models.validate_xform', lambda _, __: None)
+    return mock.patch('corehq.apps.app_manager.models.validate_xform', lambda _: None)
 
 
 @unit_testing_only

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -131,15 +131,13 @@ def download_app_strings(request, domain, app_id, lang):
 @safe_cached_download
 def download_xform(request, domain, app_id, module_id, form_id):
     """
-    See Application.fetch_xform
-
+    See FormBase.render_xform
     """
     profile = _get_build_profile_id(request)
     try:
         form = request.app.get_module(module_id).get_form(form_id)
-        return HttpResponse(
-            request.app.fetch_xform(form, build_profile_id=profile)
-        )
+        form = form.validate_form()
+        return HttpResponse(form.render_xform(build_profile_id=profile))
     except (IndexError, ModuleNotFoundException):
         raise Http404()
     except AppManagerException:

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -620,7 +620,7 @@ def autoset_owner_id_for_advanced_action(action):
     return False
 
 
-def validate_xform(domain, source):
+def validate_xform(source):
     if isinstance(source, str):
         source = source.encode("utf-8")
     # normalize and strip comments


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[SAAS-13318](https://dimagi-dev.atlassian.net/browse/SAAS-13318)

This came up in QA ([QA-3863](https://dimagi-dev.atlassian.net/browse/QA-3863)) and was originally deemed not an issue due to a misunderstanding on my part. As Ben described, after making changes to a form, the changes would be reflected in form submissions, but the form version would still be set to the previous version. 

From what I can tell, this was due to the combination of a hack where we set the form's version to the previous version to avoid triggering a diff, and https://github.com/dimagi/commcare-hq/pull/30146 which started caching the `render_xform` method. Since this `render_xform` method was called with the form set to the previous version and then cached, future calls to this method would hit the cache and accept the form with its version set to the previous form. The key future call happens in `get_direct_ccz` which is used by formplayer when installing an app. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested, but should QA this change as well. 
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests, but would like to add some. I'm a bit overwhelmed by this method/module as far as testing goes. My best method for adding tests to existing code usually involves refactoring, which is time consuming and a fix like this should go out ASAP. 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-4031

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

Reverting this PR will re-introduce the versioning bug.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
