### PR TITLE
Replace hard-coded value for app_version with actual version in CaseSessionDataHelper

### DIFF
--- a/corehq/apps/cloudcare/touchforms_api.py
+++ b/corehq/apps/cloudcare/touchforms_api.py
@@ -18,7 +18,6 @@ class BaseSessionDataHelper(object):
         """
         session_data = {
             'device_id': device_id,
-            'app_version': '2.0',
             'domain': self.domain,
         }
         session_data.update(get_user_contributions_to_touchforms_session(self.domain, self.couch_user))
@@ -89,6 +88,7 @@ class CaseSessionDataHelper(BaseSessionDataHelper):
                 session_data[self.case_session_variable_name] = self.case_id
         if self.app:
             session_data["app_id"] = self.app.get_id
+            session_data["app_version"] = self.app.version
         return session_data
 
     @property

--- a/corehq/apps/smsforms/tests/test_app.py
+++ b/corehq/apps/smsforms/tests/test_app.py
@@ -95,7 +95,7 @@ class TestStartSession(TestCase):
         session, responses = self._start_session(yield_responses=True)
 
         expected_session_data = {
-            'device_id': 'commconnect', 'app_version': '2.0', 'domain': self.domain,
+            'device_id': 'commconnect', 'app_version': self.app.version, 'domain': self.domain,
             'username': self.recipient.raw_username, 'user_id': self.recipient.get_id,
             'user_data': {},
             'app_id': None
@@ -121,7 +121,7 @@ class TestStartSession(TestCase):
         session, responses = self._start_session(yield_responses=True)
 
         expected_session_data = {
-            'device_id': 'commconnect', 'app_version': '2.0', 'domain': self.domain,
+            'device_id': 'commconnect', 'app_version': self.app.version, 'domain': self.domain,
             'username': self.recipient.raw_username, 'user_id': self.recipient.get_id,
             'user_data': {
                 'commcare_first_name': None,


### PR DESCRIPTION

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
A pending formplayer change, https://github.com/dimagi/formplayer/pull/1075, will make use of the `appVersion` property in session data for a new sms forms session request. **Currently nothing in formplayer makes use of that property which is why it is safe to change what this value represents.** 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
A trivial change. A previously hard-coded value is now replaced by `app.version`. 
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
I don't think it is worth adding automated test coverage for this data class.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will not run through QA before merged to master, but will run through QA as part of the formplayer work.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Rolling this back will break the formplayer change referenced above once that is deployed. 

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
