### PR TITLE
remove safe filter from openmrs

### DIFF
--- a/corehq/motech/openmrs/forms.py
+++ b/corehq/motech/openmrs/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.core.exceptions import ValidationError
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 
@@ -103,7 +104,8 @@ class OpenmrsImporterForm(forms.Form):
                                    help_text=_('Space-separated column(s) to be concatenated to create the case '
                                                'name (e.g. "givenName familyName")'))
     column_map = JsonField(label=_('Map columns to properties'), required=True, expected_type=list,
-                           help_text=_('e.g. [{"column": "givenName", "property": "first_name"}, ...]'))
+                           help_text=mark_safe(  # nosec: no user input
+                               _('e.g. [{"column": "givenName", "property": "first_name"}, ...]')))
 
 
 class OpenmrsRepeaterForm(CaseRepeaterForm):

--- a/corehq/motech/openmrs/templates/openmrs/partials/openmrs_importer_template.html
+++ b/corehq/motech/openmrs/templates/openmrs/partials/openmrs_importer_template.html
@@ -39,7 +39,7 @@
                        data-bind="value: {{ field.html_name }}" />
                 {% endif %}
                 {% if field.help_text %}
-                <p class="help-block">{{ field.help_text|safe }}</p>
+                <p class="help-block">{{ field.help_text }}</p>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
## Technical Summary
One of many PRs [removing safe from templates](https://dimagi-dev.atlassian.net/browse/SAAS-12098)

## Safety Assurance

### Safety story
This will be QA'd on staging

### Automated test coverage

None

### QA Plan
Will be releasing several PRs to QA for easier testing.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
