### PR TITLE
feature flag dependencies

### DIFF
--- a/corehq/apps/domain/tests/test_domain_transfer.py
+++ b/corehq/apps/domain/tests/test_domain_transfer.py
@@ -25,7 +25,7 @@ class BaseDomainTest(TestCase):
 
         self.domain = Domain(name="fandago", is_active=True)
         self.domain.save()
-        toggles.TRANSFER_DOMAIN.set("domain:{domain}".format(domain=self.domain.name), True)
+        toggles.TRANSFER_DOMAIN.set(self.domain.name, True, toggles.NAMESPACE_DOMAIN)
 
         self.username = 'bananafana'
         self.password = '*******'

--- a/corehq/apps/enterprise/tests/test_enterprise_mobile_worker_settings.py
+++ b/corehq/apps/enterprise/tests/test_enterprise_mobile_worker_settings.py
@@ -282,7 +282,7 @@ class TestEnterpriseMobileWorkerSettingsCustomDeactivation(TestCase):
             one_year_ago
         )
         toggles.AUTO_DEACTIVATE_MOBILE_WORKERS.set(
-            cls.domains3[0].name, True
+            cls.domains3[0].name, True, toggles.NAMESPACE_DOMAIN
         )
 
         cls.emw_settings1 = EnterpriseMobileWorkerSettings.objects.create(

--- a/corehq/apps/hqcase/tests/test_loadtest_users.py
+++ b/corehq/apps/hqcase/tests/test_loadtest_users.py
@@ -10,7 +10,7 @@ from casexml.apps.phone.restore import RestoreConfig, RestoreParams
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import CommCareUser
-from corehq.toggles import ENABLE_LOADTEST_USERS
+from corehq.toggles import ENABLE_LOADTEST_USERS, NAMESPACE_DOMAIN
 
 
 class LoadtestUserTest(TestCase):
@@ -23,7 +23,7 @@ class LoadtestUserTest(TestCase):
         cls.user = CommCareUser.create(cls.domain.name, 'somebody', 'password', None, None)
         cls.user_id = cls.user._id
         cls.factory = CaseFactory(domain='foo', case_defaults={'owner_id': cls.user_id})
-        ENABLE_LOADTEST_USERS.set('foo', True, namespace='domain')
+        ENABLE_LOADTEST_USERS.set('foo', True, namespace=NAMESPACE_DOMAIN)
 
     def setUp(self):
         delete_all_cases()

--- a/corehq/apps/toggle_ui/admin.py
+++ b/corehq/apps/toggle_ui/admin.py
@@ -6,6 +6,6 @@ from corehq.apps.toggle_ui.models import ToggleAudit
 @admin.register(ToggleAudit)
 class ToggleAdmin(admin.ModelAdmin):
     date_hierarchy = 'created'
-    list_display = ('username', 'slug', 'action', 'namespace', 'item', 'randomness')
+    list_display = ('created', 'username', 'slug', 'action', 'namespace', 'item', 'randomness')
     list_filter = ('slug', 'namespace')
     ordering = ('created',)

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -115,14 +115,14 @@
         </div>
       {% endif %}
 
-      {% if static_toggle.dependent_toggles %}
+      {% if static_toggle.parent_toggles %}
         <div class="alert alert-info">
           <p><i class="fa fa-info-circle"></i>
           {% blocktrans %}
             This feature flag also requires the following flags to be enabled:
           {% endblocktrans %}
           <ul>
-            {% for dependency in static_toggle.dependent_toggles %}
+            {% for dependency in static_toggle.parent_toggles %}
               <li><a href="{% url "edit_toggle" dependency.slug %}" target="_blank">{{ dependency.label }}</a></li>
             {% endfor %}
           </ul></p>

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -115,6 +115,23 @@
         </div>
       {% endif %}
 
+      {% if static_toggle.dependent_toggles %}
+        <div class="alert alert-info">
+          <p><i class="fa fa-info-circle"></i>
+          {% blocktrans %}
+            This feature flag also requires the following flags to be enabled:
+          {% endblocktrans %}
+          <ul>
+            {% for dependency in static_toggle.dependent_toggles %}
+              <li><a href="{% url "edit_toggle" dependency.slug %}" target="_blank">{{ dependency.label }}</a></li>
+            {% endfor %}
+          </ul></p>
+          <p>{% blocktrans %}
+            Enabling this feature flag will automatically enable the flags listed above.
+          {% endblocktrans %}</p>
+        </div>
+      {% endif %}
+
       <hr/>
       <div id="toggle_editing_ko">
         <div data-bind="saveButton: saveButton"></div>

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -257,8 +257,8 @@ def _call_save_fn_and_clear_cache_and_enable_dependencies(request_username, stat
 
 
 def _enable_dependencies(request_username, static_toggle, item, namespace, is_enabled):
-    if is_enabled and static_toggle.dependent_toggles:
-        for dependency in static_toggle.dependent_toggles:
+    if is_enabled and static_toggle.parent_toggles:
+        for dependency in static_toggle.parent_toggles:
             _set_toggle(request_username, dependency, item, namespace, is_enabled)
 
 

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -253,9 +253,13 @@ def _call_save_fn_and_clear_cache_and_enable_dependencies(request_username, stat
         namespace, entry = parse_toggle(entry)
         _call_save_fn_for_toggle(static_toggle, namespace, entry, enabled)
         _clear_cache_for_toggle(namespace, entry)
-        if enabled and static_toggle.dependent_toggles:
-            for dependency in static_toggle.dependent_toggles:
-                _set_toggle(request_username, dependency, entry, namespace, enabled)
+        _enable_dependencies(request_username, static_toggle, entry, namespace, enabled)
+
+
+def _enable_dependencies(request_username, static_toggle, item, namespace, is_enabled):
+    if is_enabled and static_toggle.dependent_toggles:
+        for dependency in static_toggle.dependent_toggles:
+            _set_toggle(request_username, dependency, item, namespace, is_enabled)
 
 
 def _set_toggle(request_username, static_toggle, item, namespace, is_enabled):
@@ -269,6 +273,7 @@ def _set_toggle(request_username, static_toggle, item, namespace, is_enabled):
             _notify_on_change(static_toggle, [item], request_username)
 
         _clear_cache_for_toggle(namespace, item)
+        _enable_dependencies(request_username, static_toggle, item, namespace, is_enabled)
 
 
 def _call_save_fn_for_toggle(static_toggle, namespace, entry, enabled):

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -203,7 +203,8 @@ class ToggleEditView(BasePageView):
             self.toggle_slug, self.request.user.username, currently_enabled, previously_enabled, randomness
         )
         _notify_on_change(self.static_toggle, currently_enabled - previously_enabled, self.request.user.username)
-        _call_save_fn_and_clear_cache(self.static_toggle, previously_enabled, currently_enabled)
+        _call_save_fn_and_clear_cache_and_enable_dependencies(
+            self.request.user.username, self.static_toggle, previously_enabled, currently_enabled)
 
         data = {
             'items': item_list
@@ -244,13 +245,30 @@ def _notify_on_change(static_toggle, added_entries, username):
         _assert(False, subject)
 
 
-def _call_save_fn_and_clear_cache(static_toggle, previously_enabled, currently_enabled):
+def _call_save_fn_and_clear_cache_and_enable_dependencies(request_username, static_toggle,
+                                                          previously_enabled, currently_enabled):
     changed_entries = previously_enabled ^ currently_enabled  # ^ means XOR
     for entry in changed_entries:
         enabled = entry in currently_enabled
         namespace, entry = parse_toggle(entry)
         _call_save_fn_for_toggle(static_toggle, namespace, entry, enabled)
         _clear_cache_for_toggle(namespace, entry)
+        if enabled and static_toggle.dependent_toggles:
+            for dependency in static_toggle.dependent_toggles:
+                _set_toggle(request_username, dependency, entry, namespace, enabled)
+
+
+def _set_toggle(request_username, static_toggle, item, namespace, is_enabled):
+    if static_toggle.set(item=item, enabled=is_enabled, namespace=namespace):
+        action = ToggleAudit.ACTION_ADD if is_enabled else ToggleAudit.ACTION_REMOVE
+        ToggleAudit.objects.log_toggle_action(
+            static_toggle.slug, request_username, [namespaced_item(item, namespace)], action
+        )
+
+        if is_enabled:
+            _notify_on_change(static_toggle, [item], request_username)
+
+        _clear_cache_for_toggle(namespace, item)
 
 
 def _call_save_fn_for_toggle(static_toggle, namespace, entry, enabled):
@@ -357,16 +375,7 @@ def set_toggle(request, toggle_slug):
     item = request.POST['item']
     enabled = request.POST['enabled'] == 'true'
     namespace = request.POST['namespace']
-    if static_toggle.set(item=item, enabled=enabled, namespace=namespace):
-        action = ToggleAudit.ACTION_ADD if enabled else ToggleAudit.ACTION_REMOVE
-        ToggleAudit.objects.log_toggle_action(
-            toggle_slug, request.user.username, [namespaced_item(item, namespace)], action
-        )
-
-    if enabled:
-        _notify_on_change(static_toggle, [item], request.user.username)
-
-    _clear_cache_for_toggle(namespace, item)
+    _set_toggle(request.user.username, static_toggle, item, namespace, enabled)
 
     return HttpResponse(json.dumps({'success': True}), content_type="application/json")
 

--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -18,7 +18,7 @@ from corehq.const import USER_CHANGE_VIA_WEB
 from corehq.util.test_utils import generate_cases
 from corehq.apps.locations.tests.util import make_loc, delete_all_locations
 from corehq.apps.locations.models import LocationType
-from corehq.toggles import FILTERED_BULK_USER_DOWNLOAD
+from corehq.toggles import FILTERED_BULK_USER_DOWNLOAD, NAMESPACE_DOMAIN
 from corehq.toggles.shortcuts import set_toggle
 
 
@@ -222,7 +222,7 @@ class TestCountWebUsers(TestCase):
         cls.domain = 'test'
         cls.domain_obj = create_domain(cls.domain)
 
-        set_toggle(FILTERED_BULK_USER_DOWNLOAD.slug, cls.domain, True, namespace='domain')
+        set_toggle(FILTERED_BULK_USER_DOWNLOAD.slug, cls.domain, True, namespace=NAMESPACE_DOMAIN)
 
         location_type = LocationType(domain=cls.domain, name='phony')
         location_type.save()

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_new_sync.py
@@ -17,7 +17,7 @@ from casexml.apps.phone.utils import MockDevice
 
 from corehq.apps.domain.models import Domain
 from corehq.form_processor.tests.utils import sharded
-from corehq.toggles import LEGACY_SYNC_SUPPORT
+from corehq.toggles import LEGACY_SYNC_SUPPORT, NAMESPACE_DOMAIN
 from corehq.util.global_request.api import set_request
 
 
@@ -97,7 +97,7 @@ class TestNewSyncSpecifics(TestCase):
 
         # enabling the toggle should prevent the failure the second time
         # though we also need to hackily set the request object in the threadlocals
-        LEGACY_SYNC_SUPPORT.set(self.domain, True, namespace='domain')
+        LEGACY_SYNC_SUPPORT.set(self.domain, True, namespace=NAMESPACE_DOMAIN)
         request = JsonObject(domain=self.domain, path='testsubmit')
         set_request(request)
         factory.create_or_update_cases([

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -123,7 +123,7 @@ class StaticToggle(object):
     def __init__(self, slug, label, tag, namespaces=None, help_link=None,
                  description=None, save_fn=None, enabled_for_new_domains_after=None,
                  enabled_for_new_users_after=None, relevant_environments=None,
-                 notification_emails=None, dependent_toggles=None):
+                 notification_emails=None, parent_toggles=None):
         self.slug = slug
         self.label = label
         self.tag = tag
@@ -143,7 +143,7 @@ class StaticToggle(object):
         self.enabled_for_new_users_after = enabled_for_new_users_after
         # pass in a set of environments where this toggle applies
         self.relevant_environments = relevant_environments
-        self.dependent_toggles = dependent_toggles or []
+        self.parent_toggles = parent_toggles or []
 
         if namespaces:
             self.namespaces = [None if n == NAMESPACE_USER else n for n in namespaces]
@@ -151,7 +151,7 @@ class StaticToggle(object):
             self.namespaces = [None]
         self.notification_emails = notification_emails
 
-        for dependency in self.dependent_toggles:
+        for dependency in self.parent_toggles:
             if not set(self.namespaces) & set(dependency.namespaces):
                 raise Exception(
                     "Namespaces of dependent toggles must overlap with dependency:"
@@ -869,7 +869,7 @@ USH_CASE_CLAIM_UPDATES = StaticToggle(
     "search first", "see more", and "skip to default case search results", Geocoder
     and other options in Webapps Case Search.
     """,
-    dependent_toggles=[SYNC_SEARCH_CASE_CLAIM]
+    parent_toggles=[SYNC_SEARCH_CASE_CLAIM]
 )
 
 USH_USERCASES_FOR_WEB_USERS = StaticToggle(
@@ -1091,7 +1091,7 @@ MOBILE_UCR = StaticToggle(
      'through the app builder'),
     TAG_SOLUTIONS_LIMITED,
     namespaces=[NAMESPACE_DOMAIN],
-    dependent_toggles=[USER_CONFIGURABLE_REPORTS]
+    parent_toggles=[USER_CONFIGURABLE_REPORTS]
 )
 
 API_THROTTLE_WHITELIST = StaticToggle(
@@ -1352,7 +1352,7 @@ SEND_UCR_REBUILD_INFO = StaticToggle(
     'Notify when UCR rebuilds finish or error.',
     TAG_SOLUTIONS_CONDITIONAL,
     namespaces=[NAMESPACE_USER],
-    dependent_toggles=[USER_CONFIGURABLE_REPORTS]
+    parent_toggles=[USER_CONFIGURABLE_REPORTS]
 )
 
 ALLOW_USER_DEFINED_EXPORT_COLUMNS = StaticToggle(
@@ -1990,7 +1990,7 @@ ONE_PHONE_NUMBER_MULTIPLE_CONTACTS = StaticToggle(
     Otherwise the recipient has no way to know who they're supposed to be enter information about.
     """,
     help_link="https://confluence.dimagi.com/display/saas/One+Phone+Number+-+Multiple+Contacts",
-    dependent_toggles=[INBOUND_SMS_LENIENCY]
+    parent_toggles=[INBOUND_SMS_LENIENCY]
 )
 
 CHANGE_FORM_LANGUAGE = StaticToggle(
@@ -2158,7 +2158,7 @@ DATA_REGISTRY_UCR = StaticToggle(
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
     help_link="https://confluence.dimagi.com/display/USH/Data+Registry#DataRegistry-CrossDomainReports",
-    dependent_toggles=[DATA_REGISTRY]
+    parent_toggles=[DATA_REGISTRY]
 )
 
 DATA_REGISTRY_CASE_UPDATE_REPEATER = StaticToggle(
@@ -2167,7 +2167,7 @@ DATA_REGISTRY_CASE_UPDATE_REPEATER = StaticToggle(
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
     help_link="https://confluence.dimagi.com/display/USH/Data+Registry+Case+Update+Repeater",
-    dependent_toggles=[DATA_REGISTRY]
+    parent_toggles=[DATA_REGISTRY]
 )
 
 CASE_IMPORT_DATA_DICTIONARY_VALIDATION = StaticToggle(

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -143,13 +143,19 @@ class StaticToggle(object):
         self.enabled_for_new_users_after = enabled_for_new_users_after
         # pass in a set of environments where this toggle applies
         self.relevant_environments = relevant_environments
-        self.dependent_toggles = dependent_toggles
+        self.dependent_toggles = dependent_toggles or []
 
         if namespaces:
             self.namespaces = [None if n == NAMESPACE_USER else n for n in namespaces]
         else:
             self.namespaces = [None]
         self.notification_emails = notification_emails
+
+        for dependency in self.dependent_toggles:
+            if not set(self.namespaces) & set(dependency.namespaces):
+                raise Exception(
+                    "Namespaces of dependent toggles must overlap with dependency:"
+                    f" {self.slug}, {dependency.slug}")
 
     def enabled(self, item, namespace=Ellipsis):
         if self.relevant_environments and not (

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -858,7 +858,8 @@ USH_CASE_CLAIM_UPDATES = StaticToggle(
     USH Specific toggle to support several different case search/claim workflows in web apps:
     "search first", "see more", and "skip to default case search results", Geocoder
     and other options in Webapps Case Search.
-    """
+    """,
+    dependent_toggles=[SYNC_SEARCH_CASE_CLAIM]
 )
 
 USH_USERCASES_FOR_WEB_USERS = StaticToggle(
@@ -1080,6 +1081,7 @@ MOBILE_UCR = StaticToggle(
      'through the app builder'),
     TAG_SOLUTIONS_LIMITED,
     namespaces=[NAMESPACE_DOMAIN],
+    dependent_toggles=[USER_CONFIGURABLE_REPORTS]
 )
 
 API_THROTTLE_WHITELIST = StaticToggle(
@@ -1339,7 +1341,8 @@ SEND_UCR_REBUILD_INFO = StaticToggle(
     'send_ucr_rebuild_info',
     'Notify when UCR rebuilds finish or error.',
     TAG_SOLUTIONS_CONDITIONAL,
-    [NAMESPACE_USER]
+    namespaces=[NAMESPACE_USER],
+    dependent_toggles=[USER_CONFIGURABLE_REPORTS]
 )
 
 ALLOW_USER_DEFINED_EXPORT_COLUMNS = StaticToggle(

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -210,6 +210,10 @@ class StaticToggle(object):
         if namespace == NAMESPACE_USER:
             namespace = None  # because:
             #     __init__() ... self.namespaces = [None if n == NAMESPACE_USER else n for n in namespaces]
+
+        if namespace not in self.namespaces:
+            return False
+
         return set_toggle(self.slug, item, enabled, namespace)
 
     def required_decorator(self):

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -123,7 +123,7 @@ class StaticToggle(object):
     def __init__(self, slug, label, tag, namespaces=None, help_link=None,
                  description=None, save_fn=None, enabled_for_new_domains_after=None,
                  enabled_for_new_users_after=None, relevant_environments=None,
-                 notification_emails=None):
+                 notification_emails=None, dependent_toggles=None):
         self.slug = slug
         self.label = label
         self.tag = tag
@@ -143,6 +143,7 @@ class StaticToggle(object):
         self.enabled_for_new_users_after = enabled_for_new_users_after
         # pass in a set of environments where this toggle applies
         self.relevant_environments = relevant_environments
+        self.dependent_toggles = dependent_toggles
 
         if namespaces:
             self.namespaces = [None if n == NAMESPACE_USER else n for n in namespaces]
@@ -1975,7 +1976,8 @@ ONE_PHONE_NUMBER_MULTIPLE_CONTACTS = StaticToggle(
     Only use this feature if every form behind an SMS survey begins by identifying the contact.
     Otherwise the recipient has no way to know who they're supposed to be enter information about.
     """,
-    help_link="https://confluence.dimagi.com/display/saas/One+Phone+Number+-+Multiple+Contacts"
+    help_link="https://confluence.dimagi.com/display/saas/One+Phone+Number+-+Multiple+Contacts",
+    dependent_toggles=[INBOUND_SMS_LENIENCY]
 )
 
 CHANGE_FORM_LANGUAGE = StaticToggle(
@@ -2143,6 +2145,7 @@ DATA_REGISTRY_UCR = StaticToggle(
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
     help_link="https://confluence.dimagi.com/display/USH/Data+Registry#DataRegistry-CrossDomainReports",
+    dependent_toggles=[DATA_REGISTRY]
 )
 
 DATA_REGISTRY_CASE_UPDATE_REPEATER = StaticToggle(
@@ -2151,6 +2154,7 @@ DATA_REGISTRY_CASE_UPDATE_REPEATER = StaticToggle(
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
     help_link="https://confluence.dimagi.com/display/USH/Data+Registry+Case+Update+Repeater",
+    dependent_toggles=[DATA_REGISTRY]
 )
 
 CASE_IMPORT_DATA_DICTIONARY_VALIDATION = StaticToggle(


### PR DESCRIPTION
## Product Description
In some cases feature flags depend on each other. Although this is not ideal since it adds complexity we already have a number of dependencies. This PR makes those dependencies explicit and simplifies the process for enabling flags that depend on others.

![image](https://user-images.githubusercontent.com/249606/160840096-3add0e3d-65f1-4078-b60d-f9fed2722a28.png)

## Technical Summary
* Dependencies are statically declared in the code
* At least one namespace must be shared between the dependent toggle and its dependencies

## Safety Assurance

### Safety story
Changes to the toggles would prevent the Django process from starting if there were errors so would be caught by the build. The view changes have been tested locally.

### Automated test coverage
None

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
