### PR TITLE
Add ability to close cases via the API

### DIFF
--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -37,6 +37,7 @@ class BaseJsonCaseChange(jsonobject.JsonObject):
     owner_id = jsonobject.StringProperty()
     properties = jsonobject.DictProperty(validators=[is_simple_dict], default={})
     indices = jsonobject.DictProperty(JsonIndex)
+    close = jsonobject.BooleanProperty(default=False)
     _is_case_creation = False
 
     _allow_dynamic_properties = False
@@ -68,6 +69,7 @@ class BaseJsonCaseChange(jsonobject.JsonObject):
             owner_id=_if_specified(self.owner_id),
             create=self._is_case_creation,
             update=dict(self.properties),
+            close=self.close,
             index={
                 name: IndexAttrs(index.case_type, index.case_id, index.relationship)
                 for name, index in self.indices.items()


### PR DESCRIPTION
## Product Description
Adds a "close" param that can be used to close cases via the API

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
Enable the v0.6 Case API

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This is not yet in use

### Automated test coverage
Tests included
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
