### PR TITLE
Raise 404 if no couch user

### DIFF
--- a/corehq/apps/linked_domain/decorators.py
+++ b/corehq/apps/linked_domain/decorators.py
@@ -11,10 +11,10 @@ REMOTE_REQUESTER_HEADER = 'HTTP_HQ_REMOTE_REQUESTER'
 def require_access_to_linked_domains(view_func):
     @wraps(view_func)
     def _inner(request, domain, *args, **kwargs):
-        if hasattr(request, 'couch_user'):
-            couch_user = request.couch_user
-        else:
+        if not hasattr(request, 'couch_user'):
             raise Http404()
+
+        couch_user = request.couch_user
 
         def call_view():
             return view_func(request, domain, *args, **kwargs)

--- a/corehq/apps/linked_domain/decorators.py
+++ b/corehq/apps/linked_domain/decorators.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from django.http import HttpResponseBadRequest, HttpResponseForbidden
+from django.http import HttpResponseBadRequest, HttpResponseForbidden, Http404
 
 from corehq.apps.linked_domain.dbaccessors import get_upstream_domain_link
 from corehq.apps.linked_domain.util import can_access_linked_domains
@@ -11,11 +11,14 @@ REMOTE_REQUESTER_HEADER = 'HTTP_HQ_REMOTE_REQUESTER'
 def require_access_to_linked_domains(view_func):
     @wraps(view_func)
     def _inner(request, domain, *args, **kwargs):
-        user = request.couch_user
+        if hasattr(request, 'couch_user'):
+            couch_user = request.couch_user
+        else:
+            raise Http404()
 
         def call_view():
             return view_func(request, domain, *args, **kwargs)
-        if can_access_linked_domains(user, domain):
+        if can_access_linked_domains(couch_user, domain):
             return call_view()
         else:
             return HttpResponseForbidden()


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This [sentry error](https://staging.commcarehq.org/a/qa-mrm-pro-upstream/settings/project/domain_links/) came up in QA. I saw one instance where the request redirected to the login page, but the majority appeared to raise a 404. What is the desired behavior in this case?
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Just a safety check to handle an error case more gracefully.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
