### PR TITLE
add lock to reporting metadata task

### DIFF
--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -20,6 +20,7 @@ from casexml.apps.case.xform import get_case_ids_from_form
 from corehq.util.metrics import metrics_gauge
 from corehq.util.metrics.const import MPM_MAX
 from couchforms.exceptions import UnexpectedDeletedXForm
+from dimagi.utils.couch import get_redis_lock
 from dimagi.utils.couch.bulk import BulkFetchException
 from dimagi.utils.logging import notify_exception
 from soil import DownloadBase
@@ -311,22 +312,34 @@ def process_reporting_metadata_staging():
     from corehq.apps.users.models import (
         CouchUser, UserReportingMetadataStaging
     )
+    lock_key = "PROCESS_REPORTING_METADATA_STAGING_TASK"
+    process_reporting_metadata_lock = get_redis_lock(
+        lock_key,
+        timeout=60 * 60, # one hour
+        name=lock_key,
+    )
+    if not process_reporting_metadata_lock.acquire(blocking=False):
+        metrics_counter("commcare.process_reporting_metadata.locked_out")
+        return
 
-    start = datetime.utcnow()
+    try:
+        start = datetime.utcnow()
 
-    with transaction.atomic():
-        records = (
-            UserReportingMetadataStaging.objects.select_for_update(skip_locked=True).order_by('pk')
-        )[:100]
-        for record in records:
-            user = CouchUser.get_by_user_id(record.user_id, record.domain)
-            try:
-                record.process_record(user)
-            except ResourceConflict:
-                # https://sentry.io/organizations/dimagi/issues/1479516073/
+        with transaction.atomic():
+            records = (
+                UserReportingMetadataStaging.objects.select_for_update(skip_locked=True).order_by('pk')
+            )[:100]
+            for record in records:
                 user = CouchUser.get_by_user_id(record.user_id, record.domain)
-                record.process_record(user)
-            record.delete()
+                try:
+                    record.process_record(user)
+                except ResourceConflict:
+                    # https://sentry.io/organizations/dimagi/issues/1479516073/
+                    user = CouchUser.get_by_user_id(record.user_id, record.domain)
+                    record.process_record(user)
+                record.delete()
+    finally:
+        process_reporting_metadata_lock.release()
 
     duration = datetime.utcnow() - start
     run_again = run_periodic_task_again(process_reporting_metadata_staging_schedule, start, duration)


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This ensures only one copy of `process_reporting_metadata_staging` is running at a time. I am relatively certain our recent pgmain issues are due to lock contention in this table, and this task hold locks on the rows it processes for its duration (the length of the transaction). Limiting how many can run at once limits how many rows are locked at once, and it looks like the task was designed to run one at a time. It runs once every 5 minutes or if it thinks it can finish before the next task will start, so I think this keeps with the spirit of the task, while handling failure conditions a bit better.

I only held the lock for the db access part, since having multiple tasks at the end would not cause the same issue. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This does not change the behavior of the task itself, and errors would be limited to the task so would not affect user experience.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
