### PR TITLE
[bugfix] remove extra quote from template

### DIFF
--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -33,7 +33,7 @@
               {% endif %}
               {% if is_rebuilding %}
                 <span class="hq-help-template"
-                  data-title="{% trans_html_attr "Rebuilding Custom Web Report Source"" %}"
+                  data-title="{% trans_html_attr "Rebuilding Custom Web Report Source" %}"
                   data-content="{% trans_html_attr "Currently a rebuild is already in progress for this custom web report source. The next rebuild will start when the previous rebuild(s) finishes." %}"
                   data-placement="left"></span>
               {% endif %}


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
While renaming the titles for UCR, an extra `"` was left which caused HQ to throw 500 while parsing the template.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
