### PR TITLE
Add LOADTEST_USERS privilege

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -99,6 +99,7 @@ pro_v1 = standard_v1 + [
     privileges.CASE_SHARING_GROUPS,
     privileges.CHILD_CASES,
     privileges.LITE_RELEASE_MANAGEMENT,
+    privileges.LOADTEST_USERS,
 ]
 
 

--- a/corehq/apps/accounting/migrations/0060_add_loadtest_users_priv.py
+++ b/corehq/apps/accounting/migrations/0060_add_loadtest_users_priv.py
@@ -22,5 +22,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(_grandfather_basic_privs),
+        migrations.RunPython(
+            _grandfather_basic_privs,
+            reverse_code=migrations.RunPython.noop,
+        ),
     ]

--- a/corehq/apps/accounting/migrations/0060_add_loadtest_users_priv.py
+++ b/corehq/apps/accounting/migrations/0060_add_loadtest_users_priv.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+from django.core.management import call_command
+
+from corehq.privileges import LOADTEST_USERS
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _grandfather_basic_privs(apps, schema_editor):
+    call_command('cchq_prbac_bootstrap')
+    call_command(
+        'cchq_prbac_grandfather_privs',
+        LOADTEST_USERS,
+        skip_edition='Paused,Community,Standard',
+        noinput=True,
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('accounting', '0059_add_lite_release_management_priv'),
+    ]
+
+    operations = [
+        migrations.RunPython(_grandfather_basic_privs),
+    ]

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -176,6 +176,9 @@ class Command(BaseCommand):
         Role(slug=privileges.LITE_RELEASE_MANAGEMENT,
              name='Lite Release Management',
              description='A limited version of Release Management'),
+        Role(slug=privileges.LOADTEST_USERS,
+             name='Loadtest Users',
+             description='Allows creating loadtest users'),
     ]
 
     BOOTSTRAP_PLANS = [

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -85,6 +85,8 @@ RELEASE_MANAGEMENT = 'release_management'
 
 LITE_RELEASE_MANAGEMENT = 'lite_release_management'
 
+LOADTEST_USERS = 'loadtest_users'
+
 MAX_PRIVILEGES = [
     LOOKUP_TABLES,
     API_ACCESS,
@@ -131,6 +133,7 @@ MAX_PRIVILEGES = [
     DEFAULT_EXPORT_SETTINGS,
     RELEASE_MANAGEMENT,
     LITE_RELEASE_MANAGEMENT,
+    LOADTEST_USERS,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -189,4 +192,5 @@ class Titles(object):
             DEFAULT_EXPORT_SETTINGS: _("Default Export Settings"),
             RELEASE_MANAGEMENT: _("Enterprise Release Management"),
             LITE_RELEASE_MANAGEMENT: _("Multi-Environment Release Management"),
+            LOADTEST_USERS: _('Loadtest Users'),
         }.get(privilege, privilege)

--- a/migrations.lock
+++ b/migrations.lock
@@ -79,6 +79,7 @@ accounting
  0057_add_sms_report_toggle
  0058_delete_linked_projects_role
  0059_add_lite_release_management_priv
+ 0060_add_loadtest_users_priv
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Technical Summary

This is the migration for moving the Loadtest Users feature from Feature Flag to Generally Available.

See the original PR https://github.com/dimagi/commcare-hq/pull/31095 for context and discussion.

## Feature Flag

Was "Loadtest Users", now Pro Plan or higher.

## Safety Assurance

### Safety story

This migration has run successfully locally and on Staging. Forward and reverse have been tested locally.


### Migrations

- [x] The migrations in this code can be safely applied first independently of the code


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

This migration has a no-op reverse. (It is idempotent, in that it can be applied multiple times without causing an error.)

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
