### PR TITLE
Removed more deprecated_init

### DIFF
--- a/corehq/apps/hqcase/tests/test_bugs.py
+++ b/corehq/apps/hqcase/tests/test_bugs.py
@@ -27,7 +27,7 @@ class OtaRestoreBugTest(TestCase):
 
         def _submit_case(domain):
             case_id = uuid.uuid4().hex
-            case_block = CaseBlock.deprecated_init(
+            case_block = CaseBlock(
                 create=True,
                 case_id=case_id,
                 case_name='donald',

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -57,7 +57,7 @@ class CaseClaimEndpointTests(TestCase):
         CaseSearchConfig.objects.get_or_create(pk=DOMAIN, enabled=True)
         delete_all_cases()
         self.case_id = uuid4().hex
-        _, [self.case] = post_case_blocks([CaseBlock.deprecated_init(
+        _, [self.case] = post_case_blocks([CaseBlock(
             create=True,
             case_id=self.case_id,
             case_type=CASE_TYPE,

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -562,14 +562,14 @@ class ProcessRelatedDocTypePillowTest(TestCase):
     def _post_case_blocks(self, iteration=0):
         return post_case_blocks(
             [
-                CaseBlock.deprecated_init(
+                CaseBlock(
                     create=iteration == 0,
                     case_id='parent-id',
                     case_name='parent-name',
                     case_type='bug',
                     update={'update-prop-parent': iteration},
                 ).as_xml(),
-                CaseBlock.deprecated_init(
+                CaseBlock(
                     create=iteration == 0,
                     case_id='child-id',
                     case_name='child-name',
@@ -650,14 +650,14 @@ class ReuseEvaluationContextTest(TestCase):
     def _post_case_blocks(self, iteration=0):
         return post_case_blocks(
             [
-                CaseBlock.deprecated_init(
+                CaseBlock(
                     create=iteration == 0,
                     case_id='parent-id',
                     case_name='parent-name',
                     case_type='bug',
                     update={'update-prop-parent': iteration},
                 ).as_xml(),
-                CaseBlock.deprecated_init(
+                CaseBlock(
                     create=iteration == 0,
                     case_id='child-id',
                     case_name='child-name',
@@ -738,14 +738,14 @@ class AsyncIndicatorTest(TestCase):
             since = self.pillow.get_change_feed().get_latest_offsets()
             form, cases = post_case_blocks(
                 [
-                    CaseBlock.deprecated_init(
+                    CaseBlock(
                         create=i == 0,
                         case_id=parent_id,
                         case_name='parent-name',
                         case_type='bug',
                         update={'update-prop-parent': i},
                     ).as_xml(),
-                    CaseBlock.deprecated_init(
+                    CaseBlock(
                         create=i == 0,
                         case_id=child_id,
                         case_name='child-name',
@@ -783,14 +783,14 @@ class AsyncIndicatorTest(TestCase):
         parent_id, child_id = uuid.uuid4().hex, uuid.uuid4().hex
         form, cases = post_case_blocks(
             [
-                CaseBlock.deprecated_init(
+                CaseBlock(
                     create=True,
                     case_id=parent_id,
                     case_name='parent-name',
                     case_type='bug',
                     update={'update-prop-parent': 0},
                 ).as_xml(),
-                CaseBlock.deprecated_init(
+                CaseBlock(
                     create=True,
                     case_id=child_id,
                     case_name='child-name',
@@ -844,14 +844,14 @@ class AsyncIndicatorTest(TestCase):
         for i in range(3):
             form, cases = post_case_blocks(
                 [
-                    CaseBlock.deprecated_init(
+                    CaseBlock(
                         create=i == 0,
                         case_id=parent_id,
                         case_name='parent-name',
                         case_type='bug',
                         update={'update-prop-parent': i},
                     ).as_xml(),
-                    CaseBlock.deprecated_init(
+                    CaseBlock(
                         create=i == 0,
                         case_id=child_id,
                         case_name='child-name',
@@ -916,7 +916,7 @@ def _save_sql_case(doc):
     with drop_connected_signals(sql_case_post_save):
         form, cases = post_case_blocks(
             [
-                CaseBlock.deprecated_init(
+                CaseBlock(
                     create=True,
                     case_id=doc['_id'],
                     case_name=doc['name'],

--- a/corehq/motech/dhis2/entities_helpers.py
+++ b/corehq/motech/dhis2/entities_helpers.py
@@ -460,7 +460,7 @@ def save_case_updates(domain, case_id, case_updates):
             kwargs[case_property] = value
         else:
             case_update[case_property] = value
-    case_block = CaseBlock.deprecated_init(
+    case_block = CaseBlock(
         case_id=case_id,
         create=False,
         update=case_update,

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -87,14 +87,14 @@ class BaseRepeaterTest(TestCase, DomainSubscriptionMixin):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.case_block = CaseBlock.deprecated_init(
+        cls.case_block = CaseBlock(
             case_id=CASE_ID,
             create=True,
             case_type="repeater_case",
             case_name="ABC 123",
         ).as_text()
 
-        cls.update_case_block = CaseBlock.deprecated_init(
+        cls.update_case_block = CaseBlock(
             case_id=CASE_ID,
             create=False,
             case_name="ABC 234",
@@ -576,7 +576,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         self.repeater.white_listed_case_types = ['planet']
         self.repeater.save()
 
-        white_listed_case = CaseBlock.deprecated_init(
+        white_listed_case = CaseBlock(
             case_id="a_case_id",
             create=True,
             case_type="planet",
@@ -584,7 +584,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         CaseFactory(self.domain).post_case_blocks([white_listed_case])
         self.assertEqual(1, len(self.repeat_records(self.domain).all()))
 
-        non_white_listed_case = CaseBlock.deprecated_init(
+        non_white_listed_case = CaseBlock(
             case_id="b_case_id",
             create=True,
             case_type="cat",
@@ -598,7 +598,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         black_list_user_id = 'black_listed_user'
 
         # case-creations by black-listed users shouldn't be forwarded
-        black_listed_user_case = CaseBlock.deprecated_init(
+        black_listed_user_case = CaseBlock(
             case_id="b_case_id",
             create=True,
             case_type="planet",
@@ -616,7 +616,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         self.assertEqual(0, len(self.repeat_records(self.domain).all()))
 
         # case-creations by normal users should be forwarded
-        normal_user_case = CaseBlock.deprecated_init(
+        normal_user_case = CaseBlock(
             case_id="a_case_id",
             create=True,
             case_type="planet",
@@ -634,7 +634,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         self.assertEqual(1, len(self.repeat_records(self.domain).all()))
 
         # case-updates by black-listed users shouldn't be forwarded
-        black_listed_user_case = CaseBlock.deprecated_init(
+        black_listed_user_case = CaseBlock(
             case_id="b_case_id",
             case_type="planet",
             owner_id="owner",
@@ -650,7 +650,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         self.assertEqual(1, len(self.repeat_records(self.domain).all()))
 
         # case-updates by normal users should be forwarded
-        normal_user_case = CaseBlock.deprecated_init(
+        normal_user_case = CaseBlock(
             case_id="a_case_id",
             case_type="planet",
             owner_id="owner",


### PR DESCRIPTION
## Technical Summary
Another one like https://github.com/dimagi/commcare-hq/pull/31190

Once this is merged, there will be ~20 calls left, out of the original ~200. Most of the remaining calls do break tests.

## Safety Assurance

### Safety story
Should be fine so long as tests pass.

### Automated test coverage

Some, in PR

### QA Plan

None

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
