### PR TITLE
moves auth decorators first

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1904,9 +1904,9 @@ class FormDataView(BaseProjectReportSectionView):
         return page_context
 
 
+@login_and_domain_required
 @require_form_view_permission
 @location_safe
-@login_and_domain_required
 def view_form_attachment(request, domain, instance_id, attachment_id):
     # Open form attachment in browser
     return get_form_attachment_response(request, domain, instance_id, attachment_id)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Redo of the changes in https://github.com/dimagi/commcare-hq/pull/31062/commits/be334d32dc60a6d4c33d7519a9ec5b745f5582bc#diff-3ee284c76d901bb74bc51d844c455d014f9a2675460fa35fb4fde2febe057942 which got removed, possibly during some code conflict resolution https://github.com/dimagi/commcare-hq/pull/31078/files#r808155440

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
No new changes. Just flipped decorator order to auth first.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
