### PR TITLE
[bugfix] set query data inputs to null to indicate no inputs

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -145,7 +145,7 @@ hqDefine("cloudcare/js/formplayer/router", function () {
     FormplayerFrontend.on("menu:select", function (index) {
         var urlObject = Util.currentUrlToObject();
         if (index === undefined) {
-            urlObject.setQueryData({}, false, true);
+            urlObject.setQueryData(null, false, true);
             urlObject.setForceManualAction(true);
         } else {
             urlObject.addSelection(index);


### PR DESCRIPTION
## Product Description
Fix a regression in Web Apps where search defaults are not populated after selecting 'Search Again'

Jira: https://dimagi-dev.atlassian.net/browse/USH-1780
## Technical Summary
Formplayer interprets and empty JSON object as "the user selected empty for all answers" and will therefore not use the default values. Changing this to 'null' tells Formplayer to supply the defaults.

## Feature Flag
Case Search

## Safety Assurance

### Safety story
Reverting to previous behaviour. I also tested this locally.

### Automated test coverage
None

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
