### PR TITLE
Add --divided-we-run=XX option to test command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         TEST: ${{ matrix.TEST }}
         NOSE_DIVIDED_WE_RUN: ${{ matrix.NOSE_DIVIDED_WE_RUN }}
         JS_SETUP: yes
-      run: scripts/docker test --noinput --stop --verbosity=2 --divide-depth=1 --with-timing --with-flaky --threshold=10 --max-test-time=29
+      run: scripts/docker test --noinput --stop -v --divided-we-run=${{ matrix.NOSE_DIVIDED_WE_RUN }} --divide-depth=1 --with-timing --with-flaky --threshold=10 --max-test-time=29
     - name: "Codecov upload"
       uses: codecov/codecov-action@v2
       with:


### PR DESCRIPTION
Make it easier to see what options are used by each CI runner. This option is particularly important because it selects a subset of tests, and is often necessary when attempting to track down failures related to bad test cleanup affecting later tests. The option is redundant with the NOSE_DIVIDED_WE_RUN environment variable, which is also set (and must be set for datadog test metrics).

## Safety Assurance

### Safety story

This change only applies to Github Actions automation output.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
