### PR TITLE
Revert "Multi-Environment Release Management"

### DIFF
--- a/corehq/apps/accounting/utils/account.py
+++ b/corehq/apps/accounting/utils/account.py
@@ -2,7 +2,7 @@ from django.http import Http404
 from django_prbac.utils import has_privilege
 
 from corehq import privileges
-from corehq.apps.accounting.models import BillingAccount, Subscription, SoftwarePlanEdition
+from corehq.apps.accounting.models import BillingAccount
 
 
 def get_account_or_404(domain):

--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -13,12 +13,14 @@ from corehq.apps.builds.models import BuildSpec
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.linked_domain.models import DomainLink
+from corehq import toggles
 
 from .dbaccessors import get_all_built_app_ids_and_versions
 from .models import LATEST_APK_VALUE, LATEST_APP_VALUE
 from .util import get_commcare_builds
+from ..accounting.utils import domain_has_privilege
 from ..hqwebapp.widgets import BootstrapCheckboxInput
-from ..linked_domain.util import can_domain_access_release_management
+from ...privileges import RELEASE_MANAGEMENT
 
 
 class CopyApplicationForm(forms.Form):
@@ -57,7 +59,9 @@ class CopyApplicationForm(forms.Form):
         self.from_domain = from_domain
         if app:
             self.fields['name'].initial = app.name
-        if can_domain_access_release_management(self.from_domain, include_toggle=True) and not is_linked_app(app):
+        if (toggles.LINKED_DOMAINS.enabled(self.from_domain)
+            or domain_has_privilege(self.from_domain, RELEASE_MANAGEMENT)) \
+                and not is_linked_app(app):
             fields.append(PrependedText('linked', ''))
 
         self.helper = FormHelper()
@@ -84,7 +88,7 @@ class CopyApplicationForm(forms.Form):
     def clean(self):
         domain = self.cleaned_data.get('domain')
         if self.cleaned_data.get('linked'):
-            if not can_domain_access_release_management(domain, include_toggle=True):
+            if not domain_has_privilege(domain, RELEASE_MANAGEMENT) and not toggles.LINKED_DOMAINS.enabled(domain):
                 raise forms.ValidationError("The target project space does not have this feature enabled.")
             link = DomainLink.objects.filter(linked_domain=domain)
             if link and link[0].master_domain != self.from_domain:

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -7,6 +7,7 @@ from django_prbac.utils import has_privilege
 from dimagi.utils.couch.resource_conflict import retry_resource
 
 from corehq import privileges, toggles
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager import add_ons
 from corehq.apps.app_manager.const import APP_V1
 from corehq.apps.app_manager.dbaccessors import get_app
@@ -48,7 +49,7 @@ from corehq.apps.linked_domain.dbaccessors import (
     get_upstream_domain_link,
     is_active_downstream_domain,
 )
-from corehq.apps.linked_domain.util import can_domain_access_release_management
+from corehq.privileges import RELEASE_MANAGEMENT
 from corehq.util.soft_assert import soft_assert
 
 
@@ -271,7 +272,7 @@ def view_generic(request, domain, app_id, module_id=None, form_id=None,
                 and get_upstream_domain_link(request.domain).master_domain == d.name)
     }
     domain_names.add(request.domain)
-    if can_domain_access_release_management(request.domain):
+    if domain_has_privilege(request.domain, RELEASE_MANAGEMENT):
         linkable_domains = get_accessible_downstream_domains(domain, request.couch_user)
     else:
         # keep behavior the same as before for LINKED_DOMAINS toggle
@@ -279,7 +280,7 @@ def view_generic(request, domain, app_id, module_id=None, form_id=None,
     context.update({
         'domain_names': sorted(domain_names),
         'linkable_domains': sorted(linkable_domains),
-        'limit_to_linked_domains': (can_domain_access_release_management(request.domain)
+        'limit_to_linked_domains': (domain_has_privilege(request.domain, RELEASE_MANAGEMENT)
                                     and not request.couch_user.is_superuser)
     })
     context.update({

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -24,9 +24,9 @@ hqDefine('hqwebapp/js/multiselect_utils', [
         });
     };
 
-    var _renderAction = function (buttonId, buttonClass, buttonIcon, text, disabled = false) {
+    var _renderAction = function (buttonId, buttonClass, buttonIcon, text) {
         var action = _.template(
-            '<button class="btn <%-actionButtonClass %> btn-xs pull-right" id="<%- actionButtonId %>" <% if (actionDisabled) { %> disabled <% } %>>' +
+            '<button class="btn <%-actionButtonClass %> btn-xs pull-right" id="<%- actionButtonId %>">' +
                 '<i class="<%- actionButtonIcon %>"></i> <%- actionButtonText %>' +
             '</button>'
         );
@@ -35,7 +35,6 @@ hqDefine('hqwebapp/js/multiselect_utils', [
             actionButtonClass: buttonClass,
             actionButtonIcon: buttonIcon,
             actionButtonText: text,
-            actionDisabled: disabled,
         });
     };
 
@@ -54,22 +53,11 @@ hqDefine('hqwebapp/js/multiselect_utils', [
         });
     };
 
-    /**
-     * Given an element, configures multiselect functionality based on the multiselect.js library
-     * @param {object} properties - a key-value object that expects the following optional keys:
-     * selectableHeaderTitle -  String title for items yet to be selected. Defaults to "Items".
-     * selectedHeaderTitle - String for selected items title. Defaults to "Selected items".
-     * searchItemTitle - String for search bar placeholder title. Defaults to "Search items".
-     * willSelectAllListener - Function to call before the multiselect processes the Add All action.
-     * disableModifyAllActions - Boolean value to enable/disable Add All and Remove All buttons. Defaults to false.
-     */
     multiselect_utils.createFullMultiselectWidget = function (elementOrId, properties) {
-        assertProperties.assert(properties, [], ['selectableHeaderTitle', 'selectedHeaderTitle', 'searchItemTitle', 'willSelectAllListener', 'disableModifyAllActions']);
+        assertProperties.assert(properties, [], ['selectableHeaderTitle', 'selectedHeaderTitle', 'searchItemTitle']);
         var selectableHeaderTitle = properties.selectableHeaderTitle || gettext("Items");
         var selectedHeaderTitle = properties.selectedHeaderTitle || gettext("Selected items");
         var searchItemTitle = properties.searchItemTitle || gettext("Search items");
-        var willSelectAllListener = properties.willSelectAllListener;
-        var disableModifyAllActions = properties['disableModifyAllActions'] || false;
 
         var $element = _.isString(elementOrId) ? $('#' + elementOrId) : $(elementOrId),
             baseId = _.isString(elementOrId) ? elementOrId : "multiselect-" + String(Math.random()).substring(2),
@@ -81,12 +69,12 @@ hqDefine('hqwebapp/js/multiselect_utils', [
         $element.multiSelect({
             selectableHeader: _renderHeader(
                 selectableHeaderTitle,
-                _renderAction(selectAllId, 'btn-default', 'fa fa-plus', gettext("Add All"), disableModifyAllActions),
+                _renderAction(selectAllId, 'btn-default', 'fa fa-plus', gettext("Add All")),
                 _renderSearch(searchSelectableId, searchItemTitle)
             ),
             selectionHeader: _renderHeader(
                 selectedHeaderTitle,
-                _renderAction(removeAllId, 'btn-default', 'fa fa-remove', gettext("Remove All"), disableModifyAllActions),
+                _renderAction(removeAllId, 'btn-default', 'fa fa-remove', gettext("Remove All")),
                 _renderSearch(searchSelectedId, searchItemTitle)
             ),
             afterInit: function () {
@@ -108,9 +96,7 @@ hqDefine('hqwebapp/js/multiselect_utils', [
                         if (that.search_left.val().length > 0) {
                             $('#' + selectAllId).addClass('disabled').prop('disabled', true);
                         } else {
-                            if (!disableModifyAllActions) {
-                                $('#' + selectAllId).removeClass('disabled').prop('disabled', false);
-                            }
+                            $('#' + selectAllId).removeClass('disabled').prop('disabled', false);
                         }
                     });
 
@@ -125,7 +111,7 @@ hqDefine('hqwebapp/js/multiselect_utils', [
                     // disable remove all functionality so that user is not confused
                         if (that.search_right.val().length > 0) {
                             $('#' + removeAllId).addClass('disabled').prop('disabled', true);
-                        } else if (!disableModifyAllActions) {
+                        } else {
                             $('#' + removeAllId).removeClass('disabled').prop('disabled', false);
                         }
                     });
@@ -134,26 +120,19 @@ hqDefine('hqwebapp/js/multiselect_utils', [
                 this.search_left.cache();
                 // remove search option so that user doesn't get confused
                 this.search_right.val('').search('');
-                if (!disableModifyAllActions) {
-                    $('#' + removeAllId).removeClass('disabled').prop('disabled', false);
-                }
+                $('#' + removeAllId).removeClass('disabled').prop('disabled', false);
                 this.search_right.cache();
             },
             afterDeselect: function () {
                 // remove search option so that user doesn't get confused
                 this.search_left.val('').search('');
-                if (!disableModifyAllActions) {
-                    $('#' + selectAllId).removeClass('disabled').prop('disabled', false);
-                }
+                $('#' + selectAllId).removeClass('disabled').prop('disabled', false);
                 this.search_left.cache();
                 this.search_right.cache();
             },
         });
 
         $('#' + selectAllId).click(function () {
-            if (willSelectAllListener) {
-                willSelectAllListener();
-            }
             $element.multiSelect('select_all');
             return false;
         });
@@ -163,44 +142,33 @@ hqDefine('hqwebapp/js/multiselect_utils', [
         });
     };
 
-    multiselect_utils.rebuildMultiselect = function (elementOrId, multiselectProperties) {
-        var $element = _.isString(elementOrId) ? $('#' + elementOrId) : $(elementOrId);
-        // multiSelect('refresh') breaks existing click handlers, so the alternative is to destroy and rebuild
-        $element.multiSelect('destroy');
-        multiselect_utils.createFullMultiselectWidget(elementOrId, multiselectProperties);
-    };
-
     /*
      * A custom binding for setting multiselect properties and additional knockout bindings
      * The only dynamic part of this binding are the options
      * For a list of configurable multiselect properties, see http://loudev.com/ under Options
-     * properties - a dictionary of properties used by the multiselect element (see createFullMultiselectWidget above)
-     * options - an observable array of option elements (only supports array of strings)
-     * didUpdateListener - method to invoke when the multiselect updates
      */
     ko.bindingHandlers.multiselect = {
         init: function (element, valueAccessor) {
             var model = valueAccessor();
-            assertProperties.assert(model, [], ['properties', 'options', 'didUpdateListener']);
+            assertProperties.assert(model, [], ['properties', 'options']);
             multiselect_utils.createFullMultiselectWidget(element, model.properties);
 
             if (model.options) {
-                // apply bindings after the multiselect has been setup
+                // add the `options` binding to the element, valueAccessor() should return an observable
+                // NOTE: apply bindings after the multiselect has been setup
                 ko.applyBindingsToNode(element, {options: model.options});
             }
         },
         update: function (element, valueAccessor) {
             var model = valueAccessor();
-            assertProperties.assert(model, [], ['properties', 'options', 'didUpdateListener']);
             if (model.options) {
                 // have to access the observable to get the `update` method to fire on changes to options
                 ko.unwrap(model.options());
             }
 
-            multiselect_utils.rebuildMultiselect(element, model.properties);
-            if (model.didUpdateListener) {
-                model.didUpdateListener();
-            }
+            // multiSelect('refresh') breaks existing click handlers, so the alternative is to destroy and rebuild
+            $(element).multiSelect('destroy');
+            multiselect_utils.createFullMultiselectWidget(element, model.properties);
         },
     };
 

--- a/corehq/apps/linked_domain/decorators.py
+++ b/corehq/apps/linked_domain/decorators.py
@@ -3,7 +3,7 @@ from functools import wraps
 from django.http import HttpResponseBadRequest, HttpResponseForbidden, Http404
 
 from corehq.apps.linked_domain.dbaccessors import get_upstream_domain_link
-from corehq.apps.linked_domain.util import can_user_access_release_management
+from corehq.apps.linked_domain.util import can_access_linked_domains
 
 REMOTE_REQUESTER_HEADER = 'HTTP_HQ_REMOTE_REQUESTER'
 
@@ -18,7 +18,7 @@ def require_access_to_linked_domains(view_func):
 
         def call_view():
             return view_func(request, domain, *args, **kwargs)
-        if can_user_access_release_management(couch_user, domain, include_toggle=True):
+        if can_access_linked_domains(couch_user, domain):
             return call_view()
         else:
             return HttpResponseForbidden()

--- a/corehq/apps/linked_domain/exceptions.py
+++ b/corehq/apps/linked_domain/exceptions.py
@@ -10,18 +10,6 @@ class DomainLinkNotAllowed(Exception):
     pass
 
 
-class AttemptedPushViolatesConstraints(Exception):
-    pass
-
-
-class DomainLinkNotFound(Exception):
-    pass
-
-
-class NoDownstreamDomainsProvided(Exception):
-    pass
-
-
 class MultipleDownstreamAppsError(Exception):
     pass
 

--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -9,10 +9,8 @@ from django.utils.translation import gettext as _
 
 import jsonobject
 
-from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.linked_domain.const import ALL_LINKED_MODELS
 from corehq.apps.linked_domain.exceptions import DomainLinkError
-from corehq.privileges import RELEASE_MANAGEMENT
 
 
 class RemoteLinkDetails(namedtuple('RemoteLinkDetails', 'url_base username api_key')):
@@ -67,11 +65,6 @@ class DomainLink(models.Model):
     @property
     def is_remote(self):
         return bool(self.remote_base_url) or 'http' in self.linked_domain
-
-    def has_full_access(self):
-        return (domain_has_privilege(self.master_domain, RELEASE_MANAGEMENT)
-                and domain_has_privilege(self.linked_domain, RELEASE_MANAGEMENT))
-
 
     @atomic
     def update_last_pull(self, model, user_id, date=None, model_detail=None):

--- a/corehq/apps/linked_domain/tasks.py
+++ b/corehq/apps/linked_domain/tasks.py
@@ -12,6 +12,7 @@ from dimagi.utils.logging import notify_exception
 from dimagi.utils.web import get_url_base
 
 from corehq import toggles
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
 from corehq.apps.app_manager.util import is_linked_app
 from corehq.apps.app_manager.views.utils import update_linked_app
@@ -40,12 +41,12 @@ from corehq.apps.linked_domain.ucr import (
 from corehq.apps.linked_domain.updates import update_model_type
 from corehq.apps.linked_domain.util import (
     pull_missing_multimedia_for_app_and_notify,
-    can_domain_access_release_management,
 )
 from corehq.apps.reminders.views import KeywordsListView
 from corehq.apps.sms.models import Keyword
 from corehq.apps.userreports.models import ReportConfiguration
 from corehq.apps.users.models import CouchUser
+from corehq.privileges import RELEASE_MANAGEMENT
 
 
 @task(queue='linked_domain_queue')
@@ -167,7 +168,7 @@ The following linked project spaces received content:
         linked_report = get_downstream_report(domain_link.linked_domain, report_id)
 
         if not linked_report:
-            if can_domain_access_release_management(self.upstream_domain):
+            if domain_has_privilege(self.upstream_domain, RELEASE_MANAGEMENT):
                 try:
                     linked_report_info = create_linked_ucr(domain_link, report_id)
                     linked_report = linked_report_info.report
@@ -206,7 +207,7 @@ The following linked project spaces received content:
             linked_keyword_id = (Keyword.objects.values_list('id', flat=True)
                                  .get(domain=domain_link.linked_domain, upstream_id=upstream_id))
         except Keyword.DoesNotExist:
-            if can_domain_access_release_management(self.upstream_domain):
+            if domain_has_privilege(self.upstream_domain, RELEASE_MANAGEMENT):
                 linked_keyword_id = create_linked_keyword(domain_link, upstream_id)
             else:
                 return self._error_tuple(

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -75,7 +75,7 @@
         <div class="modal-body">
           <div class="ko-model">
             <label >{% trans 'Project Space:' %}</label>
-            {% if view_data.is_superuser %}
+            {% if is_superuser %}
               <select class="form-control" data-bind="autocompleteSelect2: availableDomains, value: domainToAdd"></select>
             {% else %}
               <select class="form-control" data-bind="select2: availableDomains, value: domainToAdd"></select>

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/manage_downstream_domains.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/manage_downstream_domains.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 <div id="ko-tabs-manage-downstream" data-bind="with: $root">
-  <div data-bind="if: domainLinks().length">
+  <div data-bind="if: domain_links().length">
     <h3>{% trans "Manage Downstream Project Spaces" %}</h3>
     <p>
       {% blocktrans trimmed %}

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
@@ -17,7 +17,7 @@
           {% trans "Content" %}
         </label>
         <div class="col-sm-9 col-md-10 controls">
-          <select multiple class="form-control" id="model-multiselect"
+          <select multiple class="form-control"
                   data-bind="selectedOptions: modelsToPush,
                              multiselect: {
                                  properties: {
@@ -39,22 +39,9 @@
           {% trans "Project Spaces" %}
         </label>
         <div class="col-sm-9 col-md-10 controls">
-          <select multiple class="form-control" id="domain-multiselect"
+          <select multiple class="form-control"
                   data-bind="selectedOptions: domainsToPush, multiselect: domainMultiselect">
           </select>
-          <div class="spacer"></div>
-          <p data-bind="visible: shouldShowSelectedMRMDomain">
-            <i class="fa fa-info-circle" aria-hidden="true"></i>
-            {% blocktrans %}
-              The selected project can only be pushed individually. See <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Linked Project Spaces</a> documentation for more information.
-            {% endblocktrans %}
-          </p>
-          <p data-bind="visible: shouldShowSelectedERMDomain">
-            <i class="fa fa-info-circle" aria-hidden="true"></i>
-            {% blocktrans %}
-              Disabled project spaces can only be pushed individually. See <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Linked Project Spaces</a> documentation for more information.
-            {% endblocktrans %}
-          </p>
         </div>
       </div>
       <div class="form-group">

--- a/corehq/apps/linked_domain/tests/test_dbaccessors.py
+++ b/corehq/apps/linked_domain/tests/test_dbaccessors.py
@@ -6,107 +6,105 @@ from corehq.apps.linked_domain.dbaccessors import (
     get_available_domains_to_link,
     get_available_upstream_domains,
 )
-from corehq.privileges import LITE_RELEASE_MANAGEMENT, RELEASE_MANAGEMENT
 from corehq.util.test_utils import flag_enabled
 
 
-@patch('corehq.apps.users.models.CouchUser')
-class TestGetAvailableUpstreamDomains(SimpleTestCase):
+class TestGetAvailableUpstreamDomainsForDownstreamDomain(SimpleTestCase):
 
-    def setUp(self):
-        super().setUp()
-        self.expected_domains = ['upstream-1', 'upstream-2']
-
-        privilege_patcher = patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege')
-        self.mock_domain_has_privilege = privilege_patcher.start()
-        self.addCleanup(privilege_patcher.stop)
-
-        user_patcher = patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_user')
-        self.mock_available_user_domains = user_patcher.start()
-        self.addCleanup(user_patcher.stop)
-
-    def test_returns_empty_if_no_privilege_or_feature_flag(self, mock_user):
-        self.mock_domain_has_privilege.return_value = False
-
-        upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
-
+    @patch('corehq.apps.users.models.CouchUser')
+    @patch('corehq.apps.accounting.models.BillingAccount')
+    def test_no_privilege_or_feature_flag_returns_none(self, mock_user, mock_account):
+        mock_account.get_domains.return_value = ['upstream', 'downstream-1', 'downstream-2']
+        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
+            upstream_domains = get_available_upstream_domains(
+                'downstream-1', mock_user, mock_account
+            )
         self.assertFalse(upstream_domains)
 
-    def test_returns_domains_for_user_if_release_management_privilege(self, mock_user):
-        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
-        self.mock_available_user_domains.return_value = self.expected_domains
-
-        upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
-
-        self.mock_available_user_domains.assert_called_with('downstream-1', mock_user, should_enforce_admin=True)
-        self.assertSetEqual(set(upstream_domains), set(self.expected_domains))
-
-    def test_returns_domains_for_user_if_lite_release_management_privilege(self, mock_user):
-        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == LITE_RELEASE_MANAGEMENT
-        self.mock_available_user_domains.return_value = self.expected_domains
-
-        upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
-
-        self.mock_available_user_domains.assert_called_with('downstream-1', mock_user, should_enforce_admin=True)
-        self.assertSetEqual(set(upstream_domains), set(self.expected_domains))
+    @flag_enabled("LINKED_DOMAINS")
+    @patch('corehq.apps.users.models.CouchUser')
+    @patch('corehq.apps.accounting.models.BillingAccount')
+    def test_release_management_privilege_returns_domains_for_account(self, mock_user, mock_account):
+        """NOTE: this also tests that the release_management privilege overrides the linked domains flag"""
+        mock_account.get_domains.return_value = ['upstream', 'downstream-1', 'downstream-2']
+        expected_upstream_domains = ['upstream']
+        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
+             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_account') \
+             as mock_account_domains,\
+             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_user') \
+             as mock_user_domains:
+            mock_domain_has_privilege.return_value = True
+            mock_account_domains.return_value = expected_upstream_domains
+            mock_user_domains.return_value = ['wrong']
+            upstream_domains = get_available_upstream_domains(
+                'downstream-1', mock_user, mock_account
+            )
+        self.assertEqual(expected_upstream_domains, upstream_domains)
 
     @flag_enabled("LINKED_DOMAINS")
-    def test_returns_domains_for_user_if_linked_domains_flag(self, mock_user):
-        self.mock_domain_has_privilege.return_value = False
-        self.mock_available_user_domains.return_value = self.expected_domains
+    @patch('corehq.apps.users.models.CouchUser')
+    @patch('corehq.apps.accounting.models.BillingAccount')
+    def test_linked_domains_flag_returns_domains_for_user(self, mock_user, mock_account):
+        expected_upstream_domains = ['upstream']
+        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
+             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_account') \
+             as mock_account_domains,\
+             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_user') \
+             as mock_user_domains:
+            mock_domain_has_privilege.return_value = False
+            mock_account_domains.return_value = ['wrong']
+            mock_user_domains.return_value = expected_upstream_domains
+            upstream_domains = get_available_upstream_domains(
+                'downstream-1', mock_user, mock_account
+            )
 
-        upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
-
-        self.mock_available_user_domains.assert_called_with('downstream-1', mock_user, should_enforce_admin=False)
-        self.assertSetEqual(set(upstream_domains), set(self.expected_domains))
+        self.assertEqual(expected_upstream_domains, upstream_domains)
 
 
-@patch('corehq.apps.users.models.CouchUser')
 class TestGetAvailableDomainsToLink(SimpleTestCase):
 
-    def setUp(self):
-        super().setUp()
-        self.expected_domains = ['downstream-1', 'downstream-2']
+    @patch('corehq.apps.users.models.CouchUser')
+    @patch('corehq.apps.accounting.models.BillingAccount')
+    def test_no_privilege_or_feature_flag_returns_none(self, mock_user, mock_account):
+        mock_account.get_domains.return_value = ['upstream', 'downstream-1', 'downstream-2']
+        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
+            domains = get_available_domains_to_link('upstream', mock_user, mock_account)
 
-        privilege_patcher = patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege')
-        self.mock_domain_has_privilege = privilege_patcher.start()
-        self.addCleanup(privilege_patcher.stop)
-
-        user_patcher = patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_user')
-        self.mock_available_user_domains = user_patcher.start()
-        self.addCleanup(user_patcher.stop)
-
-    def test_returns_empty_if_no_privilege_or_feature_flag(self, mock_user):
-        self.mock_domain_has_privilege.return_value = False
-
-        domains = get_available_domains_to_link('upstream', mock_user)
-
-        self.assertFalse(domains)
-
-    def test_returns_domains_for_user_if_release_management_privilege(self, mock_user):
-        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
-        self.mock_available_user_domains.return_value = self.expected_domains
-
-        domains = get_available_domains_to_link('upstream', mock_user)
-
-        self.mock_available_user_domains.assert_called_with('upstream', mock_user, should_enforce_admin=True)
-        self.assertSetEqual(set(domains), set(self.expected_domains))
-
-    def test_returns_domains_for_user_if_lite_release_management_privilege(self, mock_user):
-        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == LITE_RELEASE_MANAGEMENT
-        self.mock_available_user_domains.return_value = self.expected_domains
-
-        domains = get_available_domains_to_link('upstream', mock_user)
-
-        self.mock_available_user_domains.assert_called_with('upstream', mock_user, should_enforce_admin=True)
-        self.assertSetEqual(set(domains), set(self.expected_domains))
+        self.assertEqual([], domains)
 
     @flag_enabled("LINKED_DOMAINS")
-    def test_returns_domains_for_user_for_linked_domains_flag(self, mock_user):
-        self.mock_domain_has_privilege.return_value = False
-        self.mock_available_user_domains.return_value = self.expected_domains
+    @patch('corehq.apps.users.models.CouchUser')
+    @patch('corehq.apps.accounting.models.BillingAccount')
+    def test_release_management_privilege_returns_domains_for_account(self, mock_user, mock_account):
+        """NOTE: this also tests that the release_management privilege overrides the linked domains flag"""
+        expected_domains = ['downstream-1', 'downstream-2']
+        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
+             patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_account') \
+             as mock_account_domains,\
+             patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_user') \
+             as mock_user_domains:
+            mock_domain_has_privilege.return_value = True
+            mock_account_domains.return_value = expected_domains
+            mock_user_domains.return_value = ['wrong']
+            domains = get_available_domains_to_link('upstream', mock_user, mock_account)
 
-        domains = get_available_domains_to_link('upstream', mock_user)
+        self.assertEqual(expected_domains, domains)
 
-        self.mock_available_user_domains.assert_called_with('upstream', mock_user, should_enforce_admin=False)
-        self.assertSetEqual(set(domains), set(self.expected_domains))
+    @flag_enabled("LINKED_DOMAINS")
+    @patch('corehq.apps.users.models.CouchUser')
+    @patch('corehq.apps.accounting.models.BillingAccount')
+    def test_linked_domains_flag_returns_domains_for_user(self, mock_user, mock_account):
+        expected_domains = ['downstream-1', 'downstream-2']
+        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
+             patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_account') \
+             as mock_account_domains,\
+             patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_user') \
+             as mock_user_domains:
+            mock_domain_has_privilege.return_value = False
+            mock_account_domains.return_value = ['wrong']
+            mock_user_domains.return_value = expected_domains
+            domains = get_available_domains_to_link('upstream', mock_user, mock_account)
+
+        self.assertEqual(expected_domains, domains)

--- a/corehq/apps/linked_domain/tests/test_decorators.py
+++ b/corehq/apps/linked_domain/tests/test_decorators.py
@@ -2,24 +2,23 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
-from corehq.apps.linked_domain.util import can_user_access_release_management, can_domain_access_release_management
-from corehq.privileges import LITE_RELEASE_MANAGEMENT, RELEASE_MANAGEMENT
+from corehq.apps.linked_domain.util import can_access_linked_domains
 from corehq.util.test_utils import flag_enabled
 
 
-class TestCanUserAccessReleaseManagement(SimpleTestCase):
+class TestCanAccessLinkedDomains(SimpleTestCase):
 
     def test_returns_false_if_no_user(self):
-        result = can_user_access_release_management(None, 'test')
+        result = can_access_linked_domains(None, 'test')
         self.assertFalse(result)
 
     @patch('corehq.apps.users.models.CouchUser')
     def test_returns_false_if_no_domain(self, mock_user):
-        result = can_user_access_release_management(mock_user, None)
+        result = can_access_linked_domains(mock_user, None)
         self.assertFalse(result)
 
     def test_returns_false_if_no_user_and_no_domain(self):
-        result = can_user_access_release_management(None, None)
+        result = can_access_linked_domains(None, None)
         self.assertFalse(result)
 
     @patch('corehq.apps.users.models.CouchUser')
@@ -28,7 +27,7 @@ class TestCanUserAccessReleaseManagement(SimpleTestCase):
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = True
-            result = can_user_access_release_management(mock_user, 'test')
+            result = can_access_linked_domains(mock_user, 'test')
 
         self.assertFalse(result)
 
@@ -38,133 +37,15 @@ class TestCanUserAccessReleaseManagement(SimpleTestCase):
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = True
-            result = can_user_access_release_management(mock_user, 'test')
+            result = can_access_linked_domains(mock_user, 'test')
 
         self.assertTrue(result)
-
-    @patch('corehq.apps.users.models.CouchUser')
-    def test_returns_true_if_domain_has_lite_privilege_and_user_is_admin(self, mock_user):
-        mock_user.is_domain_admin.return_value = True
-
-        def mock_handler(domain, privilege):
-            return privilege == LITE_RELEASE_MANAGEMENT
-
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.side_effect = mock_handler
-            result = can_user_access_release_management(mock_user, 'test')
-
-        self.assertTrue(result)
-
-    @patch('corehq.apps.users.models.CouchUser')
-    def test_false_if_domain_has_lite_privilege_and_user_is_admin_but_include_lite_is_false(self, mock_user):
-        mock_user.is_domain_admin.return_value = True
-
-        def mock_handler(domain, privilege):
-            return privilege == LITE_RELEASE_MANAGEMENT
-
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.side_effect = mock_handler
-            result = can_user_access_release_management(mock_user, 'test', include_lite_version=False)
-
-        self.assertFalse(result)
 
     @flag_enabled("LINKED_DOMAINS")
     @patch('corehq.apps.users.models.CouchUser')
-    def test_returns_false_if_domain_has_linked_domain_toggle_enabled_and_include_toggle_is_false(self, mock_user):
+    def test_returns_true_if_domain_has_linked_domain_toggle_enabled(self, mock_user):
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
-            result = can_user_access_release_management(mock_user, 'test')
-
-        self.assertFalse(result)
-
-    @patch('corehq.apps.users.models.CouchUser')
-    def test_false_if_domain_has_no_linked_domain_toggle_enabled_and_include_toggle_is_true(self, mock_user):
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
-            result = can_user_access_release_management(mock_user, 'test', include_toggle=True)
-
-        self.assertFalse(result)
-
-    @flag_enabled("LINKED_DOMAINS")
-    @patch('corehq.apps.users.models.CouchUser')
-    def test_returns_true_if_domain_has_linked_domain_toggle_enabled_and_include_toggle_is_true(self, mock_user):
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
-            result = can_user_access_release_management(mock_user, 'test', include_toggle=True)
-
-        self.assertTrue(result)
-
-
-class TestCanDomainAccessReleaseManagement(SimpleTestCase):
-
-    def test_returns_false_if_no_domain(self):
-        result = can_domain_access_release_management(None)
-        self.assertFalse(result)
-
-    def test_returns_true_if_domain_has_release_management_privilege(self):
-        def mock_handler(domain, privilege):
-            return privilege == RELEASE_MANAGEMENT
-
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.side_effect = mock_handler
-            result = can_domain_access_release_management('test')
-
-        self.assertTrue(result)
-
-    def test_returns_false_if_domain_does_not_have_release_management_privilege(self):
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
-            result = can_domain_access_release_management('test')
-
-        self.assertFalse(result)
-
-    def test_returns_true_if_domain_has_lite_release_management_and_include_lite_version_is_true(self):
-        def mock_handler(domain, privilege):
-            return privilege == LITE_RELEASE_MANAGEMENT
-
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.side_effect = mock_handler
-            # include_lite_version is True by default
-            result = can_domain_access_release_management('test')
-
-        self.assertTrue(result)
-
-    def test_returns_false_if_domain_does_not_have_lite_release_management_and_include_lite_version_is_true(self):
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
-            # include_lite_version is True by default
-            result = can_domain_access_release_management('test')
-
-        self.assertFalse(result)
-
-    def test_returns_false_if_domain_has_lite_release_management_and_include_lite_version_is_false(self):
-        def mock_handler(domain, privilege):
-            return privilege == LITE_RELEASE_MANAGEMENT
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.side_effect = mock_handler
-            result = can_domain_access_release_management('test', include_lite_version=False)
-
-        self.assertFalse(result)
-
-    @flag_enabled("LINKED_DOMAINS")
-    def test_returns_false_if_domain_has_linked_domain_toggle_enabled_and_include_toggle_is_false(self):
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
-            result = can_domain_access_release_management('test')
-
-        self.assertFalse(result)
-
-    def test_returns_false_if_domain_has_no_linked_domain_toggle_enabled_and_include_toggle_is_true(self):
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
-            result = can_domain_access_release_management('test', include_toggle=True)
-
-        self.assertFalse(result)
-
-    @flag_enabled("LINKED_DOMAINS")
-    def test_returns_true_if_domain_has_linked_domain_toggle_enabled_and_include_toggle_is_true(self):
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
-            result = can_domain_access_release_management('test', include_toggle=True)
+            result = can_access_linked_domains(mock_user, 'test')
 
         self.assertTrue(result)

--- a/corehq/apps/linked_domain/tests/test_release_manager.py
+++ b/corehq/apps/linked_domain/tests/test_release_manager.py
@@ -230,8 +230,8 @@ class TestReleaseReport(BaseReleaseManagerTest):
         )
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
-            mock_access_check.return_value = False
+        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
             errors = manager._release_report(self.domain_link, model, 'test-user')
         self.assertIsNone(errors)
 
@@ -254,8 +254,8 @@ class TestReleaseReport(BaseReleaseManagerTest):
         )
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
-            mock_access_check.return_value = True
+        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = True
             errors = manager._release_report(self.domain_link, model, 'test-user')
         self.assertIsNone(errors)
 
@@ -272,8 +272,8 @@ class TestReleaseReport(BaseReleaseManagerTest):
         )
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
-            mock_access_check.return_value = False
+        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
             errors = manager._release_report(self.domain_link, model, 'test-user')
         self.assertTrue('Could not find report. Please check that the report has been linked.' in errors)
 
@@ -286,8 +286,8 @@ class TestReleaseReport(BaseReleaseManagerTest):
         )
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
-            mock_access_check.return_value = True
+        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = True
             errors = manager._release_report(self.domain_link, model, 'test-user')
         self.assertIsNone(errors)
 
@@ -321,8 +321,8 @@ class TestReleaseKeyword(BaseReleaseManagerTest):
         )
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
-            mock_access_check.return_value = False
+        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
             errors = manager._release_keyword(self.domain_link, model, 'test-user')
         self.assertIsNone(errors)
 
@@ -344,8 +344,8 @@ class TestReleaseKeyword(BaseReleaseManagerTest):
         )
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
-            mock_access_check.return_value = True
+        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = True
             errors = manager._release_keyword(self.domain_link, model, 'test-user')
         self.assertIsNone(errors)
 
@@ -363,8 +363,8 @@ class TestReleaseKeyword(BaseReleaseManagerTest):
 
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
-            mock_access_check.return_value = False
+        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
             errors = manager._release_keyword(self.domain_link, model, 'test-user')
         self.assertTrue('Could not find linked keyword. Please check the keyword has been linked.' in errors)
 
@@ -377,8 +377,8 @@ class TestReleaseKeyword(BaseReleaseManagerTest):
 
         manager = ReleaseManager(self.domain, self.user.username)
 
-        with patch('corehq.apps.linked_domain.tasks.can_domain_access_release_management') as mock_access_check:
-            mock_access_check.return_value = True
+        with patch('corehq.apps.linked_domain.tasks.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = True
             errors = manager._release_keyword(self.domain_link, model, 'test-user')
         self.assertIsNone(errors)
 

--- a/corehq/apps/linked_domain/tests/test_views.py
+++ b/corehq/apps/linked_domain/tests/test_views.py
@@ -1,23 +1,14 @@
 from unittest.mock import Mock, patch
 
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase
 
 from corehq.apps.domain.exceptions import DomainDoesNotExist
 from corehq.apps.linked_domain.exceptions import (
-    AttemptedPushViolatesConstraints,
     DomainLinkAlreadyExists,
     DomainLinkError,
     DomainLinkNotAllowed,
-    DomainLinkNotFound,
-    NoDownstreamDomainsProvided,
 )
-from corehq.apps.linked_domain.models import DomainLink
-from corehq.apps.linked_domain.views import (
-    link_domains,
-    validate_push,
-    validate_push_for_user,
-)
-from corehq.apps.users.models import WebUser
+from corehq.apps.linked_domain.views import link_domains
 
 
 class LinkDomainsTests(SimpleTestCase):
@@ -69,155 +60,3 @@ class LinkDomainsTests(SimpleTestCase):
             domain_link = link_domains(Mock(), self.upstream_domain, self.downstream_domain)
 
         self.assertIsNotNone(domain_link)
-
-
-class ValidatePushTests(TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.user = WebUser()
-        cls.user.username = 'superuser'
-        cls.user.save()
-        cls.addClassCleanup(cls.user.delete, 'test-domain', deleted_by=None)
-
-        validate_patcher = patch('corehq.apps.linked_domain.views.validate_push_for_user')
-        cls.mock_validate_push_for_user = validate_patcher.start()
-        cls.addClassCleanup(validate_patcher.stop)
-
-    def test_raises_exception_if_no_downstream_domains_selected(self):
-        with self.assertRaises(NoDownstreamDomainsProvided):
-            validate_push(self.user, 'upstream', [])
-
-    def test_raises_exception_if_link_not_found(self):
-        with self.assertRaises(DomainLinkNotFound):
-            validate_push(self.user, 'upstream', ['downstream'])
-
-    def test_raises_exception_if_user_attempts_invalid_push(self):
-        DomainLink.objects.create(master_domain='upstream', linked_domain='downstream')
-        self.mock_validate_push_for_user.side_effect = AttemptedPushViolatesConstraints
-
-        with self.assertRaises(AttemptedPushViolatesConstraints):
-            validate_push(self.user, 'upstream', ['downstream'])
-
-    def test_successful_validation(self):
-        DomainLink.objects.create(master_domain='upstream', linked_domain='downstream')
-        self.mock_validate_push_for_user.side_effect = None
-
-        validate_push(self.user, 'upstream', ['downstream'])
-
-
-class ValidatePushForUserTests(TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.superuser = WebUser()
-        cls.superuser.username = 'superuser'
-        cls.superuser.is_superuser = True
-        cls.superuser.save()
-        cls.addClassCleanup(cls.superuser.delete, 'test-domain', deleted_by=None)
-
-        cls.non_superuser = WebUser()
-        cls.non_superuser.username = 'nonsuperuser'
-        cls.non_superuser.is_superuser = False
-        cls.non_superuser.save()
-        cls.addClassCleanup(cls.non_superuser.delete, 'test-domain', deleted_by=None)
-
-    def test_superuser_can_push_multiple_full_access_links(self):
-        full_access_link1 = DomainLink.objects.create(master_domain='upstream', linked_domain='full1')
-        full_access_link2 = DomainLink.objects.create(master_domain='upstream', linked_domain='full2')
-
-        link1_patcher = patch.object(full_access_link1, 'has_full_access', return_value=True)
-        link1_patcher.start()
-        self.addCleanup(link1_patcher.stop)
-
-        link2_patcher = patch.object(full_access_link2, 'has_full_access', return_value=True)
-        link2_patcher.start()
-        self.addCleanup(link2_patcher.stop)
-
-        try:
-            validate_push_for_user(self.superuser, [full_access_link1, full_access_link2])
-        except Exception as e:
-            self.fail(f"Unexpected exception raised {e}")
-
-    def test_non_superuser_can_push_to_multiple_full_access_links(self):
-        full_access_link1 = DomainLink.objects.create(master_domain='upstream', linked_domain='full1')
-        full_access_link2 = DomainLink.objects.create(master_domain='upstream', linked_domain='full2')
-
-        link1_patcher = patch.object(full_access_link1, 'has_full_access', return_value=True)
-        link1_patcher.start()
-        self.addCleanup(link1_patcher.stop)
-
-        link2_patcher = patch.object(full_access_link2, 'has_full_access', return_value=True)
-        link2_patcher.start()
-        self.addCleanup(link2_patcher.stop)
-
-        try:
-            validate_push_for_user(self.non_superuser, [full_access_link1, full_access_link2])
-        except Exception as e:
-            self.fail(f"Unexpected exception raised {e}")
-
-    def test_superuser_can_push_multiple_mixed_access_links(self):
-        full_access_link = DomainLink.objects.create(master_domain='upstream', linked_domain='full')
-        limited_access_link = DomainLink.objects.create(master_domain='upstream', linked_domain='limited')
-
-        link1_patcher = patch.object(full_access_link, 'has_full_access', return_value=True)
-        link1_patcher.start()
-        self.addCleanup(link1_patcher.stop)
-
-        link2_patcher = patch.object(limited_access_link, 'has_full_access', return_value=False)
-        link2_patcher.start()
-        self.addCleanup(link2_patcher.stop)
-
-        try:
-            validate_push_for_user(self.superuser, [full_access_link, limited_access_link])
-        except Exception as e:
-            self.fail(f"Unexpected exception raised {e}")
-
-    def test_raises_exception_if_non_superuser_pushes_to_multiple_mixed_access_links(self):
-        full_access_link = DomainLink.objects.create(master_domain='upstream', linked_domain='full')
-        limited_access_link = DomainLink.objects.create(master_domain='upstream', linked_domain='limited')
-
-        link1_patcher = patch.object(full_access_link, 'has_full_access', return_value=True)
-        link1_patcher.start()
-        self.addCleanup(link1_patcher.stop)
-
-        link2_patcher = patch.object(limited_access_link, 'has_full_access', return_value=False)
-        link2_patcher.start()
-        self.addCleanup(link2_patcher.stop)
-
-        with self.assertRaises(AttemptedPushViolatesConstraints):
-            validate_push_for_user(self.non_superuser, [full_access_link, limited_access_link])
-
-    def test_superuser_can_push_multiple_limited_access_links(self):
-        limited_access_link1 = DomainLink.objects.create(master_domain='upstream', linked_domain='limited1')
-        limited_access_link2 = DomainLink.objects.create(master_domain='upstream', linked_domain='limited2')
-
-        link1_patcher = patch.object(limited_access_link1, 'has_full_access', return_value=False)
-        link1_patcher.start()
-        self.addCleanup(link1_patcher.stop)
-
-        link2_patcher = patch.object(limited_access_link2, 'has_full_access', return_value=False)
-        link2_patcher.start()
-        self.addCleanup(link2_patcher.stop)
-
-        try:
-            validate_push_for_user(self.superuser, [limited_access_link1, limited_access_link2])
-        except Exception as e:
-            self.fail(f"Unexpected exception raised {e}")
-
-    def test_raises_exception_if_non_superuser_pushes_to_multiple_limited_access_links(self):
-        limited_access_link1 = DomainLink.objects.create(master_domain='upstream', linked_domain='limited1')
-        limited_access_link2 = DomainLink.objects.create(master_domain='upstream', linked_domain='limited2')
-
-        link1_patcher = patch.object(limited_access_link1, 'has_full_access', return_value=False)
-        link1_patcher.start()
-        self.addCleanup(link1_patcher.stop)
-
-        link2_patcher = patch.object(limited_access_link2, 'has_full_access', return_value=False)
-        link2_patcher.start()
-        self.addCleanup(link2_patcher.stop)
-
-        with self.assertRaises(AttemptedPushViolatesConstraints):
-            validate_push_for_user(self.non_superuser, [limited_access_link1, limited_access_link2])

--- a/corehq/apps/linked_domain/util.py
+++ b/corehq/apps/linked_domain/util.py
@@ -9,55 +9,21 @@ from corehq.apps.app_manager.exceptions import MultimediaMissingError
 from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.linked_domain.remote_accessors import fetch_remote_media
-from corehq.privileges import RELEASE_MANAGEMENT, LITE_RELEASE_MANAGEMENT
+from corehq.privileges import RELEASE_MANAGEMENT
 from corehq.util.timezones.conversions import ServerTime
 
 
-def can_user_access_release_management(user, domain, include_lite_version=True, include_toggle=False):
-    """
-    :param include_lite_version: set to True if the LITE_RELEASE_MANAGEMENT privilege should be checked
-    :param include_toggle: set to True if the deprecated linked domains toggle should be checked
-    NOTE: can remove include_toggle once the linked domains toggle is deleted
-    Checks if the current domain has any of the following enabled:
-    - privileges.RELEASE_MANAGEMENT
-    - privileges.LITE_RELEASE_MANAGEMENT
-    - toggles.LINKED_DOMAINS
-    If yes, and the user meets the criteria needed, returns True
-    """
+def can_access_linked_domains(user, domain):
     if not user or not domain:
         return False
-
-    is_admin = user.is_domain_admin(domain)
-
-    if domain_has_privilege(domain, RELEASE_MANAGEMENT) and is_admin:
-        return True
-    if include_lite_version and domain_has_privilege(domain, LITE_RELEASE_MANAGEMENT) and is_admin:
-        return True
-    if include_toggle and toggles.LINKED_DOMAINS.enabled(domain):
-        return True
-    return False
+    if domain_has_privilege(domain, RELEASE_MANAGEMENT):
+        return user.is_domain_admin(domain)
+    else:
+        return toggles.LINKED_DOMAINS.enabled(domain)
 
 
-def can_domain_access_release_management(domain, include_lite_version=True, include_toggle=False):
-    """
-    :param include_lite_version: set to True if the LITE_RELEASE_MANAGEMENT privilege should be checked
-    :param include_toggle: set to True if the deprecated linked domains toggle should be checked
-    NOTE: can remove include_toggle once the linked domains toggle is deleted
-    Checks if the current domain has any of the following enabled:
-    - privileges.RELEASE_MANAGEMENT
-    - privileges.LITE_RELEASE_MANAGEMENT
-    - toggles.LINKED_DOMAINS
-    """
-    if not domain:
-        return False
-
-    has_access = domain_has_privilege(domain, RELEASE_MANAGEMENT)
-    if include_lite_version:
-        has_access |= domain_has_privilege(domain, LITE_RELEASE_MANAGEMENT)
-    if include_toggle:
-        has_access |= toggles.LINKED_DOMAINS.enabled(domain)
-
-    return has_access
+def can_access_release_management_feature(user, domain):
+    return domain_has_privilege(domain, RELEASE_MANAGEMENT) and user.is_domain_admin(domain)
 
 
 def _clean_json(doc):

--- a/corehq/apps/linked_domain/view_helpers.py
+++ b/corehq/apps/linked_domain/view_helpers.py
@@ -40,7 +40,6 @@ def build_domain_link_view_model(link, timezone):
         'downstream_url': link.downstream_url,
         'is_remote': link.is_remote,
         'last_update': server_to_user_time(link.last_pull, timezone) if link.last_pull else _('Never'),
-        'has_full_access': link.has_full_access(),
     }
 
 

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -10,8 +10,8 @@ from django.views import View
 from couchdbkit import ResourceNotFound
 from memoized import memoized
 
-from dimagi.utils.logging import notify_exception
-
+from corehq.apps.accounting.models import BillingAccount
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.app_manager.dbaccessors import (
     get_app,
@@ -56,12 +56,9 @@ from corehq.apps.linked_domain.decorators import (
     require_linked_domain,
 )
 from corehq.apps.linked_domain.exceptions import (
-    AttemptedPushViolatesConstraints,
     DomainLinkAlreadyExists,
     DomainLinkError,
     DomainLinkNotAllowed,
-    DomainLinkNotFound,
-    NoDownstreamDomainsProvided,
     UnsupportedActionError,
 )
 from corehq.apps.linked_domain.local_accessors import (
@@ -93,7 +90,6 @@ from corehq.apps.linked_domain.util import (
     pull_missing_multimedia_for_app,
     server_to_user_time,
     user_has_admin_access_in_all_domains,
-    can_domain_access_release_management,
 )
 from corehq.apps.linked_domain.view_helpers import (
     build_domain_link_view_model,
@@ -115,6 +111,7 @@ from corehq.apps.userreports.models import (
 )
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions, WebUser
+from corehq.privileges import RELEASE_MANAGEMENT
 from corehq.util.jqueryrmi import JSONResponseMixin, allow_remote_invocation
 from corehq.util.timezones.utils import get_timezone_for_request
 
@@ -282,7 +279,8 @@ class DomainLinkView(BaseAdminProjectSettingsView):
     @property
     def page_context(self):
         """
-        This view services both domains that are upstream, downstream, and legacy domains that are both
+        This view services both domains that are master domains and domains that are linked domains
+        (and legacy domains that are both).
         """
         timezone = get_timezone_for_request()
         upstream_link = get_upstream_domain_link(self.domain)
@@ -304,10 +302,16 @@ class DomainLinkView(BaseAdminProjectSettingsView):
             is_superuser=is_superuser
         )
 
-        available_domains_to_link = get_available_domains_to_link(self.request.domain, self.request.couch_user)
+        account = BillingAccount.get_account_by_domain(self.request.domain)
+        available_domains_to_link = get_available_domains_to_link(self.request.domain,
+                                                                  self.request.couch_user,
+                                                                  billing_account=account)
 
         upstream_domain_urls = []
-        for domain in get_available_upstream_domains(self.request.domain, self.request.couch_user):
+        upstream_domains = get_available_upstream_domains(self.request.domain,
+                                                          self.request.couch_user,
+                                                          billing_account=account)
+        for domain in upstream_domains:
             upstream_domain_urls.append({'name': domain, 'url': reverse('domain_links', args=[domain])})
 
         if upstream_link and upstream_link.is_remote:
@@ -318,9 +322,9 @@ class DomainLinkView(BaseAdminProjectSettingsView):
         return {
             'domain': self.domain,
             'timezone': timezone.localize(datetime.utcnow()).tzname(),
-            'has_release_management_privilege': can_domain_access_release_management(self.domain),
+            'has_release_management_privilege': domain_has_privilege(self.domain, RELEASE_MANAGEMENT),
+            'is_superuser': is_superuser,
             'view_data': {
-                'is_superuser': is_superuser,
                 'is_downstream_domain': bool(upstream_link),
                 'upstream_domains': upstream_domain_urls,
                 'available_domains': available_domains_to_link,
@@ -329,7 +333,6 @@ class DomainLinkView(BaseAdminProjectSettingsView):
                 'view_models_to_push': sorted(view_models_to_push, key=lambda m: m['name']),
                 'linked_domains': sorted(linked_domains, key=lambda d: d['downstream_domain']),
                 'linkable_ucr': remote_linkable_ucr,
-                'has_full_access': can_domain_access_release_management(self.domain, include_lite_version=False),
             },
         }
 
@@ -382,28 +385,6 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
 
     @allow_remote_invocation
     def create_release(self, in_data):
-        error_message = ''
-        try:
-            validate_push(self.request.couch_user, self.domain, in_data['linked_domains'])
-        except NoDownstreamDomainsProvided:
-            error_message = ugettext("No downstream project spaces were selected. Please contact support.")
-        except DomainLinkNotFound:
-            error_message = ugettext(
-                "Links between one or more project spaces do not exist. Please contact support."
-            )
-        except AttemptedPushViolatesConstraints:
-            formatted_domains = ', '.join(in_data['linked_domains'])
-            error_message = ugettext('''
-                The attempted push from {} to {} is disallowed. Please contact support.
-            '''.format(self.domain, formatted_domains))
-            notify_exception(self.request, "Triggered AttemptedPushViolatesConstraints exception")
-        finally:
-            if error_message:
-                return {
-                    'success': False,
-                    'message': error_message,
-                }
-
         push_models.delay(self.domain, in_data['models'], in_data['linked_domains'],
                           in_data['build_apps'], self.request.couch_user.username)
 
@@ -469,37 +450,6 @@ def link_domains(couch_user, upstream_domain, downstream_domain):
         raise DomainLinkNotAllowed(error)
 
     return DomainLink.link_domains(downstream_domain, upstream_domain)
-
-
-def validate_push(user, domain, downstream_domains):
-    if not downstream_domains:
-        raise NoDownstreamDomainsProvided
-
-    try:
-        domain_links = [
-            DomainLink.objects.get(master_domain=domain, linked_domain=dd) for dd in downstream_domains
-        ]
-    except DomainLink.DoesNotExist:
-        raise DomainLinkNotFound
-
-    validate_push_for_user(user, domain_links)
-
-
-def validate_push_for_user(user, domain_links):
-    if user.is_superuser:
-        return
-
-    if len(domain_links) == 1:
-        # pushing to one domain is fine regardless of access status
-        return
-
-    limited_access_links = list(filter(lambda link: not link.has_full_access(), domain_links))
-
-    if not limited_access_links:
-        # all links are full access
-        return
-
-    raise AttemptedPushViolatesConstraints
 
 
 class DomainLinkHistoryReport(GenericTabularReport):

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -14,6 +14,7 @@ from dimagi.utils.logging import notify_exception
 
 from corehq import privileges
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.hqwebapp.decorators import use_multiselect
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
@@ -21,11 +22,11 @@ from corehq.apps.linked_domain.dbaccessors import get_linked_domains
 from corehq.apps.linked_domain.exceptions import DomainLinkError
 from corehq.apps.linked_domain.keywords import create_linked_keyword
 from corehq.apps.linked_domain.models import DomainLink, KeywordLinkDetail
-from corehq.apps.linked_domain.util import can_domain_access_release_management
 from corehq.apps.reminders.forms import NO_RESPONSE, KeywordForm
 from corehq.apps.reminders.util import get_combined_id, split_combined_id
 from corehq.apps.sms.models import Keyword, KeywordAction
 from corehq.apps.sms.views import BaseMessagingSectionView
+from corehq.privileges import RELEASE_MANAGEMENT
 
 
 class AddStructuredKeywordView(BaseMessagingSectionView):
@@ -287,7 +288,7 @@ class KeywordsListView(BaseMessagingSectionView, CRUDPaginatedViewMixin):
             for domain_link in get_linked_domains(self.domain)
         ]
         context['linkable_keywords'] = self._linkable_keywords()
-        context['has_release_management_privilege'] = can_domain_access_release_management(self.domain)
+        context['has_release_management_privilege'] = domain_has_privilege(self.domain, RELEASE_MANAGEMENT)
         return context
 
     def _linkable_keywords(self):

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -350,5 +350,7 @@ class ReleaseManagementReportDispatcher(ReportDispatcher):
     map_name = 'RELEASE_MANAGEMENT_REPORTS'
 
     def permissions_check(self, report, request, domain=None, is_navigation_check=False):
-        from corehq.apps.linked_domain.util import can_user_access_release_management
-        return can_user_access_release_management(request.couch_user, domain, include_toggle=True)
+        from corehq.apps.linked_domain.util import can_access_linked_domains
+        # will eventually only be accessible via the release_management privilege, but shared with linked domains
+        # feature flag for now
+        return can_access_linked_domains(request.couch_user, domain)

--- a/corehq/apps/styleguide/templates/styleguide/_includes/molecules/selections.html
+++ b/corehq/apps/styleguide/templates/styleguide/_includes/molecules/selections.html
@@ -57,29 +57,9 @@
   <h2>Multiselects</h2>
   <p>
     This is a custom widget we built. It can be useful in situations where the user is adding/removing
-    items from a list and wants to be able to see both the included and excluded items.
-  </p>
-  <p>
-    It's more complicated than a dropdown and takes up much more space. <strong>Be cautious adding it to new
-    pages</strong> - be sure that the visual weight and potential learning curve is worthwhile for the workflow
-    you're creating.
-  </p>
-  <h4>Optional Properties</h4>
-  <p>
-    In addition to the optional title properties, the following properties can be useful in situations where more
-    control is needed.
-  </p>
-  <p>
-    <dl>
-      <dd>
-        <strong>disableModifyAllActions</strong> - defaults to false, useful when the preferred workflow is to disable
-        the ability to select and remove all items at once
-      </dd>
-      <dd>
-        <strong>willSelectAllListener</strong> - provides an opportunity to execute code prior to all items being
-        selected
-      </dd>
-    </dl>
+    items from a list and wants to be able to see both the included and excluded items. It's more complicated
+    than a dropdown and takes up much more space. Be cautious adding it to new pages - be sure that
+    the visual weight and potential learning curve is worthwhile for the workflow you're creating.
   </p>
   {% include 'styleguide/example_html.html' with slug='multiselect' title='Multiselect' content=examples.selections.multiselect %}
 

--- a/corehq/apps/styleguide/templates/styleguide/examples/multiselect.html
+++ b/corehq/apps/styleguide/templates/styleguide/examples/multiselect.html
@@ -7,18 +7,12 @@
 </select>
 
 <script>
-  let listener = function() {
-    console.log("Triggered willSelectAllListener");
-  };
-
   $(function () {
     var multiselect_utils = hqImport('hqwebapp/js/multiselect_utils');
     multiselect_utils.createFullMultiselectWidget('example-multiselect', {
       selectableHeaderTitle: gettext("Available Letters"),
       selectedHeaderTitle: gettext("Letters Selected"),
       searchItemTitle: gettext("Search Letters..."),
-      disableModifyAllActions: false,
-      willSelectAllListener: listener,
     });
   });
 </script>

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -68,7 +68,7 @@ from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.linked_domain.models import DomainLink, ReportLinkDetail
 from corehq.apps.linked_domain.ucr import create_linked_ucr, linked_downstream_reports_by_domain
-from corehq.apps.linked_domain.util import is_linked_report, can_domain_access_release_management
+from corehq.apps.linked_domain.util import is_linked_report
 from corehq.apps.locations.permissions import conditionally_location_safe
 from corehq.apps.registry.helper import DataRegistryHelper
 from corehq.apps.registry.models import DataRegistry
@@ -152,6 +152,7 @@ from corehq.apps.userreports.util import (
 )
 from corehq.apps.users.decorators import get_permission_name, require_permission
 from corehq.apps.users.models import Permissions
+from corehq.privileges import RELEASE_MANAGEMENT
 from corehq.tabs.tabclasses import ProjectReportsTab
 from corehq.util import reverse
 from corehq.util.couch import get_document_or_404
@@ -269,7 +270,7 @@ class BaseEditConfigReportView(BaseUserConfigReportsView):
             'linked_report_domain_list': linked_downstream_reports_by_domain(
                 self.domain, self.report_id
             ),
-            'has_release_management_privilege': can_domain_access_release_management(self.domain),
+            'has_release_management_privilege': domain_has_privilege(self.domain, RELEASE_MANAGEMENT),
         }
 
     @property
@@ -651,7 +652,7 @@ class ConfigureReport(ReportBuilderView):
             'linked_report_domain_list': linked_downstream_reports_by_domain(
                 self.domain, self.existing_report.get_id
             ) if self.existing_report else {},
-            'has_release_management_privilege': can_domain_access_release_management(self.domain),
+            'has_release_management_privilege': domain_has_privilege(self.domain, RELEASE_MANAGEMENT),
         }
 
     def _get_bound_form(self, report_data):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -52,7 +52,7 @@ from corehq.apps.integration.views import (
     GaenOtpServerSettingsView,
     HmacCalloutSettingsView,
 )
-from corehq.apps.linked_domain.util import can_user_access_release_management, can_domain_access_release_management
+from corehq.apps.linked_domain.util import can_access_release_management_feature
 from corehq.apps.locations.analytics import users_have_locations
 from corehq.apps.receiverwrapper.rate_limiter import (
     SHOULD_RATE_LIMIT_SUBMISSIONS,
@@ -102,7 +102,7 @@ from corehq.messaging.scheduling.views import (
 from corehq.motech.dhis2.views import DataSetMapListView
 from corehq.motech.openmrs.views import OpenmrsImporterView
 from corehq.motech.views import ConnectionSettingsListView, MotechLogListView
-from corehq.privileges import DAILY_SAVED_EXPORT, EXCEL_DASHBOARD
+from corehq.privileges import DAILY_SAVED_EXPORT, EXCEL_DASHBOARD, RELEASE_MANAGEMENT
 from corehq.tabs.uitab import UITab
 from corehq.tabs.utils import (
     dropdown_dict,
@@ -1777,10 +1777,9 @@ class ProjectSettingsTab(UITab):
         if feature_flag_items and has_project_access:
             items.append((_('Pre-release Features'), feature_flag_items))
 
-        release_management_title, release_management_items = _get_release_management_items(self.couch_user,
-                                                                                           self.domain)
+        release_management_items = _get_release_management_items(self.couch_user, self.domain)
         if release_management_items:
-            items.append((release_management_title, release_management_items))
+            items.append((_('Enterprise Release Management'), release_management_items))
 
         from corehq.apps.users.models import WebUser
         if isinstance(self.couch_user, WebUser):
@@ -2035,10 +2034,10 @@ def _get_feature_flag_items(domain, couch_user):
             'url': reverse(LocationFixtureConfigView.urlname, args=[domain])
         })
 
-    # DEPRECATED: only show this if the domain does not have release_management access
+    # show ERM version of linked projects if domain has privilege
     can_access_linked_domains = (
         user_is_admin and toggles.LINKED_DOMAINS.enabled(domain)
-        and not can_domain_access_release_management(domain)
+        and not domain_has_privilege(domain, RELEASE_MANAGEMENT)
     )
     if can_access_linked_domains:
         feature_flag_items.append({
@@ -2067,27 +2066,19 @@ def _get_feature_flag_items(domain, couch_user):
 
 
 def _get_release_management_items(user, domain):
-    items = []
-    title = None
-    if not can_user_access_release_management(user, domain):
-        return title, items
+    release_management_items = []
 
-    if domain_has_privilege(domain, privileges.RELEASE_MANAGEMENT):
-        title = _('Enterprise Release Management')
-    elif domain_has_privilege(domain, privileges.LITE_RELEASE_MANAGEMENT):
-        title = _('Multi-Environment Release Management')
-
-    if title:
-        items.append({
+    if can_access_release_management_feature(user, domain):
+        release_management_items.append({
             'title': _('Linked Project Spaces'),
             'url': reverse('domain_links', args=[domain])
         })
-        items.append({
+        release_management_items.append({
             'title': _('Linked Project Space History'),
             'url': reverse('domain_report_dispatcher', args=[domain, 'project_link_report'])
         })
 
-    return title, items
+    return release_management_items
 
 
 class MySettingsTab(UITab):

--- a/corehq/tabs/tests.py
+++ b/corehq/tabs/tests.py
@@ -2,12 +2,7 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
-from corehq.apps.users.models import WebUser
-from corehq.privileges import LITE_RELEASE_MANAGEMENT, RELEASE_MANAGEMENT
-from corehq.tabs.tabclasses import (
-    _get_feature_flag_items,
-    _get_release_management_items,
-)
+from corehq.tabs.tabclasses import _get_release_management_items, _get_feature_flag_items
 from corehq.tabs.utils import path_starts_with_url
 
 __test__ = {
@@ -20,102 +15,72 @@ from corehq.util.test_utils import flag_enabled
 @patch('corehq.apps.users.models.CouchUser')
 class TestAccessToLinkedProjects(SimpleTestCase):
 
-    def setUp(self):
-        super().setUp()
-
-        access_patcher = patch('corehq.tabs.tabclasses.can_domain_access_release_management')
-        self.mock_can_access = access_patcher.start()
-        self.addCleanup(access_patcher.stop)
-
-        privilege_patcher = patch('corehq.tabs.tabclasses.domain_has_privilege')
-        self.mock_domain_has_privilege = privilege_patcher.start()
-        self.addCleanup(privilege_patcher.stop)
-
-    def test_returns_empty_if_no_release_management_access_and_is_admin_but_no_toggle(self, mock_user):
+    def test_get_feature_flag_items_returns_none(self, mock_user):
         mock_user.is_domain_admin.return_value = True
-        self.mock_can_access.return_value = False
-
-        items = _get_feature_flag_items("domain", mock_user)
-
-        self.assertFalse(items)
-
-    @flag_enabled('LINKED_DOMAINS')
-    def test_returns_empty_if_no_release_management_access_and_toggle_but_not_admin(self, mock_user):
-        mock_user.is_domain_admin.return_value = False
-        self.mock_can_access.return_value = False
-
-        items = _get_feature_flag_items("domain", mock_user)
-
-        self.assertFalse(items)
-
-    @flag_enabled('LINKED_DOMAINS')
-    def test_returns_empty_if_is_admin_and_has_toggle_but_can_access_release_management_privilege(self, mock_user):
-        mock_user.is_domain_admin.return_value = True
-        self.mock_can_access.return_value = True
-
-        items = _get_feature_flag_items("domain", mock_user)
-
-        self.assertFalse(items)
-
-    @flag_enabled('LINKED_DOMAINS')
-    def test_returns_items_if_toggle_enabled_with_no_release_management_access_and_is_admin(self, mock_user):
-        mock_user.is_domain_admin.return_value = True
-        self.mock_can_access.return_value = False
-
-        with patch('corehq.tabs.tabclasses.reverse', return_value='dummy_url'):
+        with patch('corehq.tabs.tabclasses.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
             items = _get_feature_flag_items("domain", mock_user)
 
-        self.assertEqual(items[0]['title'], 'Linked Project Spaces')
-        self.assertEqual(items[1]['title'], 'Linked Project Space History')
-
-
-class TestAccessToReleaseManagementTab(SimpleTestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.user = WebUser(username='test-username')
-
-    def setUp(self):
-        super().setUp()
-
-        access_patcher = patch('corehq.tabs.tabclasses.can_user_access_release_management')
-        self.mock_can_access = access_patcher.start()
-        self.addCleanup(access_patcher.stop)
-
-        privilege_patcher = patch('corehq.tabs.tabclasses.domain_has_privilege')
-        self.mock_domain_has_privilege = privilege_patcher.start()
-        self.addCleanup(privilege_patcher.stop)
-
-        reverse_patcher = patch('corehq.tabs.tabclasses.reverse')
-        self.mock_reverse = reverse_patcher.start()
-        self.mock_reverse.return_value = 'dummy_url'
-        self.addCleanup(reverse_patcher.stop)
-
-    def test_returns_none_if_cannot_user_access_release_management(self):
-        self.mock_can_access.return_value = False
-
-        title, items = _get_release_management_items(self.user, "domain")
-
-        self.assertFalse(title)
         self.assertFalse(items)
 
-    def test_returns_erm_if_can_access_full_release_management(self):
-        self.mock_can_access.return_value = True
-        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
+    @flag_enabled('LINKED_DOMAINS')
+    def test_get_feature_flag_items_returns_some(self, mock_user):
+        mock_user.is_domain_admin.return_value = True
+        with patch('corehq.tabs.tabclasses.domain_has_privilege') as mock_domain_has_privilege, \
+             patch('corehq.tabs.tabclasses.reverse') as mock_reverse:
+            mock_domain_has_privilege.return_value = False
+            mock_reverse.return_value = 'dummy_url'
+            items = _get_feature_flag_items("domain", mock_user)
 
-        title, items = _get_release_management_items(self.user, "domain")
+        self.assertTrue(items)
 
-        self.assertEqual(title, 'Enterprise Release Management')
-        self.assertEqual(items[0]['title'], 'Linked Project Spaces')
-        self.assertEqual(items[1]['title'], 'Linked Project Space History')
+    @flag_enabled('LINKED_DOMAINS')
+    def test_get_feature_flag_items_returns_none_if_domain_has_release_management_privilege(self, mock_user):
+        mock_user.is_domain_admin.return_value = True
+        with patch('corehq.tabs.tabclasses.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = True
+            items = _get_feature_flag_items("domain", mock_user)
 
-    def test_returns_mrm_if_has_privilege_but_not_admin(self):
-        self.mock_can_access.return_value = True
-        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == LITE_RELEASE_MANAGEMENT
+        self.assertFalse(items)
 
-        title, items = _get_release_management_items(self.user, "domain")
 
-        self.assertEqual(title, 'Multi-Environment Release Management')
-        self.assertEqual(items[0]['title'], 'Linked Project Spaces')
-        self.assertEqual(items[1]['title'], 'Linked Project Space History')
+@patch('corehq.apps.users.models.CouchUser')
+class TestAccessToReleaseManagementTab(SimpleTestCase):
+
+    def test_get_release_management_items_returns_none(self, mock_user):
+        mock_user.is_domain_admin.return_value = False
+
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
+            items = _get_release_management_items(mock_user, "domain")
+
+        self.assertFalse(items)
+
+    def test_get_release_management_items_returns_none_with_admin(self, mock_user):
+        mock_user.is_domain_admin.return_value = True
+
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = False
+            items = _get_release_management_items(mock_user, "domain")
+
+        self.assertFalse(items)
+
+    def test_get_release_management_items_returns_none_with_domain_privilege(self, mock_user):
+        mock_user.is_domain_admin.return_value = False
+
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.return_value = True
+            items = _get_release_management_items(mock_user, "domain")
+
+        self.assertFalse(items)
+
+    def test_get_release_management_items_returns_some(self, mock_user):
+        mock_user.is_domain_admin.return_value = True
+
+        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege, \
+             patch('corehq.tabs.tabclasses.reverse') as mock_reverse:
+            mock_domain_has_privilege.return_value = True
+            mock_reverse.return_value = 'dummy_url'
+            items = _get_release_management_items(mock_user, "domain")
+
+        self.assertTrue(items)


### PR DESCRIPTION
Reverts dimagi/commcare-hq#31047

There aren't any issues. I just realized I jumped the gun on merging so reverting this to avoid a ~day where feature flag users that should be grandfathered into ERM are shown MRM. I somehow convinced myself initially that this wasn't the case which is why I merged and was anticipating on deploying tonight. 