### PR TITLE
Upgrade to Django 3.2

### DIFF
--- a/migrations.lock
+++ b/migrations.lock
@@ -143,6 +143,7 @@ auth
  0009_alter_user_last_name_max_length
  0010_alter_group_name_max_length
  0011_update_proxy_permissions
+ 0012_alter_user_first_name_max_length
 blobs
  0001_squashed_0009_domains
  0002_blobmeta

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -37,7 +37,7 @@ django-transfer
 django-two-factor-auth
 django-user-agents
 django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websocket-redis/0.6.0.1/releases/django_websocket_redis-0.6.0.1-py3-none-any.whl
-django>=2.2.27,<3.0  # we are not ready to move to django 3.0
+django>=2.2.27,<4.0  # we are not ready to move to django 3.0
 djangorestframework
 dnspython
 dropbox

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -61,7 +61,7 @@ Jinja2
 json-delta
 jsonfield
 jsonobject-couchdbkit
-jsonobject
+jsonobject>=2.0.0
 # jsonpath-ng with support for "wherenot" operator, and building documents
 # Upgrade when changes merged upstream
 jsonpath-ng @ https://github.com/kaapstorm/python-jsonpath-rw/raw/wherenot+find_or_create/wheel/jsonpath_ng-1.5.2.2-py3-none-any.whl

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -12,6 +12,8 @@ amqp==2.6.1
     # via kombu
 architect==0.6.0
     # via -r base-requirements.in
+asgiref==3.5.0
+    # via django
 asttokens==2.0.5
     # via stack-data
 attrs==18.2.0
@@ -95,7 +97,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==2.2.27
+django==3.2.12
     # via
     #   -r base-requirements.in
     #   django-appconf

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -294,7 +294,7 @@ jsonfield==2.1.1
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==0.9.10
+jsonobject==2.0.0
     # via
     #   -r base-requirements.in
     #   git-build-branch

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -246,7 +246,7 @@ jsonfield==2.1.1
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==0.9.10
+jsonobject==2.0.0
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -12,6 +12,8 @@ amqp==2.6.1
     # via kombu
 architect==0.6.0
     # via -r base-requirements.in
+asgiref==3.5.0
+    # via django
 attrs==21.2.0
     # via
     #   -r base-requirements.in
@@ -72,7 +74,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==2.2.27
+django==3.2.12
     # via
     #   -r base-requirements.in
     #   django-appconf

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -10,6 +10,8 @@ amqp==2.6.1
     # via kombu
 architect==0.6.0
     # via -r base-requirements.in
+asgiref==3.5.0
+    # via django
 asttokens==2.0.5
     # via stack-data
 attrs==18.2.0
@@ -83,7 +85,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==2.2.27
+django==3.2.12
     # via
     #   -r base-requirements.in
     #   django-appconf

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -254,7 +254,7 @@ jsonfield==2.1.1
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==0.9.10
+jsonobject==2.0.0
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,6 +10,8 @@ amqp==2.6.1
     # via kombu
 architect==0.6.0
     # via -r base-requirements.in
+asgiref==3.5.0
+    # via django
 attrs==18.2.0
     # via
     #   -r base-requirements.in
@@ -69,7 +71,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==2.2.27
+django==3.2.12
     # via
     #   -r base-requirements.in
     #   django-appconf

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -231,7 +231,7 @@ jsonfield==2.1.1
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==0.9.10
+jsonobject==2.0.0
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -249,7 +249,7 @@ jsonfield==2.1.1
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==0.9.10
+jsonobject==2.0.0
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -10,6 +10,8 @@ amqp==2.6.1
     # via kombu
 architect==0.6.0
     # via -r base-requirements.in
+asgiref==3.5.0
+    # via django
 attrs==18.2.0
     # via
     #   -r base-requirements.in
@@ -77,7 +79,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==2.2.27
+django==3.2.12
     # via
     #   -r base-requirements.in
     #   django-appconf


### PR DESCRIPTION
## Safety Assurance

### Safety story

Many backward-compatible PRs have been submitted (and merged) in preparation for this upgrade. Django 3.2 has been on staging for a while now, and a full QA review has been completed.

### Automated test coverage

Automated tests have uncovered many issues related to the upgrade. A few new tests have been added in some of the PRs mentioned above.

### QA Plan

[QA pass](https://dimagi-dev.atlassian.net/browse/QA-4017).

### Migrations

- [x] The migrations in this code can be safely applied first independently of the code

The migration included in the Django 3.2 upgrade increases the max length of the `first_name` field from 30 to 150 characters.

### Rollback instructions

~This PR can be reverted after deploy with no further considerations~

Rolling back will put us on a version of Django that is past EOL. It would be best to fix the issue another way.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
