### PR TITLE
Refactor and add tests to submit_unfinished_form innards 

### DIFF
--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -276,16 +276,18 @@ class FormplayerInterface:
 
         return self._user_id
 
-    def get_raw_instance(self):
+    def get_raw_instance(self, for_submission=False):
         """
         Gets the raw xml instance of the current session regardless of the state that we're in
         (used for logging partially complete forms to couch when errors happen).
+        :param for_submission: indicates whether relevancy should be respected when serializing instance xml
         """
 
         data = {
             "action": "get-instance",
             "session-id": self.session_id,
-            "domain": self.domain
+            "domain": self.domain,
+            "for_submission": for_submission
         }
 
         response = _post_data(data, self.user_id)

--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -276,18 +276,17 @@ class FormplayerInterface:
 
         return self._user_id
 
-    def get_raw_instance(self, respect_relevancy=True):
+    def get_raw_instance(self):
         """
         Gets the raw xml instance of the current session regardless of the state that we're in
-        (used for logging partially complete forms to couch when errors happen).
-        :param respect_relevancy: indicates if irrelevant nodes should be included or not
+        Used for submitting partially complete sms surveys when a session expires
+        XML returned in the response ignores irrelevant nodes
         """
 
         data = {
             "action": "get-instance",
             "session-id": self.session_id,
             "domain": self.domain,
-            "respect_relevancy": respect_relevancy
         }
 
         response = _post_data(data, self.user_id)

--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -276,18 +276,18 @@ class FormplayerInterface:
 
         return self._user_id
 
-    def get_raw_instance(self, for_submission=False):
+    def get_raw_instance(self, respect_relevancy=False):
         """
         Gets the raw xml instance of the current session regardless of the state that we're in
         (used for logging partially complete forms to couch when errors happen).
-        :param for_submission: indicates whether relevancy should be respected when serializing instance xml
+        :param respect_relevancy: indicates if irrelevant nodes should be included or not
         """
 
         data = {
             "action": "get-instance",
             "session-id": self.session_id,
             "domain": self.domain,
-            "for_submission": for_submission
+            "respect_relevancy": respect_relevancy
         }
 
         response = _post_data(data, self.user_id)

--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -276,7 +276,7 @@ class FormplayerInterface:
 
         return self._user_id
 
-    def get_raw_instance(self, respect_relevancy=False):
+    def get_raw_instance(self, respect_relevancy=True):
         """
         Gets the raw xml instance of the current session regardless of the state that we're in
         (used for logging partially complete forms to couch when errors happen).

--- a/corehq/apps/formplayer_api/smsforms/exceptions.py
+++ b/corehq/apps/formplayer_api/smsforms/exceptions.py
@@ -11,7 +11,3 @@ class XFormException(TouchFormsError):
 
 class BadDataError(TouchFormsError):
     pass
-
-
-class PartialSubmissionXMLIsNone(Exception):
-    pass

--- a/corehq/apps/formplayer_api/smsforms/exceptions.py
+++ b/corehq/apps/formplayer_api/smsforms/exceptions.py
@@ -1,6 +1,3 @@
-
-
-
 class TouchFormsError(Exception):
     pass
 
@@ -13,4 +10,8 @@ class XFormException(TouchFormsError):
 
 
 class BadDataError(TouchFormsError):
+    pass
+
+
+class PartialSubmissionXMLIsNone(Exception):
     pass

--- a/corehq/apps/formplayer_api/smsforms/tests/test_formplayer_interface.py
+++ b/corehq/apps/formplayer_api/smsforms/tests/test_formplayer_interface.py
@@ -40,7 +40,7 @@ class FormplayerInterfaceTests(SimpleTestCase):
             'domain': DOMAIN,
             'oneQuestionPerScreen': True,
             'nav_mode': 'prompt',
-            'for_submission': False,
+            'respect_relevancy': False,
         }
         self.validate_request(request, expected_request_data)
 

--- a/corehq/apps/formplayer_api/smsforms/tests/test_formplayer_interface.py
+++ b/corehq/apps/formplayer_api/smsforms/tests/test_formplayer_interface.py
@@ -40,27 +40,6 @@ class FormplayerInterfaceTests(SimpleTestCase):
             'domain': DOMAIN,
             'oneQuestionPerScreen': True,
             'nav_mode': 'prompt',
-            # defaults to True
-            'respect_relevancy': True,
-        }
-        self.validate_request(request, expected_request_data)
-
-    def test_get_raw_instance_where_respect_relevancy_is_false(self):
-        action = 'get-instance'
-        with MockFormplayerRequest(action, {}) as mocker:
-            self.interface.get_raw_instance(respect_relevancy=False)
-
-        mocker.assert_exactly_one_request()
-        request = mocker.get_last_request()
-
-        expected_request_data = {
-            'action': action,
-            'session-id': SESSION_ID,
-            'session_id': SESSION_ID,
-            'domain': DOMAIN,
-            'oneQuestionPerScreen': True,
-            'nav_mode': 'prompt',
-            'respect_relevancy': False,
         }
         self.validate_request(request, expected_request_data)
 

--- a/corehq/apps/formplayer_api/smsforms/tests/test_formplayer_interface.py
+++ b/corehq/apps/formplayer_api/smsforms/tests/test_formplayer_interface.py
@@ -40,6 +40,7 @@ class FormplayerInterfaceTests(SimpleTestCase):
             'domain': DOMAIN,
             'oneQuestionPerScreen': True,
             'nav_mode': 'prompt',
+            'for_submission': False,
         }
         self.validate_request(request, expected_request_data)
 

--- a/corehq/apps/formplayer_api/smsforms/tests/test_formplayer_interface.py
+++ b/corehq/apps/formplayer_api/smsforms/tests/test_formplayer_interface.py
@@ -40,7 +40,27 @@ class FormplayerInterfaceTests(SimpleTestCase):
             'domain': DOMAIN,
             'oneQuestionPerScreen': True,
             'nav_mode': 'prompt',
+            # defaults to False
             'respect_relevancy': False,
+        }
+        self.validate_request(request, expected_request_data)
+
+    def test_get_raw_instance_where_respect_relevancy_is_true(self):
+        action = 'get-instance'
+        with MockFormplayerRequest(action, {}) as mocker:
+            self.interface.get_raw_instance(respect_relevancy=True)
+
+        mocker.assert_exactly_one_request()
+        request = mocker.get_last_request()
+
+        expected_request_data = {
+            'action': action,
+            'session-id': SESSION_ID,
+            'session_id': SESSION_ID,
+            'domain': DOMAIN,
+            'oneQuestionPerScreen': True,
+            'nav_mode': 'prompt',
+            'respect_relevancy': True,
         }
         self.validate_request(request, expected_request_data)
 

--- a/corehq/apps/formplayer_api/smsforms/tests/test_formplayer_interface.py
+++ b/corehq/apps/formplayer_api/smsforms/tests/test_formplayer_interface.py
@@ -40,15 +40,15 @@ class FormplayerInterfaceTests(SimpleTestCase):
             'domain': DOMAIN,
             'oneQuestionPerScreen': True,
             'nav_mode': 'prompt',
-            # defaults to False
-            'respect_relevancy': False,
+            # defaults to True
+            'respect_relevancy': True,
         }
         self.validate_request(request, expected_request_data)
 
-    def test_get_raw_instance_where_respect_relevancy_is_true(self):
+    def test_get_raw_instance_where_respect_relevancy_is_false(self):
         action = 'get-instance'
         with MockFormplayerRequest(action, {}) as mocker:
-            self.interface.get_raw_instance(respect_relevancy=True)
+            self.interface.get_raw_instance(respect_relevancy=False)
 
         mocker.assert_exactly_one_request()
         request = mocker.get_last_request()
@@ -60,7 +60,7 @@ class FormplayerInterfaceTests(SimpleTestCase):
             'domain': DOMAIN,
             'oneQuestionPerScreen': True,
             'nav_mode': 'prompt',
-            'respect_relevancy': True,
+            'respect_relevancy': False,
         }
         self.validate_request(request, expected_request_data)
 

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -16,7 +16,6 @@ from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.utils import is_commcarecase
 from corehq.messaging.scheduling.util import utcnow
 
-from ..formplayer_api.smsforms.exceptions import PartialSubmissionXMLIsNone
 from .models import SQLXFormsSession
 
 COMMCONNECT_DEVICE_ID = "commconnect"
@@ -134,9 +133,6 @@ def _clean_xml_for_partial_submission(xml, should_remove_case_actions):
     :param should_remove_case_actions: if True, remove case actions (create, update, close) from xml
     :return: byte str of cleaned xml
     """
-    if not xml:
-        raise PartialSubmissionXMLIsNone
-
     root = XML(xml)
     case_tag_regex = re.compile(r"^(\{.*\}){0,1}case$") # Use regex in order to search regardless of namespace
     meta_tag_regex = re.compile(r"^(\{.*\}){0,1}meta$")

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -116,7 +116,7 @@ def _fetch_xml(formplayer_interface):
     :return: xml if successful
     """
     try:
-        response = formplayer_interface.get_raw_instance(respect_relevancy=True)
+        response = formplayer_interface.get_raw_instance()
         # Formplayer's ExceptionResponseBean includes the exception message,
         # status ("error"), url, and type ("text")
         if response.get('status') == 'error':

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -102,7 +102,8 @@ def submit_unfinished_form(session):
     """
     # Get and clean the raw xml
     try:
-        response = FormplayerInterface(session.session_id, session.domain).get_raw_instance(for_submission=True)
+        # since form is used for submission, ensure only relevant nodes are included
+        response = FormplayerInterface(session.session_id, session.domain).get_raw_instance(respect_relevancy=True)
         # Formplayer's ExceptionResponseBean includes the exception message,
         # stautus ("error"), url, and type ("text")
         if response.get('status') == 'error':

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -103,9 +103,9 @@ def submit_unfinished_form(session):
     # Get and clean the raw xml
     try:
         # since form is used for submission, ensure only relevant nodes are included
-        response = FormplayerInterface(session.session_id, session.domain).get_raw_instance(respect_relevancy=True)
+        response = FormplayerInterface(session.session_id, session.domain).get_raw_instance()
         # Formplayer's ExceptionResponseBean includes the exception message,
-        # stautus ("error"), url, and type ("text")
+        # status ("error"), url, and type ("text")
         if response.get('status') == 'error':
             raise TouchformsError(response.get('exception'))
         xml = response['output']

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -16,6 +16,7 @@ from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.utils import is_commcarecase
 from corehq.messaging.scheduling.util import utcnow
 
+from ..formplayer_api.smsforms.exceptions import PartialSubmissionXMLIsNone
 from .models import SQLXFormsSession
 
 COMMCONNECT_DEVICE_ID = "commconnect"
@@ -101,7 +102,10 @@ def submit_unfinished_form(session):
     The form is only submitted if the smsforms session has not yet completed.
     """
     formplayer_interface = FormplayerInterface(session.session_id, session.domain)
-    xml = _fetch_xml(formplayer_interface)
+    try:
+        xml = _fetch_xml(formplayer_interface)
+    except InvalidSessionIdException:
+        return
 
     remove_case_actions = not session.include_case_updates_in_partial_submissions
     cleaned_xml = _clean_xml_for_partial_submission(xml, should_remove_case_actions=remove_case_actions)
@@ -113,19 +117,14 @@ def submit_unfinished_form(session):
 def _fetch_xml(formplayer_interface):
     """
     :param formplayer_interface: FormplayerInterface obj
-    :return: xml if successful
+    :return: serialized instance xml with relevant nodes only
     """
-    try:
-        response = formplayer_interface.get_raw_instance()
-        # Formplayer's ExceptionResponseBean includes the exception message,
-        # status ("error"), url, and type ("text")
-        if response.get('status') == 'error':
-            raise TouchformsError(response.get('exception'))
-        xml = response['output']
-    except InvalidSessionIdException:
-        return
-
-    return xml
+    response = formplayer_interface.get_raw_instance()
+    # Formplayer's ExceptionResponseBean includes the exception message,
+    # status ("error"), url, and type ("text")
+    if response.get('status') == 'error':
+        raise TouchformsError(response.get('exception'))
+    return response['output']
 
 
 def _clean_xml_for_partial_submission(xml, should_remove_case_actions):
@@ -135,6 +134,9 @@ def _clean_xml_for_partial_submission(xml, should_remove_case_actions):
     :param should_remove_case_actions: if True, remove case actions (create, update, close) from xml
     :return: byte str of cleaned xml
     """
+    if not xml:
+        raise PartialSubmissionXMLIsNone
+
     root = XML(xml)
     case_tag_regex = re.compile(r"^(\{.*\}){0,1}case$") # Use regex in order to search regardless of namespace
     meta_tag_regex = re.compile(r"^(\{.*\}){0,1}meta$")

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -102,7 +102,7 @@ def submit_unfinished_form(session):
     """
     # Get and clean the raw xml
     try:
-        response = FormplayerInterface(session.session_id, session.domain).get_raw_instance()
+        response = FormplayerInterface(session.session_id, session.domain).get_raw_instance(for_submission=True)
         # Formplayer's ExceptionResponseBean includes the exception message,
         # stautus ("error"), url, and type ("text")
         if response.get('status') == 'error':

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -116,7 +116,7 @@ def _fetch_xml(formplayer_interface):
     :return: xml if successful
     """
     try:
-        response = formplayer_interface.get_raw_instance()
+        response = formplayer_interface.get_raw_instance(respect_relevancy=True)
         # Formplayer's ExceptionResponseBean includes the exception message,
         # status ("error"), url, and type ("text")
         if response.get('status') == 'error':

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -100,10 +100,23 @@ def submit_unfinished_form(session):
 
     The form is only submitted if the smsforms session has not yet completed.
     """
-    # Get and clean the raw xml
+    formplayer_interface = FormplayerInterface(session.session_id, session.domain)
+    xml = _fetch_xml(formplayer_interface)
+
+    remove_case_actions = not session.include_case_updates_in_partial_submissions
+    cleaned_xml = _clean_xml_for_partial_submission(xml, should_remove_case_actions=remove_case_actions)
+
+    result = submit_form_locally(cleaned_xml, session.domain, app_id=session.app_id, partial_submission=True)
+    session.submission_id = result.xform.form_id
+
+
+def _fetch_xml(formplayer_interface):
+    """
+    :param formplayer_interface: FormplayerInterface obj
+    :return: xml if successful
+    """
     try:
-        # since form is used for submission, ensure only relevant nodes are included
-        response = FormplayerInterface(session.session_id, session.domain).get_raw_instance()
+        response = formplayer_interface.get_raw_instance()
         # Formplayer's ExceptionResponseBean includes the exception message,
         # status ("error"), url, and type ("text")
         if response.get('status') == 'error':
@@ -111,18 +124,28 @@ def submit_unfinished_form(session):
         xml = response['output']
     except InvalidSessionIdException:
         return
+
+    return xml
+
+
+def _clean_xml_for_partial_submission(xml, should_remove_case_actions):
+    """
+    Helper method to cleanup partially completed xml for submission
+    :param xml: partially completed xml
+    :param should_remove_case_actions: if True, remove case actions (create, update, close) from xml
+    :return: byte str of cleaned xml
+    """
     root = XML(xml)
     case_tag_regex = re.compile(r"^(\{.*\}){0,1}case$") # Use regex in order to search regardless of namespace
     meta_tag_regex = re.compile(r"^(\{.*\}){0,1}meta$")
     timeEnd_tag_regex = re.compile(r"^(\{.*\}){0,1}timeEnd$")
-    current_timstamp = json_format_datetime(utcnow())
+    current_timestamp = json_format_datetime(utcnow())
     for child in root:
         if case_tag_regex.match(child.tag) is not None:
             # Found the case tag
             case_element = child
-            case_element.set("date_modified", current_timstamp)
-            if not session.include_case_updates_in_partial_submissions:
-                # Remove case actions (create, update, close)
+            case_element.set("date_modified", current_timestamp)
+            if should_remove_case_actions:
                 child_elements = [case_action for case_action in case_element]
                 for case_action in child_elements:
                     case_element.remove(case_action)
@@ -130,9 +153,5 @@ def submit_unfinished_form(session):
             # Found the meta tag, now set the value for timeEnd
             for meta_child in child:
                 if timeEnd_tag_regex.match(meta_child.tag):
-                    meta_child.text = current_timstamp
-    cleaned_xml = tostring(root)
-    
-    # Submit the xml
-    result = submit_form_locally(cleaned_xml, session.domain, app_id=session.app_id, partial_submission=True)
-    session.submission_id = result.xform.form_id
+                    meta_child.text = current_timestamp
+    return tostring(root)

--- a/corehq/apps/smsforms/tests/test_app.py
+++ b/corehq/apps/smsforms/tests/test_app.py
@@ -14,7 +14,6 @@ from corehq.apps.formplayer_api.smsforms.api import (
     TouchformsError,
     XformsResponse,
 )
-from corehq.apps.formplayer_api.smsforms.exceptions import PartialSubmissionXMLIsNone
 from corehq.apps.formplayer_api.smsforms.sms import SessionStartInfo
 from corehq.apps.smsforms.app import (
     _clean_xml_for_partial_submission,
@@ -256,7 +255,3 @@ class TestCleanXMLForPartialSubmission(SimpleTestCase):
         self.assertIsNone(xml.find('case').find('create'))
         self.assertIsNone(xml.find('case').find('update'))
         self.assertIsNone(xml.find('case').find('close'))
-
-    def test_raises_exception_if_xml_is_none(self):
-        with self.assertRaises(PartialSubmissionXMLIsNone):
-            _clean_xml_for_partial_submission(None, should_remove_case_actions=True)

--- a/corehq/apps/smsforms/tests/test_app.py
+++ b/corehq/apps/smsforms/tests/test_app.py
@@ -14,6 +14,7 @@ from corehq.apps.formplayer_api.smsforms.api import (
     TouchformsError,
     XformsResponse,
 )
+from corehq.apps.formplayer_api.smsforms.exceptions import PartialSubmissionXMLIsNone
 from corehq.apps.formplayer_api.smsforms.sms import SessionStartInfo
 from corehq.apps.smsforms.app import (
     _clean_xml_for_partial_submission,
@@ -187,10 +188,10 @@ class TestFetchXml(TestCase):
         result = _fetch_xml(self.formplayer_interface)
         self.assertEqual(result, expected_result)
 
-    def test_returns_none_if_invalid_session_id(self):
+    def test_raises_exception_if_invalid_session_id(self):
         self.mock_get_raw_instance.side_effect = InvalidSessionIdException
-        result = _fetch_xml(self.formplayer_interface)
-        self.assertIsNone(result)
+        with self.assertRaises(InvalidSessionIdException):
+            _fetch_xml(self.formplayer_interface)
 
     def test_raises_touchforms_error_if_response_errors(self):
         self.mock_get_raw_instance.return_value = {'status': 'error'}
@@ -255,3 +256,7 @@ class TestCleanXMLForPartialSubmission(SimpleTestCase):
         self.assertIsNone(xml.find('case').find('create'))
         self.assertIsNone(xml.find('case').find('update'))
         self.assertIsNone(xml.find('case').find('close'))
+
+    def test_raises_exception_if_xml_is_none(self):
+        with self.assertRaises(PartialSubmissionXMLIsNone):
+            _clean_xml_for_partial_submission(None, should_remove_case_actions=True)

--- a/corehq/apps/smsforms/tests/test_app.py
+++ b/corehq/apps/smsforms/tests/test_app.py
@@ -181,11 +181,7 @@ class TestFetchXml(TestCase):
         self.addCleanup(patcher.stop)
 
     def test_successful_response(self):
-        expected_result = '''
-        <data>
-            <question>answer</question>
-        </data>
-        '''.strip()
+        expected_result = '<data><question>answer</question></data>'
 
         self.mock_get_raw_instance.return_value = {'status': 'success', 'output': expected_result}
         result = _fetch_xml(self.formplayer_interface)
@@ -199,7 +195,7 @@ class TestFetchXml(TestCase):
     def test_raises_touchforms_error_if_response_errors(self):
         self.mock_get_raw_instance.return_value = {'status': 'error'}
         with self.assertRaises(TouchformsError):
-            _ = _fetch_xml(self.formplayer_interface)
+            _fetch_xml(self.formplayer_interface)
 
 
 class TestCleanXMLForPartialSubmission(SimpleTestCase):

--- a/corehq/apps/smsforms/tests/test_app.py
+++ b/corehq/apps/smsforms/tests/test_app.py
@@ -1,20 +1,24 @@
 import uuid
+from xml.etree.ElementTree import XML
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from unittest.mock import patch
+
+from dimagi.utils.parsing import json_format_datetime
 
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.xform_builder import XFormBuilder
 from corehq.apps.formplayer_api.smsforms.api import (
     TouchformsError,
-    XformsResponse,
+    XformsResponse, FormplayerInterface, InvalidSessionIdException,
 )
 from corehq.apps.formplayer_api.smsforms.sms import SessionStartInfo
-from corehq.apps.smsforms.app import start_session
+from corehq.apps.smsforms.app import start_session, _fetch_xml, _clean_xml_for_partial_submission
 from corehq.apps.smsforms.models import SQLXFormsSession
 from corehq.apps.users.models import WebUser
 from corehq.form_processor.models import CommCareCase
+from corehq.messaging.scheduling.util import utcnow
 
 
 @patch('corehq.apps.smsforms.app.tfsms.start_session')
@@ -155,3 +159,98 @@ class TestStartSession(TestCase):
         session, responses = self._start_session(yield_responses=False)
 
         self.assertEqual(responses, ["human-error"])
+
+
+class TestFetchXml(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.session = SQLXFormsSession(session_id='abc123', domain='test-domain', user_id='user_id')
+        cls.formplayer_interface = FormplayerInterface(cls.session.session_id, cls.session.domain)
+
+    def setUp(self) -> None:
+        super().setUp()
+        patcher = patch.object(self.formplayer_interface, 'get_raw_instance')
+        self.mock_get_raw_instance = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_successful_response(self):
+        expected_result = '''
+        <data>
+            <question>answer</question>
+        </data>
+        '''.strip()
+
+        self.mock_get_raw_instance.return_value = {'status': 'success', 'output': expected_result}
+        result = _fetch_xml(self.formplayer_interface)
+        self.assertEqual(result, expected_result)
+
+    def test_returns_none_if_invalid_session_id(self):
+        self.mock_get_raw_instance.side_effect = InvalidSessionIdException
+        result = _fetch_xml(self.formplayer_interface)
+        self.assertIsNone(result)
+
+    def test_raises_touchforms_error_if_response_errors(self):
+        self.mock_get_raw_instance.return_value = {'status': 'error'}
+        with self.assertRaises(TouchformsError):
+            _ = _fetch_xml(self.formplayer_interface)
+
+
+class TestCleanXMLForPartialSubmission(SimpleTestCase):
+
+    def test_timeEnd_value_is_set(self):
+        xml_with_case_action = '''
+        <data>
+            <question>answer</question>
+            <meta>
+                <timeEnd/>
+            </meta>
+        </data>
+        '''.strip()
+
+        now = utcnow()
+        expected_time_end = json_format_datetime(now)
+        with patch('corehq.apps.smsforms.app.utcnow', return_value=now):
+            cleaned_xml = _clean_xml_for_partial_submission(xml_with_case_action, should_remove_case_actions=True)
+
+        xml = XML(cleaned_xml)
+        self.assertEqual(xml.find('meta').find('timeEnd').text, expected_time_end)
+
+    def test_case_actions_are_not_removed_when_false(self):
+        xml_with_case_create = '''
+                <data>
+                    <question>answer</question>
+                    <case>
+                        <create></create>
+                        <update></update>
+                        <close></close>
+                    </case>
+                </data>
+                '''.strip()
+
+        cleaned_xml = _clean_xml_for_partial_submission(xml_with_case_create, should_remove_case_actions=False)
+        xml = XML(cleaned_xml)
+        self.assertIsNotNone(xml.find('case'))
+        self.assertIsNotNone(xml.find('case').find('create'))
+        self.assertIsNotNone(xml.find('case').find('update'))
+        self.assertIsNotNone(xml.find('case').find('close'))
+
+    def test_case_actions_are_removed_when_true(self):
+        xml_with_case_create = '''
+                <data>
+                    <question>answer</question>
+                    <case>
+                        <create></create>
+                        <update></update>
+                        <close></close>
+                    </case>
+                </data>
+                '''.strip()
+
+        cleaned_xml = _clean_xml_for_partial_submission(xml_with_case_create, should_remove_case_actions=True)
+        xml = XML(cleaned_xml)
+        self.assertIsNotNone(xml.find('case'))
+        self.assertIsNone(xml.find('case').find('create'))
+        self.assertIsNone(xml.find('case').find('update'))
+        self.assertIsNone(xml.find('case').find('close'))

--- a/corehq/apps/smsforms/tests/test_app.py
+++ b/corehq/apps/smsforms/tests/test_app.py
@@ -1,20 +1,25 @@
 import uuid
+from unittest.mock import patch
 from xml.etree.ElementTree import XML
 
 from django.test import SimpleTestCase, TestCase
-
-from unittest.mock import patch
 
 from dimagi.utils.parsing import json_format_datetime
 
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.xform_builder import XFormBuilder
 from corehq.apps.formplayer_api.smsforms.api import (
+    FormplayerInterface,
+    InvalidSessionIdException,
     TouchformsError,
-    XformsResponse, FormplayerInterface, InvalidSessionIdException,
+    XformsResponse,
 )
 from corehq.apps.formplayer_api.smsforms.sms import SessionStartInfo
-from corehq.apps.smsforms.app import start_session, _fetch_xml, _clean_xml_for_partial_submission
+from corehq.apps.smsforms.app import (
+    _clean_xml_for_partial_submission,
+    _fetch_xml,
+    start_session,
+)
 from corehq.apps.smsforms.models import SQLXFormsSession
 from corehq.apps.users.models import WebUser
 from corehq.form_processor.models import CommCareCase

--- a/corehq/apps/smsforms/tests/test_app.py
+++ b/corehq/apps/smsforms/tests/test_app.py
@@ -201,10 +201,6 @@ class TestFetchXml(TestCase):
         with self.assertRaises(TouchformsError):
             _ = _fetch_xml(self.formplayer_interface)
 
-    def test_get_raw_instance_respects_relevancy(self):
-        _ = _fetch_xml(self.formplayer_interface)
-        self.mock_get_raw_instance.assert_called_once_with(respect_relevancy=True)
-
 
 class TestCleanXMLForPartialSubmission(SimpleTestCase):
 

--- a/corehq/apps/smsforms/tests/test_app.py
+++ b/corehq/apps/smsforms/tests/test_app.py
@@ -201,6 +201,10 @@ class TestFetchXml(TestCase):
         with self.assertRaises(TouchformsError):
             _ = _fetch_xml(self.formplayer_interface)
 
+    def test_get_raw_instance_respects_relevancy(self):
+        _ = _fetch_xml(self.formplayer_interface)
+        self.mock_get_raw_instance.assert_called_once_with(respect_relevancy=True)
+
 
 class TestCleanXMLForPartialSubmission(SimpleTestCase):
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13204

Accompanies this [formplayer PR](https://github.com/dimagi/formplayer/pull/1101). Formplayer needs to know if the instance is going to be used for submission or not before serializing a form's xml to know whether or not to respect relevancy. The bug here is that when an sms survey session expires, the partially completed form that is submitted does not respect relevancy because formplayer does not properly serialize the xml.

I am now wondering if it is helpful or adds to confusion to name this parameter `for_submission` vs something like `serialize_all_data` or `respect_relevancy`. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Added tests in formplayer. Will test on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned, but could request if that seems advisable. 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
