### PR TITLE
Fix calculation to truncate values to 1 dp

### DIFF
--- a/custom/gcc_sangath/rules/custom_actions.py
+++ b/custom/gcc_sangath/rules/custom_actions.py
@@ -75,16 +75,17 @@ def _get_case_updates(peer_rating_cases):
 
 
 def _get_sum(case_property, peer_rating_cases):
-    return sum([
+    total = sum([
         float(peer_rating_case.get_case_property(case_property) or 0)
         for peer_rating_case in peer_rating_cases
     ])
+    return float("{:.1f}".format(total))
 
 
 def _get_aggregate(case_property, peer_rating_cases):
     total = _get_sum(case_property, peer_rating_cases)
     count = len(peer_rating_cases)
-    return round(total / count, 1)
+    return float("{:.1f}".format(total / count))
 
 
 def _get_latest_peer_review_date(peer_rating_cases):

--- a/custom/gcc_sangath/tests/test_custom_actions.py
+++ b/custom/gcc_sangath/tests/test_custom_actions.py
@@ -71,26 +71,26 @@ class SanitizeSessionPeerRatingTest(BaseCaseRuleTest):
         )
         self._set_up_cases([
             {
-                MEAN_GENERAL_SKILLS_SCORE_CASE_PROP: 1,
-                MEAN_TREATMENT_SPECIFIC_SCORE_CASE_PROP: 2,
-                SESSION_RATING_CASE_PROP: 3,
+                MEAN_GENERAL_SKILLS_SCORE_CASE_PROP: 1.5,
+                MEAN_TREATMENT_SPECIFIC_SCORE_CASE_PROP: 2.3,
+                SESSION_RATING_CASE_PROP: 3.7,
                 DATE_OF_PEER_REVIEW_CASE_PROP: date(2020, 1, 1)
             },
             {
                 MEAN_GENERAL_SKILLS_SCORE_CASE_PROP: 2,
-                MEAN_TREATMENT_SPECIFIC_SCORE_CASE_PROP: 3,
-                SESSION_RATING_CASE_PROP: 5,
+                MEAN_TREATMENT_SPECIFIC_SCORE_CASE_PROP: 3.3,
+                SESSION_RATING_CASE_PROP: 5.2,
                 DATE_OF_PEER_REVIEW_CASE_PROP: date(2020, 8, 10)
             },
             {
-                MEAN_GENERAL_SKILLS_SCORE_CASE_PROP: 1,
+                MEAN_GENERAL_SKILLS_SCORE_CASE_PROP: 1.8,
                 MEAN_TREATMENT_SPECIFIC_SCORE_CASE_PROP: 2,
                 SESSION_RATING_CASE_PROP: 4,
                 DATE_OF_PEER_REVIEW_CASE_PROP: date(2020, 3, 10)
             },
             {
-                MEAN_GENERAL_SKILLS_SCORE_CASE_PROP: 1.5,
-                MEAN_TREATMENT_SPECIFIC_SCORE_CASE_PROP: 2.5,
+                MEAN_GENERAL_SKILLS_SCORE_CASE_PROP: 1.9,
+                MEAN_TREATMENT_SPECIFIC_SCORE_CASE_PROP: 2.9,
                 SESSION_RATING_CASE_PROP: 4,
                 DATE_OF_PEER_REVIEW_CASE_PROP: date(2020, 3, 10)
             },
@@ -103,50 +103,13 @@ class SanitizeSessionPeerRatingTest(BaseCaseRuleTest):
         self.assertDictEqual(
             session_case.case_json,
             {
-                'agg_mean_general_skills_score': '1.4',
-                'agg_mean_treatment_specific_score': '2.4',
-                'agg_rating': '4.0',
+                'agg_mean_general_skills_score': '1.8',
+                'agg_mean_treatment_specific_score': '2.6',
+                'agg_rating': '4.2',
                 'date_of_peer_review': '2020-08-10',
                 'feedback_num': '4',
                 'share_score_check': 'yes',
-                'total_session_rating': '16.0',
-                NEEDS_AGGREGATION_CASE_PROP: NEEDS_AGGREGATION_NO_VALUE,
-            }
-        )
-
-    def test_with_peer_rating_cases_when_values_truncated(self):
-        rule = create_empty_rule(
-            self.domain, AutomaticUpdateRule.WORKFLOW_CASE_UPDATE, case_type=SESSION_CASE_TYPE,
-        )
-        self._set_up_cases([
-            {
-                MEAN_GENERAL_SKILLS_SCORE_CASE_PROP: 2.2,
-                MEAN_TREATMENT_SPECIFIC_SCORE_CASE_PROP: 2.1,
-                SESSION_RATING_CASE_PROP: 4.3,
-                DATE_OF_PEER_REVIEW_CASE_PROP: date(2020, 1, 1)
-            },
-            {
-                MEAN_GENERAL_SKILLS_SCORE_CASE_PROP: 2.1,
-                MEAN_TREATMENT_SPECIFIC_SCORE_CASE_PROP: 4,
-                SESSION_RATING_CASE_PROP: 6.1,
-                DATE_OF_PEER_REVIEW_CASE_PROP: date(2020, 8, 10)
-            },
-        ])
-
-        result = sanitize_session_peer_rating(self.session_case, rule)
-
-        self.assertEqual(result.num_updates, 1)
-        session_case = CommCareCase.objects.get_case(self.session_case.case_id, self.session_case.domain)
-        self.assertDictEqual(
-            session_case.case_json,
-            {
-                'agg_mean_general_skills_score': '2.1',
-                'agg_mean_treatment_specific_score': '3.0',
-                'agg_rating': '5.2',
-                'date_of_peer_review': '2020-08-10',
-                'feedback_num': '2',
-                'share_score_check': 'yes',
-                'total_session_rating': '10.4',
+                'total_session_rating': '16.9',
                 NEEDS_AGGREGATION_CASE_PROP: NEEDS_AGGREGATION_NO_VALUE,
             }
         )

--- a/custom/gcc_sangath/tests/test_custom_actions.py
+++ b/custom/gcc_sangath/tests/test_custom_actions.py
@@ -114,7 +114,7 @@ class SanitizeSessionPeerRatingTest(BaseCaseRuleTest):
             }
         )
 
-    def test_with_peer_rating_cases_2(self):
+    def test_with_peer_rating_cases_when_values_truncated(self):
         rule = create_empty_rule(
             self.domain, AutomaticUpdateRule.WORKFLOW_CASE_UPDATE, case_type=SESSION_CASE_TYPE,
         )


### PR DESCRIPTION
## Product Description
As part of https://github.com/dimagi/commcare-hq/pull/30921, changes were merged for custom action case update. Requirement came to provide float values up to 1 decimal place by truncating, which currently was done by rounding.

## Technical Summary
Ref. https://dimagi-dev.atlassian.net/browse/INDIV-34?focusedCommentId=193671
Replaced float calculation rounding with truncation.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Added test for the usecase.

### Automated test coverage
Added test for the usecase.

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
