### PR TITLE
test child module parent select other rewrite filter

### DIFF
--- a/corehq/apps/app_manager/suite_xml/utils.py
+++ b/corehq/apps/app_manager/suite_xml/utils.py
@@ -21,19 +21,22 @@ def get_select_chain_with_sessions(app, module, include_self=True):
     i = len(select_chain)
     while hasattr(current_module, 'parent_select') and current_module.parent_select.active:
         is_other_relation = current_module.parent_select.relationship is None
-        current_module = app.get_module_by_unique_id(
+        parent_module = app.get_module_by_unique_id(
             current_module.parent_select.module_id,
             error=_("Case list used by parent child selection in '{}' not found").format(
                 current_module.default_name()),
         )
-        if is_other_relation and case_type == current_module.case_type:
+        if is_other_relation and case_type == parent_module.case_type:
             session_var = 'case_id_' + case_type
         else:
             session_var = ('parent_' * i or 'case_') + 'id'
-        case_type = current_module.case_type
-        if current_module in [m for (m, _) in select_chain]:
+        if parent_module in [m for (m, _) in select_chain]:
             raise SuiteValidationError("Circular reference in case hierarchy")
-        select_chain.append((current_module, session_var))
+        select_chain.append((parent_module, session_var))
+
+        # update vars for next loop
+        current_module = parent_module
+        case_type = parent_module.case_type
         i += 1
     return select_chain
 

--- a/corehq/apps/app_manager/tests/data/suite/child-module-entry-datums-parent-select-other-same-case-type.xml
+++ b/corehq/apps/app_manager/tests/data/suite/child-module-entry-datums-parent-select-other-same-case-type.xml
@@ -1,0 +1,37 @@
+<partial>
+  <entry>
+    <command id="m0-f0">
+      <text>
+        <locale id="forms.m0f0"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <datum id="case_id"
+             nodeset="instance('casedb')/casedb/case[@case_type='gold_fish'][@status='open']"
+             value="./@case_id"
+             detail-select="m0_case_short"
+             detail-confirm="m0_case_long"/>
+    </session>
+  </entry>
+  <entry>
+    <command id="m1-f0">
+      <text>
+        <locale id="forms.m1f0"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
+    <session>
+      <datum id="case_id"
+             nodeset="instance('casedb')/casedb/case[@case_type='gold_fish'][@status='open']"
+             value="./@case_id"
+             detail-select="m0_case_short"/>
+      <datum id="case_id_gold_fish"
+             nodeset="instance('casedb')/casedb/case[@case_type='gold_fish'][@status='open'][parent_id = instance('commcaresession')/session/data/case_id]"
+             value="./@case_id"
+             detail-select="m1_case_short"
+             detail-confirm="m1_case_long"/>
+    </session>
+  </entry>
+</partial>

--- a/corehq/apps/app_manager/tests/data/suite/child-module-entry-datums-parent-select-other.xml
+++ b/corehq/apps/app_manager/tests/data/suite/child-module-entry-datums-parent-select-other.xml
@@ -1,0 +1,37 @@
+<partial>
+  <entry>
+    <command id="m0-f0">
+      <text>
+        <locale id="forms.m0f0"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <datum id="case_id"
+             nodeset="instance('casedb')/casedb/case[@case_type='gold-fish'][@status='open']"
+             value="./@case_id"
+             detail-select="m0_case_short"
+             detail-confirm="m0_case_long"/>
+    </session>
+  </entry>
+  <entry>
+    <command id="m1-f0">
+      <text>
+        <locale id="forms.m1f0"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
+    <session>
+      <datum id="case_id"
+             nodeset="instance('casedb')/casedb/case[@case_type='gold-fish'][@status='open']"
+             value="./@case_id"
+             detail-select="m0_case_short"/>
+      <datum id="case_id_guppy"
+             nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][parent_id = instance('commcaresession')/session/data/case_id]"
+             value="./@case_id"
+             detail-select="m1_case_short"
+             detail-confirm="m1_case_long"/>
+    </session>
+  </entry>
+</partial>

--- a/corehq/apps/app_manager/tests/test_child_module.py
+++ b/corehq/apps/app_manager/tests/test_child_module.py
@@ -341,7 +341,7 @@ class BasicModuleAsChildTest(ModuleAsChildTestBase, SimpleTestCase):
         self.factory.form_requires_case(m0f0)
 
         m1f0 = self.module_1.get_form(0)
-        self.factory.form_requires_case(m1f0, 'gold-fish')
+        self.factory.form_requires_case(m1f0)
 
         self.module_1.parent_select.active = True
         self.module_1.parent_select.module_id = self.module_0.unique_id
@@ -353,6 +353,32 @@ class BasicModuleAsChildTest(ModuleAsChildTestBase, SimpleTestCase):
 
         self.assertXmlPartialEqual(
             self.get_xml('child-module-entry-datums-parent-select-other'),
+            self.app.create_suite(),
+            "./entry"
+        )
+
+    @patch_get_xform_resource_overrides()
+    def test_child_module_parent_select_other_same_case_type(self, *args):
+        # set module case types to match
+        self.module_0.case_type = 'gold_fish'
+        self.module_1.case_type = self.module_0.case_type
+
+        m0f0 = self.module_0.get_form(0)
+        self.factory.form_requires_case(m0f0)
+
+        m1f0 = self.module_1.get_form(0)
+        self.factory.form_requires_case(m1f0)
+
+        self.module_1.parent_select.active = True
+        self.module_1.parent_select.module_id = self.module_0.unique_id
+        self.module_1.parent_select.relationship = None
+
+        # the filter expression does not get rewritten
+        filter_expression = "parent_id = instance('commcaresession')/session/data/case_id"
+        self.module_1.case_details.short.filter = filter_expression
+
+        self.assertXmlPartialEqual(
+            self.get_xml('child-module-entry-datums-parent-select-other-same-case-type'),
             self.app.create_suite(),
             "./entry"
         )

--- a/corehq/apps/app_manager/tests/test_child_module.py
+++ b/corehq/apps/app_manager/tests/test_child_module.py
@@ -335,6 +335,28 @@ class BasicModuleAsChildTest(ModuleAsChildTestBase, SimpleTestCase):
             "./entry"
         )
 
+    @patch_get_xform_resource_overrides()
+    def test_child_module_parent_select_other(self, *args):
+        m0f0 = self.module_0.get_form(0)
+        self.factory.form_requires_case(m0f0)
+
+        m1f0 = self.module_1.get_form(0)
+        self.factory.form_requires_case(m1f0, 'gold-fish')
+
+        self.module_1.parent_select.active = True
+        self.module_1.parent_select.module_id = self.module_0.unique_id
+        self.module_1.parent_select.relationship = None
+
+        # the filter expression gets rewritten to use `case_id` instead of `parent_id`
+        filter_expression = "parent_id = instance('commcaresession')/session/data/parent_id"
+        self.module_1.case_details.short.filter = filter_expression
+
+        self.assertXmlPartialEqual(
+            self.get_xml('child-module-entry-datums-parent-select-other'),
+            self.app.create_suite(),
+            "./entry"
+        )
+
 
 class UsercaseOnlyModuleAsChildTest(ModuleAsChildTestBase, SimpleTestCase):
     """


### PR DESCRIPTION
## Technical Summary
Tests to verify the functionality when using child modules in conjunction with `parent_select = 'other'` workflow.

This also tests the rewriting of the case filter expression in the child module to match the parent select datum.

Jira: https://dimagi-dev.atlassian.net/browse/USH-1781

I have also added one commit with a very minor refactor of the `get_select_chain_with_sessions` function to make it easier to follow. This is a non-functional change.

## Safety Assurance

### Safety story
Test only + minor refactor.

Code is well tested.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
