### PR TITLE
Allow oauth decorator to handle custom scopes and add reports:view oa…

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -207,11 +207,11 @@ def api_key():
     return real_decorator
 
 
-def _oauth2_check():
+def _oauth2_check(scopes):
     def auth_check(request):
         oauthlib_core = get_oauthlib_core()
         # as of now, this is only used in our APIs, so explictly check that particular scope
-        valid, r = oauthlib_core.verify_request(request, scopes=['access_apis'])
+        valid, r = oauthlib_core.verify_request(request, scopes=scopes)
         if valid:
             request.user = r.user
             return True
@@ -341,9 +341,9 @@ def login_or_api_key_ex(allow_cc_users=False, allow_sessions=True, require_domai
     )
 
 
-def login_or_oauth2_ex(allow_cc_users=False, allow_sessions=True, require_domain=True):
+def login_or_oauth2_ex(allow_cc_users=False, allow_sessions=True, require_domain=True, oauth_scopes=['access_apis']):
     return _login_or_challenge(
-        _oauth2_check(),
+        _oauth2_check(oauth_scopes),
         allow_cc_users=allow_cc_users,
         api_key=True,
         allow_sessions=allow_sessions,
@@ -351,7 +351,7 @@ def login_or_oauth2_ex(allow_cc_users=False, allow_sessions=True, require_domain
     )
 
 
-def get_multi_auth_decorator(default, allow_formplayer=False):
+def get_multi_auth_decorator(default, allow_formplayer=False, oauth_scopes=['access_apis']):
     """
     :param allow_formplayer: If True this will allow one additional auth mechanism which is used
          by Formplayer:
@@ -372,7 +372,7 @@ def get_multi_auth_decorator(default, allow_formplayer=False):
                 )
                 return HttpResponseForbidden()
             request.auth_type = authtype  # store auth type on request for access in views
-            function_wrapper = get_auth_decorator_map(allow_cc_users=True)[authtype]
+            function_wrapper = get_auth_decorator_map(allow_cc_users=True, oauth_scopes=oauth_scopes)[authtype]
             return function_wrapper(fn)(request, *args, **kwargs)
         return _inner
     return decorator
@@ -391,9 +391,14 @@ def two_factor_exempt(view_func):
     return wraps(view_func, assigned=available_attrs(view_func))(wrapped_view)
 
 
-# Use this decorator to allow any auth type -
-# basic, digest, session, or apikey
+# Use api_auth or api_auth_with_scope decorators to allow -
+# any auth type basic, digest, session, apikey, or oauth
 api_auth = get_multi_auth_decorator(default=DIGEST)
+
+
+def api_auth_with_scope(oauth_scopes):
+    return get_multi_auth_decorator(default=DIGEST, oauth_scopes=oauth_scopes)
+
 
 # Use these decorators on views to allow sesson-auth or an extra authorization method
 login_or_digest = login_or_digest_ex()
@@ -405,7 +410,7 @@ api_key_auth = login_or_api_key_ex(allow_sessions=False)
 basic_auth_or_try_api_key_auth = login_or_basic_or_api_key_ex(allow_sessions=False)
 
 
-def get_auth_decorator_map(allow_cc_users=False, require_domain=True, allow_sessions=True):
+def get_auth_decorator_map(allow_cc_users=False, require_domain=True, allow_sessions=True, oauth_scopes=['access_apis']):
     # get a mapped set of decorators for different auth types with the specified parameters
     decorator_function_kwargs = {
         'allow_cc_users': allow_cc_users,
@@ -416,7 +421,7 @@ def get_auth_decorator_map(allow_cc_users=False, require_domain=True, allow_sess
         DIGEST: login_or_digest_ex(**decorator_function_kwargs),
         BASIC: login_or_basic_ex(**decorator_function_kwargs),
         API_KEY: login_or_api_key_ex(**decorator_function_kwargs),
-        OAUTH2: login_or_oauth2_ex(**decorator_function_kwargs),
+        OAUTH2: login_or_oauth2_ex(oauth_scopes=oauth_scopes, **decorator_function_kwargs),
         FORMPLAYER: login_or_formplayer_ex(**decorator_function_kwargs),
     }
 

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -341,7 +341,8 @@ def login_or_api_key_ex(allow_cc_users=False, allow_sessions=True, require_domai
     )
 
 
-def login_or_oauth2_ex(allow_cc_users=False, allow_sessions=True, require_domain=True, oauth_scopes=['access_apis']):
+def login_or_oauth2_ex(allow_cc_users=False, allow_sessions=True, require_domain=True, oauth_scopes=None):
+    oauth_scopes = oauth_scopes or ['access_apis']
     return _login_or_challenge(
         _oauth2_check(oauth_scopes),
         allow_cc_users=allow_cc_users,
@@ -351,7 +352,7 @@ def login_or_oauth2_ex(allow_cc_users=False, allow_sessions=True, require_domain
     )
 
 
-def get_multi_auth_decorator(default, allow_formplayer=False, oauth_scopes=['access_apis']):
+def get_multi_auth_decorator(default, allow_formplayer=False, oauth_scopes=None):
     """
     :param allow_formplayer: If True this will allow one additional auth mechanism which is used
          by Formplayer:
@@ -361,6 +362,8 @@ def get_multi_auth_decorator(default, allow_formplayer=False, oauth_scopes=['acc
              endpoints we validate each formplayer request using a shared key. See the auth
              function for more details.
     """
+    oauth_scopes = oauth_scopes or ['access_apis']
+
     def decorator(fn):
         @wraps(fn)
         def _inner(request, *args, **kwargs):
@@ -410,8 +413,9 @@ api_key_auth = login_or_api_key_ex(allow_sessions=False)
 basic_auth_or_try_api_key_auth = login_or_basic_or_api_key_ex(allow_sessions=False)
 
 
-def get_auth_decorator_map(allow_cc_users=False, require_domain=True, allow_sessions=True, oauth_scopes=['access_apis']):
+def get_auth_decorator_map(allow_cc_users=False, require_domain=True, allow_sessions=True, oauth_scopes=None):
     # get a mapped set of decorators for different auth types with the specified parameters
+    oauth_scopes = oauth_scopes or ['access_apis']
     decorator_function_kwargs = {
         'allow_cc_users': allow_cc_users,
         'require_domain': require_domain,

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -53,7 +53,7 @@ from corehq.apps.app_manager.util import purge_report_from_mobile_ucr
 from corehq.apps.change_feed.data_sources import (
     get_document_store_for_doc_type,
 )
-from corehq.apps.domain.decorators import api_auth, login_and_domain_required, domain_admin_required
+from corehq.apps.domain.decorators import api_auth_with_scope, login_and_domain_required, domain_admin_required
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqwebapp.decorators import (
@@ -1397,7 +1397,7 @@ def process_url_params(params, columns):
     return ExportParameters(format_, keyword_filters, sql_filters)
 
 
-@api_auth
+@api_auth_with_scope(['reports:view'])
 @require_permission(Permissions.view_reports)
 @swallow_programming_errors
 def export_data_source(request, domain, config_id):

--- a/settings.py
+++ b/settings.py
@@ -872,6 +872,7 @@ OAUTH2_PROVIDER = {
     'PKCE_REQUIRED': _pkce_required,
     'SCOPES': {
         'access_apis': 'Access API data on all your CommCare projects',
+        'reports:view': 'Allow users to view and download all report data',
     },
     'REFRESH_TOKEN_EXPIRE_SECONDS': 60 * 60 * 24 * 15,  # 15 days
 }


### PR DESCRIPTION
Allow oauth decorator to handle custom scopes and add reports:view oauth scopes

https://dimagi-dev.atlassian.net/browse/SC-1995

The current default scope `access_apis` gives access to all API endpoints. Ideally, we should restrict each API with specific scopes such as `users`, `apps`, `reports` and `forms` etc ( and further `read`, `write` on each).

But that's beyond the scope of the current work, so I have simply created a new decorator that can handle a custom scope that we are planning to use on SolTech.

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

The current `api_auth` [decorator](https://github.com/dimagi/commcare-hq/pull/29367) is already rolled out without any issues. The new decorator is only used in one place and I have tested this locally using the API Explorer.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

@czue @proteusvacuum 