### PR TITLE
Django 3.2 fixes: response headers and empty keyword actions set

### DIFF
--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -369,10 +369,12 @@ class TestDownloadCaseSummaryViewByAPIKey(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response._headers["content-type"],
-            ("Content-Type", "application/vnd.ms-excel"),
-        )
+        try:
+            content_type = response.headers['content-type']
+        except AttributeError:
+            # TODO remove after upgrading to Django 3.2
+            content_type = response._headers['content-type'][1]
+        self.assertEqual(content_type, "application/vnd.ms-excel")
 
     def test_incorrect_api_key(self):
         """Sending an incorrect (or missing) API key returns a 401 response."""
@@ -407,10 +409,12 @@ class TestDownloadCaseSummaryViewByAPIKey(TestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response._headers["content-type"],
-            ("Content-Type", "application/vnd.ms-excel"),
-        )
+        try:
+            content_type = response.headers['content-type']
+        except AttributeError:
+            # TODO remove after upgrading to Django 3.2
+            content_type = response._headers['content-type'][1]
+        self.assertEqual(content_type, "application/vnd.ms-excel")
 
     def test_unsupported_request_methods(self):
         """Test sending requests by unsupported HTTP methods to the view."""

--- a/corehq/apps/linked_domain/keywords.py
+++ b/corehq/apps/linked_domain/keywords.py
@@ -35,7 +35,7 @@ def create_linked_keyword(domain_link, keyword_id):
                 keyword=keyword.keyword, domain=domain_link.linked_domain)
         )
 
-    keyword_actions = keyword.keywordaction_set.all()
+    keyword_actions = list(keyword.keywordaction_set.all())
 
     keyword.upstream_id = keyword.id
     keyword.id = None

--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -234,7 +234,9 @@ class SubmissionErrorTest(TestCase, TestFileMixin):
             status_code = 200
             streaming = False
             cookies = []
-            _closable_objects = []
+            headers = {}
+            _resource_closers = []
+            _closable_objects = []  # TODO remove when Django 2 is no longer supported
 
             def has_header(self, name):
                 return False
@@ -243,7 +245,12 @@ class SubmissionErrorTest(TestCase, TestFileMixin):
                 pass
 
             def close(self):
-                pass
+                for close in self._resource_closers:
+                    close()
+
+                # TODO remove when Django 2 is no longer supported
+                for obj in self._closable_objects:
+                    obj.close()
 
         def process_device_log(self_, xform):
             result = FormProcessingResult(xform)

--- a/corehq/apps/reports/tests/test_export_response.py
+++ b/corehq/apps/reports/tests/test_export_response.py
@@ -64,9 +64,12 @@ class ExportResponseTest(TestCase):
 
         self.assertEqual(res.status_code, 200)
 
-        expected_content_type = ('Content-Type', 'application/vnd.ms-excel')
-
-        self.assertEqual(res._headers['content-type'], expected_content_type)
+        try:
+            content_type = res.headers['content-type']
+        except AttributeError:
+            # TODO remove after upgrading to Django 3.2
+            content_type = res._headers['content-type'][1]
+        self.assertEqual(content_type, 'application/vnd.ms-excel')
 
     @patch('corehq.apps.reports.standard.monitoring.WorkerActivityReport.export_table', return_value=[])
     @patch('corehq.apps.reports.generic.export_from_tables')


### PR DESCRIPTION
Fix issues found by running tests on Django 3.2.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

The first two commits change to tests only. All changes are covered by automated tests.

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
