### PR TITLE
Fix warning from $URL in kafka init script

### DIFF
--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -126,7 +126,7 @@ services:
           KAFKA_ADVERTISED_PORT: 9092
           CUSTOM_INIT_SCRIPT: |
             URL="https://raw.githubusercontent.com/vishnubob/wait-for-it/c096cface5fbd9f2d6b037391dfecae6fde1362e/wait-for-it.sh"
-            if curl --max-time 10 $URL > wait.sh ; then
+            if curl --max-time 10 $$URL > wait.sh ; then
               chmod +x ./wait.sh
               ./wait.sh -t 30 zookeeper:2181 || exit 1
             else


### PR DESCRIPTION
```
WARNING: The URL variable is not set. Defaulting to a blank string.
```

https://stackoverflow.com/a/40621373/10840

## Safety Assurance

### Safety story

Only affects docker compose setup, which is used mainly by tests and in development environments.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
