### PR TITLE
Improve Couch document evaluation command

### DIFF
--- a/corehq/apps/cleanup/management/commands/evaluate_couch_model_for_sql.py
+++ b/corehq/apps/cleanup/management/commands/evaluate_couch_model_for_sql.py
@@ -7,10 +7,10 @@ from couchdbkit.ext.django import schema
 from django.core.management.base import BaseCommand
 from django.utils.dateparse import parse_date, parse_datetime
 
-from corehq.dbaccessors.couchapps.all_docs import get_doc_ids_by_class
 from corehq.util.couchdb_management import couch_config
+from corehq.util.doc_processor.couch import DocsIterator
+from corehq.util.log import with_progress_bar
 from dimagi.ext import jsonobject
-from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.modules import to_function
 
 logger = logging.getLogger(__name__)
@@ -37,6 +37,13 @@ class Command(BaseCommand):
         parser.add_argument(
             'class_name',
         )
+        parser.add_argument(
+            '--chunk-size',
+            type=int,
+            default=100,
+            help="Chunk size for batches of documents fetched from Couch. "
+                 "Default: 100",
+        )
 
     COUCH_FIELDS = {'_id', '_rev', 'doc_type', 'base_doc', '_attachments'}
 
@@ -55,7 +62,7 @@ class Command(BaseCommand):
     field_params = {}
     index_fields = set()
 
-    def handle(self, django_app, class_name, **options):
+    def handle(self, django_app, class_name, chunk_size, **options):
         self.class_name = class_name
         self.django_app = django_app
         self.models_path = f"corehq.apps.{self.django_app}.models.{self.class_name}"
@@ -65,11 +72,15 @@ class Command(BaseCommand):
             self.couch_class = to_function(self.models_path)
             self.class_name = self.models_path.split(".")[-1]
 
-        doc_ids = get_doc_ids_by_class(self.couch_class)
-        print("Found {} {} docs\n".format(len(doc_ids), self.class_name))
+        docs = DocsIterator(self.couch_class, chunk_size)
+        print("Found {} {} docs\n".format(len(docs), self.class_name))
+        print("CTRL+C to stop evaluating documents.")
 
-        for doc in iter_docs(self.couch_class.get_db(), doc_ids):
-            self.evaluate_doc(doc)
+        try:
+            for doc in with_progress_bar(docs, oneline="concise"):
+                self.evaluate_doc(doc)
+        except KeyboardInterrupt:
+            pass
 
         self.standardize_max_lengths()
         self.correlate_with_couch_schema(self.couch_class)

--- a/corehq/dbaccessors/couchapps/all_docs.py
+++ b/corehq/dbaccessors/couchapps/all_docs.py
@@ -67,7 +67,10 @@ def get_all_docs_with_doc_types(db, doc_types):
 
 
 def get_doc_ids_by_class(doc_class):
-    """Useful for migrations, but has the potential to be very large"""
+    """Useful for migrations, but has the potential to be very large
+
+    Suggested alternative: corehq.util.doc_processor.couch.DocsIterator
+    """
     doc_type = doc_class.__name__
     return [row['id'] for row in doc_class.get_db().view(
         'all_docs/by_doc_type',

--- a/corehq/util/doc_processor/couch.py
+++ b/corehq/util/doc_processor/couch.py
@@ -1,4 +1,3 @@
-from couchdbkit import ResourceNotFound
 from uuid import uuid4
 
 from corehq.dbaccessors.couchapps.all_docs import get_doc_count_by_type
@@ -45,7 +44,8 @@ class DocsIterator:
             discard_state()
 
 
-def resumable_view_iterator(db, iteration_key, view_name, view_keys, chunk_size=100, view_event_handler=None, full_row=False):
+def resumable_view_iterator(db, iteration_key, view_name, view_keys,
+        chunk_size=100, view_event_handler=None, full_row=False):
     """Perform one-time resumable iteration over a CouchDB View
 
     Iteration can be efficiently stopped and resumed. The iteration may
@@ -156,7 +156,7 @@ class CouchDocumentProvider(DocumentProvider):
             raise ValueError("Invalid (duplicate?) doc types")
 
         self.couchdb = next(iter(self.doc_type_map.values())).get_db()
-        couchid = lambda db: getattr(db, "dbname", id(db))
+        couchid = lambda db: getattr(db, "dbname", id(db))  # noqa: E731
         dbid = couchid(self.couchdb)
         assert all(couchid(m.get_db()) == dbid for m in self.doc_type_map.values()), \
             "documents must live in same couch db: %s" % repr(self.doc_type_map)

--- a/corehq/util/doc_processor/couch.py
+++ b/corehq/util/doc_processor/couch.py
@@ -1,8 +1,48 @@
 from couchdbkit import ResourceNotFound
+from uuid import uuid4
 
+from corehq.dbaccessors.couchapps.all_docs import get_doc_count_by_type
 from corehq.util.couch_helpers import MultiKeyViewArgsProvider, MultiKwargViewArgsProvider
 from corehq.util.doc_processor.interface import DocumentProvider, ProcessorProgressLogger
 from corehq.util.pagination import ResumableFunctionIterator
+
+from dimagi.utils.couch.database import retry_on_couch_error
+
+
+class DocsIterator:
+    """Iterate over all documents of the given Couch document class
+
+    The number of documents can be counted with `len()`.
+    Yields unwrapped document dicts.
+    """
+
+    def __init__(self, couch_class, chunk_size=100):
+        self.couch_class = couch_class
+        self.db = couch_class.get_db()
+        self.doc_type = couch_class.__name__
+        self.chunk_size = chunk_size
+
+    def __len__(self):
+        if not hasattr(self, "_len"):
+            self._len = get_doc_count_by_type(self.db, self.doc_type)
+        return self._len
+
+    def __iter__(self):
+        @retry_on_couch_error
+        def discard_state():
+            docs.discard_state()
+
+        docs = resumable_view_iterator(
+            self.db,
+            uuid4().hex,
+            'all_docs/by_doc_type',
+            [[self.doc_type]],
+            self.chunk_size,
+        )
+        try:
+            yield from docs
+        finally:
+            discard_state()
 
 
 def resumable_view_iterator(db, iteration_key, view_name, view_keys, chunk_size=100, view_event_handler=None, full_row=False):


### PR DESCRIPTION
Allow `evalute_couch_model_for_sql` management command to be interrupted

Doc types with a very large number of documents can take a long time to process. A random sampling of documents is probably good enough for most cases, and evaluating the first N documents is probably a suitably random sampling since most documents have no meaningful order in the `all_docs/by_doc_type` view because they  are keyed with random UUIDs.

`DocsIterator` also improves on the previous solution because it does not load all document ids into memory before any documents can be evaluated. Documents are loaded in chunks of 100 by default, and the chunk size can be customized with a command line parameter.

Any code that loads all document ids from Couch and then chunks that list of ids to fetch documents can probably be switched to use `DocsIterator` for a better user experience.

## Safety Assurance

### Safety story

Adds a new Couch document iteration utility and updates a seldomly-used management command. The management command was tested locally.

### Automated test coverage

No.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
