### PR TITLE
Remove pygments dependency from base-requirements.in

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
@@ -29,13 +29,6 @@
   {% endif %}
 {% endfor %}
 
-<h3>Code Context</h3>
-{% if code %}
-  <div>{{ code|safe }}</div>
-{% else %}
-  <div>Not available.</div>
-{% endif %}
-
 <h3>Parameters</h3>
 
 <h4>GET</h4>

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -177,14 +177,6 @@ class HqAdminEmailHandler(AdminEmailHandler):
         return subject
 
 
-class NotifyExceptionEmailer(HqAdminEmailHandler):
-
-    def get_context(self, record):
-        context = super(NotifyExceptionEmailer, self).get_context(record)
-        context['subject'] = record.getMessage()
-        return context
-
-
 class HQRequestFilter(Filter):
     """
     Filter that adds custom context to log records for HQ domain, username, and path.

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -21,8 +21,8 @@ def clean_exception(exception):
 
     # couchdbkit doesn't provide a better way for us to catch this exception
     if (
-        isinstance(exception, AssertionError) and
-        str(exception).startswith('received an invalid response of type')
+        isinstance(exception, AssertionError)
+        and str(exception).startswith('received an invalid response of type')
     ):
         message = ("It looks like couch returned an invalid response to "
                    "couchdbkit.  This could contain sensitive information, "
@@ -177,8 +177,9 @@ def with_progress_bar(iterable, length=None, prefix='Processing', oneline=True,
         draw(i, done=True)
     if oneline != "concise":
         end = datetime.now()
-        print("{}Finished at {:%Y-%m-%d %H:%M:%S}".format(info_prefix, end), file=stream)
-        print("{}Elapsed time: {}".format(info_prefix, display_seconds((end - start).total_seconds())), file=stream)
+        elapsed_seconds = (end - start).total_seconds()
+        print(f"{info_prefix}Finished at {end:%Y-%m-%d %H:%M:%S}", file=stream)
+        print(f"{info_prefix}Elapsed time: {display_seconds(elapsed_seconds)}", file=stream)
 
 
 def step_calculator(length, granularity):

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -1,14 +1,10 @@
 import sys
 from collections import defaultdict
-from itertools import islice
 from logging import Filter
 import traceback
 from datetime import timedelta, datetime
 
 from celery._state import get_current_task
-from pygments import highlight
-from pygments.lexers import PythonLexer
-from pygments.formatters import HtmlFormatter
 
 from dimagi.utils.django.email import send_HTML_email as _send_HTML_email
 from django.core import mail
@@ -75,7 +71,6 @@ class HqAdminEmailHandler(AdminEmailHandler):
         request_repr = get_sanitized_request_repr(request)
 
         tb_list = []
-        code = None
         if record.exc_info:
             etype, _value, tb = record.exc_info
             value = clean_exception(_value)
@@ -83,7 +78,6 @@ class HqAdminEmailHandler(AdminEmailHandler):
             formatted_exception = traceback.format_exception_only(etype, value)
             tb_list.extend(formatted_exception)
             extracted_tb = list(reversed(traceback.extract_tb(tb)))
-            code = self.get_code(extracted_tb)
             tb_list.extend(traceback.format_list(extracted_tb))
             stack_trace = '\n'.join(tb_list)
             subject = '%s: %s' % (record.levelname,
@@ -102,7 +96,6 @@ class HqAdminEmailHandler(AdminEmailHandler):
             'tb_list': tb_list,
             'request_repr': request_repr,
             'stack_trace': stack_trace,
-            'code': code,
         })
         if request:
             sanitized_url = sanitize_url(request.build_absolute_uri())
@@ -138,31 +131,6 @@ class HqAdminEmailHandler(AdminEmailHandler):
         if details:
             formatted = '\n'.join('{item[0]}: {item[1]}'.format(item=item) for item in details.items())
             return 'Details:\n{}'.format(formatted)
-
-    @staticmethod
-    def get_code(extracted_tb):
-        try:
-            trace = next((trace for trace in extracted_tb if 'site-packages' not in trace[0]), None)
-            if not trace:
-                return None
-
-            filename = trace[0]
-            lineno = trace[1]
-            offset = 10
-            with open(filename, encoding='utf-8') as f:
-                code_context = list(islice(f, lineno - offset, lineno + offset))
-
-            return highlight(''.join(code_context),
-                PythonLexer(),
-                HtmlFormatter(
-                    noclasses=True,
-                    linenos='table',
-                    hl_lines=[offset, offset],
-                    linenostart=(lineno - offset + 1),
-                )
-            )
-        except Exception as e:
-            return "Unable to extract code. {}".format(e)
 
     @classmethod
     def _clean_subject(cls, subject):

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -1,24 +1,14 @@
 import sys
-from collections import defaultdict
-from itertools import islice
 from logging import Filter
 import traceback
 from datetime import timedelta, datetime
 
 from celery._state import get_current_task
-from pygments import highlight
-from pygments.lexers import PythonLexer
-from pygments.formatters import HtmlFormatter
 
 from dimagi.utils.django.email import send_HTML_email as _send_HTML_email
-from django.core import mail
 from django.http import HttpRequest
-from django.utils.log import AdminEmailHandler
-from django.views.debug import SafeExceptionReporterFilter, get_exception_reporter_filter
-from django.template.loader import render_to_string
+from django.views.debug import get_exception_reporter_filter
 from corehq.util.view_utils import get_request
-from corehq.util.metrics.utils import get_url_group, sanitize_url
-from corehq.util.metrics.const import TAG_UNKNOWN
 
 
 def clean_exception(exception):
@@ -52,137 +42,6 @@ def get_sanitized_request_repr(request):
         return repr(filter.get_post_parameters(request))
 
     return request
-
-
-class HqAdminEmailHandler(AdminEmailHandler):
-    """
-    Custom AdminEmailHandler to include additional details which can be supplied as follows:
-
-    logger.error(message,
-        extra={
-            'details': {'domain': 'demo', 'user': 'user1'}
-        }
-    )
-    """
-
-    def get_context(self, record):
-        from corehq.util.metrics import metrics_counter
-        try:
-            request = record.request
-        except Exception:
-            request = None
-
-        request_repr = get_sanitized_request_repr(request)
-
-        tb_list = []
-        code = None
-        if record.exc_info:
-            etype, _value, tb = record.exc_info
-            value = clean_exception(_value)
-            tb_list = ['Traceback (most recent call first):\n']
-            formatted_exception = traceback.format_exception_only(etype, value)
-            tb_list.extend(formatted_exception)
-            extracted_tb = list(reversed(traceback.extract_tb(tb)))
-            code = self.get_code(extracted_tb)
-            tb_list.extend(traceback.format_list(extracted_tb))
-            stack_trace = '\n'.join(tb_list)
-            subject = '%s: %s' % (record.levelname,
-                                  formatted_exception[0].strip() if formatted_exception else record.getMessage())
-        else:
-            stack_trace = 'No stack trace available'
-            subject = '%s: %s' % (
-                record.levelname,
-                record.getMessage()
-            )
-        context = defaultdict(lambda: '')
-        context.update({
-            'subject': self.format_subject(subject),
-            'message': record.getMessage(),
-            'details': getattr(record, 'details', None),
-            'tb_list': tb_list,
-            'request_repr': request_repr,
-            'stack_trace': stack_trace,
-            'code': code,
-        })
-        if request:
-            sanitized_url = sanitize_url(request.build_absolute_uri())
-            metrics_counter('commcare.error.count', tags={
-                'url': sanitized_url,
-                'group': get_url_group(sanitized_url),
-                'domain': getattr(request, 'domain', TAG_UNKNOWN),
-            })
-
-            context.update({
-                'get': list(request.GET.items()),
-                'post': SafeExceptionReporterFilter().get_post_parameters(request),
-                'method': request.method,
-                'username': request.user.username if getattr(request, 'user', None) else "",
-                'url': request.build_absolute_uri(),
-            })
-        return context
-
-    def emit(self, record):
-        context = self.get_context(record)
-
-        message = "\n\n".join([_f for _f in [
-            context['message'],
-            self.format_details(context['details']),
-            context['stack_trace'],
-            context['request_repr'],
-        ] if _f])
-        html_message = render_to_string('hqadmin/email/error_email.html', context)
-        mail.mail_admins(self._clean_subject(context['subject']), message, fail_silently=True,
-                         html_message=html_message)
-
-    def format_details(self, details):
-        if details:
-            formatted = '\n'.join('{item[0]}: {item[1]}'.format(item=item) for item in details.items())
-            return 'Details:\n{}'.format(formatted)
-
-    @staticmethod
-    def get_code(extracted_tb):
-        try:
-            trace = next((trace for trace in extracted_tb if 'site-packages' not in trace[0]), None)
-            if not trace:
-                return None
-
-            filename = trace[0]
-            lineno = trace[1]
-            offset = 10
-            with open(filename, encoding='utf-8') as f:
-                code_context = list(islice(f, lineno - offset, lineno + offset))
-
-            return highlight(''.join(code_context),
-                PythonLexer(),
-                HtmlFormatter(
-                    noclasses=True,
-                    linenos='table',
-                    hl_lines=[offset, offset],
-                    linenostart=(lineno - offset + 1),
-                )
-            )
-        except Exception as e:
-            return "Unable to extract code. {}".format(e)
-
-    @classmethod
-    def _clean_subject(cls, subject):
-        # Django raises BadHeaderError if subject contains following bad_strings
-        # to guard against Header Inejction.
-        # see https://docs.djangoproject.com/en/1.8/topics/email/#preventing-header-injection
-        # bad-strings list from http://nyphp.org/phundamentals/8_Preventing-Email-Header-Injection
-        bad_strings = ["\r", "\n", "%0a", "%0d", "Content-Type:", "bcc:", "to:", "cc:"]
-        replacement = "-"
-        for i in bad_strings:
-            subject = subject.replace(i, replacement)
-        return subject
-
-
-class NotifyExceptionEmailer(HqAdminEmailHandler):
-
-    def get_context(self, record):
-        context = super(NotifyExceptionEmailer, self).get_context(record)
-        context['subject'] = record.getMessage()
-        return context
 
 
 class HQRequestFilter(Filter):

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -87,7 +87,6 @@ psycopg2>=2.8.4  # Python 3.8 support
 py-KISSmetrics
 pycryptodome>=3.6.6  # security update
 PyGithub
-Pygments
 pygooglechart
 python-dateutil
 python-imap

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -390,7 +390,6 @@ pygithub==1.54.1
     # via -r base-requirements.in
 pygments==2.11.2
     # via
-    #   -r base-requirements.in
     #   ipython
     #   sphinx
 pygooglechart==0.4.0

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -302,9 +302,7 @@ pycryptodome==3.10.1
 pygithub==1.54.1
     # via -r base-requirements.in
 pygments==2.11.2
-    # via
-    #   -r base-requirements.in
-    #   sphinx
+    # via sphinx
 pygooglechart==0.4.0
     # via -r base-requirements.in
 pyjwt==1.7.1

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -328,9 +328,7 @@ pycryptodome==3.10.1
 pygithub==1.54.1
     # via -r base-requirements.in
 pygments==2.11.2
-    # via
-    #   -r base-requirements.in
-    #   ipython
+    # via ipython
 pygooglechart==0.4.0
     # via -r base-requirements.in
 pyjwt==1.7.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -278,8 +278,6 @@ pycryptodome==3.10.1
     # via -r base-requirements.in
 pygithub==1.54.1
     # via -r base-requirements.in
-pygments==2.11.2
-    # via -r base-requirements.in
 pygooglechart==0.4.0
     # via -r base-requirements.in
 pyjwt==1.7.1

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -311,8 +311,6 @@ pycryptodome==3.10.1
     # via -r base-requirements.in
 pygithub==1.54.1
     # via -r base-requirements.in
-pygments==2.11.2
-    # via -r base-requirements.in
 pygooglechart==0.4.0
     # via -r base-requirements.in
 pyjwt==1.7.1

--- a/settings.py
+++ b/settings.py
@@ -1335,14 +1335,6 @@ LOGGING = {
             'maxBytes': 10 * 1024 * 1024,  # 10 MB
             'backupCount': 20  # Backup 200 MB of logs
         },
-        'mail_admins': {
-            'level': 'ERROR',
-            'class': 'corehq.util.log.HqAdminEmailHandler',
-        },
-        'notify_exception': {
-            'level': 'ERROR',
-            'class': 'corehq.util.log.NotifyExceptionEmailer',
-        },
         'null': {
             'class': 'logging.NullHandler',
         },
@@ -1404,7 +1396,7 @@ LOGGING = {
             'propagate': False,
         },
         'smsbillables': {
-            'handlers': ['file', 'console', 'mail_admins'],
+            'handlers': ['file', 'console'],
             'level': 'INFO',
             'propagate': False,
         },

--- a/settings.py
+++ b/settings.py
@@ -1335,6 +1335,14 @@ LOGGING = {
             'maxBytes': 10 * 1024 * 1024,  # 10 MB
             'backupCount': 20  # Backup 200 MB of logs
         },
+        'mail_admins': {
+            'level': 'ERROR',
+            'class': 'corehq.util.log.HqAdminEmailHandler',
+        },
+        'notify_exception': {
+            'level': 'ERROR',
+            'class': 'corehq.util.log.NotifyExceptionEmailer',
+        },
         'null': {
             'class': 'logging.NullHandler',
         },
@@ -1396,7 +1404,7 @@ LOGGING = {
             'propagate': False,
         },
         'smsbillables': {
-            'handlers': ['file', 'console'],
+            'handlers': ['file', 'console', 'mail_admins'],
             'level': 'INFO',
             'propagate': False,
         },

--- a/settings.py
+++ b/settings.py
@@ -1339,10 +1339,6 @@ LOGGING = {
             'level': 'ERROR',
             'class': 'corehq.util.log.HqAdminEmailHandler',
         },
-        'notify_exception': {
-            'level': 'ERROR',
-            'class': 'corehq.util.log.NotifyExceptionEmailer',
-        },
         'null': {
             'class': 'logging.NullHandler',
         },


### PR DESCRIPTION
Pygments was only used directly in HQ code by `HqAdminEmailHandler` and `NotifyExceptionEmailer`, which, according to my inbox, have not been triggered since April 2020. Sentry should cover all use cases for which these handlers were intended.

After this PR is merged pygments is still required indirectly by sphinx and ipython.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

This only removes a couple of logging handlers that sent emails, and appear not to have been triggered for a long time.

### Automated test coverage

No.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
