### PR TITLE
Patched os.path.exists in testBuildTemplateApps

### DIFF
--- a/corehq/apps/app_manager/tests/test_apps.py
+++ b/corehq/apps/app_manager/tests/test_apps.py
@@ -275,7 +275,7 @@ class AppManagerTest(TestCase, TestXmlMixin):
 
             # Tests that these apps successfully build
             for slug in ['agriculture', 'health', 'wash']:
-                load_app_from_slug(self.domain, 'username', slug)
+                self.assertIsNotNone(load_app_from_slug(self.domain, 'username', slug))
 
     def testGetLatestBuild(self):
         factory = AppFactory(build_version='2.40.0')

--- a/corehq/apps/app_manager/tests/test_apps.py
+++ b/corehq/apps/app_manager/tests/test_apps.py
@@ -262,7 +262,8 @@ class AppManagerTest(TestCase, TestXmlMixin):
         self._check_has_build_files(copy, self.min_paths)
         self._check_legacy_odk_files(copy)
 
-    def testBuildTemplateApps(self):
+    @patch('os.path.exists', return_value=False)
+    def testBuildTemplateApps(self, exists_mock):
         # Tests that these apps successfully build
         for slug in ['agriculture', 'health', 'wash']:
             load_app_from_slug(self.domain, 'username', slug)


### PR DESCRIPTION
## Technical Summary
This test is slow enough to intermittently fail.

Its original intent was to protect against issues when the template app json files got updated.

Patching this cuts off multimedia handling, which is the slow part, because each piece of multimedia is fetched via an HTTP request: https://github.com/dimagi/commcare-hq/blob/57f1f8530359a76422b8d6871e51dd2f957c2991/corehq/apps/app_manager/views/apps.py#L522-L541

## Safety Assurance

### Safety story
It's a test.

### Automated test coverage

It's a test.

### QA Plan

No


### Rollback instructions


- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
