### PR TITLE
Cleanup UUID pickling errors

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -120,7 +120,7 @@ def _get_active_scheduling_rules(domain, survey_only=False):
 def get_refresh_alert_schedule_instances_call(broadcast):
     def refresh():
         refresh_alert_schedule_instances.delay(
-            broadcast.schedule_id,
+            broadcast.schedule_id.hex,
             broadcast.recipients,
         )
 

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -130,7 +130,7 @@ def get_refresh_alert_schedule_instances_call(broadcast):
 def get_refresh_timed_schedule_instances_call(broadcast):
     def refresh():
         refresh_timed_schedule_instances.delay(
-            broadcast.schedule_id,
+            broadcast.schedule_id.hex,
             broadcast.recipients,
             start_date_iso_string=json_format_date(broadcast.start_date)
         )

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -392,7 +392,7 @@ class DeactivateScheduleTest(TransactionTestCase):
             p1.assert_has_calls(
                 [
                     call(
-                        broadcast.schedule_id,
+                        broadcast.schedule_id.hex,
                         broadcast.recipients,
                         start_date_iso_string=json_format_date(broadcast.start_date)
                     )
@@ -404,7 +404,7 @@ class DeactivateScheduleTest(TransactionTestCase):
             self.assertEqual(p2.call_count, 2)
             p2.assert_has_calls(
                 [
-                    call(broadcast.schedule_id, broadcast.recipients)
+                    call(broadcast.schedule_id.hex, broadcast.recipients)
                     for broadcast in (self.domain_1_sms_schedules[1], self.domain_1_survey_schedules[1])
                 ],
                 any_order=True

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -438,13 +438,13 @@ class DeactivateScheduleTest(TransactionTestCase):
 
             b = self.domain_1_survey_schedules[0]
             p1.assert_called_once_with(
-                b.schedule_id,
+                b.schedule_id.hex,
                 b.recipients,
                 start_date_iso_string=json_format_date(b.start_date)
             )
 
             b = self.domain_1_survey_schedules[1]
-            p2.assert_called_once_with(b.schedule_id, b.recipients)
+            p2.assert_called_once_with(b.schedule_id.hex, b.recipients)
 
             rule = self.domain_1_survey_schedules[2]
             p3.assert_called_once_with(rule)

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -273,9 +273,9 @@ class AutomaticUpdateRule(models.Model):
                 schedule.deleted = True
                 schedule.save()
                 if isinstance(schedule, AlertSchedule):
-                    delete_case_alert_schedule_instances.delay(schedule.schedule_id)
+                    delete_case_alert_schedule_instances.delay(schedule.schedule_id.hex)
                 elif isinstance(schedule, TimedSchedule):
-                    delete_case_timed_schedule_instances.delay(schedule.schedule_id)
+                    delete_case_timed_schedule_instances.delay(schedule.schedule_id.hex)
                 else:
                     raise TypeError("Unexpected schedule type")
 

--- a/corehq/messaging/scheduling/models/alert_schedule.py
+++ b/corehq/messaging/scheduling/models/alert_schedule.py
@@ -122,4 +122,4 @@ class ImmediateBroadcast(Broadcast):
             self.save()
             self.schedule.deleted = True
             self.schedule.save()
-            delete_alert_schedule_instances.delay(self.schedule_id)
+            delete_alert_schedule_instances.delay(self.schedule_id.hex)

--- a/corehq/messaging/scheduling/models/timed_schedule.py
+++ b/corehq/messaging/scheduling/models/timed_schedule.py
@@ -659,4 +659,4 @@ class ScheduledBroadcast(Broadcast):
             self.save()
             self.schedule.deleted = True
             self.schedule.save()
-            delete_timed_schedule_instances.delay(self.schedule_id)
+            delete_timed_schedule_instances.delay(self.schedule_id.hex)

--- a/corehq/messaging/scheduling/scheduling_partitioned/dbaccessors.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/dbaccessors.py
@@ -308,7 +308,7 @@ def delete_case_schedule_instance(instance):
     instance.delete()
 
 
-def delete_alert_schedule_instances_for_schedule(cls, schedule_id):
+def delete_alert_schedule_instances_for_schedule(cls, schedule_uuid):
     from corehq.messaging.scheduling.scheduling_partitioned.models import (
         AlertScheduleInstance,
         CaseAlertScheduleInstance,
@@ -317,13 +317,13 @@ def delete_alert_schedule_instances_for_schedule(cls, schedule_id):
     if cls not in (AlertScheduleInstance, CaseAlertScheduleInstance):
         raise TypeError("Expected AlertScheduleInstance or CaseAlertScheduleInstance")
 
-    _validate_uuid(schedule_id)
+    _validate_uuid(schedule_uuid)
 
     for db_name in get_db_aliases_for_partitioned_query():
-        cls.objects.using(db_name).filter(alert_schedule_id=schedule_id).delete()
+        cls.objects.using(db_name).filter(alert_schedule_id=schedule_uuid).delete()
 
 
-def delete_timed_schedule_instances_for_schedule(cls, schedule_id):
+def delete_timed_schedule_instances_for_schedule(cls, schedule_uuid):
     from corehq.messaging.scheduling.scheduling_partitioned.models import (
         TimedScheduleInstance,
         CaseTimedScheduleInstance,
@@ -332,10 +332,10 @@ def delete_timed_schedule_instances_for_schedule(cls, schedule_id):
     if cls not in (TimedScheduleInstance, CaseTimedScheduleInstance):
         raise TypeError("Expected TimedScheduleInstance or CaseTimedScheduleInstance")
 
-    _validate_uuid(schedule_id)
+    _validate_uuid(schedule_uuid)
 
     for db_name in get_db_aliases_for_partitioned_query():
-        cls.objects.using(db_name).filter(timed_schedule_id=schedule_id).delete()
+        cls.objects.using(db_name).filter(timed_schedule_id=schedule_uuid).delete()
 
 
 def delete_schedule_instances_by_case_id(domain, case_id):

--- a/corehq/messaging/scheduling/tasks.py
+++ b/corehq/messaging/scheduling/tasks.py
@@ -331,11 +331,12 @@ def refresh_timed_schedule_instances(schedule_id, recipients, start_date_iso_str
                 default_retry_delay=60 * 60, max_retries=24, bind=True)
 def delete_alert_schedule_instances(self, schedule_id):
     """
-    :param schedule_id: the AlertSchedule schedule_id
+    :param schedule_id: type str that is hex representation of the AlertSchedule schedule_id (UUID)
     """
+    schedule_uuid = uuid.UUID(schedule_id)
     try:
-        with CriticalSection(['refresh-alert-schedule-instances-for-%s' % schedule_id.hex], timeout=30 * 60):
-            delete_alert_schedule_instances_for_schedule(AlertScheduleInstance, schedule_id)
+        with CriticalSection(['refresh-alert-schedule-instances-for-%s' % schedule_id], timeout=30 * 60):
+            delete_alert_schedule_instances_for_schedule(AlertScheduleInstance, schedule_uuid)
     except Exception as e:
         self.retry(exc=e)
 
@@ -344,11 +345,12 @@ def delete_alert_schedule_instances(self, schedule_id):
                 default_retry_delay=60 * 60, max_retries=24, bind=True)
 def delete_timed_schedule_instances(self, schedule_id):
     """
-    :param schedule_id: the TimedSchedule schedule_id
+    :param schedule_id: type str that is hex representation of the TimedSchedule schedule_id (UUID)
     """
+    schedule_uuid = uuid.UUID(schedule_id)
     try:
-        with CriticalSection(['refresh-timed-schedule-instances-for-%s' % schedule_id.hex], timeout=30 * 60):
-            delete_timed_schedule_instances_for_schedule(TimedScheduleInstance, schedule_id)
+        with CriticalSection(['refresh-timed-schedule-instances-for-%s' % schedule_id], timeout=30 * 60):
+            delete_timed_schedule_instances_for_schedule(TimedScheduleInstance, schedule_uuid)
     except Exception as e:
         self.retry(exc=e)
 
@@ -357,10 +359,11 @@ def delete_timed_schedule_instances(self, schedule_id):
                 default_retry_delay=60 * 60, max_retries=24, bind=True)
 def delete_case_alert_schedule_instances(self, schedule_id):
     """
-    :param schedule_id: the AlertSchedule schedule_id
+    :param schedule_id: type str that is hex representation of the AlertSchedule schedule_id (UUID)
     """
+    schedule_uuid = uuid.UUID(schedule_id)
     try:
-        delete_alert_schedule_instances_for_schedule(CaseAlertScheduleInstance, schedule_id)
+        delete_alert_schedule_instances_for_schedule(CaseAlertScheduleInstance, schedule_uuid)
     except Exception as e:
         self.retry(exc=e)
 
@@ -369,10 +372,11 @@ def delete_case_alert_schedule_instances(self, schedule_id):
                 default_retry_delay=60 * 60, max_retries=24, bind=True)
 def delete_case_timed_schedule_instances(self, schedule_id):
     """
-    :param schedule_id: the TimedSchedule schedule_id
+    :param schedule_id: type str that is hex representation of the TimedSchedule schedule_id (UUID)
     """
+    schedule_uuid = uuid.UUID(schedule_id)
     try:
-        delete_timed_schedule_instances_for_schedule(CaseTimedScheduleInstance, schedule_id)
+        delete_timed_schedule_instances_for_schedule(CaseTimedScheduleInstance, schedule_uuid)
     except Exception as e:
         self.retry(exc=e)
 

--- a/corehq/messaging/scheduling/tasks.py
+++ b/corehq/messaging/scheduling/tasks.py
@@ -312,7 +312,7 @@ def refresh_alert_schedule_instances(schedule_id, recipients):
 @task(queue=settings.CELERY_REMINDER_RULE_QUEUE, ignore_result=True)
 def refresh_timed_schedule_instances(schedule_id, recipients, start_date_iso_string=None):
     """
-    :param schedule_id: type str that is hex representation of the TimeSchedule schedule_id (UUID)
+    :param schedule_id: type str that is hex representation of the TimedSchedule schedule_id (UUID)
     :param recipients: a list of (recipient_type, recipient_id) tuples; the
     recipient type should be one of the values checked in ScheduleInstance.recipient
     :param start_date_iso_string: the date to start the TimedSchedule formatted as an iso string

--- a/corehq/messaging/scheduling/tests/test_schedules.py
+++ b/corehq/messaging/scheduling/tests/test_schedules.py
@@ -406,11 +406,11 @@ class DeleteScheduleInstancesTest(BaseScheduleTest):
 
     def test_delete_alert_schedule_instances_for_schedule(self):
         refresh_alert_schedule_instances(
-            self.alert_schedule_1.schedule_id,
+            self.alert_schedule_1.schedule_id.hex,
             (('CommCareUser', self.user1.get_id),)
         )
         refresh_alert_schedule_instances(
-            self.alert_schedule_2.schedule_id,
+            self.alert_schedule_2.schedule_id.hex,
             (('CommCareUser', self.user1.get_id), ('CommCareUser', self.user2.get_id))
         )
         self.assertEqual(self.count(get_alert_schedule_instances_for_schedule(self.alert_schedule_1)), 1)
@@ -1418,7 +1418,7 @@ class AlertTest(TestCase):
 
         # Schedule the alert
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 42, 21)
-        refresh_alert_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),))
+        refresh_alert_schedule_instances(self.schedule.schedule_id.hex, (('CommCareUser', self.user1.get_id),))
         self.assertNumInstancesForSchedule(1)
         [instance] = get_alert_schedule_instances_for_schedule(self.schedule)
         self.assertAlertScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 6, 42, 21), True, self.user1)
@@ -1432,7 +1432,7 @@ class AlertTest(TestCase):
         self.assertEqual(send_patch.call_count, 1)
 
         # Test copying of the alert schedule instance for a new recipient
-        refresh_alert_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user2.get_id),))
+        refresh_alert_schedule_instances(self.schedule.schedule_id.hex, (('CommCareUser', self.user2.get_id),))
         self.assertNumInstancesForSchedule(1)
         [instance] = get_alert_schedule_instances_for_schedule(self.schedule)
         self.assertAlertScheduleInstance(instance, 0, 2, datetime(2017, 3, 16, 6, 42, 21), False, self.user2)
@@ -1443,7 +1443,7 @@ class AlertTest(TestCase):
 
         # Schedule the alert
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 42, 21)
-        refresh_alert_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),))
+        refresh_alert_schedule_instances(self.schedule.schedule_id.hex, (('CommCareUser', self.user1.get_id),))
         self.assertNumInstancesForSchedule(1)
         [instance] = get_alert_schedule_instances_for_schedule(self.schedule)
         self.assertAlertScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 6, 42, 21), True, self.user1)
@@ -1464,7 +1464,7 @@ class AlertTest(TestCase):
 
         # Scheduling the alert creates an inactive schedule instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 42, 21)
-        refresh_alert_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),))
+        refresh_alert_schedule_instances(self.schedule.schedule_id.hex, (('CommCareUser', self.user1.get_id),))
         self.assertNumInstancesForSchedule(1)
         [instance] = get_alert_schedule_instances_for_schedule(self.schedule)
         self.assertAlertScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 6, 42, 21), False, self.user1)
@@ -1480,7 +1480,7 @@ class AlertTest(TestCase):
             # to the next event and being put into an inactive state as a result.
             # On the second iteration, it realizes the total iterations have been completed,
             # so nothing changes.
-            refresh_alert_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),))
+            refresh_alert_schedule_instances(self.schedule.schedule_id.hex, (('CommCareUser', self.user1.get_id),))
             self.assertNumInstancesForSchedule(1)
             [instance] = get_alert_schedule_instances_for_schedule(self.schedule)
             self.assertAlertScheduleInstance(instance, 0, 2, datetime(2017, 3, 16, 6, 42, 21), False, self.user1)
@@ -1491,7 +1491,7 @@ class AlertTest(TestCase):
 
         # Schedule the alert
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 42, 21)
-        refresh_alert_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),))
+        refresh_alert_schedule_instances(self.schedule.schedule_id.hex, (('CommCareUser', self.user1.get_id),))
         self.assertNumInstancesForSchedule(1)
         [instance] = get_alert_schedule_instances_for_schedule(self.schedule)
         self.assertAlertScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 6, 42, 21), True, self.user1)
@@ -1500,7 +1500,7 @@ class AlertTest(TestCase):
         # Deactivate
         self.schedule.active = False
         self.schedule.save()
-        refresh_alert_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),))
+        refresh_alert_schedule_instances(self.schedule.schedule_id.hex, (('CommCareUser', self.user1.get_id),))
         self.assertNumInstancesForSchedule(1)
         [instance] = get_alert_schedule_instances_for_schedule(self.schedule)
         self.assertAlertScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 6, 42, 21), False, self.user1)
@@ -1517,7 +1517,7 @@ class AlertTest(TestCase):
 
         # Schedule the alert
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 42, 21)
-        refresh_alert_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),))
+        refresh_alert_schedule_instances(self.schedule.schedule_id.hex, (('CommCareUser', self.user1.get_id),))
         self.assertNumInstancesForSchedule(1)
         [instance] = get_alert_schedule_instances_for_schedule(self.schedule)
         self.assertAlertScheduleInstance(instance, 0, 1, datetime(2017, 3, 16, 6, 47, 21), True, self.user1)
@@ -1531,7 +1531,7 @@ class AlertTest(TestCase):
         self.assertEqual(send_patch.call_count, 1)
 
         # Test copying of the alert schedule instance for a new recipient
-        refresh_alert_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user2.get_id),))
+        refresh_alert_schedule_instances(self.schedule.schedule_id.hex, (('CommCareUser', self.user2.get_id),))
         self.assertNumInstancesForSchedule(1)
         [instance] = get_alert_schedule_instances_for_schedule(self.schedule)
         self.assertAlertScheduleInstance(instance, 1, 1, datetime(2017, 3, 16, 7, 2, 21), True, self.user2)

--- a/corehq/messaging/scheduling/tests/test_schedules.py
+++ b/corehq/messaging/scheduling/tests/test_schedules.py
@@ -109,7 +109,9 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 16))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -121,7 +123,9 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
         self.schedule.active = False
         self.schedule.save()
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 16))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -136,7 +140,9 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 16))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -149,7 +155,9 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
         self.schedule.save()
         utcnow_patch.return_value = datetime(2017, 3, 16, 7, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 16))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -164,7 +172,9 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 16))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -177,7 +187,9 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
         self.schedule.save()
         utcnow_patch.return_value = datetime(2017, 3, 16, 17, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 16))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -192,7 +204,9 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 16))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -209,8 +223,11 @@ class TimedScheduleActiveFlagTest(BaseScheduleTest):
         self.schedule.save()
         utcnow_patch.return_value = datetime(2017, 4, 1, 17, 0)
         for i in range(2):
-            refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),),
-                                             json_format_date(date(2017, 3, 16)))
+            refresh_timed_schedule_instances(
+                self.schedule.schedule_id.hex,
+                (('CommCareUser', self.user1.get_id),),
+                json_format_date(date(2017, 3, 16))
+            )
             self.assertNumInstancesForSchedule(1)
             [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
             self.assertTimedScheduleInstance(instance, 0, 3, datetime(2017, 3, 18, 16, 0), False,
@@ -422,11 +439,11 @@ class DeleteScheduleInstancesTest(BaseScheduleTest):
 
     def test_delete_timed_schedule_instances_for_schedule(self):
         refresh_timed_schedule_instances(
-            self.timed_schedule_1.schedule_id,
+            self.timed_schedule_1.schedule_id.hex,
             (('CommCareUser', self.user1.get_id),)
         )
         refresh_timed_schedule_instances(
-            self.timed_schedule_2.schedule_id,
+            self.timed_schedule_2.schedule_id.hex,
             (('CommCareUser', self.user1.get_id), ('CommCareUser', self.user2.get_id))
         )
         self.assertEqual(self.count(get_timed_schedule_instances_for_schedule(self.timed_schedule_1)), 1)
@@ -467,7 +484,9 @@ class DailyScheduleTest(BaseScheduleTest):
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 16))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -499,7 +518,9 @@ class DailyScheduleTest(BaseScheduleTest):
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 16))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -509,7 +530,9 @@ class DailyScheduleTest(BaseScheduleTest):
 
         # Set start date one day back
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 15))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 15))
         )
         old_id = instance.schedule_instance_id
         self.assertNumInstancesForSchedule(1)
@@ -521,7 +544,9 @@ class DailyScheduleTest(BaseScheduleTest):
 
         # Set start date one more day back
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 14))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 14))
         )
         old_id = instance.schedule_instance_id
         self.assertNumInstancesForSchedule(1)
@@ -537,7 +562,9 @@ class DailyScheduleTest(BaseScheduleTest):
         # Schedule the instance for user1
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 16))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -547,7 +574,7 @@ class DailyScheduleTest(BaseScheduleTest):
         # Add user2
         recipients = (('CommCareUser', self.user1.get_id), ('CommCareUser', self.user2.get_id))
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, recipients, json_format_date(date(2017, 3, 16))
+            self.schedule.schedule_id.hex, recipients, json_format_date(date(2017, 3, 16))
         )
 
         self.assertNumInstancesForSchedule(2)
@@ -566,7 +593,9 @@ class DailyScheduleTest(BaseScheduleTest):
 
         # Remove user1
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user2.get_id),), json_format_date(date(2017, 3, 16))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user2.get_id),),
+            json_format_date(date(2017, 3, 16))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -609,7 +638,9 @@ class CustomDailyScheduleTest(BaseScheduleTest):
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 16))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -684,7 +715,9 @@ class RandomTimedEventTest(BaseScheduleTest):
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 16))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -741,7 +774,9 @@ class RandomTimedEventSpanningTwoDaysTest(BaseScheduleTest):
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 3, 16, 6, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 16))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 16))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -781,7 +816,7 @@ class StartDayOfWeekTest(BaseScheduleTest):
         # Schedule the instance using "today's date" (a Wednesday) as a start date.
         # Based on the schedule we should start sending on the next Monday
         utcnow_patch.return_value = datetime(2017, 8, 9, 7, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),))
+        refresh_timed_schedule_instances(self.schedule.schedule_id.hex, (('CommCareUser', self.user1.get_id),))
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 8, 14, 16, 0), True, date(2017, 8, 9),
@@ -795,7 +830,9 @@ class StartDayOfWeekTest(BaseScheduleTest):
         # Based on the schedule we should start sending on the next Monday
         utcnow_patch.return_value = datetime(2017, 8, 2, 7, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 8, 3))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 8, 3))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -809,7 +846,7 @@ class StartDayOfWeekTest(BaseScheduleTest):
         # Schedule the instance using "today's date" (Monday) as the start date.
         # Since the time has already passed for today's event, we schedule it for next Monday.
         utcnow_patch.return_value = datetime(2017, 8, 7, 20, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),))
+        refresh_timed_schedule_instances(self.schedule.schedule_id.hex, (('CommCareUser', self.user1.get_id),))
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 8, 14, 16, 0), True, date(2017, 8, 14),
@@ -822,7 +859,7 @@ class StartDayOfWeekTest(BaseScheduleTest):
         # Schedule the instance using "today's date" (Monday) as the start date.
         # Since the time has not yet passed for today's event, we schedule it for today.
         utcnow_patch.return_value = datetime(2017, 8, 7, 7, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),))
+        refresh_timed_schedule_instances(self.schedule.schedule_id.hex, (('CommCareUser', self.user1.get_id),))
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 8, 7, 16, 0), True, date(2017, 8, 7),
@@ -836,7 +873,9 @@ class StartDayOfWeekTest(BaseScheduleTest):
         # Since the date is so far back, the schedule is automatically deactivated.
         utcnow_patch.return_value = datetime(2017, 8, 9, 7, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 7, 1))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 7, 1))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -849,7 +888,7 @@ class StartDayOfWeekTest(BaseScheduleTest):
 
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 8, 6, 6, 0)
-        refresh_timed_schedule_instances(self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),))
+        refresh_timed_schedule_instances(self.schedule.schedule_id.hex, (('CommCareUser', self.user1.get_id),))
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
         self.assertTimedScheduleInstance(instance, 0, 1, datetime(2017, 8, 7, 16, 0), True, date(2017, 8, 6),
@@ -908,7 +947,9 @@ class StartDayOfWeekWithStartOffsetTest(BaseScheduleTest):
         # Based on the schedule (with start offset 3) we should start sending on the next Monday
         utcnow_patch.return_value = datetime(2017, 8, 2, 7, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 8, 6))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 8, 6))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -986,7 +1027,9 @@ class MonthlyScheduleTest(TestCase):
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 4, 1, 6, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 4, 1))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 4, 1))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -1031,7 +1074,9 @@ class MonthlyScheduleTest(TestCase):
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 4, 15, 6, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 4, 15))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 4, 15))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -1040,7 +1085,9 @@ class MonthlyScheduleTest(TestCase):
 
         # Set start date in previous month
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 3, 14))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 3, 14))
         )
         old_id = instance.schedule_instance_id
         self.assertNumInstancesForSchedule(1)
@@ -1051,7 +1098,9 @@ class MonthlyScheduleTest(TestCase):
 
         # Set start date two months back
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 2, 1))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 2, 1))
         )
         old_id = instance.schedule_instance_id
         self.assertNumInstancesForSchedule(1)
@@ -1112,7 +1161,9 @@ class EndOfMonthScheduleTest(TestCase):
         # Schedule the instance
         utcnow_patch.return_value = datetime(2017, 4, 1, 6, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2017, 4, 1))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2017, 4, 1))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -1168,7 +1219,9 @@ class DailyRepeatEveryTest(BaseScheduleTest):
         # Schedule the instance
         utcnow_patch.return_value = datetime(2018, 3, 1, 0, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2018, 3, 1))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2018, 3, 1))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -1238,7 +1291,9 @@ class WeeklyRepeatEveryTest(BaseScheduleTest):
         # Schedule the instance
         utcnow_patch.return_value = datetime(2018, 3, 5, 0, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2018, 3, 5))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2018, 3, 5))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)
@@ -1334,7 +1389,9 @@ class MonthlyRepeatEveryTest(BaseScheduleTest):
         # Schedule the instance
         utcnow_patch.return_value = datetime(2018, 1, 1, 0, 0)
         refresh_timed_schedule_instances(
-            self.schedule.schedule_id, (('CommCareUser', self.user1.get_id),), json_format_date(date(2018, 1, 1))
+            self.schedule.schedule_id.hex,
+            (('CommCareUser', self.user1.get_id),),
+            json_format_date(date(2018, 1, 1))
         )
         self.assertNumInstancesForSchedule(1)
         [instance] = get_timed_schedule_instances_for_schedule(self.schedule)

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -390,7 +390,7 @@ class BroadcastListView(BaseMessagingSectionView):
 
         TimedSchedule.objects.filter(schedule_id=broadcast.schedule_id).update(active=active_flag)
         refresh_timed_schedule_instances.delay(
-            broadcast.schedule_id,
+            broadcast.schedule_id.hex,
             broadcast.recipients,
             start_date_iso_string=json_format_date(broadcast.start_date)
         )


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I've done a poor job of converting these tasks to use json serialization instead of pickling. I basically missed all of the uuid instances the first time around, then only fixed a number of them the second time around, then Matt fixed one recently, and now I noticed these errors on [staging](https://sentry.io/organizations/dimagi/issues/2724698279/?environment=staging&project=136860&query=is%3Aunresolved&statsPeriod=1h) and then also on [prod](https://sentry.io/organizations/dimagi/issues/2724698279/?environment=production&project=136860&query=is%3Aunresolved+xpected+an+instance+of+%3Cclass+%27uuid.UUID%27%3E&statsPeriod=14d).

I ensured _all_ tasks in the scheduling/tasks.py file properly send a hex representation and convert back to a uuid on the other side. The 2nd commit was mainly cleanup for consistency purposes since there isn't any `validate_uuid` call and you can use either the string representation or the UUID object when filtering for objects in the db (tested via django shell). 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
