### PR TITLE
Adjust for Django 3.1 backwards incompatibilities

### DIFF
--- a/corehq/apps/auditcare/tests/testutils.py
+++ b/corehq/apps/auditcare/tests/testutils.py
@@ -2,7 +2,11 @@ from uuid import uuid4
 
 from django.db import router
 from django.test import TestCase
-from django.utils.decorators import classproperty
+try:
+    from django.utils.functional import classproperty
+except ImportError:
+    # Django < 3.1 compatibility
+    from django.utils.decorators import classproperty
 
 from couchdbkit.ext.django.loading import get_db
 

--- a/corehq/apps/locations/adjacencylist.py
+++ b/corehq/apps/locations/adjacencylist.py
@@ -1,6 +1,7 @@
+from django.core.exceptions import EmptyResultSet
 from django.db import models
 from django.db.models.expressions import Exists, F, Func, OuterRef, Value
-from django.db.models.query import EmptyResultSet, Q, QuerySet
+from django.db.models.query import Q, QuerySet
 
 from django_cte import With
 

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -5,7 +5,12 @@ from unittest.mock import patch
 
 from django.conf import settings
 from django.test import TestCase, TransactionTestCase
-from django.utils.decorators import classproperty
+try:
+    from django.utils.functional import classproperty
+except ImportError:
+    # Django < 3.1 compatibility
+    from django.utils.decorators import classproperty
+
 from nose.plugins.attrib import attr
 from nose.tools import nottest
 from unittest import skipIf, skipUnless


### PR DESCRIPTION
https://docs.djangoproject.com/en/4.0/releases/3.1/#backwards-incompatible-changes-in-3-1

## Safety Assurance

### Safety story

Once again, two very minor changes.
- `EmptyResultSet` imported from the proper place. The old alias was removed.
- `classproperty` must be imported from a different place in Django 3.1. This change affects tests only.

### Automated test coverage

No new tests.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
