### PR TITLE
Update translations workflow

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,0 +1,38 @@
+on: workflow_dispatch
+
+name: Update transifex translations
+jobs:
+  update_translations:
+    name: Update transifex translations
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install transifex client
+        run: |
+          mkdir -p /home/runner/.local/bin
+          cd /home/runner/.local/bin
+          curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
+          sudo apt-get install -y gettext
+      - name: Run update-translations script
+        # From https://github.com/marketplace/actions/create-pr-action:
+        # > executes an arbitrary command and commits the changes to the new pull request
+        uses: technote-space/create-pr-action@v2
+        env:
+          TRANSIFEX_TOKEN: ${{ secrets.TRANSIFEX_TOKEN }}
+          UPDATE_TRANSLATIONS_SKIP_GIT: 1
+        with:
+          EXECUTE_COMMANDS: |
+            git submodule update --init --recursive > /dev/null 2>&1
+            pip install --upgrade pip > /dev/null 2>&1
+            # install requirements, excluding difficult to install ones
+            grep -Ev 'xmlsec|python3-saml' requirements/dev-requirements.txt > ../requirements.txt
+            pip install -r ../requirements.txt  > /dev/null 2>&1
+            # copy .transifexrc.example to ~/.transifexrc, edited to include token
+            grep -v '^token =' .transifexrc.example > ~/.transifexrc
+            echo "token = ${TRANSIFEX_TOKEN}" >> ~/.transifexrc
+            ./scripts/update-translations.sh
+          COMMIT_MESSAGE: |
+            Update translations.
+
+            [ci skip]
+          PR_BRANCH_NAME: 'update-translations'
+          PR_TITLE: 'Update Translations'


### PR DESCRIPTION
## Technical Summary

Best reviewed with Ignore Whitespace (?w=1).

I got this to work! Merging this PR will do the following:
- Allow any of us to go to the Actions tab of this repo and trigger update-translations.sh as Github Actions workflow run, which will result in a PR to master being automatically opened with the changes
- ...or continue to run update-translations.sh locally.

Once we're happy with that workflow, we can easily go one step further and make it run on a schedule (say, once a week).

## Safety Assurance

### Safety story
The only way this affects production is through the translations it updates, and those are (1) updated using the same script as before and (2) verified by an approver via a PR, so the risk there seems very low. This PR doesn't touch any production code, so other than that it can't cause any problems in production.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
