### PR TITLE
unwrap date function args

### DIFF
--- a/corehq/apps/case_search/dsl_utils.py
+++ b/corehq/apps/case_search/dsl_utils.py
@@ -1,0 +1,30 @@
+from django.utils.translation import gettext as _
+
+from eulxml.xpath.ast import FunctionCall, UnaryExpression, serialize
+
+from corehq.apps.case_search.exceptions import (
+    CaseFilterError,
+    XPathFunctionException,
+)
+from corehq.apps.case_search.xpath_functions import XPATH_VALUE_FUNCTIONS
+
+
+def unwrap_value(domain, node):
+    """Returns the value of the node if it is wrapped in a function, otherwise just returns the node
+    """
+    if isinstance(node, UnaryExpression) and node.op == '-':
+        return -1 * node.right
+    if not isinstance(node, FunctionCall):
+        return node
+    try:
+        return XPATH_VALUE_FUNCTIONS[node.name](domain, node)
+    except KeyError:
+        raise CaseFilterError(
+            _("We don't know what to do with the function \"{}\". Accepted functions are: {}").format(
+                node.name,
+                ", ".join(list(XPATH_VALUE_FUNCTIONS.keys())),
+            ),
+            serialize(node)
+        )
+    except XPathFunctionException as e:
+        raise CaseFilterError(str(e), serialize(node))

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -11,6 +11,7 @@ from eulxml.xpath.ast import (
     serialize,
 )
 
+from corehq.apps.case_search.dsl_utils import unwrap_value
 from corehq.apps.case_search.exceptions import (
     CaseFilterError,
     TooManyRelatedCasesError,
@@ -18,7 +19,6 @@ from corehq.apps.case_search.exceptions import (
 )
 from corehq.apps.case_search.xpath_functions import (
     XPATH_QUERY_FUNCTIONS,
-    XPATH_VALUE_FUNCTIONS,
 )
 from corehq.apps.es import filters
 from corehq.apps.es.case_search import (
@@ -159,26 +159,6 @@ def build_filter_from_ast(domain, node, fuzzy=False):
             serialize(node)
         )
 
-    def _unwrap_function(node):
-        """Returns the value of the node if it is wrapped in a function, otherwise just returns the node
-        """
-        if isinstance(node, UnaryExpression) and node.op == '-':
-            return -1 * node.right
-        if not isinstance(node, FunctionCall):
-            return node
-        try:
-            return XPATH_VALUE_FUNCTIONS[node.name](domain, node)
-        except KeyError:
-            raise CaseFilterError(
-                _("We don't know what to do with the function \"{}\". Accepted functions are: {}").format(
-                    node.name,
-                    ", ".join(list(XPATH_VALUE_FUNCTIONS.keys())),
-                ),
-                serialize(node)
-            )
-        except XPathFunctionException as e:
-            raise CaseFilterError(str(e), serialize(node))
-
     def _equality(node):
         """Returns the filter for an equality operation (=, !=)
 
@@ -188,7 +168,7 @@ def build_filter_from_ast(domain, node, fuzzy=False):
                 isinstance(node.right, acceptable_rhs_types)):
             # This is a leaf node
             case_property_name = serialize(node.left)
-            value = _unwrap_function(node.right)
+            value = unwrap_value(domain, node.right)
             q = case_property_query(case_property_name, value, fuzzy=fuzzy)
 
             if node.op == '!=':
@@ -210,7 +190,7 @@ def build_filter_from_ast(domain, node, fuzzy=False):
         """
         try:
             case_property_name = serialize(node.left)
-            value = _unwrap_function(node.right)
+            value = unwrap_value(domain, node.right)
             return case_property_range_query(case_property_name, **{COMPARISON_MAPPING[node.op]: value})
         except (TypeError, ValueError):
             raise CaseFilterError(

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -575,6 +575,66 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         with self.assertRaises(CaseFilterError):
             build_filter_from_ast(None, parse_xpath("parent/name > other_property"))
 
+    @freeze_time('2021-08-02')
+    def test_filter_today(self):
+        parsed = parse_xpath("age > today()")
+        expected_filter = {
+            "nested": {
+                "path": "case_properties",
+                "query": {
+                    "bool": {
+                        "filter": [
+                            {
+                                "term": {
+                                    "case_properties.key.exact": "age"
+                                }
+                            }
+                        ],
+                        "must": {
+                            "range": {
+                                "case_properties.value.date": {
+                                    "gt": "2021-08-02"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        built_filter = build_filter_from_ast("domain", parsed, fuzzy=False)
+        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
+
+    @freeze_time('2021-08-02')
+    def test_filter_date_today(self):
+        parsed = parse_xpath("age > date(today())")
+        expected_filter = {
+            "nested": {
+                "path": "case_properties",
+                "query": {
+                    "bool": {
+                        "filter": [
+                            {
+                                "term": {
+                                    "case_properties.key.exact": "age"
+                                }
+                            }
+                        ],
+                        "must": {
+                            "range": {
+                                "case_properties.value.date": {
+                                    "gt": "2021-08-02"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        built_filter = build_filter_from_ast("domain", parsed, fuzzy=False)
+        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
+
 
 @es_test
 class TestFilterDslLookups(ElasticTestMixin, TestCase):

--- a/corehq/apps/case_search/tests/test_value_functions.py
+++ b/corehq/apps/case_search/tests/test_value_functions.py
@@ -5,7 +5,7 @@ from freezegun import freeze_time
 from testil import eq
 
 from corehq.apps.case_search.exceptions import XPathFunctionException
-from corehq.apps.case_search.xpath_functions.value_functions import today
+from corehq.apps.case_search.xpath_functions.value_functions import today, date
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
 
@@ -37,3 +37,22 @@ class TestToday(TestCase):
         node = parse_xpath("today('utc')")
         with self.assertRaises(XPathFunctionException):
             today("domain", node)
+
+
+@freeze_time('2021-08-02T22:00:00Z')
+class TestDate(TestCase):
+    def test_date_string(self):
+        the_date = '2021-01-01'
+        node = parse_xpath(f"date('{the_date}')")
+        result = date("domain", node)
+        eq(result, the_date)
+
+    def test_date_int(self):
+        node = parse_xpath("date(15)")
+        result = date("domain", node)
+        eq(result, '1970-01-16')
+
+    def test_date_today(self):
+        node = parse_xpath("date(today())")
+        result = date("domain", node)
+        eq(result, '2021-08-02')

--- a/corehq/apps/case_search/xpath_functions/value_functions.py
+++ b/corehq/apps/case_search/xpath_functions/value_functions.py
@@ -12,6 +12,8 @@ from dimagi.utils.parsing import ISO_DATE_FORMAT
 
 
 def date(domain, node):
+    from corehq.apps.case_search.dsl_utils import unwrap_value
+
     assert node.name == 'date'
     if len(node.args) != 1:
         raise XPathFunctionException(
@@ -19,6 +21,8 @@ def date(domain, node):
             serialize(node)
         )
     arg = node.args[0]
+
+    arg = unwrap_value(domain, arg)
 
     if isinstance(arg, int):
         return (datetime.date(1970, 1, 1) + datetime.timedelta(days=arg)).strftime("%Y-%m-%d")


### PR DESCRIPTION
## Technical Summary
Allow writing case search query expressions using functions as arguments e.g. `date(today())`

## Feature Flag
Case search, case list explorer

## Safety Assurance

### Safety story
Well tested area of the code. Impact would be limited to case search and CLE. Since this didn't work before it is fairly certain that there are no existing usages. Also the `today()` function was only added this week.

### Automated test coverage
Added

### QA Plan
None

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
