### PR TITLE
Fix minor bug with Feature Discoverability

### DIFF
--- a/corehq/apps/notifications/views.py
+++ b/corehq/apps/notifications/views.py
@@ -48,7 +48,7 @@ class NotificationsServiceRMIView(JSONResponseMixin, View):
             plan_tier = 'basic'
 
         def should_hide_feature_notifs(domain, plan):
-            groups = Group.get_case_sharing_groups(domain)
+            groups = Group.get_case_sharing_groups(domain, wrap=False)
             subscription_type = Subscription.get_active_subscription_by_domain(domain).service_type
             if plan == 'pro' and groups != []:
                 return True


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

[Feature Discoverability notifications](https://github.com/dimagi/commcare-hq/pull/31320) was being hidden from users on some domains that should be seeing them. This PR fixes that. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Feature Discoverability notifications are hidden from the user based on what domain they are currently working in. It is hidden entirely if 1. The domain's plan is Pro/Advanced/Enterprise edition AND has at least one case sharing enabled group in the domain or 2. The subscription type is 'Implementation' or 'Sandbox' (roughly meaning they belong to either USH or Solutions). 

The previous method of retrieving groups from a domain was too broad and included groups tied to Locations under Organization Structure. These groups are always case-sharing groups. To skip over that step, `wrap=False` was passed to 
the `get_case_sharing_groups` method.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested locally and on staging. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
