### PR TITLE
Upgrade to django-countries==7.3.2

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -132,7 +132,7 @@ django-celery-results==1.0.4
     # via -r base-requirements.in
 django-compressor==2.4
     # via -r base-requirements.in
-django-countries==4.6
+django-countries==7.3.2
     # via -r base-requirements.in
 django-crispy-forms==1.10.0
     # via -r base-requirements.in

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -645,7 +645,9 @@ turn-python==0.0.1
 twilio==6.5.1
     # via -r base-requirements.in
 typing-extensions==4.1.1
-    # via black
+    # via
+    #   black
+    #   django-countries
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -109,7 +109,7 @@ django-celery-results==1.0.4
     # via -r base-requirements.in
 django-compressor==2.4
     # via -r base-requirements.in
-django-countries==4.6
+django-countries==7.3.2
     # via -r base-requirements.in
 django-crispy-forms==1.10.0
     # via -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -515,6 +515,8 @@ turn-python==0.0.1
     # via -r base-requirements.in
 twilio==6.5.1
     # via -r base-requirements.in
+typing-extensions==4.1.1
+    # via django-countries
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -119,7 +119,7 @@ django-celery-results==1.0.4
     # via -r base-requirements.in
 django-compressor==2.4
     # via -r base-requirements.in
-django-countries==4.6
+django-countries==7.3.2
     # via -r base-requirements.in
 django-crispy-forms==1.10.0
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -535,7 +535,9 @@ turn-python==0.0.1
 twilio==6.5.1
     # via -r base-requirements.in
 typing-extensions==4.1.1
-    # via black
+    # via
+    #   black
+    #   django-countries
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -105,7 +105,7 @@ django-celery-results==1.0.4
     # via -r base-requirements.in
 django-compressor==2.4
     # via -r base-requirements.in
-django-countries==4.6
+django-countries==7.3.2
     # via -r base-requirements.in
 django-crispy-forms==1.10.0
     # via -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -467,6 +467,8 @@ turn-python==0.0.1
     # via -r base-requirements.in
 twilio==6.5.1
     # via -r base-requirements.in
+typing-extensions==4.1.1
+    # via django-countries
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -518,6 +518,8 @@ turn-python==0.0.1
     # via -r base-requirements.in
 twilio==6.5.1
     # via -r base-requirements.in
+typing-extensions==4.1.1
+    # via django-countries
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -113,7 +113,7 @@ django-celery-results==1.0.4
     # via -r base-requirements.in
 django-compressor==2.4
     # via -r base-requirements.in
-django-countries==4.6
+django-countries==7.3.2
     # via -r base-requirements.in
 django-crispy-forms==1.10.0
     # via -r base-requirements.in


### PR DESCRIPTION
Upgrade to the latest version of django-countries, which supports Django 3.2. The previous version (4.6) did not.

The only way we use this library is
```py
from django_countries.data import COUNTRIES
```
`COUNTRIES` is a `dict[str, str]`, and the difference between the two is
```py
# from django_countries[4.6].data import COUNTRIES as old_countries
# from django_countries[7.3.2].data import COUNTRIES as new_countries
>>> old_countries.keys() == new_countries.keys()
True

>>> [(k, v, new_countries[k]) for k, v in old_countries.items() if v != new_countries[k]]
# key   old                                            new
[('FK', 'Falkland Islands  [Malvinas]',                'Falkland Islands (Malvinas)'),
 ('MK', 'Macedonia (the former Yugoslav Republic of)', 'North Macedonia'),
 ('SZ', 'Swaziland',                                   'Eswatini'),
 ('TZ', 'Tanzania, United Republic of',                'Tanzania, the United Republic of')]
```


## Safety Assurance

### Safety story

We only use the `COUNTRIES` constant, which has not changed in a way that would break anything (only values, not keys, have changed).

### Automated test coverage

No new tests.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
