### PR TITLE
Replace ugettext with gettext

### DIFF
--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -507,6 +507,6 @@ class RecoveryMeasuresHistory(BaseAdminProjectSettingsView):
 
 
 class ManageDomainMobileWorkersView(ManageMobileWorkersMixin, BaseAdminProjectSettingsView):
-    page_title = ugettext_lazy("Manage Mobile Workers")
+    page_title = gettext_lazy("Manage Mobile Workers")
     template_name = 'enterprise/manage_mobile_workers.html'
     urlname = 'domain_manage_mobile_workers'

--- a/corehq/apps/enterprise/forms.py
+++ b/corehq/apps/enterprise/forms.py
@@ -229,9 +229,9 @@ class EnterpriseSettingsForm(forms.Form):
 
 class EnterpriseManageMobileWorkersForm(forms.Form):
     enable_auto_deactivation = forms.BooleanField(
-        label=ugettext_lazy("Auto-Deactivation by Inactivity"),
+        label=gettext_lazy("Auto-Deactivation by Inactivity"),
         widget=BootstrapCheckboxInput(
-            inline_label=ugettext_lazy(
+            inline_label=gettext_lazy(
                 "Automatically deactivate Mobile Workers who have not "
                 "submitted a form within the Inactivity Period below."
             ),
@@ -239,32 +239,32 @@ class EnterpriseManageMobileWorkersForm(forms.Form):
         required=False,
     )
     inactivity_period = forms.ChoiceField(
-        label=ugettext_lazy("Inactivity Period"),
+        label=gettext_lazy("Inactivity Period"),
         required=False,
         initial=90,
         choices=(
-            (30, ugettext_lazy("30 days")),
-            (60, ugettext_lazy("60 days")),
-            (90, ugettext_lazy("90 days")),
-            (120, ugettext_lazy("120 days")),
-            (150, ugettext_lazy("150 days")),
-            (180, ugettext_lazy("180 days")),
+            (30, gettext_lazy("30 days")),
+            (60, gettext_lazy("60 days")),
+            (90, gettext_lazy("90 days")),
+            (120, gettext_lazy("120 days")),
+            (150, gettext_lazy("150 days")),
+            (180, gettext_lazy("180 days")),
         ),
-        help_text=ugettext_lazy(
+        help_text=gettext_lazy(
             "Mobile workers who have not submitted a form after these many "
             "days will be considered inactive."
         ),
     )
     allow_custom_deactivation = forms.BooleanField(
-        label=ugettext_lazy("Auto-Deactivation by Month"),
+        label=gettext_lazy("Auto-Deactivation by Month"),
         required=False,
         widget=BootstrapCheckboxInput(
-            inline_label=ugettext_lazy(
+            inline_label=gettext_lazy(
                 "Allow auto-deactivation of Mobile Workers after "
                 "a specific month."
             ),
         ),
-        help_text=ugettext_lazy(
+        help_text=gettext_lazy(
             "When this is enabled, an option to select a month and "
             "year for deactivating a Mobile Worker will be present when "
             "creating that Mobile Worker."

--- a/corehq/apps/enterprise/mixins.py
+++ b/corehq/apps/enterprise/mixins.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.http import (
     HttpResponseRedirect,
 )
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from corehq.apps.enterprise.models import (
     EnterpriseMobileWorkerSettings,

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -449,6 +449,6 @@ def update_enterprise_permissions_source_domain(request, domain):
 
 
 class ManageEnterpriseMobileWorkersView(ManageMobileWorkersMixin, BaseEnterpriseAdminView):
-    page_title = ugettext_lazy("Manage Mobile Workers")
+    page_title = gettext_lazy("Manage Mobile Workers")
     template_name = 'enterprise/manage_mobile_workers.html'
     urlname = 'enterprise_manage_mobile_workers'

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -414,9 +414,9 @@ class UpdateCommCareUserInfoForm(BaseUserInfoForm, UpdateUserRoleForm):
         ),
         widget=forms.HiddenInput())
     deactivate_after_date = forms.CharField(
-        label=ugettext_lazy("Deactivate After"),
+        label=gettext_lazy("Deactivate After"),
         required=False,
-        help_text=ugettext_lazy(
+        help_text=gettext_lazy(
             "When specified, the mobile worker is automatically deactivated "
             "on the first day of the month and year selected."
         )
@@ -670,9 +670,9 @@ class NewMobileWorkerForm(forms.Form):
         label=gettext_noop("Password"),
     )
     deactivate_after_date = forms.CharField(
-        label=ugettext_lazy("Deactivate After"),
+        label=gettext_lazy("Deactivate After"),
         required=False,
-        help_text=ugettext_lazy(
+        help_text=gettext_lazy(
             "When specified, the mobile worker is automatically deactivated "
             "on the first day of the month and year selected."
         ),


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I noticed there were some unresolved references to `ugettext_lazy` that must have been due poor timing of merges/conflict resolutions between @millerdev's django deprecations work and @biyeun's enterprise mobile worker work. For context, Daniel replaced ugettext references with gettext due to django 3 deprecations, and since Biyeun added new code that still referenced ugettext, it's possible there weren't any conflicts between the two.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
