### PR TITLE
Upgrade python dependencies requiring single point release bump

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -115,7 +115,7 @@ django==2.2.27
     #   django-user-agents
     #   djangorestframework
     #   jsonfield
-django-appconf==1.0.4
+django-appconf==1.0.5
     # via
     #   django-compressor
     #   django-statici18n
@@ -161,15 +161,15 @@ django-recaptcha==2.0.6
     # via -r base-requirements.in
 django-redis==4.12.1
     # via -r base-requirements.in
-django-redis-sessions==0.6.1
+django-redis-sessions==0.6.2
     # via -r base-requirements.in
 django-statici18n==1.9.0
     # via -r base-requirements.in
-django-tastypie==0.14.3
+django-tastypie==0.14.4
     # via -r base-requirements.in
 django-transfer==0.4
     # via -r base-requirements.in
-django-two-factor-auth==1.13.1
+django-two-factor-auth==1.13.2
     # via -r base-requirements.in
 django-user-agents==0.4.0
     # via -r base-requirements.in
@@ -200,7 +200,7 @@ ethiopian-date-converter==0.1.5
     # via -r base-requirements.in
 eulxml==1.1.3
     # via -r base-requirements.in
-executing==0.8.2
+executing==0.8.3
     # via stack-data
 fakecouch==0.0.15
     # via -r test-requirements.in
@@ -274,7 +274,7 @@ ipython==8.0.1
     # via -r dev-requirements.in
 iso8601==0.1.13
     # via -r base-requirements.in
-isodate==0.6.0
+isodate==0.6.1
     # via python3-saml
 jdcal==1.4.1
     # via openpyxl
@@ -379,7 +379,7 @@ ply==3.11
     # via
     #   eulxml
     #   jsonpath-ng
-polib==1.1.0
+polib==1.1.1
     # via -r base-requirements.in
 prometheus-client==0.7.1
     # via -r base-requirements.in
@@ -442,7 +442,7 @@ pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
     # via twilio
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   -r base-requirements.in
     #   alembic
@@ -510,7 +510,7 @@ requests==2.25.1
     #   twilio
 requests-mock==1.9.3
     # via -r test-requirements.in
-requests-oauthlib==1.3.0
+requests-oauthlib==1.3.1
     # via
     #   -r base-requirements.in
     #   google-auth-oauthlib
@@ -617,7 +617,7 @@ stack-data==0.1.4
     # via ipython
 stripe==2.54.0
     # via -r base-requirements.in
-suds-py3==1.4.4.1
+suds-py3==1.4.5.0
     # via -r base-requirements.in
 tenacity==6.2.0
     # via ddtrace
@@ -631,7 +631,7 @@ tinys3==0.1.12
     # via -r base-requirements.in
 toml==0.10.2
     # via pep517
-tomli==2.0.0
+tomli==2.0.1
     # via black
 toposort==1.7
     # via -r base-requirements.in
@@ -671,7 +671,7 @@ wcwidth==0.2.5
     # via prompt-toolkit
 werkzeug==1.0.1
     # via -r base-requirements.in
-wheel==0.37.0
+wheel==0.37.1
     # via
     #   -r dev-requirements.in
     #   pip-tools
@@ -681,7 +681,7 @@ xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
-xmlsec==1.3.11
+xmlsec==1.3.12
     # via python3-saml
 yapf==0.31.0
     # via -r dev-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -92,7 +92,7 @@ django==2.2.27
     #   django-user-agents
     #   djangorestframework
     #   jsonfield
-django-appconf==1.0.4
+django-appconf==1.0.5
     # via
     #   django-compressor
     #   django-statici18n
@@ -136,15 +136,15 @@ django-recaptcha==2.0.6
     # via -r base-requirements.in
 django-redis==4.12.1
     # via -r base-requirements.in
-django-redis-sessions==0.6.1
+django-redis-sessions==0.6.2
     # via -r base-requirements.in
 django-statici18n==1.9.0
     # via -r base-requirements.in
-django-tastypie==0.14.3
+django-tastypie==0.14.4
     # via -r base-requirements.in
 django-transfer==0.4
     # via -r base-requirements.in
-django-two-factor-auth==1.13.1
+django-two-factor-auth==1.13.2
     # via -r base-requirements.in
 django-user-agents==0.4.0
     # via -r base-requirements.in
@@ -306,7 +306,7 @@ ply==3.11
     # via
     #   eulxml
     #   jsonpath-ng
-polib==1.1.0
+polib==1.1.1
     # via -r base-requirements.in
 prometheus-client==0.7.1
     # via -r base-requirements.in
@@ -351,7 +351,7 @@ pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
     # via twilio
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   -r base-requirements.in
     #   alembic
@@ -409,7 +409,7 @@ requests==2.25.1
     #   stripe
     #   tinys3
     #   twilio
-requests-oauthlib==1.3.0
+requests-oauthlib==1.3.1
     # via
     #   -r base-requirements.in
     #   google-auth-oauthlib
@@ -498,7 +498,7 @@ sqlparse==0.3.1
     # via django
 stripe==2.54.0
     # via -r base-requirements.in
-suds-py3==1.4.4.1
+suds-py3==1.4.5.0
     # via -r base-requirements.in
 tenacity==6.2.0
     # via ddtrace

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -102,7 +102,7 @@ django==2.2.27
     #   django-user-agents
     #   djangorestframework
     #   jsonfield
-django-appconf==1.0.4
+django-appconf==1.0.5
     # via
     #   django-compressor
     #   django-statici18n
@@ -144,15 +144,15 @@ django-recaptcha==2.0.6
     # via -r base-requirements.in
 django-redis==4.12.1
     # via -r base-requirements.in
-django-redis-sessions==0.6.1
+django-redis-sessions==0.6.2
     # via -r base-requirements.in
 django-statici18n==1.9.0
     # via -r base-requirements.in
-django-tastypie==0.14.3
+django-tastypie==0.14.4
     # via -r base-requirements.in
 django-transfer==0.4
     # via -r base-requirements.in
-django-two-factor-auth==1.13.1
+django-two-factor-auth==1.13.2
     # via -r base-requirements.in
 django-user-agents==0.4.0
     # via -r base-requirements.in
@@ -178,7 +178,7 @@ ethiopian-date-converter==0.1.5
     # via -r base-requirements.in
 eulxml==1.1.3
     # via -r base-requirements.in
-executing==0.8.2
+executing==0.8.3
     # via stack-data
 faker==5.0.2
     # via -r base-requirements.in
@@ -236,7 +236,7 @@ ipython==8.0.1
     # via -r prod-requirements.in
 iso8601==0.1.13
     # via -r base-requirements.in
-isodate==0.6.0
+isodate==0.6.1
     # via python3-saml
 jdcal==1.4.1
     # via openpyxl
@@ -322,7 +322,7 @@ ply==3.11
     # via
     #   eulxml
     #   jsonpath-ng
-polib==1.1.0
+polib==1.1.1
     # via -r base-requirements.in
 prometheus-client==0.7.1
     # via -r base-requirements.in
@@ -378,7 +378,7 @@ pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
     # via twilio
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   -r base-requirements.in
     #   alembic
@@ -436,7 +436,7 @@ requests==2.25.1
     #   stripe
     #   tinys3
     #   twilio
-requests-oauthlib==1.3.0
+requests-oauthlib==1.3.1
     # via
     #   -r base-requirements.in
     #   google-auth-oauthlib
@@ -509,7 +509,7 @@ stack-data==0.1.4
     # via ipython
 stripe==2.54.0
     # via -r base-requirements.in
-suds-py3==1.4.4.1
+suds-py3==1.4.5.0
     # via -r base-requirements.in
 tenacity==6.2.0
     # via ddtrace
@@ -519,7 +519,7 @@ text-unidecode==1.3
     #   faker
 tinys3==0.1.12
     # via -r base-requirements.in
-tomli==2.0.0
+tomli==2.0.1
     # via black
 toposort==1.7
     # via -r base-requirements.in
@@ -569,7 +569,7 @@ xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
-xmlsec==1.3.11
+xmlsec==1.3.12
     # via python3-saml
 zipp==3.7.0
     # via importlib-metadata

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -88,7 +88,7 @@ django==2.2.27
     #   django-user-agents
     #   djangorestframework
     #   jsonfield
-django-appconf==1.0.4
+django-appconf==1.0.5
     # via
     #   django-compressor
     #   django-statici18n
@@ -130,15 +130,15 @@ django-recaptcha==2.0.6
     # via -r base-requirements.in
 django-redis==4.12.1
     # via -r base-requirements.in
-django-redis-sessions==0.6.1
+django-redis-sessions==0.6.2
     # via -r base-requirements.in
 django-statici18n==1.9.0
     # via -r base-requirements.in
-django-tastypie==0.14.3
+django-tastypie==0.14.4
     # via -r base-requirements.in
 django-transfer==0.4
     # via -r base-requirements.in
-django-two-factor-auth==1.13.1
+django-two-factor-auth==1.13.2
     # via -r base-requirements.in
 django-user-agents==0.4.0
     # via -r base-requirements.in
@@ -215,7 +215,7 @@ intervaltree==3.1.0
     # via ddtrace
 iso8601==0.1.13
     # via -r base-requirements.in
-isodate==0.6.0
+isodate==0.6.1
     # via python3-saml
 jdcal==1.4.1
     # via openpyxl
@@ -283,7 +283,7 @@ ply==3.11
     # via
     #   eulxml
     #   jsonpath-ng
-polib==1.1.0
+polib==1.1.1
     # via -r base-requirements.in
 prometheus-client==0.7.1
     # via -r base-requirements.in
@@ -326,7 +326,7 @@ pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
     # via twilio
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   -r base-requirements.in
     #   alembic
@@ -382,7 +382,7 @@ requests==2.25.1
     #   stripe
     #   tinys3
     #   twilio
-requests-oauthlib==1.3.0
+requests-oauthlib==1.3.1
     # via
     #   -r base-requirements.in
     #   google-auth-oauthlib
@@ -450,7 +450,7 @@ sqlparse==0.3.1
     # via django
 stripe==2.54.0
     # via -r base-requirements.in
-suds-py3==1.4.4.1
+suds-py3==1.4.5.0
     # via -r base-requirements.in
 tenacity==6.2.0
     # via ddtrace
@@ -496,7 +496,7 @@ xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
-xmlsec==1.3.11
+xmlsec==1.3.12
     # via python3-saml
 zipp==3.7.0
     # via importlib-metadata

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -96,7 +96,7 @@ django==2.2.27
     #   django-user-agents
     #   djangorestframework
     #   jsonfield
-django-appconf==1.0.4
+django-appconf==1.0.5
     # via
     #   django-compressor
     #   django-statici18n
@@ -140,15 +140,15 @@ django-recaptcha==2.0.6
     # via -r base-requirements.in
 django-redis==4.12.1
     # via -r base-requirements.in
-django-redis-sessions==0.6.1
+django-redis-sessions==0.6.2
     # via -r base-requirements.in
 django-statici18n==1.9.0
     # via -r base-requirements.in
-django-tastypie==0.14.3
+django-tastypie==0.14.4
     # via -r base-requirements.in
 django-transfer==0.4
     # via -r base-requirements.in
-django-two-factor-auth==1.13.1
+django-two-factor-auth==1.13.2
     # via -r base-requirements.in
 django-user-agents==0.4.0
     # via -r base-requirements.in
@@ -233,7 +233,7 @@ intervaltree==3.1.0
     # via ddtrace
 iso8601==0.1.13
     # via -r base-requirements.in
-isodate==0.6.0
+isodate==0.6.1
     # via python3-saml
 jdcal==1.4.1
     # via openpyxl
@@ -314,7 +314,7 @@ ply==3.11
     # via
     #   eulxml
     #   jsonpath-ng
-polib==1.1.0
+polib==1.1.1
     # via -r base-requirements.in
 prometheus-client==0.7.1
     # via -r base-requirements.in
@@ -359,7 +359,7 @@ pyrsistent==0.17.3
     # via jsonschema
 pysocks==1.7.1
     # via twilio
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   -r base-requirements.in
     #   alembic
@@ -421,7 +421,7 @@ requests==2.25.1
     #   twilio
 requests-mock==1.9.3
     # via -r test-requirements.in
-requests-oauthlib==1.3.0
+requests-oauthlib==1.3.1
     # via
     #   -r base-requirements.in
     #   google-auth-oauthlib
@@ -497,7 +497,7 @@ sqlparse==0.3.1
     # via django
 stripe==2.54.0
     # via -r base-requirements.in
-suds-py3==1.4.4.1
+suds-py3==1.4.5.0
     # via -r base-requirements.in
 tenacity==6.2.0
     # via ddtrace
@@ -549,7 +549,7 @@ xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
-xmlsec==1.3.11
+xmlsec==1.3.12
     # via python3-saml
 zipp==3.7.0
     # via importlib-metadata


### PR DESCRIPTION
## Technical Summary
Another little exploration for today: can we reliably bulk upgrade single point release versions (i.e. `x.y.z` to `x.y.(z+1)`)? This PR tries to do that for all such libraries we have currently.

## Safety Assurance

### Safety story

- django-appconf: [harmless](https://github.com/django-compressor/django-appconf/blob/develop/docs/changelog.rst#105-2021-09-24)
- django-redis-sessions: [changes](https://github.com/martinrusev/django-redis-sessions/compare/0.6.1...0.6.2) are a little less well-summarized, but appear benign
- django-tastypie: [changes](https://django-tastypie.readthedocs.io/en/latest/release_notes/v0.14.4.html) look okay
- django-two-factor-auth: [changes](https://github.com/jazzband/django-two-factor-auth/blob/master/CHANGELOG.md#1132) look okay
- executing: [changes](https://github.com/alexmojaki/executing/compare/v0.8.2...v0.8.3) look fine
- isodate: [changes](https://github.com/gweis/isodate/blob/master/CHANGES.txt#L14) look fine
- polib: [changes](https://github.com/izimobil/polib/blob/master/CHANGELOG#L5) look fine
- python-dateutil: [changes](https://dateutil.readthedocs.io/en/stable/changelog.html#version-2-8-2-2021-07-08) look okay
- requests-oauthlib: [changes](https://github.com/requests/requests-oauthlib/blob/master/HISTORY.rst#v131-21-january-2022) look fine
- suds-py3: [changes](https://github.com/cackharot/suds-py3/compare/v1.4.4.1...v1.4.5.0) look fine
- tomli: [changes](https://github.com/hukkin/tomli/blob/master/CHANGELOG.md#201) look fine
- wheel: [changes](https://wheel.readthedocs.io/en/stable/news.html#release-notes) look fine
- xmlsec: [changes](https://github.com/mehcode/python-xmlsec/releases) look okay
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

I'll defer to @dimagi/dependency-watchers, but I don't think QA is necessary here.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
