### PR TITLE
Add an option to control a UCR source's visibility in ANALYTICS

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -244,6 +244,7 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
     is_deactivated = BooleanProperty(default=False)
     last_modified = DateTimeProperty()
     asynchronous = BooleanProperty(default=False)
+    is_available_in_analytics = BooleanProperty(default=False)
     sql_column_indexes = SchemaListProperty(SQLColumnIndexes)
     disable_destructive_rebuild = BooleanProperty(default=False)
     sql_settings = SchemaProperty(SQLSettings)

--- a/corehq/apps/userreports/ui/forms.py
+++ b/corehq/apps/userreports/ui/forms.py
@@ -171,6 +171,13 @@ class ConfigurableDataSourceEditForm(DocumentFormBase):
             inline_label="Asynchronous processing"
         )
     )
+    is_available_in_analytics = forms.BooleanField(
+        initial=False,
+        required=False,
+        label="",
+        widget=forms.HiddenInput(),
+        help_text=help_text.ANALYTICS
+    )
 
     def __init__(self, domain, data_source_config, read_only, *args, **kwargs):
         self.domain = domain
@@ -182,6 +189,11 @@ class ConfigurableDataSourceEditForm(DocumentFormBase):
                 ('Location', _('locations'))
             )
             self.fields['referenced_doc_type'].choices = choices
+
+        if toggles.SUPERSET_ANALYTICS.enabled(domain):
+            self.fields['is_available_in_analytics'].widget = BootstrapCheckboxInput(
+                inline_label="Availabe in Analytics"
+            )
         self.helper = FormHelper()
 
         self.helper.form_method = 'POST'
@@ -202,6 +214,7 @@ class ConfigurableDataSourceEditForm(DocumentFormBase):
             'named_expressions',
             'named_filters',
             'asynchronous',
+            'is_available_in_analytics',
         ]
         if data_source_config.get_id:
             fields.append('_id')

--- a/corehq/apps/userreports/ui/help_text.py
+++ b/corehq/apps/userreports/ui/help_text.py
@@ -41,3 +41,6 @@ NAMED_EXPRESSIONS = _(
     'wherever an expression goes using: <code>{"type": "named", "name": "myvarname"}</code>')
 NAMED_FILTER = _('These behave exactly like named expressions (see above), except the values '
                  'should be a valid filter, and they can be used wherever filters are used above.')
+ANALYTICS = _(
+    'Enabling this will let this data source and the data be imported into Analytics'
+)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2169,3 +2169,10 @@ SAVE_ONLY_EDITED_FORM_FIELDS = FeatureRelease(
     Manager only if the question's inputted answer is different from the current value in the case.
     """
 )
+
+SUPERSET_ANALYTICS = StaticToggle(
+    'superset-analytics',
+    'Activates Analytics features to create Superset based reports and dashboards using UCR data',
+    TAG_SOLUTIONS_LIMITED,
+    [NAMESPACE_DOMAIN],
+)


### PR DESCRIPTION
## Product Description

https://dimagi-dev.atlassian.net/browse/SC-1994

This adds a SUPERSET toggle and when it's enabled adds an option to control a UCR source's visibility in ANALYTICS.


<img width="865" alt="Screenshot 2022-02-28 at 12 25 35 PM" src="https://user-images.githubusercontent.com/829142/155938402-ec8df07b-54bb-4f1e-83b5-b9d16a57f014.png">

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
Adds a new one `SUPERSET_ANALYTICS`

## Safety Assurance


### Safety story

This simply adds a new field to the data source model and exposes an option to toggle this via the UI. I have tested the UI for correctness. Since it's a well-known model change, it should be safe.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

Not necessary.


### Migrations
No migrations

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

@proteusvacuum 