### PR TITLE
Django 3.2 test fixes

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/tests/rendered/initial_page_data.html
+++ b/corehq/apps/hqwebapp/templatetags/tests/rendered/initial_page_data.html
@@ -1,3 +1,3 @@
 <body>
-<div data-name="scalar" data-value="estrella"></div><div data-name="special_chars" data-value="here&#39;s &quot;something&quot; irritating to parse &amp; deal with"></div><div data-name="list" data-value="[1, 2, 3]"></div><div data-name="maps" data-value="[{&quot;hen&quot;: &quot;brood&quot;}, {&quot;nightingale&quot;: &quot;watch&quot;}, {&quot;quail&quot;: &quot;bevy&quot;}, {&quot;starling&quot;: &quot;murmuration&quot;}]"></div>
+<div data-name="scalar" data-value="estrella"></div><div data-name="special_chars" data-value="here&#x27;s &quot;something&quot; irritating to parse &amp; deal with"></div><div data-name="list" data-value="[1, 2, 3]"></div><div data-name="maps" data-value="[{&quot;hen&quot;: &quot;brood&quot;}, {&quot;nightingale&quot;: &quot;watch&quot;}, {&quot;quail&quot;: &quot;bevy&quot;}, {&quot;starling&quot;: &quot;murmuration&quot;}]"></div>
 </body>

--- a/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
+++ b/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
@@ -52,6 +52,11 @@ class TagTest(SimpleTestCase):
         expected_template = self._get_file('rendered', '{}.html'.format(filename))
         expected = self._render_template(expected_template)
 
+        # Removed when Django 2.x is no longer supported
+        import django
+        if django.VERSION[0] < 3:
+            expected = expected.replace("&#x27;", "&#39;")
+
         self.assertEqual(
             self._normalize_whitespace(actual),
             self._normalize_whitespace(expected),

--- a/corehq/apps/hqwebapp/tests/test_compress_command.py
+++ b/corehq/apps/hqwebapp/tests/test_compress_command.py
@@ -1,7 +1,7 @@
 import os
 
 from django.conf import settings
-from django.template.loaders.app_directories import get_app_template_dirs
+from django.template.utils import get_app_template_dirs
 from django.test import SimpleTestCase
 
 from nose.plugins.attrib import attr
@@ -35,7 +35,7 @@ class TestDjangoCompressOffline(SimpleTestCase):
     def test_compress_offline(self):
         template_dir_list = []
         for template_dir in get_app_template_dirs('templates'):
-            if settings.BASE_DIR in template_dir:
+            if str(template_dir).startswith(settings.BASE_DIR):
                 template_dir_list.append(template_dir)
 
         template_list = []

--- a/corehq/apps/oauth_integrations/migrations/0003_livegooglesheetrefreshstatus.py
+++ b/corehq/apps/oauth_integrations/migrations/0003_livegooglesheetrefreshstatus.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
                 ('date_end', models.DateTimeField(blank=True, null=True)),
                 ('refresh_error_reason', models.CharField(choices=[(None, 'No Error'), ('token', 'Invalid Token'), ('timeout', 'Data Timeout'), ('other', 'Other...')], default=None, max_length=7, null=True)),
                 ('refresh_error_note', models.TextField(blank=True, null=True)),
-                ('schedule', models.ForeignKey(on_delete='cascade', to='oauth_integrations.LiveGoogleSheetSchedule')),
+                ('schedule', models.ForeignKey(on_delete=models.CASCADE, to='oauth_integrations.LiveGoogleSheetSchedule')),
             ],
         ),
     ]


### PR DESCRIPTION
Fix some tests that would fail on Django 3.2.

FYI @RynhardPietersen https://github.com/dimagi/commcare-hq/commit/1cafb0ae33d2263e7460a1f69b94c2c15ce9dc2c fixes the bad `on_delete='cascade'` value in `0003_livegooglesheetrefreshstatus.py`. I'm not sure how that got committed to master since it appears to be a broken migration.

## Safety Assurance

### Safety story

Only modifies tests, and modifies them in a backward-compatible way.

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
