### PR TITLE
Fix linked_domain dbaccessor tests

### DIFF
--- a/corehq/apps/linked_domain/tests/test_dbaccessors.py
+++ b/corehq/apps/linked_domain/tests/test_dbaccessors.py
@@ -51,7 +51,7 @@ class TestGetAvailableUpstreamDomains(SimpleTestCase):
 
         upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
 
-        self.assertEqual(upstream_domains, ['account-domain'] + ['user-domain'])
+        self.assertSetEqual(set(upstream_domains), {'account-domain', 'user-domain'})
 
     def test_does_not_return_duplicate_domains_if_enterprise_and_release_management_privilege(self, mock_user):
         self.mock_is_enterprise.return_value = True
@@ -61,7 +61,7 @@ class TestGetAvailableUpstreamDomains(SimpleTestCase):
 
         upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
 
-        self.assertEqual(upstream_domains, ['domain'])
+        self.assertSetEqual(set(upstream_domains), {'domain'})
 
     def test_returns_domains_for_user_if_not_enterprise_and_release_management_privilege(self, mock_user):
         self.mock_is_enterprise.return_value = False
@@ -70,7 +70,7 @@ class TestGetAvailableUpstreamDomains(SimpleTestCase):
 
         upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
 
-        self.assertEqual(upstream_domains, self.expected_domains)
+        self.assertSetEqual(set(upstream_domains), set(self.expected_domains))
 
     def test_returns_admin_domains_for_user_if_lite_release_management_privilege(self, mock_user):
         self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == LITE_RELEASE_MANAGEMENT
@@ -79,7 +79,7 @@ class TestGetAvailableUpstreamDomains(SimpleTestCase):
         upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
 
         self.mock_available_user_domains.assert_called_with('downstream-1', mock_user, should_enforce_admin=True)
-        self.assertEqual(upstream_domains, self.expected_domains)
+        self.assertSetEqual(set(upstream_domains), set(self.expected_domains))
 
     @flag_enabled("LINKED_DOMAINS")
     def test_returns_domains_for_user_if_linked_domains_flag(self, mock_user):
@@ -89,7 +89,7 @@ class TestGetAvailableUpstreamDomains(SimpleTestCase):
         upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
 
         self.mock_available_user_domains.assert_called_with('downstream-1', mock_user, should_enforce_admin=False)
-        self.assertEqual(upstream_domains, self.expected_domains)
+        self.assertSetEqual(set(upstream_domains), set(self.expected_domains))
 
 
 @patch('corehq.apps.users.models.CouchUser')
@@ -133,7 +133,7 @@ class TestGetAvailableDomainsToLink(SimpleTestCase):
 
         domains = get_available_domains_to_link('upstream', mock_user)
 
-        self.assertEqual(domains, ['account-domain'] + ['user-domain'])
+        self.assertSetEqual(set(domains), {'account-domain', 'user-domain'})
 
     def test_does_not_return_duplicate_domains_if_enterprise_and_release_management_privilege(self, mock_user):
         self.mock_is_enterprise.return_value = True
@@ -143,7 +143,7 @@ class TestGetAvailableDomainsToLink(SimpleTestCase):
 
         domains = get_available_domains_to_link('upstream', mock_user)
 
-        self.assertEqual(domains, ['domain'])
+        self.assertSetEqual(set(domains), {'domain'})
 
     def test_returns_domains_for_user_if_not_enterprise_and_release_management_privilege(self, mock_user):
         self.mock_is_enterprise.return_value = False
@@ -153,7 +153,7 @@ class TestGetAvailableDomainsToLink(SimpleTestCase):
 
         domains = get_available_domains_to_link('upstream', mock_user)
 
-        self.assertEqual(domains, self.expected_domains)
+        self.assertSetEqual(set(domains), set(self.expected_domains))
 
     def test_returns_admin_domains_for_users_if_lite_release_management_privilege(self, mock_user):
         self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == LITE_RELEASE_MANAGEMENT
@@ -163,7 +163,7 @@ class TestGetAvailableDomainsToLink(SimpleTestCase):
         domains = get_available_domains_to_link('upstream', mock_user)
 
         self.mock_available_user_domains.assert_called_with('upstream', mock_user, should_enforce_admin=True)
-        self.assertEqual(domains, self.expected_domains)
+        self.assertSetEqual(set(domains), set(self.expected_domains))
 
     @flag_enabled("LINKED_DOMAINS")
     def test_returns_domains_for_user_for_linked_domains_flag(self, mock_user):
@@ -174,4 +174,4 @@ class TestGetAvailableDomainsToLink(SimpleTestCase):
         domains = get_available_domains_to_link('upstream', mock_user)
 
         self.mock_available_user_domains.assert_called_with('upstream', mock_user, should_enforce_admin=False)
-        self.assertEqual(domains, self.expected_domains)
+        self.assertSetEqual(set(domains), set(self.expected_domains))

--- a/corehq/apps/linked_domain/tests/test_dbaccessors.py
+++ b/corehq/apps/linked_domain/tests/test_dbaccessors.py
@@ -61,7 +61,8 @@ class TestGetAvailableUpstreamDomains(SimpleTestCase):
 
         upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
 
-        self.assertSetEqual(set(upstream_domains), {'domain'})
+        self.assertEqual(len(upstream_domains), 1)
+        self.assertEqual(upstream_domains[0], 'domain')
 
     def test_returns_domains_for_user_if_not_enterprise_and_release_management_privilege(self, mock_user):
         self.mock_is_enterprise.return_value = False
@@ -143,7 +144,8 @@ class TestGetAvailableDomainsToLink(SimpleTestCase):
 
         domains = get_available_domains_to_link('upstream', mock_user)
 
-        self.assertSetEqual(set(domains), {'domain'})
+        self.assertEqual(len(domains), 1)
+        self.assertEqual(domains[0], 'domain')
 
     def test_returns_domains_for_user_if_not_enterprise_and_release_management_privilege(self, mock_user):
         self.mock_is_enterprise.return_value = False


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Parent PR: https://github.com/dimagi/commcare-hq/pull/31047

Tests implicitly tested order of elements in a list which is not relevant (order does not matter). Changed to convert to sets and assert sets are equal (duplicates are also not expected and tests explicitly ensure this is the case). 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
