### PR TITLE
User History Report "Export to Excel"

### DIFF
--- a/corehq/apps/reports/standard/users/reports.py
+++ b/corehq/apps/reports/standard/users/reports.py
@@ -172,21 +172,20 @@ class UserHistoryReport(GetParamsMixin, DatespanMixin, GenericTabularReport, Pro
             query_filters = Q(changes__has_key=user_property)
         return query_filters
 
-    def get_rows(self, for_export):
+    @property
+    def rows(self):
         records = self._get_queryset().order_by(self.ordering)[
             self.pagination.start:self.pagination.start + self.pagination.count
         ]
         for record in records:
-            yield self._user_history_row(record, self.domain, self.timezone, for_export)
-
-    @property
-    def rows(self):
-        return self.get_rows(for_export=False)
+            yield self._user_history_row(record, self.domain, self.timezone, False)
 
     # Override parent method to add new lines to cell values of certain columns
     @property
     def export_rows(self):
-        return self.get_rows(for_export=True)
+        records = self._get_queryset().order_by(self.ordering)
+        for record in records:
+            yield self._user_history_row(record, self.domain, self.timezone, True)
 
     @property
     def ordering(self):

--- a/corehq/apps/reports/standard/users/reports.py
+++ b/corehq/apps/reports/standard/users/reports.py
@@ -270,7 +270,7 @@ class UserHistoryReport(GetParamsMixin, DatespanMixin, GenericTabularReport, Pro
                     if not key:
                         continue
                     elif not changes_dict[key]:
-                        s += key + ": None"
+                        s += key + ": " + _("None")
                     else:
                         s += key + ': ' + str(changes_dict[key])
                     if not i == len(changes_dict) - 1:

--- a/corehq/apps/reports/standard/users/reports.py
+++ b/corehq/apps/reports/standard/users/reports.py
@@ -42,6 +42,9 @@ class UserHistoryReport(GetParamsMixin, DatespanMixin, GenericTabularReport, Pro
     name = ugettext_lazy("User History")
     section_name = ugettext_lazy("User Management")
 
+    exportable = True
+    exportable_all = True
+
     dispatcher = UserManagementReportDispatcher
 
     fields = [

--- a/corehq/apps/reports/standard/users/reports.py
+++ b/corehq/apps/reports/standard/users/reports.py
@@ -254,20 +254,10 @@ class UserHistoryReport(GetParamsMixin, DatespanMixin, GenericTabularReport, Pro
         more_count = len(all_changes) - len(primary_changes)
 
         if for_export:
-            # Just adds a comma and newline between each change
-            def _convert_dict_to_string(changes_dict):
-                s = ''
-                for i, key in enumerate(changes_dict):
-                    if not key:
-                        continue
-                    elif not changes_dict[key]:
-                        s += key + ": " + _("None")
-                    else:
-                        s += key + f": {changes_dict[key]}"
-                    if not i == len(changes_dict) - 1:
-                        s += ', \n'
-                return s
-            return _convert_dict_to_string(all_changes)
+            # This just adds a comma and newline between each change
+            return ", \n".join(
+                [f"{key}: {value or _('None')}" for key, value in list(all_changes.items())]
+            )
         else:
             return render_to_string("reports/standard/partials/user_history_changes.html", {
                 "primary_changes": self._html_list(primary_changes),


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

On certain kinds of reports in HQ (such as Case List Explorer), there is an "Export to Excel" button that allows you to export the report data.

![Screen Shot 2022-03-29 at 10 02 00 AM](https://user-images.githubusercontent.com/6729291/160628959-e0996601-49be-46a2-87a5-9a22c07c43e3.png)

This PR adds such a button to the User History Report ([example on staging, adjust dates to last year](https://staging.commcarehq.org/a/addison-test-st/reports/user_management/user_history/)). 

![Screen Shot 2022-03-29 at 10 04 08 AM](https://user-images.githubusercontent.com/6729291/160629392-41c367c9-4a0f-4b4d-b3af-63fd63c1f7fc.png)

 When the user clicks the “Export to Excel” button, two different ways of exporting can be utilized:

A) The file can be downloaded directly to the user’s computer via a browser
B) A download link can be sent to the user via email for a separate download

We went with B because a user history report can be quite long and the user might want to designate a separate tab/process for downloading the file (instead of, say, clicking Export to Excel and then having the download interrupt their workflow while it takes possibly minutes to process).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

All the code is in a single file.

The pre-existing `rows` property in `UserHistoryReport` had of the necessary data. But we needed to remove the HTML templates and add line breaks and commas to two columns to make them more readable: "Changes" and "Change Message". So my code just overrides the parent method `export_rows` to do that.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

USER_HISTORY_REPORT

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Testing locally and on staging. Changes should be limited to User History Reports.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

No tests. I don't think you can test exports?

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

I want this to go through a quick QA round after peer review.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
