### PR TITLE
Disable newly linked domain if necessary in linked project spaces

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -174,27 +174,33 @@ hqDefine('hqwebapp/js/multiselect_utils', [
      * A custom binding for setting multiselect properties and additional knockout bindings
      * The only dynamic part of this binding are the options
      * For a list of configurable multiselect properties, see http://loudev.com/ under Options
+     * properties - a dictionary of properties used by the multiselect element (see createFullMultiselectWidget above)
+     * options - an observable array of option elements (only supports array of strings)
+     * didUpdateListener - method to invoke when the multiselect updates
      */
     ko.bindingHandlers.multiselect = {
         init: function (element, valueAccessor) {
             var model = valueAccessor();
-            assertProperties.assert(model, [], ['properties', 'options']);
+            assertProperties.assert(model, [], ['properties', 'options', 'didUpdateListener']);
             multiselect_utils.createFullMultiselectWidget(element, model.properties);
 
             if (model.options) {
-                // add the `options` binding to the element, valueAccessor() should return an observable
-                // NOTE: apply bindings after the multiselect has been setup
+                // apply bindings after the multiselect has been setup
                 ko.applyBindingsToNode(element, {options: model.options});
             }
         },
         update: function (element, valueAccessor) {
             var model = valueAccessor();
+            assertProperties.assert(model, [], ['properties', 'options', 'didUpdateListener']);
             if (model.options) {
                 // have to access the observable to get the `update` method to fire on changes to options
                 ko.unwrap(model.options());
             }
 
             multiselect_utils.rebuildMultiselect(element, model.properties);
+            if (model.didUpdateListener) {
+                model.didUpdateListener();
+            }
         },
     };
 

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -257,6 +257,32 @@ hqDefine("linked_domain/js/domain_links", [
             return _.uniq(_.pluck(self.parent.domainLinks(), 'hasFullAccess')).length === 2;
         });
 
+
+        self.multiselectBindingDidUpdate = function () {
+            let shouldRebuildMultiselect = false;
+            for (const option of $('#domain-multiselect')[0].options) {
+                if (self.domainsToPush().includes(option.value)) {
+                    continue;
+                }
+                // option is enabled by default, only rebuild if disabled is set to true
+                let shouldDisable = false;
+                if (self.shouldShowSelectedERMDomain()) {
+                    // disable if not full access
+                    shouldDisable = !self.parent.domainLinksByName[option.value].hasFullAccess;
+                } else if (self.shouldShowSelectedMRMDomain()) {
+                    shouldDisable = true;
+                }
+                if (shouldDisable && !option.disabled) {
+                    option.disabled = true;
+                    shouldRebuildMultiselect = true;
+                }
+            }
+
+            if (shouldRebuildMultiselect) {
+                multiselectUtils.rebuildMultiselect('domain-multiselect', self.domainMultiselect.properties);
+            }
+        };
+
         self.domainsToPushSubscription = self.domainsToPush.subscribe(function (newValue) {
             // receives updates every time a domain is selected/unselected from the multiselect
 
@@ -328,6 +354,7 @@ hqDefine("linked_domain/js/domain_links", [
                 },
             },
             options: self.localDownstreamDomains,
+            didUpdateListener: self.multiselectBindingDidUpdate,
         };
 
         self.canPush = ko.computed(function () {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Discovered in QA: https://dimagi-dev.atlassian.net/browse/QA-3931

Parent PR: https://github.com/dimagi/commcare-hq/pull/31047

The two options were to listen to changes on the multiselect options property, or reset the tab after navigating to the other tab. This implements the former by adding an optional listener to the multiselect to be notified of updates on the element. 

The reason I added the listener on the multiselect is because I needed to be sure the options on the multiselect were up to date, which I could not do through existing knockout observables.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
UI change. Locally tested and will run through QA.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Caught in QA and will re-run in QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
