### PR TITLE
Updates to migrate_case_search_prompt_itemset_ids

### DIFF
--- a/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_itemset_ids.py
+++ b/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_itemset_ids.py
@@ -22,7 +22,8 @@ class Command(AppMigrationCommandBase):
                 if not isinstance(properties, list):
                     continue
                 for prop in properties:
-                    (new_itemset, should_save) = wrap_itemset(prop.get('itemset'))
+                    (new_itemset, updated) = wrap_itemset(prop.get('itemset'))
+                    should_save = should_save or updated
                     prop['itemset'] = new_itemset
 
         return app_doc if should_save else None

--- a/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_itemset_ids.py
+++ b/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_itemset_ids.py
@@ -3,7 +3,6 @@ import re
 from corehq.apps.app_manager.management.commands.helpers import (
     AppMigrationCommandBase,
 )
-from corehq.apps.app_manager.util import get_correct_app_class
 from corehq.apps.fixtures.fixturegenerators import ItemListsProvider
 from corehq.toggles import SYNC_SEARCH_CASE_CLAIM
 
@@ -26,7 +25,7 @@ class Command(AppMigrationCommandBase):
                     (new_itemset, should_save) = wrap_itemset(prop.get('itemset'))
                     prop['itemset'] = new_itemset
 
-        return get_correct_app_class(app_doc).wrap(app_doc) if should_save else None
+        return app_doc if should_save else None
 
     def get_domains(self):
         return sorted(SYNC_SEARCH_CASE_CLAIM.get_enabled_domains())

--- a/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_itemset_ids.py
+++ b/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_itemset_ids.py
@@ -5,6 +5,7 @@ from corehq.apps.app_manager.management.commands.helpers import (
 )
 from corehq.apps.app_manager.util import get_correct_app_class
 from corehq.apps.fixtures.fixturegenerators import ItemListsProvider
+from corehq.toggles import SYNC_SEARCH_CASE_CLAIM
 
 
 class Command(AppMigrationCommandBase):
@@ -26,6 +27,9 @@ class Command(AppMigrationCommandBase):
                     prop['itemset'] = new_itemset
 
         return get_correct_app_class(app_doc).wrap(app_doc) if should_save else None
+
+    def get_domains(self):
+        return sorted(SYNC_SEARCH_CASE_CLAIM.get_enabled_domains())
 
 
 def wrap_itemset(data):

--- a/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_itemset_ids.py
+++ b/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_itemset_ids.py
@@ -18,7 +18,10 @@ class Command(AppMigrationCommandBase):
         should_save = False
         for module in app_doc.get('modules', []):
             if module.get('search_config'):
-                for prop in module.get('search_config').get('properties', []):
+                properties = module.get('search_config').get('properties')
+                if not isinstance(properties, list):
+                    continue
+                for prop in properties:
                     (new_itemset, should_save) = wrap_itemset(prop.get('itemset'))
                     prop['itemset'] = new_itemset
 
@@ -26,6 +29,9 @@ class Command(AppMigrationCommandBase):
 
 
 def wrap_itemset(data):
+    if data is None:
+        return None, False
+
     should_save = False
     if (data.get('instance_uri') or '').startswith(f'jr://fixture/{ItemListsProvider.id}:'):
         instance_id = data.get('instance_id')

--- a/corehq/apps/app_manager/tests/test_management_commands.py
+++ b/corehq/apps/app_manager/tests/test_management_commands.py
@@ -10,6 +10,7 @@ from corehq.apps.app_manager.models import (
     Itemset,
     Module,
 )
+from corehq.apps.app_manager.util import get_correct_app_class
 
 
 class MigrateCaseSearchPromptItemsetIdsTest(SimpleTestCase):
@@ -37,9 +38,10 @@ class MigrateCaseSearchPromptItemsetIdsTest(SimpleTestCase):
 
     def _migrate_property(self, prop):
         self.doc['modules'][0]['search_config']['properties'] = [prop.to_json()]
-        update = Command().migrate_app(self.doc)
-        if update:
-            return update.modules[0].search_config.properties[0].itemset
+        app_doc = Command().migrate_app(self.doc)
+        if app_doc:
+            app = get_correct_app_class(app_doc).wrap(app_doc)
+            return app.modules[0].search_config.properties[0].itemset
 
     def test_text(self):
         self.assertIsNone(self._migrate_property(CaseSearchProperty(name='name', label={'en': 'Name'})))


### PR DESCRIPTION
## Technical Summary
Another followup to https://github.com/dimagi/commcare-hq/pull/31121, both to handle some bad app docs and to more easily run only across domains that have case claim enabled.

## Feature Flag
Case claim

## Safety Assurance

### Safety story
Fairly minor management command updates. Tested locally.

### Automated test coverage

I don't think there's any coverage for `AppMigrationCommandBase` itself.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
