### PR TITLE
Deprecate LINKED_DOMAINS toggle

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1576,11 +1576,11 @@ COMPARE_UCR_REPORTS = DynamicallyPredictablyRandomToggle(
 
 LINKED_DOMAINS = StaticToggle(
     'linked_domains',
-    'Allow linking project spaces (successor to linked apps)',
-    TAG_SAAS_CONDITIONAL,
+    'DEPRECATED: Allow linking project spaces (successor to linked apps). Moved to permission.',
+    TAG_DEPRECATED,
     [NAMESPACE_DOMAIN],
     description=(
-        "Link project spaces to allow syncing apps, lookup tables, organizations etc."
+        "Replaced by Enterprise Release Management (release_management privilege)."
     ),
     help_link='https://confluence.dimagi.com/display/saas/Linked+Project+Spaces',
 )


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The `LINKED_DOMAINS` feature flag is being replaced by Enterprise Release Management and Multi-Environment Release Management which are access controlled via privileges (`release_management` and `lite_release_management` respectively). 
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13110


Now that ERM/MRM is being officially released, we can deprecate this feature flag.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LINKED_DOMAINS`
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Only modifies a toggle's metadata.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated test coverage needed.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
