### PR TITLE
Remove acks_late from build_last_month_MALT

### DIFF
--- a/corehq/apps/data_analytics/tasks.py
+++ b/corehq/apps/data_analytics/tasks.py
@@ -26,7 +26,7 @@ def build_last_month_MALT():
     domains = Domain.get_all_names()
     task_results = []
     for chunk in chunked(domains, 1000):
-        task_results.append(update_current_MALT_for_domains.delay(last_month, chunk))
+        task_results.append(update_malt.delay(last_month, chunk))
 
     for result in task_results:
         result.get(disable_sync_subtasks=False)
@@ -41,7 +41,7 @@ def update_current_MALT():
     this_month_dict = {'month': today.month, 'year': today.year}
     domains = Domain.get_all_names()
     for chunk in chunked(domains, 1000):
-        update_current_MALT_for_domains.delay(this_month_dict, chunk)
+        update_malt.delay(this_month_dict, chunk)
 
 
 @periodic_task(queue=settings.CELERY_PERIODIC_QUEUE, run_every=crontab(hour=1, minute=0, day_of_month='3'),
@@ -69,7 +69,7 @@ def build_last_month_GIR():
 
 
 @task(queue='malt_generation_queue')
-def update_current_MALT_for_domains(month_dict, domains):
+def update_malt(month_dict, domains):
     month = DateSpan.from_month(month_dict['month'], month_dict['year'])
     generate_malt([month], domains=domains)
 

--- a/corehq/apps/data_analytics/tasks.py
+++ b/corehq/apps/data_analytics/tasks.py
@@ -20,7 +20,7 @@ logger = get_task_logger(__name__)
 
 
 @periodic_task(queue=settings.CELERY_PERIODIC_QUEUE, run_every=crontab(hour=1, minute=0, day_of_month='2'),
-               acks_late=True, ignore_result=True)
+               ignore_result=True)
 def build_last_month_MALT():
     last_month = last_month_dict()
     domains = Domain.get_all_names()


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
`acks_late=True` appears to have been initially added [here](https://github.com/dimagi/commcare-hq/commit/bb698451e48e038aa9b02c249fcdf3af903ca2fd) as a way of ensuring malt tasks would be retried if killed in the middle of processing. I imagine this was more of an issue when the malt tasks had much longer run times, but now that runtimes are manageable (as seen by `update_current_MALT`), we should be able to safely remove this. 

This behavior is made worse by the fact that the `build_last_month_MALT` is put on the periodic queue and blocks until all child tasks are finished, which appears to put us in a never ending cycle of child tasks being processed.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
