### PR TITLE
PhoneTime constructor requires a datetime

### DIFF
--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -175,7 +175,7 @@ class CaseDisplay:
 
     def _dateprop(self, prop):
         date = self.parse_date(self.case[prop])
-        if date:
+        if isinstance(date, datetime.datetime):
             user_time = PhoneTime(date, self.timezone).user_time(self.timezone)
             return user_time.ui_string(self.date_format)
         else:

--- a/corehq/apps/reports/tests/test_case_display.py
+++ b/corehq/apps/reports/tests/test_case_display.py
@@ -1,4 +1,6 @@
-from nose.tools import assert_equal
+from datetime import datetime, timezone
+
+from nose.tools import assert_equal, assert_not_equal
 from corehq.apps.reports.standard.cases.data_sources import CaseDisplay
 
 
@@ -18,3 +20,38 @@ def test_bad_case_display():
     }
     case_display = CaseDisplay(case_dict)
     assert_equal(case_display.modified_on, '')
+
+
+def test_parse_date_iso_datetime():
+    parsed = CaseDisplay({}).parse_date('2022-04-06T12:13:14Z')
+    assert_equal(parsed, datetime(2022, 4, 6, 12, 13, 14))
+    # `date` is timezone naive
+    assert_not_equal(parsed, datetime(2022, 4, 6, 12, 13, 14,
+                                      tzinfo=timezone.utc))
+
+
+def test_parse_date_noniso_datetime():
+    parsed = CaseDisplay({}).parse_date('Apr 06, 2022 12:13:14 UTC')
+    assert_equal(parsed, datetime(2022, 4, 6, 12, 13, 14))
+    assert_not_equal(parsed, datetime(2022, 4, 6, 12, 13, 14,
+                                      tzinfo=timezone.utc))
+
+
+def test_parse_date_date():
+    parsed = CaseDisplay({}).parse_date('2022-04-06')
+    assert_equal(parsed, datetime(2022, 4, 6, 0, 0, 0))
+
+
+def test_parse_date_str():
+    parsed = CaseDisplay({}).parse_date('broken')
+    assert_equal(parsed, 'broken')
+
+
+def test_parse_date_none():
+    parsed = CaseDisplay({}).parse_date(None)
+    assert_equal(parsed, None)
+
+
+def test_parse_date_int():
+    parsed = CaseDisplay({}).parse_date(4)
+    assert_equal(parsed, 4)

--- a/corehq/apps/reports/tests/test_case_display.py
+++ b/corehq/apps/reports/tests/test_case_display.py
@@ -1,0 +1,20 @@
+from nose.tools import assert_equal
+from corehq.apps.reports.standard.cases.data_sources import CaseDisplay
+
+
+def test_happy_case_display():
+    case_dict = {
+        'name': 'Foo',
+        'modified_on': '2022-04-06T12:13:14Z',
+    }
+    case_display = CaseDisplay(case_dict)
+    assert_equal(case_display.modified_on, 'Apr 06, 2022 12:13:14 UTC')
+
+
+def test_bad_case_display():
+    case_dict = {
+        'name': "It's a trap",
+        'modified_on': 'broken',
+    }
+    case_display = CaseDisplay(case_dict)
+    assert_equal(case_display.modified_on, '')


### PR DESCRIPTION
## Technical Summary

`PhoneTime`'s constructor requires a datetime instance, but `CaseDisplay.parse_date()` returns a datetime or a string.

[Jira](https://dimagi-dev.atlassian.net/browse/SC-1917)
[Sentry](https://sentry.io/organizations/dimagi/issues/2922356850/?environment=production&project=136860&query=is%3Aunresolved+domain%3Aben-talbot&statsPeriod=14d)


## Safety Assurance

### Safety story

### Automated test coverage

Includes tests.

### QA Plan

Ticket raised by QA.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
