### PR TITLE
Renamed _create_casexml_2* functions

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -361,7 +361,7 @@ class EntriesHelper(object):
             if 'subcases' in actions:
                 for subcase in actions['subcases']:
                     # don't put this in the loop to be consistent with the form's indexing
-                    # see XForm._create_casexml_2
+                    # see XForm._create_casexml
                     if not subcase.repeat_context:
                         datums.append(FormDatumMeta(
                             datum=SessionDatum(

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1402,12 +1402,12 @@ class XForm(WrappedNode):
 
     def add_case_and_meta(self, form):
         form.get_app().assert_app_v2()
-        self._create_casexml_2(form)
+        self._create_casexml(form)
         self._add_usercase(form)
         self._add_meta_2(form)
 
     def add_case_and_meta_advanced(self, form):
-        self._create_casexml_2_advanced(form)
+        self._create_casexml_advanced(form)
         self._add_meta_2(form)
 
     def already_has_meta(self):
@@ -1618,7 +1618,7 @@ class XForm(WrappedNode):
         else:
             return 'false()'
 
-    def _create_casexml_2(self, form):
+    def _create_casexml(self, form):
         actions = form.active_actions()
 
         form_opens_case = 'open_case' in actions
@@ -1818,7 +1818,7 @@ class XForm(WrappedNode):
         )
         self.data_node.append(_make_elem(SCHEDULE_NEXT_DUE))
 
-    def _create_casexml_2_advanced(self, form):
+    def _create_casexml_advanced(self, form):
         self._scheduler_case_updates_populated = True
         from corehq.apps.app_manager.util import split_path
 


### PR DESCRIPTION
I was going to do more refactoring today but this was as far as I got.

I assume the `2` is supposed to refer to the major version of CommCare, but given that it's been the only version of CommCare for a long time, and there are no other `create_casexml` functions, the names are just confusing.