### PR TITLE
Update translations script tx push -s -t instead of -st

### DIFF
--- a/scripts/update-translations.sh
+++ b/scripts/update-translations.sh
@@ -81,7 +81,7 @@ if [[ $? -ne "0" ]]; then
     echo "The output above from compilemessages should have specifics about the locale/ file and line where the error(s) occurred."
     echo "1. Open those files, go to the appropriate lines and fix the errors."
     echo "2. Run './manage.py compilemessages' again to make sure it's fixed."
-    echo "3. Run 'tx push -st' to update them on transifex."
+    echo "3. Run 'tx push -s -t' to update them on transifex."
     echo "4. Now if you do 'git checkout -- locale' and run this script again, it should succeed."
     echo "5. You should probably also reach out to the translator to make sure they don't mess this up again."
     abort
@@ -89,7 +89,7 @@ fi
 set -e
 
 echo "Pushing updates to transifex."
-tx push -st
+tx push -s -t
 
 has_local_changes=`git diff-index HEAD` && true
 if [[ ! $has_local_changes ]]


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ran into:
```
Incorrect Usage: flag provided but not defined: -st

NAME:
   tx push - tx push [options] [resource_id...]

USAGE:
   tx push [command options] [arguments...]

OPTIONS:
   --source, -s                 Push the source file (default: false)
   --translation, -t            Push the translation files (default: false)
   --force, -f                  Push source files without checking modification times (default: false)
   --skip                       Whether to skip on errors (default: false)
   --xliff                      Whether to push XLIFF files (default: false)
   --use-git-timestamps         Compare local files to their Transifex version by their latest commit timestamps. Use this option, for example, when cloning a Git repository. (default: false)
   --all, -a                    Whether to create missing languages on the remote server when possible (default: false)
   --languages value, -l value  Specify which languages you want to push translations for
   --resources value, -r value  Specify which resources you want to push the translations
   --branch value               Push to specific branch (use empty argument '' to use the current branch, if it can be determined) (default: "-1")
   --help, -h                   show help (default: false)

2022/02/16 14:22:48 flag provided but not defined: -st
```
when running this script with the new version of the transifex client (v1.0.0). 

@minhaminha successfully ran `tx push -s -t` so that this has been tested.

Updated [docs](https://confluence.dimagi.com/display/saas/Internationalization+and+Localization+-+Transifex+Translations) as well.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
