### PR TITLE
Revert "remove redundant global admin check"

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -588,7 +588,9 @@ class _AuthorizableMixin(IsMemberOfMixin):
     @memoized
     def has_permission(self, domain, permission, data=None):
         # is_admin is the same as having all the permissions set
-        if self.is_domain_admin(domain):
+        if self.is_global_admin() and (domain is None or not domain_restricts_superusers(domain)):
+            return True
+        elif self.is_domain_admin(domain):
             return True
 
         dm = self.get_domain_membership(domain, allow_enterprise=True)

--- a/corehq/apps/users/tests/test_authorization.py
+++ b/corehq/apps/users/tests/test_authorization.py
@@ -263,6 +263,9 @@ class TestSuperUserAuthorizationFunctions(BaseAuthorizationTest):
     def test_has_permission__default_yes__no_membership(self):
         self.assertTrue(self.user.has_permission('other', 'report_an_issue'))
 
+    def test_has_permission__default_yes__null_domain(self):
+        self.assertTrue(self.user.has_permission(None, 'report_an_issue'))
+
     @patch('corehq.apps.users.models.domain_restricts_superusers', return_value=True)
     def test_has_permission__default_no__domain_restricts_superusers(self, _mock):
         self.assertFalse(self.user.has_permission(self.domain, 'edit_web_users'))


### PR DESCRIPTION
This is a follow-up for https://dimagi-dev.atlassian.net/browse/SAAS-13388. The redundant check here was not redunant, as the removed test demonstrated. For admin reports, no domain was available to use, so replacing a global check with a domain check was not possible.

This reverts commit a6ca0e1d9256ddf2cba29a7ac2067e1e1e553eb8.

## Safety Assurance

### Safety story
Verified locally that this fixes the witnessed issue with exporting to Excel.

### Automated test coverage

This revert re-introduces the test that was designed to catch this bug.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA needed.

### Rollback instructions

Rolling back with reintroduce this bug, but is safe.

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
