### PR TITLE
Add XPath curly bracket interpolation syntax in Default Search Filters

### DIFF
--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -731,3 +731,35 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         </partial>
         """
         self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
+
+    def test_convert_curly_braces_to_concat(self, *args):
+        inputted_query_1 = "name = '{$name}' and owner_id = '{instance('commcaresession')/user/data/user_id}'"
+        expected_output_1 = """
+        concat("name = '", $name, "' and owner_id = '", instance('commcaresession')/user/data/user_id, "'")
+        """.strip()
+        self.assertEqual(
+            RemoteRequestFactory._convert_curly_braces_to_concat(inputted_query_1),
+            expected_output_1
+        )
+
+        inputted_query_2 = """
+        "name = 'john' and owner_id = '12345'"
+        """.strip()
+        expected_output_2 = """
+        "name = 'john' and owner_id = '12345'"
+        """.strip()
+        self.assertEqual(
+            expected_output_2,
+            RemoteRequestFactory._convert_curly_braces_to_concat(inputted_query_2)
+        )
+
+        inputted_query_3 = """
+        name = 'john' and owner_id = '{instance('commcaresession')/user/data/user_id}'"
+        """.strip()
+        expected_output_3 = """
+        concat("name = 'john' and owner_id = '", instance('commcaresession')/user/data/user_id, "'")
+        """.strip()
+        self.assertEqual(
+            expected_output_3,
+            RemoteRequestFactory._convert_curly_braces_to_concat(inputted_query_3)
+        )


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Currently, app builders rely upon `concat` functions when using XPath functions in Default Search Filters. This allows them to run part of the query in HQ where the filtering happens, and part of the query in formplayer where useful variables and functions can be inserted. See [Search Properties in Confluence](https://confluence.dimagi.com/display/saas/Search+Properties) -> Filtering using an XPath Query.

This PR will allow app builders to use a curly bracket syntax instead of concat. For an example, see this [short spec doc](https://docs.google.com/document/d/1fSzwth-OPcLshpqTEitk1Is2f1DTr73YH24ouh_HO94/edit?usp=sharing). 

Here is [the related Jira ticket](https://dimagi-dev.atlassian.net/browse/USH-1740?atlOrigin=eyJpIjoiNjI0NzI2OTk2M2JhNGFkMTkzZDg3MWFlNWVkNjNlNjkiLCJwIjoiaiJ9).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

I decided to keep it simple and just create a new function in the same class where the function is called. If in the future someone wants to expand this method to add new syntax conversions then they can change the method name/location at that time.

You'll notice I added string _normalization_, but no real _validation_. Validation requires error handling either on web UI side when adding the property/saving the case list or on the formplayer side. I made some progress with validation on the former and if we want to add it I am certainly open to it, but submitted the PR without it because I was worried that is out of scope. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

All the case search flags. See [Case Search and Claim](https://confluence.dimagi.com/display/saas/Search+Properties).

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested on local and staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Simple tests added.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
