### PR TITLE
Fix user_importer test suite

### DIFF
--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -95,7 +95,7 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
     def setUp(self):
         if WebUser.get_by_user_id(self.uploading_user.get_id) is None:
             self.uploading_user = WebUser.create(self.domain_name, "admin@xyz.com", 'password', None, None,
-                                                is_superuser=True)
+                                                role_id=self.role_with_upload_permission.get_id)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

`corehq.apps.user_importer.tests.test_importer:TestMobileUserBulkUpload` was failing on account of [this commit](https://github.com/dimagi/commcare-hq/commit/3267167fcbe4fa27d779923ae8800ba650235844) which changed how the WebUsers were initially setup. My [pickle removal PR](https://github.com/dimagi/commcare-hq/pull/30550) created a new setUp function that runs between every test and rebuilds the WebUser object but the change wasn't applied there. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested locally

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
