### PR TITLE
Add dependecy watchers as codeowners of requirements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,6 +69,8 @@
 
 /docker/ @millerdev @joxl
 
+/package.json @dimagi/dependency-watchers
+
 /scripts/docker @millerdev @joxl
 /scripts/vellum-to-hq @millerdev
 
@@ -76,3 +78,5 @@
 
 /testapps/test_pillowtop/ @joxl
 /testapps/test_elasticsearch/ @joxl
+
+/yarn.lock @dimagi/dependency-watchers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,9 +61,9 @@
 /corehq/ex-submodules/pillowtop @dannyroberts @calellowitz
 /corehq/util/es/ @joxl
 
-/custom/icds_reports/ @calellowitz @Rohit25negi
-/custom/icds_reports/templates/ @calellowitz @Rohit25negi
-/custom/icds_reports/static/ @calellowitz @Rohit25negi
+/custom/icds_reports/ @calellowitz
+/custom/icds_reports/templates/ @calellowitz
+/custom/icds_reports/static/ @calellowitz
 
 /docs/js-guide/ @orangejenny @millerdev
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,5 +72,7 @@
 /scripts/docker @millerdev @joxl
 /scripts/vellum-to-hq @millerdev
 
+/requirements/ @dimagi/dependency-watchers
+
 /testapps/test_pillowtop/ @joxl
 /testapps/test_elasticsearch/ @joxl


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Could be a bad idea since this may result in lots of requested reviews for dependabot PRs, but maybe that also makes sense. 

The goal is to automate the process of raising awareness to the dependapod of dependency changes outside of dependabot PRs.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
