### PR TITLE
Drop Django 1.1 workaround

### DIFF
--- a/corehq/form_processor/models/attachment.py
+++ b/corehq/form_processor/models/attachment.py
@@ -104,17 +104,7 @@ class Attachment(IsImageMixin):
         """
         if isinstance(self.raw_content, (bytes, str)):
             return BytesIO(self.content)
-        fileobj = self.raw_content.open()
-
-        # TODO remove when Django 1 is no longer supported
-        if fileobj is None:
-            assert not isinstance(self.raw_content, BlobMeta), repr(self)
-            # work around Django 1.11 bug, fixed in 2.0
-            # https://github.com/django/django/blob/1.11.15/django/core/files/base.py#L131-L137
-            # https://github.com/django/django/blob/2.0/django/core/files/base.py#L128
-            return self.raw_content
-
-        return fileobj
+        return self.raw_content.open()
 
     @memoized
     def content_md5(self):


### PR DESCRIPTION
## Safety Assurance

### Safety story
Removing workaround that has been obsolete since we upgraded beyond Django 2.0.

### Automated test coverage

None added. I think this is tested since a test helper was modified in d5e3eb21831da08f69cbaaf579321cd63659f54f.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
