### PR TITLE
Ce/fix rate limits

### DIFF
--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -58,7 +58,7 @@ data_dictionary_rebuild_rate_limiter = RateLimiter(
             per_minute=2,
             per_second=1,
         )
-    ).get_rate_limits(),
+    ).get_rate_limits(scope),
     scope_length=1,
 )
 

--- a/corehq/apps/hqwebapp/two_factor_gateways.py
+++ b/corehq/apps/hqwebapp/two_factor_gateways.py
@@ -195,7 +195,7 @@ two_factor_rate_limiter_per_ip = RateLimiter(
             per_minute=700,
             per_second=60,
         )
-    ).get_rate_limits(),
+    ).get_rate_limits(scope),
     scope_length=1,
 )
 
@@ -210,7 +210,7 @@ two_factor_rate_limiter_per_user = RateLimiter(
             per_minute=2,
             per_second=1,
         )
-    ).get_rate_limits(),
+    ).get_rate_limits(scope),
     scope_length=1,
 )
 
@@ -225,7 +225,7 @@ two_factor_rate_limiter_per_number = RateLimiter(
             per_minute=2,
             per_second=1,
         )
-    ).get_rate_limits(),
+    ).get_rate_limits(scope),
     scope_length=1,
 )
 

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -198,7 +198,7 @@ def _delay_and_report_rate_limit_submission(domain, max_wait, delay_rather_than_
 
 @quickcache([], timeout=60)  # Only report up to once a minute
 def _report_current_global_submission_thresholds():
-    for scope, limits in global_case_rate_limiter.iter_rates():
+    for scope, limits in global_submission_rate_limiter.iter_rates():
         for window, value, threshold in limits:
             metrics_gauge('commcare.xform_submissions.global_threshold', threshold, tags={
                 'window': window,

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -12,6 +12,7 @@ from corehq.project_limits.rate_counter.presets import (
     second_rate_counter,
     week_rate_counter,
 )
+from corehq.util.metrics import metrics_counter
 from corehq.util.quickcache import quickcache
 
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This fixes 4 bugs found in the enterprise rate limit release.

The first commit fixes a bug where we reported the case limiter metrics under the wrong name (as the form limit ones). No user facing effect.

The second commit fixes the largest user facing issue, we were not correctly applying the scope when looking up limits for two factor rate limiters (per number, per ip, per user), so all users were being held against a global pool.

The third commit adds a missing import, that could cause actions that would otherwise be limited not to be, but did not result in us blocking any user action (since we swallow errors in the rate limiting code and allow the action to proceed).

The fourth commit fixes a similar problem as the second one, but for the data dictionary rebuilds, a limit unlikely to have been hit and therefore unlikely to have caused a user facing impact.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
These changes are tested locally, including the specifics of the two factor limits, and will be tested on staging before deploy.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

If this PR is rolled back, https://github.com/dimagi/commcare-hq/pull/31382 must be merged.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
