### PR TITLE
Use POST for EmailReportForm

### DIFF
--- a/corehq/apps/reports/static/reports/js/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/hq_report.js
@@ -233,7 +233,7 @@ hqDefine("reports/js/hq_report", [
                 var $sendButton = $(hqReport.emailReportModal).find('.send-button');
                 $sendButton.button('loading');
 
-                $.get(self.getReportRenderUrl("email_onceoff", $.param(self.unwrap())))
+                $.post(getReportBaseUrl("email_onceoff"), $.param(self.unwrap()))
                     .done(function () {
                         $(hqReport.emailReportModal).modal('hide');
                         self.resetModal();

--- a/corehq/apps/reports/templates/reports/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/base_template.html
@@ -126,7 +126,7 @@
               {{ datespan.enddate|date:"Y-m-d" }}
             </h4>
           </div>
-          <form class="form form-horizontal">
+          <form class="form form-horizontal" method="post">
             <div class="modal-body">
               <div class="form-group">
                 <label class="control-label col-xs-2" for="email-report-subject">{% trans "Subject" %}</label>

--- a/corehq/apps/reports/tests/test_views.py
+++ b/corehq/apps/reports/tests/test_views.py
@@ -76,6 +76,11 @@ class TestEmailReport(TestCase):
         with self.assertRaises(Http404):
             self.email_report(report_name='worker_activity')
 
+    def test_disallowed_request_get_method(self):
+        self.request = self._create_request(method='get')
+        response = self.email_report()
+        self.assertEqual(response.status_code, 405)
+
 # ################ Helpers / Setup
     def email_report(self, domain=None, report_name='worker_activity'):
         domain = domain or self.domain
@@ -115,12 +120,17 @@ class TestEmailReport(TestCase):
 
         super().tearDown()
 
-    def _create_request(self, params=None):
+    def _create_request(self, params=None, method='post'):
         if params is None:
             params = {'send_to_owner': True}
 
         url = f'/a/{self.domain}/emailReport'
-        request = RequestFactory().post(url, params)
+
+        if method == 'get':
+            request = RequestFactory().get(url, params)
+        else:
+            request = RequestFactory().post(url, params)
+
         request.user = self.user
         return request
 

--- a/corehq/apps/reports/tests/test_views.py
+++ b/corehq/apps/reports/tests/test_views.py
@@ -119,11 +119,8 @@ class TestEmailReport(TestCase):
         if params is None:
             params = {'send_to_owner': True}
 
-        params = urlencode(params)
-
-        base_url = f'/a/{self.domain}/emailReport'
-        url = f'{base_url}?{params}'
-        request = RequestFactory().get(url)
+        url = f'/a/{self.domain}/emailReport'
+        request = RequestFactory().post(url, params)
         request.user = self.user
         return request
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -544,10 +544,11 @@ class AddSavedReportConfigView(View):
 
 @login_and_domain_required
 @datespan_default
+@require_POST
 def email_report(request, domain, report_slug, dispatcher_class=ProjectReportDispatcher, once=False):
     from .forms import EmailReportForm
 
-    form = EmailReportForm(request.GET)
+    form = EmailReportForm(request.POST)
     if not form.is_valid():
         return HttpResponseBadRequest()
 


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12825

## Safety Assurance

### Safety story
The change has been tested locally and on staging, to verify that the form still works as intended
and that a GET request would receive a 405 (Method Not Allowed) response.

### Automated test coverage

TestEmailReport has been updated to use a POST request, and a new test called
test_disallowed_request_get_method has been added to check that a GET request
would receive a 405 response.

### QA Plan

I believe that the manual testing performed and the TestEmailReport coverage is sufficient to
confirm that no regressions have been introduced.

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
