### PR TITLE
Remove enterprise specific "limitation"

### DIFF
--- a/corehq/apps/accounting/utils/account.py
+++ b/corehq/apps/accounting/utils/account.py
@@ -15,11 +15,3 @@ def get_account_or_404(domain):
 def request_has_permissions_for_enterprise_admin(request, account):
     return (account.has_enterprise_admin(request.couch_user.username)
             or has_privilege(request, privileges.ACCOUNTING_ADMIN))
-
-
-def domain_is_enterprise(domain):
-    subscription = Subscription.get_active_subscription_by_domain(domain)
-    try:
-        return subscription.plan_version.plan.edition == SoftwarePlanEdition.ENTERPRISE
-    except AttributeError:
-        return False

--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -1,9 +1,7 @@
 from django.db.models.expressions import RawSQL
 
 from corehq import toggles
-from corehq.apps.accounting.models import BillingAccount
 from corehq.apps.accounting.utils import domain_has_privilege
-from corehq.apps.accounting.utils.account import domain_is_enterprise
 from corehq.apps.domain.models import Domain
 from corehq.apps.linked_domain.models import DomainLink, DomainLinkHistory
 from corehq.apps.linked_domain.util import (

--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -89,31 +89,14 @@ def get_available_upstream_domains(downstream_domain, user):
     :param user: user object
     :return: list of domain names available to link as downstream projects
     """
-    upstream_domains = set()
-    if domain_is_enterprise(downstream_domain) and domain_has_privilege(downstream_domain, RELEASE_MANAGEMENT):
-        upstream_domains = upstream_domains.union(
-            get_available_upstream_domains_for_enterprise(downstream_domain, user)
-        )
-
     if domain_has_privilege(downstream_domain, RELEASE_MANAGEMENT) or \
             domain_has_privilege(downstream_domain, LITE_RELEASE_MANAGEMENT):
-        upstream_domains = upstream_domains.union(
-            get_available_upstream_domains_for_user(downstream_domain, user, should_enforce_admin=True)
-        )
-
-    if upstream_domains:
-        return list(upstream_domains)
+        return get_available_upstream_domains_for_user(downstream_domain, user, should_enforce_admin=True)
 
     # DEPRECATED: acting as a fallback for now. Will remove once all domains are migrated off of this flag
     if toggles.LINKED_DOMAINS.enabled(downstream_domain):
         return get_available_upstream_domains_for_user(downstream_domain, user, should_enforce_admin=False)
     return []
-
-
-def get_available_upstream_domains_for_enterprise(downstream_domain, user):
-    account = BillingAccount.get_account_by_domain(downstream_domain)
-    domains = account.get_domains() if account else []
-    return list({d for d in domains if is_available_upstream_domain(d, downstream_domain, user)})
 
 
 def get_available_upstream_domains_for_user(domain_name, user, should_enforce_admin):

--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -63,36 +63,14 @@ def get_available_domains_to_link(upstream_domain, user):
     :param user: user object
     :return: list of domain names available to link as downstream projects
     """
-    available_domains = set()
-
-    if domain_is_enterprise(upstream_domain) and domain_has_privilege(upstream_domain, RELEASE_MANAGEMENT):
-        available_domains = available_domains.union(
-            get_available_domains_to_link_for_enterprise(upstream_domain, user)
-        )
-
     if domain_has_privilege(upstream_domain, RELEASE_MANAGEMENT) or \
             domain_has_privilege(upstream_domain, LITE_RELEASE_MANAGEMENT):
-        available_domains = available_domains.union(
-            get_available_domains_to_link_for_user(upstream_domain, user, should_enforce_admin=True)
-        )
-
-    if available_domains:
-        return list(available_domains)
+        return get_available_domains_to_link_for_user(upstream_domain, user, should_enforce_admin=True)
 
     # DEPRECATED: acting as a fallback for now. Will remove once all domains are migrated off of this flag
     if toggles.LINKED_DOMAINS.enabled(upstream_domain):
         return get_available_domains_to_link_for_user(upstream_domain, user, should_enforce_admin=False)
     return []
-
-
-def get_available_domains_to_link_for_enterprise(upstream_domain_name, user):
-    """
-    Finds available domains to link based on domains associated with the provided account
-    """
-    account = BillingAccount.get_account_by_domain(upstream_domain_name)
-    domains = account.get_domains() if account else []
-    return list({domain for domain in domains
-                 if is_domain_available_to_link(upstream_domain_name, domain, user)})
 
 
 def get_available_domains_to_link_for_user(upstream_domain_name, user, should_enforce_admin):

--- a/corehq/apps/linked_domain/tests/test_dbaccessors.py
+++ b/corehq/apps/linked_domain/tests/test_dbaccessors.py
@@ -104,20 +104,9 @@ class TestGetAvailableDomainsToLink(SimpleTestCase):
         self.mock_domain_has_privilege = privilege_patcher.start()
         self.addCleanup(privilege_patcher.stop)
 
-        account_patcher = patch(
-            'corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_enterprise'
-        )
-        self.mock_available_account_domains = account_patcher.start()
-        self.addCleanup(account_patcher.stop)
-
         user_patcher = patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_user')
         self.mock_available_user_domains = user_patcher.start()
         self.addCleanup(user_patcher.stop)
-
-        enterprise_patcher = patch('corehq.apps.linked_domain.dbaccessors.domain_is_enterprise')
-        self.mock_is_enterprise = enterprise_patcher.start()
-        self.mock_is_enterprise.return_value = False
-        self.addCleanup(enterprise_patcher.stop)
 
     def test_returns_empty_if_no_privilege_or_feature_flag(self, mock_user):
         self.mock_domain_has_privilege.return_value = False
@@ -126,41 +115,18 @@ class TestGetAvailableDomainsToLink(SimpleTestCase):
 
         self.assertFalse(domains)
 
-    def test_returns_domains_for_account_and_user_if_enterprise_and_release_management_privilege(self, mock_user):
-        self.mock_is_enterprise.return_value = True
-        self.mock_domain_has_privilege.return_value = True
-        self.mock_available_account_domains.return_value = ['account-domain']
-        self.mock_available_user_domains.return_value = ['user-domain']
-
-        domains = get_available_domains_to_link('upstream', mock_user)
-
-        self.assertSetEqual(set(domains), {'account-domain', 'user-domain'})
-
-    def test_does_not_return_duplicate_domains_if_enterprise_and_release_management_privilege(self, mock_user):
-        self.mock_is_enterprise.return_value = True
-        self.mock_domain_has_privilege.return_value = True
-        self.mock_available_account_domains.return_value = ['domain']
-        self.mock_available_user_domains.return_value = ['domain']
-
-        domains = get_available_domains_to_link('upstream', mock_user)
-
-        self.assertEqual(len(domains), 1)
-        self.assertEqual(domains[0], 'domain')
-
-    def test_returns_domains_for_user_if_not_enterprise_and_release_management_privilege(self, mock_user):
-        self.mock_is_enterprise.return_value = False
-        self.mock_domain_has_privilege.return_value = True
+    def test_returns_domains_for_user_if_release_management_privilege(self, mock_user):
+        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
         self.mock_available_user_domains.return_value = self.expected_domains
-        self.mock_available_account_domains.return_value = ['wrong']
 
         domains = get_available_domains_to_link('upstream', mock_user)
 
+        self.mock_available_user_domains.assert_called_with('upstream', mock_user, should_enforce_admin=True)
         self.assertSetEqual(set(domains), set(self.expected_domains))
 
-    def test_returns_admin_domains_for_users_if_lite_release_management_privilege(self, mock_user):
+    def test_returns_domains_for_user_if_lite_release_management_privilege(self, mock_user):
         self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == LITE_RELEASE_MANAGEMENT
         self.mock_available_user_domains.return_value = self.expected_domains
-        self.mock_available_account_domains.return_value = ['wrong']
 
         domains = get_available_domains_to_link('upstream', mock_user)
 
@@ -171,7 +137,6 @@ class TestGetAvailableDomainsToLink(SimpleTestCase):
     def test_returns_domains_for_user_for_linked_domains_flag(self, mock_user):
         self.mock_domain_has_privilege.return_value = False
         self.mock_available_user_domains.return_value = self.expected_domains
-        self.mock_available_account_domains.return_value = ['wrong']
 
         domains = get_available_domains_to_link('upstream', mock_user)
 

--- a/corehq/apps/linked_domain/tests/test_dbaccessors.py
+++ b/corehq/apps/linked_domain/tests/test_dbaccessors.py
@@ -21,20 +21,9 @@ class TestGetAvailableUpstreamDomains(SimpleTestCase):
         self.mock_domain_has_privilege = privilege_patcher.start()
         self.addCleanup(privilege_patcher.stop)
 
-        account_patcher = patch(
-            'corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_enterprise'
-        )
-        self.mock_available_account_domains = account_patcher.start()
-        self.addCleanup(account_patcher.stop)
-
         user_patcher = patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_user')
         self.mock_available_user_domains = user_patcher.start()
         self.addCleanup(user_patcher.stop)
-
-        enterprise_patcher = patch('corehq.apps.linked_domain.dbaccessors.domain_is_enterprise')
-        self.mock_is_enterprise = enterprise_patcher.start()
-        self.mock_is_enterprise.return_value = False
-        self.addCleanup(enterprise_patcher.stop)
 
     def test_returns_empty_if_no_privilege_or_feature_flag(self, mock_user):
         self.mock_domain_has_privilege.return_value = False
@@ -43,37 +32,16 @@ class TestGetAvailableUpstreamDomains(SimpleTestCase):
 
         self.assertFalse(upstream_domains)
 
-    def test_returns_domains_for_account_and_user_if_enterprise_and_release_management_privilege(self, mock_user):
-        self.mock_is_enterprise.return_value = True
-        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
-        self.mock_available_account_domains.return_value = ['account-domain']
-        self.mock_available_user_domains.return_value = ['user-domain']
-
-        upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
-
-        self.assertSetEqual(set(upstream_domains), {'account-domain', 'user-domain'})
-
-    def test_does_not_return_duplicate_domains_if_enterprise_and_release_management_privilege(self, mock_user):
-        self.mock_is_enterprise.return_value = True
-        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
-        self.mock_available_account_domains.return_value = ['domain']
-        self.mock_available_user_domains.return_value = ['domain']
-
-        upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
-
-        self.assertEqual(len(upstream_domains), 1)
-        self.assertEqual(upstream_domains[0], 'domain')
-
-    def test_returns_domains_for_user_if_not_enterprise_and_release_management_privilege(self, mock_user):
-        self.mock_is_enterprise.return_value = False
+    def test_returns_domains_for_user_if_release_management_privilege(self, mock_user):
         self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
         self.mock_available_user_domains.return_value = self.expected_domains
 
         upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
 
+        self.mock_available_user_domains.assert_called_with('downstream-1', mock_user, should_enforce_admin=True)
         self.assertSetEqual(set(upstream_domains), set(self.expected_domains))
 
-    def test_returns_admin_domains_for_user_if_lite_release_management_privilege(self, mock_user):
+    def test_returns_domains_for_user_if_lite_release_management_privilege(self, mock_user):
         self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == LITE_RELEASE_MANAGEMENT
         self.mock_available_user_domains.return_value = self.expected_domains
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Parent PR: https://github.com/dimagi/commcare-hq/pull/31047

I realized the check for domains within the enterprise account adds complexity but no value since the check still enforces the current user being an admin in any eligible domain. This combined with the fact that ERM users are also shown domains they are admins in outside of the enterprise account means this logic can be simplified by just showing the user domains they are admins in. This reduces the differences between ERM and MRM, reduces code complexity, and maintains the existing behavior. 


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Maintains existing behavior, backed by tests.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests cover this logic.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
