### PR TITLE
Fix missing default value on Django 3.0

### DIFF
--- a/corehq/apps/fixtures/tests/test_views.py
+++ b/corehq/apps/fixtures/tests/test_views.py
@@ -1,0 +1,48 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.test.client import Client
+from django.urls import reverse
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import WebUser
+
+DOMAIN = "lookup"
+USER = "test@test.com"
+PASS = "password"
+
+
+class LookupTableViewsTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(LookupTableViewsTest, cls).setUpClass()
+        cls.domain = create_domain(DOMAIN)
+        cls.domain.save()
+        cls.addClassCleanup(cls.domain.delete)
+        cls.user = WebUser.create(DOMAIN, USER, PASS, created_by=None, created_via=None)
+        cls.user.is_superuser = True
+        cls.user.save()
+        cls.addClassCleanup(cls.user.delete, DOMAIN, deleted_by=None)
+
+    def test_update_tables_post_without_data_type_id(self):
+        data = {
+            "fields": {},
+            "tag": "invalid tag",
+            "is_global": False,
+            "description": ""
+        }
+        client = Client()
+        client.login(username=USER, password=PASS)
+        url = reverse("update_lookup_tables", kwargs={'domain': DOMAIN})
+        allow_all = patch('django_prbac.decorators.has_privilege', return_value=True)
+
+        # Not sure why _to_kwargs doesn't work on a test client request,
+        # or maybe why it does work in the real world? Mocking it was
+        # the easiest way I could find to work around the issue.
+        json_data = patch('corehq.apps.fixtures.views._to_kwargs', return_value=data)
+
+        with allow_all, json_data:
+            response = client.post(url, data)
+        self.assertEqual(response.status_code, 200, str(response))
+        self.assertIn("validation_errors", response.json())

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -93,7 +93,7 @@ def _to_kwargs(req):
 
 
 @require_can_edit_fixtures
-def update_tables(request, domain, data_type_id):
+def update_tables(request, domain, data_type_id=None):
     """
     receives a JSON-update patch like following
     {


### PR DESCRIPTION
`RegexPattern`, used by `re_path()`, no longer returns keyword arguments with `None` values to be passed to the view for the optional named groups that are missing.
https://docs.djangoproject.com/en/4.0/releases/3.0/#miscellaneous

Demo:
```py
from django.urls.resolvers import RegexPattern
pattern = RegexPattern(
    r"^edit_lookup_tables/update-tables/(?P<data_type_id>[\w-]+)?$",
    name="update_lookup_tables",
    is_endpoint=True,
)
pattern.match("edit_lookup_tables/update-tables/")

# Django 2.2: ('', (), {'data_type_id': None})
# Django 3.2: ('', (), {})
```

## Safety Assurance

### Safety story

Backward-compatible change to view signature to support Django 3.0+.

### Automated test coverage

Yes.

### QA Plan

Bug found by QA team: https://dimagi-dev.atlassian.net/browse/QA-4038

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
