### PR TITLE
Improve error on metrics provider lookup failure

### DIFF
--- a/corehq/util/metrics/__init__.py
+++ b/corehq/util/metrics/__init__.py
@@ -313,7 +313,7 @@ def _get_metrics_provider():
         _global_setup()
         providers = []
         for provider_path in settings.METRICS_PROVIDERS:
-            provider = to_function(provider_path)()
+            provider = to_function(provider_path, failhard=True)()
             providers.append(provider)
 
         if not providers:


### PR DESCRIPTION
Previously it caused an unhelpful error: `TypeError: 'NoneType' object is not callable`

This error is happening intermittently in Celery tasks on staging.

## Safety Assurance

### Safety story

Very simple change that will ~cause a more helpful error to be raised~ log the error to Sentry and skip the provider when metrics provider lookup fails.

### Automated test coverage

No.

### QA Plan

This PR is to help with an ongoing QA testing of Django 3. See https://dimagi-dev.atlassian.net/browse/QA-4035

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
