### PR TITLE
Upgrade to architect 0.6.0

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -10,7 +10,7 @@ alembic==1.4.3
     # via -r base-requirements.in
 amqp==2.6.1
     # via kombu
-architect==0.5.6
+architect==0.6.0
     # via -r base-requirements.in
 asttokens==2.0.5
     # via stack-data

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -10,7 +10,7 @@ alembic==1.4.3
     # via -r base-requirements.in
 amqp==2.6.1
     # via kombu
-architect==0.5.6
+architect==0.6.0
     # via -r base-requirements.in
 attrs==21.2.0
     # via

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -8,7 +8,7 @@ alembic==1.4.3
     # via -r base-requirements.in
 amqp==2.6.1
     # via kombu
-architect==0.5.6
+architect==0.6.0
     # via -r base-requirements.in
 asttokens==2.0.5
     # via stack-data

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,7 +8,7 @@ alembic==1.4.3
     # via -r base-requirements.in
 amqp==2.6.1
     # via kombu
-architect==0.5.6
+architect==0.6.0
     # via -r base-requirements.in
 attrs==18.2.0
     # via

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -8,7 +8,7 @@ alembic==1.4.3
     # via -r base-requirements.in
 amqp==2.6.1
     # via kombu
-architect==0.5.6
+architect==0.6.0
     # via -r base-requirements.in
 attrs==18.2.0
     # via


### PR DESCRIPTION
This is required for upgrade to Django 3.2

## Safety Assurance

### Safety story

I don't know how well our tests cover usage of architect. It is used by auditcare, project_access, hqwebapp, sync logs, device reports, and project_limits for 2fa logging. The architect project does test against Django 2.2, 3.0, and 3.1, but notably not Django 3.2. A PR was submitted to [test on Python 3.9 and Django 3.2](https://github.com/maxtepkeev/architect/pull/86).

I reviewed the change log from 0.5.6 to 0.6.0, and it appears not much has changed other than adding compatibility for Django 3.x and removing support for older versions of various libraries.

### Automated test coverage

No new tests added.

### QA Plan

Probably will QA as part of the Django 3.2 upgrade.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
