### PR TITLE
Fix test that was failing locally

### DIFF
--- a/corehq/apps/saved_reports/tests/test_models.py
+++ b/corehq/apps/saved_reports/tests/test_models.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.test import SimpleTestCase, TestCase
 from smtplib import SMTPSenderRefused
 from dimagi.utils.django.email import LARGE_FILE_SIZE_ERROR_CODE
@@ -160,7 +161,7 @@ class TestSendEmails(SimpleTestCase):
         self.mock_send_email.assert_called_with('Test Report',
             ['test1@dimagi.com', 'test2@dimagi.com'],
             'Unable to generate email report. Excel files are attached.',
-            email_from='commcarehq-noreply@example.com',
+            email_from=settings.DEFAULT_FROM_EMAIL,
             file_attachments=['abba'])
 
     def test_failing_emails_are_logged(self):


### PR DESCRIPTION
Because I have a different DEFAULT_FROM_EMAIL in my localsettings.

## Safety Assurance

### Safety story

Changes one test, not production code.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
