### PR TITLE
Multi _xpath_query field support for case search

### DIFF
--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -251,8 +251,6 @@ def build_filter_from_xpath(domain, xpath, fuzzy=False):
         "Please try reformatting your query. "
         "The operators we accept are: {}"
     )
-    if isinstance(xpath, list):
-        xpath = ' and '.join(xpath)
     try:
         return build_filter_from_ast(domain, parse_xpath(xpath), fuzzy=fuzzy)
     except TypeError as e:

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -251,6 +251,8 @@ def build_filter_from_xpath(domain, xpath, fuzzy=False):
         "Please try reformatting your query. "
         "The operators we accept are: {}"
     )
+    if isinstance(xpath, list):
+        xpath = ' and '.join(xpath)
     try:
         return build_filter_from_ast(domain, parse_xpath(xpath), fuzzy=fuzzy)
     except TypeError as e:

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -93,7 +93,7 @@ class SearchCriteria:
         disallowed_parameters = [
             CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
             'owner_id',
-            CASE_SEARCH_XPATH_QUERY_KEY,
+            # CASE_SEARCH_XPATH_QUERY_KEY,
         ]
 
         if self.key in disallowed_parameters or self.is_daterange:
@@ -154,7 +154,6 @@ def extract_search_request_config(request_dict):
         config_name: params.pop(param_name, None)
         for param_name, config_name in CONFIG_KEYS_MAPPING.items()
     }
-
     criteria = criteria_dict_to_criteria_list(params)
     return CaseSearchRequestConfig(criteria=criteria, **kwargs_from_params)
 

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -120,7 +120,6 @@ class SearchCriteria:
 
 
 def criteria_dict_to_criteria_list(criteria_dict):
-    print(criteria_dict)
     criteria = [SearchCriteria(k, v) for k, v in criteria_dict.items()]
     for search_criteria in criteria:
         search_criteria.validate()

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -93,7 +93,6 @@ class SearchCriteria:
         disallowed_parameters = [
             CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
             'owner_id',
-            # CASE_SEARCH_XPATH_QUERY_KEY,
         ]
 
         if self.key in disallowed_parameters or self.is_daterange:
@@ -121,6 +120,7 @@ class SearchCriteria:
 
 
 def criteria_dict_to_criteria_list(criteria_dict):
+    print(criteria_dict)
     criteria = [SearchCriteria(k, v) for k, v in criteria_dict.items()]
     for search_criteria in criteria:
         search_criteria.validate()

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -93,7 +93,6 @@ class SearchCriteria:
         disallowed_parameters = [
             CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
             'owner_id',
-            # CASE_SEARCH_XPATH_QUERY_KEY,
         ]
 
         if self.key in disallowed_parameters or self.is_daterange:

--- a/corehq/apps/case_search/tests/test_models.py
+++ b/corehq/apps/case_search/tests/test_models.py
@@ -88,7 +88,6 @@ def _make_request_dict(params):
 @generate_cases([
     (CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY, ["a", "b"]),
     ("owner_id", ["a", "b"]),
-    (CASE_SEARCH_XPATH_QUERY_KEY, ["a", "b"]),
     ("date", ["a", "__range__2022-01-01__2022-02-01"]),
     ("date", "__range__2022-01-01__2022"),
     ("parent/foo", ["a", "b"])

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -169,7 +169,12 @@ class CaseSearchQueryBuilder:
     def _apply_filter(self, search_es, criteria):
         if criteria.key == CASE_SEARCH_XPATH_QUERY_KEY:
             if not criteria.is_empty:
-                return search_es.filter(build_filter_from_xpath(self.query_domains, criteria.value))
+                if criteria.has_multiple_terms:
+                    for value in criteria.value:
+                        search_es = search_es.filter(build_filter_from_xpath(self.query_domains, value))
+                    return search_es
+                else:
+                    return search_es.filter(build_filter_from_xpath(self.query_domains, criteria.value))
         elif criteria.key == 'owner_id':
             if not criteria.is_empty:
                 return search_es.filter(case_search.owner(criteria.value))

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -197,6 +197,7 @@ class CaseClaimEndpointTests(TestCase):
             {'name': 'Jamie Hand'},
             {'name': 'Jamie Hand', CASE_SEARCH_XPATH_QUERY_KEY: 'date_opened > "2015-03-25"'},
             {CASE_SEARCH_XPATH_QUERY_KEY: 'name = "not Jamie" or name = "Jamie Hand"'},
+            {CASE_SEARCH_XPATH_QUERY_KEY: ['name = "Jamie Hand"', 'date_opened > "2015-03-25"']},
         ]
         for params in matching_criteria:
             params.update({'case_type': CASE_TYPE})
@@ -207,6 +208,7 @@ class CaseClaimEndpointTests(TestCase):
             {'name': 'Jamie Face'},
             {'name': 'Jamie Hand', CASE_SEARCH_XPATH_QUERY_KEY: 'date_opened < "2015-03-25"'},
             {CASE_SEARCH_XPATH_QUERY_KEY: 'name = "not Jamie" and name = "Jamie Hand"'},
+            {CASE_SEARCH_XPATH_QUERY_KEY: ['name = "Jamie Face"', 'date_opened < "2015-03-25"']},
         ]
         for params in non_matching_criteria:
             params.update({'case_type': CASE_TYPE})


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Allows the user to define multiple _xpath_query search filters in mobile case search. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Jira](https://dimagi-dev.atlassian.net/browse/USH-1729?atlOrigin=eyJpIjoiNzQ2OGQzMzhjOTk2NDUwMjljNjRhZjg2ZDU5ODZjZTkiLCJwIjoiaiJ9)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
SEARCH_CLAIM

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This PR does not involve any changes to the xpath parsing logic for case claim. This only adds a check for multiple xpath fields and joins them together in a single xpath filter.  

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added a test case to `test_search_endpoint`

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
