### PR TITLE
Updated default logic in migrate_case_search_prompt_itemset_ids

### DIFF
--- a/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_itemset_ids.py
+++ b/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_itemset_ids.py
@@ -18,7 +18,7 @@ class Command(AppMigrationCommandBase):
         should_save = False
         for module in app_doc.get('modules', []):
             if module.get('search_config'):
-                for prop in module.get('search_config').get('properties'):
+                for prop in module.get('search_config').get('properties', []):
                     (new_itemset, should_save) = wrap_itemset(prop.get('itemset'))
                     prop['itemset'] = new_itemset
 
@@ -27,13 +27,13 @@ class Command(AppMigrationCommandBase):
 
 def wrap_itemset(data):
     should_save = False
-    if data.get('instance_uri', '').startswith(f'jr://fixture/{ItemListsProvider.id}:'):
+    if (data.get('instance_uri') or '').startswith(f'jr://fixture/{ItemListsProvider.id}:'):
         instance_id = data.get('instance_id')
         if instance_id and ItemListsProvider.id not in instance_id:
             should_save = True
             data['instance_id'] = f'{ItemListsProvider.id}:{instance_id}'
             data['nodeset'] = re.sub(r"instance\((.)" + instance_id,
                                      r"instance(\1" + ItemListsProvider.id + r":" + instance_id,
-                                     data.get('nodeset', ''))
+                                     (data.get('nodeset') or ''))
 
     return data, should_save


### PR DESCRIPTION
## Technical Summary
Minor followup for https://github.com/dimagi/commcare-hq/pull/31121

## Feature Flag
Case claim 

## Safety Assurance

### Safety story
Tiny updates to one-off management command.

### Automated test coverage

Command has tests, though they don't cover this logic (perhaps obviously).

### QA Plan
 No


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
