### PR TITLE
Use default username max length in auth forms

### DIFF
--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -29,7 +29,7 @@ LOCKOUT_MESSAGE = mark_safe(_(  # nosec: no user input
 
 
 class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
-    username = forms.EmailField(label=_("Email Address"), max_length=75,
+    username = forms.EmailField(label=_("Email Address"),
                                 widget=forms.TextInput(attrs={'class': 'form-control'}))
     password = forms.CharField(label=_("Password"), widget=forms.PasswordInput(attrs={'class': 'form-control'}))
     if settings.ADD_CAPTCHA_FIELD_TO_FORMS:
@@ -37,6 +37,7 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._fix_username_max_length()
         if settings.ENFORCE_SSO_LOGIN:
             self.fields['username'].widget = forms.TextInput(attrs={
                 'class': 'form-control',
@@ -47,6 +48,14 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
                 'class': 'form-control',
                 'placeholder': _("Enter password"),
             })
+
+    def _fix_username_max_length(self):
+        # TODO remove when Django 2 is no longer supported
+        # Django overwrites username max length with
+        # UserModel._meta.get_field(UserModel.USERNAME_FIELD).max_length
+        # This was done incompletely prior to Django 3.1
+        # https://github.com/django/django/commit/6c9778a58e4f680db180d4cc9dc5639d2ec1b40c
+        self.fields['username'].widget.attrs["maxlength"] = self.fields['username'].max_length
 
     def clean_username(self):
         username = self.cleaned_data.get('username', '').lower()
@@ -82,7 +91,7 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
 
 
 class CloudCareAuthenticationForm(EmailAuthenticationForm):
-    username = forms.CharField(label=_("Username"), max_length=75,
+    username = forms.CharField(label=_("Username"),
                                widget=forms.TextInput(attrs={'class': 'form-control'}))
 
 

--- a/corehq/apps/hqwebapp/tests/test_sso_enforced_login.py
+++ b/corehq/apps/hqwebapp/tests/test_sso_enforced_login.py
@@ -231,7 +231,7 @@ class TestEmailAuthenticationFormWithSso(TestCase):
             form.fields['username'].widget.attrs,
             {
                 'class': 'form-control',
-                'maxlength': '75',
+                'maxlength': 150,
             }
         )
         self.assertEqual(
@@ -240,3 +240,7 @@ class TestEmailAuthenticationFormWithSso(TestCase):
                 'class': 'form-control',
             }
         )
+
+    def test_form_username_max_length(self):
+        username = EmailAuthenticationForm().fields["username"]
+        self.assertEqual(username.max_length, username.widget.attrs["maxlength"])


### PR DESCRIPTION
Username max length values were inconsistent between the form field (used in Python code) and the widget (presumably used in JavaScript). The default [username max length](https://github.com/django/django/blob/39ae8d740e30c18e46873cf82aff76588f1974c7/django/contrib/auth/models.py#L346) in Django is 150, and [`AuthenticationForm.__init__()` overwrites its username max length](https://github.com/django/django/blob/39ae8d740e30c18e46873cf82aff76588f1974c7/django/contrib/auth/forms.py#L206-L208) with that value ([less completely prior to Django 3.1](https://github.com/django/django/commit/6c9778a58e4f680db180d4cc9dc5639d2ec1b40c)).

This PR removes `max_length=75` since that value is overwritten. It also fixes the inconsistency between the field and its widget.

## Safety Assurance

### Automated test coverage

Some. The modified test was failing on Django 3.2, which is how this issue was discovered. A test was added to ensure field `max_length` matches the widget `maxlength`.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
