### PR TITLE
Cs/support 12674 check permission on web user

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1499,12 +1499,13 @@ class UserFilterForm(forms.Form):
 
     def clean(self):
         data = self.cleaned_data
+        user = self.couch_user
 
-        if not data.get('location_id'):
+        if not user.has_permission(self.domain, 'access_all_locations') and not data.get('location_id'):
             # Add (web) user assigned_location_ids so as to
             # 1) reflect all locations user is assigned to ('All' option)
             # 2) restrict user access
-            domain_membership = self.couch_user.get_domain_membership(self.domain)
+            domain_membership = user.get_domain_membership(self.domain)
             if domain_membership and domain_membership.assigned_location_ids:
                 data['web_user_assigned_location_ids'] = list(domain_membership.assigned_location_ids)
 

--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -266,7 +266,6 @@ class TestCountWebUsers(TestCase):
 
         cls.admin_user_with_location.delete(cls.domain_obj.name, deleted_by=None)
         cls.admin_user.delete(cls.domain_obj.name, deleted_by=None)
-        cls.normal_role.delete()
 
         cls.domain_obj.delete()
         super().tearDownClass()

--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -3,6 +3,10 @@ import json
 from django.test import TestCase
 from django.urls import reverse
 
+from corehq.apps.es.tests.utils import populate_user_index
+from corehq.util.elastic import ensure_index_deleted
+from corehq.pillows.mappings.user_mapping import USER_INDEX
+
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.audit.change_messages import UserChangeMessage
 from corehq.apps.users.dbaccessors import delete_all_users
@@ -12,6 +16,10 @@ from corehq.apps.users.views import _update_role_from_view
 from corehq.apps.users.views.mobile.users import MobileWorkerListView
 from corehq.const import USER_CHANGE_VIA_WEB
 from corehq.util.test_utils import generate_cases
+from corehq.apps.locations.tests.util import make_loc, delete_all_locations
+from corehq.apps.locations.models import LocationType
+from corehq.toggles import FILTERED_BULK_USER_DOWNLOAD
+from corehq.toggles.shortcuts import set_toggle
 
 
 class TestMobileWorkerListView(TestCase):
@@ -201,3 +209,80 @@ class TestDeletePhoneNumberView(TestCase):
         self.assertEqual(user_history_log.by_domain, self.domain)
         self.assertEqual(user_history_log.for_domain, self.domain)
         self.assertEqual(user_history_log.changed_via, USER_CHANGE_VIA_WEB)
+
+
+class TestCountWebUsers(TestCase):
+
+    view = 'count_web_users'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.domain = 'test'
+        cls.domain_obj = create_domain(cls.domain)
+
+        set_toggle(FILTERED_BULK_USER_DOWNLOAD.slug, cls.domain, True, namespace='domain')
+
+        location_type = LocationType(domain=cls.domain, name='phony')
+        location_type.save()
+
+        cls.some_location = make_loc('1', 'some_location', type=location_type, domain=cls.domain_obj.name)
+
+        cls.admin_user = WebUser.create(
+            cls.domain_obj.name,
+            'edith1@wharton.com',
+            'badpassword',
+            None,
+            None,
+            email='edith@wharton.com',
+            first_name='Edith',
+            last_name='Wharton',
+            is_admin=True,
+        )
+
+        cls.admin_user_with_location = WebUser.create(
+            cls.domain_obj.name,
+            'edith2@wharton.com',
+            'badpassword',
+            None,
+            None,
+            email='edith2@wharton.com',
+            first_name='Edith',
+            last_name='Wharton',
+            is_admin=True,
+        )
+        cls.admin_user_with_location.set_location(cls.domain, cls.some_location)
+
+        populate_user_index([
+            cls.admin_user_with_location,
+            cls.admin_user,
+        ])
+
+    @classmethod
+    def tearDownClass(cls):
+        ensure_index_deleted(USER_INDEX)
+        delete_all_locations()
+
+        cls.admin_user_with_location.delete(cls.domain_obj.name, deleted_by=None)
+        cls.admin_user.delete(cls.domain_obj.name, deleted_by=None)
+        cls.normal_role.delete()
+
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+    def test_admin_user_sees_all_web_users(self):
+        self.client.login(
+            username=self.admin_user.username,
+            password='badpassword',
+        )
+        result = self.client.get(reverse(self.view, kwargs={'domain': self.domain}))
+        self.assertEqual(json.loads(result.content)['count'], 2)
+
+    def test_admin_location_user_sees_all_web_users(self):
+        self.client.login(
+            username=self.admin_user_with_location.username,
+            password='badpassword',
+        )
+        result = self.client.get(reverse(self.view, kwargs={'domain': self.domain}))
+        self.assertEqual(json.loads(result.content)['count'], 2)


### PR DESCRIPTION
## Product Description
This is a fix that allows location-assigned admin (or any role that has the "access_all_locations" permission for that matter) web users to see the complete list of web users when downloading the web users, and not just the web users that are assigned to the location(s) the currently logged-in web user is assigned to. 

(See the relevant [support ticket](https://dimagi-dev.atlassian.net/browse/SUPPORT-12674))

## Technical Summary
The role's permissions of the web user is now also considered in addition to that web user's assigned location(s) when that respective web user tries to download users. 

## Feature Flag
This does not affect only a specific FF.

## Safety Assurance

### Safety story
- Unit tests
- Tested on staging

### Automated test coverage
New unit tests cover the "count_web_users" part (which is enough to conclude that the correct users will be downloaded, since the same view is used and cleaned in both scenarios).

### QA Plan
- No formal QA plan, except me testing on staging myself.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
