### PR TITLE
Allow superuser to bypass lite release management (MRM) push constraints

### DIFF
--- a/corehq/apps/linked_domain/exceptions.py
+++ b/corehq/apps/linked_domain/exceptions.py
@@ -14,6 +14,14 @@ class AttemptedPushViolatesConstraints(Exception):
     pass
 
 
+class DomainLinkNotFound(Exception):
+    pass
+
+
+class NoDownstreamDomainsProvided(Exception):
+    pass
+
+
 class MultipleDownstreamAppsError(Exception):
     pass
 

--- a/corehq/apps/linked_domain/exceptions.py
+++ b/corehq/apps/linked_domain/exceptions.py
@@ -10,6 +10,10 @@ class DomainLinkNotAllowed(Exception):
     pass
 
 
+class AttemptedPushViolatesConstraints(Exception):
+    pass
+
+
 class MultipleDownstreamAppsError(Exception):
     pass
 

--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -68,7 +68,6 @@ class DomainLink(models.Model):
     def is_remote(self):
         return bool(self.remote_base_url) or 'http' in self.linked_domain
 
-    @property
     def has_full_access(self):
         return (domain_has_privilege(self.master_domain, RELEASE_MANAGEMENT)
                 and domain_has_privilege(self.linked_domain, RELEASE_MANAGEMENT))

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -60,7 +60,7 @@ hqDefine("linked_domain/js/domain_links", [
     var DomainLinksViewModel = function (data) {
         var self = {};
         self.upstreamLink = data.upstream_link ? DomainLink(data.upstream_link) : null;
-
+        self.isSuperuser = data.is_superuser;
         // setup getting started view model
         var gettingStartedData = {
             parent: self,
@@ -259,6 +259,9 @@ hqDefine("linked_domain/js/domain_links", [
 
         self.domainsToPushSubscription = self.domainsToPush.subscribe(function (newValue) {
             // receives updates every time a domain is selected/unselected from the multiselect
+            if (self.parent.isSuperuser) {
+                return;
+            }
 
             // handles the Add All edge case if both lite and full access links exist
             if (newValue.length > 1 && self.containsLiteAndFullLinks()) {
@@ -312,8 +315,11 @@ hqDefine("linked_domain/js/domain_links", [
                 selectableHeaderTitle: gettext("All project spaces"),
                 selectedHeaderTitle: gettext("Project spaces to push to"),
                 searchItemTitle: gettext("Search project spaces"),
-                disableModifyAllActions: !self.parent.hasFullAccess,
+                disableModifyAllActions: !self.parent.hasFullAccess && !self.parent.isSuperuser,
                 willSelectAllListener: function () {
+                    if (self.parent.isSuperuser) {
+                        return;
+                    }
                     var requiresRebuild = false;
                     for (var option of $('#domain-multiselect')[0].options) {
                         var tempLink = self.parent.domainLinksByName()[option.value];

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -75,7 +75,7 @@
         <div class="modal-body">
           <div class="ko-model">
             <label >{% trans 'Project Space:' %}</label>
-            {% if is_superuser %}
+            {% if view_data.is_superuser %}
               <select class="form-control" data-bind="autocompleteSelect2: availableDomains, value: domainToAdd"></select>
             {% else %}
               <select class="form-control" data-bind="select2: availableDomains, value: domainToAdd"></select>

--- a/corehq/apps/linked_domain/view_helpers.py
+++ b/corehq/apps/linked_domain/view_helpers.py
@@ -40,7 +40,7 @@ def build_domain_link_view_model(link, timezone):
         'downstream_url': link.downstream_url,
         'is_remote': link.is_remote,
         'last_update': server_to_user_time(link.last_pull, timezone) if link.last_pull else _('Never'),
-        'has_full_access': link.has_full_access,
+        'has_full_access': link.has_full_access(),
     }
 
 

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -11,6 +11,8 @@ from couchdbkit import ResourceNotFound
 from djng.views.mixins import JSONResponseMixin, allow_remote_invocation
 from memoized import memoized
 
+from dimagi.utils.logging import notify_exception
+
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.app_manager.dbaccessors import (
     get_app,
@@ -393,6 +395,7 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
             error_message = ugettext(
                 "The attempted push from {} to {} is disallowed.".format(self.domain, formatted_domains)
             )
+            notify_exception(self.request, "Triggered AttemptedPushViolatesConstraints exception")
         finally:
             if error_message:
                 return {

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -387,14 +387,16 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
         try:
             validate_push(self.request.couch_user, self.domain, in_data['linked_domains'])
         except NoDownstreamDomainsProvided:
-            error_message = ugettext("No downstream project spaces were selected.")
+            error_message = ugettext("No downstream project spaces were selected. Please contact support.")
         except DomainLinkNotFound:
-            error_message = ugettext("Links between one or more project spaces do not exist.")
-        except AttemptedPushViolatesConstraints:
-            formatted_domains = ','.join(in_data['linked_domains'])
             error_message = ugettext(
-                "The attempted push from {} to {} is disallowed.".format(self.domain, formatted_domains)
+                "Links between one or more project spaces do not exist. Please contact support."
             )
+        except AttemptedPushViolatesConstraints:
+            formatted_domains = ', '.join(in_data['linked_domains'])
+            error_message = ugettext('''
+                The attempted push from {} to {} is disallowed. Please contact support.
+            '''.format(self.domain, formatted_domains))
             notify_exception(self.request, "Triggered AttemptedPushViolatesConstraints exception")
         finally:
             if error_message:

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -319,7 +319,6 @@ class DomainLinkView(BaseAdminProjectSettingsView):
             'domain': self.domain,
             'timezone': timezone.localize(datetime.utcnow()).tzname(),
             'has_release_management_privilege': can_domain_access_release_management(self.domain),
-            'is_superuser': is_superuser,
             'view_data': {
                 'is_superuser': is_superuser,
                 'is_downstream_domain': bool(upstream_link),

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -316,6 +316,7 @@ class DomainLinkView(BaseAdminProjectSettingsView):
             'has_release_management_privilege': can_domain_access_release_management(self.domain),
             'is_superuser': is_superuser,
             'view_data': {
+                'is_superuser': is_superuser,
                 'is_downstream_domain': bool(upstream_link),
                 'upstream_domains': upstream_domain_urls,
                 'available_domains': available_domains_to_link,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
**Review by commit**

QA Ticket: https://dimagi-dev.atlassian.net/browse/QA-3928

Parent PR: https://github.com/dimagi/commcare-hq/pull/31047

I completely forgot to support the superuser's ability to bypass lite release management (MRM) restrictions. It seemed best to enforce this on the backend as well as the frontend, so the first commit handles ignoring restriction logic if a superuser, and the remaining commits handle enforcing on the backend by adding a new `validate_push` method. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests for push validation logic on the backend.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Discovered in the QA ticket linked above, will test again.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

This specific PR is part of a larger PR related to the release of MRM.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
