### PR TITLE
[fix] add missing URL for system info page JS

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/system_info.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/system_info.html
@@ -10,6 +10,7 @@
   {% initial_page_data "couch_update" couch_update %}
   {% initial_page_data "is_bigcouch" is_bigcouch %}
   {% registerurl "pillow_operation_api" %}
+  {% registerurl "system_ajax" %}
   <div class="row" style="margin-top: 15px;">
     <div class="col-sm-12">
       {% with deploy_history|first as last_deploy %}


### PR DESCRIPTION
## Technical Summary
Add back a URL into the page template for the System Info page. This URL get's used by JavaScript functions on the page.

This was removed (accidentally) here: https://github.com/dimagi/commcare-hq/commit/80606354b1dbdd962c538447c21b704b08a7a192#diff-cacbdfbb052f35ba714c2d59ab95d8b1e26c949d250e4d1c0604f2f5381cf7c1L13

## Safety Assurance

### Safety story
Template only change to admin only page.

### Automated test coverage
NA

### QA Plan
NA


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
