### PR TITLE
replattr -> patch.object

### DIFF
--- a/corehq/blobs/tests/test_migrate.py
+++ b/corehq/blobs/tests/test_migrate.py
@@ -118,7 +118,9 @@ Tests below are commented out because they are slow and no longer relevant
 to any current envs (all envs have been migrated). Kept for reference when
 writing new migrations.
 
-from testil import replattr, tempdir
+from unittest.mock import patch
+
+from testil import tempdir
 
 from corehq.apps.app_manager.models import Application, RemoteApp
 from corehq.blobs.mixin import BlobMixin
@@ -223,7 +225,7 @@ class BaseMigrationTest(TestCase):
                     modified.add(doc["_id"])
                 return super(ConcurrentModify, self)._do_migration(doc)
 
-        with replattr(migrator, "doc_migrator_class", ConcurrentModify):
+        with patch.object(migrator, "doc_migrator_class", ConcurrentModify):
             # do migration
             migrated, skipped = migrator.migrate(max_retry=0)
             self.assertGreaterEqual(skipped, len(docs))

--- a/corehq/blobs/tests/test_migratingdb.py
+++ b/corehq/blobs/tests/test_migratingdb.py
@@ -1,6 +1,5 @@
 from io import BytesIO
-
-from testil import replattr
+from unittest.mock import patch
 
 import corehq.blobs.migratingdb as mod
 from corehq.blobs.tests.util import (
@@ -38,7 +37,7 @@ class TestMigratingBlobDB(get_base_class()):
         content.seek(0)
         self.db.copy_blob(content, key=meta.key)
         self.assertEndsWith(self.fsdb.get_path(key=meta.key), "/" + meta.key)
-        with replattr(self.fsdb, "get", blow_up, sigcheck=False):
+        with patch.object(self.fsdb, "get", blow_up, sigcheck=False):
             with self.assertRaises(Boom):
                 self.fsdb.get(meta=meta)
             with self.db.get(meta=meta) as fh:

--- a/corehq/blobs/tests/test_migratingdb.py
+++ b/corehq/blobs/tests/test_migratingdb.py
@@ -37,7 +37,7 @@ class TestMigratingBlobDB(get_base_class()):
         content.seek(0)
         self.db.copy_blob(content, key=meta.key)
         self.assertEndsWith(self.fsdb.get_path(key=meta.key), "/" + meta.key)
-        with patch.object(self.fsdb, "get", blow_up, sigcheck=False):
+        with patch.object(self.fsdb, "get", blow_up):
             with self.assertRaises(Boom):
                 self.fsdb.get(meta=meta)
             with self.db.get(meta=meta) as fh:

--- a/corehq/ex-submodules/dimagi/utils/tests/test_decorators.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/test_decorators.py
@@ -1,7 +1,8 @@
 import sys
 from io import StringIO
+from unittest.mock import patch
 
-from testil import Regex, eq, replattr
+from testil import Regex, eq
 
 from .. import profile
 
@@ -14,7 +15,7 @@ def test_profile_decorator():
     def func(arg):
         args.append(arg)
 
-    with replattr(sys.stderr, "write", output.write):
+    with patch.object(sys.stderr, "write", output.write):
         func(1)
     eq(args, [1])
     eq(output.getvalue(), Regex(r"test_decorators.py:\d+\(func\)"))


### PR DESCRIPTION
`testil.replattr()` uses `inspect.getargspec()`, which is deprecated. Somehow that caused `dimagi.utils.tests.test_decorators:test_profile_decorator` to segfault when running tests with Django 3.2 ([example](https://github.com/dimagi/commcare-hq/runs/5691367237?check_suite_focus=true)).

This could possibly have been fixed with an update to [testil](https://github.com/millerdev/testil), but `patch.object()` is a more standard way to do the same thing.

## Safety Assurance

### Safety story

Modifies tests only.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
