### PR TITLE
Add --reusedb=bootstrap option

### DIFF
--- a/corehq/apps/accounting/bootstrap/utils.py
+++ b/corehq/apps/accounting/bootstrap/utils.py
@@ -1,5 +1,3 @@
-from django.conf import settings
-
 from corehq.apps.accounting.models import (
     FeatureType,
     SoftwarePlanEdition,

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -839,7 +839,7 @@ class DefaultProductPlan(models.Model):
             return default_product_plan.plan.get_version()
         except DefaultProductPlan.DoesNotExist:
             raise AccountingError(
-                "No default product plan was set up, did you forget to run migrations?"
+                f"No default {edition!r} product plan was set up, did you forget to run migrations?"
             )
 
     @classmethod

--- a/corehq/apps/accounting/tests/generator.py
+++ b/corehq/apps/accounting/tests/generator.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 
 from django.apps import apps
 from django.conf import settings
+from django.core.management import call_command
 
 from unittest import mock
 from nose.tools import nottest
@@ -29,6 +30,21 @@ from corehq.apps.accounting.models import (
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import CommCareUser
 from corehq.util.test_utils import unit_testing_only
+
+
+def bootstrap_accounting():
+    from ..bootstrap.config.enterprise import BOOTSTRAP_CONFIG as enterprise_config
+    from ..bootstrap.config.report_builder_v0 import BOOTSTRAP_CONFIG as report_builder_config
+    from ..bootstrap.config.resellers_and_managed_hosting import BOOTSTRAP_CONFIG as resellers_config
+    from ..bootstrap.config.user_buckets_jan_2017 import BOOTSTRAP_CONFIG as self_service_config
+    from ..bootstrap.config.new_plans_dec_2019 import BOOTSTRAP_CONFIG as new_plans_dec_2019
+    call_command('cchq_prbac_bootstrap')
+    pricing_config = self_service_config
+    pricing_config.update(enterprise_config)
+    pricing_config.update(report_builder_config)
+    pricing_config.update(resellers_config)
+    pricing_config.update(new_plans_dec_2019)
+    ensure_plans(pricing_config, verbose=True, apps=apps)
 
 
 @unit_testing_only

--- a/corehq/apps/smsbillables/tests/utils.py
+++ b/corehq/apps/smsbillables/tests/utils.py
@@ -1,6 +1,9 @@
 import uuid
 from datetime import datetime
 
+from django.apps import apps
+from django.conf import settings
+
 from corehq.apps.sms.models import OUTGOING, SMS
 
 short_text = "This is a test text message under 160 characters."
@@ -10,6 +13,37 @@ long_text = (
     "Or at least it will be. Thinking about kale. I like kale. Kale is "
     "a fantastic thing. Also bass music. I really like dat bass."
 )
+
+
+def bootstrap_smsbillables():
+    from ..management.commands.add_moz_zero_charge import add_moz_zero_charge
+    from ..management.commands.bootstrap_grapevine_gateway import bootstrap_grapevine_gateway
+    from ..management.commands.bootstrap_grapevine_gateway_update import bootstrap_grapevine_gateway_update
+    from ..management.commands.bootstrap_mach_gateway import bootstrap_mach_gateway
+    from ..management.commands.bootstrap_moz_gateway import bootstrap_moz_gateway
+    from ..management.commands.bootstrap_telerivet_gateway import bootstrap_telerivet_gateway
+    from ..management.commands.bootstrap_test_gateway import bootstrap_test_gateway
+    from ..management.commands.bootstrap_tropo_gateway import bootstrap_tropo_gateway
+    from ..management.commands.bootstrap_unicel_gateway import bootstrap_unicel_gateway
+    from ..management.commands.bootstrap_usage_fees import bootstrap_usage_fees
+    from ..management.commands.bootstrap_yo_gateway import bootstrap_yo_gateway
+
+    Currency = apps.get_model("accounting", "Currency")
+    Currency.objects.get_or_create(code=settings.DEFAULT_CURRENCY)
+    Currency.objects.get_or_create(code='EUR')
+    Currency.objects.get_or_create(code='INR')
+
+    bootstrap_grapevine_gateway(apps)
+    bootstrap_mach_gateway(apps)
+    bootstrap_tropo_gateway(apps)
+    bootstrap_unicel_gateway(apps)
+    bootstrap_usage_fees(apps)
+    bootstrap_moz_gateway(apps)
+    bootstrap_test_gateway(apps)
+    bootstrap_telerivet_gateway(apps)
+    bootstrap_yo_gateway(apps)
+    add_moz_zero_charge(apps)
+    bootstrap_grapevine_gateway_update(apps)
 
 
 def get_fake_sms(domain, backend_api_id, backend_couch_id, text):

--- a/corehq/tests/nose.py
+++ b/corehq/tests/nose.py
@@ -184,7 +184,7 @@ class HqdbContext(DatabaseContext):
     and migrated.
 
     When using REUSE_DB=1, you may also want to provide a value for the
-    --reusedb option, either reset, flush, migrate, or teardown.
+    --reusedb option, either reset, flush, bootstrap, migrate, or teardown.
     ./manage.py test --help will give you a description of these.
     """
 
@@ -213,6 +213,8 @@ class HqdbContext(DatabaseContext):
                 call_command('migrate_multi', interactive=False)
             if self.reuse_db == "flush":
                 flush_databases()
+            if self.reuse_db == "bootstrap":
+                bootstrap_migrated_db_state()
             return  # skip remaining setup
 
         if self.reuse_db == "reset":
@@ -368,6 +370,15 @@ def flush_databases():
         except (ResourceNotFound, HTTPError):
             pass
     call_command('flush', interactive=False)
+    bootstrap_migrated_db_state()
+
+
+@unit_testing_only
+def bootstrap_migrated_db_state():
+    from corehq.apps.accounting.tests.generator import bootstrap_accounting
+    from corehq.apps.smsbillables.tests.utils import bootstrap_smsbillables
+    bootstrap_accounting()
+    bootstrap_smsbillables()
 
 
 if os.environ.get("HQ_TESTS_PRINT_IMPORTS"):

--- a/corehq/tests/noseplugins/cmdline_params.py
+++ b/corehq/tests/noseplugins/cmdline_params.py
@@ -9,7 +9,10 @@ reset: Drop existing test dbs, then create and migrate new ones, but do not
     teardown after running tests. This is convenient when the existing databases
     are outdated and need to be rebuilt.
 flush: Flush all objects from the old test databases before running tests.
-    Much faster than `reset`.
+    Much faster than `reset`. Also runs `bootstrap` (see below).
+bootstrap: Restore database state such as software plan versions and currencies
+    initialized by database migrations. Sometimes when running tests with
+    REUSE_DB=1 this state is lost, causing tests that depend on it to fail.
 migrate: Migrate the test databases before running tests.
 teardown: Skip database setup; do normal teardown after running tests.
 """
@@ -26,7 +29,7 @@ class CmdLineParametersPlugin(Plugin):
         parser.add_option(
             '--reusedb',
             default=None,
-            choices=['reset', 'flush', 'migrate', 'teardown'],
+            choices=['reset', 'flush', 'bootstrap', 'migrate', 'teardown'],
             help=REUSE_DB_HELP,
         )
         # --collect-only is a built-in option, adding it here causes a warning


### PR DESCRIPTION
After manually running bootstrap commands in a shell for way too long I finally took the time to think critically about how to add a command line option.

`--reusedb=bootstrap` (or `REUSE_DB=bootstrap` environment variable) restores database state such as software plan versions and currencies initialized by database migrations. Sometimes when running tests with `REUSE_DB=1` this state is lost, causing tests that depend on it to fail on subsequent test runs.

Also updates `--reusedb=flush` to bootstrap the database after flushing.

The bootstrapping code may be incomplete. It can be updated if more state is discovered that should be bootstrapped.

## Safety Assurance

### Safety story

The changes in this PR affect tests run with `--reusedb=(bootstrap|flush)` by developers.

### Automated test coverage

Not directly, but the new `--reusedb=bootstrap` option is used when running tests, and it has been tested locally.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
