### PR TITLE
Fix QueryDict serialization bug 

### DIFF
--- a/corehq/apps/reports/tests/test_generic.py
+++ b/corehq/apps/reports/tests/test_generic.py
@@ -1,11 +1,17 @@
+import json
 from unittest import expectedFailure
 
+from django.http import QueryDict
 from django.utils.safestring import mark_safe
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
+
+from dimagi.utils.dates import DateSpan
 
 from corehq.apps.reports.generic import GenericTabularReport
+from ..app_config import get_report_class
 
 from ..generic import _sanitize_rows
+from ...users.models import WebUser
 
 
 class GenericTabularReportTests(SimpleTestCase):
@@ -74,3 +80,95 @@ class SanitizeRowTests(SimpleTestCase):
         self.assertEqual(result[0], ['One', 'Two'])
         self.assertEqual(result[1], ['Three', 'Four'])
         self.assertEqual(result[2], ['Five', 'Six'])
+
+
+class GetSerializableReportParameters(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = WebUser(domain='test-domain', username='test-user')
+        cls.user.save()
+        cls.addClassCleanup(cls.user.delete, deleted_by_domain='test-domain', deleted_by=None)
+        cls.report = object.__new__(get_report_class('daily_form_stats'))
+        GET_params = QueryDict('', mutable=True)
+        GET_params.update({
+            'emw': ['t__0', 't__5'],
+            'sub_time': '',
+            'startdate': '2022-03-20',
+            'enddate': '2022-03-28'
+        })
+        cls.report_params = {
+            'request': {
+                'GET': GET_params,
+                'META': {
+                    'QUERY_STRING': '',
+                    'PATH_INFO': '/a/practice-tracker/reports/export/daily_form_stats/'
+                },
+                'couch_user': cls.user._id,
+                'can_access_all_locations': True
+            },
+            'request_params': {
+                'sub_time': '',
+                'startdate': '2022-03-20T00:00:00',
+                'enddate': '2022-03-28T00:00:00'
+            },
+            'domain': 'practice-tracker',
+            'context': {}
+        }
+        cls.report.set_report_parameters(cls.report_params)
+
+    def test_returns_serializable_state(self):
+        serializable_state = self.report.get_json_report_parameters()
+        try:
+            json.dumps(serializable_state)
+        except TypeError:
+            self.fail('Expected json serializable state.')
+
+    def test_equivalent(self):
+        serializable_state = self.report.get_json_report_parameters()
+        self.assertEqual(serializable_state, self.report_params)
+
+    def test_query_dict_elements_preserved_after_serializing(self):
+        """
+        QueryDict.dict() only includes 1 element per key which is what json.dumps() invokes
+        """
+        test_querydict = QueryDict('', mutable=True)
+        test_querydict.update({'test-key': 'test-value-1'})
+        test_querydict.update({'test-key': 'test-value-2'})
+        expected_result = dict(test_querydict.lists())
+
+        self.report_params['request']['GET'] = test_querydict
+        self.report.set_report_parameters(self.report_params)
+
+        serializable_state = self.report.get_json_report_parameters()
+        serialized_state = json.dumps(serializable_state)
+        state = json.loads(serialized_state)
+        self.assertFalse(isinstance(state['request']['GET'], QueryDict))
+        self.assertEqual(expected_result, state['request']['GET'])
+
+
+class SetReportParametersTests(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = WebUser(domain='test-domain', username='test-user')
+        cls.user.save()
+        cls.addClassCleanup(cls.user.delete, deleted_by_domain='test-domain', deleted_by=None)
+        cls.report = object.__new__(get_report_class('daily_form_stats'))
+
+    def test_recreates_query_dict(self):
+        test_querydict = QueryDict('', mutable=True)
+        test_querydict.update({'test-key': 'test-value-1'})
+        test_querydict.update({'test-key': 'test-value-2'})
+
+        self.report.set_report_parameters({
+            'request': {
+                'GET': dict(test_querydict.lists()),
+                'couch_user': self.user._id,
+            },
+            'request_params': {},
+        })
+
+        self.assertEqual(self.report.request.GET, test_querydict)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This is a bug when using the "Export to Excel" option on certain reports. 
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13332

This specifically impacts reports that have `exportable_all` set to True because those kick off a `export_all_rows_task` celery task which requires serializing report data. This serializing is what caused the bug. When serializing a `QueryDict`, it uses its `dict()` representation which only uses one value per key (since it is designed to allow multiple values per key). Here's a quick example to visualize:
```
>>> querydict = QueryDict('', mutable=True)
>>> querydict.update({'key': 'value1'})
>>> querydict.update({'key': 'value2'})
>>> querydict
<QueryDict: {'key': ['value1', 'value2']}>
>>> json.dumps(querydict)
'{"key": "value2"}'
```
So to fix this, we need to convert the QueryDict to our desired representation prior to serializing, which is why I added `request['GET'] = dict(request['GET'].lists())` in `get_json_report_parameters`. 
```
>>> dict(querydict.lists())
{'key': ['value1', 'value2']}
```

However when converting back to a QueryDict, we need to be careful with what values we update the QueryDict. To illustrate, here's an example:
```
>>> new_querydict = QueryDict('', mutable=True)
>>> new_querydict.update({"key": ["value1", "value2"]})
>>> new_querydict
<QueryDict: {'key': [['value1', 'value2']]}>
```
So now the QueryDict is not analogous to what it was prior to serializing. This is why I added the loop to update each key/value individually:
```
  for key, values in state['request']['GET'].items():
      for value in values:
          GET_data.update({key: value})
```
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested and tested on staging. 
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests to verify query dict values when setting and getting report parameters.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
