### PR TITLE
don't require case type when updating cases via data registry repeater

### DIFF
--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -397,7 +397,6 @@ class CaseUpdateConfig:
         "registry_slug",
         "domain",
         "case_id",
-        "case_type",
     ]
 
     intent_case = attr.ib()
@@ -463,6 +462,8 @@ class CaseUpdateConfig:
         if self.create_case:
             if not self.owner_id:
                 raise DataRegistryCaseUpdateError("'owner_id' required when creating cases")
+            if not self.case_type:
+                raise DataRegistryCaseUpdateError("'case_type' required when creating cases")
             kwargs = {
                 "create": True,
                 "case_type": self.case_type,
@@ -592,7 +593,7 @@ class CaseUpdateConfig:
         if for_create:
             raise DataRegistryCaseUpdateError(f"Unable to create case as it already exists: {case_id}")
 
-        if case.domain != domain or case.type != case_type:
+        if case.domain != domain or (case_type and case.type != case_type):
             raise DataRegistryCaseUpdateError(f"Case not found: {case_id}")
 
         return case


### PR DESCRIPTION
## Product Description
Update Data Registry Forwarder to not require case type when updating a case.

Jira: https://dimagi-dev.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/custom/81/SUPPORT-12777

## Feature Flag
Data registry case update repeater

## Safety Assurance

### Safety story
Isolated feature with good test coverage

### Automated test coverage
Update

### QA Plan
None

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
