### PR TITLE
Improve performance of collapsible groups in web apps

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -53,7 +53,7 @@
       </div>
       <span class="ix"></span>
     </fieldset>
-      <div data-bind="if: showChildren()">
+      <div data-bind="visible: showChildren">
         <fieldset>
         <legend aria-hidden="true" class="sr-only">{% trans "Question Group" %}</legend>
           <div class="children" data-bind="slideVisible: showChildren(), template: { name: childTemplate, foreach: $data.children,


### PR DESCRIPTION
## Product Description

Previously, collapsing a group would remove that group entirely from the page HTML, and expanding it would require regenerating it.  With very large groups, this had the advantage that loading "default-closed" groups was deferred until they were first opened.  This meant that the initial form load was faster, but expanding the group would be slow.

This change makes all that HTML load up-front when the form is first loaded, regardless of whether it's default-open or default-closed.  This can slow down the form start-up time for some forms, but makes expanding and collapsing these groups near-instantaneous.

See Kiran's excellent testing in the QA ticket:
https://dimagi-dev.atlassian.net/browse/QA-4019
[results here](https://docs.google.com/spreadsheets/d/1s0a03x-M0lp9yUdZLrxfy-vff4J0XMXXiZ5pYbBG39g/edit#gid=0)

## Technical Summary

<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Toggle only element visibility, don't remove the HTML

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA'd on staging

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
