### PR TITLE
separate redis DB for tests

### DIFF
--- a/dev_settings.py
+++ b/dev_settings.py
@@ -91,6 +91,11 @@ COUCH_DATABASES = {
 redis_cache = {
     'BACKEND': 'django_redis.cache.RedisCache',
     'LOCATION': 'redis://127.0.0.1:6379/0',
+    # match production settings
+    'PARSER_CLASS': 'redis.connection.HiredisParser',
+    'REDIS_CLIENT_KWARGS': {
+        'health_check_interval': 15,
+    }
 }
 
 CACHES = {

--- a/dev_settings.py
+++ b/dev_settings.py
@@ -95,7 +95,8 @@ redis_cache = {
     'PARSER_CLASS': 'redis.connection.HiredisParser',
     'REDIS_CLIENT_KWARGS': {
         'health_check_interval': 15,
-    }
+    },
+    'TEST_LOCATION': 'redis://127.0.0.1:6379/1',
 }
 
 CACHES = {

--- a/dev_settings.py
+++ b/dev_settings.py
@@ -96,6 +96,7 @@ redis_cache = {
     'REDIS_CLIENT_KWARGS': {
         'health_check_interval': 15,
     },
+    # see `settingshelper.update_redis_location_for_tests`
     'TEST_LOCATION': 'redis://127.0.0.1:6379/1',
 }
 

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -82,6 +82,13 @@ redis_host = 'redis'
 redis_cache = {
     'BACKEND': 'django_redis.cache.RedisCache',
     'LOCATION': 'redis://{}:6379/0'.format(redis_host),
+    # match production settings
+    'PARSER_CLASS': 'redis.connection.HiredisParser',
+    'REDIS_CLIENT_KWARGS': {
+        'health_check_interval': 15,
+    },
+    # see `settingshelper.update_redis_location_for_tests`
+    'TEST_LOCATION': 'redis://{}:6379/1'.format(redis_host),
 }
 
 CACHES = {

--- a/settingshelper.py
+++ b/settingshelper.py
@@ -287,6 +287,8 @@ def get_git_commit(base_dir):
 
 
 def update_redis_location_for_tests(settings_caches):
+    if not is_testing():
+        raise Exception("Attempt to update Redis settings outside of tests")
 
     for name, config in settings_caches.items():
         if not config.get("BACKEND", "").startswith("django_redis"):

--- a/settingshelper.py
+++ b/settingshelper.py
@@ -1,12 +1,12 @@
 import logging
-import subprocess
-from collections import namedtuple
 import os
+import re
+import subprocess
 import sys
 import tempfile
 import uuid
+from collections import namedtuple
 
-import re
 from django.db.backends.base.creation import TEST_DATABASE_PREFIX
 
 
@@ -195,8 +195,8 @@ class CouchSettingsHelper(namedtuple('CouchSettingsHelper',
 
 
 def celery_failure_handler(task, exc, task_id, args, kwargs, einfo):
-    from redis.exceptions import ConnectionError
     from django_redis.exceptions import ConnectionInterrupted
+    from redis.exceptions import ConnectionError
     if isinstance(exc, (ConnectionInterrupted, ConnectionError)):
         task.retry(args=args, kwargs=kwargs, exc=exc, max_retries=3, countdown=60 * 5)
 
@@ -233,11 +233,11 @@ def fix_logger_obfuscation(fix_logger_obfuscation_, logging_config):
 
 def configure_sentry(base_dir, server_env, dsn):
     import sentry_sdk
-    from sentry_sdk.integrations.logging import ignore_logger
-    from sentry_sdk.integrations.django import DjangoIntegration
     from sentry_sdk.integrations.celery import CeleryIntegration
-    from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+    from sentry_sdk.integrations.django import DjangoIntegration
+    from sentry_sdk.integrations.logging import ignore_logger
     from sentry_sdk.integrations.redis import RedisIntegration
+    from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 
     def _before_send(event, hint):
         # can't import this during load since settings is not fully configured yet

--- a/settingshelper.py
+++ b/settingshelper.py
@@ -295,12 +295,11 @@ def update_redis_location_for_tests(settings_caches):
             continue
 
         test_location = config.get("TEST_LOCATION")
-        if not test_location:
+        if test_location:
+            config["LOCATION"] = test_location
+        else:
             logging.warning(
                 "Unable to set Redis DB in '%(name)s' cache for tests. Using '%(location)s'.\n"
                 "\tTo configure a separate Redis DB for tests add a 'TEST_LOCATION' to the"
                 " '%(name)s' cache configuration.", {"name": name, "location": config["LOCATION"]}
             )
-
-        logging.info("Using '%s' connection for Redis", test_location)
-        config["LOCATION"] = test_location

--- a/settingshelper.py
+++ b/settingshelper.py
@@ -1,3 +1,4 @@
+import logging
 import subprocess
 from collections import namedtuple
 import os
@@ -283,3 +284,21 @@ def get_git_commit(base_dir):
         return out.strip().decode('ascii')
     except OSError:
         pass
+
+
+def update_redis_location_for_tests(settings_caches):
+
+    for name, config in settings_caches.items():
+        if not config.get("BACKEND", "").startswith("django_redis"):
+            continue
+
+        test_location = config.get("TEST_LOCATION")
+        if not test_location:
+            logging.warning(
+                "Unable to set Redis DB in '%(name)s' cache for tests. Using '%(location)s'.\n"
+                "\tTo configure a separate Redis DB for tests add a 'TEST_LOCATION' to the"
+                " '%(name)s' cache configuration.", {"name": name, "location": config["LOCATION"]}
+            )
+
+        logging.info("Using '%s' connection for Redis", test_location)
+        config["LOCATION"] = test_location

--- a/testsettings.py
+++ b/testsettings.py
@@ -107,7 +107,8 @@ LOGGING = {
     'loggers': {},
 }
 
-helper.assign_test_db_names(DATABASES)
+helper.assign_test_db_names(DATABASES)  # noqa: F405
+helper.update_redis_location_for_tests(CACHES)  # noqa: F405
 
 # See comment under settings.SMS_QUEUE_ENABLED
 SMS_QUEUE_ENABLED = False
@@ -122,5 +123,3 @@ METRICS_PROVIDERS = [
 ES_SEARCH_TIMEOUT = 5
 
 FORMPLAYER_INTERNAL_AUTH_KEY = "abc123"
-
-helper.update_redis_location_for_tests(CACHES)  # noqa: F405

--- a/testsettings.py
+++ b/testsettings.py
@@ -122,3 +122,5 @@ METRICS_PROVIDERS = [
 ES_SEARCH_TIMEOUT = 5
 
 FORMPLAYER_INTERNAL_AUTH_KEY = "abc123"
+
+helper.update_redis_location_for_tests(CACHES)  # noqa: F405


### PR DESCRIPTION
Redo of https://github.com/dimagi/commcare-hq/pull/31426

## Technical Summary
Use a different Redis DB for tests if one is specified. This avoids polluting the main cache.

Also a change to `dev_settings.py` to match the production Redis client settings.

## Safety Assurance

### Safety story
Only affects tests.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
