### PR TITLE
separate feature flag for Data Registry reports

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -91,7 +91,7 @@ from corehq.toggles import (
     SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER,
     OVERRIDE_EXPANDED_COLUMN_LIMIT_IN_REPORT_BUILDER,
     SHOW_IDS_IN_REPORT_BUILDER,
-    DATA_REGISTRY
+    DATA_REGISTRY_UCR
 )
 from dimagi.utils.couch.undo import undo_delete
 
@@ -983,7 +983,7 @@ class DataSourceForm(forms.Form):
         # TODO: Map reports.
         self.app_source_helper = ApplicationDataSourceUIHelper(
             enable_raw=SHOW_RAW_DATA_SOURCES_IN_REPORT_BUILDER.enabled(self.domain),
-            enable_registry=(DATA_REGISTRY.enabled(self.domain)
+            enable_registry=(DATA_REGISTRY_UCR.enabled(self.domain)
                              and self.registry_permission_checker.can_view_some_data_registry_contents()),
             registry_permission_checker=self.registry_permission_checker
         )
@@ -1019,7 +1019,7 @@ class DataSourceForm(forms.Form):
         )
 
     def get_data_layout(self):
-        if not (DATA_REGISTRY.enabled(self.domain)
+        if not (DATA_REGISTRY_UCR.enabled(self.domain)
                 and self.registry_permission_checker.can_view_some_data_registry_contents()):
             return crispy.Fieldset(
                 _('Data'), *self.app_source_helper.get_crispy_fields(),

--- a/corehq/apps/userreports/templates/userreports/report_error.html
+++ b/corehq/apps/userreports/templates/userreports/report_error.html
@@ -18,7 +18,7 @@
       <div id="error-message"></div>
     </div>
   {% endblock report_alerts %}
-  {% if report_id and not is_static %}
+  {% if allow_delete %}
     <form method='post' action="{% url 'delete_configurable_report' domain report_id %}?redirect={% url 'reports_home' domain %}" >
       {% csrf_token %}
       <input type="submit" value="{% trans 'Delete Report'%}" class="btn btn-danger disable-on-submit pull-right">

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -88,8 +88,14 @@ def _can_edit_report(request, report):
     ucr_toggle = toggle_enabled(request, toggles.USER_CONFIGURABLE_REPORTS)
     report_builder_toggle = toggle_enabled(request, toggles.REPORT_BUILDER)
     report_builder_beta_toggle = toggle_enabled(request, toggles.REPORT_BUILDER_BETA_GROUP)
+    data_registry_ucr_toggle = toggle_enabled(request, toggles.DATA_REGISTRY_UCR)
     add_on_priv = has_report_builder_add_on_privilege(request)
     created_by_builder = report.spec.report_meta.created_by_builder
+    is_data_registry_report = report.spec.config.meta.build.registry_slug
+
+    if is_data_registry_report and not data_registry_ucr_toggle:
+        # disable editing or deleting DR reports
+        return False
 
     if created_by_builder:
         return report_builder_toggle or report_builder_beta_toggle or add_on_priv

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -510,10 +510,6 @@ class ConfigureReport(ReportBuilderView):
             self.app_id = self.request.GET.get('application', None)
             self.source_id = self.request.GET['source']
             if self.registry_slug:
-                if not toggles.DATA_REGISTRY_UCR.enabled(self.domain):
-                    return self.render_error_response(
-                        _("Data Registry Reports are not available to this project.")
-                    )
                 helper = DataRegistryHelper(self.domain, registry_slug=self.registry_slug)
                 helper.check_data_access(request.couch_user, [self.source_id], case_domain=self.domain)
                 self.source_type = DATA_SOURCE_TYPE_CASE
@@ -521,6 +517,11 @@ class ConfigureReport(ReportBuilderView):
             else:
                 self.app = Application.get(self.app_id)
                 self.source_type = self.request.GET['source_type']
+
+        if self.registry_slug and not toggles.DATA_REGISTRY_UCR.enabled(self.domain):
+            return self.render_error_response(
+                _("Creating or Editing Data Registry Reports are not enabled for this project."),
+            )
 
         if not self.app_id and self.source_type != DATA_SOURCE_TYPE_RAW and not self.registry_slug:
             raise BadBuilderConfigError(DATA_SOURCE_MISSING_APP_ERROR_MESSAGE)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -113,7 +113,9 @@ from corehq.apps.userreports.models import (
     get_datasource_config,
     get_report_config,
     id_is_static,
-    report_config_id_is_static, RegistryReportConfiguration,
+    report_config_id_is_static,
+    RegistryReportConfiguration,
+    RegistryDataSourceConfiguration,
 )
 from corehq.apps.userreports.rebuild import DataSourceResumeHelper
 from corehq.apps.userreports.reports.builder.forms import (
@@ -861,7 +863,9 @@ def delete_report(request, domain, report_id):
 def undelete_report(request, domain, report_id):
     _assert_report_delete_privileges(request)
     config = get_document_or_404(ReportConfiguration, domain, report_id, additional_doc_types=[
-        get_deleted_doc_type(ReportConfiguration)
+        get_deleted_doc_type(ReportConfiguration),
+        RegistryReportConfiguration.doc_type,
+        get_deleted_doc_type(RegistryReportConfiguration)
     ])
     if config and is_deleted(config):
         undo_delete(config)
@@ -1236,7 +1240,9 @@ def delete_data_source_shared(domain, config_id, request=None):
 @require_POST
 def undelete_data_source(request, domain, config_id):
     config = get_document_or_404(DataSourceConfiguration, domain, config_id, additional_doc_types=[
-        get_deleted_doc_type(DataSourceConfiguration)
+        get_deleted_doc_type(DataSourceConfiguration),
+        RegistryDataSourceConfiguration.doc_type,
+        get_deleted_doc_type(RegistryDataSourceConfiguration),
     ])
     if config and is_deleted(config):
         undo_delete(config)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -521,6 +521,7 @@ class ConfigureReport(ReportBuilderView):
         if self.registry_slug and not toggles.DATA_REGISTRY_UCR.enabled(self.domain):
             return self.render_error_response(
                 _("Creating or Editing Data Registry Reports are not enabled for this project."),
+                allow_delete=False
             )
 
         if not self.app_id and self.source_type != DATA_SOURCE_TYPE_RAW and not self.registry_slug:
@@ -535,12 +536,15 @@ class ConfigureReport(ReportBuilderView):
         self._populate_data_source_properties_from_interface(data_source_interface)
         return super(ConfigureReport, self).dispatch(request, *args, **kwargs)
 
-    def render_error_response(self, message):
+    def render_error_response(self, message, allow_delete=None):
         if self.existing_report:
-            context = {'report_id': self.existing_report.get_id,
-                       'is_static': self.existing_report.is_static}
+            context = {
+                'allow_delete': self.existing_report.get_id and not self.existing_report.is_static
+            }
         else:
             context = {}
+        if allow_delete is not None:
+            context['allow_delete'] = allow_delete
         context['error_message'] = message
         context.update(self.main_context)
         return render(self.request, 'userreports/report_error.html', context)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1909,15 +1909,6 @@ REFER_CASE_REPEATER = StaticToggle(
     help_link="https://confluence.dimagi.com/display/saas/COVID%3A+Allow+refer+case+repeaters+to+be+setup",
 )
 
-DATA_REGISTRY_CASE_UPDATE_REPEATER = StaticToggle(
-    'data_registry_case_update_repeater',
-    'USH: Allow data registry repeater to be setup to update cases in other domains',
-    TAG_CUSTOM,
-    namespaces=[NAMESPACE_DOMAIN],
-    help_link="https://confluence.dimagi.com/display/USH/Data+Registry+Case+Update+Repeater",
-)
-
-
 WIDGET_DIALER = StaticToggle(
     'widget_dialer',
     'USH: Enable usage of AWS Connect Dialer',
@@ -2152,6 +2143,14 @@ DATA_REGISTRY_UCR = StaticToggle(
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
     help_link="https://confluence.dimagi.com/display/USH/Data+Registry#DataRegistry-CrossDomainReports",
+)
+
+DATA_REGISTRY_CASE_UPDATE_REPEATER = StaticToggle(
+    'data_registry_case_update_repeater',
+    'USH: Allow data registry repeater to be setup to update cases in other domains',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
+    help_link="https://confluence.dimagi.com/display/USH/Data+Registry+Case+Update+Repeater",
 )
 
 CASE_IMPORT_DATA_DICTIONARY_VALIDATION = StaticToggle(

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2146,6 +2146,14 @@ DATA_REGISTRY = StaticToggle(
     help_link="https://docs.google.com/document/d/1h1chIrRkDtnPVQzFJHuB7JbZq8S4HNQf2dBA8z_MCkg/edit",
 )
 
+DATA_REGISTRY_UCR = StaticToggle(
+    'data_registry_ucr',
+    'USH: Enable the creation of Custom Web Reports backed by Data Registries',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
+    help_link="https://confluence.dimagi.com/display/USH/Data+Registry#DataRegistry-CrossDomainReports",
+)
+
 CASE_IMPORT_DATA_DICTIONARY_VALIDATION = StaticToggle(
     'case_import_data_dictionary_validaton',
     'USH: Validate data per data dictionary definitions during case import',

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2143,7 +2143,7 @@ DATA_REGISTRY = StaticToggle(
     'USH: Enable Data Registries for sharing data between project spaces',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
-    help_link="https://docs.google.com/document/d/1h1chIrRkDtnPVQzFJHuB7JbZq8S4HNQf2dBA8z_MCkg/edit",
+    help_link="https://confluence.dimagi.com/display/USH/Data+Registry",
 )
 
 DATA_REGISTRY_UCR = StaticToggle(


### PR DESCRIPTION
## Product Description
Splitting out custom web report creation from the other features allows more flexible control over their usage.

## Technical Summary
New FF and one additional check in the view.

## Feature Flag
Data Registry, Data Registry UCR

## Safety Assurance

### Safety story
New FF is used in the same way as the previous one. The only change is an additional validation check in the report view which follows the same pattern as other existing checks.

### Automated test coverage
None

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
