### PR TITLE
allow passing a string as the property name to selected* functions

### DIFF
--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -1,6 +1,7 @@
 from django.utils.translation import gettext as _
 
 from eulxml.xpath import serialize
+from eulxml.xpath.ast import Step
 
 from corehq.apps.case_search.exceptions import XPathFunctionException
 from corehq.apps.es import filters
@@ -32,6 +33,13 @@ def _selected_query(node, fuzzy, operator):
             _("The {name} function accepts exactly two arguments.").format(name=node.name),
             serialize(node)
         )
-    property_name = serialize(node.args[0])
+    property_name = node.args[0]
+    if isinstance(property_name, Step):
+        property_name = serialize(property_name)
+    elif not isinstance(property_name, str):
+        raise XPathFunctionException(
+            _("The first argument to '{name}' must be a valid case property name").format(name=node.name),
+            serialize(node)
+        )
     search_values = node.args[1]
     return case_property_query(property_name, search_values, fuzzy=fuzzy, multivalue_mode=operator)


### PR DESCRIPTION
## Product Description
Be a bit more lenient in the accepted types for the 1st argument of the `selected*` case search query functions.

Prior to this PR an expression like this `selected('fruit', 'apple pear')` would attempt to search the `"'fruit'"` property (with quotes).

## Technical Summary
Accept string or step as the first argument.

## Feature Flag
Case Search

## Safety Assurance

### Safety story
Well tested

### Automated test coverage
Updated

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
