### PR TITLE
DEFAULT_AUTO_FIELD to avoid deprecation warnings

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -200,6 +200,7 @@ PASSWORD_HASHERS = (
 )
 
 ROOT_URLCONF = "urls"
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 DEFAULT_APPS = (
     'django.contrib.admin',


### PR DESCRIPTION
The new default for this setting in Django 3.2 is `BigAutoField`, but we have many models that were created with the old default. It is easier to set our global default to the old default (`AutoField`) since that does not require migrating existing fields. If in the future we decide to change it to `BigAutoField` we have these options for existing models with implicit primary keys:

- Migrate primary key to `BigAutoField`.
- Explicitly add `id = models.AutoField(primary_key=True)` to override the default (also requires a state-only migration).

Another option would be to change the `settings.py` value to `BigAutoField` and add `AppConfig` overrides where we do not want to deal with migrations and don't mind having the default be `AutoField`.

## Safety Assurance

### Safety story

This adds an explicit setting that was previously an implied default to eliminate deprecation warnings like
```
(models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
```
### Automated test coverage

No.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
