### PR TITLE
Updated HTTP return codes for case claim request

### DIFF
--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -105,11 +105,10 @@ class CaseClaimEndpointTests(TestCase):
         url = reverse('claim_case', kwargs={'domain': DOMAIN})
         # First claim
         response = client.post(url, {'case_id': self.case_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 201)
         # Dup claim
         response = client.post(url, {'case_id': self.case_id})
-        self.assertEqual(response.status_code, 409)
-        self.assertEqual(response.content.decode('utf-8'), 'You have already claimed that case')
+        self.assertEqual(response.status_code, 204)
 
     def test_duplicate_user_claim(self):
         """
@@ -120,13 +119,12 @@ class CaseClaimEndpointTests(TestCase):
         url = reverse('claim_case', kwargs={'domain': DOMAIN})
         # First claim
         response = client1.post(url, {'case_id': self.case_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 201)
         # Dup claim
         client2 = Client()
         client2.login(username=USERNAME, password=PASSWORD)
         response = client2.post(url, {'case_id': self.case_id})
-        self.assertEqual(response.status_code, 409)
-        self.assertEqual(response.content.decode('utf-8'), 'You have already claimed that case')
+        self.assertEqual(response.status_code, 204)
 
     @flaky
     def test_claim_restore_as(self):

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -145,8 +145,7 @@ def claim(request, domain):
 
     try:
         if get_first_claim(domain, restore_user.user_id, case_id):
-            return HttpResponse('You have already claimed that {}'.format(request.POST.get('case_type', 'case')),
-                                status=204)
+            return HttpResponse(status=204)
 
         claim_case(domain, restore_user, case_id,
                    host_type=unquote(request.POST.get('case_type', '')),

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -146,7 +146,7 @@ def claim(request, domain):
     try:
         if get_first_claim(domain, restore_user.user_id, case_id):
             return HttpResponse('You have already claimed that {}'.format(request.POST.get('case_type', 'case')),
-                                status=409)
+                                status=204)
 
         claim_case(domain, restore_user, case_id,
                    host_type=unquote(request.POST.get('case_type', '')),
@@ -155,7 +155,7 @@ def claim(request, domain):
     except CaseNotFound:
         return HttpResponse('The case "{}" you are trying to claim was not found'.format(case_id),
                             status=410)
-    return HttpResponse(status=200)
+    return HttpResponse(status=201)
 
 
 def get_restore_params(request, domain):


### PR DESCRIPTION
## Technical Summary
Update return codes as discussed [here](https://dimagi-dev.atlassian.net/browse/USH-1794?focusedCommentId=196673).

I verified with [this gist](https://gist.github.com/orangejenny/22c7167d37737121e5e45bdcd05f3da8) that all real apps on production and india have `CaseSearch.default_relevant` set to True anyway, so they won't try to claim cases that are already in the user's casedb.

I'll do a followup to remove `CaseSearch.default_relevant` altogether but wanted this to be its own tiny PR to minimize conflicts with https://github.com/dimagi/commcare-hq/pull/31304  Didn't update the error text for the same reason.

@proteusvacuum Looking back over the ticket conversation, I see you raised the possibility that this could affect behavior in low connectivity situations, but I haven't been able to come up with a specific problematic scenario. I'm assuming that if there's low connectivity, the claim request will error, and that would mean the app won't let the user proceed on to sync.

## Feature Flag
Case search & claim

## Safety Assurance

### Safety story
I'm reasonably certain this change won't have a user-facing effect.

### Automated test coverage

None.

### QA Plan

Not requesting QA. I deployed to staging and tested selecting the following kinds of cases from case search results
1. A case my user already owned
2. A case my user did not own
3. A case my user did not own and had previously claimed

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
