### PR TITLE
Improve update translations workflow

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -6,33 +6,46 @@ jobs:
     name: Update transifex translations
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+          submodules: recursive
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - name: Install Python requirements
+        run: |
+          pip install --upgrade pip
+          # install requirements, excluding difficult to install ones
+          grep -Ev 'xmlsec|python3-saml' requirements/dev-requirements.txt > ../requirements.txt
+          pip install -r ../requirements.txt
       - name: Install transifex client
         run: |
           mkdir -p /home/runner/.local/bin
           cd /home/runner/.local/bin
           curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
           sudo apt-get install -y gettext
-      - name: Run update-translations script
-        # From https://github.com/marketplace/actions/create-pr-action:
-        # > executes an arbitrary command and commits the changes to the new pull request
-        uses: technote-space/create-pr-action@v2
+      - name: Configure transifex client
         env:
           TRANSIFEX_TOKEN: ${{ secrets.TRANSIFEX_TOKEN }}
+        run: |
+          # copy .transifexrc.example to ~/.transifexrc, edited to include token
+          grep -v '^token =' .transifexrc.example > ~/.transifexrc
+          echo "token = ${TRANSIFEX_TOKEN}" >> ~/.transifexrc
+      - name: Run update-translations script
+        run: |
+          ./scripts/update-translations.sh
+        env:
           UPDATE_TRANSLATIONS_SKIP_GIT: 1
+      - name: Create Pull Request
+        # https://github.com/marketplace/actions/create-pull-request
+        # Pinned to the commit of https://github.com/peter-evans/create-pull-request/releases/tag/v4.0.2
+        uses: peter-evans/create-pull-request@bd72e1b7922d417764d27d30768117ad7da78a0e
         with:
-          EXECUTE_COMMANDS: |
-            git submodule update --init --recursive > /dev/null 2>&1
-            pip install --upgrade pip > /dev/null 2>&1
-            # install requirements, excluding difficult to install ones
-            grep -Ev 'xmlsec|python3-saml' requirements/dev-requirements.txt > ../requirements.txt
-            pip install -r ../requirements.txt  > /dev/null 2>&1
-            # copy .transifexrc.example to ~/.transifexrc, edited to include token
-            grep -v '^token =' .transifexrc.example > ~/.transifexrc
-            echo "token = ${TRANSIFEX_TOKEN}" >> ~/.transifexrc
-            ./scripts/update-translations.sh
-          COMMIT_MESSAGE: |
-            Update translations.
-
-            [ci skip]
-          PR_BRANCH_NAME: 'update-translations'
-          PR_TITLE: 'Update Translations'
+          base: master
+          branch: create-pull-request/update-translations
+          branch-suffix: short-commit-hash
+          commit-message: |
+            Update translations
+          title: 'Update Translations'
+          labels: product/invisible


### PR DESCRIPTION
## Technical Summary
Follow up to #31429. I think I addressed all the feedback from that PR.

I also used a different third-party Github Actions action that appeared to be more widely-used and better documented, and I pinned it to the specific commit hash.

This will now create PRs that look like this https://github.com/dimagi/commcare-hq/pull/31447.

Tested:
- PRs are starting from master and into master
- Label is automatically applied
- PR's are made from a branch name that includes the commit hash
- If run twice from the same commit (and thus the same branch/PR), the second time will force push over the first.

## Safety Assurance

### Safety story
Doesn't affect production directly, same rationale as #31429.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
