### PR TITLE
add enterprise limits to per user rate definitions

### DIFF
--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -306,9 +306,10 @@ def get_project_limits_context(name_limiter_tuple_list, scope=None):
 
 def _get_rate_limits(scope, rate_limiter):
     return [
-        {'key': key, 'current_usage': int(current_usage), 'limit': int(limit),
+        {'key': scope + ' ' + key, 'current_usage': int(current_usage), 'limit': int(limit),
          'percent_usage': round(100 * current_usage / limit, 1)}
-        for key, current_usage, limit in rate_limiter.iter_rates(scope)
+        for scope, limits in rate_limiter.iter_rates(scope)
+        for key, current_usage, limit in limits
     ]
 
 

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -306,7 +306,7 @@ def get_project_limits_context(name_limiter_tuple_list, scope=None):
 
 def _get_rate_limits(scope, rate_limiter):
     return [
-        {'key': scope + ' ' + key, 'current_usage': int(current_usage), 'limit': int(limit),
+        {'key': ','.join(scope) + ' ' + key, 'current_usage': int(current_usage), 'limit': int(limit),
          'percent_usage': round(100 * current_usage / limit, 1)}
         for scope, limits in rate_limiter.iter_rates(scope)
         for key, current_usage, limit in limits

--- a/corehq/apps/hqwebapp/two_factor_gateways.py
+++ b/corehq/apps/hqwebapp/two_factor_gateways.py
@@ -249,10 +249,13 @@ def _report_usage(ip_address, number, username):
 
 
 def _report_current_global_two_factor_setup_rate_limiter():
-    for window, value, threshold in global_two_factor_setup_rate_limiter.iter_rates():
-        metrics_gauge('commcare.two_factor.global_two_factor_setup_threshold', threshold, tags={
-            'window': window
-        }, multiprocess_mode=MPM_MAX)
-        metrics_gauge('commcare.two_factor.global_two_factor_setup_usage', value, tags={
-            'window': window
-        }, multiprocess_mode=MPM_MAX)
+    for scope, limits in global_two_factor_setup_rate_limiter.iter_rates():
+        for window, value, threshold in limits:
+            metrics_gauge('commcare.two_factor.global_two_factor_setup_threshold', threshold, tags={
+                'window': window,
+                'scope': ','.join(scope)
+            }, multiprocess_mode=MPM_MAX)
+            metrics_gauge('commcare.two_factor.global_two_factor_setup_usage', value, tags={
+                'window': window,
+                'scope': ','.join(scope)
+            }, multiprocess_mode=MPM_MAX)

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -198,21 +198,27 @@ def _delay_and_report_rate_limit_submission(domain, max_wait, delay_rather_than_
 
 @quickcache([], timeout=60)  # Only report up to once a minute
 def _report_current_global_submission_thresholds():
-    for window, value, threshold in global_submission_rate_limiter.iter_rates():
-        metrics_gauge('commcare.xform_submissions.global_threshold', threshold, tags={
-            'window': window
-        }, multiprocess_mode='max')
-        metrics_gauge('commcare.xform_submissions.global_usage', value, tags={
-            'window': window
-        }, multiprocess_mode='max')
+    for scope, limits in global_case_rate_limiter.iter_rates():
+        for window, value, threshold in limits:
+            metrics_gauge('commcare.xform_submissions.global_threshold', threshold, tags={
+                'window': window,
+                'scope': ','.join(scope)
+            }, multiprocess_mode='max')
+            metrics_gauge('commcare.xform_submissions.global_usage', value, tags={
+                'window': window,
+                'scope': ','.join(scope)
+            }, multiprocess_mode='max')
 
 
 @quickcache([], timeout=60)  # Only report up to once a minute
 def _report_current_global_case_update_thresholds():
-    for window, value, threshold in global_case_rate_limiter.iter_rates():
-        metrics_gauge('commcare.case_updates.global_threshold', threshold, tags={
-            'window': window
-        }, multiprocess_mode='max')
-        metrics_gauge('commcare.case_updates.global_usage', value, tags={
-            'window': window
-        }, multiprocess_mode='max')
+    for scope, limits in global_case_rate_limiter.iter_rates():
+        for window, value, threshold in limits:
+            metrics_gauge('commcare.case_updates.global_threshold', threshold, tags={
+                'window': window,
+                'scope': ','.join(scope)
+            }, multiprocess_mode='max')
+            metrics_gauge('commcare.case_updates.global_usage', value, tags={
+                'window': window,
+                'scope': ','.join(scope)
+            }, multiprocess_mode='max')

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -61,7 +61,7 @@ class RateLimiter(object):
     def allow_usage(self, scope=None):
         for rates in self.iter_rates(scope):
             allowed = all(current_rate < limit
-                          for rate_counter_key, current_rate, limit in self.iter_rates(scope))
+                          for rate_counter_key, current_rate, limit in rates)
             # allow usage if any limiter is below the threshold
             if allowed:
                 return True

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -52,14 +52,15 @@ class RateLimiter(object):
                 rate_counter.increment((self.feature_key,) + limit_scope, delta=delta)
 
     def get_window_of_first_exceeded_limit(self, scope=None):
-        for rate_counter_key, current_rate, limit in self.iter_rates(scope):
-            if current_rate >= limit:
-                return rate_counter_key
+        for limit_scope, rates in self.iter_rates(scope):
+            for rate_counter_key, current_rate, limit in rates:
+                if current_rate >= limit:
+                    return rate_counter_key
 
         return None
 
     def allow_usage(self, scope=None):
-        for rates in self.iter_rates(scope):
+        for limit_scope, rates in self.iter_rates(scope):
             allowed = all(current_rate < limit
                           for rate_counter_key, current_rate, limit in rates)
             # allow usage if any limiter is below the threshold
@@ -69,19 +70,23 @@ class RateLimiter(object):
 
     def iter_rates(self, scope=None):
         """
-        Get generator of (key, current rate, rate limit) for each set of limits returned by get_rate_limits
+        Get generator of tuples for each set of limits returned by get_rate_limits, where the first item
+        of the tuple is the normalized scope, and the second is a generator of (key, current rate, rate limit)
+        for each limit in that scope
 
         e.g.
+        (('test-domain'), [
             ('week', 92359, 115000)
             ('day', ...)
             ...
-
+        ])
         """
         scope = self.get_normalized_scope(scope)
         for limit_scope, limits in self.get_rate_limits(*scope):
             yield (
-                (rate_counter.key, rate_counter.get((self.feature_key,) + limit_scope), limit)
-                for rate_counter, limit in limits
+                limit_scope,
+                ((rate_counter.key, rate_counter.get((self.feature_key,) + limit_scope), limit)
+                for rate_counter, limit in limits)
             )
 
     def wait(self, scope, timeout, windows_not_to_wait_on=('hour', 'day', 'week')):
@@ -90,7 +95,8 @@ class RateLimiter(object):
         delay = 0
         larger_windows_allow = all(
             current_rate < limit
-            for rate_counter_key, current_rate, limit in self.iter_rates(scope)
+            for limit_scope, limits in self.iter_rates(scope)
+            for rate_counter_key, current_rate, limit in limits
             if rate_counter_key in windows_not_to_wait_on
         )
         if not larger_windows_allow:
@@ -113,39 +119,18 @@ class RateLimiter(object):
                 time.sleep(delay)
 
 
-@quickcache(['domain', 'enterprise_limit'], memoize_timeout=60, timeout=60 * 60)
-def get_n_users_for_rate_limiting(domain, enterprise_limit=False):
-    """
-    Returns the number of users "allocated" to the project
-
-    That is, the actual number of users or the number of users included in the subscription,
-    whichever is higher.
-
-    This number is then used to portion out resource allocation through rate limiting.
-
-    """
-    n_users_included_in_subscription = _get_users_included_in_subscription(domain, enterprise_limit)
-    if enterprise_limit:
-        n_users = 0
-    else:
-        n_users = _get_user_count(domain)
-    return max(n_users_included_in_subscription, n_users)
-
-
-def _get_user_count(domain):
+@quickcache(['domain'], memoize_timeout=60, timeout=60 * 60)
+def get_n_users_in_domain(domain):
     return CommCareUser.total_by_domain(domain, is_active=True)
 
 
-def _get_users_included_in_subscription(domain, enterprise_limit):
+@quickcache(['domain'], memoize_timeout=60, timeout=60 * 60)
+def get_n_users_in_subscription(domain):
     from corehq.apps.accounting.models import Subscription
     subscription = Subscription.get_active_subscription_by_domain(domain)
     if subscription:
         plan_version = subscription.plan_version
-        num_users = plan_version.feature_rates.get(feature__feature_type='User').monthly_limit
-        if enterprise_limit or not plan_version.plan.is_customer_software_plan:
-            return num_users
-        else:
-            return 0
+        return plan_version.feature_rates.get(feature__feature_type='User').monthly_limit
     else:
         return 0
 
@@ -153,7 +138,11 @@ def _get_users_included_in_subscription(domain, enterprise_limit):
 @quickcache(['domain'], memoize_timeout=60, timeout=60 * 60)
 def _get_account_name(domain):
     from corehq.apps.accounting.models import BillingAccount
-    return BillingAccount.get_account_by_domain(domain).name
+    account = BillingAccount.get_account_by_domain(domain)
+    if account is not None:
+        return account.name
+    else:
+        return domain + 'no_account'
 
 
 class PerUserRateDefinition(object):
@@ -162,8 +151,8 @@ class PerUserRateDefinition(object):
         self.constant_rate_definition = constant_rate_definition or RateDefinition()
 
     def get_rate_limits(self, domain):
-        domain_users = get_n_users_for_rate_limiting(domain)
-        enterprise_users = get_n_users_for_rate_limiting(domain, enterprise_limit=True)
+        domain_users = get_n_users_in_domain(domain)
+        enterprise_users = get_n_users_in_subscription(domain)
         limit_pairs = [
             (domain_users, domain),
             (enterprise_users, _get_account_name(domain))
@@ -175,7 +164,7 @@ class PerUserRateDefinition(object):
                 .times(n_users)
                 .plus(self.constant_rate_definition)
             ).get_rate_limits((scope_key,))
-            limits.append(domain_limit)
+            limits.extend(domain_limit)
         return limits
 
 
@@ -214,14 +203,14 @@ class RateDefinition(object):
     def get_rate_limits(self, scope=None):
         if scope is None:
             scope = ()
-        return (scope, [(rate_counter, limit) for limit, rate_counter in (
+        return [(scope, [(rate_counter, limit) for limit, rate_counter in (
             # order matters for returning the highest priority window
             (self.per_week, week_rate_counter),
             (self.per_day, day_rate_counter),
             (self.per_hour, hour_rate_counter),
             (self.per_minute, minute_rate_counter),
             (self.per_second, second_rate_counter),
-        ) if limit])
+        ) if limit])]
 
 
 @quickcache(['key'], timeout=24 * 60 * 60)

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -145,7 +145,7 @@ def get_n_users_old_enterprise_count(domain):
     if subscription:
         plan_version = subscription.plan_version
         if plan_version.plan.is_customer_software_plan:
-            n_included_users = plan_version.feature_rates.get(feature__feature_type='User').monthly_limit)
+            n_included_users = plan_version.feature_rates.get(feature__feature_type='User').monthly_limit
             # For now just give each domain that's part of an enterprise account
             # access to nearly all of the throughput allocation.
             # Really what we want is to limit enterprise accounts' submissions accross all
@@ -181,11 +181,12 @@ class PerUserRateDefinition(object):
             (domain_users, domain),
             (enterprise_users, _get_account_name(domain))
         ]
-        old_enterprise_calculation = get_n_users_old_enterprise_count
+        old_enterprise_calculation = get_n_users_old_enterprise_count(domain)
         if old_enterprise_calculation is not None:
             limit_pairs.append((old_enterprise_calculation, f'old_enterprise:{domain}'))
         limits = []
         for n_users, scope_key in limit_pairs:
+            print(n_users, scope_key)
             domain_limit = (
                 self.per_user_rate_definition
                 .times(n_users)

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -164,7 +164,7 @@ def _get_account_name(domain):
     from corehq.apps.accounting.models import BillingAccount
     account = BillingAccount.get_account_by_domain(domain)
     if account is not None:
-        return account.name
+        return f'account:{account.name}'
     else:
         return f'no_account:{domain}'
 

--- a/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
+++ b/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
@@ -67,9 +67,9 @@ class GetNUsersForRateLimitingTest(TestCase, DomainSubscriptionMixin):
         # No change on the original domain
         self._assert_value_equals(domain_1, 9)
 
-        # The new domain should get a proportion of total included users for the shared account
+        # Shared account domains return 0
 
-        self._assert_value_equals(domain_2, 7.2)
+        self._assert_value_equals(domain_2, 0)
 
     def _assert_value_equals(self, domain, value):
         get_n_users_for_rate_limiting.clear(domain)

--- a/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
+++ b/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
@@ -6,7 +6,7 @@ from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import format_username
-from corehq.project_limits.rate_limiter import get_n_users_for_rate_limiting
+from corehq.project_limits.rate_limiter import get_n_users_in_domain
 
 
 class GetNUsersForRateLimitingTest(TestCase, DomainSubscriptionMixin):
@@ -53,8 +53,8 @@ class GetNUsersForRateLimitingTest(TestCase, DomainSubscriptionMixin):
 
         _setup(domain_1)
 
-        # With no real users, it's the number of users in the subscription
-        self._assert_value_equals(domain_1, _get_included_in_subscription())
+        # There are no users yet
+        self._assert_value_equals(domain_1, 0)
 
         self._set_n_users(domain_1, 9)
 
@@ -67,13 +67,12 @@ class GetNUsersForRateLimitingTest(TestCase, DomainSubscriptionMixin):
         # No change on the original domain
         self._assert_value_equals(domain_1, 9)
 
-        # Shared account domains return 0
-
+        # new domain has no users
         self._assert_value_equals(domain_2, 0)
 
     def _assert_value_equals(self, domain, value):
-        get_n_users_for_rate_limiting.clear(domain)
-        self.assertEqual(get_n_users_for_rate_limiting(domain), value)
+        get_n_users_in_domain.clear(domain)
+        self.assertEqual(get_n_users_in_domain(domain), value)
 
     def _set_n_users(self, domain, n_users):
         start_n_users = CommCareUser.total_by_domain(domain, is_active=True)

--- a/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
+++ b/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
@@ -6,7 +6,7 @@ from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import format_username
-from corehq.project_limits.rate_limiter import get_n_users_in_domain
+from corehq.project_limits.rate_limiter import get_n_users_in_domain, get_n_users_in_subscription
 
 
 class GetNUsersForRateLimitingTest(TestCase, DomainSubscriptionMixin):
@@ -16,11 +16,11 @@ class GetNUsersForRateLimitingTest(TestCase, DomainSubscriptionMixin):
         domain_obj = create_domain(domain)
         self.addCleanup(domain_obj.delete)
 
-        self._assert_value_equals(domain, 0)
+        self._assert_domain_value_equals(domain, 0)
 
         self._set_n_users(domain, 1)
 
-        self._assert_value_equals(domain, 1)
+        self._assert_domain_value_equals(domain, 1)
 
     def test_with_subscription(self):
 
@@ -54,25 +54,39 @@ class GetNUsersForRateLimitingTest(TestCase, DomainSubscriptionMixin):
         _setup(domain_1)
 
         # There are no users yet
-        self._assert_value_equals(domain_1, 0)
+        self._assert_domain_value_equals(domain_1, 0)
+
+        # subscription value returns those included
+        self._assert_subscription_value_equals(domain_1, 8)
 
         self._set_n_users(domain_1, 9)
 
         # With more users than included in subscription, it's the number of users
         self._assert_value_equals(domain_1, 9)
 
+        # subscription still returns only the billing amount
+        self._assert_subscription_value_equals(domain_1, 8)
+
         _setup(domain_2)
         _link_domains(domain_1, domain_2)
 
         # No change on the original domain
-        self._assert_value_equals(domain_1, 9)
+        self._assert_domain_value_equals(domain_1, 9)
 
         # new domain has no users
-        self._assert_value_equals(domain_2, 0)
+        self._assert_domain_value_equals(domain_2, 0)
 
-    def _assert_value_equals(self, domain, value):
+        # domain_2 still has full subscription allocation
+        self._assert_subscription_value_equals(domain_2, 8)
+
+    def _assert_domain_value_equals(self, domain, value):
         get_n_users_in_domain.clear(domain)
         self.assertEqual(get_n_users_in_domain(domain), value)
+
+
+    def _assert_subscription_value_equals(self, domain, value):
+        get_n_users_in_subscription.clear(domain)
+        self.assertEqual(get_n_users_in_subscription(domain), value)
 
     def _set_n_users(self, domain, n_users):
         start_n_users = CommCareUser.total_by_domain(domain, is_active=True)

--- a/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
+++ b/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
@@ -62,7 +62,7 @@ class GetNUsersForRateLimitingTest(TestCase, DomainSubscriptionMixin):
         self._set_n_users(domain_1, 9)
 
         # With more users than included in subscription, it's the number of users
-        self._assert_value_equals(domain_1, 9)
+        self._assert_domain_value_equals(domain_1, 9)
 
         # subscription still returns only the billing amount
         self._assert_subscription_value_equals(domain_1, 8)

--- a/corehq/project_limits/tests/test_rate_limiter.py
+++ b/corehq/project_limits/tests/test_rate_limiter.py
@@ -8,6 +8,7 @@ from corehq.project_limits.rate_limiter import RateLimiter, RateDefinition, \
 
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_old_enterprise_count', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_rate_limit_interface():
     """
@@ -24,6 +25,7 @@ def test_rate_limit_interface():
 
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_old_enterprise_count', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_get_window_of_first_exceeded_limit():
     per_user_rate_def = RateDefinition(per_second=10)
@@ -38,6 +40,7 @@ def test_get_window_of_first_exceeded_limit():
 
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_old_enterprise_count', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_get_window_of_first_exceeded_limit_none():
     per_user_rate_def = RateDefinition(per_second=10)
@@ -52,6 +55,7 @@ def test_get_window_of_first_exceeded_limit_none():
 
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_old_enterprise_count', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_get_window_of_first_exceeded_limit_priority():
     per_user_rate_def = RateDefinition(per_second=10, per_week=10)

--- a/corehq/project_limits/tests/test_rate_limiter.py
+++ b/corehq/project_limits/tests/test_rate_limiter.py
@@ -6,7 +6,8 @@ from corehq.project_limits.rate_limiter import RateLimiter, RateDefinition, \
     PerUserRateDefinition
 
 
-@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain, enterprise_limit=False: 10)
+@patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_rate_limit_interface():
     """
     Just test that very basic usage doesn't error
@@ -20,7 +21,8 @@ def test_rate_limit_interface():
         my_feature_rate_limiter.report_usage('my_domain')
 
 
-@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain, enterprise_limit=False: 10)
+@patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_get_window_of_first_exceeded_limit():
     per_user_rate_def = RateDefinition(per_second=10)
     min_rate_def = RateDefinition(per_second=100)
@@ -32,7 +34,8 @@ def test_get_window_of_first_exceeded_limit():
     eq(actual_window, expected_window)
 
 
-@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain, enterprise_limit=False: 10)
+@patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_get_window_of_first_exceeded_limit_none():
     per_user_rate_def = RateDefinition(per_second=10)
     min_rate_def = RateDefinition(per_second=100)
@@ -44,7 +47,8 @@ def test_get_window_of_first_exceeded_limit_none():
     eq(actual_window, expected_window)
 
 
-@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain, enterprise_limit=False: 10)
+@patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_get_window_of_first_exceeded_limit_priority():
     per_user_rate_def = RateDefinition(per_second=10, per_week=10)
     min_rate_def = RateDefinition(per_second=100)

--- a/corehq/project_limits/tests/test_rate_limiter.py
+++ b/corehq/project_limits/tests/test_rate_limiter.py
@@ -6,7 +6,8 @@ from corehq.project_limits.rate_limiter import RateLimiter, RateDefinition, \
     PerUserRateDefinition
 
 
-@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain, enterprise_limit=False: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_rate_limit_interface():
     """
@@ -21,40 +22,43 @@ def test_rate_limit_interface():
         my_feature_rate_limiter.report_usage('my_domain')
 
 
-@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain, enterprise_limit=False: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_get_window_of_first_exceeded_limit():
     per_user_rate_def = RateDefinition(per_second=10)
     min_rate_def = RateDefinition(per_second=100)
     per_user_rate_def = PerUserRateDefinition(per_user_rate_def, min_rate_def)
     rate_limiter = RateLimiter('my_feature', per_user_rate_def.get_rate_limits)
-    rate_limiter.iter_rates = Mock(return_value=[('second', 11, 10)])
+    rate_limiter.iter_rates = Mock(return_value=[((), [('second', 11, 10)])])
     expected_window = 'second'
     actual_window = rate_limiter.get_window_of_first_exceeded_limit('my_domain')
     eq(actual_window, expected_window)
 
 
-@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain, enterprise_limit=False: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_get_window_of_first_exceeded_limit_none():
     per_user_rate_def = RateDefinition(per_second=10)
     min_rate_def = RateDefinition(per_second=100)
     per_user_rate_def = PerUserRateDefinition(per_user_rate_def, min_rate_def)
     rate_limiter = RateLimiter('my_feature', per_user_rate_def.get_rate_limits)
-    rate_limiter.iter_rates = Mock(return_value=[('second', 9, 10)])
+    rate_limiter.iter_rates = Mock(return_value=[((), [('second', 9, 10)])])
     expected_window = None
     actual_window = rate_limiter.get_window_of_first_exceeded_limit('my_domain')
     eq(actual_window, expected_window)
 
 
-@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain, enterprise_limit=False: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_get_window_of_first_exceeded_limit_priority():
     per_user_rate_def = RateDefinition(per_second=10, per_week=10)
     min_rate_def = RateDefinition(per_second=100)
     per_user_rate_def = PerUserRateDefinition(per_user_rate_def, min_rate_def)
     rate_limiter = RateLimiter('my_feature', per_user_rate_def.get_rate_limits)
-    rate_limiter.iter_rates = Mock(return_value=[('week', 11, 10), ('second', 11, 10)])
+    rate_limiter.iter_rates = Mock(return_value=[((), [('week', 11, 10), ('second', 11, 10)])])
     expected_window = 'week'
     actual_window = rate_limiter.get_window_of_first_exceeded_limit('my_domain')
     eq(actual_window, expected_window)


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This implements enterprise level rate limiting in the per user rate limiters.

`PerUserRateDefinition`s now check against both the total account limit and the domain limit if those two differ (because the account includes other domains). For domains that are part of enterprise accounts, the domain limit is taken to be the actual number of users in the domain. Only if both of those limits are exceeded does `allow_usage` return `False`

To accommodate this work, a few of the `RateLimiter` methods were modified to allow `get_rate_limits` to return multiple limits of different scopes.

I decided to include this work in the existing user rate limiter because this seemed like the correct behavior for "per user" rate limits. We would always want them to operate against actual user limits. It also has the added benefit of not requiring modification to usage of the rate limiters. Existing rate limiting code will continue to work as written, but with more correct limits.

I plan to add tests to this PR, but wanted to open it up for design review while I did that.

Original design doc https://docs.google.com/document/d/1a-ELOcCgHSFOFXjAN-ZhbVgxz4kK2yp9E_6PK5Fn2ZA/edit#

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This code is covered by tests, and I will be adding more. Additionally exceptions in rate limit code never block the requested action so code errors will not break submissions.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There are existing tests for these limiters, but I am also adding more for the specific enterprise changes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
