### PR TITLE
[bugfix] get additional case types from shadow module's source

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2697,6 +2697,10 @@ class Module(ModuleBase, ModuleDetailsMixin):
     def grid_display_style(self):
         return self.display_style == 'grid'
 
+    @property
+    def additional_case_types(self):
+        return self.search_config.additional_case_types
+
 
 class AdvancedForm(IndexedFormBase, FormMediaMixin, NavMenuItemMediaMixin):
     form_type = 'advanced_form'
@@ -3289,6 +3293,10 @@ class AdvancedModule(ModuleBase):
         return self._uses_case_type(USERCASE_TYPE)
 
     @property
+    def additional_case_types(self):
+        return self.search_config.additional_case_types
+
+    @property
     def phase_anchors(self):
         return [phase.anchor for phase in self.schedule_phases]
 
@@ -3835,6 +3843,12 @@ class ShadowModule(ModuleBase, ModuleDetailsMixin):
         if not self.source_module:
             return None
         return self.source_module.case_type
+
+    @property
+    def additional_case_types(self):
+        if not self.source_module:
+            return []
+        return self.source_module.additional_case_types
 
     @property
     def requires(self):

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -181,7 +181,7 @@ class RemoteRequestFactory(object):
 
         nodeset = CaseTypeXpath(self.module.case_type).case(instance_name=RESULTS_INSTANCE)
         if toggles.USH_CASE_CLAIM_UPDATES.enabled(self.app.domain):
-            additional_types = list(set(self.module.search_config.additional_case_types) - {self.module.case_type})
+            additional_types = list(set(self.module.additional_case_types) - {self.module.case_type})
             if additional_types:
                 nodeset = CaseTypeXpath(self.module.case_type).cases(
                     additional_types, instance_name=RESULTS_INSTANCE)

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -501,7 +501,7 @@ class EntriesHelper(object):
                 instance_name, root_element,
                 datum['case_type'],
                 filter_xpath=filter_xpath,
-                additional_types=datum['module'].search_config.additional_case_types
+                additional_types=datum['module'].additional_case_types
             )
 
             datums.append(FormDatumMeta(
@@ -549,7 +549,7 @@ class EntriesHelper(object):
         ]
         data.extend([
             QueryData(key='case_type', ref=f"'{case_type}'")
-            for case_type in get_ordered_case_types(datum.case_type, module.search_config.additional_case_types)
+            for case_type in get_ordered_case_types(datum.case_type, module.additional_case_types)
         ])
         data.extend([
             QueryData(key='case_id', ref=case_id_xpath)

--- a/corehq/apps/app_manager/suite_xml/utils.py
+++ b/corehq/apps/app_manager/suite_xml/utils.py
@@ -99,7 +99,7 @@ def get_form_locale_id(form):
 
 
 def get_ordered_case_types_for_module(module):
-    return get_ordered_case_types(module.case_type, module.search_config.additional_case_types)
+    return get_ordered_case_types(module.case_type, module.additional_case_types)
 
 
 def get_ordered_case_types(case_type, additional_case_types=None):


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/SUPPORT-12939

## Technical Summary
Additional case types are stored in the module's `search_config` which get's overwritten on Shadow Modules. This change uses the additional case types from the source module which matches what we do for Shadow Module `case_type`.

## Feature Flag
USH_CASE_CLAIM_UPDATES

## Safety Assurance

### Safety story
Good coverage in tests

### Automated test coverage
New tests added to verify the functionality

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
