### PR TITLE
Make .editorconfig match our YAML style of 2-space indents

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,5 +18,8 @@ indent_size = 2
 [*.json]
 indent_size = 2
 
+[*.yml]
+indent_size = 2
+
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
## Technical Summary
`.editorconfig` is something (some of) our local editors (including PyCharm) look at when determining certain style rules for certain filetypes. Our existing YAML files use 2-space indents, so I'm updating it there to match.

## Safety Assurance

### Safety story
Couldn't possibly affect production.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
