### PR TITLE
ensure that appnope is always removed from requirements files

### DIFF
--- a/requirements/Makefile
+++ b/requirements/Makefile
@@ -7,6 +7,8 @@ requirements:
 	pip-compile -o test-requirements.txt test-requirements.in --allow-unsafe
 	pip-compile -o dev-requirements.txt dev-requirements.in --allow-unsafe
 	pip-compile -o docs-requirements.txt docs-requirements.in --allow-unsafe
+	awk 'BEGIN { del=0 } /appnope/ { del=1 } del<=0 { print } /via ipython/ { del -= 1 }' prod-requirements.txt > temp-prod-requirements.txt && mv temp-prod-requirements.txt prod-requirements.txt
+	awk 'BEGIN { del=0 } /appnope/ { del=1 } del<=0 { print } /via ipython/ { del -= 1 }' dev-requirements.txt > temp-dev-requirements.txt && mv temp-dev-requirements.txt dev-requirements.txt
 
 upgrade-requirements: export CUSTOM_COMPILE_COMMAND=`make requirements` or `make upgrade-requirements`
 upgrade-requirements:
@@ -15,3 +17,5 @@ upgrade-requirements:
 	pip-compile --upgrade -o test-requirements.txt test-requirements.in --allow-unsafe
 	pip-compile --upgrade -o dev-requirements.txt dev-requirements.in --allow-unsafe
 	pip-compile --upgrade -o docs-requirements.txt docs-requirements.in --allow-unsafe
+	awk 'BEGIN { del=0 } /appnope/ { del=1 } del<=0 { print } /via ipython/ { del -= 1 }' prod-requirements.txt > temp-prod-requirements.txt && mv temp-prod-requirements.txt prod-requirements.txt
+	awk 'BEGIN { del=0 } /appnope/ { del=1 } del<=0 { print } /via ipython/ { del -= 1 }' dev-requirements.txt > temp-dev-requirements.txt && mv temp-dev-requirements.txt dev-requirements.txt


### PR DESCRIPTION
## Technical Summary
When `make requirements` is run on a mac the `appnope` dependency likes to add itself to the `prod-requirements.txt` and `dev-requirements.txt` files. This makes sure that `appnope` no longer makes its sneaky appearance.

## Safety Assurance

### Safety story
just dependencies

### Automated test coverage
yes

### QA Plan
No


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
