### PR TITLE
Add acks_late back to build_last_month_MALT

### DIFF
--- a/corehq/apps/data_analytics/tasks.py
+++ b/corehq/apps/data_analytics/tasks.py
@@ -20,7 +20,7 @@ logger = get_task_logger(__name__)
 
 
 @periodic_task(queue=settings.CELERY_PERIODIC_QUEUE, run_every=crontab(hour=1, minute=0, day_of_month='2'),
-               ignore_result=True)
+               acks_late=True, ignore_result=True)
 def build_last_month_MALT():
     last_month = last_month_dict()
     domains = Domain.get_all_names()


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Reverts https://github.com/dimagi/commcare-hq/pull/31186 (mostly)

After talking it over with Danny, it seems like this should not have had an impact on the strange behavior observed by build_last_month_MALT today.

The current understanding is:
While `acks_late` does determine when a task is acknowledged (before or after execution), in the context AMQP transactions, `acks_late` acts as a method to retry a task if the worker becomes unreachable mid-execution. So while setting `acks_late` to False might prevent the behavior observed today since the task would not be placed back in the queue/retried, it isn't a long term solution since the root of the issue is why the worker became unreachable in the first place.

Sidenote: didn't do an actual revert of the previous PR because I also changed the task name and wanted to keep that change.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
