### PR TITLE
[SAMVEG] Adds ability to skip call validator

### DIFF
--- a/custom/samveg/case_importer/exceptions.py
+++ b/custom/samveg/case_importer/exceptions.py
@@ -33,3 +33,7 @@ class CallNotInLastMonthError(CaseRowError):
 
 class UploadLimitReachedError(CaseRowError):
     title = ugettext_noop('Upload limit reached for owner and call type')
+
+
+class UnexpectedSkipCallValidatorValueError(CaseRowError):
+    title = ugettext_noop('Unexpected value for skipping call validator column')

--- a/custom/samveg/case_importer/validators.py
+++ b/custom/samveg/case_importer/validators.py
@@ -14,6 +14,7 @@ from custom.samveg.case_importer.exceptions import (
     OwnerNameMissingError,
     RequiredValueMissingError,
     UnexpectedFileError,
+    UnexpectedSkipCallValidatorValueError,
     UploadLimitReachedError,
 )
 from custom.samveg.case_importer.operations import BaseRowOperation
@@ -24,6 +25,8 @@ from custom.samveg.const import (
     RCH_REQUIRED_COLUMNS,
     REQUIRED_COLUMNS,
     ROW_LIMIT_PER_OWNER_PER_CALL_TYPE,
+    SKIP_CALL_VALIDATOR,
+    SKIP_CALL_VALIDATOR_YES,
     SNCU_BENEFICIARY_IDENTIFIER,
     SNCU_REQUIRED_COLUMNS,
 )
@@ -124,6 +127,15 @@ class CallValidator(BaseRowOperation):
     @classmethod
     def run(cls, row_num, raw_row, fields_to_update, import_context):
         error_messages = []
+        if raw_row.get(SKIP_CALL_VALIDATOR):
+            # skip the row
+            # add error message if the value isn't the only expected value
+            if raw_row.get(SKIP_CALL_VALIDATOR) != SKIP_CALL_VALIDATOR_YES:
+                error_messages.append(
+                    UnexpectedSkipCallValidatorValueError()
+                )
+            return fields_to_update, error_messages
+
         call_date = None
         call_value, call_number = _get_latest_call_value_and_number(fields_to_update)
         if not call_value:

--- a/custom/samveg/const.py
+++ b/custom/samveg/const.py
@@ -6,6 +6,8 @@ SNCU_BENEFICIARY_IDENTIFIER = 'admission_id'
 NEWBORN_WEIGHT_COLUMN = 'newborn_weight'
 OWNER_NAME = 'owner_name'
 MOBILE_NUMBER = 'MobileNo'
+SKIP_CALL_VALIDATOR = 'skip_last_month_call_check'
+SKIP_CALL_VALIDATOR_YES = 'yes'
 
 REQUIRED_COLUMNS = [
     'name',

--- a/custom/samveg/tests/case_importer/validators.py
+++ b/custom/samveg/tests/case_importer/validators.py
@@ -23,6 +23,8 @@ from custom.samveg.const import (
     RCH_BENEFICIARY_IDENTIFIER,
     REQUIRED_COLUMNS,
     ROW_LIMIT_PER_OWNER_PER_CALL_TYPE,
+    SKIP_CALL_VALIDATOR,
+    SKIP_CALL_VALIDATOR_YES,
     SNCU_BENEFICIARY_IDENTIFIER,
 )
 
@@ -149,6 +151,32 @@ class TestCallValidator(SimpleTestCase):
         self.assertListEqual(
             [error.title for error in errors],
             ['Latest call not in last month']
+        )
+
+    def test_skipping_call_validator(self):
+        raw_row = _sample_valid_rch_upload()
+        raw_row[SKIP_CALL_VALIDATOR] = SKIP_CALL_VALIDATOR_YES
+        fields_to_update = raw_row.copy()
+        fields_to_update['external_id'] = fields_to_update.pop(RCH_BENEFICIARY_IDENTIFIER)
+        row_num = 1
+
+        fields_to_update, errors = CallValidator.run(row_num, raw_row, fields_to_update, {})
+        self.assertListEqual(
+            [error.title for error in errors],
+            []
+        )
+
+    def test_skipping_call_validator_unexpected_value(self):
+        raw_row = _sample_valid_rch_upload()
+        raw_row[SKIP_CALL_VALIDATOR] = 'yup'
+        fields_to_update = raw_row.copy()
+        fields_to_update['external_id'] = fields_to_update.pop(RCH_BENEFICIARY_IDENTIFIER)
+        row_num = 1
+
+        fields_to_update, errors = CallValidator.run(row_num, raw_row, fields_to_update, {})
+        self.assertListEqual(
+            [error.title for error in errors],
+            ['Unexpected value for skipping call validator column']
         )
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A slight modification to custom case uploads originally added in https://github.com/dimagi/commcare-hq/pull/30921 for SAMVEG project space. 
This change allows the project to do off cycle case uploads that need to skip [call validator](https://docs.google.com/document/d/1OYrKoJbuEdUrt4M46k3LMiUz6rjnevLx6BsLJ3eCmzs/edit#heading=h.xt3and1gtjfb) which validates that the latest "Call" for the case was in last month.
So now, if the upload is done with a column called `skip_last_month_call_check` and set to `yes`, for that case the call validation is skipped. 
The column would need to be removed in the case import on step 2 so it does not get stored as a case property on the case. Even if it is missed, it would have no side effect.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I went ahead with the approach the have this flexibility in the excel itself
1. to avoid making changes to UI, like giving a checkbox because that would need changes in the core HQ implementation.
2. the upload is done by internal team only, so it would not get misused.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Added tests and changes are only applicable to samveg domains through extensions

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
