### PR TITLE
don't 500 in multimedia size request for app that isn't a build

### DIFF
--- a/corehq/apps/app_manager/views/multimedia.py
+++ b/corehq/apps/app_manager/views/multimedia.py
@@ -3,7 +3,7 @@ from django.shortcuts import render
 from django.template.defaultfilters import filesizeformat
 from django.utils.translation import gettext as _
 
-from corehq.apps.app_manager.dbaccessors import get_app, get_apps_in_domain
+from corehq.apps.app_manager.dbaccessors import get_app, get_apps_in_domain, get_app_cached
 from corehq.apps.app_manager.decorators import require_deploy_apps
 from corehq.apps.app_manager.util import is_linked_app, is_remote_app
 from corehq.apps.app_manager.views.utils import (
@@ -67,7 +67,12 @@ def get_multimedia_sizes(request, domain, app_id, build_profile_id=None):
     """
     return size for different multimedia types and total for an app, directly presentable to the user
     """
-    mm_sizes = get_multimedia_sizes_for_build(domain, build_id=app_id, build_profile_id=build_profile_id)
+    build = get_app_cached(domain, app_id)
+    if not build.copy_of:
+        return JsonResponse({
+            "message": _("Multimedia size comparison is only available for app builds")
+        }, status=400)
+    mm_sizes = get_multimedia_sizes_for_build(domain, build, build_profile_id=build_profile_id)
     if mm_sizes:
         mm_sizes = _update_mm_sizes(mm_sizes)
     return JsonResponse(mm_sizes)

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -427,8 +427,7 @@ def get_new_multimedia_between_builds(domain, target_build_id, source_build_id, 
     return total_size
 
 
-def get_multimedia_sizes_for_build(domain, build_id, build_profile_id=None):
-    build = get_app_cached(domain, build_id)
+def get_multimedia_sizes_for_build(build, build_profile_id=None):
     assert build.copy_of, _("Size calculation available only for builds")
     build_profile = build.build_profiles.get(build_profile_id) if build_profile_id else None
     multimedia_map_for_build = build.multimedia_map_for_build(build_profile=build_profile)


### PR DESCRIPTION
## Product Description
When viewing the app source files for a non-build (the dev version) the multimedia size endpoint errors and the page produces a JS popup that is annoying.

This fixes the issue by returning an error message instead of a 500 response.

## Feature Flag
SUPPORT

## Safety Assurance

### Safety story
Minor refactor that only affects an advanced page that's mostly inaccessible to users.

Tested this locally.

### Automated test coverage
None

### QA Plan
None


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
