### PR TITLE
Fix broken table formatting in doc

### DIFF
--- a/docs/forms_and_cases.rst
+++ b/docs/forms_and_cases.rst
@@ -6,9 +6,8 @@ generic functions and accessors to access and operate on the models.
 
 This document provides a basic guide for how to do that.
 
-Models
-------
-
++-------------------+
+| Models            |
 +===================+
 | CommCareCase      |
 +-------------------+


### PR DESCRIPTION

While going through CommCare docs, I found this RST broken formatted table. Attached is small fix.