### PR TITLE
add 'today()' function to ES filter DSL

### DIFF
--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -167,7 +167,7 @@ def build_filter_from_ast(domain, node, fuzzy=False):
         if not isinstance(node, FunctionCall):
             return node
         try:
-            return XPATH_VALUE_FUNCTIONS[node.name](node)
+            return XPATH_VALUE_FUNCTIONS[node.name](domain, node)
         except KeyError:
             raise CaseFilterError(
                 _("We don't know what to do with the function \"{}\". Accepted functions are: {}").format(

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -1,6 +1,7 @@
 from django.test import SimpleTestCase, TestCase
 
 from eulxml.xpath import parse as parse_xpath
+from freezegun import freeze_time
 
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from pillowtop.es_utils import initialize_index_and_mapping
@@ -115,6 +116,34 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
                             "range": {
                                 "case_properties.value.date": {
                                     "gte": "2017-02-12"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        self.checkQuery(expected_filter, build_filter_from_ast("domain", parsed), is_raw_query=True)
+
+    @freeze_time('2021-08-02')
+    def test_date_comparison__today(self):
+        parsed = parse_xpath("dob >= today()")
+        expected_filter = {
+            "nested": {
+                "path": "case_properties",
+                "query": {
+                    "bool": {
+                        "filter": [
+                            {
+                                "term": {
+                                    "case_properties.key.exact": "dob"
+                                }
+                            }
+                        ],
+                        "must": {
+                            "range": {
+                                "case_properties.value.date": {
+                                    "gte": "2021-08-02"
                                 }
                             }
                         }

--- a/corehq/apps/case_search/tests/test_value_functions.py
+++ b/corehq/apps/case_search/tests/test_value_functions.py
@@ -1,0 +1,39 @@
+from django.test import TestCase
+
+from eulxml.xpath import parse as parse_xpath
+from freezegun import freeze_time
+from testil import eq
+
+from corehq.apps.case_search.exceptions import XPathFunctionException
+from corehq.apps.case_search.xpath_functions.value_functions import today
+from corehq.apps.domain.models import Domain
+from corehq.apps.domain.shortcuts import create_domain
+
+
+@freeze_time('2021-08-02T22:00:00Z')
+class TestToday(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.domain_name = "test_today"
+        cls.domain = create_domain(cls.domain_name)
+        cls.domain.default_timezone = "Asia/Kolkata"
+        cls.domain.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        Domain.get_db().delete_doc(cls.domain)
+
+    def test_today_no_domain(self):
+        node = parse_xpath("today()")
+        result = today("domain", node)
+        eq(result, '2021-08-02')
+
+    def test_today_domain_tz(self):
+        node = parse_xpath("today()")
+        result = today(self.domain_name, node)
+        eq(result, '2021-08-03')
+
+    def test_arg_validation(self):
+        node = parse_xpath("today('utc')")
+        with self.assertRaises(XPathFunctionException):
+            today("domain", node)

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -1,10 +1,11 @@
 from .query_functions import not_, selected_all, selected_any
 from .subcase_functions import subcase
-from .value_functions import date
+from .value_functions import date, today
 
-# functions that transform a value
+# functions that transform or produce a value
 XPATH_VALUE_FUNCTIONS = {
     'date': date,
+    'today': today,
 }
 
 


### PR DESCRIPTION
## Product Description
Add support for the `today()` function in the case search query DSL. This allows users to use the function without having to break out into xpath:
```
concat("dob < '", today(), "'")
```
can become
```
"dob < today()"
```

Docs added here: https://confluence.dimagi.com/display/saas/Case+Search+Query+Language#CaseSearchQueryLanguage-today

## Technical Summary
`today()` will evaluate to the current date in the domains timezone formatted as an ISO date string.

## Feature Flag
* case search
* case list explorer

## Safety Assurance

### Safety story
The change is purely additive and well tested.

### Automated test coverage
Added unit and 'integration' tests

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
