### PR TITLE
Enable Markdown formatting in UCR columns

### DIFF
--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -1810,6 +1810,24 @@ Round to the nearest whole number
        "format_string": "{0:.0f}"
    }
 
+
+Rich text formatting with Markdown
+''''''''''''''''''''''''''''''''''
+
+This can be used to do some rich text formatting, using [Markdown](https://www.markdownguide.org/).
+
+There is no configuration required, it will assume the input is valid, markdown-ready text.
+
+.. code:: json
+
+   {
+       "type": "markdown"
+   }
+
+**This transform works for report columns only.**
+Using it in a data source will add HTML markup, but it will not be displayed properly in HQ.
+
+
 Always round to 3 decimal places
 ''''''''''''''''''''''''''''''''
 

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -13,6 +13,7 @@ from django.http import (
 )
 from django.http.response import HttpResponseServerError
 from django.shortcuts import redirect, render
+from django.utils.safestring import SafeText
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop
 from django.utils.html import escape
@@ -418,9 +419,8 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
 
     @classmethod
     def _sanitize_column(cls, col):
-        if isinstance(col, str):
+        if isinstance(col, str) and not isinstance(col, SafeText):
             return escape(col)
-
         return col
 
     def get_ajax(self, params):

--- a/corehq/apps/userreports/tests/test_transforms.py
+++ b/corehq/apps/userreports/tests/test_transforms.py
@@ -233,3 +233,5 @@ class MarkdownTransformTest(SimpleTestCase):
         self.assertEqual(transform('Hello **strong** world!'), '<p>Hello <strong>strong</strong> world!</p>')
         self.assertEqual(transform('Hello [example](http://www.example.com)!'),
                          '<p>Hello <a href="http://www.example.com">example</a>!</p>')
+        self.assertEqual(transform('Hello <script>alert("pwned!");</script>'),
+                         '<p>Hello &lt;script&gt;alert(&quot;pwned!&quot;);&lt;/script&gt;</p>')

--- a/corehq/apps/userreports/tests/test_transforms.py
+++ b/corehq/apps/userreports/tests/test_transforms.py
@@ -221,3 +221,15 @@ class MultiValueStringTranslationTransform(SimpleTestCase):
         self.assertEqual(transform('#800080 #123456'), 'Purple #123456')
         self.assertEqual(transform('#123 #123456'), '#123 #123456')
         self.assertEqual(transform("#0000FF"), "Blue")
+
+
+class MarkdownTransformTest(SimpleTestCase):
+
+    def test_markdown_rendering(self):
+        transform = TransformFactory.get_transform({
+            "type": "markdown",
+        }).get_transform_function()
+        self.assertEqual(transform('Hello World!'), '<p>Hello World!</p>')
+        self.assertEqual(transform('Hello **strong** world!'), '<p>Hello <strong>strong</strong> world!</p>')
+        self.assertEqual(transform('Hello [example](http://www.example.com)!'),
+                         '<p>Hello <a href="http://www.example.com">example</a>!</p>')

--- a/corehq/apps/userreports/transforms/factory.py
+++ b/corehq/apps/userreports/transforms/factory.py
@@ -11,7 +11,7 @@ from corehq.apps.userreports.transforms.specs import (
     MultipleValueStringTranslationTransform,
     NumberFormatTransform,
     TranslationTransform,
-    MarkDownTransform,
+    MarkdownTransform,
 )
 
 
@@ -22,7 +22,7 @@ class TransformFactory(object):
         'number_format': NumberFormatTransform,
         'translation': TranslationTransform,
         'multiple_value_string_translation': MultipleValueStringTranslationTransform,
-        'markdown': MarkDownTransform,
+        'markdown': MarkdownTransform,
     }
 
     @classmethod

--- a/corehq/apps/userreports/transforms/factory.py
+++ b/corehq/apps/userreports/transforms/factory.py
@@ -11,6 +11,7 @@ from corehq.apps.userreports.transforms.specs import (
     MultipleValueStringTranslationTransform,
     NumberFormatTransform,
     TranslationTransform,
+    MarkDownTransform,
 )
 
 
@@ -20,7 +21,8 @@ class TransformFactory(object):
         'date_format': DateFormatTransform,
         'number_format': NumberFormatTransform,
         'translation': TranslationTransform,
-        'multiple_value_string_translation': MultipleValueStringTranslationTransform
+        'multiple_value_string_translation': MultipleValueStringTranslationTransform,
+        'markdown': MarkDownTransform,
     }
 
     @classmethod

--- a/corehq/apps/userreports/transforms/specs.py
+++ b/corehq/apps/userreports/transforms/specs.py
@@ -133,7 +133,7 @@ class MultipleValueStringTranslationTransform(TranslationTransform):
         return transform_function
 
 
-class MarkDownTransform(Transform):
+class MarkdownTransform(Transform):
     """Transform that lets you render markdown to HTML in a report."""
     type = TypeProperty('markdown')
 

--- a/corehq/apps/userreports/transforms/specs.py
+++ b/corehq/apps/userreports/transforms/specs.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 
 import markdown
+from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language
 
@@ -139,7 +140,8 @@ class MarkDownTransform(Transform):
     def get_transform_function(self):
         def _markdown_text(value):
             if isinstance(value, str):
-                return mark_safe(markdown.markdown(value))
+                escaped_value = conditional_escape(value)
+                return mark_safe(markdown.markdown(escaped_value))
             return value
 
         return _markdown_text

--- a/corehq/apps/userreports/transforms/specs.py
+++ b/corehq/apps/userreports/transforms/specs.py
@@ -141,7 +141,7 @@ class MarkDownTransform(Transform):
         def _markdown_text(value):
             if isinstance(value, str):
                 escaped_value = conditional_escape(value)
-                return mark_safe(markdown.markdown(escaped_value))
+                return mark_safe(markdown.markdown(escaped_value))  # nosec: trust markdown after escaping value
             return value
 
         return _markdown_text

--- a/corehq/apps/userreports/transforms/specs.py
+++ b/corehq/apps/userreports/transforms/specs.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
 
+import markdown
+from django.utils.safestring import mark_safe
 from django.utils.translation import get_language
 
 from dimagi.ext.jsonobject import DictProperty, JsonObject, StringProperty
@@ -128,3 +130,14 @@ class MultipleValueStringTranslationTransform(TranslationTransform):
             return delimiter.join(translated_values_list)
 
         return transform_function
+
+
+class MarkDownTransform(Transform):
+    """Transform that lets you render markdown to HTML in a report."""
+    type = TypeProperty('markdown')
+
+    def get_transform_function(self):
+        def _markdown_text(value):
+            return mark_safe(markdown.markdown(value))
+
+        return _markdown_text

--- a/corehq/apps/userreports/transforms/specs.py
+++ b/corehq/apps/userreports/transforms/specs.py
@@ -138,6 +138,8 @@ class MarkDownTransform(Transform):
 
     def get_transform_function(self):
         def _markdown_text(value):
-            return mark_safe(markdown.markdown(value))
+            if isinstance(value, str):
+                return mark_safe(markdown.markdown(value))
+            return value
 
         return _markdown_text

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -77,6 +77,7 @@ billiard!=3.5.0.5 # Should be resolved in celery 4.3: https://github.com/celery/
     # This comment can be removed when that issue is resolved.
 laboratory
 lxml
+markdown
 openpyxl
 phonenumberslite
 pickle5  # For Pythons pre 3.8.3. Can be removed when no environment will ever revert to < 3.8

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -266,6 +266,8 @@ idna==2.10
     #   requests
 imagesize==1.2.0
     # via sphinx
+importlib-metadata==4.11.3
+    # via markdown
 intervaltree==3.1.0
     # via ddtrace
 ipython==8.0.1
@@ -321,6 +323,8 @@ mako==1.1.3
     # via alembic
 mando==0.6.4
     # via radon
+markdown==3.3.6
+    # via -r base-requirements.in
 markupsafe==1.1.1
     # via
     #   jinja2
@@ -681,6 +685,8 @@ xmlsec==1.3.11
     # via python3-saml
 yapf==0.31.0
     # via -r dev-requirements.in
+zipp==3.7.0
+    # via importlib-metadata
 zope-event==4.5.0
     # via gevent
 zope-interface==5.4.0

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -223,6 +223,8 @@ idna==2.10
     #   requests
 imagesize==1.2.0
     # via sphinx
+importlib-metadata==4.11.3
+    # via markdown
 intervaltree==3.1.0
     # via ddtrace
 iso8601==0.1.13
@@ -268,6 +270,8 @@ lxml==4.7.1
     #   eulxml
 mako==1.1.3
     # via alembic
+markdown==3.3.6
+    # via -r base-requirements.in
 markdown-it-py==1.1.0
     # via
     #   mdit-py-plugins
@@ -540,6 +544,8 @@ xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
+zipp==3.7.0
+    # via importlib-metadata
 zope-event==4.5.0
     # via gevent
 zope-interface==5.4.0

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -228,6 +228,8 @@ idna==2.10
     #   -r prod-requirements.in
     #   email-validator
     #   requests
+importlib-metadata==4.11.3
+    # via markdown
 intervaltree==3.1.0
     # via ddtrace
 ipython==8.0.1
@@ -278,6 +280,8 @@ lxml==4.7.1
     #   xmlsec
 mako==1.1.3
     # via alembic
+markdown==3.3.6
+    # via -r base-requirements.in
 markupsafe==1.1.1
     # via
     #   jinja2
@@ -567,6 +571,8 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.11
     # via python3-saml
+zipp==3.7.0
+    # via importlib-metadata
 zope-event==4.5.0
     # via gevent
 zope-interface==5.4.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -209,6 +209,8 @@ idna==2.10
     # via
     #   email-validator
     #   requests
+importlib-metadata==4.11.3
+    # via markdown
 intervaltree==3.1.0
     # via ddtrace
 iso8601==0.1.13
@@ -255,6 +257,8 @@ lxml==4.7.1
     #   xmlsec
 mako==1.1.3
     # via alembic
+markdown==3.3.6
+    # via -r base-requirements.in
 markupsafe==1.1.1
     # via
     #   jinja2
@@ -494,6 +498,8 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.11
     # via python3-saml
+zipp==3.7.0
+    # via importlib-metadata
 zope-event==4.5.0
     # via gevent
 zope-interface==5.4.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -227,6 +227,8 @@ idna==2.10
     # via
     #   email-validator
     #   requests
+importlib-metadata==4.11.3
+    # via markdown
 intervaltree==3.1.0
     # via ddtrace
 iso8601==0.1.13
@@ -275,6 +277,8 @@ mako==1.1.3
     # via alembic
 mando==0.6.4
     # via radon
+markdown==3.3.6
+    # via -r base-requirements.in
 markupsafe==1.1.1
     # via
     #   jinja2
@@ -547,6 +551,8 @@ xlwt==1.3.0
     # via -r base-requirements.in
 xmlsec==1.3.11
     # via python3-saml
+zipp==3.7.0
+    # via importlib-metadata
 zope-event==4.5.0
     # via gevent
 zope-interface==5.4.0


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This allows creating a UCR data source column as Markdown text and then rendering it in the Report UI. It can be used to do things like add links to URLs (the most immediate example).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

@idiene asked me to see how far I could get with this in an hour and this was the result. ~~I was almost able to finish it, but my `make requirements` generated files that had several other changes so I didn't commit the updated files yet.~~ (fixed by upgrading pip-tools)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

UCR

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

I added a test and tested locally. Also, it's an obscure feature in an already-feature-flagged area.

The only thing I haven't fully thought through is whether there are any security implications of not sanitizing the text coming out of this column before passing it to the front end.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Added a test. UCRs have lots of adjacent tests.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Not recommending QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
