### PR TITLE
Upgrade to private release of django-websocket-redis

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -36,7 +36,7 @@ django-tastypie
 django-transfer
 django-two-factor-auth
 django-user-agents
-django-websocket-redis
+django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websocket-redis/0.6.0.1/releases/django_websocket_redis-0.6.0.1-py3-none-any.whl
 django>=2.2.27,<3.0  # we are not ready to move to django 3.0
 djangorestframework
 dnspython

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -173,7 +173,7 @@ django-two-factor-auth==1.13.1
     # via -r base-requirements.in
 django-user-agents==0.4.0
     # via -r base-requirements.in
-django-websocket-redis==0.6.0
+django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websocket-redis/0.6.0.1/releases/django_websocket_redis-0.6.0.1-py3-none-any.whl
     # via -r base-requirements.in
 djangorestframework==3.12.2
     # via -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -148,7 +148,7 @@ django-two-factor-auth==1.13.1
     # via -r base-requirements.in
 django-user-agents==0.4.0
     # via -r base-requirements.in
-django-websocket-redis==0.6.0
+django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websocket-redis/0.6.0.1/releases/django_websocket_redis-0.6.0.1-py3-none-any.whl
     # via -r base-requirements.in
 djangorestframework==3.12.2
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -156,7 +156,7 @@ django-two-factor-auth==1.13.1
     # via -r base-requirements.in
 django-user-agents==0.4.0
     # via -r base-requirements.in
-django-websocket-redis==0.6.0
+django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websocket-redis/0.6.0.1/releases/django_websocket_redis-0.6.0.1-py3-none-any.whl
     # via -r base-requirements.in
 djangorestframework==3.12.2
     # via -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -142,7 +142,7 @@ django-two-factor-auth==1.13.1
     # via -r base-requirements.in
 django-user-agents==0.4.0
     # via -r base-requirements.in
-django-websocket-redis==0.6.0
+django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websocket-redis/0.6.0.1/releases/django_websocket_redis-0.6.0.1-py3-none-any.whl
     # via -r base-requirements.in
 djangorestframework==3.12.2
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -152,7 +152,7 @@ django-two-factor-auth==1.13.1
     # via -r base-requirements.in
 django-user-agents==0.4.0
     # via -r base-requirements.in
-django-websocket-redis==0.6.0
+django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websocket-redis/0.6.0.1/releases/django_websocket_redis-0.6.0.1-py3-none-any.whl
     # via -r base-requirements.in
 djangorestframework==3.12.2
     # via -r base-requirements.in


### PR DESCRIPTION
The latest release on PyPI is from 2019, and it does not support Django 3.2. This release is comprised of changes on https://github.com/jrief/django-websocket-redis since the 0.6.0 release. A new release has also been [requested](https://github.com/jrief/django-websocket-redis/issues/298).

The release procedure is documented at https://github.com/dimagi/django-websocket-redis/releases/tag/0.6.0.1

## Safety Assurance

### Safety story

Reviewed new commits since 0.6.0 release.

### Automated test coverage

Unknown.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
