### PR TITLE
Add MasterDataReport to app_config

### DIFF
--- a/corehq/apps/reports/app_config.py
+++ b/corehq/apps/reports/app_config.py
@@ -40,6 +40,6 @@ class ReportsModule(AppConfig):
 
 def get_report_class(slug):
     if slug not in reports:
-        raise Exception("Report class not supported yet, try adding the slug in reports/const.py")
+        raise Exception("Report class not supported yet, try adding the slug in reports/app_config.py")
     else:
         return reports[slug]

--- a/corehq/apps/reports/app_config.py
+++ b/corehq/apps/reports/app_config.py
@@ -18,6 +18,7 @@ class ReportsModule(AppConfig):
         from corehq.apps.hqadmin.reports import DeviceLogSoftAssertReport
         from corehq.apps.smsbillables.interface import SMSBillablesInterface, SMSGatewayFeeCriteriaInterface
         from phonelog.reports import DeviceLogDetailsReport
+        from custom.inddex.reports.r1_master_data import MasterDataReport
 
         global reports
         reports.update({
@@ -33,6 +34,7 @@ class ReportsModule(AppConfig):
             CaseListExplorer.slug: CaseListExplorer,
             DuplicateCasesExplorer.slug: DuplicateCasesExplorer,
             CurrentStockStatusReport.slug: CurrentStockStatusReport,
+            MasterDataReport.slug: MasterDataReport,
         })
 
 


### PR DESCRIPTION
(Please feel free to include additional reviewers who might have better context of custom reports than me, but for this change I think Minha might have the most context)

## Product Description
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2036)
Clicking the "Export to Excel" button does not deliver the email to the necessary recipients. I have reproduced the issue locally and found that [this](https://github.com/dimagi/commcare-hq/blob/47c45c743df180f7c0572e1ca187abf98658938c/corehq/apps/reports/app_config.py#L43) error is raised. This PR aims to fix that problem. 
("Export to Excel" is a really bad name for that button)

Note that this is a P2 issue.

## Technical Summary
[This](https://github.com/dimagi/commcare-hq/commit/7b5efafd81d7f3d97a60898586c3192c5ef9ff8e) PR implemented the `get_report_class` function which returns the report class based on the slug, but it seems the `MasterDataReport` was not included. This PR simply includes it. 

## Feature Flag
Custom Reports

## Safety Assurance

### Safety story
Local testing shows it works (going to try and see if I can test this on staging in the meantime, but due to urgency I have created this PR so long)

### Automated test coverage
No additional tests added

### QA Plan
QA once it's deployed to production.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
