### PR TITLE
attempt to use a different Redis DB for tests

### DIFF
--- a/dev_settings.py
+++ b/dev_settings.py
@@ -91,6 +91,11 @@ COUCH_DATABASES = {
 redis_cache = {
     'BACKEND': 'django_redis.cache.RedisCache',
     'LOCATION': 'redis://127.0.0.1:6379/0',
+    # match production settings
+    'PARSER_CLASS': 'redis.connection.HiredisParser',
+    'REDIS_CLIENT_KWARGS': {
+        'health_check_interval': 15,
+    }
 }
 
 CACHES = {

--- a/settingshelper.py
+++ b/settingshelper.py
@@ -1,13 +1,12 @@
 import logging
-import subprocess
-from collections import namedtuple
 import os
+import re
+import subprocess
 import sys
 import tempfile
 import uuid
-
-import re
-from urllib.parse import urlencode, urlparse, parse_qs
+from collections import namedtuple
+from urllib.parse import parse_qs, urlencode, urlparse
 
 from django.db.backends.base.creation import TEST_DATABASE_PREFIX
 
@@ -197,8 +196,8 @@ class CouchSettingsHelper(namedtuple('CouchSettingsHelper',
 
 
 def celery_failure_handler(task, exc, task_id, args, kwargs, einfo):
-    from redis.exceptions import ConnectionError
     from django_redis.exceptions import ConnectionInterrupted
+    from redis.exceptions import ConnectionError
     if isinstance(exc, (ConnectionInterrupted, ConnectionError)):
         task.retry(args=args, kwargs=kwargs, exc=exc, max_retries=3, countdown=60 * 5)
 
@@ -235,11 +234,11 @@ def fix_logger_obfuscation(fix_logger_obfuscation_, logging_config):
 
 def configure_sentry(base_dir, server_env, dsn):
     import sentry_sdk
-    from sentry_sdk.integrations.logging import ignore_logger
-    from sentry_sdk.integrations.django import DjangoIntegration
     from sentry_sdk.integrations.celery import CeleryIntegration
-    from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+    from sentry_sdk.integrations.django import DjangoIntegration
+    from sentry_sdk.integrations.logging import ignore_logger
     from sentry_sdk.integrations.redis import RedisIntegration
+    from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 
     def _before_send(event, hint):
         # can't import this during load since settings is not fully configured yet

--- a/testsettings.py
+++ b/testsettings.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import settingshelper as helper
@@ -122,3 +123,9 @@ METRICS_PROVIDERS = [
 ES_SEARCH_TIMEOUT = 5
 
 FORMPLAYER_INTERNAL_AUTH_KEY = "abc123"
+
+try:
+    if not helper.update_redis_location_for_tests(CACHES):  # noqa: F405
+        logging.warning("Unable to set Redis DB for tests. Using main Redis DB.")
+except Exception:
+    logging.warning("Unable to set Redis DB for tests. Using main Redis DB.")

--- a/testsettings.py
+++ b/testsettings.py
@@ -124,8 +124,4 @@ ES_SEARCH_TIMEOUT = 5
 
 FORMPLAYER_INTERNAL_AUTH_KEY = "abc123"
 
-try:
-    if not helper.update_redis_location_for_tests(CACHES):  # noqa: F405
-        logging.warning("Unable to set Redis DB for tests. Using main Redis DB.")
-except Exception:
-    logging.warning("Unable to set Redis DB for tests. Using main Redis DB.")
+helper.update_redis_location_for_tests(CACHES)  # noqa: F405

--- a/testsettings.py
+++ b/testsettings.py
@@ -1,4 +1,3 @@
-import logging
 import os
 
 import settingshelper as helper


### PR DESCRIPTION
## Technical Summary
Attempt to use a different Redis DB for tests to avoid polluting the main cache.

Also a change to `dev_settings.py` to match the production Redis client settings.

## Safety Assurance

### Safety story
Only affects tests.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
