### PR TITLE
Remove safe filter from custom data fields

### DIFF
--- a/corehq/apps/custom_data_fields/edit_model.py
+++ b/corehq/apps/custom_data_fields/edit_model.py
@@ -7,6 +7,8 @@ from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, validate_slug
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
+from django.utils.safestring import mark_safe
+from django.utils.html import format_html_join
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq import privileges
 
@@ -151,7 +153,9 @@ class CustomDataFieldsForm(forms.Form):
         errors.update(self.verify_profiles_validate(data_fields, profiles))
 
         if errors:
-            raise ValidationError('<br/>'.join(sorted(errors)))
+            separator = mark_safe('<br/>')  # nosec: no user input
+            error_html = format_html_join(separator, '{}', ((error,) for error in sorted(errors)))
+            raise ValidationError(error_html)
 
         return cleaned_data
 

--- a/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
+++ b/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
@@ -33,7 +33,7 @@
       {% for field, errors in custom_fields_form.errors.items %}
         {% for error in errors %}
           <div class="alert alert-danger">
-            {{ error|safe }}
+            {{ error }}
             <button type="button" class="close" data-dismiss="alert">&times;</button>
           </div>
         {% endfor %}


### PR DESCRIPTION
## Technical Summary
One of many PRs [removing safe from templates](https://dimagi-dev.atlassian.net/browse/SAAS-12098)

## Safety Assurance

### Safety story
This will be QA'd on staging

### Automated test coverage

None

### QA Plan
Will be releasing several PRs to QA for easier testing.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
