### PR TITLE
Modify logic for returning available domains to link

### DIFF
--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -63,19 +63,21 @@ def get_available_domains_to_link(upstream_domain, user):
     :param user: user object
     :return: list of domain names available to link as downstream projects
     """
-    available_domains = []
+    available_domains = set()
 
     if domain_is_enterprise(upstream_domain) and domain_has_privilege(upstream_domain, RELEASE_MANAGEMENT):
-        available_domains.extend(get_available_domains_to_link_for_enterprise(upstream_domain, user))
+        available_domains = available_domains.union(
+            get_available_domains_to_link_for_enterprise(upstream_domain, user)
+        )
 
     if domain_has_privilege(upstream_domain, RELEASE_MANAGEMENT) or \
             domain_has_privilege(upstream_domain, LITE_RELEASE_MANAGEMENT):
-        available_domains.extend(
+        available_domains = available_domains.union(
             get_available_domains_to_link_for_user(upstream_domain, user, should_enforce_admin=True)
         )
 
     if available_domains:
-        return available_domains
+        return list(available_domains)
 
     # DEPRECATED: acting as a fallback for now. Will remove once all domains are migrated off of this flag
     if toggles.LINKED_DOMAINS.enabled(upstream_domain):
@@ -109,20 +111,20 @@ def get_available_upstream_domains(downstream_domain, user):
     :param user: user object
     :return: list of domain names available to link as downstream projects
     """
-    upstream_domains = []
+    upstream_domains = set()
     if domain_is_enterprise(downstream_domain) and domain_has_privilege(downstream_domain, RELEASE_MANAGEMENT):
-        upstream_domains.extend(
+        upstream_domains = upstream_domains.union(
             get_available_upstream_domains_for_enterprise(downstream_domain, user)
         )
 
     if domain_has_privilege(downstream_domain, RELEASE_MANAGEMENT) or \
             domain_has_privilege(downstream_domain, LITE_RELEASE_MANAGEMENT):
-        upstream_domains.extend(
+        upstream_domains = upstream_domains.union(
             get_available_upstream_domains_for_user(downstream_domain, user, should_enforce_admin=True)
         )
 
     if upstream_domains:
-        return upstream_domains
+        return list(upstream_domains)
 
     # DEPRECATED: acting as a fallback for now. Will remove once all domains are migrated off of this flag
     if toggles.LINKED_DOMAINS.enabled(downstream_domain):

--- a/corehq/apps/linked_domain/tests/test_dbaccessors.py
+++ b/corehq/apps/linked_domain/tests/test_dbaccessors.py
@@ -53,6 +53,16 @@ class TestGetAvailableUpstreamDomains(SimpleTestCase):
 
         self.assertEqual(upstream_domains, ['account-domain'] + ['user-domain'])
 
+    def test_does_not_return_duplicate_domains_if_enterprise_and_release_management_privilege(self, mock_user):
+        self.mock_is_enterprise.return_value = True
+        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
+        self.mock_available_account_domains.return_value = ['domain']
+        self.mock_available_user_domains.return_value = ['domain']
+
+        upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
+
+        self.assertEqual(upstream_domains, ['domain'])
+
     def test_returns_domains_for_user_if_not_enterprise_and_release_management_privilege(self, mock_user):
         self.mock_is_enterprise.return_value = False
         self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
@@ -124,6 +134,16 @@ class TestGetAvailableDomainsToLink(SimpleTestCase):
         domains = get_available_domains_to_link('upstream', mock_user)
 
         self.assertEqual(domains, ['account-domain'] + ['user-domain'])
+
+    def test_does_not_return_duplicate_domains_if_enterprise_and_release_management_privilege(self, mock_user):
+        self.mock_is_enterprise.return_value = True
+        self.mock_domain_has_privilege.return_value = True
+        self.mock_available_account_domains.return_value = ['domain']
+        self.mock_available_user_domains.return_value = ['domain']
+
+        domains = get_available_domains_to_link('upstream', mock_user)
+
+        self.assertEqual(domains, ['domain'])
 
     def test_returns_domains_for_user_if_not_enterprise_and_release_management_privilege(self, mock_user):
         self.mock_is_enterprise.return_value = False

--- a/corehq/apps/linked_domain/tests/test_dbaccessors.py
+++ b/corehq/apps/linked_domain/tests/test_dbaccessors.py
@@ -43,14 +43,15 @@ class TestGetAvailableUpstreamDomains(SimpleTestCase):
 
         self.assertFalse(upstream_domains)
 
-    def test_returns_domains_for_account_if_enterprise_and_release_management_privilege(self, mock_user):
+    def test_returns_domains_for_account_and_user_if_enterprise_and_release_management_privilege(self, mock_user):
         self.mock_is_enterprise.return_value = True
         self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
-        self.mock_available_account_domains.return_value = self.expected_domains
+        self.mock_available_account_domains.return_value = ['account-domain']
+        self.mock_available_user_domains.return_value = ['user-domain']
 
         upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
 
-        self.assertEqual(upstream_domains, self.expected_domains)
+        self.assertEqual(upstream_domains, ['account-domain'] + ['user-domain'])
 
     def test_returns_domains_for_user_if_not_enterprise_and_release_management_privilege(self, mock_user):
         self.mock_is_enterprise.return_value = False
@@ -114,15 +115,15 @@ class TestGetAvailableDomainsToLink(SimpleTestCase):
 
         self.assertFalse(domains)
 
-    def test_returns_domains_for_account_if_enterprise_and_release_management_privilege(self, mock_user):
+    def test_returns_domains_for_account_and_user_if_enterprise_and_release_management_privilege(self, mock_user):
         self.mock_is_enterprise.return_value = True
         self.mock_domain_has_privilege.return_value = True
-        self.mock_available_account_domains.return_value = self.expected_domains
-        self.mock_available_user_domains.return_value = ['wrong']
+        self.mock_available_account_domains.return_value = ['account-domain']
+        self.mock_available_user_domains.return_value = ['user-domain']
 
         domains = get_available_domains_to_link('upstream', mock_user)
 
-        self.assertEqual(domains, self.expected_domains)
+        self.assertEqual(domains, ['account-domain'] + ['user-domain'])
 
     def test_returns_domains_for_user_if_not_enterprise_and_release_management_privilege(self, mock_user):
         self.mock_is_enterprise.return_value = False


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Found in QA: https://dimagi-dev.atlassian.net/browse/QA-3926

The design decision was made to allow ERM users in enterprise accounts to also have access to linking to domains that they are admins in, but at the MRM level. So rather than _only_ returning domains within an enterprise account when finding domains available to link to, we want to also include domains the current user is an admin in. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Updated tests for both methods that grab available domains. There is good coverage at the moment.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
