### PR TITLE
Add feature discovery notification types

### DIFF
--- a/corehq/apps/notifications/models.py
+++ b/corehq/apps/notifications/models.py
@@ -36,7 +36,7 @@ class Notification(models.Model):
         ordering = ["-activated"]
 
     @classmethod
-    def get_by_user(cls, django_user, couch_user, limit=10, plan='Community'):
+    def get_by_user(cls, django_user, couch_user, limit=10, plan='Community', has_cs_groups='False'):
         """Returns notifications for a particular user
 
         After five notifications all notifications should be marked as read.
@@ -63,6 +63,8 @@ class Notification(models.Model):
         notifications = list(map(_fmt_note, enumerate(notes)))
         if any(p in str(plan) for p in ['Pro', 'Advanced', 'Enterprise']):
             remove = 'feat_basic'
+            if has_cs_groups:
+                notifications = [notif for notif in notifications if notif['type'] != 'feat_pro']
         else:
             remove = 'feat_pro'
         return [notif for notif in notifications if notif['type'] != remove]

--- a/corehq/apps/notifications/models.py
+++ b/corehq/apps/notifications/models.py
@@ -9,8 +9,6 @@ NOTIFICATION_TYPES = (
     ('billing', 'Billing Notification'),
     ('info', 'Product Notification'),
     ('alert', 'Maintenance Notification'),
-    ('feat_basic', 'Feature Discovery (Basic)'),
-    ('feat_pro', 'Feature Discovery (Advanced)')
 )
 
 

--- a/corehq/apps/notifications/models.py
+++ b/corehq/apps/notifications/models.py
@@ -9,6 +9,8 @@ NOTIFICATION_TYPES = (
     ('billing', 'Billing Notification'),
     ('info', 'Product Notification'),
     ('alert', 'Maintenance Notification'),
+    ('feat_basic', 'Feature Discovery (Basic)'),
+    ('feat_pro', 'Feature Discovery (Advanced)')
 )
 
 
@@ -34,7 +36,7 @@ class Notification(models.Model):
         ordering = ["-activated"]
 
     @classmethod
-    def get_by_user(cls, django_user, couch_user, limit=10):
+    def get_by_user(cls, django_user, couch_user, limit=10, plan='Community'):
         """Returns notifications for a particular user
 
         After five notifications all notifications should be marked as read.
@@ -58,7 +60,12 @@ class Notification(models.Model):
             }
             return note_dict
 
-        return list(map(_fmt_note, enumerate(notes)))
+        notifications = list(map(_fmt_note, enumerate(notes)))
+        if any(p in str(plan) for p in ['Pro', 'Advanced', 'Enterprise']):
+            remove = 'feat_basic'
+        else:
+            remove = 'feat_pro'
+        return [notif for notif in notifications if notif['type'] != remove]
 
     def mark_as_read(self, user):
         self.users_read.add(user)

--- a/corehq/apps/notifications/models.py
+++ b/corehq/apps/notifications/models.py
@@ -36,7 +36,8 @@ class Notification(models.Model):
         ordering = ["-activated"]
 
     @classmethod
-    def get_by_user(cls, django_user, couch_user, limit=10, plan='Community', has_cs_groups='False'):
+    def get_by_user(cls, django_user, couch_user, limit=10, plan='Community',
+                    has_cs_groups=False, is_USH_or_Solutions=False):
         """Returns notifications for a particular user
 
         After five notifications all notifications should be marked as read.
@@ -61,13 +62,34 @@ class Notification(models.Model):
             return note_dict
 
         notifications = list(map(_fmt_note, enumerate(notes)))
-        if any(p in str(plan) for p in ['Pro', 'Advanced', 'Enterprise']):
-            remove = 'feat_basic'
-            if has_cs_groups:
-                notifications = [notif for notif in notifications if notif['type'] != 'feat_pro']
+
+        # pushes feature discovery notification to new web users
+        if not notifications:
+            all_notes = cls.objects.filter(Q(domain_specific=False) | Q(domains__overlap=couch_user.domains),
+                                        is_active=True)[:limit]
+            notifications = list(map(_fmt_note, enumerate(all_notes)))
+            notifications = [notif for notif in notifications
+                             if notif['type'] == 'feat_basic' or notif['type'] == 'feat_pro']
+
+        def remove_feature_notifications(feat_basic=False, feat_pro=False, both=False):
+            if both:
+                return [notif for notif in notifications
+                        if notif['type'] != 'feat_basic' and notif['type'] != 'feat_pro']
+            if feat_basic:
+                notif = [notif for notif in notifications if notif['type'] != 'feat_basic']
+            if feat_pro:
+                notif = [notif for notif in notifications if notif['type'] != 'feat_pro']
+            return notif
+
+        if is_USH_or_Solutions:
+            return remove_feature_notifications(both=True)
         else:
-            remove = 'feat_pro'
-        return [notif for notif in notifications if notif['type'] != remove]
+            if any(p in str(plan) for p in ['Pro', 'Advanced', 'Enterprise']):
+                if has_cs_groups:
+                    return remove_feature_notifications(both=True)
+                return remove_feature_notifications(feat_basic=True)
+            else:
+                return remove_feature_notifications(feat_pro=True)
 
     def mark_as_read(self, user):
         self.users_read.add(user)

--- a/corehq/apps/notifications/static/notifications/js/notifications_service.js
+++ b/corehq/apps/notifications/static/notifications/js/notifications_service.js
@@ -86,6 +86,9 @@ hqDefine('notifications/js/notifications_service', [
         })
 
         self.seen = ko.computed(function () {
+            if (self.hasUnreadFeatureNotification()) {
+                return false;
+            }
 
             if (!self.hasUnread()) {
                 return true;

--- a/corehq/apps/notifications/static/notifications/js/notifications_service.js
+++ b/corehq/apps/notifications/static/notifications/js/notifications_service.js
@@ -127,7 +127,6 @@ hqDefine('notifications/js/notifications_service', [
                 .done(function (data) {
                     self.lastSeenNotificationDate(data.activated);
                     if (self.hasUnreadFeatureNotification()) {
-                        console.log("in here")
                         kissmetrics.track.event("Notifications tab - Clicked notifications tab",
                             {email: data.email, domain: data.domain});
                     }

--- a/corehq/apps/notifications/static/notifications/js/notifications_service.js
+++ b/corehq/apps/notifications/static/notifications/js/notifications_service.js
@@ -48,6 +48,9 @@ hqDefine('notifications/js/notifications_service', [
         self.isInfo = ko.computed(function () {
             return self.type() === 'info';
         });
+        self.isFeature = ko.computed(function () {
+            return self.type() === 'feat_basic' || self.type() === 'feat_pro';
+        });
         self.markAsRead = function () {
             _private.RMI("mark_as_read", {id: self.id()});
             self.isRead(true);

--- a/corehq/apps/notifications/templates/notifications/partials/global_notifications.html
+++ b/corehq/apps/notifications/templates/notifications/partials/global_notifications.html
@@ -21,8 +21,7 @@
           <i class="notifications-type fa"
              data-bind="css: {
                   'fa-exclamation-triangle icon-warning-sign': isAlert(),
-                  'fa-info-circle icon-info-sign': isInfo(),
-                  'fa-plus-circle icon-plus-sign': isFeature(),
+                  'fa-info-circle icon-info-sign': isInfo() || isFeature(),
               }"></i>
         </span>
         <span class="notifications-text" data-bind="text: content"></span>

--- a/corehq/apps/notifications/templates/notifications/partials/global_notifications.html
+++ b/corehq/apps/notifications/templates/notifications/partials/global_notifications.html
@@ -13,7 +13,7 @@
     <!-- ko foreach: notifications -->
     <li data-bind="css: {
                 'notifications-alert': isAlert(),
-                'notifications-info': isInfo(),
+                'notifications-info': isInfo() || isFeature(),
                 'notifications-unread': !isRead()
             }">
       <a data-bind="attr: {href: url}, click: markAsRead" class="clearfix notification-link" target="_blank">
@@ -21,7 +21,8 @@
           <i class="notifications-type fa"
              data-bind="css: {
                   'fa-exclamation-triangle icon-warning-sign': isAlert(),
-                  'fa-info-circle icon-info-sign': isInfo()
+                  'fa-info-circle icon-info-sign': isInfo(),
+                  'fa-plus-circle icon-plus-sign': isFeature(),
               }"></i>
         </span>
         <span class="notifications-text" data-bind="text: content"></span>

--- a/corehq/apps/notifications/views.py
+++ b/corehq/apps/notifications/views.py
@@ -36,7 +36,9 @@ class NotificationsServiceRMIView(JSONResponseMixin, View):
     @allow_remote_invocation
     def get_notifications(self, in_data):
         # todo always grab alerts if they are still relevant
-        notifications = Notification.get_by_user(self.request.user, self.request.couch_user)
+        notifications = Notification.get_by_user(self.request.user,
+                                                 self.request.couch_user,
+                                                 plan=self.request.plan)
         has_unread = len([x for x in notifications if not x['isRead']]) > 0
         last_seen_notification_date = LastSeenNotification.get_last_seen_notification_date_for_user(
             self.request.user

--- a/corehq/apps/notifications/views.py
+++ b/corehq/apps/notifications/views.py
@@ -1,3 +1,5 @@
+import re
+
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
@@ -13,6 +15,7 @@ from djng.views.mixins import (
 from memoized import memoized
 
 from corehq.apps.domain.decorators import login_required, require_superuser
+from corehq.apps.groups.models import Group
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.notifications.forms import NotificationCreationForm
 from corehq.apps.notifications.models import (
@@ -36,9 +39,11 @@ class NotificationsServiceRMIView(JSONResponseMixin, View):
     @allow_remote_invocation
     def get_notifications(self, in_data):
         # todo always grab alerts if they are still relevant
+        groups = Group.get_case_sharing_groups(self.get_domain())
         notifications = Notification.get_by_user(self.request.user,
                                                  self.request.couch_user,
-                                                 plan=self.request.plan)
+                                                 plan=self.request.plan,
+                                                 has_cs_groups=groups != [])
         has_unread = len([x for x in notifications if not x['isRead']]) > 0
         last_seen_notification_date = LastSeenNotification.get_last_seen_notification_date_for_user(
             self.request.user
@@ -73,7 +78,6 @@ class NotificationsServiceRMIView(JSONResponseMixin, View):
         }
 
     def get_domain(self):
-        import re
         regex = '(?<=a\/)(.*?)(?=\s*\/)'
         domain = re.search(regex, self.request.META['HTTP_REFERER'])
         if domain:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Two new notification types have been added to the Manage Notifications page (Feature Discovery (Basic) and Feature Discovery (Advanced)). When a notification is made of the Feature Discovery (Basic) type, it'll show the notification to only users on domains with a Community or Standard plan. Notifications made with the Feature Discovery (Advanced) will show only to users on domains with a Pro, Advanced, Enterprise plan and only if the domain does not already have a case sharing group. If the domain belongs to USH or Solutions, it won't show either notification. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-13258)

This ticket was made to test the new Feature Discoverability notifications, which highlights the case sharing groups feature. 
To gauge interest and effectiveness of this notification, kissmetric will track clicks on the notification bell as well as clicks on the feature discovery notifications themselves.

USH and Solutions domains are filtered based on whether the domain's subscription type is `IMPLEMENTATION` or `SANDBOX`, which doesn't have a 100% accuracy for determining whether a given domain belongs to USH or Solutions but will work about 95% of the time (this is intentional). 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested locally and on staging. 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

[Passed QA testing.](https://dimagi-dev.atlassian.net/browse/QA-3997) 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
