### PR TITLE
only add registry slug if it's supported by the app

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -37,6 +37,7 @@ from corehq.apps.app_manager.util import (
     is_linked_app,
     module_offers_search,
     module_uses_smart_links,
+    module_offers_registry_search,
 )
 from corehq.apps.app_manager.xpath import (
     CaseClaimXpath,
@@ -215,7 +216,7 @@ class RemoteRequestFactory(object):
                     ref=self.module.search_config.blacklisted_owner_ids_expression,
                 )
             )
-        if self.module.search_config.data_registry:
+        if module_offers_registry_search(self.module):
             datums.append(
                 QueryData(
                     key=CASE_SEARCH_REGISTRY_ID_KEY,


### PR DESCRIPTION
## Technical Summary
Update to suite file XML to prevent half functioning apps that have the data registry config but are not on a supported version. I'm not sure how this happens but it was an issue during a regression test on staging.

## Feature Flag
DATA REGISTRY

## Safety Assurance

### Safety story
Removes a query param if the app version does not support it. This change only affects the FF and only for uncommon edge cases.

### Automated test coverage
No tests specifically for this issue.

### QA Plan
None

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
