### PR TITLE
Rename Configurable Reports to Custom Web Reports

### DIFF
--- a/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
+++ b/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
@@ -15,7 +15,7 @@ hqDefine("userreports/js/configurable_reports_home", [
     });
 
     $select.select2({
-        placeholder: gettext("Edit a report or data source"),
+        placeholder: gettext("Edit a custom web report or custom web report source"),
         templateResult: function (item) {
             var text = item.text.trim();
             if (!item.element) {

--- a/corehq/apps/userreports/templates/userreports/configurable_reports_home.html
+++ b/corehq/apps/userreports/templates/userreports/configurable_reports_home.html
@@ -5,18 +5,18 @@
 {% requirejs_main 'userreports/js/configurable_reports_home' %}
 
 {% block page_content %}
-  <h1>{% trans "Configurable Reports" %}</h1>
+  <h1>{% trans "Custom Web Reports" %}</h1>
   <a href="{% url 'create_configurable_report' domain %}" class="btn btn-default">
     <i class="fa fa-plus"></i>
-    {% trans 'Add Report' %}
+    {% trans 'Add Custom Web Report' %}
   </a>
   <a href="{% url 'import_configurable_report' domain %}" class="btn btn-default">
     <i class="fa fa-cloud-upload"></i>
-    {% trans 'Import Report' %}
+    {% trans 'Import Custom Web Report' %}
   </a>
   <a href="{% url 'create_configurable_data_source' domain %}" class="btn btn-default">
     <i class="fa fa-plus"></i>
-    {% trans 'Add Data Source' %}
+    {% trans 'Add Custom Web Report Source' %}
   </a>
 
   <br><br><br>

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -7,8 +7,8 @@
   {% if data_source.get_id %}
     <div class="btn-toolbar pull-right">
         <div class="btn-group">
-          <a href="{% url 'preview_configurable_data_source' domain data_source.get_id %}" class="btn btn-default">{% trans 'Preview Data' %}</a>
-          <a href="{% url 'summary_configurable_data_source' domain data_source.get_id %}" class="btn btn-default">{% trans 'Data Source Summary' %}</a>
+          <a href="{% url 'preview_configurable_data_source' domain data_source.get_id %}" class="btn btn-default">{% trans 'Preview Custom Web Report Data' %}</a>
+          <a href="{% url 'summary_configurable_data_source' domain data_source.get_id %}" class="btn btn-default">{% trans 'Custom Web Report Source Summary' %}</a>
         </div>
         <div class="btn-group">
           <form method='post' action="{% url 'rebuild_configurable_data_source' domain data_source.get_id %}" >
@@ -22,19 +22,19 @@
                 data-content="{% trans_html_attr "Rebuilding data sources erases all the existing data and will start populating it again. While the rebuild is happening, reports based on this data source will show incomplete data" %}"
                 data-trigger="hover"
                 {% if data_source.disable_destructive_rebuild %}disabled{% endif %}>
-                {% trans 'Rebuild Data Source'%}
+                {% trans 'Rebuild Custom Web Report Source'%}
               </button>
               {# janky: can't use a tooltip on a disabled button, so instead add a help icon and force extra space (above) so it's clear which button this is for #}
               {% if data_source.disable_destructive_rebuild %}
                 <span class="hq-help-template"
                   data-title="{% trans_html_attr "Rebuild Unavailable" %}"
-                  data-content="{% trans_html_attr "Fully rebuilding has been disabled for this data source. Please use the in place rebuild if necessary." %}"
+                  data-content="{% trans_html_attr "Fully rebuilding has been disabled for this custom web report source. Please use the in place rebuild if necessary." %}"
                   data-placement="left"></span>
               {% endif %}
               {% if is_rebuilding %}
                 <span class="hq-help-template"
-                  data-title="{% trans_html_attr "Rebuilding Data Source" %}"
-                  data-content="{% trans_html_attr "Currently a rebuild is already in progress for this data source. The next rebuild will start when the previous rebuild(s) finishes." %}"
+                  data-title="{% trans_html_attr "Rebuilding Custom Web Report Source"" %}"
+                  data-content="{% trans_html_attr "Currently a rebuild is already in progress for this custom web report source. The next rebuild will start when the previous rebuild(s) finishes." %}"
                   data-placement="left"></span>
               {% endif %}
             </div>
@@ -50,7 +50,7 @@
                class="track-usage-link"
                data-category="UCR"
                data-action="View Source"
-               data-label="Data Source">{% trans "Data Source JSON" %}</a>
+               data-label="Data Source">{% trans "Custom Web Report Source JSON" %}</a>
           </li>
           {% if not data_source.is_deactivated %}
             <li>
@@ -85,11 +85,11 @@
           {% if not used_by_reports %}
             <form method='post' action="{% url 'delete_configurable_data_source' domain data_source.get_id %}" >
               {% csrf_token %}
-              <input type="submit" value="{% trans 'Delete Data Source'%}" class="btn btn-danger disable-on-submit">
+              <input type="submit" value="{% trans 'Delete Custom Web Report Source'%}" class="btn btn-danger disable-on-submit">
             </form>
           {% else %}
             <a href="#confirm_delete" class="btn btn-danger" data-toggle="modal">
-              {% trans 'Delete Data Source'%}
+              {% trans 'Delete Custom Web Report Source'%}
             </a>
           {% endif %}
         {% endif %}

--- a/corehq/apps/userreports/templates/userreports/edit_report_config.html
+++ b/corehq/apps/userreports/templates/userreports/edit_report_config.html
@@ -10,17 +10,17 @@
     <div class="btn-toolbar">
       {% if report.get_id %}
         <div class="btn-group">
-          <a href="{% url 'configurable' domain report.get_id %}" class="btn btn-default">{% trans 'View Report' %}</a>
+          <a href="{% url 'configurable' domain report.get_id %}" class="btn btn-default">{% trans 'View Custom Web Report' %}</a>
         </div>
         <div class="btn-group">
-          <a href="{% url 'edit_configurable_data_source' domain report.config_id %}" class="btn btn-default">{% trans 'View Data Source' %}</a>
+          <a href="{% url 'edit_configurable_data_source' domain report.config_id %}" class="btn btn-default">{% trans 'View Custom Web Report Source' %}</a>
         </div>
         <div class="btn-group">
           <a href="{% url 'configurable_report_json' domain report.get_id %}"
              class="btn btn-default track-usage-link"
              data-category="UCR"
              data-action="View Source"
-             data-label="Report Config">{% trans 'Report Source' %}</a>
+             data-label="Report Config">{% trans 'Custom Web Report Source' %}</a>
         </div>
         {% if not report.is_static%}
           {% include 'userreports/partials/delete_report_button.html' with report_id=report.get_id %}

--- a/corehq/apps/userreports/templates/userreports/partials/delete_report_button.html
+++ b/corehq/apps/userreports/templates/userreports/partials/delete_report_button.html
@@ -6,7 +6,7 @@
     class="btn btn-danger"
     href="{% url 'delete_configurable_report' domain report_id %}?redirect={% url 'reports_home' domain %}"
   >
-    {% trans 'Delete Report' %}
+    {% trans 'Delete Custom Web Report' %}
   </a>
 {% else %}
   <div class="btn-group">
@@ -17,7 +17,7 @@
     {% else %}
       <form method='post' action="{% url 'delete_configurable_report' domain report_id %}" >
         {% csrf_token %}
-        <input type="submit" value="{% trans 'Delete Report'%}" class="btn btn-danger disable-on-submit pull-right">
+        <input type="submit" value="{% trans 'Delete Custom Web Report'%}" class="btn btn-danger disable-on-submit pull-right">
       </form>
     {% endif %}
   </div>

--- a/corehq/apps/userreports/templates/userreports/userreports_base.html
+++ b/corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -21,31 +21,31 @@
     <li>
       <a href="{% url 'configurable_reports_home' domain %}">
         <i class="fa fa-wrench"></i>
-        {% trans "Configurable Reports" %}
+        {% trans "Custom Web Reports" %}
       </a>
     </li>
     <li>
       <a href="{% url 'create_configurable_report' domain %}">
         <i class="fa fa-plus"></i>
-        {% trans "Add report" %}
+        {% trans "Add Custom Web Report" %}
       </a>
     </li>
     <li>
       <a href="{% url 'import_configurable_report' domain %}">
         <i class="fa fa-cloud-upload"></i>
-        {% trans "Import report" %}
+        {% trans "Import Custom Web Report" %}
       </a>
     </li>
     <li>
       <a href="{% url 'create_configurable_data_source' domain %}">
         <i class="fa fa-plus"></i>
-        {% trans "Add data source" %}
+        {% trans "Add Custom Web Report Source" %}
       </a>
     </li>
     <li>
       <a href="{% url 'create_configurable_data_source_from_app' domain %}">
         <i class="fa fa-copy"></i>
-        {% trans "Data source from application" %}
+        {% trans "Custom Web Report Source from Application" %}
       </a>
     </li>
     <li>
@@ -57,7 +57,7 @@
     <li>
       <a href="{% url 'data_source_debugger' domain %}">
         <i class="fa fa-search"></i>
-        {% trans "Data Source Debugger" %}
+        {% trans "Custom Web Report Source Debugger" %}
       </a>
     </li>
   </ul>

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -194,7 +194,7 @@ def swallow_programming_errors(fn):
 
 @method_decorator(toggles.USER_CONFIGURABLE_REPORTS.required_decorator(), name='dispatch')
 class BaseUserConfigReportsView(BaseDomainView):
-    section_name = ugettext_lazy("Configurable Reports")
+    section_name = ugettext_lazy("Custom Web Reports")
 
     @property
     def main_context(self):

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -359,10 +359,10 @@ hqDefine('users/js/roles',[
                     }];
                 self.ucrs = [{
                     visibilityRestraint: self.permissions.access_all_locations,
-                    text: gettext("Create and Edit Configurable Reports"),
+                    text: gettext("Create and Edit Custom Web Reports"),
                     checkboxLabel: "create-and-edit-configurable-reports-checkbox",
                     checkboxPermission: self.permissions.edit_ucrs,
-                    checkboxText: gettext("Allow role to create and edit configurable reports."),
+                    checkboxText: gettext("Allow role to create and edit custom web reports."),
                 }];
 
                 self.registryPermissions = [


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The PR renames Configurable Reports to Custom Web Reports as mentioned below which are as per the changes mentioned in the [spec](https://docs.google.com/document/d/19oscr4oHnaZiRE7IG6oyBsAR0kKLQViF4Y-ufXggjAg/edit)

Configurable Reports > Custom Web  Reports
Add Report > Add Custom Web Report
Import Report > Import Custom Web Report
Add Data Source > Import Custom Web Report Source
Data Source from Application > Custom Web Report Source from applications
Data Source Debugger > Custom Web Report Source Debugger
Edit Reports > Edit Custom Web Reports
Edit Data Sources > Edit Custom Web Report Sources 

Configurable Reports > Custom Web Reports
Add Report > Add Custom Web Report
Import Report > Import Custom Web Report
Add Data Source > Add Custom Web Report Source 
Edit a report or data source > Edit a custom web report or custom web report source

View Report > View Custom Web Report
View Data Source > View Custom Web Report Source
Report Source > Report Custom Web Report Source
Delete Report > Delete Custom Web Report

Preview Data > Preview Custom Web Report Data
Data Source Summary> Custom Web Report Source Summary
Rebuild Data Source > Rebuild Custom Web Report Source
Data Source JSON> Custom Web Report Source JSON
Delete Data Source > Delete Custom Web Report Source

JIRA Ticket - https://dimagi-dev.atlassian.net/browse/SAAS-13122
## Safety Assurance
Only UI renames. No functionality changes.
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan
NA
<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
