### PR TITLE
Removed some more deprecated_init

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2213,7 +2213,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                 index.update(self.supply_point_index_mapping(sp))
 
         from corehq.apps.commtrack.util import location_map_case_id
-        caseblock = CaseBlock.deprecated_init(
+        caseblock = CaseBlock(
             create=True,
             case_type=USER_LOCATION_OWNER_MAP_TYPE,
             case_id=location_map_case_id(self),

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -190,7 +190,7 @@ def remove_indices_from_deleted_cases(domain, case_ids):
     indexes_referencing_deleted_cases = \
         CommCareCaseIndex.objects.get_all_reverse_indices_info(domain, list(case_ids))
     case_updates = [
-        CaseBlock.deprecated_init(
+        CaseBlock(
             case_id=index_info.case_id,
             index={
                 index_info.identifier: (index_info.referenced_type, '')  # blank string = delete index

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -86,7 +86,7 @@ class RetireUserTestCase(TestCase):
         for i, case_id in enumerate(case_ids):
             owner_id = self.commcare_user._id
 
-            caseblocks.append(CaseBlock.deprecated_init(
+            caseblocks.append(CaseBlock(
                 create=True,
                 case_id=case_id,
                 owner_id=owner_id,
@@ -134,7 +134,7 @@ class RetireUserTestCase(TestCase):
         for case_id in case_ids:
             owner_id = self.commcare_user._id
 
-            caseblocks.append(CaseBlock.deprecated_init(
+            caseblocks.append(CaseBlock(
                 create=True,
                 case_id=case_id,
                 owner_id=owner_id,
@@ -144,7 +144,7 @@ class RetireUserTestCase(TestCase):
 
         # submit a system form to update one, and another to update two
         caseblocks = [
-            CaseBlock.deprecated_init(
+            CaseBlock(
                 create=False,
                 case_id=case_id,
                 user_id=SYSTEM_USER_ID,
@@ -212,7 +212,7 @@ class RetireUserTestCase(TestCase):
         """
 
         case_id = uuid.uuid4().hex
-        caseblock = CaseBlock.deprecated_init(
+        caseblock = CaseBlock(
             create=True,
             case_id=case_id,
             owner_id=self.commcare_user._id,
@@ -231,7 +231,7 @@ class RetireUserTestCase(TestCase):
         """ Don't rebuild cases that are owned by other users """
 
         case_id = uuid.uuid4().hex
-        caseblock = CaseBlock.deprecated_init(
+        caseblock = CaseBlock(
             create=True,
             case_id=case_id,
             owner_id=self.commcare_user._id,
@@ -250,7 +250,7 @@ class RetireUserTestCase(TestCase):
 
         case_ids = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
 
-        caseblocks = [CaseBlock.deprecated_init(
+        caseblocks = [CaseBlock(
             create=True,
             case_id=case_id,
             owner_id=self.commcare_user._id,
@@ -283,7 +283,7 @@ class RetireUserTestCase(TestCase):
             else:
                 owner_id = self.commcare_user._id
 
-            caseblock = CaseBlock.deprecated_init(
+            caseblock = CaseBlock(
                 create=True,
                 case_id=case_id,
                 owner_id=owner_id,
@@ -306,7 +306,7 @@ class RetireUserTestCase(TestCase):
         usercase_id = self.commcare_user.get_usercase_id()
 
         # other user submits form against the case (should get deleted)
-        caseblock = CaseBlock.deprecated_init(
+        caseblock = CaseBlock(
             create=False,
             case_id=usercase_id,
         )
@@ -331,7 +331,7 @@ class RetireUserTestCase(TestCase):
 
     def test_forms_touching_live_case_not_deleted(self):
         case_id = uuid.uuid4().hex
-        caseblock = CaseBlock.deprecated_init(
+        caseblock = CaseBlock(
             create=True,
             case_id=case_id,
             owner_id=self.commcare_user._id,
@@ -342,11 +342,11 @@ class RetireUserTestCase(TestCase):
         # other user submits form against the case and another case not owned by the user
         # should NOT get deleted since this form touches a case that's still 'alive'
         double_case_xform, _ = submit_case_blocks([
-            CaseBlock.deprecated_init(
+            CaseBlock(
                 create=False,
                 case_id=case_id,
             ).as_text(),
-            CaseBlock.deprecated_init(
+            CaseBlock(
                 create=True,
                 case_id=uuid.uuid4().hex,
                 owner_id=self.other_user._id,

--- a/corehq/ex-submodules/casexml/apps/case/cleanup.py
+++ b/corehq/ex-submodules/casexml/apps/case/cleanup.py
@@ -32,7 +32,7 @@ def close_cases(case_ids, domain, user, device_id, case_db=None):
         user_id = user
         username = user
 
-    case_blocks = [ElementTree.tostring(CaseBlock.deprecated_init(
+    case_blocks = [ElementTree.tostring(CaseBlock(
         create=False,
         case_id=case_id,
         close=True,
@@ -104,7 +104,7 @@ def claim_case(domain, restore_user, host_id, host_type=None, host_name=None, de
         host_type = case.type
         host_name = case.name
     identifier = DEFAULT_CASE_INDEX_IDENTIFIERS[CASE_INDEX_EXTENSION]
-    claim_case_block = CaseBlock.deprecated_init(
+    claim_case_block = CaseBlock(
         create=True,
         case_id=claim_id,
         case_name=host_name,

--- a/corehq/ex-submodules/casexml/apps/case/mock/mock.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/mock.py
@@ -79,7 +79,7 @@ class CaseFactory(object):
     def get_case_block(self, case_id, **kwargs):
         for k, v in self.case_defaults.items():
             kwargs.setdefault(k, v)
-        return CaseBlock.deprecated_init(case_id=case_id, **kwargs).as_xml()
+        return CaseBlock(case_id=case_id, **kwargs).as_xml()
 
     def get_case_blocks(self, case_structures):
 

--- a/corehq/ex-submodules/casexml/apps/case/mock/tests/test_case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/tests/test_case_block.py
@@ -17,7 +17,7 @@ class CaseBlockTest(SimpleTestCase):
         cls.CASE_ID = 'test-case-id'
 
     def test_basic(self):
-        actual = ElementTree.tostring(CaseBlock.deprecated_init(
+        actual = ElementTree.tostring(CaseBlock(
             case_id=self.CASE_ID,
             date_opened=self.NOW,
             date_modified=self.NOW,
@@ -33,7 +33,7 @@ class CaseBlockTest(SimpleTestCase):
     def test_does_not_let_you_specify_a_keyword_twice(self):
         """Doesn't let you specify a keyword twice (here 'case_name')"""
         with self.assertRaises(CaseBlockError) as context:
-            CaseBlock.deprecated_init(
+            CaseBlock(
                 case_id=self.CASE_ID,
                 case_name='Johnny',
                 update={'case_name': 'Johnny'},
@@ -58,7 +58,7 @@ class CaseBlockTest(SimpleTestCase):
 
     def test_buggy_behavior(self):
         """The following is a BUG; should fail!! Should fix and change tests"""
-        expected = ElementTree.tostring(CaseBlock.deprecated_init(
+        expected = ElementTree.tostring(CaseBlock(
             case_id=self.CASE_ID,
             date_opened=self.NOW,
             date_modified=self.NOW,

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -39,7 +39,7 @@ class CaseBugTest(TestCase, TestFileMixin):
         """
         Ensure that form processor fails on empty id
         """
-        case_block = CaseBlock.deprecated_init(
+        case_block = CaseBlock(
             case_id='',
             create=True,
         ).as_text()
@@ -49,14 +49,14 @@ class CaseBugTest(TestCase, TestFileMixin):
 
     def _test_datatypes_in_various_properties(self, value):
         case_id = uuid.uuid4().hex
-        create_caseblock = CaseBlock.deprecated_init(
+        create_caseblock = CaseBlock(
             case_id=case_id,
             user_id=value,
             case_name=value,
             case_type=value,
             create=True,
         ).as_text()
-        update_caseblock = CaseBlock.deprecated_init(
+        update_caseblock = CaseBlock(
             case_id=case_id,
             user_id=value,
             update={
@@ -92,7 +92,7 @@ class CaseBugTest(TestCase, TestFileMixin):
         """
         case_id = '061ecbae-d9be-4bb5-bdd4-e62abd5eaf7b'
         post_case_blocks([
-            CaseBlock.deprecated_init(create=True, case_id=case_id).as_xml()
+            CaseBlock(create=True, case_id=case_id).as_xml()
         ])
         xml_data = self.get_xml('duplicate_case_properties')
         result = submit_form_locally(xml_data, 'test-domain')
@@ -106,11 +106,11 @@ class CaseBugTest(TestCase, TestFileMixin):
         """Ensure we can submit a form with multiple blocks for the same case"""
         case_id = uuid.uuid4().hex
         case_blocks = [
-            CaseBlock.deprecated_init(create=True, case_id=case_id, update={
+            CaseBlock(create=True, case_id=case_id, update={
                 'p1': 'v1',
                 'p2': 'v2',
             }).as_text(),
-            CaseBlock.deprecated_init(case_id=case_id, update={
+            CaseBlock(case_id=case_id, update={
                 'p2': 'v4',
                 'p3': 'v3',
             }).as_text(),
@@ -135,7 +135,7 @@ class CaseBugTest(TestCase, TestFileMixin):
         """submitting to a deleted case should succeed and affect the case"""
         case_id = uuid.uuid4().hex
         xform, [case] = post_case_blocks([
-            CaseBlock.deprecated_init(create=True, case_id=case_id, user_id='whatever',
+            CaseBlock(create=True, case_id=case_id, user_id='whatever',
                 update={'foo': 'bar'}).as_xml()
         ], domain="test-domain")
         CommCareCase.objects.soft_delete_cases("test-domain", [case_id])
@@ -145,7 +145,7 @@ class CaseBugTest(TestCase, TestFileMixin):
         self.assertTrue(case.is_deleted)
 
         xform, [case] = post_case_blocks([
-            CaseBlock.deprecated_init(create=False, case_id=case_id, user_id='whatever',
+            CaseBlock(create=False, case_id=case_id, user_id='whatever',
                       update={'foo': 'not_bar'}).as_xml()
         ])
         self.assertEqual('not_bar', case.dynamic_case_properties()['foo'])
@@ -156,10 +156,10 @@ class CaseBugTest(TestCase, TestFileMixin):
         case_id2 = uuid.uuid4().hex
         # updates before create and case blocks for different cases interleaved
         blocks = [
-            CaseBlock.deprecated_init(create=False, case_id=case_id1, update={'p': '2'}).as_xml(),
-            CaseBlock.deprecated_init(create=False, case_id=case_id2, update={'p': '2'}).as_xml(),
-            CaseBlock.deprecated_init(create=True, case_id=case_id1, update={'p': '1'}).as_xml(),
-            CaseBlock.deprecated_init(create=True, case_id=case_id2, update={'p': '1'}).as_xml()
+            CaseBlock(create=False, case_id=case_id1, update={'p': '2'}).as_xml(),
+            CaseBlock(create=False, case_id=case_id2, update={'p': '2'}).as_xml(),
+            CaseBlock(create=True, case_id=case_id1, update={'p': '1'}).as_xml(),
+            CaseBlock(create=True, case_id=case_id2, update={'p': '1'}).as_xml()
         ]
 
         xform, cases = post_case_blocks(blocks)
@@ -310,7 +310,7 @@ class TestCaseHierarchy(TestCase):
         case_id1 = uuid.uuid4().hex
         case_id2 = uuid.uuid4().hex
         form_id = uuid.uuid4().hex
-        case_block = CaseBlock.deprecated_init(
+        case_block = CaseBlock(
             case_id=case_id1,
             create=True,
         ).as_text()
@@ -319,7 +319,7 @@ class TestCaseHierarchy(TestCase):
             CommCareCase.objects.get_case(case_id2, 'domain_name')
 
         # form with same ID submitted but now has a new case transaction
-        new_case_block = CaseBlock.deprecated_init(
+        new_case_block = CaseBlock(
             case_id=case_id2,
             create=True,
             case_type='t1',

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_case_block.py
@@ -5,6 +5,6 @@ from casexml.apps.case.mock import CaseBlock
 class TestCaseBlock(SimpleTestCase):
 
     def test_numeric_properties(self):
-        xml = CaseBlock.deprecated_init("arbitrary_id", update={'float': float(1.2), 'int': 5}).as_xml()
+        xml = CaseBlock("arbitrary_id", update={'float': float(1.2), 'int': 5}).as_xml()
         self.assertEqual(xml.findtext('update/float'), "1.2")
         self.assertEqual(xml.findtext('update/int'), "5")

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -25,7 +25,7 @@ def _post_util(create=False, case_id=None, user_id=None, owner_id=None,
     def uid():
         return uuid.uuid4().hex
     case_id = case_id or uid()
-    block = CaseBlock.deprecated_init(create=create,
+    block = CaseBlock(create=create,
                       case_id=case_id,
                       user_id=user_id or uid(),
                       owner_id=owner_id or uid(),
@@ -209,11 +209,11 @@ class CaseRebuildTest(TestCase):
         earlier = now - timedelta(hours=1)
         way_earlier = now - timedelta(days=1)
         # make sure we timestamp everything so they have the right order
-        create_block = CaseBlock.deprecated_init(case_id, create=True, date_modified=way_earlier)
+        create_block = CaseBlock(case_id, create=True, date_modified=way_earlier)
         post_case_blocks(
             [create_block.as_xml()], form_extras={'received_on': way_earlier}
         )
-        update_block = CaseBlock.deprecated_init(case_id, update={'foo': 'bar'}, date_modified=earlier)
+        update_block = CaseBlock(case_id, update={'foo': 'bar'}, date_modified=earlier)
         post_case_blocks(
             [update_block.as_xml()], form_extras={'received_on': earlier}
         )
@@ -247,14 +247,14 @@ class CaseRebuildTest(TestCase):
     def test_archive_removes_index(self):
         parent_case_id = uuid.uuid4().hex
         post_case_blocks([
-            CaseBlock.deprecated_init(parent_case_id, create=True).as_xml()
+            CaseBlock(parent_case_id, create=True).as_xml()
         ])
         child_case_id = uuid.uuid4().hex
         post_case_blocks([
-            CaseBlock.deprecated_init(child_case_id, create=True).as_xml()
+            CaseBlock(child_case_id, create=True).as_xml()
         ])
         xform, _ = post_case_blocks([
-            CaseBlock.deprecated_init(child_case_id, index={'mom': ('mother', parent_case_id)}).as_xml()
+            CaseBlock(child_case_id, index={'mom': ('mother', parent_case_id)}).as_xml()
         ])
 
         case = CommCareCase.objects.get_case(child_case_id, 'test-domain')

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
@@ -106,7 +106,7 @@ class Version2CaseParsingTest(TestCase):
         user_id = "bar-user-id"
         for prereq in ["some_referenced_id", "some_other_referenced_id"]:
             post_case_blocks([
-                CaseBlock.deprecated_init(
+                CaseBlock(
                     create=True, case_id=prereq,
                     user_id=user_id
                 ).as_xml()

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore_v3.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore_v3.py
@@ -30,7 +30,7 @@ class OtaV3RestoreTest(TestCase):
         restore_user = create_restore_user(domain=self.domain)
         case_id = 'my-case-id'
         device = MockDevice(self.project, restore_user)
-        device.change_cases(CaseBlock.deprecated_init(
+        device.change_cases(CaseBlock(
             create=True,
             case_id=case_id,
             user_id=restore_user.user_id,

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
@@ -61,8 +61,8 @@ class StateHashTest(TestCase):
         sync = self.device.last_sync
         self.assertEqual(CaseStateHash(EMPTY_HASH), sync.log.get_state_hash())
 
-        c1 = CaseBlock.deprecated_init(case_id="abc123", create=True, owner_id=self.user.user_id)
-        c2 = CaseBlock.deprecated_init(case_id="123abc", create=True, owner_id=self.user.user_id)
+        c1 = CaseBlock(case_id="abc123", create=True, owner_id=self.user.user_id)
+        c2 = CaseBlock(case_id="123abc", create=True, owner_id=self.user.user_id)
         self.device.post_changes([c1, c2])
 
         real_hash = CaseStateHash("409c5c597fa2c2a693b769f0d2ad432b")

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -158,7 +158,7 @@ class SyncTokenUpdateTest(BaseSyncTest):
         child_id, parent_id, index_id, parent_ref = self._initialize_parent_child()
         # update the child's index (parent type)
         updated_type = "updated_type"
-        self.device.post_changes(CaseBlock.deprecated_init(
+        self.device.post_changes(CaseBlock(
             create=False, case_id=child_id, user_id=self.user_id,
             index={index_id: (updated_type, parent_id)},
         ))
@@ -217,7 +217,7 @@ class SyncTokenUpdateTest(BaseSyncTest):
     def test_delete_only_index(self):
         child_id, parent_id, index_id, parent_ref = self._initialize_parent_child()
         # delete the first index
-        self.device.post_changes(CaseBlock.deprecated_init(
+        self.device.post_changes(CaseBlock(
             create=False,
             case_id=child_id,
             user_id=self.user_id,
@@ -260,7 +260,7 @@ class SyncTokenUpdateTest(BaseSyncTest):
                                                 child_id: [parent_ref_1, parent_ref_2]})
 
         # delete the first index
-        self.device.post_changes(CaseBlock.deprecated_init(
+        self.device.post_changes(CaseBlock(
             create=False,
             case_id=child_id,
             user_id=self.user_id,
@@ -319,7 +319,7 @@ class SyncTokenUpdateTest(BaseSyncTest):
             {parent_id: [], child_id: [index_ref]})
 
         # close the mother case
-        close = CaseBlock.deprecated_init(create=False, case_id=parent_id, user_id=self.user_id, close=True)
+        close = CaseBlock(create=False, case_id=parent_id, user_id=self.user_id, close=True)
         self.device.post_changes(close)
         self._testUpdate(self.device.last_sync.log.get_id, {child_id: [index_ref]},
                          {parent_id: []})
@@ -355,7 +355,7 @@ class SyncTokenUpdateTest(BaseSyncTest):
         # assign the child to a new owner
         new_owner = "not_mine"
         self.device.post_changes(
-            CaseBlock.deprecated_init(create=False, case_id=child_id, user_id=self.user_id, owner_id=new_owner),
+            CaseBlock(create=False, case_id=child_id, user_id=self.user_id, owner_id=new_owner),
         )
 
         # child should be moved, parent should still be there
@@ -370,7 +370,7 @@ class SyncTokenUpdateTest(BaseSyncTest):
         self.device.change_cases(case_id=case_id, create=True)
         self.assertEqual(self.device.sync().cases, {})
 
-        self.device.change_cases(CaseBlock.deprecated_init(
+        self.device.change_cases(CaseBlock(
             create=False,
             case_id=case_id,
             user_id=self.user_id,
@@ -1184,7 +1184,7 @@ class SyncTokenCachingTest(BaseSyncTest):
         # posting a case associated with this sync token should invalidate the cache
         # submitting a case not with the token will not touch the cache for that token
         case_id = "cache_noninvalidation"
-        post_case_blocks([CaseBlock.deprecated_init(
+        post_case_blocks([CaseBlock(
             create=True,
             case_id=case_id,
             user_id=self.user.user_id,
@@ -1298,7 +1298,7 @@ class MultiUserSyncTest(BaseSyncTest):
         # sync to the other's phone to be able to edit
         self.assertIn(case_id, self.ferrel.sync().cases)
 
-        self.ferrel.post_changes(CaseBlock.deprecated_init(
+        self.ferrel.post_changes(CaseBlock(
             create=True,
             case_id=mother_id,
             date_modified=time,
@@ -1310,7 +1310,7 @@ class MultiUserSyncTest(BaseSyncTest):
         self.assertNotIn(mother_id, self.guy.sync().cases)
 
         # update the original case from another, adding an indexed case
-        self.ferrel.post_changes(CaseBlock.deprecated_init(
+        self.ferrel.post_changes(CaseBlock(
             case_id=case_id,
             user_id=self.ferrel.user_id,
             owner_id=self.guy.user_id,
@@ -1345,7 +1345,7 @@ class MultiUserSyncTest(BaseSyncTest):
         self.ferrel.sync()
 
         # update case from same user
-        self.guy.post_changes(CaseBlock.deprecated_init(
+        self.guy.post_changes(CaseBlock(
             date_modified=time,
             case_id=case_id,
             user_id=self.user_id,
@@ -1353,7 +1353,7 @@ class MultiUserSyncTest(BaseSyncTest):
         ))
 
         # update from another user
-        self.ferrel.post_changes(CaseBlock.deprecated_init(
+        self.ferrel.post_changes(CaseBlock(
             date_modified=time,
             case_id=case_id,
             user_id=self.user_id,
@@ -1374,7 +1374,7 @@ class MultiUserSyncTest(BaseSyncTest):
         self.guy.post_changes(create=True, case_id=case_id)
 
         # sync then close case from another user
-        self.ferrel.post_changes(CaseBlock.deprecated_init(
+        self.ferrel.post_changes(CaseBlock(
             case_id=case_id,
             user_id=self.user_id,
             close=True
@@ -1399,7 +1399,7 @@ class MultiUserSyncTest(BaseSyncTest):
         fsync = self.ferrel.sync()
         self.assertIn(case_id, fsync.cases)
 
-        self.ferrel.post_changes(CaseBlock.deprecated_init(
+        self.ferrel.post_changes(CaseBlock(
             case_id=case_id,
             user_id=self.ferrel.user_id,
             update={'greeting': 'hello'},
@@ -1417,7 +1417,7 @@ class MultiUserSyncTest(BaseSyncTest):
             case_id=parent_id,
             owner_id=self.user_id,
         )
-        self.guy.post_changes(CaseBlock.deprecated_init(
+        self.guy.post_changes(CaseBlock(
             create=True,
             case_id=case_id,
             user_id=self.user_id,
@@ -1431,7 +1431,7 @@ class MultiUserSyncTest(BaseSyncTest):
         self.assertNotIn(parent_id, fsync.cases)
 
         # assign just the child case to a second user
-        self.guy.post_changes(CaseBlock.deprecated_init(
+        self.guy.post_changes(CaseBlock(
             create=False,
             case_id=case_id,
             user_id=self.user_id,
@@ -1451,7 +1451,7 @@ class MultiUserSyncTest(BaseSyncTest):
         self.guy.change_cases(case_id=parent_id, create=True)
         self.guy.sync()
 
-        self.guy.change_cases(CaseBlock.deprecated_init(
+        self.guy.change_cases(CaseBlock(
             create=True,
             case_id=case_id,
             user_id=self.user_id,
@@ -1463,7 +1463,7 @@ class MultiUserSyncTest(BaseSyncTest):
         self.assertNotIn(parent_id, gsync.cases)
 
         # assign the parent case away from same user
-        self.guy.change_cases(CaseBlock.deprecated_init(
+        self.guy.change_cases(CaseBlock(
             case_id=parent_id,
             user_id=self.user_id,
             owner_id=self.ferrel.user_id,
@@ -1478,7 +1478,7 @@ class MultiUserSyncTest(BaseSyncTest):
         # make sure the other user gets the reassigned case
         self.assertIn(parent_id, self.ferrel.sync().cases)
         # update the parent case from another user
-        self.ferrel.post_changes(CaseBlock.deprecated_init(
+        self.ferrel.post_changes(CaseBlock(
             case_id=parent_id,
             user_id=self.ferrel.user_id,
             update={"greeting2": "hi"},
@@ -1515,13 +1515,13 @@ class MultiUserSyncTest(BaseSyncTest):
 
         # change the child's owner from another user
         # also change the parent from the second user
-        child_reassignment = CaseBlock.deprecated_init(
+        child_reassignment = CaseBlock(
             case_id=case_id,
             user_id=self.ferrel.user_id,
             owner_id=self.ferrel.user_id,
             update={"childgreeting": "hi!"},
         )
-        other_parent_update = CaseBlock.deprecated_init(
+        other_parent_update = CaseBlock(
             case_id=parent_id,
             user_id=self.ferrel.user_id,
             owner_id=self.ferrel.user_id,
@@ -1543,7 +1543,7 @@ class MultiUserSyncTest(BaseSyncTest):
         self.assertNotIn(parent_id, gsync.cases)
 
         # change the parent again from the second user
-        self.ferrel.post_changes(CaseBlock.deprecated_init(
+        self.ferrel.post_changes(CaseBlock(
             case_id=parent_id,
             user_id=self.ferrel.user_id,
             owner_id=self.ferrel.user_id,
@@ -1554,7 +1554,7 @@ class MultiUserSyncTest(BaseSyncTest):
         self.assertFalse(self.guy.sync().cases)
 
         # change the child again from the second user
-        self.ferrel.post_changes(CaseBlock.deprecated_init(
+        self.ferrel.post_changes(CaseBlock(
             case_id=case_id,
             user_id=self.ferrel.user_id,
             owner_id=self.ferrel.user_id,
@@ -1565,7 +1565,7 @@ class MultiUserSyncTest(BaseSyncTest):
         self.assertFalse(self.guy.sync().cases)
 
         # change owner of child back to orginal user from second user
-        self.ferrel.post_changes(CaseBlock.deprecated_init(
+        self.ferrel.post_changes(CaseBlock(
             case_id=case_id,
             user_id=self.ferrel.user_id,
             owner_id=self.user.user_id,
@@ -1730,14 +1730,14 @@ class MultiUserSyncTest(BaseSyncTest):
         self.assertEqual(set(alice.last_sync.log.case_ids_on_phone), all_cases)
         self.assertEqual(set(bob.last_sync.log.case_ids_on_phone), all_cases)
 
-        close_e1 = CaseBlock.deprecated_init(
+        close_e1 = CaseBlock(
             create=False,
             case_id=e1.case_id,
             user_id=bob.user_id,
             owner_id=None,
             close=True,
         )
-        e3 = CaseBlock.deprecated_init(
+        e3 = CaseBlock(
             create=True,
             case_id='episode-3',
             user_id=bob.user_id,
@@ -1747,7 +1747,7 @@ class MultiUserSyncTest(BaseSyncTest):
         bob.change_cases([close_e1, e3])
         bob.sync()
 
-        a1 = CaseBlock.deprecated_init(
+        a1 = CaseBlock(
             create=True,
             case_id='adherence-1',
             user_id=alice.user_id,
@@ -1906,7 +1906,7 @@ class SyncTokenReprocessingTest(BaseSyncTest):
         sync_log.case_ids_on_phone = set()
         sync_log.save()
 
-        self.device.post_changes(CaseBlock.deprecated_init(
+        self.device.post_changes(CaseBlock(
             case_id=case_id,
             user_id=self.user_id,
             owner_id=self.user_id,
@@ -1924,7 +1924,7 @@ class LooseSyncTokenValidationTest(BaseSyncTest):
     def test_submission_with_bad_log_toggle_enabled(self):
         # this is just asserting that an exception is not raised when there's no synclog
         post_case_blocks(
-            [CaseBlock.deprecated_init(create=True, case_id='bad-log-toggle-enabled').as_xml()],
+            [CaseBlock(create=True, case_id='bad-log-toggle-enabled').as_xml()],
             form_extras={"last_sync_token": 'not-a-valid-synclog-id'},
             domain='submission-domain-with-toggle',
         )

--- a/custom/inddex/example_data/data.py
+++ b/custom/inddex/example_data/data.py
@@ -72,7 +72,7 @@ def _update_case_id_properties(domain, user):
                 update[k] = case_ids_by_external_id[v]
         if update:
             case_blocks.append(
-                CaseBlock.deprecated_init(
+                CaseBlock(
                     case_id=case.case_id,
                     user_id=user._id,
                     update=update,


### PR DESCRIPTION
## Technical Summary
Another one like this: https://github.com/dimagi/commcare-hq/pull/31190

About half of our `deprecated_init` calls will be gone once this is merged.

## Safety Assurance

## Safety Assurance

### Safety story
Should be fine so long as tests pass.

### Automated test coverage

In PR.

### QA Plan

Not requesting QA.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
