### PR TITLE
Removed remnants of corehq/ex-submodules/toggles

### DIFF
--- a/corehq/ex-submodules/toggle/models.py
+++ b/corehq/ex-submodules/toggle/models.py
@@ -1,1 +1,0 @@
-from corehq.toggles.models import Toggle, generate_toggle_id


### PR DESCRIPTION
## Technical Summary
Followup for https://github.com/dimagi/commcare-hq/pull/31002

## Safety Assurance

### Safety story
This should fail very loudly.

### Automated test coverage

There's plenty of test coverage that touches feature flags, though I'm not certain if any of it exercises the [caching code](https://github.com/dimagi/commcare-hq/blob/80c68217033ad3cfc5b0f9e9563f3f9934265cae/corehq/toggles/models.py#L34-L39) that's the most likely thing to break. 

### QA Plan

Not requesting QA, as there isn't anything specific to test. I'm testing this by deploying it to staging.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
