### PR TITLE
Updated custom all_activity_complete_date rule to ignore cases with a…

### DIFF
--- a/custom/covid/rules/custom_actions.py
+++ b/custom/covid/rules/custom_actions.py
@@ -19,6 +19,9 @@ def set_all_activity_complete_date_to_today(case, rule):
     For any case matching the criteria, set the all_activity_complete_date property
     to today's date, in YYYY-MM-DD format, based on the domain's default time zone.
     """
+    if case.get_case_property("all_activity_complete_date"):
+        return CaseRuleActionResult()
+
     from dimagi.utils.parsing import ISO_DATE_FORMAT
     domain_obj = Domain.get_by_name(case.domain)
     today = datetime.now(domain_obj.get_default_timezone()).strftime(ISO_DATE_FORMAT)

--- a/custom/covid/tests/test_custom_rules.py
+++ b/custom/covid/tests/test_custom_rules.py
@@ -172,7 +172,7 @@ class AllActivityCompleteDateTest(BaseCaseRuleTest):
         today = datetime.today().strftime(ISO_DATE_FORMAT)
         case1 = CommCareCase.objects.get_case(case1.case_id)
         case2 = CommCareCase.objects.get_case(case2.case_id)
-        self.assertEqual(case1.get_case_property("all_activity_complete_date"), today)
+        self.assertEqual(case1.get_case_property("all_activity_complete_date"), "2021-06-31")
         self.assertEqual(case2.get_case_property("all_activity_complete_date"), today)
         self.assertFalse(case1.closed)
         self.assertFalse(case2.closed)


### PR DESCRIPTION
… date set

## Product Description
https://dimagi-dev.atlassian.net/browse/SUPPORT-13000

## Safety Assurance

### Safety story
Small change to a custom rule, with test coverage.

### Automated test coverage

In PR.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
