### PR TITLE
Upgrade to django-formtools==2.3

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -140,7 +140,7 @@ django-cte==1.1.4
     # via -r base-requirements.in
 django-extensions==3.1.3
     # via -r dev-requirements.in
-django-formtools==2.1
+django-formtools==2.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -117,7 +117,7 @@ django-cte==1.1.4
     # via -r base-requirements.in
 django-extensions==3.1.3
     # via -r docs-requirements.in
-django-formtools==2.1
+django-formtools==2.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -125,7 +125,7 @@ django-crispy-forms==1.10.0
     # via -r base-requirements.in
 django-cte==1.1.4
     # via -r base-requirements.in
-django-formtools==2.1
+django-formtools==2.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -111,7 +111,7 @@ django-crispy-forms==1.10.0
     # via -r base-requirements.in
 django-cte==1.1.4
     # via -r base-requirements.in
-django-formtools==2.1
+django-formtools==2.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -119,7 +119,7 @@ django-crispy-forms==1.10.0
     # via -r base-requirements.in
 django-cte==1.1.4
     # via -r base-requirements.in
-django-formtools==2.1
+django-formtools==2.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth


### PR DESCRIPTION
Upgrade required for Django 3.2.

## Safety Assurance

### Safety story

The only changes here were updating translations, adding support for new versions of Python and Django, and dropping support for EOL versions. See [change log](https://django-formtools.readthedocs.io/en/latest/changelog.html).

### Automated test coverage

No new tests.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
