### PR TITLE
Show updated UCR naming to some domains

### DIFF
--- a/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
+++ b/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
@@ -2,20 +2,26 @@ hqDefine("userreports/js/configurable_reports_home", [
     'jquery',
     'underscore',
     'DOMPurify/dist/purify.min',
+    'hqwebapp/js/initial_page_data',
     'select2/dist/js/select2.full.min',
 ], function (
     $,
     _,
-    DOMPurify
+    DOMPurify,
+    initialPageData
 ) {
     var $select = $("#select2-navigation");
-
     $select.on('select2:select', function () {
         document.location = $select.val();
     });
-
+    var selectTextHeading = '';
+    if (initialPageData.get('useUpdatedUcrNaming')) {
+        selectTextHeading = gettext("Edit a custom web report or custom web report source");
+    } else {
+        selectTextHeading = gettext("Edit a report or data source");
+    }
     $select.select2({
-        placeholder: gettext("Edit a report or data source"),
+        placeholder: selectTextHeading,
         templateResult: function (item) {
             var text = item.text.trim();
             if (!item.element) {

--- a/corehq/apps/userreports/templates/userreports/configurable_reports_home.html
+++ b/corehq/apps/userreports/templates/userreports/configurable_reports_home.html
@@ -5,20 +5,35 @@
 {% requirejs_main 'userreports/js/configurable_reports_home' %}
 
 {% block page_content %}
-  <h1>{% trans "Configurable Reports" %}</h1>
-  <a href="{% url 'create_configurable_report' domain %}" class="btn btn-default">
-    <i class="fa fa-plus"></i>
-    {% trans 'Add Report' %}
-  </a>
-  <a href="{% url 'import_configurable_report' domain %}" class="btn btn-default">
-    <i class="fa fa-cloud-upload"></i>
-    {% trans 'Import Report' %}
-  </a>
-  <a href="{% url 'create_configurable_data_source' domain %}" class="btn btn-default">
-    <i class="fa fa-plus"></i>
-    {% trans 'Add Data Source' %}
-  </a>
-
+  {% if use_updated_ucr_naming %}
+    <h1>{% trans "Custom Web Reports" %}</h1>
+    <a href="{% url 'create_configurable_report' domain %}" class="btn btn-default">
+      <i class="fa fa-plus"></i>
+      {% trans 'Add Custom Web Report' %}
+    </a>
+    <a href="{% url 'import_configurable_report' domain %}" class="btn btn-default">
+      <i class="fa fa-cloud-upload"></i>
+      {% trans 'Import Custom Web Report' %}
+    </a>
+    <a href="{% url 'create_configurable_data_source' domain %}" class="btn btn-default">
+      <i class="fa fa-plus"></i>
+      {% trans 'Add Custom Web Report Source' %}
+    </a>
+  {% else %}
+    <h1>{% trans "Configurable Reports" %}</h1>
+    <a href="{% url 'create_configurable_report' domain %}" class="btn btn-default">
+      <i class="fa fa-plus"></i>
+      {% trans 'Add Report' %}
+    </a>
+    <a href="{% url 'import_configurable_report' domain %}" class="btn btn-default">
+      <i class="fa fa-cloud-upload"></i>
+      {% trans 'Import Report' %}
+    </a>
+    <a href="{% url 'create_configurable_data_source' domain %}" class="btn btn-default">
+      <i class="fa fa-plus"></i>
+      {% trans 'Add Data Source' %}
+    </a>
+  {% endif %}
   <br><br><br>
 
   <div class="row">

--- a/corehq/apps/userreports/templates/userreports/data_source_debugger.html
+++ b/corehq/apps/userreports/templates/userreports/data_source_debugger.html
@@ -6,10 +6,22 @@
 {% endblock %}
 {% block page_content %}
   {% registerurl "data_source_evaluator" domain %}
-  <h1>{% trans "UCR Data Source Debugger" %}</h1>
+  <h1>
+    {% if use_updated_ucr_naming %}
+      {% trans "Custom Web Report Source Debugger" %}
+    {% else %}
+      {% trans "UCR Data Source Debugger" %}
+    {% endif %}
+  </h1>
   <form id="data-source-debugger" class="form-horizontal" data-bind="submit: evaluateDataSource">
     <div class="form-group">
-      <label for="data_source_id" class="col-sm-2 control-label">{% trans "Data Source" %}</label>
+      <label for="data_source_id" class="col-sm-2 control-label">
+        {% if use_updated_ucr_naming %}
+          {% trans "Custom Web Report Source" %}
+        {% else %}
+          {% trans "Data Source" %}
+        {% endif %}
+      </label>
       <div class="col-sm-6">
         <select class="form-control hqwebapp-select2" id="data_source_id" data-bind="value: dataSourceId">
           {% for data_source in data_sources %}

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -7,13 +7,30 @@
   {% if data_source.get_id %}
     <div class="btn-toolbar pull-right">
         <div class="btn-group">
-          <a href="{% url 'preview_configurable_data_source' domain data_source.get_id %}" class="btn btn-default">{% trans 'Preview Data' %}</a>
-          <a href="{% url 'summary_configurable_data_source' domain data_source.get_id %}" class="btn btn-default">{% trans 'Data Source Summary' %}</a>
+          {% if use_updated_ucr_naming %}
+            <a href="{% url 'preview_configurable_data_source' domain data_source.get_id %}" class="btn btn-default">{% trans 'Preview Custom Web Report Data' %}</a>
+            <a href="{% url 'summary_configurable_data_source' domain data_source.get_id %}" class="btn btn-default">{% trans 'Custom Web Report Source Summary' %}</a>
+          {% else %}
+            <a href="{% url 'preview_configurable_data_source' domain data_source.get_id %}" class="btn btn-default">{% trans 'Preview Data' %}</a>
+            <a href="{% url 'summary_configurable_data_source' domain data_source.get_id %}" class="btn btn-default">{% trans 'Data Source Summary' %}</a>
+          {% endif %}
         </div>
         <div class="btn-group">
           <form method='post' action="{% url 'rebuild_configurable_data_source' domain data_source.get_id %}" >
             {% csrf_token %}
             <div {% if is_rebuilding or data_source.disable_destructive_rebuild %}style="margin-right: 15px;"{% endif %}>
+              {% if use_updated_ucr_naming %}
+              <button type="submit"
+                class="btn btn-default disable-on-submit"
+                data-toggle="popover"
+                title="Warning"
+                data-container="body"
+                data-content="{% trans_html_attr "Rebuilding report sources erases all the existing data and will start populating it again. While the rebuild is happening, reports based on this data source will show incomplete data" %}"
+                data-trigger="hover"
+                {% if data_source.disable_destructive_rebuild %}disabled{% endif %}>
+                {% trans 'Rebuild Custom Web Report Source' %}
+              </button>
+              {% else %}
               <button type="submit"
                 class="btn btn-default disable-on-submit"
                 data-toggle="popover"
@@ -24,6 +41,7 @@
                 {% if data_source.disable_destructive_rebuild %}disabled{% endif %}>
                 {% trans 'Rebuild Data Source'%}
               </button>
+              {% endif %}
               {# janky: can't use a tooltip on a disabled button, so instead add a help icon and force extra space (above) so it's clear which button this is for #}
               {% if data_source.disable_destructive_rebuild %}
                 <span class="hq-help-template"
@@ -50,7 +68,14 @@
                class="track-usage-link"
                data-category="UCR"
                data-action="View Source"
-               data-label="Data Source">{% trans "Data Source JSON" %}</a>
+               data-label="Data Source"
+              >
+              {% if use_updated_ucr_naming %}
+                {% trans "Custom Web Report Source JSON" %}
+              {% else %}
+                {% trans "Data Source JSON" %}
+              {% endif %}
+              </a>
           </li>
           {% if not data_source.is_deactivated %}
             <li>
@@ -85,11 +110,19 @@
           {% if not used_by_reports %}
             <form method='post' action="{% url 'delete_configurable_data_source' domain data_source.get_id %}" >
               {% csrf_token %}
-              <input type="submit" value="{% trans 'Delete Data Source'%}" class="btn btn-danger disable-on-submit">
+              {% if use_updated_ucr_naming %}
+                <input type="submit" value="{% trans 'Delete Custom Web Report Source'%}" class="btn btn-danger disable-on-submit">
+              {% else %}
+                <input type="submit" value="{% trans 'Delete Data Source'%}" class="btn btn-danger disable-on-submit">
+              {% endif %}
             </form>
           {% else %}
             <a href="#confirm_delete" class="btn btn-danger" data-toggle="modal">
-              {% trans 'Delete Data Source'%}
+              {% if use_updated_ucr_naming %}
+                {% trans 'Delete Custom Web Report Source'%}
+              {% else %}
+                {% trans 'Delete Data Source'%}
+              {% endif %}
             </a>
           {% endif %}
         {% endif %}

--- a/corehq/apps/userreports/templates/userreports/edit_report_config.html
+++ b/corehq/apps/userreports/templates/userreports/edit_report_config.html
@@ -10,17 +10,35 @@
     <div class="btn-toolbar">
       {% if report.get_id %}
         <div class="btn-group">
-          <a href="{% url 'configurable' domain report.get_id %}" class="btn btn-default">{% trans 'View Report' %}</a>
+          <a href="{% url 'configurable' domain report.get_id %}" class="btn btn-default">
+            {% if use_updated_ucr_naming %}
+              {% trans "View Custom Web Report" %}
+            {% else %}
+              {% trans 'View Report' %}
+            {% endif %}
+          </a>
         </div>
         <div class="btn-group">
-          <a href="{% url 'edit_configurable_data_source' domain report.config_id %}" class="btn btn-default">{% trans 'View Data Source' %}</a>
+          <a href="{% url 'edit_configurable_data_source' domain report.config_id %}" class="btn btn-default">
+            {% if use_updated_ucr_naming %}
+                {% trans 'View Custom Web Report Source' %}
+            {% else %}
+              {% trans 'View Data Source' %}
+            {% endif %}
+          </a>
         </div>
         <div class="btn-group">
           <a href="{% url 'configurable_report_json' domain report.get_id %}"
              class="btn btn-default track-usage-link"
              data-category="UCR"
              data-action="View Source"
-             data-label="Report Config">{% trans 'Report Source' %}</a>
+             data-label="Report Config">
+              {% if use_updated_ucr_naming %}
+                {% trans 'Custom Web Report JSON' %}
+              {% else %}
+                {% trans 'Report Source' %}
+              {% endif %}
+          </a>
         </div>
         {% if not report.is_static%}
           {% include 'userreports/partials/delete_report_button.html' with report_id=report.get_id %}

--- a/corehq/apps/userreports/templates/userreports/expression_debugger.html
+++ b/corehq/apps/userreports/templates/userreports/expression_debugger.html
@@ -10,7 +10,14 @@
   {% initial_page_data "document_type" request.GET.type %}
   {% initial_page_data "document_id" request.GET.id %}
   {% initial_page_data "data_source_id" request.GET.data_source %}
-  <h1>{% trans "UCR Expression Debugger" %}</h1>
+
+  <h1>
+    {% if use_updated_ucr_naming %}
+      {% trans "Custom Web Report Expression Debugger" %}
+    {% else %}
+      {% trans "UCR Expression Debugger" %}
+    {% endif %}
+  </h1>
   <p>{% trans "Paste an expression and document information below to see the result of that expression evaluated on the document." %}</p>
   <form id="expression-debugger" class="form-horizontal ko-template" data-bind="submit: evaluateExpression">
     <div class="form-group">
@@ -42,7 +49,13 @@
     </div>
     {% if data_sources %}
       <div class="form-group">
-        <label for="data_source_id" class="col-sm-2 control-label">{% trans "Data Source (optional)" %}</label>
+        <label for="data_source_id" class="col-sm-2 control-label">
+          {% if use_updated_ucr_naming %}
+            {% trans "Custom Web Report Source (optional)" %}
+          {% else %}
+            {% trans "Data Source (optional)" %}
+          {% endif %}
+        </label>
         <div class="col-sm-6">
           <select class="hqwebapp-select2" data-bind="value: dataSourceId">
             <option></option>

--- a/corehq/apps/userreports/templates/userreports/partials/delete_report_button.html
+++ b/corehq/apps/userreports/templates/userreports/partials/delete_report_button.html
@@ -6,7 +6,11 @@
     class="btn btn-danger"
     href="{% url 'delete_configurable_report' domain report_id %}?redirect={% url 'reports_home' domain %}"
   >
+  {% if use_updated_ucr_naming %}
+    {% trans 'Delete Custom Web Report' %}
+  {% else %}
     {% trans 'Delete Report' %}
+  {% endif %}
   </a>
 {% else %}
   <div class="btn-group">
@@ -17,7 +21,11 @@
     {% else %}
       <form method='post' action="{% url 'delete_configurable_report' domain report_id %}" >
         {% csrf_token %}
-        <input type="submit" value="{% trans 'Delete Report'%}" class="btn btn-danger disable-on-submit pull-right">
+        {% if use_updated_ucr_naming %}
+          <input type="submit" value="{% trans 'Delete Custom Web Report'%}" class="btn btn-danger disable-on-submit pull-right">
+        {% else %}
+          <input type="submit" value="{% trans 'Delete Report'%}" class="btn btn-danger disable-on-submit pull-right">
+        {% endif %}
       </form>
     {% endif %}
   </div>

--- a/corehq/apps/userreports/templates/userreports/userreports_base.html
+++ b/corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -19,48 +19,93 @@
   {% initial_page_data 'useUpdatedUcrNaming' use_updated_ucr_naming %}
   <h2 class="text-hq-nav-header">{% trans "Tools" %}</h2>
   <ul class="nav nav-hq-sidebar">
-    <li>
-      <a href="{% url 'configurable_reports_home' domain %}">
-        <i class="fa fa-wrench"></i>
-        {% trans "Configurable Reports" %}
-      </a>
-    </li>
-    <li>
-      <a href="{% url 'create_configurable_report' domain %}">
-        <i class="fa fa-plus"></i>
-        {% trans "Add report" %}
-      </a>
-    </li>
-    <li>
-      <a href="{% url 'import_configurable_report' domain %}">
-        <i class="fa fa-cloud-upload"></i>
-        {% trans "Import report" %}
-      </a>
-    </li>
-    <li>
-      <a href="{% url 'create_configurable_data_source' domain %}">
-        <i class="fa fa-plus"></i>
-        {% trans "Add data source" %}
-      </a>
-    </li>
-    <li>
-      <a href="{% url 'create_configurable_data_source_from_app' domain %}">
-        <i class="fa fa-copy"></i>
-        {% trans "Data source from application" %}
-      </a>
-    </li>
-    <li>
-      <a href="{% url 'expression_debugger' domain %}">
-        <i class="fa fa-search"></i>
-        {% trans "Expression Debugger" %}
-      </a>
-    </li>
-    <li>
-      <a href="{% url 'data_source_debugger' domain %}">
-        <i class="fa fa-search"></i>
-        {% trans "Data Source Debugger" %}
-      </a>
-    </li>
+    {% if use_updated_ucr_naming %}
+      <li>
+        <a href="{% url 'configurable_reports_home' domain %}">
+          <i class="fa fa-wrench"></i>
+          {% trans "Custom Web Reports" %}
+        </a>
+      </li>
+      <li>
+        <a href="{% url 'create_configurable_report' domain %}">
+          <i class="fa fa-plus"></i>
+          {% trans "Add Custom Web Report" %}
+        </a>
+      </li>
+      <li>
+        <a href="{% url 'import_configurable_report' domain %}">
+          <i class="fa fa-cloud-upload"></i>
+          {% trans "Import Custom Web Report" %}
+        </a>
+      </li>
+      <li>
+        <a href="{% url 'create_configurable_data_source' domain %}">
+          <i class="fa fa-plus"></i>
+          {% trans "Add Custom Web Report Source" %}
+        </a>
+      </li>
+      <li>
+        <a href="{% url 'create_configurable_data_source_from_app' domain %}">
+          <i class="fa fa-copy"></i>
+          {% trans "Custom Web Report Source from Application" %}
+        </a>
+      </li>
+      <li>
+        <a href="{% url 'expression_debugger' domain %}">
+          <i class="fa fa-search"></i>
+          {% trans "Expression Debugger" %}
+        </a>
+      </li>
+      <li>
+        <a href="{% url 'data_source_debugger' domain %}">
+          <i class="fa fa-search"></i>
+          {% trans "Custom Web Report Source Debugger" %}
+        </a>
+      </li>
+    {% else %}
+      <li>
+        <a href="{% url 'configurable_reports_home' domain %}">
+          <i class="fa fa-wrench"></i>
+          {% trans "Configurable Reports" %}
+        </a>
+      </li>
+      <li>
+        <a href="{% url 'create_configurable_report' domain %}">
+          <i class="fa fa-plus"></i>
+          {% trans "Add report" %}
+        </a>
+      </li>
+      <li>
+        <a href="{% url 'import_configurable_report' domain %}">
+          <i class="fa fa-cloud-upload"></i>
+          {% trans "Import report" %}
+        </a>
+      </li>
+      <li>
+        <a href="{% url 'create_configurable_data_source' domain %}">
+          <i class="fa fa-plus"></i>
+          {% trans "Add data source" %}
+        </a>
+      </li>
+      <li>
+        <a href="{% url 'create_configurable_data_source_from_app' domain %}">
+          <i class="fa fa-copy"></i>
+          {% trans "Data source from application" %}
+        </a>
+      </li>
+      <li>
+        <a href="{% url 'expression_debugger' domain %}">
+          <i class="fa fa-search"></i>
+          {% trans "Expression Debugger" %}
+        </a>
+      </li>
+      <li>
+        <a href="{% url 'data_source_debugger' domain %}">
+          <i class="fa fa-search"></i>
+          {% trans "Data Source Debugger" %}
+        </a>
+      </li>
+    {% endif %}
   </ul>
 
   <h2 class="text-hq-nav-header">{% trans "Edit Reports" %}</h2>
@@ -79,7 +124,14 @@
     {% endwith %}
   </ul>
 
-  <h2 class="text-hq-nav-header">{% trans "Edit Data Sources" %}</h2>
+  <h2 class="text-hq-nav-header">
+    {% if use_updated_ucr_naming %}
+      {% trans "Edit Custom Data Sources" %}
+    {% else %}
+      {% trans "Edit Data Sources" %}
+    {% endif %}
+
+  </h2>
   <ul class="nav nav-hq-sidebar">
     {% with data_source as selected_data_source %}
       {% for data_source in data_sources %}

--- a/corehq/apps/userreports/templates/userreports/userreports_base.html
+++ b/corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -16,6 +16,7 @@
 {% endblock %}
 
 {% block page_navigation %}
+  {% initial_page_data 'useUpdatedUcrNaming' use_updated_ucr_naming %}
   <h2 class="text-hq-nav-header">{% trans "Tools" %}</h2>
   <ul class="nav nav-hq-sidebar">
     <li>

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -230,6 +230,9 @@ class BaseUserConfigReportsView(BaseDomainView):
                 get_permission_name(Permissions.edit_ucrs)
             )
         )
+        if toggles.UCR_UPDATED_NAMING.enabled(self.domain):
+            self.section_name = gettext_lazy("Custom Web Reports")
+
         if allow_access_to_ucrs:
             return super().dispatch(*args, **kwargs)
         raise Http404()

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -207,6 +207,8 @@ class BaseUserConfigReportsView(BaseDomainView):
                 + RegistryReportConfiguration.by_domain(self.domain)
                 + static_reports
             ),
+            'data_sources': get_datasources_for_domain(self.domain, include_static=True),
+            'use_updated_ucr_naming': toggle_enabled(self.request, toggles.UCR_UPDATED_NAMING)
         })
         if toggle_enabled(self.request, toggles.AGGREGATE_UCRS):
             from corehq.apps.aggregate_ucrs.models import AggregateTableDefinition

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -924,6 +924,11 @@ class DataSourceDebuggerView(BaseUserConfigReportsView):
     template_name = 'userreports/data_source_debugger.html'
     page_title = gettext_lazy("Data Source Debugger")
 
+    def dispatch(self, *args, **kwargs):
+        if toggles.UCR_UPDATED_NAMING.enabled(self.domain):
+            self.page_title = gettext_lazy("Custom Web Report Source Debugger")
+        return super().dispatch(*args, **kwargs)
+
 
 @login_and_domain_required
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -202,8 +202,11 @@ class BaseUserConfigReportsView(BaseDomainView):
         static_reports = list(StaticReportConfiguration.by_domain(self.domain))
         context = super(BaseUserConfigReportsView, self).main_context
         context.update({
-            'reports': ReportConfiguration.by_domain(self.domain) + RegistryReportConfiguration.by_domain(self.domain) + static_reports,
-            'data_sources': get_datasources_for_domain(self.domain, include_static=True)
+            'reports': (
+                ReportConfiguration.by_domain(self.domain)
+                + RegistryReportConfiguration.by_domain(self.domain)
+                + static_reports
+            ),
         })
         if toggle_enabled(self.request, toggles.AGGREGATE_UCRS):
             from corehq.apps.aggregate_ucrs.models import AggregateTableDefinition

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -4,7 +4,7 @@ hqDefine('users/js/roles',[
     'knockout',
     'hqwebapp/js/toggles',
     'hqwebapp/js/alert_user',
-], function ($, _, ko, toggles) {
+], function ($, _, ko, toggles, alertUser) {
     let selectPermissionModel = function (id, permissionModel, text) {
         /*
         Function to build the view model for permissions that aren't simple booleans. The data is

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -2,8 +2,9 @@ hqDefine('users/js/roles',[
     'jquery',
     'underscore',
     'knockout',
+    'hqwebapp/js/toggles',
     'hqwebapp/js/alert_user',
-], function ($, _, ko, alertUser) {
+], function ($, _, ko, toggles) {
     let selectPermissionModel = function (id, permissionModel, text) {
         /*
         Function to build the view model for permissions that aren't simple booleans. The data is
@@ -357,14 +358,23 @@ hqDefine('users/js/roles',[
                         checkboxPermission: self.reportPermissions.all,
                         checkboxText: gettext("Allow role to access all reports."),
                     }];
-                self.ucrs = [{
-                    visibilityRestraint: self.permissions.access_all_locations,
-                    text: gettext("Create and Edit Configurable Reports"),
-                    checkboxLabel: "create-and-edit-configurable-reports-checkbox",
-                    checkboxPermission: self.permissions.edit_ucrs,
-                    checkboxText: gettext("Allow role to create and edit configurable reports."),
-                }];
-
+                if (toggles.toggleEnabled('UCR_UPDATED_NAMING')) {
+                    self.ucrs = [{
+                        visibilityRestraint: self.permissions.access_all_locations,
+                        text: gettext("Create and Edit Custom Web Reports"),
+                        checkboxLabel: "create-and-edit-configurable-reports-checkbox",
+                        checkboxPermission: self.permissions.edit_ucrs,
+                        checkboxText: gettext("Allow role to create and edit custom web reports."),
+                    }];
+                } else {
+                    self.ucrs = [{
+                        visibilityRestraint: self.permissions.access_all_locations,
+                        text: gettext("Create and Edit Configurable Reports"),
+                        checkboxLabel: "create-and-edit-configurable-reports-checkbox",
+                        checkboxPermission: self.permissions.edit_ucrs,
+                        checkboxText: gettext("Allow role to create and edit configurable reports."),
+                    }];
+                }
                 self.registryPermissions = [
                     selectPermissionModel(
                         'manage_registries',

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -179,8 +179,11 @@ class ProjectReportsTab(UITab):
         if is_ucr_toggle_enabled and has_ucr_permissions:
 
             from corehq.apps.userreports.views import UserConfigReportsHomeView
+            title = _(UserConfigReportsHomeView.section_name)
+            if toggles.UCR_UPDATED_NAMING.enabled(self.domain):
+                title = _("Custom Web Reports")
             tools.append({
-                'title': _(UserConfigReportsHomeView.section_name),
+                'title': title,
                 'url': reverse(UserConfigReportsHomeView.urlname, args=[self.domain]),
                 'icon': 'icon-tasks fa fa-wrench',
             })

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -732,6 +732,17 @@ USER_CONFIGURABLE_REPORTS = StaticToggle(
     help_link='https://confluence.dimagi.com/display/GTDArchive/User+Configurable+Reporting',
 )
 
+UCR_UPDATED_NAMING = StaticToggle(
+    'ucr_updated_naming',
+    'Show updated naming of UCRS',
+    TAG_SAAS_CONDITIONAL,
+    [NAMESPACE_DOMAIN],
+    description=(
+        "Displays updated UCR naming if the feature flag is enabled."
+        "This is a temporary flag which would be removed when the updated naming is agreed upon by all divisons."
+    )
+)
+
 LOCATIONS_IN_UCR = StaticToggle(
     'locations_in_ucr',
     'ICDS: Add Locations as one of the Source Types for User Configurable Reports',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
https://dimagi-dev.atlassian.net/browse/SAAS-13337
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
For the time we do not get approval to use updated UCR naming from all Divisions we are going with a middle way where we are displaying updated naming only to domains which SaaS wants.
This is being done by introducing a new feature flag `UCR_UPDATED_NAMING`.
This is a temporary change and hopefully would be removed as soon as we get buy in from all domains. 

Review by commit 🐟 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
UCR_UPDATED_NAMING
## Safety Assurance
Affects only UI for UCRs and would be going through QA
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This has been tested on local and is on staging for QA
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-4003

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
