### PR TITLE
fix enterprise rate limits

### DIFF
--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -58,7 +58,7 @@ data_dictionary_rebuild_rate_limiter = RateLimiter(
             per_minute=2,
             per_second=1,
         )
-    ).get_rate_limits(),
+    ).get_rate_limits(scope),
     scope_length=1,
 )
 

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -59,7 +59,6 @@ data_dictionary_rebuild_rate_limiter = RateLimiter(
             per_second=1,
         )
     ).get_rate_limits(scope),
-    scope_length=1,
 )
 
 @login_and_domain_required

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -306,9 +306,10 @@ def get_project_limits_context(name_limiter_tuple_list, scope=None):
 
 def _get_rate_limits(scope, rate_limiter):
     return [
-        {'key': key, 'current_usage': int(current_usage), 'limit': int(limit),
+        {'key': ','.join(scope) + ' ' + key, 'current_usage': int(current_usage), 'limit': int(limit),
          'percent_usage': round(100 * current_usage / limit, 1)}
-        for key, current_usage, limit in rate_limiter.iter_rates(scope)
+        for scope, limits in rate_limiter.iter_rates(scope)
+        for key, current_usage, limit in limits
     ]
 
 

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -306,7 +306,7 @@ def get_project_limits_context(name_limiter_tuple_list, scope=None):
 
 def _get_rate_limits(scope, rate_limiter):
     return [
-        {'key': ','.join(scope) + ' ' + key, 'current_usage': int(current_usage), 'limit': int(limit),
+        {'key': scope + ' ' + key, 'current_usage': int(current_usage), 'limit': int(limit),
          'percent_usage': round(100 * current_usage / limit, 1)}
         for scope, limits in rate_limiter.iter_rates(scope)
         for key, current_usage, limit in limits

--- a/corehq/apps/hqwebapp/two_factor_gateways.py
+++ b/corehq/apps/hqwebapp/two_factor_gateways.py
@@ -195,7 +195,7 @@ two_factor_rate_limiter_per_ip = RateLimiter(
             per_minute=700,
             per_second=60,
         )
-    ).get_rate_limits(),
+    ).get_rate_limits(scope),
     scope_length=1,
 )
 
@@ -210,7 +210,7 @@ two_factor_rate_limiter_per_user = RateLimiter(
             per_minute=2,
             per_second=1,
         )
-    ).get_rate_limits(),
+    ).get_rate_limits(scope),
     scope_length=1,
 )
 
@@ -225,7 +225,7 @@ two_factor_rate_limiter_per_number = RateLimiter(
             per_minute=2,
             per_second=1,
         )
-    ).get_rate_limits(),
+    ).get_rate_limits(scope),
     scope_length=1,
 )
 

--- a/corehq/apps/hqwebapp/two_factor_gateways.py
+++ b/corehq/apps/hqwebapp/two_factor_gateways.py
@@ -196,7 +196,6 @@ two_factor_rate_limiter_per_ip = RateLimiter(
             per_second=60,
         )
     ).get_rate_limits(scope),
-    scope_length=1,
 )
 
 two_factor_rate_limiter_per_user = RateLimiter(
@@ -211,7 +210,6 @@ two_factor_rate_limiter_per_user = RateLimiter(
             per_second=1,
         )
     ).get_rate_limits(scope),
-    scope_length=1,
 )
 
 two_factor_rate_limiter_per_number = RateLimiter(
@@ -226,18 +224,16 @@ two_factor_rate_limiter_per_number = RateLimiter(
             per_second=1,
         )
     ).get_rate_limits(scope),
-    scope_length=1,
 )
 
 global_two_factor_setup_rate_limiter = RateLimiter(
     feature_key='global_two_factor_setup_attempts',
-    get_rate_limits=lambda: get_dynamic_rate_definition(
+    get_rate_limits=lambda scope: get_dynamic_rate_definition(
         'global_two_factor_setup_attempts',
         default=RateDefinition(
             per_day=100,
         )
     ).get_rate_limits(),
-    scope_length=0,
 )
 
 
@@ -253,9 +249,9 @@ def _report_current_global_two_factor_setup_rate_limiter():
         for window, value, threshold in limits:
             metrics_gauge('commcare.two_factor.global_two_factor_setup_threshold', threshold, tags={
                 'window': window,
-                'scope': ','.join(scope)
+                'scope': scope
             }, multiprocess_mode=MPM_MAX)
             metrics_gauge('commcare.two_factor.global_two_factor_setup_usage', value, tags={
                 'window': window,
-                'scope': ','.join(scope)
+                'scope': scope
             }, multiprocess_mode=MPM_MAX)

--- a/corehq/apps/hqwebapp/two_factor_gateways.py
+++ b/corehq/apps/hqwebapp/two_factor_gateways.py
@@ -249,10 +249,13 @@ def _report_usage(ip_address, number, username):
 
 
 def _report_current_global_two_factor_setup_rate_limiter():
-    for window, value, threshold in global_two_factor_setup_rate_limiter.iter_rates():
-        metrics_gauge('commcare.two_factor.global_two_factor_setup_threshold', threshold, tags={
-            'window': window
-        }, multiprocess_mode=MPM_MAX)
-        metrics_gauge('commcare.two_factor.global_two_factor_setup_usage', value, tags={
-            'window': window
-        }, multiprocess_mode=MPM_MAX)
+    for scope, limits in global_two_factor_setup_rate_limiter.iter_rates():
+        for window, value, threshold in limits:
+            metrics_gauge('commcare.two_factor.global_two_factor_setup_threshold', threshold, tags={
+                'window': window,
+                'scope': ','.join(scope)
+            }, multiprocess_mode=MPM_MAX)
+            metrics_gauge('commcare.two_factor.global_two_factor_setup_usage', value, tags={
+                'window': window,
+                'scope': ','.join(scope)
+            }, multiprocess_mode=MPM_MAX)

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -198,7 +198,7 @@ def _delay_and_report_rate_limit_submission(domain, max_wait, delay_rather_than_
 
 @quickcache([], timeout=60)  # Only report up to once a minute
 def _report_current_global_submission_thresholds():
-    for scope, limits in global_case_rate_limiter.iter_rates():
+    for scope, limits in global_submission_rate_limiter.iter_rates():
         for window, value, threshold in limits:
             metrics_gauge('commcare.xform_submissions.global_threshold', threshold, tags={
                 'window': window,

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -198,21 +198,27 @@ def _delay_and_report_rate_limit_submission(domain, max_wait, delay_rather_than_
 
 @quickcache([], timeout=60)  # Only report up to once a minute
 def _report_current_global_submission_thresholds():
-    for window, value, threshold in global_submission_rate_limiter.iter_rates():
-        metrics_gauge('commcare.xform_submissions.global_threshold', threshold, tags={
-            'window': window
-        }, multiprocess_mode='max')
-        metrics_gauge('commcare.xform_submissions.global_usage', value, tags={
-            'window': window
-        }, multiprocess_mode='max')
+    for scope, limits in global_case_rate_limiter.iter_rates():
+        for window, value, threshold in limits:
+            metrics_gauge('commcare.xform_submissions.global_threshold', threshold, tags={
+                'window': window,
+                'scope': ','.join(scope)
+            }, multiprocess_mode='max')
+            metrics_gauge('commcare.xform_submissions.global_usage', value, tags={
+                'window': window,
+                'scope': ','.join(scope)
+            }, multiprocess_mode='max')
 
 
 @quickcache([], timeout=60)  # Only report up to once a minute
 def _report_current_global_case_update_thresholds():
-    for window, value, threshold in global_case_rate_limiter.iter_rates():
-        metrics_gauge('commcare.case_updates.global_threshold', threshold, tags={
-            'window': window
-        }, multiprocess_mode='max')
-        metrics_gauge('commcare.case_updates.global_usage', value, tags={
-            'window': window
-        }, multiprocess_mode='max')
+    for scope, limits in global_case_rate_limiter.iter_rates():
+        for window, value, threshold in limits:
+            metrics_gauge('commcare.case_updates.global_threshold', threshold, tags={
+                'window': window,
+                'scope': ','.join(scope)
+            }, multiprocess_mode='max')
+            metrics_gauge('commcare.case_updates.global_usage', value, tags={
+                'window': window,
+                'scope': ','.join(scope)
+            }, multiprocess_mode='max')

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -55,7 +55,7 @@ def _get_per_user_submission_rate_definition(domain):
 
 global_submission_rate_limiter = RateLimiter(
     feature_key='global_submissions',
-    get_rate_limits=lambda: get_dynamic_rate_definition(
+    get_rate_limits=lambda scope: get_dynamic_rate_definition(
         'global_submissions',
         default=RateDefinition(
             per_hour=17000,
@@ -63,13 +63,12 @@ global_submission_rate_limiter = RateLimiter(
             per_second=30,
         )
     ).get_rate_limits(),
-    scope_length=0,
 )
 
 
 global_case_rate_limiter = RateLimiter(
     feature_key='global_case_updates',
-    get_rate_limits=lambda: get_dynamic_rate_definition(
+    get_rate_limits=lambda scope: get_dynamic_rate_definition(
         'global_case_updates',
         default=RateDefinition(
             per_hour=170000,
@@ -77,7 +76,6 @@ global_case_rate_limiter = RateLimiter(
             per_second=300,
         )
     ).get_rate_limits(),
-    scope_length=0,
 )
 
 
@@ -202,11 +200,11 @@ def _report_current_global_submission_thresholds():
         for window, value, threshold in limits:
             metrics_gauge('commcare.xform_submissions.global_threshold', threshold, tags={
                 'window': window,
-                'scope': ','.join(scope)
+                'scope': scope
             }, multiprocess_mode='max')
             metrics_gauge('commcare.xform_submissions.global_usage', value, tags={
                 'window': window,
-                'scope': ','.join(scope)
+                'scope': scope
             }, multiprocess_mode='max')
 
 
@@ -216,9 +214,9 @@ def _report_current_global_case_update_thresholds():
         for window, value, threshold in limits:
             metrics_gauge('commcare.case_updates.global_threshold', threshold, tags={
                 'window': window,
-                'scope': ','.join(scope)
+                'scope': scope
             }, multiprocess_mode='max')
             metrics_gauge('commcare.case_updates.global_usage', value, tags={
                 'window': window,
-                'scope': ','.join(scope)
+                'scope': scope
             }, multiprocess_mode='max')

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -50,7 +50,7 @@ class RateLimiter(object):
         allowed = False
         for limit_scope, rates in self.iter_rates(scope):
             allow = all(current_rate < limit
-                          for rate_counter_key, current_rate, limit in rates)
+                        for rate_counter_key, current_rate, limit in rates)
             # allow usage if any limiter is below the threshold
             if allow:
                 allowed = True

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -47,35 +47,50 @@ class RateLimiter(object):
 
     def report_usage(self, scope=None, delta=1):
         scope = self.get_normalized_scope(scope)
-        for rate_counter, limit in self.get_rate_limits(*scope):
-            rate_counter.increment((self.feature_key,) + scope, delta=delta)
+        for limit_scope, limits in self.get_rate_limits(*scope):
+            for rate_counter, limit in limits:
+                rate_counter.increment((self.feature_key,) + limit_scope, delta=delta)
 
     def get_window_of_first_exceeded_limit(self, scope=None):
-        for rate_counter_key, current_rate, limit in self.iter_rates(scope):
-            if current_rate >= limit:
-                return rate_counter_key
+        for limit_scope, rates in self.iter_rates(scope):
+            for rate_counter_key, current_rate, limit in rates:
+                if current_rate >= limit:
+                    return rate_counter_key
 
         return None
 
     def allow_usage(self, scope=None):
-        return all(current_rate < limit
-                   for rate_counter_key, current_rate, limit in self.iter_rates(scope))
+        allowed = False
+        for limit_scope, rates in self.iter_rates(scope):
+            allow = all(current_rate < limit
+                          for rate_counter_key, current_rate, limit in rates)
+            # allow usage if any limiter is below the threshold
+            if allow:
+                allowed = True
+            else:
+                metrics_counter('commcare.rate_limit_exceeded', tags={'key': self.feature_key, 'scope': ','.join(scope)})
+        return allowed
 
     def iter_rates(self, scope=None):
         """
-        Get generator of (key, current rate, rate limit) as applies to scope
+        Get generator of tuples for each set of limits returned by get_rate_limits, where the first item
+        of the tuple is the normalized scope, and the second is a generator of (key, current rate, rate limit)
+        for each limit in that scope
 
         e.g.
+        (('test-domain'), [
             ('week', 92359, 115000)
             ('day', ...)
             ...
-
+        ])
         """
         scope = self.get_normalized_scope(scope)
-        return (
-            (rate_counter.key, rate_counter.get((self.feature_key,) + scope), limit)
-            for rate_counter, limit in self.get_rate_limits(*scope)
-        )
+        for limit_scope, limits in self.get_rate_limits(*scope):
+            yield (
+                limit_scope,
+                ((rate_counter.key, rate_counter.get((self.feature_key,) + limit_scope), limit)
+                for rate_counter, limit in limits)
+            )
 
     def wait(self, scope, timeout, windows_not_to_wait_on=('hour', 'day', 'week')):
         start = time.time()
@@ -83,7 +98,8 @@ class RateLimiter(object):
         delay = 0
         larger_windows_allow = all(
             current_rate < limit
-            for rate_counter_key, current_rate, limit in self.iter_rates(scope)
+            for limit_scope, limits in self.iter_rates(scope)
+            for rate_counter_key, current_rate, limit in limits
             if rate_counter_key in windows_not_to_wait_on
         )
         if not larger_windows_allow:
@@ -107,35 +123,29 @@ class RateLimiter(object):
 
 
 @quickcache(['domain'], memoize_timeout=60, timeout=60 * 60)
-def get_n_users_for_rate_limiting(domain):
-    """
-    Returns the number of users "allocated" to the project
-
-    That is, the actual number of users or the number of users included in the subscription,
-    whichever is higher.
-
-    This number is then used to portion out resource allocation through rate limiting.
-
-    """
-    n_users = _get_user_count(domain)
-    n_users_included_in_subscription = _get_users_included_in_subscription(domain)
-    return max(n_users_included_in_subscription, n_users)
-
-
-def _get_user_count(domain):
+def get_n_users_in_domain(domain):
     return CommCareUser.total_by_domain(domain, is_active=True)
 
 
-def _get_users_included_in_subscription(domain):
+@quickcache(['domain'], memoize_timeout=60, timeout=60 * 60)
+def get_n_users_in_subscription(domain):
     from corehq.apps.accounting.models import Subscription
     subscription = Subscription.get_active_subscription_by_domain(domain)
     if subscription:
         plan_version = subscription.plan_version
+        return plan_version.feature_rates.get(feature__feature_type='User').monthly_limit
+    else:
+        return 0
 
-        n_included_users = (
-            plan_version.feature_rates.get(feature__feature_type='User').monthly_limit)
 
+@quickcache(['domain'], memoize_timeout=60, timeout=60 * 60)
+def get_n_users_old_enterprise_count(domain):
+    from corehq.apps.accounting.models import Subscription
+    subscription = Subscription.get_active_subscription_by_domain(domain)
+    if subscription:
+        plan_version = subscription.plan_version
         if plan_version.plan.is_customer_software_plan:
+            n_included_users = plan_version.feature_rates.get(feature__feature_type='User').monthly_limit
             # For now just give each domain that's part of an enterprise account
             # access to nearly all of the throughput allocation.
             # Really what we want is to limit enterprise accounts' submissions accross all
@@ -146,10 +156,17 @@ def _get_users_included_in_subscription(domain):
             # 80% minimum, plus a fraction of 20% inversely proportional
             # to the number of domains that share the throughput allocation.
             return n_included_users * (.8 + .2 / n_domains)
-        else:
-            return n_included_users
+    return None
+
+
+@quickcache(['domain'], memoize_timeout=60, timeout=60 * 60)
+def _get_account_name(domain):
+    from corehq.apps.accounting.models import BillingAccount
+    account = BillingAccount.get_account_by_domain(domain)
+    if account is not None:
+        return f'account:{account.name}'
     else:
-        return 0
+        return f'no_account:{domain}'
 
 
 class PerUserRateDefinition(object):
@@ -158,12 +175,25 @@ class PerUserRateDefinition(object):
         self.constant_rate_definition = constant_rate_definition or RateDefinition()
 
     def get_rate_limits(self, domain):
-        n_users = get_n_users_for_rate_limiting(domain)
-        return (
-            self.per_user_rate_definition
-            .times(n_users)
-            .plus(self.constant_rate_definition)
-        ).get_rate_limits()
+        domain_users = get_n_users_in_domain(domain)
+        enterprise_users = get_n_users_in_subscription(domain)
+        limit_pairs = [
+            (domain_users, domain),
+            (enterprise_users, _get_account_name(domain))
+        ]
+        old_enterprise_calculation = get_n_users_old_enterprise_count(domain)
+        if old_enterprise_calculation is not None:
+            limit_pairs.append((old_enterprise_calculation, f'old_enterprise:{domain}'))
+        limits = []
+        for n_users, scope_key in limit_pairs:
+            print(n_users, scope_key)
+            domain_limit = (
+                self.per_user_rate_definition
+                .times(n_users)
+                .plus(self.constant_rate_definition)
+            ).get_rate_limits((scope_key,))
+            limits.extend(domain_limit)
+        return limits
 
 
 @attr.s
@@ -198,15 +228,17 @@ class RateDefinition(object):
                 kwargs[attribute.name] = math_func(value)
         return self.__class__(**kwargs)
 
-    def get_rate_limits(self):
-        return [(rate_counter, limit) for limit, rate_counter in (
+    def get_rate_limits(self, scope=None):
+        if scope is None:
+            scope = ()
+        return [(scope, [(rate_counter, limit) for limit, rate_counter in (
             # order matters for returning the highest priority window
             (self.per_week, week_rate_counter),
             (self.per_day, day_rate_counter),
             (self.per_hour, hour_rate_counter),
             (self.per_minute, minute_rate_counter),
             (self.per_second, second_rate_counter),
-        ) if limit]
+        ) if limit])]
 
 
 @quickcache(['key'], timeout=24 * 60 * 60)

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -12,6 +12,7 @@ from corehq.project_limits.rate_counter.presets import (
     second_rate_counter,
     week_rate_counter,
 )
+from corehq.util.metrics import metrics_counter
 from corehq.util.quickcache import quickcache
 
 

--- a/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
+++ b/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
@@ -83,7 +83,6 @@ class GetNUsersForRateLimitingTest(TestCase, DomainSubscriptionMixin):
         get_n_users_in_domain.clear(domain)
         self.assertEqual(get_n_users_in_domain(domain), value)
 
-
     def _assert_subscription_value_equals(self, domain, value):
         get_n_users_in_subscription.clear(domain)
         self.assertEqual(get_n_users_in_subscription(domain), value)

--- a/corehq/project_limits/tests/test_rate_limiter.py
+++ b/corehq/project_limits/tests/test_rate_limiter.py
@@ -6,7 +6,10 @@ from corehq.project_limits.rate_limiter import RateLimiter, RateDefinition, \
     PerUserRateDefinition
 
 
-@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_old_enterprise_count', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_rate_limit_interface():
     """
     Just test that very basic usage doesn't error
@@ -20,37 +23,46 @@ def test_rate_limit_interface():
         my_feature_rate_limiter.report_usage('my_domain')
 
 
-@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_old_enterprise_count', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_get_window_of_first_exceeded_limit():
     per_user_rate_def = RateDefinition(per_second=10)
     min_rate_def = RateDefinition(per_second=100)
     per_user_rate_def = PerUserRateDefinition(per_user_rate_def, min_rate_def)
     rate_limiter = RateLimiter('my_feature', per_user_rate_def.get_rate_limits)
-    rate_limiter.iter_rates = Mock(return_value=[('second', 11, 10)])
+    rate_limiter.iter_rates = Mock(return_value=[((), [('second', 11, 10)])])
     expected_window = 'second'
     actual_window = rate_limiter.get_window_of_first_exceeded_limit('my_domain')
     eq(actual_window, expected_window)
 
 
-@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_old_enterprise_count', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_get_window_of_first_exceeded_limit_none():
     per_user_rate_def = RateDefinition(per_second=10)
     min_rate_def = RateDefinition(per_second=100)
     per_user_rate_def = PerUserRateDefinition(per_user_rate_def, min_rate_def)
     rate_limiter = RateLimiter('my_feature', per_user_rate_def.get_rate_limits)
-    rate_limiter.iter_rates = Mock(return_value=[('second', 9, 10)])
+    rate_limiter.iter_rates = Mock(return_value=[((), [('second', 9, 10)])])
     expected_window = None
     actual_window = rate_limiter.get_window_of_first_exceeded_limit('my_domain')
     eq(actual_window, expected_window)
 
 
-@patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_old_enterprise_count', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_get_window_of_first_exceeded_limit_priority():
     per_user_rate_def = RateDefinition(per_second=10, per_week=10)
     min_rate_def = RateDefinition(per_second=100)
     per_user_rate_def = PerUserRateDefinition(per_user_rate_def, min_rate_def)
     rate_limiter = RateLimiter('my_feature', per_user_rate_def.get_rate_limits)
-    rate_limiter.iter_rates = Mock(return_value=[('week', 11, 10), ('second', 11, 10)])
+    rate_limiter.iter_rates = Mock(return_value=[((), [('week', 11, 10), ('second', 11, 10)])])
     expected_window = 'week'
     actual_window = rate_limiter.get_window_of_first_exceeded_limit('my_domain')
     eq(actual_window, expected_window)

--- a/corehq/project_limits/tests/test_rate_limiter.py
+++ b/corehq/project_limits/tests/test_rate_limiter.py
@@ -32,7 +32,7 @@ def test_get_window_of_first_exceeded_limit():
     min_rate_def = RateDefinition(per_second=100)
     per_user_rate_def = PerUserRateDefinition(per_user_rate_def, min_rate_def)
     rate_limiter = RateLimiter('my_feature', per_user_rate_def.get_rate_limits)
-    rate_limiter.iter_rates = Mock(return_value=[((), [('second', 11, 10)])])
+    rate_limiter.iter_rates = Mock(return_value=[('', [('second', 11, 10)])])
     expected_window = 'second'
     actual_window = rate_limiter.get_window_of_first_exceeded_limit('my_domain')
     eq(actual_window, expected_window)
@@ -47,7 +47,7 @@ def test_get_window_of_first_exceeded_limit_none():
     min_rate_def = RateDefinition(per_second=100)
     per_user_rate_def = PerUserRateDefinition(per_user_rate_def, min_rate_def)
     rate_limiter = RateLimiter('my_feature', per_user_rate_def.get_rate_limits)
-    rate_limiter.iter_rates = Mock(return_value=[((), [('second', 9, 10)])])
+    rate_limiter.iter_rates = Mock(return_value=[('', [('second', 9, 10)])])
     expected_window = None
     actual_window = rate_limiter.get_window_of_first_exceeded_limit('my_domain')
     eq(actual_window, expected_window)
@@ -62,7 +62,7 @@ def test_get_window_of_first_exceeded_limit_priority():
     min_rate_def = RateDefinition(per_second=100)
     per_user_rate_def = PerUserRateDefinition(per_user_rate_def, min_rate_def)
     rate_limiter = RateLimiter('my_feature', per_user_rate_def.get_rate_limits)
-    rate_limiter.iter_rates = Mock(return_value=[((), [('week', 11, 10), ('second', 11, 10)])])
+    rate_limiter.iter_rates = Mock(return_value=[('', [('week', 11, 10), ('second', 11, 10)])])
     expected_window = 'week'
     actual_window = rate_limiter.get_window_of_first_exceeded_limit('my_domain')
     eq(actual_window, expected_window)


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Attempt 2 at https://github.com/dimagi/commcare-hq/pull/31385

The first commit unreverts https://github.com/dimagi/commcare-hq/pull/31300, and the rest address issues in the rate limiting code.

The second commit fixes a bug where we reported the case limiter metrics under the wrong name (as the form limit ones). No user facing effect.

The third commit fixes the largest user facing issue, we were not correctly applying the scope when looking up limits for two factor rate limiters (per number, per ip, per user), so all users were being held against a global pool.

The fourth commit adds a missing import, that could cause actions that would otherwise be limited not to be, but did not result in us blocking any user action (since we swallow errors in the rate limiting code and allow the action to proceed).

The fifth commit fixes a similar problem as the third one, but for the data dictionary rebuilds, a limit unlikely to have been hit and therefore unlikely to have caused a user facing impact.

The sixth commit is a minor refactor, making `scope` always a string, rather than sometimes a string and sometimes a tuple, since that led to a number of subtle bugs and we were never using scopes with length longer than one, but instead constructing namespaced strings anyway (like `number:{phone_number}`).

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Local tests pass and this will be tested on staging before deploy.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Individual rate limiter components are well tested in `project_limits/tests`

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
