### PR TITLE
Support for float values in peer rating

### DIFF
--- a/custom/gcc_sangath/rules/custom_actions.py
+++ b/custom/gcc_sangath/rules/custom_actions.py
@@ -76,7 +76,7 @@ def _get_case_updates(peer_rating_cases):
 
 def _get_sum(case_property, peer_rating_cases):
     return sum([
-        float(peer_rating_case.get_case_property(case_property) or 0.0)
+        float(peer_rating_case.get_case_property(case_property) or 0)
         for peer_rating_case in peer_rating_cases
     ])
 

--- a/custom/gcc_sangath/rules/custom_actions.py
+++ b/custom/gcc_sangath/rules/custom_actions.py
@@ -76,7 +76,7 @@ def _get_case_updates(peer_rating_cases):
 
 def _get_sum(case_property, peer_rating_cases):
     return sum([
-        int(peer_rating_case.get_case_property(case_property) or 0)
+        float(peer_rating_case.get_case_property(case_property) or 0.0)
         for peer_rating_case in peer_rating_cases
     ])
 

--- a/custom/gcc_sangath/tests/test_custom_actions.py
+++ b/custom/gcc_sangath/tests/test_custom_actions.py
@@ -100,7 +100,6 @@ class SanitizeSessionPeerRatingTest(BaseCaseRuleTest):
 
         self.assertEqual(result.num_updates, 1)
         session_case = CommCareCase.objects.get_case(self.session_case.case_id, self.session_case.domain)
-        print(session_case.case_json)
         self.assertDictEqual(
             session_case.case_json,
             {

--- a/custom/gcc_sangath/tests/test_custom_actions.py
+++ b/custom/gcc_sangath/tests/test_custom_actions.py
@@ -60,7 +60,7 @@ class SanitizeSessionPeerRatingTest(BaseCaseRuleTest):
                 'date_of_peer_review': '',
                 'feedback_num': '1',
                 'share_score_check': 'yes',
-                'total_session_rating': '0',
+                'total_session_rating': '0.0',
                 NEEDS_AGGREGATION_CASE_PROP: NEEDS_AGGREGATION_NO_VALUE,
             }
         )
@@ -87,23 +87,30 @@ class SanitizeSessionPeerRatingTest(BaseCaseRuleTest):
                 MEAN_TREATMENT_SPECIFIC_SCORE_CASE_PROP: 2,
                 SESSION_RATING_CASE_PROP: 4,
                 DATE_OF_PEER_REVIEW_CASE_PROP: date(2020, 3, 10)
-            }
+            },
+            {
+                MEAN_GENERAL_SKILLS_SCORE_CASE_PROP: 1.5,
+                MEAN_TREATMENT_SPECIFIC_SCORE_CASE_PROP: 2.5,
+                SESSION_RATING_CASE_PROP: 4,
+                DATE_OF_PEER_REVIEW_CASE_PROP: date(2020, 3, 10)
+            },
         ])
 
         result = sanitize_session_peer_rating(self.session_case, rule)
 
         self.assertEqual(result.num_updates, 1)
         session_case = CommCareCase.objects.get_case(self.session_case.case_id, self.session_case.domain)
+        print(session_case.case_json)
         self.assertDictEqual(
             session_case.case_json,
             {
-                'agg_mean_general_skills_score': '1.3',
-                'agg_mean_treatment_specific_score': '2.3',
+                'agg_mean_general_skills_score': '1.4',
+                'agg_mean_treatment_specific_score': '2.4',
                 'agg_rating': '4.0',
                 'date_of_peer_review': '2020-08-10',
-                'feedback_num': '3',
+                'feedback_num': '4',
                 'share_score_check': 'yes',
-                'total_session_rating': '12',
+                'total_session_rating': '16.0',
                 NEEDS_AGGREGATION_CASE_PROP: NEEDS_AGGREGATION_NO_VALUE,
             }
         )


### PR DESCRIPTION
## Product Description
Provide support for float peer rating, which was missed as part of https://github.com/dimagi/commcare-hq/pull/31119

## Technical Summary
Changed cast to float from int for getting sum of values utility function

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance


### Safety story
Tested via unit test

### Automated test coverage

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->




<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
