### PR TITLE
[bugfix] fix application case summary when using advanced modules

### DIFF
--- a/corehq/apps/app_manager/app_schemas/app_case_metadata.py
+++ b/corehq/apps/app_manager/app_schemas/app_case_metadata.py
@@ -218,8 +218,8 @@ class _AdvancedFormCaseMetadataBuilder(_BaseFormCaseMetadataBuilder):
 
     def _add_load_update_actions(self):
         for action in self.form.actions.load_update_cases:
-            for name, question_path in action.case_properties.items():
-                self._add_property_save(action.case_type, name, question_path)
+            for name, conditional_update in action.case_properties.items():
+                self._add_property_save(action.case_type, name, conditional_update.question_path)
             for question_path, name in action.preload.items():
                 self._add_property_load(action.case_type, name, question_path)
             if action.close_condition.is_active():


### PR DESCRIPTION
See https://forum.dimagi.com/t/error-on-app-summary-case-type/8833/2

## Technical Summary
Only include the question path in the app summary instead of the full conditional update class.

## Safety Assurance

### Safety story
Tests added to verify and tested locally.

### Automated test coverage
Added

### QA Plan
None

### Migrations
NA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
