### PR TITLE
TypeError: Abstract models cannot be instantiated

### DIFF
--- a/corehq/messaging/scheduling/tests/test_content.py
+++ b/corehq/messaging/scheduling/tests/test_content.py
@@ -1,6 +1,5 @@
 from unittest.mock import Mock
 
-from django.apps import apps
 from django.test import TestCase, override_settings
 
 from corehq.apps.domain.shortcuts import create_domain
@@ -22,6 +21,7 @@ from corehq.messaging.scheduling.scheduling_partitioned.models import (
     CaseAlertScheduleInstance,
     CaseTimedScheduleInstance,
 )
+from corehq.util.test_utils import unregistered_django_model
 
 
 AVAILABLE_CUSTOM_SCHEDULING_CONTENT = {
@@ -45,18 +45,6 @@ class TestContent(TestCase):
         cls.sms_translations = get_or_create_sms_translations(cls.domain)
         cls.sms_translations.set_translations('es', {})
         cls.sms_translations.save()
-
-        global Content, Schedule
-
-        class Content(AbstractContent):
-            pass
-
-        class Schedule(AbstractSchedule):
-            pass
-
-        # unregister test models to prevent other test failures
-        del apps.get_app_config("scheduling").models["content"]
-        del apps.get_app_config("scheduling").models["schedule"]
 
     @classmethod
     def tearDownClass(cls):
@@ -223,3 +211,13 @@ class TestContent(TestCase):
             content.get_translation_from_message_dict(self.domain_obj, message_dict, user_lang),
             message_dict['*']
         )
+
+
+@unregistered_django_model
+class Content(AbstractContent):
+    pass
+
+
+@unregistered_django_model
+class Schedule(AbstractSchedule):
+    pass

--- a/corehq/messaging/scheduling/tests/test_content.py
+++ b/corehq/messaging/scheduling/tests/test_content.py
@@ -1,3 +1,7 @@
+from unittest.mock import Mock
+
+from django.test import TestCase, override_settings
+
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.sms.forms import (
     LANGUAGE_FALLBACK_NONE,
@@ -6,15 +10,17 @@ from corehq.apps.sms.forms import (
     LANGUAGE_FALLBACK_UNTRANSLATED,
 )
 from corehq.apps.users.models import CommCareUser
-from corehq.messaging.scheduling.models import Schedule, Content, CustomContent
+from corehq.messaging.scheduling.models import (
+    Content as AbstractContent,
+    CustomContent,
+    Schedule as AbstractSchedule,
+)
 from corehq.messaging.scheduling.scheduling_partitioned.models import (
     AlertScheduleInstance,
     TimedScheduleInstance,
     CaseAlertScheduleInstance,
     CaseTimedScheduleInstance,
 )
-from django.test import TestCase, override_settings
-from unittest.mock import Mock
 
 
 AVAILABLE_CUSTOM_SCHEDULING_CONTENT = {
@@ -204,3 +210,11 @@ class TestContent(TestCase):
             content.get_translation_from_message_dict(self.domain_obj, message_dict, user_lang),
             message_dict['*']
         )
+
+
+class Content(AbstractContent):
+    pass
+
+
+class Schedule(AbstractSchedule):
+    pass

--- a/corehq/messaging/scheduling/tests/test_content.py
+++ b/corehq/messaging/scheduling/tests/test_content.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock
 
+from django.apps import apps
 from django.test import TestCase, override_settings
 
 from corehq.apps.domain.shortcuts import create_domain
@@ -44,6 +45,18 @@ class TestContent(TestCase):
         cls.sms_translations = get_or_create_sms_translations(cls.domain)
         cls.sms_translations.set_translations('es', {})
         cls.sms_translations.save()
+
+        global Content, Schedule
+
+        class Content(AbstractContent):
+            pass
+
+        class Schedule(AbstractSchedule):
+            pass
+
+        # unregister test models to prevent other test failures
+        del apps.get_app_config("scheduling").models["content"]
+        del apps.get_app_config("scheduling").models["schedule"]
 
     @classmethod
     def tearDownClass(cls):
@@ -210,11 +223,3 @@ class TestContent(TestCase):
             content.get_translation_from_message_dict(self.domain_obj, message_dict, user_lang),
             message_dict['*']
         )
-
-
-class Content(AbstractContent):
-    pass
-
-
-class Schedule(AbstractSchedule):
-    pass

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -2,7 +2,6 @@ import contextlib
 import uuid
 from datetime import time
 
-from django.apps import apps
 from django.test import TestCase, override_settings
 
 from unittest.mock import patch
@@ -39,7 +38,11 @@ from corehq.messaging.scheduling.scheduling_partitioned.models import (
     ScheduleInstance as AbstractScheduleInstance,
 )
 from corehq.messaging.scheduling.tests.util import delete_timed_schedules
-from corehq.util.test_utils import create_test_case, set_parent_case
+from corehq.util.test_utils import (
+    create_test_case,
+    set_parent_case,
+    unregistered_django_model,
+)
 from testapps.test_pillowtop.utils import process_pillow_changes
 
 
@@ -128,14 +131,6 @@ class SchedulingRecipientTest(TestCase):
 
         cls.process_pillow_changes = process_pillow_changes('DefaultChangeFeedPillow')
         cls.process_pillow_changes.add_pillow(get_case_messaging_sync_pillow())
-
-        global ScheduleInstance
-
-        class ScheduleInstance(AbstractScheduleInstance):
-            pass
-
-        # unregister test model to prevent other test failures
-        del apps.get_app_config("scheduling").models["scheduleinstance"]
 
     @classmethod
     def tearDownClass(cls):
@@ -853,3 +848,8 @@ class SchedulingRecipientTest(TestCase):
         self.assertPhoneEntryCount(3)
         self.assertPhoneEntryCount(1, only_count_two_way=True)
         self.assertTwoWayEntry(Content.get_two_way_entry_or_phone_number(user), '23456')
+
+
+@unregistered_django_model
+class ScheduleInstance(AbstractScheduleInstance):
+    pass

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -35,7 +35,7 @@ from corehq.messaging.scheduling.models import (
 from corehq.messaging.scheduling.scheduling_partitioned.models import (
     CaseScheduleInstanceMixin,
     CaseTimedScheduleInstance,
-    ScheduleInstance,
+    ScheduleInstance as AbstractScheduleInstance,
 )
 from corehq.messaging.scheduling.tests.util import delete_timed_schedules
 from corehq.util.test_utils import create_test_case, set_parent_case
@@ -844,3 +844,7 @@ class SchedulingRecipientTest(TestCase):
         self.assertPhoneEntryCount(3)
         self.assertPhoneEntryCount(1, only_count_two_way=True)
         self.assertTwoWayEntry(Content.get_two_way_entry_or_phone_number(user), '23456')
+
+
+class ScheduleInstance(AbstractScheduleInstance):
+    pass

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -2,6 +2,7 @@ import contextlib
 import uuid
 from datetime import time
 
+from django.apps import apps
 from django.test import TestCase, override_settings
 
 from unittest.mock import patch
@@ -127,6 +128,14 @@ class SchedulingRecipientTest(TestCase):
 
         cls.process_pillow_changes = process_pillow_changes('DefaultChangeFeedPillow')
         cls.process_pillow_changes.add_pillow(get_case_messaging_sync_pillow())
+
+        global ScheduleInstance
+
+        class ScheduleInstance(AbstractScheduleInstance):
+            pass
+
+        # unregister test model to prevent other test failures
+        del apps.get_app_config("scheduling").models["scheduleinstance"]
 
     @classmethod
     def tearDownClass(cls):
@@ -844,7 +853,3 @@ class SchedulingRecipientTest(TestCase):
         self.assertPhoneEntryCount(3)
         self.assertPhoneEntryCount(1, only_count_two_way=True)
         self.assertTwoWayEntry(Content.get_two_way_entry_or_phone_number(user), '23456')
-
-
-class ScheduleInstance(AbstractScheduleInstance):
-    pass

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -20,6 +20,7 @@ from textwrap import indent, wrap
 from time import sleep, time
 from unittest import SkipTest, TestCase
 
+from django.apps import apps
 from django.conf import settings
 from django.db import connections
 from django.db.backends import utils
@@ -345,6 +346,12 @@ class capture_log_output(ContextDecorator):
 
     def get_output(self):
         return self.output.getvalue()
+
+
+def unregistered_django_model(model_class):
+    app_config = apps.get_app_config(model_class._meta.app_label)
+    del app_config.models[model_class.__name__.lower()]
+    return model_class
 
 
 def generate_cases(argsets, cls=None):

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -349,6 +349,16 @@ class capture_log_output(ContextDecorator):
 
 
 def unregistered_django_model(model_class):
+    """Model class decorator that unregisters the model from Django
+
+    Apply to model classes in test modules to prevent the models from
+    being seen by other tests that check registered models. Examples
+    of tests that check registered models include
+    - corehq.apps.domain.tests.test_deletion_models:test_deletion_sql_models
+    - corehq.sql_db.tests.test_model_partitioning
+      :TestPartitionedModelsWithMultipleDBs
+      .test_models_are_located_in_correct_dbs('scheduling', False)
+    """
     app_config = apps.get_app_config(model_class._meta.app_label)
     del app_config.models[model_class.__name__.lower()]
     return model_class


### PR DESCRIPTION
Instantiating an abstract model raises TypeError in Django 3.2.
https://docs.djangoproject.com/en/4.0/releases/3.2/#miscellaneous

## Safety Assurance

### Safety story

Affects tests only.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
