### PR TITLE
Hard-delete forms and cases with domain

### DIFF
--- a/corehq/apps/domain/management/commands/delete_domain.py
+++ b/corehq/apps/domain/management/commands/delete_domain.py
@@ -79,7 +79,7 @@ def iter_ids(model_class, field, domain, chunk_size=1000):
         model_class,
         where,
         values=[field],
-        load_source='couch_to_sql_migration',
+        load_source='delete_domain',
         query_size=chunk_size,
     )
     yield from with_progress_bar(

--- a/corehq/apps/domain/management/commands/delete_domain.py
+++ b/corehq/apps/domain/management/commands/delete_domain.py
@@ -1,7 +1,18 @@
+import textwrap
+
 from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from dimagi.utils.chunked import chunked
 
 from corehq.apps.domain.dbaccessors import iter_all_domains_and_deleted_domains_with_name
-from corehq.apps.domain.models import Domain
+from corehq.apps.domain.utils import silence_during_tests
+from corehq.form_processor.models import CommCareCase, XFormInstance
+from corehq.sql_db.util import (
+    estimate_partitioned_row_count,
+    paginate_query_across_partitioned_databases,
+)
+from corehq.util.log import with_progress_bar
 
 
 class Command(BaseCommand):
@@ -28,22 +39,53 @@ class Command(BaseCommand):
             print("FYI: There are multiple domain objects for this domain"
                   "and they will all be soft-deleted.")
         if not options['noinput']:
-            confirm = input(
-                """
-                Are you sure you want to delete the domain "{}" and all of it's data?
+            confirm = input(textwrap.dedent(
+                f"""
+                Are you sure you want to delete the domain "{domain_name}" and all of it's data?
                 This operation is not reversible and all forms and cases will be PERMANENTLY deleted.
 
                 Type the domain's name again to continue, or anything else to cancel:
-                """.format(domain_name)
-            )
+                """
+            ))
             if confirm != domain_name:
                 print("\n\t\tDomain deletion cancelled.")
                 return
-        print("Soft-Deleting domain {} "
+        self.hard_delete_cases(domain_name)
+        self.hard_delete_forms(domain_name)
+        print(f"Soft-Deleting domain {domain_name} "
               "(i.e. switching its type to Domain-Deleted, "
-              "which will prevent anyone from reusing that domain)"
-              .format(domain_name))
+              "which will prevent anyone from reusing that domain)")
         for domain_obj in domain_objs:
             assert domain_obj.name == domain_name  # Just to be really sure!
             domain_obj.delete(leave_tombstone=True)
         print("Operation completed")
+
+    def hard_delete_cases(self, domain_name):
+        print("Hard-deleting cases...")
+        case_ids = iter_ids(CommCareCase, 'case_id', domain_name)
+        for chunk in chunked(case_ids, 1000, list):
+            CommCareCase.objects.hard_delete_cases(domain_name, chunk)
+
+    def hard_delete_forms(self, domain_name):
+        print("Hard-deleting forms...")
+        form_ids = iter_ids(XFormInstance, 'form_id', domain_name)
+        for chunk in chunked(form_ids, 1000, list):
+            XFormInstance.objects.hard_delete_forms(domain_name, chunk)
+
+
+def iter_ids(model_class, field, domain, chunk_size=1000):
+    where = Q(domain=domain)
+    rows = paginate_query_across_partitioned_databases(
+        model_class,
+        where,
+        values=[field],
+        load_source='couch_to_sql_migration',
+        query_size=chunk_size,
+    )
+    yield from with_progress_bar(
+        (r[0] for r in rows),
+        estimate_partitioned_row_count(model_class, where),
+        prefix="",
+        oneline="concise",
+        stream=silence_during_tests(),
+    )


### PR DESCRIPTION
The message printed by this command claims that "all forms and cases will be PERMANENTLY deleted," but that was not true. That was probably from the days when forms and cases were in Couch.

It was inconvenient and introduced more room for errors to have to run two separate management commands to fully delete a domain, and that workflow resulted in a lot of unnecessary db writes because all forms and cases were first soft-deleted before they were hard-deleted.

## Safety Assurance

### Safety story
Modifies management command only.

### Automated test coverage

No tests.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
