### PR TITLE
Removed some deprecated_init

### DIFF
--- a/corehq/apps/commtrack/helpers.py
+++ b/corehq/apps/commtrack/helpers.py
@@ -29,7 +29,7 @@ def make_supply_point(domain, location):
     user_id = const.get_commtrack_user_id(domain)
     owner_id = location.location_id
     kwargs = {'external_id': location.external_id} if location.external_id else {}
-    caseblock = CaseBlock.deprecated_init(
+    caseblock = CaseBlock(
         case_id=case_id,
         create=True,
         case_name=location.name,
@@ -57,7 +57,7 @@ def update_supply_point_from_location(supply_point, location):
 
     if are_different:
         kwargs = {'external_id': location.external_id} if location.external_id else {}
-        caseblock = CaseBlock.deprecated_init(
+        caseblock = CaseBlock(
             case_id=supply_point.case_id,
             create=False,
             case_name=location.name,

--- a/corehq/apps/commtrack/management/commands/update_supply_point_locations.py
+++ b/corehq/apps/commtrack/management/commands/update_supply_point_locations.py
@@ -16,7 +16,7 @@ def needs_update(case):
 
 
 def case_block(case):
-    return ElementTree.tostring(CaseBlock.deprecated_init(
+    return ElementTree.tostring(CaseBlock(
         create=False,
         case_id=case['_id'],
         owner_id=case['location_id'],

--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -532,7 +532,7 @@ class BugSubmissionsTest(CommTrackSubmissionTest):
     def test_xform_id_added_to_case_xform_list_only_once(self):
         initial_amounts = [(p._id, float(100)) for p in self.products]
         submissions = [balance_submission([amount]) for amount in initial_amounts]
-        case_block = CaseBlock.deprecated_init(
+        case_block = CaseBlock(
             create=False,
             case_id=self.sp.case_id,
             user_id='jack',
@@ -575,7 +575,7 @@ class CommTrackSyncTest(CommTrackSubmissionTest):
         self.group.save()
 
         self.restore_user = self.user.to_ota_restore_user()
-        self.sp_block = CaseBlock.deprecated_init(
+        self.sp_block = CaseBlock(
             case_id=self.sp.case_id,
         ).as_xml()
 


### PR DESCRIPTION
## Technical Summary
Experimenting with killing `deprecated_init`, as per [this comment](https://github.com/dimagi/commcare-hq/blob/c949580553f740afaba7e4578d768ce4d7cfbe5a/corehq/ex-submodules/casexml/apps/case/mock/case_block.py#L61-L69).

If tests pass I'll merge this, otherwise I'll either fix them or close it.

## Safety Assurance

### Safety story
Should be fine so long as tests pass.

### Automated test coverage

In PR.

### QA Plan

Not requesting QA.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
