### PR TITLE
Rename metric commcare.security.ssrf_attempt to reflect more general usage

### DIFF
--- a/corehq/motech/auth.py
+++ b/corehq/motech/auth.py
@@ -97,7 +97,7 @@ class AuthManager:
         Returns an instance of requests.Session. Manages authentication
         tokens, if applicable.
         """
-        session = get_public_only_session(domain_name, src='sent_attempt')
+        session = get_public_only_session(domain_name, src='motech_send_attempt')
         session.auth = self.get_auth()
         return session
 
@@ -230,7 +230,7 @@ class OAuth2ClientGrantManager(AuthManager):
             auto_refresh_kwargs=refresh_kwargs,
             token_updater=set_last_token
         )
-        make_session_public_only(session, domain_name, src='oauth_sent_attempt')
+        make_session_public_only(session, domain_name, src='motech_oauth_send_attempt')
         return session
 
 
@@ -313,5 +313,5 @@ class OAuth2PasswordGrantManager(AuthManager):
             auto_refresh_kwargs=refresh_kwargs,
             token_updater=set_last_token
         )
-        make_session_public_only(session, domain_name, src='oauth_sent_attempt')
+        make_session_public_only(session, domain_name, src='motech_oauth_send_attempt')
         return session

--- a/corehq/motech/forms.py
+++ b/corehq/motech/forms.py
@@ -199,7 +199,7 @@ class ConnectionSettingsForm(forms.ModelForm):
 
     def _clean_url(self, url):
         try:
-            validate_user_input_url_for_repeaters(url, domain=self.domain, src='save_config')
+            validate_user_input_url_for_repeaters(url, domain=self.domain, src='motech_save_config')
         except CannotResolveHost:
             # Catching and wrapping this error means that unreachable hosts do not cause the form to be invalid.
             # The reason this is important is because we want to accept configurations where the host has not

--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -322,7 +322,7 @@ def validate_user_input_url_for_repeaters(url, domain, src):
         if settings.DEBUG and e.reason == 'is_loopback':
             pass
         else:
-            metrics_counter('commcare.repeaters.ssrf_attempt', tags={
+            metrics_counter('commcare.security.ssrf_attempt', tags={
                 'domain': domain,
                 'src': src,
                 'reason': e.reason


### PR DESCRIPTION
## Product Description
No user facing change.

## Technical Summary
Rename metric `commcare.repeaters.ssrf_attempt` to `commcare.security.ssrf_attempt` to reflect more general usage and update tag names to reflect this as well (by namespacing the ones related to repeaters).

## Safety Assurance

### Safety story
This change is strictly limited to the names of metrics, so it should risk changing any user-facing behavior at all.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

Not planning on any.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
