### PR TITLE
Removed request-level 'Search Again' flag

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -124,7 +124,6 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
                     "offset": params.page * casesPerPage,
                     "search_text": params.search,
                     "menu_session_id": params.sessionId,
-                    "force_manual_action": params.forceManualAction,
                     "query_data": params.queryData,
                     "cases_per_page": casesPerPage,
                     "oneQuestionPerScreen": displayOptions.oneQuestionPerScreen,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -146,10 +146,8 @@ hqDefine("cloudcare/js/formplayer/router", function () {
         var urlObject = Util.currentUrlToObject();
         if (index === undefined) {
             urlObject.setQueryData({}, false, true);
-            urlObject.setForceManualAction(true);
         } else {
             urlObject.addSelection(index);
-            urlObject.setForceManualAction(false);
         }
         Util.setUrlToObject(urlObject);
         API.listMenus();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -169,7 +169,6 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
         this.singleApp = options.singleApp;
         this.sortIndex = options.sortIndex;
         this.forceLoginAs = options.forceLoginAs;
-        this.forceManualAction = options.forceManualAction;
 
         this.setSelections = function (selections) {
             this.selections = selections;
@@ -221,10 +220,6 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             this.search = null;
         };
 
-        this.setForceManualAction = function (force) {
-            this.forceManualAction = force;
-        };
-
         this.replaceEndpoint = function (selections) {
             delete this.endpointId;
             delete this.endpointArgs;
@@ -238,7 +233,6 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             this.sortIndex = null;
             this.search = null;
             this.queryData = null;
-            this.forceManualAction = null;
         };
 
         this.onSubmit = function () {
@@ -246,7 +240,6 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             this.sortIndex = null;
             this.search = null;
             this.queryData = null;
-            this.forceManualAction = null;
         };
 
         this.spliceSelections = function (index) {
@@ -268,7 +261,6 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             this.search = null;
             this.sortIndex = null;
             this.queryData = null;
-            this.forceManualAction = null;
         };
     };
 
@@ -287,7 +279,6 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             singleApp: self.singleApp,
             sortIndex: self.sortIndex,
             forceLoginAs: self.forceLoginAs,
-            forceManualAction: self.forceManualAction,
         };
         return JSON.stringify(dict);
     };
@@ -307,7 +298,6 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             'singleApp': data.singleApp,
             'sortIndex': data.sortIndex,
             'forceLoginAs': data.forceLoginAs,
-            'forceManualAction': data.forceManualAction,
         };
         return new Util.CloudcareUrl(options);
     };


### PR DESCRIPTION
Reverts dimagi/commcare-hq#31201

Releases https://github.com/dimagi/commcare-hq/pull/31157 which was merged in haste (the necessary [HQ PR](https://github.com/dimagi/commcare-hq/pull/31152) had been deployed, but the necessary [formplayer PR](https://github.com/dimagi/formplayer/pull/1097) had not been).