### PR TITLE
Adjust for Django 3.0 backwards incompatibilities

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -27,7 +27,6 @@ from django.core.exceptions import ValidationError
 from django.db import DEFAULT_DB_ALIAS, models
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils.safestring import SafeBytes
 from django.utils.translation import override
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
@@ -4479,7 +4478,7 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
                     for filename in self.blobs if filename.startswith('files/')
                 }
                 all_files = {
-                    name: (contents if isinstance(contents, (bytes, SafeBytes)) else contents.encode('utf-8'))
+                    name: (contents if isinstance(contents, bytes) else contents.encode('utf-8'))
                     for name, contents in all_files.items()
                 }
                 release_date = self.built_with.datetime or datetime.datetime.utcnow()

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -13,7 +13,7 @@ from django.http import (
 )
 from django.template.response import TemplateResponse
 from django.urls import reverse
-from django.utils.decorators import available_attrs, method_decorator
+from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views import View
 
@@ -391,7 +391,7 @@ def two_factor_exempt(view_func):
     def wrapped_view(*args, **kwargs):
         return view_func(*args, **kwargs)
     wrapped_view.two_factor_exempt = True
-    return wraps(view_func, assigned=available_attrs(view_func))(wrapped_view)
+    return wraps(view_func)(wrapped_view)
 
 
 # Use api_auth or api_auth_with_scope decorators to allow -


### PR DESCRIPTION
https://docs.djangoproject.com/en/4.0/releases/3.0/#backwards-incompatible-3-0

## Safety Assurance

### Safety story

Two very minor changes were made in this PR:
- Removed `SafeBytes`, which is unused since Django 2.0.
- Removed usage of `available_attrs`, which was redundant because it returns the default value of the `assigned` parameter where it was used.

### Automated test coverage

No new tests.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
