### PR TITLE
name 'metrics_counter' is not defined

### DIFF
--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -17,7 +17,7 @@ from couchdbkit import BulkSaveError, ResourceConflict
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.xform import get_case_ids_from_form
-from corehq.util.metrics import metrics_gauge
+from corehq.util.metrics import metrics_counter, metrics_gauge
 from corehq.util.metrics.const import MPM_MAX
 from couchforms.exceptions import UnexpectedDeletedXForm
 from dimagi.utils.couch import get_redis_lock


### PR DESCRIPTION
This popped up on #ush-500-to-0
https://sentry.io/organizations/dimagi/issues/3088472236/
from https://github.com/dimagi/commcare-hq/pull/31232