### PR TITLE
SC-1947 SC-1948 Deduplication edit and create rules changes

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_deduplication_rules.py
+++ b/corehq/apps/data_interfaces/tests/test_deduplication_rules.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import Mock, create_autospec, patch
+from unittest.mock import Mock, patch
 
 from django.test import RequestFactory, TestCase
 
@@ -7,7 +7,7 @@ from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 from corehq.apps.data_interfaces.views import (
     DeduplicationRuleCreateView,
     DeduplicationRuleEditView,
-    reset_and_backfill_deduplicate_rule,
+    HttpResponseRedirect,
 )
 
 
@@ -35,7 +35,7 @@ class DeduplicationRuleCreateViewTest(TestCase):
         self.assertEqual(False, AutomaticUpdateRule.objects.all()[0].active)
 
     def _create_request(self, params=None, method='post'):
-        url = f'dummy_url'
+        url = 'dummy_url'
         if method == 'get':
             request = RequestFactory().get(url, params)
         else:
@@ -45,7 +45,7 @@ class DeduplicationRuleCreateViewTest(TestCase):
 
 
 class DeduplicationRuleEditViewTest(TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -62,15 +62,14 @@ class DeduplicationRuleEditViewTest(TestCase):
         view = DeduplicationRuleEditView()
         view.args = []
         view.kwargs = {"rule_id": rule_id, "domain": self.domain}
-        
-
         request = self._create_request(params={
             'properties_to_update': json.dumps({}),
             'case_properties': json.dumps({}),
             'name': rule_name,
             'case_type': case_type,
             'match_type': 'ttype'})
-        view.post(request)
+        resp = view.post(request)
+        self.assertEqual(HttpResponseRedirect, type(resp))
 
     def _save_dummy_rule(self, rule_name, case_type):
         res = AutomaticUpdateRule.objects.create(
@@ -86,7 +85,7 @@ class DeduplicationRuleEditViewTest(TestCase):
         return res.id
 
     def _create_request(self, params=None, method='post'):
-        url = f'dummy_url'
+        url = 'dummy_url'
         if method == 'get':
             request = RequestFactory().get(url, params)
         else:

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -1032,15 +1032,15 @@ class DeduplicationRuleCreateView(DataInterfaceSection):
         }
         return rule_params, action_params
 
-    def validate_rule_params(self, domain, rule_params, rule_id=None):
-        existing_rule: AutomaticUpdateRule = AutomaticUpdateRule.objects.filter(
+    def validate_rule_params(self, domain, rule_params, rule=None):
+        existing_rule = AutomaticUpdateRule.objects.filter(
             deleted=False,
             domain=domain,
             workflow=AutomaticUpdateRule.WORKFLOW_DEDUPLICATE,
             name=rule_params['name'],
         )
-        if existing_rule and id(existing_rule[0]) != rule_id:
-                return [_("A rule with name {name} already exists").format(name=rule_params['name'])]
+        if existing_rule and existing_rule[0] != rule:
+            return [_("A rule with name {name} already exists").format(name=rule_params['name'])]
         return []
 
     def validate_action_params(self, action_params):
@@ -1149,7 +1149,7 @@ class DeduplicationRuleEditView(DeduplicationRuleCreateView):
 
         rule_params, action_params = self.parse_params(request)
         errors = self.validate_action_params(action_params)
-        errors.extend(self.validate_rule_params(request.domain, rule_params, id(self.rule)))
+        errors.extend(self.validate_rule_params(request.domain, rule_params, self.rule))
         if errors:
             error_message = _("Deduplication rule not saved. ")
             messages.error(request, error_message + "; ".join(errors))

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -1072,7 +1072,7 @@ class DeduplicationRuleCreateView(DataInterfaceSection):
             domain=domain,
             name=name,
             case_type=case_type,
-            active=True,
+            active=False,
             deleted=False,
             filter_on_server_modified=False,
             server_modified_boundary=None,
@@ -1149,7 +1149,6 @@ class DeduplicationRuleEditView(DeduplicationRuleCreateView):
 
         rule_params, action_params = self.parse_params(request)
         errors = self.validate_action_params(action_params)
-        errors.extend(self.validate_rule_params(request.domain, rule_params))
         if errors:
             error_message = _("Deduplication rule not saved. ")
             messages.error(request, error_message + "; ".join(errors))

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -1032,15 +1032,15 @@ class DeduplicationRuleCreateView(DataInterfaceSection):
         }
         return rule_params, action_params
 
-    def validate_rule_params(self, domain, rule_params):
-        unique_name = AutomaticUpdateRule.objects.filter(
+    def validate_rule_params(self, domain, rule_params, rule_id=None):
+        existing_rule: AutomaticUpdateRule = AutomaticUpdateRule.objects.filter(
             deleted=False,
             domain=domain,
             workflow=AutomaticUpdateRule.WORKFLOW_DEDUPLICATE,
             name=rule_params['name'],
-        ).count() == 0
-        if not unique_name:
-            return [_("A rule with name {name} already exists").format(name=rule_params['name'])]
+        )
+        if existing_rule and id(existing_rule[0]) != rule_id:
+                return [_("A rule with name {name} already exists").format(name=rule_params['name'])]
         return []
 
     def validate_action_params(self, action_params):
@@ -1149,6 +1149,7 @@ class DeduplicationRuleEditView(DeduplicationRuleCreateView):
 
         rule_params, action_params = self.parse_params(request)
         errors = self.validate_action_params(action_params)
+        errors.extend(self.validate_rule_params(request.domain, rule_params, id(self.rule)))
         if errors:
             error_message = _("Deduplication rule not saved. ")
             messages.error(request, error_message + "; ".join(errors))


### PR DESCRIPTION
## Product Description
[SC-1947:](https://dimagi-dev.atlassian.net/browse/SC-1947) When a new deduplication rule is created,  do not run backfill process and rule actions automatically.
[SC-1948](https://dimagi-dev.atlassian.net/browse/SC-1947): Allow existing rule to be edited, which currently throws error during save.

## Technical Summary
For new rule creation, set the property active as False, which currently is set to True. This property is used to determine whether to run backfill process.

For rule editing, if there is an existing rule, check for object equality for the rules. 


## Feature Flag
https://confluence.dimagi.com/display/USH/Deduplication#Deduplication-EnableFeatureFlags

## Safety Assurance
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage
Added unit tests

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
