### PR TITLE
allow configuring additional case types for shadow modules

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2337,7 +2337,7 @@ class ModuleBase(IndexedSchema, ModuleMediaMixin, NavMenuItemMediaMixin, Comment
 
     @property
     def is_surveys(self):
-        return self.case_type == ""
+        return not self.case_type
 
     def assign_references(self):
         if hasattr(self, 'case_list'):

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -49,15 +49,16 @@
           <div class="panel-body">
             {% if not module.is_surveys and module.module_type != 'shadow' %}
               {% include "app_manager/partials/modules/module_view_case_type.html" %}
-
-              {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
+            {% endif %}
+            {% if not module.is_surveys and request|toggle_enabled:'USH_CASE_CLAIM_UPDATES'%}
               <div class="form-group">
                 <label class="{% css_label_class %} control-label">
                   {% trans "Additional Case List and Case Search Types" %}
                   <span class="hq-help-template"
                         data-title="{% trans "Additional Case List and Case Search Types" %}"
                         data-content="{% blocktrans %}
-                             Cases of these types will be displayed in Case List and Case Search screens, in addition to the Case Type inputted above.
+                             Cases of these types will be displayed in Case List and Case Search screens, in addition to the Case Type inputted above
+                             or in the Source Menu.
                              <a target='_blank'
                              href='https://confluence.dimagi.com/display/ccinternal/Case+Search+and+Claim'>(More   Information)</a>
                               {% endblocktrans %}">
@@ -71,7 +72,6 @@
                   </select>
                 </div>
               </div>
-              {% endif %}
             {% endif %}
 
             {% if child_module_enabled and not module.is_training_module%}


### PR DESCRIPTION
## Product Description
The 'additional case types' configuration is not inherited by Shadow Modules so allow users to configure it.

Jira: https://dimagi-dev.atlassian.net/browse/SUPPORT-12939

## Technical Summary
Show the "Additional Case List and Case Search Types" UI element for Shadow Modules.

There is also a small change to `Module.is_surveys` to check for any emtpy case type (None or empty string).
This impacts Shadow Modules that don't have a source menu selected makes the user do a browser refresh after selecting a source menu in order to get access to the case configuration tabs etc. I don't like having to make the user refresh the browser window but it should only be a one time thing. Also open to other suggestions.

An alternative to this approach would be to us the 'additional case types' setting from the source module.

## Feature Flag
USH_CASE_CLAIM_UPDATES

## Safety Assurance

### Safety story
Small UI change tested locally.

### Automated test coverage
None

### QA Plan
I don't think this needs formal QA. The change has been tested locally.

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
