### PR TITLE
Upgrade to django-cte 1.2.0

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -133,7 +133,7 @@ django-countries==7.3.2
     # via -r base-requirements.in
 django-crispy-forms==1.10.0
     # via -r base-requirements.in
-django-cte==1.1.4
+django-cte==1.2.0
     # via -r base-requirements.in
 django-extensions==3.1.3
     # via -r dev-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -110,7 +110,7 @@ django-countries==7.3.2
     # via -r base-requirements.in
 django-crispy-forms==1.10.0
     # via -r base-requirements.in
-django-cte==1.1.4
+django-cte==1.2.0
     # via -r base-requirements.in
 django-extensions==3.1.3
     # via -r docs-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -120,7 +120,7 @@ django-countries==7.3.2
     # via -r base-requirements.in
 django-crispy-forms==1.10.0
     # via -r base-requirements.in
-django-cte==1.1.4
+django-cte==1.2.0
     # via -r base-requirements.in
 django-formtools==2.3
     # via

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -106,7 +106,7 @@ django-countries==7.3.2
     # via -r base-requirements.in
 django-crispy-forms==1.10.0
     # via -r base-requirements.in
-django-cte==1.1.4
+django-cte==1.2.0
     # via -r base-requirements.in
 django-formtools==2.3
     # via

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -114,7 +114,7 @@ django-countries==7.3.2
     # via -r base-requirements.in
 django-crispy-forms==1.10.0
     # via -r base-requirements.in
-django-cte==1.1.4
+django-cte==1.2.0
     # via -r base-requirements.in
 django-formtools==2.3
     # via


### PR DESCRIPTION
See https://github.com/dimagi/django-cte/pull/51

## Safety Assurance

### Safety story

There is good test coverage for django-cte usages in HQ, and the updates to the library are minor and backward-compatible. django-cte tests are run against Django 2.2 in addition to newer versions.

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
