### PR TITLE
Add ethiopian calendar expressions

### DIFF
--- a/corehq/apps/userreports/expressions/date_specs.py
+++ b/corehq/apps/userreports/expressions/date_specs.py
@@ -275,7 +275,7 @@ class EthiopianDateToGregorianDateSpec(JsonObject):
     .. code:: json
 
         {
-            "type": "gregorian_date_to_ethiopian_date",
+            "type": "ethiopian_date_to_gregorian_date",
             "date_expression": {
                 "type": "property_name",
                 "property_name": "dob"

--- a/corehq/apps/userreports/expressions/date_specs.py
+++ b/corehq/apps/userreports/expressions/date_specs.py
@@ -3,6 +3,7 @@ import datetime
 
 from dateutil.relativedelta import relativedelta
 from jsonobject.base_properties import DefaultProperty
+from corehq.apps.userreports.transforms.custom.date import get_ethiopian_to_gregorian, get_gregorian_to_ethiopian
 
 from dimagi.ext.jsonobject import JsonObject
 
@@ -235,3 +236,58 @@ class UTCNow(JsonObject):
 
     def __str__(self):
         return "utcnow"
+
+
+class GregorianDateToEthiopianDateSpec(JsonObject):
+    """
+    ``gregorian_date_to_ethiopian_date`` returns the ethiopian date for the
+    gregorian date specified by ``date_expression``. The date_expression
+    can be any valid expression, or simply a constant.
+
+    .. code:: json
+
+        {
+            "type": "gregorian_date_to_ethiopian_date",
+            "date_expression": {
+                "type": "property_name",
+                "property_name": "dob"
+            }
+        }
+
+    """
+    type = TypeProperty("gregorian_date_to_ethiopian_date")
+    date_expression = DefaultProperty(required=True)
+
+    def configure(self, date_expression):
+        self._date_expression = date_expression
+
+    def __call__(self, item, context=None):
+        date_val = transform_date(self._date_expression(item, context))
+        return get_gregorian_to_ethiopian(date_val)
+
+
+class EthiopianDateToGregorianDateSpec(JsonObject):
+    """
+    ``ethiopian_date_to_gregorian_date`` returns the gregorian date for the
+    ethiopian date specified by ``date_expression``. The date_expression
+    can be any valid expression, or simply a constant.
+
+    .. code:: json
+
+        {
+            "type": "gregorian_date_to_ethiopian_date",
+            "date_expression": {
+                "type": "property_name",
+                "property_name": "dob"
+            }
+        }
+
+    """
+    type = TypeProperty("ethiopian_date_to_gregorian_date")
+    date_expression = DefaultProperty(required=True)
+
+    def configure(self, date_expression):
+        self._date_expression = date_expression
+
+    def __call__(self, item, context=None):
+        return transform_date(get_ethiopian_to_gregorian(self._date_expression(item, context)))

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -14,6 +14,8 @@ from corehq.apps.userreports.expressions.date_specs import (
     AddDaysExpressionSpec,
     AddMonthsExpressionSpec,
     DiffDaysExpressionSpec,
+    EthiopianDateToGregorianDateSpec,
+    GregorianDateToEthiopianDateSpec,
     MonthEndDateExpressionSpec,
     MonthStartDateExpressionSpec,
     AddHoursExpressionSpec,
@@ -207,6 +209,22 @@ def _diff_days_expression(spec, context):
     return wrapped
 
 
+def _gregorian_date_to_ethiopian_date(spec, context):
+    wrapped = GregorianDateToEthiopianDateSpec.wrap(spec)
+    wrapped.configure(
+        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, context),
+    )
+    return wrapped
+
+
+def _ethiopian_date_to_gregorian_date(spec, context):
+    wrapped = EthiopianDateToGregorianDateSpec.wrap(spec)
+    wrapped.configure(
+        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, context),
+    )
+    return wrapped
+
+
 def _evaluator_expression(spec, context):
     wrapped = EvalExpressionSpec.wrap(spec)
     wrapped.configure(
@@ -332,6 +350,8 @@ class ExpressionFactory(object):
         'month_end_date': _month_end_date_expression,
         'diff_days': _diff_days_expression,
         'utcnow': _utcnow,
+        'gregorian_date_to_ethiopian_date': _gregorian_date_to_ethiopian_date,
+        'ethiopian_date_to_gregorian_date': _ethiopian_date_to_gregorian_date,
         'evaluator': _evaluator_expression,
         'get_case_forms': _get_forms_expression,
         'get_subcases': _get_subcases_expression,

--- a/corehq/apps/userreports/tests/test_date_expressions.py
+++ b/corehq/apps/userreports/tests/test_date_expressions.py
@@ -151,3 +151,37 @@ def test_add_hours_to_datetime_expression(self, source_doc, count_expression, ex
         'count_expression': count_expression
     })
     self.assertEqual(expected_value, expression(source_doc))
+
+
+@generate_cases([
+    ({'dob': '2015-01-20'}, date(2022, 9, 30)),
+    ({'dob': date(2015, 1, 20)}, None),  # Cannot convert a native date
+    ({'dob': datetime(2015, 1, 20)}, None),
+])
+def test_ethiopian_to_gregorian_expression(self, source_doc, expected_value):
+    date_expression = {
+        'type': 'property_name',
+        'property_name': 'dob',
+    }
+    expression = ExpressionFactory.from_spec({
+        'type': 'ethiopian_date_to_gregorian_date',
+        'date_expression': date_expression,
+    })
+    self.assertEqual(expected_value, expression(source_doc))
+
+
+@generate_cases([
+    ({'dob': '2022-09-30'}, '2015-01-20'),
+    ({'dob': date(2022, 9, 30)}, '2015-01-20'),
+    ({'dob': datetime(2022, 9, 30)}, '2015-01-20'),
+])
+def test_gregorian_to_ethiopian_expression(self, source_doc, expected_value):
+    date_expression = {
+        'type': 'property_name',
+        'property_name': 'dob',
+    }
+    expression = ExpressionFactory.from_spec({
+        'type': 'gregorian_date_to_ethiopian_date',
+        'date_expression': date_expression,
+    })
+    self.assertEqual(expected_value, expression(source_doc))

--- a/corehq/apps/userreports/transforms/custom/date.py
+++ b/corehq/apps/userreports/transforms/custom/date.py
@@ -41,6 +41,9 @@ def get_ethiopian_to_gregorian(date_string):
     if not date_string:
         return ''
 
+    if not isinstance(date_string, str):
+        return ''
+
     try:
         year, month, day = split_date_string(date_string)
     except ValueError:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Adds the following two expressions to convert to and from ethiopian dates. While we do have a transform that does this already, we need an expression so it can be used in base item expressions, and other places that transforms aren't available.

```json
{
    "type": "gregorian_date_to_ethiopian_date",
    "date_expression": {
        "type": "property_name",
        "property_name": "dob"
    }
}
```
```json
{
    "type": "ethiopian_date_to_gregorian_date",
    "date_expression": {
        "type": "property_name",
        "property_name": "dob"
    }
}
```
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SC-2035

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
UCR

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests, only new code


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [ x] The set of people pinged as reviewers is appropriate for the level of risk of the change
