### PR TITLE
Refactor covid scripts

### DIFF
--- a/corehq/apps/hqcase/bulk.py
+++ b/corehq/apps/hqcase/bulk.py
@@ -84,11 +84,9 @@ def update_cases(domain, update_fn, case_ids, form_meta: SystemFormMeta = None, 
     update_fn should be a function which accepts a case and returns a list of CaseBlock objects
     if an update is to be performed, or None to skip the case.
 
-    Returns counts of number of updates made (not necessarily number of cases update)
-    and number of cases skipped.
+    Returns counts of number of updates made (not necessarily number of cases update).
     """
     update_count = 0
-    skip_count = 0
     with CaseBulkDB(domain, form_meta, throttle_secs) as bulk_db:
         for case in CommCareCase.objects.iter_cases(case_ids):
             case_blocks = update_fn(case)
@@ -96,6 +94,4 @@ def update_cases(domain, update_fn, case_ids, form_meta: SystemFormMeta = None, 
                 for case_block in case_blocks:
                     bulk_db.save(case_block)
                     update_count += 1
-            else:
-                skip_count = skip_count + 1
-    return update_count, skip_count
+    return update_count

--- a/corehq/apps/hqcase/bulk.py
+++ b/corehq/apps/hqcase/bulk.py
@@ -1,4 +1,3 @@
-import time
 from dataclasses import dataclass
 from xml.etree import cElementTree as ElementTree
 
@@ -37,14 +36,11 @@ class SystemFormMeta:
 class CaseBulkDB:
     """
     Context manager to facilitate making case changes in chunks.
-
-    Can optionally wait between each chunk to throttle the form submission rate.
     """
 
-    def __init__(self, domain, form_meta: SystemFormMeta = None, throttle_secs=None):
+    def __init__(self, domain, form_meta: SystemFormMeta = None):
         self.domain = domain
         self.form_meta = form_meta or SystemFormMeta()
-        self.throttle_secs = throttle_secs or 0
 
     def __enter__(self):
         self.to_save = []
@@ -57,8 +53,6 @@ class CaseBulkDB:
         self.to_save.append(case_block)
         if len(self.to_save) >= CASEBLOCK_CHUNKSIZE:
             self.commit()
-            if self.throttle_secs:
-                time.sleep(self.throttle_secs)
 
     def commit(self):
         if self.to_save:
@@ -77,7 +71,7 @@ class CaseBulkDB:
             self.to_save = []
 
 
-def update_cases(domain, update_fn, case_ids, form_meta: SystemFormMeta = None, throttle_secs=None):
+def update_cases(domain, update_fn, case_ids, form_meta: SystemFormMeta = None):
     """
     Perform a large number of case updates in chunks
 
@@ -87,7 +81,7 @@ def update_cases(domain, update_fn, case_ids, form_meta: SystemFormMeta = None, 
     Returns counts of number of updates made (not necessarily number of cases update).
     """
     update_count = 0
-    with CaseBulkDB(domain, form_meta, throttle_secs) as bulk_db:
+    with CaseBulkDB(domain, form_meta) as bulk_db:
         for case in CommCareCase.objects.iter_cases(case_ids):
             case_blocks = update_fn(case)
             if case_blocks:

--- a/corehq/apps/hqcase/tests/test_bulk.py
+++ b/corehq/apps/hqcase/tests/test_bulk.py
@@ -47,7 +47,7 @@ class TestUpdateCases(TestCase):
 
 def _set_phase_2(case):
     if case.get_case_property('to_update') == 'yes':
-        return CaseBlock(
+        return [CaseBlock(
             case_id=case.case_id,
             update={'phase': '2'},
-        )
+        )]

--- a/custom/covid/management/commands/README.rst
+++ b/custom/covid/management/commands/README.rst
@@ -1,0 +1,24 @@
+COVID Management Commands
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+So you need to run a script to update a lot of cases. You've come to the right place.
+
+Most of these scripts build off of the base class ``CaseUpdateCommand``, which has the following features:
+
+* Update all cases of a given type, or supply logic to select a subset
+
+* Update cases in bulk
+
+* Skip cases meeting specific criteria
+
+* Run for either a single domain or a single domain plus all of its linked domains.
+
+* Throttle updates
+
+* Log activity to a file
+
+For most purposes, it's sufficient to inherit from ``CaseUpdateCommand`` and override ``case_blocks`` and possibly
+``find_case_ids``.
+
+For multi-purpose affairs, you may be able to modify or reference ``run_all_management_command``, which runs multiple
+management commands across multiple domains.

--- a/custom/covid/management/commands/README.rst
+++ b/custom/covid/management/commands/README.rst
@@ -13,6 +13,8 @@ Most of these scripts build off of the base class ``CaseUpdateCommand``, which h
 
 * Run for either a single domain or a single domain plus all of its linked domains.
 
+* Run as a particular user, or just default to SYSTEM_USER
+
 * Throttle updates
 
 * Log activity to a file

--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -33,7 +33,8 @@ def find_owner_id(case, case_property):
 class Command(CaseUpdateCommand):
     help = "Creates assignment cases for cases of a specified type in an active location"
 
-    logger_name = __name__
+    def logger_name(self):
+        return __name__
 
     def _case_block(self, case, owner_id, assignment_type):
         case_id = uuid.uuid4().hex

--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -38,7 +38,7 @@ class Command(CaseUpdateCommand):
 
     def _case_block(self, case, owner_id, assignment_type):
         case_id = uuid.uuid4().hex
-        return CaseBlock.deprecated_init(
+        return CaseBlock(
             create=True,
             case_id=case_id,
             case_type='assignment',

--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -44,15 +44,16 @@ class Command(CaseUpdateCommand):
             update={"assignment_type": assignment_type},
         ).as_xml()).decode('utf-8')
 
-    def update_cases(self, domain, user_id):
+    def find_case_ids(self, domain):
         location_id = self.extra_options['location']
         if location_id is None:
-            case_ids = []
             print("Warning: no active location was entered")
-        else:
-            case_ids = CommCareCase.objects.get_open_case_ids_in_domain_by_type(
-                domain, self.case_type, owner_ids=[location_id])
+            return []
+        return CommCareCase.objects.get_open_case_ids_in_domain_by_type(
+            domain, self.case_type, owner_ids=[location_id])
 
+    def update_cases(self, domain, user_id):
+        case_ids = self.find_case_ids(domain)
         case_blocks = []
         errors = []
         skip_count = 0
@@ -85,6 +86,7 @@ class Command(CaseUpdateCommand):
             total += len(chunk)
             print("Updated {} cases on domain {}".format(total, domain))
 
+        location_id = self.extra_options['location']
         self.log_data(domain, "add_assignment_cases", len(case_ids), total, errors, loc_id=location_id)
 
     def add_arguments(self, parser):

--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -33,8 +33,7 @@ def find_owner_id(case, case_property):
 class Command(CaseUpdateCommand):
     help = "Creates assignment cases for cases of a specified type in an active location"
 
-    def logger_name(self):
-        return __name__
+    logger_name = __name__
 
     def _case_block(self, case, owner_id, assignment_type):
         case_id = uuid.uuid4().hex

--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -33,16 +33,18 @@ def find_owner_id(case, case_property):
 class Command(CaseUpdateCommand):
     help = "Creates assignment cases for cases of a specified type in an active location"
 
-    def case_block(self, case, owner_id, assignment_type):
+    logger_name = __name__
+
+    def _case_block(self, case, owner_id, assignment_type):
         case_id = uuid.uuid4().hex
-        return ElementTree.tostring(CaseBlock.deprecated_init(
+        return CaseBlock.deprecated_init(
             create=True,
             case_id=case_id,
             case_type='assignment',
             owner_id=owner_id,
             index={'parent': (case.get_case_property('case_type'), case.case_id, "extension")},
             update={"assignment_type": assignment_type},
-        ).as_xml()).decode('utf-8')
+        )
 
     def find_case_ids(self, domain):
         location_id = self.extra_options['location']
@@ -52,42 +54,30 @@ class Command(CaseUpdateCommand):
         return CommCareCase.objects.get_open_case_ids_in_domain_by_type(
             domain, self.case_type, owner_ids=[location_id])
 
-    def update_cases(self, domain, user_id):
-        case_ids = self.find_case_ids(domain)
+    def case_block(self, case):
+        if case.get_case_property('current_status') == 'closed':
+            return None
+
+        if not needs_update(case):
+            return None
+
         case_blocks = []
-        errors = []
-        skip_count = 0
-        for case in CommCareCase.objects.iter_cases(case_ids, domain):
-            if case.get_case_property('current_status') == 'closed':
-                skip_count += 1
-            elif needs_update(case):
-                new_primary_owner_id = find_owner_id(case, 'assigned_to_primary_checkin_case_id')
-                new_temp_owner_id = find_owner_id(case, 'assigned_to_temp_checkin_case_id')
-                case_created = False
-                if case.get_case_property('is_assigned_primary') == 'yes' and new_primary_owner_id:
-                    case_blocks.append(self.case_block(case, new_primary_owner_id, 'primary'))
-                    case_created = True
-                if case.get_case_property('is_assigned_temp') == 'yes' and new_temp_owner_id:
-                    case_blocks.append(self.case_block(case, new_temp_owner_id, 'temp'))
-                    case_created = True
-                if not case_created:
-                    invalid_primary_id = case.get_case_property('assigned_to_primary_checkin_case_id')
-                    invalid_temp_id = case.get_case_property('assigned_to_temp_checkin_case_id')
-                    errors.append("CaseNotFound: case:{} no matching case for this case's "
-                                  "assigned_to_primary_checkin_case_id:{} or assigned_to_temp_checkin_case_id:"
-                                  "{}".format(case.case_id, invalid_primary_id, invalid_temp_id))
-                    skip_count += 1
-        print(f"{len(case_blocks)} to update in {domain}, {skip_count} cases have skipped because they're closed"
-              f" or in an inactive location")
-
-        total = 0
-        for chunk in chunked(case_blocks, BATCH_SIZE):
-            submit_case_blocks(chunk, domain, device_id=DEVICE_ID, user_id=user_id)
-            total += len(chunk)
-            print("Updated {} cases on domain {}".format(total, domain))
-
-        location_id = self.extra_options['location']
-        self.log_data(domain, "add_assignment_cases", len(case_ids), total, errors, loc_id=location_id)
+        new_primary_owner_id = find_owner_id(case, 'assigned_to_primary_checkin_case_id')
+        new_temp_owner_id = find_owner_id(case, 'assigned_to_temp_checkin_case_id')
+        case_created = False
+        if case.get_case_property('is_assigned_primary') == 'yes' and new_primary_owner_id:
+            case_blocks.append(self._case_block(case, new_primary_owner_id, 'primary'))
+            case_created = True
+        if case.get_case_property('is_assigned_temp') == 'yes' and new_temp_owner_id:
+            case_blocks.append(self._case_block(case, new_temp_owner_id, 'temp'))
+            case_created = True
+        if not case_created:
+            invalid_primary_id = case.get_case_property('assigned_to_primary_checkin_case_id')
+            invalid_temp_id = case.get_case_property('assigned_to_temp_checkin_case_id')
+            self.logger.error("CaseNotFound: case:{} no matching case for this case's "
+                              "assigned_to_primary_checkin_case_id:{} or assigned_to_temp_checkin_case_id:"
+                              "{}".format(case.case_id, invalid_primary_id, invalid_temp_id))
+        return case_blocks
 
     def add_arguments(self, parser):
         super().add_arguments(parser)

--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -44,14 +44,14 @@ class Command(CaseUpdateCommand):
             update={"assignment_type": assignment_type},
         ).as_xml()).decode('utf-8')
 
-    def update_cases(self, domain, case_type, user_id):
+    def update_cases(self, domain, user_id):
         location_id = self.extra_options['location']
         if location_id is None:
             case_ids = []
             print("Warning: no active location was entered")
         else:
             case_ids = CommCareCase.objects.get_open_case_ids_in_domain_by_type(
-                domain, case_type, owner_ids=[location_id])
+                domain, self.case_type, owner_ids=[location_id])
 
         case_blocks = []
         errors = []
@@ -85,7 +85,7 @@ class Command(CaseUpdateCommand):
             total += len(chunk)
             print("Updated {} cases on domain {}".format(total, domain))
 
-        self.log_data(domain, "add_assignment_cases", case_type, len(case_ids), total, errors, loc_id=location_id)
+        self.log_data(domain, "add_assignment_cases", len(case_ids), total, errors, loc_id=location_id)
 
     def add_arguments(self, parser):
         super().add_arguments(parser)

--- a/custom/covid/management/commands/add_assignment_cases.py
+++ b/custom/covid/management/commands/add_assignment_cases.py
@@ -55,7 +55,7 @@ class Command(CaseUpdateCommand):
         return CommCareCase.objects.get_open_case_ids_in_domain_by_type(
             domain, self.case_type, owner_ids=[location_id])
 
-    def case_block(self, case):
+    def case_blocks(self, case):
         if case.get_case_property('current_status') == 'closed':
             return None
 

--- a/custom/covid/management/commands/add_hq_user_id_to_case.py
+++ b/custom/covid/management/commands/add_hq_user_id_to_case.py
@@ -24,8 +24,8 @@ class Command(CaseUpdateCommand):
             update={'hq_user_id': user_id},
         ).as_xml(), encoding='utf-8').decode('utf-8')
 
-    def update_cases(self, domain, case_type, user_id):
-        case_ids = self.find_case_ids_by_type(domain, case_type)
+    def update_cases(self, domain, user_id):
+        case_ids = self.find_case_ids_by_type(domain)
         case_blocks = []
         errors = []
         skip_count = 0
@@ -52,4 +52,4 @@ class Command(CaseUpdateCommand):
             total += len(chunk)
             print("Updated {} cases on domain {}".format(total, domain))
 
-        self.log_data(domain, "add_hq_user_id_to_case", case_type, len(case_ids), total, errors)
+        self.log_data(domain, "add_hq_user_id_to_case", len(case_ids), total, errors)

--- a/custom/covid/management/commands/add_hq_user_id_to_case.py
+++ b/custom/covid/management/commands/add_hq_user_id_to_case.py
@@ -11,7 +11,8 @@ from custom.covid.management.commands.update_cases import CaseUpdateCommand
 class Command(CaseUpdateCommand):
     help = "Updates checkin cases to hold the userid of the mobile worker that the checkin case is associated with"
 
-    logger_name = __name__
+    def logger_name(self):
+        return __name__
 
     def case_block(self, case, **kwargs):
         username_of_associated_mobile_workers = case.get_case_property('username')

--- a/custom/covid/management/commands/add_hq_user_id_to_case.py
+++ b/custom/covid/management/commands/add_hq_user_id_to_case.py
@@ -11,8 +11,7 @@ from custom.covid.management.commands.update_cases import CaseUpdateCommand
 class Command(CaseUpdateCommand):
     help = "Updates checkin cases to hold the userid of the mobile worker that the checkin case is associated with"
 
-    def logger_name(self):
-        return __name__
+    logger_name = __name__
 
     def case_blocks(self, case):
         username_of_associated_mobile_workers = case.get_case_property('username')

--- a/custom/covid/management/commands/add_hq_user_id_to_case.py
+++ b/custom/covid/management/commands/add_hq_user_id_to_case.py
@@ -14,7 +14,7 @@ class Command(CaseUpdateCommand):
     def logger_name(self):
         return __name__
 
-    def case_block(self, case, **kwargs):
+    def case_blocks(self, case):
         username_of_associated_mobile_workers = case.get_case_property('username')
         try:
             normalized_username = normalize_username(username_of_associated_mobile_workers, case.domain)

--- a/custom/covid/management/commands/add_hq_user_id_to_case.py
+++ b/custom/covid/management/commands/add_hq_user_id_to_case.py
@@ -2,54 +2,29 @@ from xml.etree import cElementTree as ElementTree
 
 from casexml.apps.case.mock import CaseBlock
 from django.core.exceptions import ValidationError
-from dimagi.utils.chunked import chunked
 
-from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.users.util import normalize_username
 from corehq.apps.users.util import username_to_user_id
-from corehq.form_processor.models import CommCareCase
 from custom.covid.management.commands.update_cases import CaseUpdateCommand
-
-BATCH_SIZE = 100
-DEVICE_ID = __name__ + ".add_hq_user_id_to_case"
 
 
 class Command(CaseUpdateCommand):
     help = "Updates checkin cases to hold the userid of the mobile worker that the checkin case is associated with"
 
-    def case_block(self, case, user_id):
-        return ElementTree.tostring(CaseBlock.deprecated_init(
-            create=False,
-            case_id=case.case_id,
-            update={'hq_user_id': user_id},
-        ).as_xml(), encoding='utf-8').decode('utf-8')
+    logger_name = __name__
 
-    def update_cases(self, domain, user_id):
-        case_ids = self.find_case_ids(domain)
-        case_blocks = []
-        errors = []
-        skip_count = 0
-        for case in CommCareCase.objects.iter_cases(case_ids, domain):
-            username_of_associated_mobile_workers = case.get_case_property('username')
-            try:
-                normalized_username = normalize_username(username_of_associated_mobile_workers, domain)
-            except ValidationError:
-                errors.append("ValidationError: invalid username:{} associated with "
-                              "case:{}".format(case.get_case_property('username'), case.case_id))
-                skip_count += 1
-                continue
-            user_id_of_mobile_worker = username_to_user_id(normalized_username)
-            if user_id_of_mobile_worker:
-                case_blocks.append(self.case_block(case, user_id_of_mobile_worker))
-            else:
-                skip_count += 1
-        print(f"{len(case_blocks)} to update in {domain}, {skip_count} "
-              "cases have skipped due to unknown username.")
-
-        total = 0
-        for chunk in chunked(case_blocks, BATCH_SIZE):
-            submit_case_blocks(chunk, domain, device_id=DEVICE_ID, user_id=user_id)
-            total += len(chunk)
-            print("Updated {} cases on domain {}".format(total, domain))
-
-        self.log_data(domain, "add_hq_user_id_to_case", len(case_ids), total, errors)
+    def case_block(self, case, **kwargs):
+        username_of_associated_mobile_workers = case.get_case_property('username')
+        try:
+            normalized_username = normalize_username(username_of_associated_mobile_workers, case.domain)
+        except ValidationError:
+            self.logger.error("ValidationError: invalid username:{} associated with "
+                         "case:{}".format(case.get_case_property('username'), case.case_id))
+            return None
+        user_id_of_mobile_worker = username_to_user_id(normalized_username)
+        if user_id_of_mobile_worker:
+            return [CaseBlock.deprecated_init(
+                create=False,
+                case_id=case.case_id,
+                update={'hq_user_id': user_id_of_mobile_worker},
+            )]

--- a/custom/covid/management/commands/add_hq_user_id_to_case.py
+++ b/custom/covid/management/commands/add_hq_user_id_to_case.py
@@ -24,7 +24,7 @@ class Command(CaseUpdateCommand):
             return None
         user_id_of_mobile_worker = username_to_user_id(normalized_username)
         if user_id_of_mobile_worker:
-            return [CaseBlock.deprecated_init(
+            return [CaseBlock(
                 create=False,
                 case_id=case.case_id,
                 update={'hq_user_id': user_id_of_mobile_worker},

--- a/custom/covid/management/commands/add_hq_user_id_to_case.py
+++ b/custom/covid/management/commands/add_hq_user_id_to_case.py
@@ -25,7 +25,7 @@ class Command(CaseUpdateCommand):
         ).as_xml(), encoding='utf-8').decode('utf-8')
 
     def update_cases(self, domain, user_id):
-        case_ids = self.find_case_ids_by_type(domain)
+        case_ids = self.find_case_ids(domain)
         case_blocks = []
         errors = []
         skip_count = 0

--- a/custom/covid/management/commands/clear_owner_ids.py
+++ b/custom/covid/management/commands/clear_owner_ids.py
@@ -6,6 +6,9 @@ from custom.covid.management.commands.update_cases import CaseUpdateCommand
 class Command(CaseUpdateCommand):
     help = "Makes the owner_id for cases blank"
 
+    def logger_name(self):
+        return __name__
+
     def case_block(self, case, **kwargs):
         if case.get_case_property('owner_id') == '-':
             return None

--- a/custom/covid/management/commands/clear_owner_ids.py
+++ b/custom/covid/management/commands/clear_owner_ids.py
@@ -9,7 +9,7 @@ class Command(CaseUpdateCommand):
     def logger_name(self):
         return __name__
 
-    def case_block(self, case, **kwargs):
+    def case_blocks(self, case):
         if case.get_case_property('owner_id') == '-':
             return None
 

--- a/custom/covid/management/commands/clear_owner_ids.py
+++ b/custom/covid/management/commands/clear_owner_ids.py
@@ -6,8 +6,7 @@ from custom.covid.management.commands.update_cases import CaseUpdateCommand
 class Command(CaseUpdateCommand):
     help = "Makes the owner_id for cases blank"
 
-    def logger_name(self):
-        return __name__
+    logger_name = __name__
 
     def case_blocks(self, case):
         if case.get_case_property('owner_id') == '-':

--- a/custom/covid/management/commands/clear_owner_ids.py
+++ b/custom/covid/management/commands/clear_owner_ids.py
@@ -22,7 +22,7 @@ class Command(CaseUpdateCommand):
         ).as_xml(), encoding='utf-8').decode('utf-8')
 
     def update_cases(self, domain, user_id):
-        case_ids = self.find_case_ids_by_type(domain)
+        case_ids = self.find_case_ids(domain)
         case_blocks = []
 
         print(f"Found {len(case_ids)} {self.case_type} cases in {domain}. Proceeding...")

--- a/custom/covid/management/commands/clear_owner_ids.py
+++ b/custom/covid/management/commands/clear_owner_ids.py
@@ -21,11 +21,11 @@ class Command(CaseUpdateCommand):
             update=blank_owner_id,
         ).as_xml(), encoding='utf-8').decode('utf-8')
 
-    def update_cases(self, domain, case_type, user_id):
-        case_ids = self.find_case_ids_by_type(domain, case_type)
+    def update_cases(self, domain, user_id):
+        case_ids = self.find_case_ids_by_type(domain)
         case_blocks = []
 
-        print(f"Found {len(case_ids)} {case_type} cases in {domain}. Proceeding...")
+        print(f"Found {len(case_ids)} {self.case_type} cases in {domain}. Proceeding...")
 
         total_cases_updated = 0
         count_already_blank = 0
@@ -43,8 +43,8 @@ class Command(CaseUpdateCommand):
             submit_case_blocks(case_blocks, domain, device_id=DEVICE_ID, user_id=user_id)
             total_cases_updated += len(case_blocks)
 
-        print(f"{total_cases_updated} cases of case type {case_type} in domain {domain} had their owner ID"
+        print(f"{total_cases_updated} cases of case type {self.case_type} in domain {domain} had their owner ID"
             f" field cleared successfully. {count_already_blank} cases already had a blank owner ID and were"
             " skipped.")
 
-        self.log_data(domain, "clear_owner_ids", case_type, len(case_ids), total_cases_updated, errors=[])
+        self.log_data(domain, "clear_owner_ids", len(case_ids), total_cases_updated, errors=[])

--- a/custom/covid/management/commands/clear_owner_ids.py
+++ b/custom/covid/management/commands/clear_owner_ids.py
@@ -1,50 +1,17 @@
-from xml.etree import cElementTree as ElementTree
-
 from casexml.apps.case.mock import CaseBlock
 
-from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.form_processor.models import CommCareCase
 from custom.covid.management.commands.update_cases import CaseUpdateCommand
-
-BATCH_SIZE = 100
-DEVICE_ID = __name__ + ".update_owner_ids"
 
 
 class Command(CaseUpdateCommand):
     help = "Makes the owner_id for cases blank"
 
-    def case_block(self, case):
-        blank_owner_id = {'owner_id': '-'}
-        return ElementTree.tostring(CaseBlock(
+    def case_block(self, case, **kwargs):
+        if case.get_case_property('owner_id') == '-':
+            return None
+
+        return [CaseBlock(
             create=False,
             case_id=case.case_id,
-            update=blank_owner_id,
-        ).as_xml(), encoding='utf-8').decode('utf-8')
-
-    def update_cases(self, domain, user_id):
-        case_ids = self.find_case_ids(domain)
-        case_blocks = []
-
-        print(f"Found {len(case_ids)} {self.case_type} cases in {domain}. Proceeding...")
-
-        total_cases_updated = 0
-        count_already_blank = 0
-        for case in CommCareCase.objects.iter_cases(case_ids, domain):
-            if case.get_case_property('owner_id') != '-':
-                case_blocks.append(self.case_block(case))
-            else:
-                count_already_blank += 1
-            if len(case_blocks) >= BATCH_SIZE:
-                submit_case_blocks(case_blocks, domain, device_id=DEVICE_ID, user_id=user_id)
-                case_blocks = []
-                total_cases_updated += BATCH_SIZE
-
-        if case_blocks:
-            submit_case_blocks(case_blocks, domain, device_id=DEVICE_ID, user_id=user_id)
-            total_cases_updated += len(case_blocks)
-
-        print(f"{total_cases_updated} cases of case type {self.case_type} in domain {domain} had their owner ID"
-            f" field cleared successfully. {count_already_blank} cases already had a blank owner ID and were"
-            " skipped.")
-
-        self.log_data(domain, "clear_owner_ids", len(case_ids), total_cases_updated, errors=[])
+            update={'owner_id': '-'},
+        )]

--- a/custom/covid/management/commands/update_all_activity_complete_date.py
+++ b/custom/covid/management/commands/update_all_activity_complete_date.py
@@ -1,5 +1,4 @@
 import datetime
-import logging
 import textwrap
 
 from jsonobject.api import re_date
@@ -15,13 +14,10 @@ from corehq.apps.es.case_search import (
 from corehq.util.dates import iso_string_to_date
 from custom.covid.management.commands.update_cases import CaseUpdateCommand
 
-# logger.debug will record something to a file but not print it
-logger = logging.getLogger(__name__)
-logger.addHandler(logging.FileHandler('all_activity_complete_date.txt'))
-logger.setLevel(logging.DEBUG)
-
 
 class Command(CaseUpdateCommand):
+    logger_name = __name__
+
     help = textwrap.dedent("""
         Twice-off script created 2022-02-03, updated 2022-02-11. A bunch of
         cases had the property all_activity_complete_date inadvertently set to
@@ -58,7 +54,7 @@ class Command(CaseUpdateCommand):
         ):
             return None
 
-        logger.debug(f"_correct_bad_case_property {case.domain} {case.case_id}")
+        self.logger.debug(f"_correct_bad_case_property {case.domain} {case.case_id}")
         date_func = _get_new_contact_date_value if case.type == 'contact' else _get_new_patient_date_value
         new_value = date_func(case)
         return [CaseBlock(

--- a/custom/covid/management/commands/update_all_activity_complete_date.py
+++ b/custom/covid/management/commands/update_all_activity_complete_date.py
@@ -16,8 +16,6 @@ from custom.covid.management.commands.update_cases import CaseUpdateCommand
 
 
 class Command(CaseUpdateCommand):
-    logger_name = __name__
-
     help = textwrap.dedent("""
         Twice-off script created 2022-02-03, updated 2022-02-11. A bunch of
         cases had the property all_activity_complete_date inadvertently set to
@@ -26,6 +24,9 @@ class Command(CaseUpdateCommand):
         well, so this now finds those cases that were blanked out and sets them
         to an actual date.
     """)
+
+    def logger_name(self):
+        return __name__
 
     def find_case_ids(self, domain):
         query = (CaseSearchES()

--- a/custom/covid/management/commands/update_all_activity_complete_date.py
+++ b/custom/covid/management/commands/update_all_activity_complete_date.py
@@ -25,8 +25,7 @@ class Command(CaseUpdateCommand):
         to an actual date.
     """)
 
-    def logger_name(self):
-        return __name__
+    logger_name = __name__
 
     def find_case_ids(self, domain):
         query = (CaseSearchES()

--- a/custom/covid/management/commands/update_all_activity_complete_date.py
+++ b/custom/covid/management/commands/update_all_activity_complete_date.py
@@ -34,9 +34,9 @@ class Command(CaseUpdateCommand):
         to an actual date.
     """)
 
-    def update_cases(self, domain, case_type, user_id):
+    def update_cases(self, domain, user_id):
         username = user_id_to_username(user_id)     # TODO: something else
-        bad_case_ids = _get_bad_case_ids(domain, case_type)
+        bad_case_ids = _get_bad_case_ids(domain, self.case_type)
         print(f"Updating {len(bad_case_ids)} cases on {domain}")  # ({i}/{len(domains)})")  TODO: pull up
         update_cases(
             domain=domain,

--- a/custom/covid/management/commands/update_all_activity_complete_date.py
+++ b/custom/covid/management/commands/update_all_activity_complete_date.py
@@ -61,11 +61,11 @@ class Command(CaseUpdateCommand):
         logger.debug(f"_correct_bad_case_property {case.domain} {case.case_id}")
         date_func = _get_new_contact_date_value if case.type == 'contact' else _get_new_patient_date_value
         new_value = date_func(case)
-        return CaseBlock(
+        return [CaseBlock(
             create=False,
             case_id=case.case_id,
             update={"all_activity_complete_date": new_value},
-        )
+        )]
 
 
 def _get_new_patient_date_value(case):

--- a/custom/covid/management/commands/update_all_activity_complete_date.py
+++ b/custom/covid/management/commands/update_all_activity_complete_date.py
@@ -44,7 +44,7 @@ class Command(CaseUpdateCommand):
 
         return list(query.scroll_ids())
 
-    def case_block(self, case):
+    def case_blocks(self, case):
         if (
                 # Double check filters in case ES data is stale
                 case.get_case_property('all_activity_complete_date')

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -39,6 +39,8 @@ class Command(CaseUpdateCommand):
         case_type is lab_result, the owner_id of that extension case is set to '-'.
     """
 
+    logger_name = __name__
+
     def find_case_ids(self, domain):
         return CommCareCase.objects.get_case_ids_in_domain(domain, self.case_type)
 

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -39,7 +39,8 @@ class Command(CaseUpdateCommand):
         case_type is lab_result, the owner_id of that extension case is set to '-'.
     """
 
-    logger_name = __name__
+    def logger_name(self):
+        return __name__
 
     def find_case_ids(self, domain):
         return CommCareCase.objects.get_case_ids_in_domain(domain, self.case_type)

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -45,7 +45,7 @@ class Command(CaseUpdateCommand):
     def find_case_ids(self, domain):
         return CommCareCase.objects.get_case_ids_in_domain(domain, self.case_type)
 
-    def case_block(self, case):
+    def case_blocks(self, case):
         inactive_location = self.extra_options['inactive_location']
         traveler_location_id = self.extra_options['location']
 

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -52,9 +52,12 @@ class Command(CaseUpdateCommand):
             index={index.identifier: ("patient", index.referenced_id, "extension")},
         ).as_xml(), encoding='utf-8').decode('utf-8')
 
+    def find_case_ids(self, domain):
+        return CommCareCase.objects.get_case_ids_in_domain(domain, self.case_type)
+
     def update_cases(self, domain, user_id):
         inactive_location = self.extra_options['inactive_location']
-        case_ids = CommCareCase.objects.get_case_ids_in_domain(domain, self.case_type)
+        case_ids = self.find_case_ids(domain)
         print(f"Found {len(case_ids)} {self.case_type} cases in {domain}")
         traveler_location_id = self.extra_options['location']
 

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -39,8 +39,7 @@ class Command(CaseUpdateCommand):
         case_type is lab_result, the owner_id of that extension case is set to '-'.
     """
 
-    def logger_name(self):
-        return __name__
+    logger_name = __name__
 
     def case_blocks(self, case):
         inactive_location = self.extra_options['inactive_location']

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -42,9 +42,6 @@ class Command(CaseUpdateCommand):
     def logger_name(self):
         return __name__
 
-    def find_case_ids(self, domain):
-        return CommCareCase.objects.get_case_ids_in_domain(domain, self.case_type)
-
     def case_blocks(self, case):
         inactive_location = self.extra_options['inactive_location']
         traveler_location_id = self.extra_options['location']

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -52,10 +52,10 @@ class Command(CaseUpdateCommand):
             index={index.identifier: ("patient", index.referenced_id, "extension")},
         ).as_xml(), encoding='utf-8').decode('utf-8')
 
-    def update_cases(self, domain, case_type, user_id):
+    def update_cases(self, domain, user_id):
         inactive_location = self.extra_options['inactive_location']
-        case_ids = CommCareCase.objects.get_case_ids_in_domain(domain, case_type)
-        print(f"Found {len(case_ids)} {case_type} cases in {domain}")
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(domain, self.case_type)
+        print(f"Found {len(case_ids)} {self.case_type} cases in {domain}")
         traveler_location_id = self.extra_options['location']
 
         case_blocks = []
@@ -64,7 +64,7 @@ class Command(CaseUpdateCommand):
             if should_skip(case, traveler_location_id, inactive_location):
                 skip_count += 1
             elif needs_update(case):
-                owner_id = get_owner_id(case_type)
+                owner_id = get_owner_id(self.case_type)
                 case_blocks.append(self.case_block(case, owner_id))
         print(f"{len(case_blocks)} to update in {domain}, {skip_count} cases have skipped due to"
               f" multiple indices.")
@@ -75,7 +75,7 @@ class Command(CaseUpdateCommand):
             total += len(chunk)
             print("Updated {} cases on domain {}".format(total, domain))
 
-        self.log_data(domain, "update_case_index_relationship", case_type, len(case_ids), total, [])
+        self.log_data(domain, "update_case_index_relationship", len(case_ids), total, [])
 
     def add_arguments(self, parser):
         super().add_arguments(parser)

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -3,16 +3,8 @@ from xml.etree import cElementTree as ElementTree
 from custom.covid.management.commands.update_cases import CaseUpdateCommand
 
 from casexml.apps.case.mock import CaseBlock
-from dimagi.utils.chunked import chunked
 
-from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.form_processor.models import CommCareCase
-
-'''This command has an optional argument '--location' that will exclude all cases with that location. If the
-case_type is lab_result, the owner_id of that extension case is set to '-'. '''
-
-BATCH_SIZE = 100
-DEVICE_ID = __name__ + ".update_case_index_relationship"
 
 
 def should_skip(case, traveler_location_id, inactive_location):
@@ -41,44 +33,33 @@ def get_owner_id(case_type):
 
 
 class Command(CaseUpdateCommand):
-    help = ("Updates all case indices of a specfied case type to use an extension relationship instead of parent.")
-
-    def case_block(self, case, owner_id):
-        index = case.indices[0]
-        return ElementTree.tostring(CaseBlock.deprecated_init(
-            create=False,
-            case_id=case.case_id,
-            owner_id=owner_id,
-            index={index.identifier: ("patient", index.referenced_id, "extension")},
-        ).as_xml(), encoding='utf-8').decode('utf-8')
+    help = """
+        Updates all case indices of a specfied case type to use an extension relationship instead of parent.
+        This command has an optional argument '--location' that will exclude all cases with that location. If the
+        case_type is lab_result, the owner_id of that extension case is set to '-'.
+    """
 
     def find_case_ids(self, domain):
         return CommCareCase.objects.get_case_ids_in_domain(domain, self.case_type)
 
-    def update_cases(self, domain, user_id):
+    def case_block(self, case):
         inactive_location = self.extra_options['inactive_location']
-        case_ids = self.find_case_ids(domain)
-        print(f"Found {len(case_ids)} {self.case_type} cases in {domain}")
         traveler_location_id = self.extra_options['location']
 
-        case_blocks = []
-        skip_count = 0
-        for case in CommCareCase.objects.iter_cases(case_ids, domain):
-            if should_skip(case, traveler_location_id, inactive_location):
-                skip_count += 1
-            elif needs_update(case):
-                owner_id = get_owner_id(self.case_type)
-                case_blocks.append(self.case_block(case, owner_id))
-        print(f"{len(case_blocks)} to update in {domain}, {skip_count} cases have skipped due to"
-              f" multiple indices.")
+        if should_skip(case, traveler_location_id, inactive_location):
+            return None
 
-        total = 0
-        for chunk in chunked(case_blocks, BATCH_SIZE):
-            submit_case_blocks(chunk, domain, device_id=DEVICE_ID, user_id=user_id)
-            total += len(chunk)
-            print("Updated {} cases on domain {}".format(total, domain))
+        if not needs_update(case):
+            return None
 
-        self.log_data(domain, "update_case_index_relationship", len(case_ids), total, [])
+        owner_id = get_owner_id(self.case_type)
+        index = case.indices[0]
+        return [CaseBlock.deprecated_init(
+            create=False,
+            case_id=case.case_id,
+            owner_id=owner_id,
+            index={index.identifier: ("patient", index.referenced_id, "extension")},
+        )]
 
     def add_arguments(self, parser):
         super().add_arguments(parser)

--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -54,7 +54,7 @@ class Command(CaseUpdateCommand):
 
         owner_id = get_owner_id(self.case_type)
         index = case.indices[0]
-        return [CaseBlock.deprecated_init(
+        return [CaseBlock(
             create=False,
             case_id=case.case_id,
             owner_id=owner_id,

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -40,7 +40,6 @@ class CaseUpdateCommand(BaseCommand):
         )
         self.logger.debug(f"Made {update_count} updates and skipped {skip_count} cases in {domain}")
 
-    # TODO: add optional verify_case method in case we're pulling from ES
     def find_case_ids(self, domain):
         return CommCareCase.objects.get_case_ids_in_domain(domain, self.case_type)
 

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -40,7 +40,6 @@ class CaseUpdateCommand(BaseCommand):
         parser.add_argument('case_type')
         parser.add_argument('--username', type=str, default=None)
         parser.add_argument('--and-linked', action='store_true', default=False)
-        parser.add_argument('--throttle-secs', type=float, default=0)
 
     def handle(self, domain, case_type, **options):
         # logger.debug will record something to a file but not print it
@@ -63,7 +62,6 @@ class CaseUpdateCommand(BaseCommand):
             user_id = SYSTEM_USER_ID
 
         self.case_type = case_type
-        self.throttle_secs = options.pop("throttle_secs", None)
 
         self.extra_options = options
 
@@ -76,7 +74,6 @@ class CaseUpdateCommand(BaseCommand):
                 update_fn=self.case_blocks,
                 case_ids=with_progress_bar(case_ids, oneline=False),
                 form_meta=SystemFormMeta.for_script(self.logger_name(), username),
-                throttle_secs=self.throttle_secs,
             )
             self.logger.debug(f"Made {update_count} updates in {domain} ({i}/{len(domains)})")
 

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -43,9 +43,9 @@ class CaseUpdateCommand(BaseCommand):
 
     def handle(self, domain, case_type, **options):
         # logger.debug will record something to a file but not print it
-        self.logger = logging.getLogger(self.logger_name())
+        self.logger = logging.getLogger(self.logger_name)
         if not settings.UNIT_TESTING:
-            self.logger.addHandler(logging.FileHandler(self.logger_name().split(".")[-1] + ".txt"))
+            self.logger.addHandler(logging.FileHandler(self.logger_name.split(".")[-1] + ".txt"))
         self.logger.setLevel(logging.DEBUG)
 
         self.logger.debug(f"{datetime.datetime.utcnow()} Starting run: {options}")
@@ -64,7 +64,7 @@ class CaseUpdateCommand(BaseCommand):
                 domain=domain,
                 update_fn=self.case_blocks,
                 case_ids=with_progress_bar(case_ids, oneline=False),
-                form_meta=SystemFormMeta.for_script(self.logger_name(), username),
+                form_meta=SystemFormMeta.for_script(self.logger_name, username),
             )
             self.logger.debug(f"Made {update_count} updates in {domain} ({i}/{len(domains)})")
 

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -26,9 +26,8 @@ class CaseUpdateCommand(BaseCommand):
     def update_cases(self, domain, user_id):
         raise NotImplementedError()
 
-    # TODO: make a find_case_ids that isn't implemented and calls this?
     # TODO: add optional verify_case method in case we're pulling from ES
-    def find_case_ids_by_type(self, domain):
+    def find_case_ids(self, domain):
         case_ids = CommCareCase.objects.get_case_ids_in_domain(domain, self.case_type)
         print(f"Found {len(case_ids)} {self.case_type} cases in {domain}")
         return case_ids

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -20,6 +20,7 @@ class CaseUpdateCommand(BaseCommand):
     def __init__(self):
         self.extra_options = {}
 
+    @property
     def logger_name(self):
         """
         Typically __name__

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -19,7 +19,6 @@ class CaseUpdateCommand(BaseCommand):
         self.output_file = None
         self.extra_options = {}
 
-    # TODO: return list of blocks, for the sake of the upcoming script
     def case_block(self, case):
         raise NotImplementedError()
 
@@ -28,13 +27,14 @@ class CaseUpdateCommand(BaseCommand):
         username = user_id_to_username(user_id)     # TODO: something else
         case_ids = self.find_case_ids(domain)
         print(f"Found {len(case_ids)} cases in {domain}")   # ({i}/{len(domains)})")  # TODO: use logger
-        update_cases(
+        (update_count, skip_count) = update_cases(
             domain=domain,
             update_fn=self.case_block,
             case_ids=with_progress_bar(case_ids, oneline=False),
             form_meta=SystemFormMeta.for_script(__name__, username),
             throttle_secs=self.throttle_secs,
         )
+        print(f"Made {update_count} updates and skipped {skip_count} cases in {domain}")   # ({i}/{len(domains)})")  # TODO: use logger
 
     # TODO: add optional verify_case method in case we're pulling from ES
     def find_case_ids(self, domain):

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -31,14 +31,14 @@ class CaseUpdateCommand(BaseCommand):
         username = user_id_to_username(user_id)     # TODO: something else
         case_ids = self.find_case_ids(domain)
         self.logger.debug(f"Found {len(case_ids)} cases in {domain}")   # ({i}/{len(domains)})") TODO
-        (update_count, skip_count) = update_cases(
+        update_count = update_cases(
             domain=domain,
             update_fn=self.case_block,
             case_ids=with_progress_bar(case_ids, oneline=False),
             form_meta=SystemFormMeta.for_script(__name__, username),
             throttle_secs=self.throttle_secs,
         )
-        self.logger.debug(f"Made {update_count} updates and skipped {skip_count} cases in {domain}")
+        self.logger.debug(f"Made {update_count} updates in {domain}")
 
     def find_case_ids(self, domain):
         return CommCareCase.objects.get_case_ids_in_domain(domain, self.case_type)

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.core.management.base import BaseCommand
 
 from corehq.apps.linked_domain.dbaccessors import get_linked_domains
@@ -45,6 +47,7 @@ class CaseUpdateCommand(BaseCommand):
         parser.add_argument('--username', type=str, default=None)
         parser.add_argument('--and-linked', action='store_true', default=False)
         parser.add_argument('--output-file', type=str, default=None)
+        parser.add_argument('--throttle-secs', type=float, default=0)
 
     def handle(self, domain, case_type, **options):
         domains = {domain}
@@ -58,6 +61,7 @@ class CaseUpdateCommand(BaseCommand):
         else:
             user_id = SYSTEM_USER_ID
 
+        self.throttle_secs = options["throttle_secs"]
         self.output_file = options["output_file"]
 
         options.pop("and_linked")
@@ -65,6 +69,7 @@ class CaseUpdateCommand(BaseCommand):
         options.pop("output_file", None)
         self.extra_options = options
 
+        print(f"{datetime.datetime.utcnow()} Starting run: {options}")
         for domain in sorted(domains):
             print(f"Processing {domain}")
             self.update_cases(domain, case_type, user_id)

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from corehq.apps.hqcase.bulk import SystemFormMeta, update_cases
@@ -44,7 +45,8 @@ class CaseUpdateCommand(BaseCommand):
     def handle(self, domain, case_type, **options):
         # logger.debug will record something to a file but not print it
         self.logger = logging.getLogger(self.logger_name())
-        self.logger.addHandler(logging.FileHandler(self.logger_name().split(".")[-1] + ".txt"))
+        if not settings.UNIT_TESTING:
+            self.logger.addHandler(logging.FileHandler(self.logger_name().split(".")[-1] + ".txt"))
         self.logger.setLevel(logging.DEBUG)
 
         self.logger.debug(f"{datetime.datetime.utcnow()} Starting run: {options}")

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -25,7 +25,10 @@ class CaseUpdateCommand(BaseCommand):
         """
         raise NotImplementedError()
 
-    def case_block(self, case):
+    def case_blocks(self, case):
+        """
+        Return a list of CaseBlock updates, or None if no updates are needed.
+        """
         raise NotImplementedError()
 
     def find_case_ids(self, domain):
@@ -68,7 +71,7 @@ class CaseUpdateCommand(BaseCommand):
             self.logger.debug(f"Found {len(case_ids)} cases in {domain} ({i}/{len(domains)})")
             update_count = update_cases(
                 domain=domain,
-                update_fn=self.case_block,
+                update_fn=self.case_blocks,
                 case_ids=with_progress_bar(case_ids, oneline=False),
                 form_meta=SystemFormMeta.for_script(self.logger_name(), username),
                 throttle_secs=self.throttle_secs,

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -6,7 +6,6 @@ from django.core.management.base import BaseCommand
 
 from corehq.apps.hqcase.bulk import SystemFormMeta, update_cases
 from corehq.apps.linked_domain.dbaccessors import get_linked_domains
-from corehq.apps.users.util import SYSTEM_USER_ID, username_to_user_id, user_id_to_username
 from corehq.form_processor.models import CommCareCase
 from corehq.util.log import with_progress_bar
 
@@ -55,18 +54,9 @@ class CaseUpdateCommand(BaseCommand):
             domains = domains | {link.linked_domain for link in get_linked_domains(domain)}
 
         username = options.pop("username")
-        if username is not None:
-            user_id = username_to_user_id(username)
-            if not user_id:
-                raise Exception("The username you entered is invalid")
-        else:
-            user_id = SYSTEM_USER_ID
-
         self.case_type = case_type
-
         self.extra_options = options
 
-        username = user_id_to_username(user_id)
         for i, domain in enumerate(sorted(domains), start=1):
             case_ids = self.find_case_ids(domain)
             self.logger.debug(f"Found {len(case_ids)} cases in {domain} ({i}/{len(domains)})")

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -18,23 +18,28 @@ class CaseUpdateCommand(BaseCommand):
         self.output_file = None
         self.extra_options = {}
 
+    # TODO: return list of blocks, for the sake of the upcoming script
     def case_block(self):
         raise NotImplementedError()
 
-    def update_cases(self, domain, case_type, user_id):
+    # TODO: implment most of this here? use update_cases as in Ethan's script, and SystemFormMeta
+    def update_cases(self, domain, user_id):
         raise NotImplementedError()
 
-    def find_case_ids_by_type(self, domain, case_type):
-        case_ids = CommCareCase.objects.get_case_ids_in_domain(domain, case_type)
-        print(f"Found {len(case_ids)} {case_type} cases in {domain}")
+    # TODO: make a find_case_ids that isn't implemented and calls this?
+    # TODO: add optional verify_case method in case we're pulling from ES
+    def find_case_ids_by_type(self, domain):
+        case_ids = CommCareCase.objects.get_case_ids_in_domain(domain, self.case_type)
+        print(f"Found {len(case_ids)} {self.case_type} cases in {domain}")
         return case_ids
 
-    def log_data(self, domain, command, case_type, total_cases, num_updated, errors, loc_id=None):
+    # TODO: replace with logger from Ethan's script, allow overwriting - when is this called?
+    def log_data(self, domain, command, total_cases, num_updated, errors, loc_id=None):
         if self.output_file is not None:
             with open(self.output_file, "a") as output_file:
                 num_case_updated_str = "{} {}: Updated {} out of the {} {} cases".format(domain, command,
                                                                                          num_updated, total_cases,
-                                                                                         case_type)
+                                                                                         self.case_type)
                 if loc_id is not None:
                     num_case_updated_str += f" in this location:{loc_id}"
                 output_file.write(num_case_updated_str + '\n')
@@ -61,6 +66,7 @@ class CaseUpdateCommand(BaseCommand):
         else:
             user_id = SYSTEM_USER_ID
 
+        self.case_type = case_type
         self.throttle_secs = options["throttle_secs"]
         self.output_file = options["output_file"]
 
@@ -72,4 +78,4 @@ class CaseUpdateCommand(BaseCommand):
         print(f"{datetime.datetime.utcnow()} Starting run: {options}")
         for domain in sorted(domains):
             print(f"Processing {domain}")
-            self.update_cases(domain, case_type, user_id)
+            self.update_cases(domain, user_id)

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -20,7 +20,6 @@ class CaseUpdateCommand(BaseCommand):
     logger_name = __name__
 
     def __init__(self):
-        self.output_file = None
         self.extra_options = {}
 
     def case_block(self, case):
@@ -43,25 +42,11 @@ class CaseUpdateCommand(BaseCommand):
     def find_case_ids(self, domain):
         return CommCareCase.objects.get_case_ids_in_domain(domain, self.case_type)
 
-    # TODO: replace with logger from Ethan's script, allow overwriting - when is this called?
-    def log_data(self, domain, command, total_cases, num_updated, errors, loc_id=None):
-        if self.output_file is not None:
-            with open(self.output_file, "a") as output_file:
-                num_case_updated_str = "{} {}: Updated {} out of the {} {} cases".format(domain, command,
-                                                                                         num_updated, total_cases,
-                                                                                         self.case_type)
-                if loc_id is not None:
-                    num_case_updated_str += f" in this location:{loc_id}"
-                output_file.write(num_case_updated_str + '\n')
-                for error in errors:
-                    output_file.write(domain + ": " + error + '\n')
-
     def add_arguments(self, parser):
         parser.add_argument('domain')
         parser.add_argument('case_type')
         parser.add_argument('--username', type=str, default=None)
         parser.add_argument('--and-linked', action='store_true', default=False)
-        parser.add_argument('--output-file', type=str, default=None)
         parser.add_argument('--throttle-secs', type=float, default=0)
 
     def handle(self, domain, case_type, **options):
@@ -85,7 +70,6 @@ class CaseUpdateCommand(BaseCommand):
 
         self.case_type = case_type
         self.throttle_secs = options.pop("throttle_secs", None)
-        self.output_file = options.pop("output_file", None)
 
         self.extra_options = options
 

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -16,11 +16,14 @@ class CaseUpdateCommand(BaseCommand):
         Override all methods that raise NotImplementedError.
     """
 
-    # Include this line in subclasses
-    logger_name = __name__
-
     def __init__(self):
         self.extra_options = {}
+
+    def logger_name(self):
+        """
+        Typically __name__
+        """
+        raise NotImplementedError()
 
     def case_block(self, case):
         raise NotImplementedError()
@@ -37,8 +40,8 @@ class CaseUpdateCommand(BaseCommand):
 
     def handle(self, domain, case_type, **options):
         # logger.debug will record something to a file but not print it
-        self.logger = logging.getLogger(self.logger_name)
-        self.logger.addHandler(logging.FileHandler(self.logger_name.split(".")[-1] + ".txt"))
+        self.logger = logging.getLogger(self.logger_name())
+        self.logger.addHandler(logging.FileHandler(self.logger_name().split(".")[-1] + ".txt"))
         self.logger.setLevel(logging.DEBUG)
 
         self.logger.debug(f"{datetime.datetime.utcnow()} Starting run: {options}")
@@ -67,7 +70,7 @@ class CaseUpdateCommand(BaseCommand):
                 domain=domain,
                 update_fn=self.case_block,
                 case_ids=with_progress_bar(case_ids, oneline=False),
-                form_meta=SystemFormMeta.for_script(self.logger_name, username),
+                form_meta=SystemFormMeta.for_script(self.logger_name(), username),
                 throttle_secs=self.throttle_secs,
             )
             self.logger.debug(f"Made {update_count} updates in {domain} ({i}/{len(domains)})")

--- a/custom/covid/management/commands/update_cases.py
+++ b/custom/covid/management/commands/update_cases.py
@@ -51,12 +51,12 @@ class CaseUpdateCommand(BaseCommand):
 
         self.logger.debug(f"{datetime.datetime.utcnow()} Starting run: {options}")
         domains = {domain}
-        if options.pop("and_linked", False):
+        if options.pop("and_linked"):
             domains = domains | {link.linked_domain for link in get_linked_domains(domain)}
 
-        username = options.pop("username", None)
+        username = options.pop("username")
         if username is not None:
-            user_id = username_to_user_id(options["username"])
+            user_id = username_to_user_id(username)
             if not user_id:
                 raise Exception("The username you entered is invalid")
         else:

--- a/custom/covid/management/commands/update_owner_ids.py
+++ b/custom/covid/management/commands/update_owner_ids.py
@@ -26,7 +26,7 @@ class Command(CaseUpdateCommand):
         self.locations_objects[owner_id] = loc
         return loc
 
-    def case_block(self, case):
+    def case_blocks(self, case):
         owner_id = case.get_case_property('owner_id')
         try:
             location_obj = self.get_location(owner_id)

--- a/custom/covid/management/commands/update_owner_ids.py
+++ b/custom/covid/management/commands/update_owner_ids.py
@@ -12,8 +12,7 @@ class Command(CaseUpdateCommand):
 
     locations_objects = None
 
-    def logger_name(self):
-        return __name__
+    logger_name = __name__
 
     @memoized
     def get_location(self, owner_id):

--- a/custom/covid/management/commands/update_owner_ids.py
+++ b/custom/covid/management/commands/update_owner_ids.py
@@ -25,7 +25,7 @@ class Command(CaseUpdateCommand):
         ).as_xml(), encoding='utf-8').decode('utf-8')
 
     def update_cases(self, domain, user_id):
-        case_ids = self.find_case_ids_by_type(domain)
+        case_ids = self.find_case_ids(domain)
 
         locations_objects = {}
         case_blocks = []

--- a/custom/covid/management/commands/update_owner_ids.py
+++ b/custom/covid/management/commands/update_owner_ids.py
@@ -1,3 +1,5 @@
+from memoized import memoized
+
 from casexml.apps.case.mock import CaseBlock
 
 from corehq.apps.locations.models import SQLLocation

--- a/custom/covid/management/commands/update_owner_ids.py
+++ b/custom/covid/management/commands/update_owner_ids.py
@@ -10,8 +10,10 @@ class Command(CaseUpdateCommand):
     help = f"Changes the owner_id of a case to the location_id of the child location with type " \
            f"{CHILD_LOCATION_TYPE} of the current location"
 
-    logger_name = __name__
     locations_objects = None
+
+    def logger_name(self):
+        return __name__
 
     def get_location(self, owner_id):
         if self.locations_objects is None:

--- a/custom/covid/management/commands/update_owner_ids.py
+++ b/custom/covid/management/commands/update_owner_ids.py
@@ -1,15 +1,8 @@
-from xml.etree import cElementTree as ElementTree
-
 from casexml.apps.case.mock import CaseBlock
-from dimagi.utils.chunked import chunked
 
-from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.form_processor.models import CommCareCase
 from corehq.apps.locations.models import SQLLocation
 from custom.covid.management.commands.update_cases import CaseUpdateCommand
 
-BATCH_SIZE = 100
-DEVICE_ID = __name__ + ".update_owner_ids"
 CHILD_LOCATION_TYPE = 'investigators'
 
 
@@ -17,52 +10,34 @@ class Command(CaseUpdateCommand):
     help = f"Changes the owner_id of a case to the location_id of the child location with type " \
            f"{CHILD_LOCATION_TYPE} of the current location"
 
-    def case_block(self, case, child_location):
-        return ElementTree.tostring(CaseBlock.deprecated_init(
-            create=False,
-            case_id=case.case_id,
-            owner_id=child_location.location_id,
-        ).as_xml(), encoding='utf-8').decode('utf-8')
+    logger_name = __name__
+    locations_objects = None
 
-    def update_cases(self, domain, user_id):
-        case_ids = self.find_case_ids(domain)
+    def get_location(self, owner_id):
+        if self.locations_objects is None:
+            self.locations_objects = {}
 
-        locations_objects = {}
-        case_blocks = []
-        errors = []
-        skip_count = 0
-        for case in CommCareCase.objects.iter_cases(case_ids, domain):
-            owner_id = case.get_case_property('owner_id')
-            if owner_id in locations_objects:
-                location_obj = locations_objects[owner_id]
-            else:
-                try:
-                    location_obj = SQLLocation.objects.get(location_id=owner_id)
-                except SQLLocation.DoesNotExist:
-                    errors.append("Location does not exist associated with the owner_id:{}. "
-                                  "Case:{}".format(owner_id, case.case_id))
-                    skip_count += 1
-                    continue
-                locations_objects[owner_id] = location_obj
-            if location_obj:
-                children = location_obj.get_children()
-                has_correct_child_location_type = False
-                for child_location in children:
-                    if child_location.location_type.code == CHILD_LOCATION_TYPE:
-                        case_blocks.append(self.case_block(case, child_location))
-                        has_correct_child_location_type = True
-                        break
-                if not has_correct_child_location_type:
-                    skip_count += 1
-            else:
-                skip_count += 1
-        print(f"{len(case_blocks)} to update in {domain}, {skip_count} cases have skipped due to unknown owner_id"
-              f" or has no child location of type {CHILD_LOCATION_TYPE}.")
+        if owner_id in self.locations_objects:
+            return self.locations_objects[owner_id]
 
-        total = 0
-        for chunk in chunked(case_blocks, BATCH_SIZE):
-            submit_case_blocks(chunk, domain, device_id=DEVICE_ID, user_id=user_id)
-            total += len(chunk)
-            print("Updated {} cases on domain {}".format(total, domain))
+        loc = SQLLocation.objects.get(location_id=owner_id)
+        self.locations_objects[owner_id] = loc
+        return loc
 
-        self.log_data(domain, "update_owner_ids", len(case_ids), total, errors)
+    def case_block(self, case):
+        owner_id = case.get_case_property('owner_id')
+        try:
+            location_obj = self.get_location(owner_id)
+        except SQLLocation.DoesNotExist:
+            self.logger.error("Location does not exist associated with the owner_id:{}. "
+                              "Case:{}".format(owner_id, case.case_id))
+            return None
+
+        children = location_obj.get_children()
+        for child_location in children:
+            if child_location.location_type.code == CHILD_LOCATION_TYPE:
+                return [CaseBlock.deprecated_init(
+                    create=False,
+                    case_id=case.case_id,
+                    owner_id=child_location.location_id,
+                )]

--- a/custom/covid/management/commands/update_owner_ids.py
+++ b/custom/covid/management/commands/update_owner_ids.py
@@ -15,16 +15,9 @@ class Command(CaseUpdateCommand):
     def logger_name(self):
         return __name__
 
+    @memoized
     def get_location(self, owner_id):
-        if self.locations_objects is None:
-            self.locations_objects = {}
-
-        if owner_id in self.locations_objects:
-            return self.locations_objects[owner_id]
-
-        loc = SQLLocation.objects.get(location_id=owner_id)
-        self.locations_objects[owner_id] = loc
-        return loc
+        return SQLLocation.objects.get(location_id=owner_id)
 
     def case_blocks(self, case):
         owner_id = case.get_case_property('owner_id')

--- a/custom/covid/management/commands/update_owner_ids.py
+++ b/custom/covid/management/commands/update_owner_ids.py
@@ -12,8 +12,6 @@ class Command(CaseUpdateCommand):
     help = f"Changes the owner_id of a case to the location_id of the child location with type " \
            f"{CHILD_LOCATION_TYPE} of the current location"
 
-    locations_objects = None
-
     logger_name = __name__
 
     @memoized

--- a/custom/covid/management/commands/update_owner_ids.py
+++ b/custom/covid/management/commands/update_owner_ids.py
@@ -38,7 +38,7 @@ class Command(CaseUpdateCommand):
         children = location_obj.get_children()
         for child_location in children:
             if child_location.location_type.code == CHILD_LOCATION_TYPE:
-                return [CaseBlock.deprecated_init(
+                return [CaseBlock(
                     create=False,
                     case_id=case.case_id,
                     owner_id=child_location.location_id,

--- a/custom/covid/management/commands/update_owner_ids.py
+++ b/custom/covid/management/commands/update_owner_ids.py
@@ -24,8 +24,8 @@ class Command(CaseUpdateCommand):
             owner_id=child_location.location_id,
         ).as_xml(), encoding='utf-8').decode('utf-8')
 
-    def update_cases(self, domain, case_type, user_id):
-        case_ids = self.find_case_ids_by_type(domain, case_type)
+    def update_cases(self, domain, user_id):
+        case_ids = self.find_case_ids_by_type(domain)
 
         locations_objects = {}
         case_blocks = []
@@ -65,4 +65,4 @@ class Command(CaseUpdateCommand):
             total += len(chunk)
             print("Updated {} cases on domain {}".format(total, domain))
 
-        self.log_data(domain, "update_owner_ids", case_type, len(case_ids), total, errors)
+        self.log_data(domain, "update_owner_ids", len(case_ids), total, errors)

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -423,8 +423,8 @@ class TestUpdateAllActivityCompleteDate(TestCase):
     @patch('corehq.apps.hqcase.bulk.username_to_user_id', new=lambda _: 'my_username')
     def test(self):
         logging.getLogger('custom.covid.management.commands.update_all_activity_complete_date').disabled = True
-        call_command('update_all_activity_complete_date', self.domain, 'patient', username='test@example.com')
-        call_command('update_all_activity_complete_date', self.domain, 'contact', username='test@example.com')
+        call_command('update_all_activity_complete_date', self.domain, 'patient')
+        call_command('update_all_activity_complete_date', self.domain, 'contact')
 
         cases = {
             label: (CommCareCase.objects.get_case(case_block.case_id), case_block)

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -51,7 +51,7 @@ class CaseCommandsTest(TestCase):
     def submit_case_block(self, create, case_id, **kwargs):
         return post_case_blocks(
             [
-                CaseBlock.deprecated_init(
+                CaseBlock(
                     create=create,
                     case_id=case_id,
                     **kwargs


### PR DESCRIPTION
## Technical Summary
In anticipation of [USH-1678](https://dimagi-dev.atlassian.net/browse/USH-1678), I took a stab at combining Ethan's recent work on bulk case updates with Steph's structure for data cleaning management commands.

There are some changes to what's logged: there are no longer details about **why** a case was skipped, and errors are printed as they're encountered rather than at the end. I think these are acceptable, but feel free to correct me.

Review by commit.

## Safety Assurance

### Safety story
This change is limited to a set of custom scripts that are only run manually.

### Automated test coverage

There's test coverage for each of the management commands.

### QA Plan

No QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
