### PR TITLE
Add support to ERM for non-enterprise users 

### DIFF
--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -53,69 +53,53 @@ def get_actions_in_domain_link_history(link):
     ))
 
 
-def get_available_domains_to_link(upstream_domain_name, user, billing_account=None):
+def get_available_domains_to_link(upstream_domain, user):
     """
     This supports both the old feature flagged version of linked projects and the GAed version
-    The GAed version is only available to enterprise customers and only usable by admins, but the feature flagged
-    version is available to anyone who can obtain access (the wild west)
-    :param upstream_domain_name: potential upstream domain candidate
+    :param upstream_domain: name of upstream domain candidate
     :param user: user object
-    :param billing_account: optional parameter to limit available domains to within an enterprise account
     :return: list of domain names available to link as downstream projects
     """
-    if domain_has_privilege(upstream_domain_name, RELEASE_MANAGEMENT):
-        return get_available_domains_to_link_for_account(upstream_domain_name, user, billing_account)
-    elif toggles.LINKED_DOMAINS.enabled(upstream_domain_name):
-        return get_available_domains_to_link_for_user(upstream_domain_name, user)
+    if domain_has_privilege(upstream_domain, RELEASE_MANAGEMENT):
+        return get_available_domains_to_link_for_user(upstream_domain, user, should_enforce_admin=True)
 
+    # DEPRECATED: acting as a fallback for now. Will remove once all domains are migrated off of this flag
+    if toggles.LINKED_DOMAINS.enabled(upstream_domain):
+        return get_available_domains_to_link_for_user(upstream_domain, user, should_enforce_admin=False)
     return []
 
 
-def get_available_domains_to_link_for_account(upstream_domain_name, user, account):
+def get_available_domains_to_link_for_user(upstream_domain_name, user, should_enforce_admin):
     """
-    Finds available domains to link based on domains associated with the provided account
-    """
-    domains = account.get_domains() if account else []
-    return list({domain for domain in domains
-                 if is_domain_available_to_link(upstream_domain_name, domain, user)})
-
-
-def get_available_domains_to_link_for_user(upstream_domain_name, user):
-    """
-    Finds available domains to link based on domains that the provided user is active in
+    Finds available domains to link based on domains that the provided user is active or an admin in
     """
     domains = [d.name for d in Domain.active_for_user(user)]
     return list({domain for domain in domains if is_domain_available_to_link(
-        upstream_domain_name, domain, user, should_enforce_admin=False)})
+        upstream_domain_name, domain, user, should_enforce_admin=should_enforce_admin)})
 
 
-def get_available_upstream_domains(downstream_domain, user, billing_account=None):
+def get_available_upstream_domains(downstream_domain, user):
     """
     This supports both the old feature flagged version of linked projects and the GAed version
-    The GAed version is only available to enterprise customers and only usable by admins, but the feature flagged
-    version is available to anyone who can obtain access
-    :param downstream_domain: potential upstream domain candidate
+    :param downstream_domain: name of downstream domain in potential links
     :param user: user object
-    :param billing_account: optional parameter to limit available domains to within an enterprise account
     :return: list of domain names available to link as downstream projects
     """
     if domain_has_privilege(downstream_domain, RELEASE_MANAGEMENT):
-        return get_available_upstream_domains_for_account(downstream_domain, user, billing_account)
-    elif toggles.LINKED_DOMAINS.enabled(downstream_domain):
-        return get_available_upstream_domains_for_user(downstream_domain, user)
+        return get_available_upstream_domains_for_user(downstream_domain, user, should_enforce_admin=True)
 
+    # DEPRECATED: acting as a fallback for now. Will remove once all domains are migrated off of this flag
+    if toggles.LINKED_DOMAINS.enabled(downstream_domain):
+        return get_available_upstream_domains_for_user(downstream_domain, user, should_enforce_admin=False)
     return []
 
 
-def get_available_upstream_domains_for_account(downstream_domain, user, account):
-    domains = account.get_domains() if account else []
-    return list({d for d in domains if is_available_upstream_domain(d, downstream_domain, user)})
-
-
-def get_available_upstream_domains_for_user(domain_name, user):
+def get_available_upstream_domains_for_user(domain_name, user, should_enforce_admin):
     domains = [d.name for d in Domain.active_for_user(user)]
-    return list({domain for domain in domains
-                 if is_available_upstream_domain(domain, domain_name, user, should_enforce_admin=False)})
+    return list({
+        domain for domain in domains
+        if is_available_upstream_domain(domain, domain_name, user, should_enforce_admin=should_enforce_admin)
+    })
 
 
 def get_accessible_downstream_domains(upstream_domain_name, user):

--- a/corehq/apps/linked_domain/tests/test_dbaccessors.py
+++ b/corehq/apps/linked_domain/tests/test_dbaccessors.py
@@ -9,102 +9,86 @@ from corehq.apps.linked_domain.dbaccessors import (
 from corehq.util.test_utils import flag_enabled
 
 
-class TestGetAvailableUpstreamDomainsForDownstreamDomain(SimpleTestCase):
+from corehq.privileges import RELEASE_MANAGEMENT
 
-    @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.accounting.models.BillingAccount')
-    def test_no_privilege_or_feature_flag_returns_none(self, mock_user, mock_account):
-        mock_account.get_domains.return_value = ['upstream', 'downstream-1', 'downstream-2']
-        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
-            upstream_domains = get_available_upstream_domains(
-                'downstream-1', mock_user, mock_account
-            )
+
+@patch('corehq.apps.users.models.CouchUser')
+class TestGetAvailableUpstreamDomains(SimpleTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.expected_domains = ['upstream-1', 'upstream-2']
+
+        privilege_patcher = patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege')
+        self.mock_domain_has_privilege = privilege_patcher.start()
+        self.addCleanup(privilege_patcher.stop)
+
+        user_patcher = patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_user')
+        self.mock_available_user_domains = user_patcher.start()
+        self.addCleanup(user_patcher.stop)
+
+    def test_returns_empty_if_no_privilege_or_feature_flag(self, mock_user):
+        self.mock_domain_has_privilege.return_value = False
+
+        upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
         self.assertFalse(upstream_domains)
 
-    @flag_enabled("LINKED_DOMAINS")
-    @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.accounting.models.BillingAccount')
-    def test_release_management_privilege_returns_domains_for_account(self, mock_user, mock_account):
-        """NOTE: this also tests that the release_management privilege overrides the linked domains flag"""
-        mock_account.get_domains.return_value = ['upstream', 'downstream-1', 'downstream-2']
-        expected_upstream_domains = ['upstream']
-        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_account') \
-             as mock_account_domains,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_user') \
-             as mock_user_domains:
-            mock_domain_has_privilege.return_value = True
-            mock_account_domains.return_value = expected_upstream_domains
-            mock_user_domains.return_value = ['wrong']
-            upstream_domains = get_available_upstream_domains(
-                'downstream-1', mock_user, mock_account
-            )
-        self.assertEqual(expected_upstream_domains, upstream_domains)
+    def test_returns_domains_for_user_if_release_management_privilege(self, mock_user):
+        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
+        self.mock_available_user_domains.return_value = self.expected_domains
+
+        upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
+
+        self.mock_available_user_domains.assert_called_with('downstream-1', mock_user, should_enforce_admin=True)
+        self.assertSetEqual(set(upstream_domains), set(self.expected_domains))
 
     @flag_enabled("LINKED_DOMAINS")
-    @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.accounting.models.BillingAccount')
-    def test_linked_domains_flag_returns_domains_for_user(self, mock_user, mock_account):
-        expected_upstream_domains = ['upstream']
-        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_account') \
-             as mock_account_domains,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_upstream_domains_for_user') \
-             as mock_user_domains:
-            mock_domain_has_privilege.return_value = False
-            mock_account_domains.return_value = ['wrong']
-            mock_user_domains.return_value = expected_upstream_domains
-            upstream_domains = get_available_upstream_domains(
-                'downstream-1', mock_user, mock_account
-            )
+    def test_returns_domains_for_user_if_linked_domains_flag(self, mock_user):
+        self.mock_domain_has_privilege.return_value = False
+        self.mock_available_user_domains.return_value = self.expected_domains
 
-        self.assertEqual(expected_upstream_domains, upstream_domains)
+        upstream_domains = get_available_upstream_domains('downstream-1', mock_user)
+
+        self.mock_available_user_domains.assert_called_with('downstream-1', mock_user, should_enforce_admin=False)
+        self.assertSetEqual(set(upstream_domains), set(self.expected_domains))
 
 
+@patch('corehq.apps.users.models.CouchUser')
 class TestGetAvailableDomainsToLink(SimpleTestCase):
 
-    @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.accounting.models.BillingAccount')
-    def test_no_privilege_or_feature_flag_returns_none(self, mock_user, mock_account):
-        mock_account.get_domains.return_value = ['upstream', 'downstream-1', 'downstream-2']
-        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = False
-            domains = get_available_domains_to_link('upstream', mock_user, mock_account)
+    def setUp(self):
+        super().setUp()
+        self.expected_domains = ['downstream-1', 'downstream-2']
+        privilege_patcher = patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege')
+        self.mock_domain_has_privilege = privilege_patcher.start()
+        self.addCleanup(privilege_patcher.stop)
 
-        self.assertEqual([], domains)
+        user_patcher = patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_user')
+        self.mock_available_user_domains = user_patcher.start()
+        self.addCleanup(user_patcher.stop)
+
+    def test_returns_empty_if_no_privilege_or_feature_flag(self, mock_user):
+        self.mock_domain_has_privilege.return_value = False
+
+        domains = get_available_domains_to_link('upstream', mock_user)
+
+        self.assertFalse(domains)
+
+    def test_returns_domains_for_user_if_release_management_privilege(self, mock_user):
+        self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
+        self.mock_available_user_domains.return_value = self.expected_domains
+
+        domains = get_available_domains_to_link('upstream', mock_user)
+
+        self.mock_available_user_domains.assert_called_with('upstream', mock_user, should_enforce_admin=True)
+        self.assertSetEqual(set(domains), set(self.expected_domains))
 
     @flag_enabled("LINKED_DOMAINS")
-    @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.accounting.models.BillingAccount')
-    def test_release_management_privilege_returns_domains_for_account(self, mock_user, mock_account):
-        """NOTE: this also tests that the release_management privilege overrides the linked domains flag"""
-        expected_domains = ['downstream-1', 'downstream-2']
-        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_account') \
-             as mock_account_domains,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_user') \
-             as mock_user_domains:
-            mock_domain_has_privilege.return_value = True
-            mock_account_domains.return_value = expected_domains
-            mock_user_domains.return_value = ['wrong']
-            domains = get_available_domains_to_link('upstream', mock_user, mock_account)
+    def test_returns_domains_for_user_for_linked_domains_flag(self, mock_user):
+        self.mock_domain_has_privilege.return_value = False
+        self.mock_available_user_domains.return_value = self.expected_domains
 
-        self.assertEqual(expected_domains, domains)
+        domains = get_available_domains_to_link('upstream', mock_user)
 
-    @flag_enabled("LINKED_DOMAINS")
-    @patch('corehq.apps.users.models.CouchUser')
-    @patch('corehq.apps.accounting.models.BillingAccount')
-    def test_linked_domains_flag_returns_domains_for_user(self, mock_user, mock_account):
-        expected_domains = ['downstream-1', 'downstream-2']
-        with patch('corehq.apps.linked_domain.dbaccessors.domain_has_privilege') as mock_domain_has_privilege,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_account') \
-             as mock_account_domains,\
-             patch('corehq.apps.linked_domain.dbaccessors.get_available_domains_to_link_for_user') \
-             as mock_user_domains:
-            mock_domain_has_privilege.return_value = False
-            mock_account_domains.return_value = ['wrong']
-            mock_user_domains.return_value = expected_domains
-            domains = get_available_domains_to_link('upstream', mock_user, mock_account)
-
-        self.assertEqual(expected_domains, domains)
+        self.mock_available_user_domains.assert_called_with('upstream', mock_user, should_enforce_admin=False)
+        self.assertSetEqual(set(domains), set(self.expected_domains))

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -10,7 +10,6 @@ from django.views import View
 from couchdbkit import ResourceNotFound
 from memoized import memoized
 
-from corehq.apps.accounting.models import BillingAccount
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.app_manager.dbaccessors import (
@@ -302,15 +301,10 @@ class DomainLinkView(BaseAdminProjectSettingsView):
             is_superuser=is_superuser
         )
 
-        account = BillingAccount.get_account_by_domain(self.request.domain)
-        available_domains_to_link = get_available_domains_to_link(self.request.domain,
-                                                                  self.request.couch_user,
-                                                                  billing_account=account)
+        available_domains_to_link = get_available_domains_to_link(self.request.domain, self.request.couch_user)
 
         upstream_domain_urls = []
-        upstream_domains = get_available_upstream_domains(self.request.domain,
-                                                          self.request.couch_user,
-                                                          billing_account=account)
+        upstream_domains = get_available_upstream_domains(self.request.domain, self.request.couch_user)
         for domain in upstream_domains:
             upstream_domain_urls.append({'name': domain, 'url': reverse('domain_links', args=[domain])})
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13362

This simplifies the logic for fetching available to domains to link to for ERM. Since non-enterprise domains can be grandfathered into ERM, we need this logic to be flexible. The easiest way is to allow any user to link to other domains they are also an admin in that have the `release_management` privilege enabled. You'll notice that the feature flag logic is still in place which allows linking between domains the user is not an admin in.

This was initially implemented as part of MRM, but upon realizing that this change impacts ERM directly, it was decided this should be pulled out separately which makes it safe to rollback MRM if needed once deployed.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested on staging.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Has automated tests to ensure the logic is correct
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
This underwent QA as part of MRM. I've virtually copied and pasted code from my MRM PR, adjusting for the fact that this should only support ERM for the time being. https://dimagi-dev.atlassian.net/browse/QA-3875
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
This PR cannot be rolled back once https://github.com/dimagi/commcare-hq/pull/31346 has been deployed since that enables ERM for non-enterprise users, and is not easily rolled back. You are better fixing any issues that arise from this PR than reverting. 

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
