### PR TITLE
Case claim title translate prep work

### DIFF
--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -156,6 +156,13 @@ class CommCareFeatureSupportMixin(object):
         return self._require_minimum_version('2.38')
 
     @property
+    def enable_case_search_title_translation(self):
+        """
+        Ability to configure case search title through translation attribute, only supported > 2.53
+        """
+        return self._require_minimum_version('2.53')
+
+    @property
     def enable_training_modules(self):
         return self._require_minimum_version('2.43')
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2228,7 +2228,7 @@ class CaseSearch(DocumentSchema):
     data_registry = StringProperty(exclude_if_none=True)
     data_registry_workflow = StringProperty(exclude_if_none=True)  # one of REGISTRY_WORKFLOW_*
     additional_registry_cases = StringListProperty()               # list of xpath expressions
-    title_label = StringProperty()
+    title_label = DictProperty()
 
     # case property referencing another case's ID
     custom_related_case_property = StringProperty(exclude_if_none=True)
@@ -2236,6 +2236,17 @@ class CaseSearch(DocumentSchema):
     @property
     def case_session_var(self):
         return "search_case_id"
+
+    @classmethod
+    def wrap(cls, doc):
+        self = cls
+        translations = doc.get('translation')
+        title_labels = dict()
+        for lang in translations:
+            if "case.search.title" in lang.keys():
+                title_labels[lang] = lang["case.search.title"]
+        self.title_labels = title_labels
+        return super(CaseSearch, self).wrap(doc)
 
     def get_relevant(self, multi_select=False):
         if multi_select:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4865,7 +4865,7 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
             for lang, label in translations.items() if label}
         for module in self.modules:
             if hasattr(module, 'search_config'):
-                setattr(getattr(module, 'search_config', 'title label', label_dict))
+                setattr(getattr(module, 'search_config', 'title_label', label_dict))
 
         # make sure all form versions are None on working copies
         if not self.copy_of:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4865,7 +4865,7 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
             for lang, label in translations.items() if label}
         for module in self.modules:
             if hasattr(module, 'search_config'):
-                setattr(getattr(module, 'search_config', 'title_label', label_dict))
+                setattr(getattr(module, 'search_config'), 'title_label', label_dict)
 
         # make sure all form versions are None on working copies
         if not self.copy_of:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4864,8 +4864,8 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
         label_dict = {lang: label.get('case.search.title')
             for lang, label in translations.items() if label}
         for module in self.modules:
-            search_config = getattr(module, 'search_config')
-            if search_config:
+            if hasattr(module, 'search_config'):
+                search_config = getattr(module, 'search_config')
                 default_label_dict = getattr(search_config, 'title_label')
                 combined_label_dict = self._get_label_dict(data, default_label_dict, label_dict)
                 setattr(search_config, 'title_label', combined_label_dict)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4863,9 +4863,8 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
         translations = data.get('translations')
         labels = {lang: translations.get(lang).get('case.search.title') for lang in translations}
         for module in self.modules:
-            print(module.name)
             if hasattr(module, 'search_config'):
-                setattr(module, 'search_config')['title_label'] = labels
+                setattr(getattr(module, 'search_config'), 'title label', labels)
 
         # make sure all form versions are None on working copies
         if not self.copy_of:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2228,7 +2228,7 @@ class CaseSearch(DocumentSchema):
     data_registry = StringProperty(exclude_if_none=True)
     data_registry_workflow = StringProperty(exclude_if_none=True)  # one of REGISTRY_WORKFLOW_*
     additional_registry_cases = StringListProperty()               # list of xpath expressions
-    title_label = DictProperty(default={'en': 'Case Claim'})
+    title_label = DictProperty(default={})
 
     # case property referencing another case's ID
     custom_related_case_property = StringProperty(exclude_if_none=True)
@@ -4867,8 +4867,8 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
             if hasattr(module, 'search_config'):
                 search_config = getattr(module, 'search_config')
                 default_label_dict = getattr(search_config, 'title_label')
-                combined_label_dict = self._get_label_dict(data, default_label_dict, label_dict)
-                setattr(search_config, 'title_label', combined_label_dict)
+                label_dict.update(default_label_dict)
+                setattr(search_config, 'title_label', label_dict)
 
         # make sure all form versions are None on working copies
         if not self.copy_of:
@@ -4880,16 +4880,6 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
             self.multimedia_map = {}
 
         return self
-
-    # combines title_label values and translation_title_label values into one dict
-    def _get_label_dict(self, data, default_dict, translated_dict):
-        label_dict = dict()
-        for lang in data.get('langs'):
-            if lang in default_dict.keys():
-                label_dict[lang] = default_dict[lang]
-            elif lang in translated_dict.keys():
-                label_dict[lang] = translated_dict[lang]
-        return label_dict
 
     def save(self, *args, **kwargs):
         super(Application, self).save(*args, **kwargs)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2228,6 +2228,7 @@ class CaseSearch(DocumentSchema):
     data_registry = StringProperty(exclude_if_none=True)
     data_registry_workflow = StringProperty(exclude_if_none=True)  # one of REGISTRY_WORKFLOW_*
     additional_registry_cases = StringListProperty()               # list of xpath expressions
+    title_label = StringProperty()
 
     # case property referencing another case's ID
     custom_related_case_property = StringProperty(exclude_if_none=True)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4861,10 +4861,10 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
         self = super(Application, cls).wrap(data)
 
         translations = data.get('translations')
-        label_dict = {lang: label.get('case.search.title')
-            for lang, label in translations.items() if label}
         for module in self.modules:
             if hasattr(module, 'search_config'):
+                label_dict = {lang: label.get('case.search.title')
+                    for lang, label in translations.items() if label}
                 search_config = getattr(module, 'search_config')
                 default_label_dict = getattr(search_config, 'title_label')
                 label_dict.update(default_label_dict)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4861,10 +4861,11 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
         self = super(Application, cls).wrap(data)
 
         translations = data.get('translations')
-        labels = {lang: translations.get(lang).get('case.search.title') for lang in translations}
+        label_dict = {lang: label.get('case.search.title')
+            for lang, label in translations.items() if label}
         for module in self.modules:
             if hasattr(module, 'search_config'):
-                setattr(getattr(module, 'search_config'), 'title label', labels)
+                setattr(getattr(module, 'search_config', 'title label', label_dict))
 
         # make sure all form versions are None on working copies
         if not self.copy_of:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2237,17 +2237,6 @@ class CaseSearch(DocumentSchema):
     def case_session_var(self):
         return "search_case_id"
 
-    @classmethod
-    def wrap(cls, doc):
-        self = cls
-        translations = doc.get('translation')
-        title_labels = dict()
-        for lang in translations:
-            if "case.search.title" in lang.keys():
-                title_labels[lang] = lang["case.search.title"]
-        self.title_labels = title_labels
-        return super(CaseSearch, self).wrap(doc)
-
     def get_relevant(self, multi_select=False):
         if multi_select:
             return self.additional_relevant
@@ -4870,6 +4859,14 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
         data['modules'] = [module for module in data.get('modules', [])
                            if module.get('doc_type') != 'CareplanModule']
         self = super(Application, cls).wrap(data)
+
+        translations = data.get('translations')
+        labels = [{lang: translations.get(lang).get('case.search.title')}
+            for lang in translations]
+        for module in self.modules:
+            print(module.name)
+            if hasattr(module, 'search_config'):
+                setattr(module, 'search_config')['title_label'] = labels
 
         # make sure all form versions are None on working copies
         if not self.copy_of:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4861,8 +4861,7 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
         self = super(Application, cls).wrap(data)
 
         translations = data.get('translations')
-        labels = [{lang: translations.get(lang).get('case.search.title')}
-            for lang in translations]
+        labels = {lang: translations.get(lang).get('case.search.title') for lang in translations}
         for module in self.modules:
             print(module.name)
             if hasattr(module, 'search_config'):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Prep work for case claim title translation. 

- Adds `title_label` property to `CaseSearch` model
- Adds CommCare version check to `feature_support.py`
- Adds new logic to wrap function in `Application` class to assign default value to `title_label` 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[jira](https://dimagi-dev.atlassian.net/browse/USH-1823?atlOrigin=eyJpIjoiNmQ2YzEwY2YyODg4NDdkZDk1ZTI1NGQ1MWNiODYwNzIiLCJwIjoiaiJ9)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
CASE_CLAIM

## Safety Assurance


### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This has no immediate user facing effect.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
This will be QA'd once the related tickets are finished.

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->
Unsure if I should make a migration as `CaseSearch` had a property added.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
