### PR TITLE
use 'spec' reporter when running in verbose mode

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,11 +64,12 @@ module.exports = function(grunt) {
         var currentApp = queuedTests[0],
             currentTestPath = BASE_URL + currentApp,
             testText = "Running Test '" + currentApp + "'",
+            reporter = grunt.option('verbose') ? 'spec' : 'dot',
             runner_options = {
                 file: currentTestPath,
                 visible: false,
                 timeout: 120000,
-                reporter: 'dot',
+                reporter: reporter,
             };
 
         // For running in docker/travis


### PR DESCRIPTION
## Technical Summary
Change to grunt config file to output test names when verbose mode is on.

## Safety Assurance

### Safety story
Affects build config only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
