### PR TITLE
[bugfix] fix search again workflows in Web Apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/util.js
@@ -120,6 +120,7 @@ hqDefine("cloudcare/js/formplayer/menus/util", function () {
         var Util = hqImport("cloudcare/js/formplayer/utils/util");
         var urlObject = Util.currentUrlToObject();
 
+        sessionStorage.queryKey = menuResponse.queryKey;
         if (menuResponse.type === "commands") {
             return hqImport("cloudcare/js/formplayer/menus/views").MenuListView(menuData);
         } else if (menuResponse.type === "query") {
@@ -132,11 +133,9 @@ hqDefine("cloudcare/js/formplayer/menus/util", function () {
                 }
                 hqImport('analytix/js/kissmetrix').track.event('Case Search', props);
             }
-            sessionStorage.queryKey = menuResponse.queryKey;
             urlObject.setQueryData({}, false, false);
             return hqImport("cloudcare/js/formplayer/menus/views/query")(menuData);
         } else if (menuResponse.type === "entities") {
-            sessionStorage.queryKey = menuResponse.queryKey;
             if (hqImport('hqwebapp/js/toggles').toggleEnabled('APP_ANALYTICS')) {
                 var searchText = urlObject.search;
                 var event = "Viewed Case List";

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/util.js
@@ -136,6 +136,7 @@ hqDefine("cloudcare/js/formplayer/menus/util", function () {
             urlObject.setQueryData({}, false, false);
             return hqImport("cloudcare/js/formplayer/menus/views/query")(menuData);
         } else if (menuResponse.type === "entities") {
+            sessionStorage.queryKey = menuResponse.queryKey;
             if (hqImport('hqwebapp/js/toggles').toggleEnabled('APP_ANALYTICS')) {
                 var searchText = urlObject.search;
                 var event = "Viewed Case List";


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/SUPPORT-12986, https://dimagi-dev.atlassian.net/browse/USH-1804
Companion to https://github.com/dimagi/formplayer/pull/1100

Note: must be deployed after or at the same time as the Formplayer PR

## Technical Summary

Since the changes to pass `force_manual_action` in the query data the value must be associated with the correct 'command'. This only impacts the 'see more' and 'default search' workflows since it skips the query screen where the queryKey was being set.

* https://github.com/dimagi/commcare-hq/pull/31152
* https://github.com/dimagi/formplayer/pull/1097

## Feature Flag
SYNC_SEARCH_CASE_CLAIM (search_claim)

## Safety Assurance

### Safety story
Setting the `queryKey` for entity list screens should not affect the other workflows since the value will still get reset on query screens. In examining the code I think this was an issue before (the query data did not have the right key for the 'default search' workflow) but it wasn't noticed because the values being passed had the same effect as if the data was missing.

As evidence of this you can see that this test in the formplayer PR that made the change was passing before with the incorrect 'queryKey' but after the change the 'queryKey' had to be updated to the correct one: https://github.com/dimagi/formplayer/pull/1097/files#diff-d4b07acb174a84dd6775d061dae7329cc1795ded0b517da1876d744cd236fd42R223

### Automated test coverage
None

### QA Plan
I do not think this needs QA but since there have been 2 bugs related to the set of PRs linked above I'm going to request a set or regression tests be run.

https://dimagi-dev.atlassian.net/browse/QA-3996

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
