### PR TITLE
Removed default relevant option

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2225,8 +2225,7 @@ class CaseSearch(DocumentSchema):
     properties = SchemaListProperty(CaseSearchProperty)
     auto_launch = BooleanProperty(default=False)        # if true, skip the casedb case list
     default_search = BooleanProperty(default=False)     # if true, skip the search fields screen
-    default_relevant = BooleanProperty(default=True)
-    additional_relevant = StringProperty(exclude_if_none=True)
+    additional_relevant = StringProperty(exclude_if_none=True)  # in "addition" to the default relevancy condition
     search_filter = StringProperty(exclude_if_none=True)
     search_button_display_condition = StringProperty(exclude_if_none=True)
     default_properties = SchemaListProperty(DefaultCaseSearchProperty)
@@ -2244,14 +2243,10 @@ class CaseSearch(DocumentSchema):
         return "search_case_id"
 
     def get_relevant(self):
-        relevant = self.additional_relevant or ""
-        if self.default_relevant:
-            default_condition = CaseClaimXpath(self.case_session_var).default_relevant()
-            if relevant:
-                relevant = f"({default_condition}) and ({relevant})"
-            else:
-                relevant = default_condition
-        return relevant
+        default_condition = CaseClaimXpath(self.case_session_var).default_relevant()
+        if self.additional_relevant:
+            return f"({default_condition}) and ({self.additional_relevant})"
+        return default_condition
 
     def overwrite_attrs(self, src_config, slugs):
         if 'search_properties' in slugs:

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -179,7 +179,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
 
     var searchConfigKeys = [
         'autoLaunch', 'blacklistedOwnerIdsExpression', 'defaultSearch', 'searchAgainLabel',
-        'searchButtonDisplayCondition', 'searchLabel', 'searchFilter', 'searchDefaultRelevant',
+        'searchButtonDisplayCondition', 'searchLabel', 'searchFilter',
         'searchAdditionalRelevant', 'dataRegistry', 'dataRegistryWorkflow', 'additionalRegistryCases',
         'customRelatedCaseProperty',
     ];
@@ -260,7 +260,6 @@ hqDefine("app_manager/js/details/case_claim", function () {
             return {
                 auto_launch: self.autoLaunch(),
                 default_search: self.defaultSearch(),
-                search_default_relevant: self.searchDefaultRelevant(),
                 search_additional_relevant: self.searchAdditionalRelevant(),
                 search_button_display_condition: self.searchButtonDisplayCondition(),
                 data_registry: self.dataRegistry(),

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -37,7 +37,6 @@ hqDefine("app_manager/js/modules/module_view", function () {
                     fixtureSelect: detail.fixture_select,
                     multimedia: initial_page_data('multimedia_object_map'),
                     searchProperties: options.search_properties || [],
-                    searchDefaultRelevant: options.search_default_relevant,
                     searchAdditionalRelevant: options.search_additional_relevant,
                     autoLaunch: options.auto_launch,
                     defaultSearch: options.default_search,

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -211,16 +211,6 @@
             </div>
           </div>
           <div class="form-group">
-            <label class="control-label {% css_label_class %}" for="search-default-relevant">
-              {% trans "Don't claim cases already owned by the user" %}
-            </label>
-            <div class="checkbox {% css_field_class %}">
-              <label>
-                <input type="checkbox" id="search-default-relevant" data-bind="checked: searchDefaultRelevant">
-              </label>
-            </div>
-          </div>
-          <div class="form-group">
             <label for="blacklisted-user-ids" class="control-label {% css_label_class %}">
               {% trans "Don't search cases owned by the following ids" %}
               <span class="hq-help-template" data-title="{% trans "Ignore Owners" %}"

--- a/corehq/apps/app_manager/tests/test_modules.py
+++ b/corehq/apps/app_manager/tests/test_modules.py
@@ -229,7 +229,6 @@ class OverwriteCaseSearchConfigTests(SimpleTestCase):
             ],
             auto_launch=True,
             default_search=True,
-            default_relevant=False,
             additional_relevant="instance('groups')/groups/group",
             search_filter="name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name",
             search_button_display_condition="false()",

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -165,7 +165,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
                 CaseSearchProperty(name='dob', label={'en': 'Date of birth'})
             ],
-            default_relevant=True,
             additional_relevant="instance('groups')/groups/group",
             search_filter="name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name",
             default_properties=[
@@ -191,16 +190,9 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     def test_search_config_model(self, *args):
         config = CaseSearch()
 
-        config.default_relevant = True
         self.assertEqual(config.get_relevant(), "count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/search_case_id]) = 0")  # noqa: E501
 
-        config.default_relevant = False
-        self.assertEqual(config.get_relevant(), "")
-
         config.additional_relevant = "double(now()) mod 2 = 0"
-        self.assertEqual(config.get_relevant(), "double(now()) mod 2 = 0")
-
-        config.default_relevant = True
         self.assertEqual(config.get_relevant(), "(count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/search_case_id]) = 0) and (double(now()) mod 2 = 0)")  # noqa: E501
 
     @flag_enabled("USH_CASE_CLAIM_UPDATES")

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -229,8 +229,6 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
             'search_filter': module.search_config.search_filter if module_offers_search(module) else "",
             'search_button_display_condition':
                 module.search_config.search_button_display_condition if module_offers_search(module) else "",
-            'search_default_relevant':
-                module.search_config.default_relevant if module_offers_search(module) else True,
             'search_additional_relevant':
                 module.search_config.additional_relevant if module_offers_search(module) else "",
             'blacklisted_owner_ids_expression': (
@@ -1249,7 +1247,6 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
                 search_again_label=search_again_label,
                 properties=properties,
                 additional_case_types=module.search_config.additional_case_types,
-                default_relevant=bool(search_properties.get('search_default_relevant')),
                 additional_relevant=search_properties.get('search_additional_relevant', ''),
                 auto_launch=force_auto_launch or bool(search_properties.get('auto_launch')),
                 default_search=bool(search_properties.get('default_search')),

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -105,11 +105,10 @@ class CaseClaimEndpointTests(TestCase):
         url = reverse('claim_case', kwargs={'domain': DOMAIN})
         # First claim
         response = client.post(url, {'case_id': self.case_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 201)
         # Dup claim
         response = client.post(url, {'case_id': self.case_id})
-        self.assertEqual(response.status_code, 409)
-        self.assertEqual(response.content.decode('utf-8'), 'You have already claimed that case')
+        self.assertEqual(response.status_code, 204)
 
     def test_duplicate_user_claim(self):
         """
@@ -120,13 +119,12 @@ class CaseClaimEndpointTests(TestCase):
         url = reverse('claim_case', kwargs={'domain': DOMAIN})
         # First claim
         response = client1.post(url, {'case_id': self.case_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 201)
         # Dup claim
         client2 = Client()
         client2.login(username=USERNAME, password=PASSWORD)
         response = client2.post(url, {'case_id': self.case_id})
-        self.assertEqual(response.status_code, 409)
-        self.assertEqual(response.content.decode('utf-8'), 'You have already claimed that case')
+        self.assertEqual(response.status_code, 204)
 
     @flaky
     def test_claim_restore_as(self):

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -145,8 +145,7 @@ def claim(request, domain):
 
     try:
         if get_first_claim(domain, restore_user.user_id, case_id):
-            return HttpResponse('You have already claimed that {}'.format(request.POST.get('case_type', 'case')),
-                                status=204)
+            return HttpResponse(status=204)
 
         claim_case(domain, restore_user, case_id,
                    host_type=unquote(request.POST.get('case_type', '')),

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -146,7 +146,7 @@ def claim(request, domain):
     try:
         if get_first_claim(domain, restore_user.user_id, case_id):
             return HttpResponse('You have already claimed that {}'.format(request.POST.get('case_type', 'case')),
-                                status=409)
+                                status=204)
 
         claim_case(domain, restore_user, case_id,
                    host_type=unquote(request.POST.get('case_type', '')),
@@ -155,7 +155,7 @@ def claim(request, domain):
     except CaseNotFound:
         return HttpResponse('The case "{}" you are trying to claim was not found'.format(case_id),
                             status=410)
-    return HttpResponse(status=200)
+    return HttpResponse(status=201)
 
 
 def get_restore_params(request, domain):


### PR DESCRIPTION
## Product Description
Removes this option from search & claim options.

![Screen Shot 2022-03-28 at 5 39 23 PM](https://user-images.githubusercontent.com/1486591/160491917-239a51d2-9936-435f-8bea-35b7e2093e73.png)

Instead, all apps will behave as if the box is checked. There are no real apps on production or india that **don't** have the box checked, based on [this gist](https://gist.github.com/orangejenny/22c7167d37737121e5e45bdcd05f3da8).

## Technical Summary
This will make https://dimagi-dev.atlassian.net/browse/USH-1817 simpler, since default relevancy logic is different for multiple-case case lists.

First commit is from https://github.com/dimagi/commcare-hq/pull/31339

## Feature Flag
Case search & claim.

## Safety Assurance

### Safety story
This is largely removed code. Automated test coverage should be sufficient to test the logic changes.

### Automated test coverage
In PR.

### QA Plan
Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
