### PR TITLE
Optimize Web app refresh feature and make some enhancements

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -71,6 +71,7 @@ def get_latest_released_app_versions_by_app_id(domain):
     return {r['key'][2]: r['key'][3] for r in results}
 
 
+@quickcache(['domain', 'app_id'])
 def get_latest_released_build_id(domain, app_id):
     """Get the latest starred build id for an application"""
     app = _get_latest_released_build_view_result(domain, app_id)

--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -71,7 +71,7 @@ def get_latest_released_app_versions_by_app_id(domain):
     return {r['key'][2]: r['key'][3] for r in results}
 
 
-@quickcache(['domain', 'app_id'])
+@quickcache(['domain', 'app_id'], timeout=24 * 60 * 60)
 def get_latest_released_build_id(domain, app_id):
     """Get the latest starred build id for an application"""
     app = _get_latest_released_build_view_result(domain, app_id)

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -40,6 +40,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_latest_build_version,
     get_latest_released_app_version,
     get_latest_released_app_versions_by_app_id,
+    get_latest_released_build_id,
 )
 from corehq.apps.app_manager.decorators import (
     avoid_parallel_build_request,
@@ -266,6 +267,7 @@ def release_build(request, domain, app_id, saved_app_id):
     saved_app.is_auto_generated = False
     saved_app.save(increment_version=False)
     get_latest_released_app_versions_by_app_id.clear(domain)
+    get_latest_released_build_id.clear(domain, app_id)
     from corehq.apps.app_manager.signals import app_post_release
     app_post_release.send(Application, application=saved_app)
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -140,7 +140,7 @@ hqDefine('hqwebapp/js/inactivity', [
             var selectedAppId = '';
             try {
                 var urlParams = JSON.parse(decodeURIComponent(window.location.hash.substr(1)));
-                if(!urlParams.copy_of){
+                if(!urlParams.copyOf){
                     // Don't show the popup when user came from versions page
                     selectedAppId = urlParams.appId;
                 }

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -140,7 +140,10 @@ hqDefine('hqwebapp/js/inactivity', [
             var selectedAppId = '';
             try {
                 var urlParams = JSON.parse(decodeURIComponent(window.location.hash.substr(1)));
-                selectedAppId = urlParams.appId;
+                if(!urlParams.copy_of){
+                    // Don't show the popup when user came from versions page
+                    selectedAppId = urlParams.appId;
+                }
             } catch (error) {
                 console.log(error);
             }

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -543,7 +543,9 @@ def ping_response(request):
         app_id = app['copy_of'] if app['copy_of'] else app['_id']
         latest_build_id = get_latest_released_build_id(domain, app_id)
         # Do not show popup to users who have use_latest_build_cloudcare ff enabled
-        if latest_build_id and not CLOUDCARE_LATEST_BUILD.enabled_for_request(request):
+        latest_build_ff_enabled = (CLOUDCARE_LATEST_BUILD.enabled(domain)
+                or CLOUDCARE_LATEST_BUILD.enabled(request.user.username))
+        if latest_build_id and not latest_build_ff_enabled:
             new_app_version_available = current_build_id != latest_build_id
 
     return JsonResponse({

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -98,6 +98,7 @@ from corehq.apps.users.event_handlers import handle_email_invite_message
 from corehq.apps.users.landing_pages import get_redirect_url
 from corehq.apps.users.models import CouchUser, Invitation
 from corehq.apps.users.util import format_username
+from corehq.toggles import CLOUDCARE_LATEST_BUILD
 from corehq.util.context_processors import commcare_hq_names
 from corehq.util.email_event_utils import handle_email_sns_event
 from corehq.util.metrics import create_metrics_event, metrics_counter, metrics_gauge
@@ -541,7 +542,8 @@ def ping_response(request):
         app = get_app_cached(domain, current_build_id)
         app_id = app['copy_of'] if app['copy_of'] else app['_id']
         latest_build_id = get_latest_released_build_id(domain, app_id)
-        if latest_build_id:
+        # Do not show popup to users who have use_latest_build_cloudcare ff enabled
+        if latest_build_id and not CLOUDCARE_LATEST_BUILD.enabled_for_request(request):
             new_app_version_available = current_build_id != latest_build_id
 
     return JsonResponse({

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -538,14 +538,15 @@ def ping_response(request):
     current_build_id = request.GET.get('selected_app_id', '')
     domain = request.GET.get('domain', '')
     new_app_version_available = False
-    if current_build_id and domain:
+    # Do not show popup to users who have use_latest_build_cloudcare ff enabled
+    latest_build_ff_enabled = (CLOUDCARE_LATEST_BUILD.enabled(domain)
+                or CLOUDCARE_LATEST_BUILD.enabled(request.user.username))
+    if current_build_id and domain and not latest_build_ff_enabled:
         app = get_app_cached(domain, current_build_id)
         app_id = app['copy_of'] if app['copy_of'] else app['_id']
         latest_build_id = get_latest_released_build_id(domain, app_id)
-        # Do not show popup to users who have use_latest_build_cloudcare ff enabled
-        latest_build_ff_enabled = (CLOUDCARE_LATEST_BUILD.enabled(domain)
-                or CLOUDCARE_LATEST_BUILD.enabled(request.user.username))
-        if latest_build_id and not latest_build_ff_enabled:
+
+        if latest_build_id:
             new_app_version_available = current_build_id != latest_build_id
 
     return JsonResponse({


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The webworker load has been increased to 2X after we have deployed the Web App Refresh feature. The change in the PR works towards reducing the load by caching `get_latest_released_build_id`.
Along with the above optimization, it also does minor enhancements where we do not show the New version modal when the user deliberately is working on another version than the latest released version.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13132
https://dimagi-dev.atlassian.net/browse/SAAS-13129
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Changes have been tested on the local system.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
