### PR TITLE
Remove django-angular and internalize jquery.rmi integration

### DIFF
--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -8,7 +8,6 @@ from django.utils.translation import ugettext, ugettext_lazy
 from django.views import View
 
 from couchdbkit import ResourceNotFound
-from djng.views.mixins import JSONResponseMixin, allow_remote_invocation
 from memoized import memoized
 
 from corehq.apps.accounting.models import BillingAccount
@@ -113,6 +112,7 @@ from corehq.apps.userreports.models import (
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions, WebUser
 from corehq.privileges import RELEASE_MANAGEMENT
+from corehq.util.jqueryrmi import JSONResponseMixin, allow_remote_invocation
 from corehq.util.timezones.utils import get_timezone_for_request
 
 

--- a/corehq/apps/notifications/views.py
+++ b/corehq/apps/notifications/views.py
@@ -5,11 +5,6 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_noop
 from django.views.generic import View
 
-from djng.views.mixins import (
-    JSONResponseException,
-    JSONResponseMixin,
-    allow_remote_invocation,
-)
 from memoized import memoized
 
 from corehq.apps.domain.decorators import login_required, require_superuser
@@ -20,6 +15,11 @@ from corehq.apps.notifications.models import (
     IllegalModelStateException,
     LastSeenNotification,
     Notification,
+)
+from corehq.util.jqueryrmi import (
+    JSONResponseException,
+    JSONResponseMixin,
+    allow_remote_invocation,
 )
 
 

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -16,7 +16,6 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 from django.views.generic.base import TemplateView, View
 
-from djng.views.mixins import JSONResponseMixin, allow_remote_invocation
 from memoized import memoized
 
 from corehq.apps.sso.models import IdentityProvider
@@ -58,6 +57,7 @@ from corehq.apps.registration.utils import (
 from corehq.apps.users.models import CouchUser, WebUser, Invitation
 from corehq.const import USER_CHANGE_VIA_WEB
 from corehq.util.context_processors import get_per_domain_context
+from corehq.util.jqueryrmi import JSONResponseMixin, allow_remote_invocation
 from corehq.util.soft_assert import soft_assert
 
 _domainless_new_user_soft_assert = soft_assert(to=[

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -25,7 +25,6 @@ from django.views.decorators.http import require_GET, require_POST
 from django.views.generic import TemplateView, View
 from django_prbac.exceptions import PermissionDenied
 from django_prbac.utils import has_privilege
-from djng.views.mixins import JSONResponseMixin, allow_remote_invocation
 from memoized import memoized
 
 from casexml.apps.phone.models import SyncLogSQL
@@ -119,6 +118,7 @@ from corehq import toggles
 from corehq.pillows.utils import MOBILE_USER_TYPE, WEB_USER_TYPE
 from corehq.util import get_document_or_404
 from corehq.util.dates import iso_string_to_datetime
+from corehq.util.jqueryrmi import JSONResponseMixin, allow_remote_invocation
 from corehq.util.metrics import metrics_counter
 from corehq.util.workbook_json.excel import (
     WorkbookJSONError,

--- a/corehq/util/jqueryrmi.py
+++ b/corehq/util/jqueryrmi.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+import json
+import warnings
+from django.core.serializers.json import DjangoJSONEncoder
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
+
+
+def allow_remote_invocation(func, method='auto'):
+    """
+    All methods which shall be callable through a given Ajax 'action' must be
+    decorated with @allowed_action. This is required for safety reasons. It
+    inhibits the caller to invoke all available methods of a class.
+    """
+    setattr(func, 'allow_rmi', method)
+    return func
+
+
+def allowed_action(func):
+    warnings.warn("Decorator `@allowed_action` is deprecated. Use `@allow_remote_invocation` instead.", DeprecationWarning)
+    return allow_remote_invocation(func)
+
+
+class JSONResponseException(Exception):
+    """
+    Exception class for triggering HTTP 4XX responses with JSON content, where expected.
+    """
+    status_code = 400
+
+    def __init__(self, message=None, status=None, *args, **kwargs):
+        if status is not None:
+            self.status_code = status
+        super(JSONResponseException, self).__init__(message, *args, **kwargs)
+
+
+class JSONBaseMixin(object):
+    """
+    Basic mixin for encoding HTTP responses in JSON format.
+    """
+    json_encoder = DjangoJSONEncoder
+    json_content_type = 'application/json;charset=UTF-8'
+
+    def json_response(self, response_data, status=200, **kwargs):
+        out_data = json.dumps(response_data, cls=self.json_encoder, **kwargs)
+        response = HttpResponse(out_data, self.json_content_type, status=status)
+        response['Cache-Control'] = 'no-cache'
+        return response
+
+
+class JSONResponseMixin(JSONBaseMixin):
+    """
+    A mixin for View classes that dispatches requests containing the private HTTP header
+    ``DjNg-Remote-Method`` onto a method of an instance of this class, with the given method name.
+    This named method must be decorated with ``@allow_remote_invocation`` and shall return a
+    list or dictionary which is serializable to JSON.
+    The returned HTTP responses are of kind ``application/json;charset=UTF-8``.
+    """
+    def get(self, request, *args, **kwargs):
+        if not request.is_ajax():
+            return self._dispatch_super(request, *args, **kwargs)
+        if 'action' in kwargs:
+            warnings.warn("Using the keyword 'action' in URLresolvers is deprecated. Please use 'invoke_method' instead", DeprecationWarning)
+            remote_method = kwargs['action']
+        else:
+            remote_method = kwargs.get('invoke_method')
+        if remote_method:
+            # method for invocation is determined programmatically
+            handler = getattr(self, remote_method)
+        else:
+            # method for invocation is determined by HTTP header
+            remote_method = request.META.get('HTTP_DJNG_REMOTE_METHOD')
+            handler = remote_method and getattr(self, remote_method, None)
+            if not callable(handler):
+                return self._dispatch_super(request, *args, **kwargs)
+            if not hasattr(handler, 'allow_rmi'):
+                return HttpResponseForbidden("Method '{0}.{1}' has no decorator '@allow_remote_invocation'"
+                                             .format(self.__class__.__name__, remote_method))
+        try:
+            response_data = handler()
+        except JSONResponseException as e:
+            return self.json_response({'message': e.args[0]}, e.status_code)
+        return self.json_response(response_data)
+
+    def post(self, request, *args, **kwargs):
+        if not request.is_ajax():
+            return self._dispatch_super(request, *args, **kwargs)
+        try:
+            in_data = json.loads(request.body.decode('utf-8'))
+        except ValueError:
+            in_data = request.body.decode('utf-8')
+        if 'action' in in_data:
+            warnings.warn("Using the keyword 'action' inside the payload is deprecated. Please use 'djangoRMI' from module 'djng.forms'", DeprecationWarning)
+            remote_method = in_data.pop('action')
+        else:
+            remote_method = request.META.get('HTTP_DJNG_REMOTE_METHOD')
+        handler = remote_method and getattr(self, remote_method, None)
+        if not callable(handler):
+            return self._dispatch_super(request, *args, **kwargs)
+        if not hasattr(handler, 'allow_rmi'):
+            return HttpResponseForbidden("Method '{0}.{1}' has no decorator '@allow_remote_invocation'"
+                                         .format(self.__class__.__name__, remote_method), 403)
+        try:
+            response_data = handler(in_data)
+        except JSONResponseException as e:
+            return self.json_response({'message': e.args[0]}, e.status_code)
+        return self.json_response(response_data)
+
+    def _dispatch_super(self, request, *args, **kwargs):
+        base = super(JSONResponseMixin, self)
+        handler = getattr(base, request.method.lower(), None)
+        if callable(handler):
+            return handler(request, *args, **kwargs)
+        # HttpResponseNotAllowed expects permitted methods.
+        return HttpResponseBadRequest('This view can not handle method {0}'.format(request.method), status=405)

--- a/corehq/util/jqueryrmi.py
+++ b/corehq/util/jqueryrmi.py
@@ -56,37 +56,29 @@ class JSONResponseMixin(JSONBaseMixin):
     The returned HTTP responses are of kind ``application/json;charset=UTF-8``.
     """
     def get(self, request, *args, **kwargs):
-        if not request.is_ajax():
-            return self._dispatch_super(request, *args, **kwargs)
-        remote_method = request.META.get('HTTP_DJNG_REMOTE_METHOD')
-        handler = remote_method and getattr(self, remote_method, None)
-        if not callable(handler):
-            return self._dispatch_super(request, *args, **kwargs)
-        if not hasattr(handler, 'allow_rmi'):
-            return HttpResponseForbidden("Method '{0}.{1}' has no decorator '@allow_remote_invocation'"
-                                            .format(self.__class__.__name__, remote_method))
-        try:
-            response_data = handler()
-        except JSONResponseException as e:
-            return self.json_response({'message': e.args[0]}, e.status_code)
-        return self.json_response(response_data)
+        return self._invoke_remote_method(request, args, kwargs)
 
     def post(self, request, *args, **kwargs):
+        def data():
+            try:
+                return json.loads(request.body.decode('utf-8'))
+            except ValueError:
+                return request.body.decode('utf-8')
+        return self._invoke_remote_method(request, args, kwargs, data)
+
+    def _invoke_remote_method(self, request, args, kwargs, data=None):
         if not request.is_ajax():
             return self._dispatch_super(request, *args, **kwargs)
-        try:
-            in_data = json.loads(request.body.decode('utf-8'))
-        except ValueError:
-            in_data = request.body.decode('utf-8')
         remote_method = request.META.get('HTTP_DJNG_REMOTE_METHOD')
         handler = remote_method and getattr(self, remote_method, None)
         if not callable(handler):
             return self._dispatch_super(request, *args, **kwargs)
         if not hasattr(handler, 'allow_rmi'):
-            return HttpResponseForbidden("Method '{0}.{1}' has no decorator '@allow_remote_invocation'"
-                                         .format(self.__class__.__name__, remote_method), 403)
+            return HttpResponseForbidden(
+                f"Method '{type(self).__name__}.{remote_method}' has no decorator '@allow_remote_invocation'")
+        data_args = (data(),) if data is not None else ()
         try:
-            response_data = handler(in_data)
+            response_data = handler(*data_args)
         except JSONResponseException as e:
             return self.json_response({'message': e.args[0]}, e.status_code)
         return self.json_response(response_data)

--- a/corehq/util/jqueryrmi.py
+++ b/corehq/util/jqueryrmi.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
+"""jQuery RMI adaptor for Django
+
+Used with [jquery.rmi](https://github.com/dimagi/jquery.rmi).
+
+Original source (dead project):
+https://github.com/jrief/django-angular/blob/666f4ee8e57a3c/djng/views/mixins.py
+"""
 import json
-import warnings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 
@@ -8,16 +14,11 @@ from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbid
 def allow_remote_invocation(func, method='auto'):
     """
     All methods which shall be callable through a given Ajax 'action' must be
-    decorated with @allowed_action. This is required for safety reasons. It
-    inhibits the caller to invoke all available methods of a class.
+    decorated with ``@allow_remote_invocation``. This is required for safety
+    reasons. It inhibits the caller to invoke all available methods of a class.
     """
     setattr(func, 'allow_rmi', method)
     return func
-
-
-def allowed_action(func):
-    warnings.warn("Decorator `@allowed_action` is deprecated. Use `@allow_remote_invocation` instead.", DeprecationWarning)
-    return allow_remote_invocation(func)
 
 
 class JSONResponseException(Exception):
@@ -57,23 +58,13 @@ class JSONResponseMixin(JSONBaseMixin):
     def get(self, request, *args, **kwargs):
         if not request.is_ajax():
             return self._dispatch_super(request, *args, **kwargs)
-        if 'action' in kwargs:
-            warnings.warn("Using the keyword 'action' in URLresolvers is deprecated. Please use 'invoke_method' instead", DeprecationWarning)
-            remote_method = kwargs['action']
-        else:
-            remote_method = kwargs.get('invoke_method')
-        if remote_method:
-            # method for invocation is determined programmatically
-            handler = getattr(self, remote_method)
-        else:
-            # method for invocation is determined by HTTP header
-            remote_method = request.META.get('HTTP_DJNG_REMOTE_METHOD')
-            handler = remote_method and getattr(self, remote_method, None)
-            if not callable(handler):
-                return self._dispatch_super(request, *args, **kwargs)
-            if not hasattr(handler, 'allow_rmi'):
-                return HttpResponseForbidden("Method '{0}.{1}' has no decorator '@allow_remote_invocation'"
-                                             .format(self.__class__.__name__, remote_method))
+        remote_method = request.META.get('HTTP_DJNG_REMOTE_METHOD')
+        handler = remote_method and getattr(self, remote_method, None)
+        if not callable(handler):
+            return self._dispatch_super(request, *args, **kwargs)
+        if not hasattr(handler, 'allow_rmi'):
+            return HttpResponseForbidden("Method '{0}.{1}' has no decorator '@allow_remote_invocation'"
+                                            .format(self.__class__.__name__, remote_method))
         try:
             response_data = handler()
         except JSONResponseException as e:
@@ -87,11 +78,7 @@ class JSONResponseMixin(JSONBaseMixin):
             in_data = json.loads(request.body.decode('utf-8'))
         except ValueError:
             in_data = request.body.decode('utf-8')
-        if 'action' in in_data:
-            warnings.warn("Using the keyword 'action' inside the payload is deprecated. Please use 'djangoRMI' from module 'djng.forms'", DeprecationWarning)
-            remote_method = in_data.pop('action')
-        else:
-            remote_method = request.META.get('HTTP_DJNG_REMOTE_METHOD')
+        remote_method = request.META.get('HTTP_DJNG_REMOTE_METHOD')
         handler = remote_method and getattr(self, remote_method, None)
         if not callable(handler):
             return self._dispatch_super(request, *args, **kwargs)
@@ -109,5 +96,4 @@ class JSONResponseMixin(JSONBaseMixin):
         handler = getattr(base, request.method.lower(), None)
         if callable(handler):
             return handler(request, *args, **kwargs)
-        # HttpResponseNotAllowed expects permitted methods.
         return HttpResponseBadRequest('This view can not handle method {0}'.format(request.method), status=405)

--- a/corehq/util/tests/test_jqueryrmi.py
+++ b/corehq/util/tests/test_jqueryrmi.py
@@ -1,0 +1,156 @@
+import json
+
+from testil import eq
+
+from django.views import View
+from django.test.client import RequestFactory
+
+from ..jqueryrmi import JSONResponseException, JSONResponseMixin, allow_remote_invocation
+
+
+def test_get():
+    response = get_response("rmi_endpoint")
+    eq(response.status_code, 200)
+    eq(response['Cache-Control'], 'no-cache')
+    eq(json.loads(response.content), {"data": None})
+
+
+def test_data_not_passed_to_get():
+    response = get_response("rmi_endpoint", {"some": "data"})
+    eq(response.status_code, 200)
+    eq(response['Cache-Control'], 'no-cache')
+    eq(json.loads(response.content), {"data": None})
+
+
+def test_non_ajax_get():
+    response = get_response("rmi_endpoint", HTTP_X_REQUESTED_WITH="not ajax")
+    eq(response.status_code, 405)
+    eq(response.content, b'This view can not handle method GET')
+
+
+def test_non_rmi_get():
+    response = get_response(None)
+    eq(response.status_code, 405)
+    eq(response.content, b'This view can not handle method GET')
+
+
+def test_non_callable_get():
+    response = get_response("not_callable")
+    eq(response.status_code, 405)
+    eq(response.content, b'This view can not handle method GET')
+
+
+def test_private_method_get():
+    response = get_response("private_method")
+    eq(response.status_code, 403)
+    eq(response.content, b"Method 'RmiView.private_method' has no decorator '@allow_remote_invocation'")
+
+
+def test_error_get():
+    response = get_response("err_endpoint")
+    eq(response.status_code, 400)
+    eq(response['Cache-Control'], 'no-cache')
+    eq(json.loads(response.content), {"message": "something went wrong"})
+
+
+def test_post():
+    response = post_response("rmi_endpoint", {"some": "data"})
+    eq(response.status_code, 200)
+    eq(response['Cache-Control'], 'no-cache')
+    eq(json.loads(response.content), {"data": {"some": "data"}})
+
+
+def test_post_with_no_data():
+    response = post_response("rmi_endpoint")
+    eq(response.status_code, 200)
+    eq(response['Cache-Control'], 'no-cache')
+    eq(json.loads(response.content), {"data": None})
+
+
+def test_post_with_non_json_data():
+    response = post_response("rmi_endpoint", "not json", content_type="text/plain")
+    eq(response.status_code, 200)
+    eq(response['Cache-Control'], 'no-cache')
+    eq(json.loads(response.content), {"data": "not json"})
+
+
+def test_non_ajax_post():
+    response = post_response("rmi_endpoint", HTTP_X_REQUESTED_WITH="not ajax")
+    eq(response.status_code, 405)
+    eq(response.content, b'This view can not handle method POST')
+
+
+def test_non_rmi_post():
+    response = post_response(None)
+    eq(response.status_code, 405)
+    eq(response.content, b'This view can not handle method POST')
+
+
+def test_non_callable_post():
+    response = post_response("not_callable")
+    eq(response.status_code, 405)
+    eq(response.content, b'This view can not handle method POST')
+
+
+def test_private_method_post():
+    response = post_response("private_method")
+    eq(response.status_code, 403)
+    eq(response.content, b"Method 'RmiView.private_method' has no decorator '@allow_remote_invocation'")
+
+
+def test_error_post():
+    response = post_response("err_endpoint")
+    eq(response.status_code, 400)
+    eq(response['Cache-Control'], 'no-cache')
+    eq(json.loads(response.content), {"message": "something went wrong"})
+
+
+def test_put():
+    response = make_response("put", "rmi_endpoint", {}, {})
+    eq(response.status_code, 405)
+    eq(response.content, b'')
+
+
+def test_delete():
+    response = make_response("delete", "rmi_endpoint", {}, {})
+    eq(response.status_code, 405)
+    eq(response.content, b'')
+
+
+class RmiView(JSONResponseMixin, View):
+
+    not_callable = "value"
+
+    @allow_remote_invocation
+    def rmi_endpoint(self, data=None):
+        return {"data": data}
+
+    @allow_remote_invocation
+    def err_endpoint(self, data=None):
+        raise JSONResponseException("something went wrong")
+
+    def private_method(self, *args, **kw):
+        raise Exception("should not be called")
+
+
+def get_response(method, data=None, **extra):
+    return make_response("get", method, data, extra)
+
+
+def post_response(method, data=None, **extra):
+    if "content_type" not in extra:
+        data = json.dumps(data)
+        extra["content_type"] = "application/json"
+    return make_response("post", method, data, extra)
+
+
+def make_response(http_method, method, data, extra):
+    assert "HTTP_DJNG_REMOTE_METHOD" not in extra, "use 'method' arg"
+    if method is not None:
+        extra["HTTP_DJNG_REMOTE_METHOD"] = method
+    extra.setdefault("HTTP_X_REQUESTED_WITH", "XMLHttpRequest")
+    factory = RequestFactory()
+    make_request = getattr(factory, http_method)
+    request = make_request('/', data, **extra)
+    view = RmiView.as_view()
+    return view(request)

--- a/docs/js-guide/integration-patterns.rst
+++ b/docs/js-guide/integration-patterns.rst
@@ -238,9 +238,9 @@ invocation. Each RMI request creates a Promise for handling the server
 response.
 
 ``dimagi/jquery.rmi`` was modeled after `Djangular’s
-RMI <http://django-angular.readthedocs.org/en/latest/remote-method-invocation.html>`__),
-and currently relies on a portion of that library to handle server
-responses.
+RMI <http://django-angular.readthedocs.org/en/latest/remote-method-invocation.html>`__).
+Since that project is now dead we have internalized the relevant parts
+of it as ``corehq.util.jqueryrmi``.
 
 The `README for
 dimagi/jquery.rmi <http://github.com/dimagi/jquery.rmi>`__ has excellent

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -14,7 +14,6 @@ decorator==4.0.11  # required by django-digest
 defusedxml
 diff-match-patch
 dimagi-memoized
-django-angular
 django-autoslug
 django-braces
 django-bulk-update

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -98,7 +98,6 @@ dimagi-memoized==1.1.3
 django==2.2.27
     # via
     #   -r base-requirements.in
-    #   django-angular
     #   django-appconf
     #   django-braces
     #   django-bulk-update
@@ -116,8 +115,6 @@ django==2.2.27
     #   django-user-agents
     #   djangorestframework
     #   jsonfield
-django-angular==2.2.4
-    # via -r base-requirements.in
 django-appconf==1.0.4
     # via
     #   django-compressor

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -75,7 +75,6 @@ dimagi-memoized==1.1.3
 django==2.2.27
     # via
     #   -r base-requirements.in
-    #   django-angular
     #   django-appconf
     #   django-braces
     #   django-bulk-update
@@ -93,8 +92,6 @@ django==2.2.27
     #   django-user-agents
     #   djangorestframework
     #   jsonfield
-django-angular==2.2.4
-    # via -r base-requirements.in
 django-appconf==1.0.4
     # via
     #   django-compressor

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -86,7 +86,6 @@ dimagi-memoized==1.1.3
 django==2.2.27
     # via
     #   -r base-requirements.in
-    #   django-angular
     #   django-appconf
     #   django-braces
     #   django-bulk-update
@@ -103,8 +102,6 @@ django==2.2.27
     #   django-user-agents
     #   djangorestframework
     #   jsonfield
-django-angular==2.2.4
-    # via -r base-requirements.in
 django-appconf==1.0.4
     # via
     #   django-compressor

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -72,7 +72,6 @@ dimagi-memoized==1.1.3
 django==2.2.27
     # via
     #   -r base-requirements.in
-    #   django-angular
     #   django-appconf
     #   django-braces
     #   django-bulk-update
@@ -89,8 +88,6 @@ django==2.2.27
     #   django-user-agents
     #   djangorestframework
     #   jsonfield
-django-angular==2.2.4
-    # via -r base-requirements.in
 django-appconf==1.0.4
     # via
     #   django-compressor

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -80,7 +80,6 @@ dimagi-memoized==1.1.3
 django==2.2.27
     # via
     #   -r base-requirements.in
-    #   django-angular
     #   django-appconf
     #   django-braces
     #   django-bulk-update
@@ -97,8 +96,6 @@ django==2.2.27
     #   django-user-agents
     #   djangorestframework
     #   jsonfield
-django-angular==2.2.4
-    # via -r base-requirements.in
 django-appconf==1.0.4
     # via
     #   django-compressor

--- a/settings.py
+++ b/settings.py
@@ -212,7 +212,6 @@ DEFAULT_APPS = (
     'django.contrib.staticfiles',
     'django_celery_results',
     'django_prbac',
-    'djng',
     'captcha',
     'couchdbkit.ext.django',
     'crispy_forms',


### PR DESCRIPTION
[django-angular](https://github.com/jrief/django-angular#deprecation-warning-angularjs-is-dead) is no longer maintained, and is incompatible with Django 3.2. The one small part of it that we are using has been moved into a utility module: `corehq.util.jqueryrmi`.

django-angular is licensed under the MIT license, which is broadly permissive including what has been done in this PR. It is unclear if the tiny part of it that was copied is considered a "substantial [portion] of the Software" enough that the MIT license itself should be included in the module?

:blowfish: Review by commit.

## Safety Assurance

The module copied from django-angular has only two dependencies: `django` and `json`. All imports from `djng.views.mixins` were converted directly to imports from `corehq.util.jqueryrmi` with no other changes to client code.

### Automated test coverage

New tests were written for `corehq.util.jqueryrmi`, which was copied from django-angular and refactored to remove deprecated code, redundancies, and unnecessary abstractions. The tests were added and verified to pass prior to refactoring.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
